### PR TITLE
Cover block: Force LTR direction for the background URL input field

### DIFF
--- a/packages/block-library/src/cover/edit/embed-video-url-input.js
+++ b/packages/block-library/src/cover/edit/embed-video-url-input.js
@@ -57,7 +57,7 @@ export default function EmbedVideoUrlInput( {
 					</Notice>
 				) }
 				<TextControl
-					className="wp-block-cover__embed-video-url-input"
+					type="url"
 					__next40pxDefaultSize
 					label={ __( 'Video URL' ) }
 					value={ url }

--- a/packages/block-library/src/cover/edit/embed-video-url-input.js
+++ b/packages/block-library/src/cover/edit/embed-video-url-input.js
@@ -57,6 +57,7 @@ export default function EmbedVideoUrlInput( {
 					</Notice>
 				) }
 				<TextControl
+					className="wp-block-cover__embed-video-url-input"
 					__next40pxDefaultSize
 					label={ __( 'Video URL' ) }
 					value={ url }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -82,12 +82,6 @@
 	width: 100%;
 }
 
-.wp-block-cover__embed-video-url-input input {
-	// Targeting input as we're using text instead of URLs for relative paths.
-	/* rtl:ignore */
-	direction: ltr;
-}
-
 .block-library-cover__reset-button {
 	margin-left: auto;
 }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -74,13 +74,18 @@
 		bottom: 0;
 		left: 0;
 	}
-
 }
 
 [data-align="left"] > .wp-block-cover,
 [data-align="right"] > .wp-block-cover {
 	max-width: $content-width * 0.5;
 	width: 100%;
+}
+
+.wp-block-cover__embed-video-url-input input {
+	// Targeting input as we're using text instead of URLs for relative paths.
+	/* rtl:ignore */
+	direction: ltr;
 }
 
 .block-library-cover__reset-button {


### PR DESCRIPTION
Related: #70043

## What? Why? How?

Even in RTL languages, URLs are entered in LTR direction. However, since we need to allow local paths, we can't use `type=url`. We should keep `type=text` and force LTR using CSS.

## Testing Instructions

- Change your site locale to RTL language, such as Arabic (`العربية`).
- Insert a Cover block and open the video URL editing URL.

## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
| <img width="534" height="232" alt="before" src="https://github.com/user-attachments/assets/7376ccdc-3f2d-4562-9cf3-1f61b7cd0318" /> | <img width="536" height="233" alt="after" src="https://github.com/user-attachments/assets/2ad0c9a3-9a1b-4e05-b301-fd0e2ccc607a" /> |
