### PR TITLE
Writing flow: fix Cmd+A from empty RichText

### DIFF
--- a/packages/dom/src/dom/is-entirely-selected.js
+++ b/packages/dom/src/dom/is-entirely-selected.js
@@ -5,6 +5,12 @@ import { assertIsDefined } from '../utils/assert-is-defined';
 import isInputOrTextArea from './is-input-or-text-area';
 
 /**
+ * Zero width non-breaking space, used as padding in the editable DOM tree when
+ * it is empty otherwise.
+ */
+const ZWNBSP = '\ufeff';
+
+/**
  * Check whether the contents of the element have been entirely selected.
  * Returns true if there is no possibility of selection.
  *
@@ -21,6 +27,14 @@ export default function isEntirelySelected( element ) {
 	}
 
 	if ( ! element.isContentEditable ) {
+		return true;
+	}
+
+	// If the element is effectively empty (contains only the ZWNBSP
+	// placeholder or nothing), consider it entirely selected since there's
+	// nothing meaningful to select.
+	const text = element.textContent || '';
+	if ( text === '' || text === ZWNBSP ) {
 		return true;
 	}
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1655,4 +1655,40 @@ test.describe( 'List (@firefox)', () => {
 			},
 		] );
 	} );
+
+	test( 'should select the list wrapper with select all in empty list item', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/list' } );
+
+		// Verify the list item is selected after insertion.
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlock()?.name
+				)
+			)
+			.toBe( 'core/list-item' );
+
+		// The list item is empty. Press cmd+a to select all, then again to select the list block.
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+a' );
+
+		// Verify the list block is selected using the block-editor store.
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlock()?.name
+				)
+			)
+			.toBe( 'core/list' );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Fix Cmd+A from empty RichText

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently it doesn't work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check if the value is a zero width non breaking space (we don't really have much choice, even if we use BR as padding we'd probably need to add an exception for that).

## Testing Instructions

Create a list and try Cmd+A.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
