### PR TITLE
Post Author Name: Add option to link to author website

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -656,7 +656,7 @@ The author name. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/pac
 -	**Name:** core/post-author-name
 -	**Category:** theme
 -	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
--	**Attributes:** isLink, linkTarget
+-	**Attributes:** isLink, linkTarget, linkType
 
 ## Comment (deprecated)
 

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -16,6 +16,11 @@
 			"type": "string",
 			"default": "_self",
 			"role": "content"
+		},
+		"linkType": {
+			"type": "string",
+			"default": "archive",
+			"role": "content"
 		}
 	},
 	"usesContext": [ "postType", "postId" ],

--- a/packages/block-library/src/post-author-name/edit.js
+++ b/packages/block-library/src/post-author-name/edit.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import {
+	SelectControl,
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -24,7 +25,7 @@ import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 function PostAuthorNameEdit( props ) {
 	useDeprecatedTextAlign( props );
 	const {
-		attributes: { isLink, linkTarget },
+		attributes: { isLink, linkTarget, linkType },
 		setAttributes,
 		context: { postType, postId },
 	} = props;
@@ -74,6 +75,7 @@ function PostAuthorNameEdit( props ) {
 						setAttributes( {
 							isLink: false,
 							linkTarget: '_self',
+							linkType: 'archive',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -93,24 +95,61 @@ function PostAuthorNameEdit( props ) {
 						/>
 					</ToolsPanelItem>
 					{ isLink && (
-						<ToolsPanelItem
-							label={ __( 'Open in new tab' ) }
-							isShownByDefault
-							hasValue={ () => linkTarget !== '_self' }
-							onDeselect={ () =>
-								setAttributes( { linkTarget: '_self' } )
-							}
-						>
-							<ToggleControl
-								label={ __( 'Open in new tab' ) }
-								onChange={ ( value ) =>
-									setAttributes( {
-										linkTarget: value ? '_blank' : '_self',
-									} )
+						<>
+							<ToolsPanelItem
+								label={ __( 'Link destination' ) }
+								isShownByDefault
+								hasValue={ () => linkType !== 'archive' }
+								onDeselect={ () =>
+									setAttributes( { linkType: 'archive' } )
 								}
-								checked={ linkTarget === '_blank' }
-							/>
-						</ToolsPanelItem>
+							>
+								<SelectControl
+									__next40pxDefaultSize
+									label={ __( 'Link destination' ) }
+									value={ linkType }
+									options={ [
+										{
+											value: 'archive',
+											label: __( 'Author archive' ),
+											help: __(
+												'Links to a page listing all posts by this author.'
+											),
+										},
+										{
+											value: 'website',
+											label: __( 'Author website' ),
+											help: __(
+												'Links to the author’s personal website.'
+											),
+										},
+									] }
+									onChange={ ( value ) =>
+										setAttributes( { linkType: value } )
+									}
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								label={ __( 'Open in new tab' ) }
+								isShownByDefault
+								hasValue={ () => linkTarget !== '_self' }
+								onDeselect={ () =>
+									setAttributes( { linkTarget: '_self' } )
+								}
+							>
+								<ToggleControl
+									label={ __( 'Open in new tab' ) }
+									onChange={ ( value ) =>
+										setAttributes( {
+											linkTarget: value
+												? '_blank'
+												: '_self',
+										} )
+									}
+									checked={ linkTarget === '_blank' }
+								/>
+							</ToolsPanelItem>
+						</>
 					) }
 				</ToolsPanel>
 			</InspectorControls>

--- a/packages/block-library/src/post-author-name/index.php
+++ b/packages/block-library/src/post-author-name/index.php
@@ -32,7 +32,21 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 
 	$author_name = get_the_author_meta( 'display_name', $author_id );
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-		$author_name = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', get_author_posts_url( $author_id ), esc_attr( $attributes['linkTarget'] ), $author_name );
+		// Determine link destination type: 'archive' (default) or 'website'.
+		$link_type = isset( $attributes['linkType'] ) ? $attributes['linkType'] : 'archive';
+		$author_url = '';
+		
+		// If 'website' is selected, try to get the author's website URL from their profile.
+		if ( 'website' === $link_type ) {
+			$author_url = get_the_author_meta( 'user_url', $author_id );
+		}
+		
+		// Fallback to author archive if website URL is empty or if 'archive' is selected.
+		if ( empty( $author_url ) ) {
+			$author_url = get_author_posts_url( $author_id );
+		}
+		
+		$author_name = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', esc_url( $author_url ), esc_attr( $attributes['linkTarget'] ), $author_name );
 	}
 
 	$classes = array();

--- a/packages/block-library/src/post-author-name/index.php
+++ b/packages/block-library/src/post-author-name/index.php
@@ -33,19 +33,19 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 	$author_name = get_the_author_meta( 'display_name', $author_id );
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		// Determine link destination type: 'archive' (default) or 'website'.
-		$link_type = isset( $attributes['linkType'] ) ? $attributes['linkType'] : 'archive';
+		$link_type  = isset( $attributes['linkType'] ) ? $attributes['linkType'] : 'archive';
 		$author_url = '';
-		
+
 		// If 'website' is selected, try to get the author's website URL from their profile.
 		if ( 'website' === $link_type ) {
 			$author_url = get_the_author_meta( 'user_url', $author_id );
 		}
-		
+
 		// Fallback to author archive if website URL is empty or if 'archive' is selected.
 		if ( empty( $author_url ) ) {
 			$author_url = get_author_posts_url( $author_id );
 		}
-		
+
 		$author_name = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', esc_url( $author_url ), esc_attr( $attributes['linkTarget'] ), $author_name );
 	}
 

--- a/test/integration/fixtures/blocks/core__post-author-name.json
+++ b/test/integration/fixtures/blocks/core__post-author-name.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"isLink": false,
-			"linkTarget": "_self"
+			"linkTarget": "_self",
+			"linkType": "archive"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Adds the ability to link the Post Author Name block (`core/post-author-name`) to the author's website URL in addition to the author archive.
Closes #75151

## Why?
Currently, the Post Author Name block only allows linking to the author's post archive. This enhancement makes the block more flexible by allowing users to link to the author's website (as stored in their WordPress profile).



## How?
- Added a new `linkType` attribute to `block.json` with values `archive` (default) or `website`
- Added a "Link destination" dropdown in the block settings that appears when the "Link to author archive" toggle is enabled
- Updated the PHP render function to use `get_the_author_meta( 'user_url', $author_id )` when `linkType` is set to `website`
- Gracefully falls back to author archive if the website URL is empty

## Testing Instructions
1. Create or edit a post
2. Add the Author Name block (`core/post-author-name`)
3. In the block settings sidebar, enable "Link to author archive"
4. A new "Link destination" dropdown should appear
5. Select "Author website" from the dropdown
6. Save and view the post on the frontend
7. **If the author has a website URL set in their profile:** The author name should link to that URL
8. **If the author has no website URL:** The author name should fallback to linking to the author archive


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:


https://github.com/user-attachments/assets/29025f12-dd01-4d05-ac53-a79b4a55f1cc



After:

https://github.com/user-attachments/assets/b351504e-8ab0-4989-9a92-270e0896e2dc


