### PR TITLE
Cover Block: Fix dark mode detection for featured images in template context

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -188,6 +188,19 @@ function render_block_core_cover( $attributes, $content ) {
 		$content = substr( $content, 0, $offset ) . $image . substr( $content, $offset );
 	}
 
+	/*
+	 * When using a featured image without an overlay, remove the `is-light` class
+	 * as it may have been incorrectly set at template save time when no image was
+	 * available for color analysis. This aligns with the default `isDark: true` in block.json.
+	 */
+	if ( ! isset( $attributes['overlayColor'] ) ) {
+		$processor = new WP_HTML_Tag_Processor( $content );
+		if ( $processor->next_tag( array( 'class_name' => 'wp-block-cover' ) ) && $processor->has_class( 'is-light' ) ) {
+			$processor->remove_class( 'is-light' );
+			$content = $processor->get_updated_html();
+		}
+	}
+
 	return $content;
 }
 


### PR DESCRIPTION
## What?

Fixes the Cover block incorrectly rendering with light mode (`is-light` class) when using "Use Featured Image" in a template context without an overlay.

Fixes #74706

## Why?

When a Cover block is configured to use a featured image in a **template** (e.g., single post template), the `isDark` attribute is calculated at template save time. However, at that point, no actual featured image exists to analyze for color detection.

The editor's color detection defaults to white (`#FFF`) when no image is available, resulting in `isDark: false` being saved. This causes the `is-light` class to be added, making text black, even when the actual featured image on the frontend is dark.

In contrast, Cover blocks added directly to a post correctly analyze the featured image and set `isDark` appropriately.

## How?

In the PHP render callback (`index.php`), when `useFeaturedImage` is true and no `overlayColor` is set, we remove the `is-light` class from the block wrapper.

This aligns with the default `isDark: true` assumption in `block.json`, ensuring text remains readable on dark featured images when no overlay is present.

When an overlay color is set, the overlay determines text contrast, so we preserve the saved class.

## Testing Instructions

1. Create a new **Single Posts** template
2. Add a Cover block → Set to "Use Featured Image" → Remove the overlay (set opacity to 0 or clear the color)
3. Save the template
4. Create a new post → Set a **dark** featured image
5. View the post on the frontend

**Expected:** Text in the Cover block should be **white** (readable on dark background)

**Before fix:** Text was black (`is-light` class incorrectly applied)

## Screenshots or screencast

### Before

<img width="1468" height="842" alt="cover-block-1" src="https://github.com/user-attachments/assets/bf7898b2-25e2-4b30-aee3-c41a370ebb46" />
<hr>
<img width="1470" height="829" alt="cover-block-2" src="https://github.com/user-attachments/assets/a25b7065-5b34-496f-9bf9-91ab0f62fe77" />

### After

https://github.com/user-attachments/assets/d1275f36-65b8-4184-864f-7f47e5951eaf