### PR TITLE
List View Support: Only render list view on top level block with support

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -113,10 +113,10 @@ function BlockCard( {
 			const { getBlockParents, getBlockName } =
 				select( blockEditorStore );
 
-			// Find the closest parent block that is either:
+			// Find the top-most parent block that is either:
 			// 1. A navigation block (special case for ad-hoc list view support)
 			// 2. Any block with listView support
-			const parents = getBlockParents( clientId, true );
+			const parents = getBlockParents( clientId, false );
 			const foundParentId = parents.find( ( parentId ) => {
 				const parentName = getBlockName( parentId );
 				return (

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -45,30 +45,25 @@ export function ListViewPanel( { clientId, name } ) {
 			const { getBlockCount, getBlockParents, getBlockName } =
 				select( blockEditorStore );
 
-			// When the ListView is shown in a section, avoid showing List Views
-			// for both parent and child blocks that have support. In this situation
-			// the parent will show the child anyway in its List.
-			// Search parents to see if there's one that also has support, and if so
-			// skip rendering.
+			// Avoid showing List Views for both parent and child blocks that have support.
+			// In this situation the parent will show the child in its list already.
+			// Search parents to see if there's one that also has support, and if so skip rendering.
 			// This matches closely the logic in the `BlockCard` component.
-			let _isNestedListView = false;
-			if ( isSelectionWithinCurrentSection ) {
-				const parents = getBlockParents( clientId, true );
-				_isNestedListView = parents.find( ( parentId ) => {
-					const parentName = getBlockName( parentId );
-					return (
-						parentName === 'core/navigation' ||
-						hasBlockSupport( parentName, 'listView' )
-					);
-				} );
-			}
+			const parents = getBlockParents( clientId, false );
+			const _isNestedListView = parents.find( ( parentId ) => {
+				const parentName = getBlockName( parentId );
+				return (
+					parentName === 'core/navigation' ||
+					hasBlockSupport( parentName, 'listView' )
+				);
+			} );
 
 			return {
 				hasChildren: !! getBlockCount( clientId ),
 				isNestedListView: _isNestedListView,
 			};
 		},
-		[ clientId, isSelectionWithinCurrentSection ]
+		[ clientId ]
 	);
 	const title = useBlockDisplayTitle( {
 		clientId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR proposes a few small changes to the List View support feature that I think make the feature easier to use when a block with List View support is nested in another block with List View support.

This can be a common use case for indented List blocks.

## Why?
There are two things that I think might be confusing for users. First, if a user clicks a nested list block, hey're shown another smaller list view (they drill into the list view). I think it can be disorienting. I also expect the main reason to click on a block is to change its settings rather than to see a refined version of the list:

https://github.com/user-attachments/assets/9c6d8573-d83a-427c-bdac-1d783a65c669

Second, if a user clicks on a deeply nested block, they have to click the back button several times to get back to the top level. It breaks an expectation that  the user will go back to where they were, and can be a lot of clicks:

https://github.com/user-attachments/assets/bb4df92c-d6c7-47af-861c-0abf3c8a9d74

## How?
This PR changes the experience by only showing the list on the parent-most block that has List View support, I think this makes it an easier experience when working with nested blocks:

https://github.com/user-attachments/assets/fee8763a-8da9-4759-8db5-37f12f270ceb

Code-wise, it's pretty straightforward:
- In the Block Card, adjust the search for a parent block with List View support to be descending instead of ascending
- In the List View support, this experience had already been implemented for Pattern Editing. It's now the default.

## Testing Instructions
1. Insert a list block into a post and add lots of nesting levels to the list. Here's some block markup for a list:
<details><summary>Expand here for nested list block markup</summary>

```html
<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>1<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>2.1</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>2.2<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>3.1</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>3.2</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>1.2</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>1.3</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->
```

</details> 

2. Click on the most deeply nested List Item block
3. Click the back button on the block card.
4. Observe that in this PR you're taken straight back to the top-level List, while in trunk you might have to click a few times
5. Select a nested List block
6. Observe that in this PR you're shown the block settings/styles straight away, while in trunk you need to change tabs.