### PR TITLE
RangeControl: support forced-colors mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
--   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used.
+-   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
+-   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 
 ### Internal
 

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -155,12 +155,12 @@ export const Mark = styled.span`
 
 const markLabelFill = ( { isFilled }: RangeMarkProps ) => {
 	return css( {
-		color: isFilled ? COLORS.gray[ 700 ] : COLORS.gray[ 300 ],
+		color: isFilled ? COLORS.theme.gray[ 700 ] : COLORS.theme.gray[ 300 ],
 	} );
 };
 
 export const MarkLabel = styled.span`
-	color: ${ COLORS.gray[ 300 ] };
+	color: ${ COLORS.theme.gray[ 300 ] };
 	font-size: 11px;
 	position: absolute;
 	top: 8px;

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -78,17 +78,18 @@ export const AfterIconWrapper = styled.span`
 `;
 
 const railBackgroundColor = ( { disabled, railColor }: RailProps ) => {
-	let background = railColor || '';
+	return css`
+		background: ${ disabled
+			? COLORS.ui.backgroundDisabled
+			: railColor || COLORS.theme.gray[ 300 ] };
 
-	if ( disabled ) {
-		background = COLORS.ui.backgroundDisabled;
-	}
-
-	return css( { background } );
+		@media ( forced-colors: active ) {
+			background: GrayText;
+		}
+	`;
 };
 
 export const Rail = styled.span`
-	background-color: ${ COLORS.gray[ 300 ] };
 	left: 0;
 	pointer-events: none;
 	right: 0;
@@ -103,17 +104,18 @@ export const Rail = styled.span`
 `;
 
 const trackBackgroundColor = ( { disabled, trackColor }: TrackProps ) => {
-	let background = trackColor || 'currentColor';
+	return css`
+		background: ${ disabled
+			? COLORS.theme.gray[ 400 ]
+			: trackColor || 'currentColor' };
 
-	if ( disabled ) {
-		background = COLORS.gray[ 400 ];
-	}
-
-	return css( { background } );
+		@media ( forced-colors: active ) {
+			background: ${ disabled ? 'GrayText' : 'CanvasText' };
+		}
+	`;
 };
 
 export const Track = styled.span`
-	background-color: currentColor;
 	border-radius: ${ CONFIG.radiusFull };
 	height: ${ railHeight }px;
 	pointer-events: none;
@@ -173,14 +175,17 @@ export const MarkLabel = styled.span`
 	${ markLabelFill };
 `;
 
-const thumbColor = ( { disabled }: ThumbProps ) =>
-	disabled
-		? css`
-				background-color: ${ COLORS.gray[ 400 ] };
-		  `
-		: css`
-				background-color: ${ COLORS.theme.accent };
-		  `;
+const thumbColor = ( { disabled }: ThumbProps ) => {
+	return css`
+		background: ${ disabled
+			? COLORS.theme.gray[ 400 ]
+			: COLORS.theme.accent };
+
+		@media ( forced-colors: active ) {
+			background: ${ disabled ? 'GrayText' : 'CanvasText' };
+		}
+	`;
+};
 
 export const ThumbWrapper = styled.span`
 	align-items: center;
@@ -224,6 +229,10 @@ const thumbFocus = ( { isFocused }: ThumbProps ) => {
 					width: ${ thumbSize + 8 }px;
 					top: -4px;
 					left: -4px;
+
+					@media ( forced-colors: active ) {
+						background: GrayText;
+					}
 				}
 		  `
 		: '';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75146

Fix styles for the `RangeControl` component so that its track, thumb and markers can be seen in [`forced-colors` mode](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/forced-colors)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Forced colors is an important accessibility feature, and our components should support it natively

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By using the `@media ( forced-colors: active ) { /* ... */ }` media query, in combination with a few dedicated forced-colors keywords (`CanvasText` for primary, non-disabled UI, and `GrayText` for non-interactive / disabled UIs).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load the Storybook examples for RangeControls
- Enable forced colors mode, either via your OS (eg. Windows High Control mode), or by emulating it via browser dev tools ([example](https://developer.chrome.com/docs/devtools/rendering/emulate-css#emulate_css_media_feature_forced-colors))
- Make sure that the RangeControl UI is disernible and usable in forced-colors mode

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![Screenshot 2026-02-03 at 08 21 59](https://github.com/user-attachments/assets/8493a640-e459-4e73-978b-ba07bbd54c38) | ![Screenshot 2026-02-03 at 08 21 29](https://github.com/user-attachments/assets/410fe2ab-6a1a-45b0-83ed-270db6c6152b) |
| ![Screenshot 2026-02-03 at 08 21 53](https://github.com/user-attachments/assets/19b9b257-92dc-4d7b-a7fb-57f1f0fc88a0) | ![Screenshot 2026-02-03 at 08 21 43](https://github.com/user-attachments/assets/12448660-f2d9-4d72-90d6-856115442667) |
