### PR TITLE
Editor: Introduce new selectedNote editor state

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -59,7 +59,6 @@ export function Comments( {
 	commentLastUpdated,
 } ) {
 	const [ heights, setHeights ] = useState( {} );
-	const [ selectedThread, setSelectedThread ] = useState( null );
 	const [ boardOffsets, setBoardOffsets ] = useState( {} );
 	const [ blockRefs, setBlockRefs ] = useState( {} );
 
@@ -104,7 +103,7 @@ export function Comments( {
 		if ( isFloating && selectedNote === 'new' ) {
 			// Insert the new note entry at the correct location for its blockId.
 			const newNoteThread = {
-				id: 'new-note-thread',
+				id: 'new',
 				blockClientId: selectedBlockClientId,
 				content: { rendered: '' },
 			};
@@ -141,19 +140,18 @@ export function Comments( {
 
 		if ( comment.parent !== 0 ) {
 			// Move focus to the parent thread when a reply was deleted.
-			setSelectedThread( comment.parent );
+			selectNote( comment.parent );
 			focusCommentThread( comment.parent, commentSidebarRef.current );
 			return;
 		}
 
 		if ( nextThread ) {
-			setSelectedThread( nextThread.id );
+			selectNote( nextThread.id );
 			focusCommentThread( nextThread.id, commentSidebarRef.current );
 		} else if ( prevThread ) {
-			setSelectedThread( prevThread.id );
+			selectNote( prevThread.id );
 			focusCommentThread( prevThread.id, commentSidebarRef.current );
 		} else {
-			setSelectedThread( null );
 			selectNote( undefined );
 			// Move focus to the related block.
 			relatedBlockElement?.focus();
@@ -162,15 +160,8 @@ export function Comments( {
 
 	// Auto-select the related comment thread when a block is selected.
 	useEffect( () => {
-		// Fallback to 'new-note-thread' when showing the comment board for a new note.
-		setSelectedThread(
-			selectedNote === 'new' ? 'new-note-thread' : blockCommentId
-		);
-	}, [ blockCommentId, selectedNote ] );
-
-	const setBlockRef = useCallback( ( id, blockRef ) => {
-		setBlockRefs( ( prev ) => ( { ...prev, [ id ]: blockRef } ) );
-	}, [] );
+		selectNote( blockCommentId ?? undefined );
+	}, [ blockCommentId, selectNote ] );
 
 	// Recalculate floating comment thread offsets whenever the heights change.
 	useEffect( () => {
@@ -187,7 +178,7 @@ export function Comments( {
 
 			// Find the index of the selected thread.
 			const selectedThreadIndex = threads.findIndex(
-				( t ) => t.id === selectedThread
+				( t ) => t.id === selectedNote
 			);
 
 			const breakIndex =
@@ -314,7 +305,7 @@ export function Comments( {
 		blockRefs,
 		isFloating,
 		threads,
-		selectedThread,
+		selectedNote,
 		setCanvasMinHeight,
 	] );
 
@@ -331,8 +322,7 @@ export function Comments( {
 			! isSelected
 		) {
 			// Expand thread.
-			selectNote( undefined );
-			setSelectedThread( thread.id );
+			selectNote( thread.id );
 			if ( !! thread.blockClientId ) {
 				// Pass `null` as the second parameter to prevent focusing the block.
 				selectBlock( thread.blockClientId, null );
@@ -345,7 +335,6 @@ export function Comments( {
 			event.key === 'Escape'
 		) {
 			// Collapse thread.
-			setSelectedThread( null );
 			selectNote( undefined );
 			if ( thread.blockClientId ) {
 				toggleBlockSpotlight( thread.blockClientId, false );
@@ -385,6 +374,10 @@ export function Comments( {
 		}
 	};
 
+	const setBlockRef = useCallback( ( id, blockRef ) => {
+		setBlockRefs( ( prev ) => ( { ...prev, [ id ]: blockRef } ) );
+	}, [] );
+
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
 	// A special case for `template-locked` mode - https://github.com/WordPress/gutenberg/pull/72646.
 	if ( ! hasThreads && ! isFloating ) {
@@ -411,21 +404,19 @@ export function Comments( {
 					onAddReply={ onAddReply }
 					onCommentDelete={ handleDelete }
 					onEditComment={ onEditComment }
-					isSelected={ selectedThread === thread.id }
-					setSelectedThread={ setSelectedThread }
+					isSelected={ selectedNote === thread.id }
 					commentSidebarRef={ commentSidebarRef }
 					reflowComments={ reflowComments }
 					isFloating={ isFloating }
 					calculatedOffset={ boardOffsets[ thread.id ] ?? 0 }
 					setHeights={ setHeights }
 					setBlockRef={ setBlockRef }
-					selectedThread={ selectedThread }
 					commentLastUpdated={ commentLastUpdated }
 					onKeyDown={ ( event ) =>
 						handleThreadNavigation(
 							event,
 							thread,
-							selectedThread === thread.id
+							selectedNote === thread.id
 						)
 					}
 				/>
@@ -446,8 +437,6 @@ function Thread( {
 	calculatedOffset,
 	setHeights,
 	setBlockRef,
-	setSelectedThread,
-	selectedThread,
 	commentLastUpdated,
 	onKeyDown,
 } ) {
@@ -469,7 +458,7 @@ function Thread( {
 		calculatedOffset,
 		setHeights,
 		setBlockRef,
-		selectedThread,
+		selectedThread: selectedNote,
 		commentLastUpdated,
 	} );
 	const isKeyboardTabbingRef = useRef( false );
@@ -518,8 +507,7 @@ function Thread( {
 	};
 
 	const handleCommentSelect = () => {
-		selectNote( undefined );
-		setSelectedThread( thread.id );
+		selectNote( thread.id );
 		toggleBlockSpotlight( thread.blockClientId, true );
 		if ( !! thread.blockClientId ) {
 			// Pass `null` as the second parameter to prevent focusing the block.
@@ -528,13 +516,11 @@ function Thread( {
 	};
 
 	const unselectThread = () => {
-		setSelectedThread( null );
 		selectNote( undefined );
 		toggleBlockSpotlight( thread.blockClientId, false );
 	};
 
 	const allReplies = thread?.reply || [];
-
 	const lastReply =
 		allReplies.length > 0 ? allReplies[ allReplies.length - 1 ] : undefined;
 	const restReplies = allReplies.length > 0 ? allReplies.slice( 0, -1 ) : [];
@@ -555,11 +541,7 @@ function Thread( {
 				commentExcerpt
 		  );
 
-	if (
-		thread.id === 'new-note-thread' &&
-		selectedNote === 'new' &&
-		isFloating
-	) {
+	if ( isFloating && thread.id === 'new' ) {
 		return (
 			<AddComment
 				onSubmit={ onAddReply }
@@ -662,7 +644,7 @@ function Thread( {
 						variant="tertiary"
 						className="editor-collab-sidebar-panel__more-reply-button"
 						onClick={ () => {
-							setSelectedThread( thread.id );
+							selectNote( thread.id );
 							focusCommentThread(
 								thread.id,
 								commentSidebarRef.current

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -85,10 +85,15 @@ export function Comments( {
 				orderedBlockIds: getClientIdsWithDescendants(),
 			};
 		}, [] );
-	const selectedNote = useSelect(
-		( select ) => unlock( select( editorStore ) ).getSelectedNote(),
-		[]
-	);
+	const { selectedNote, noteFocused } = useSelect( ( select ) => {
+		const { getSelectedNote, isNoteFocused } = unlock(
+			select( editorStore )
+		);
+		return {
+			selectedNote: getSelectedNote(),
+			noteFocused: isNoteFocused(),
+		};
+	}, [] );
 
 	const relatedBlockElement = useBlockElement( selectedBlockClientId );
 
@@ -162,6 +167,19 @@ export function Comments( {
 	useEffect( () => {
 		selectNote( blockCommentId ?? undefined );
 	}, [ blockCommentId, selectNote ] );
+
+	// Focus the selected note when requested.
+	useEffect( () => {
+		if ( noteFocused && selectedNote ) {
+			focusCommentThread(
+				selectedNote,
+				commentSidebarRef.current,
+				selectedNote === 'new' ? 'textarea' : undefined
+			);
+			// Clear meta to avoid re-triggering.
+			selectNote( selectedNote );
+		}
+	}, [ noteFocused, selectedNote, selectNote, commentSidebarRef ] );
 
 	// Recalculate floating comment thread offsets whenever the heights change.
 	useEffect( () => {

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -53,8 +53,6 @@ export function Comments( {
 	onEditComment,
 	onAddReply,
 	onCommentDelete,
-	newNoteFormState,
-	setNewNoteFormState,
 	commentSidebarRef,
 	reflowComments,
 	isFloating = false,
@@ -65,7 +63,9 @@ export function Comments( {
 	const [ boardOffsets, setBoardOffsets ] = useState( {} );
 	const [ blockRefs, setBlockRefs ] = useState( {} );
 
-	const { setCanvasMinHeight } = unlock( useDispatch( editorStore ) );
+	const { setCanvasMinHeight, selectNote } = unlock(
+		useDispatch( editorStore )
+	);
 	const { selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
 	);
@@ -86,6 +86,10 @@ export function Comments( {
 				orderedBlockIds: getClientIdsWithDescendants(),
 			};
 		}, [] );
+	const selectedNote = useSelect(
+		( select ) => unlock( select( editorStore ) ).getSelectedNote(),
+		[]
+	);
 
 	const relatedBlockElement = useBlockElement( selectedBlockClientId );
 
@@ -97,7 +101,7 @@ export function Comments( {
 		// add a "new note" entry to the threads. This special thread type
 		// gets sorted and floated like regular threads, but shows an AddComment
 		// component instead of a regular comment thread.
-		if ( isFloating && newNoteFormState === 'open' ) {
+		if ( isFloating && selectedNote === 'new' ) {
 			// Insert the new note entry at the correct location for its blockId.
 			const newNoteThread = {
 				id: 'new-note-thread',
@@ -123,7 +127,7 @@ export function Comments( {
 	}, [
 		noteThreads,
 		isFloating,
-		newNoteFormState,
+		selectedNote,
 		selectedBlockClientId,
 		orderedBlockIds,
 	] );
@@ -150,7 +154,7 @@ export function Comments( {
 			focusCommentThread( prevThread.id, commentSidebarRef.current );
 		} else {
 			setSelectedThread( null );
-			setNewNoteFormState( 'closed' );
+			selectNote( undefined );
 			// Move focus to the related block.
 			relatedBlockElement?.focus();
 		}
@@ -160,9 +164,9 @@ export function Comments( {
 	useEffect( () => {
 		// Fallback to 'new-note-thread' when showing the comment board for a new note.
 		setSelectedThread(
-			newNoteFormState === 'open' ? 'new-note-thread' : blockCommentId
+			selectedNote === 'new' ? 'new-note-thread' : blockCommentId
 		);
-	}, [ blockCommentId, newNoteFormState ] );
+	}, [ blockCommentId, selectedNote ] );
 
 	const setBlockRef = useCallback( ( id, blockRef ) => {
 		setBlockRefs( ( prev ) => ( { ...prev, [ id ]: blockRef } ) );
@@ -327,7 +331,7 @@ export function Comments( {
 			! isSelected
 		) {
 			// Expand thread.
-			setNewNoteFormState( 'closed' );
+			selectNote( undefined );
 			setSelectedThread( thread.id );
 			if ( !! thread.blockClientId ) {
 				// Pass `null` as the second parameter to prevent focusing the block.
@@ -342,7 +346,7 @@ export function Comments( {
 		) {
 			// Collapse thread.
 			setSelectedThread( null );
-			setNewNoteFormState( 'closed' );
+			selectNote( undefined );
 			if ( thread.blockClientId ) {
 				toggleBlockSpotlight( thread.blockClientId, false );
 			}
@@ -387,8 +391,6 @@ export function Comments( {
 		return (
 			<AddComment
 				onSubmit={ onAddReply }
-				newNoteFormState={ newNoteFormState }
-				setNewNoteFormState={ setNewNoteFormState }
 				commentSidebarRef={ commentSidebarRef }
 			/>
 		);
@@ -396,11 +398,9 @@ export function Comments( {
 
 	return (
 		<>
-			{ ! isFloating && newNoteFormState === 'open' && (
+			{ ! isFloating && selectedNote === 'new' && (
 				<AddComment
 					onSubmit={ onAddReply }
-					newNoteFormState={ newNoteFormState }
-					setNewNoteFormState={ setNewNoteFormState }
 					commentSidebarRef={ commentSidebarRef }
 				/>
 			) }
@@ -413,7 +413,6 @@ export function Comments( {
 					onEditComment={ onEditComment }
 					isSelected={ selectedThread === thread.id }
 					setSelectedThread={ setSelectedThread }
-					setNewNoteFormState={ setNewNoteFormState }
 					commentSidebarRef={ commentSidebarRef }
 					reflowComments={ reflowComments }
 					isFloating={ isFloating }
@@ -422,7 +421,6 @@ export function Comments( {
 					setBlockRef={ setBlockRef }
 					selectedThread={ selectedThread }
 					commentLastUpdated={ commentLastUpdated }
-					newNoteFormState={ newNoteFormState }
 					onKeyDown={ ( event ) =>
 						handleThreadNavigation(
 							event,
@@ -442,7 +440,6 @@ function Thread( {
 	onAddReply,
 	onCommentDelete,
 	isSelected,
-	setNewNoteFormState,
 	commentSidebarRef,
 	reflowComments,
 	isFloating,
@@ -452,11 +449,15 @@ function Thread( {
 	setSelectedThread,
 	selectedThread,
 	commentLastUpdated,
-	newNoteFormState,
 	onKeyDown,
 } ) {
 	const { toggleBlockHighlight, selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
+	);
+	const { selectNote } = unlock( useDispatch( editorStore ) );
+	const selectedNote = useSelect(
+		( select ) => unlock( select( editorStore ) ).getSelectedNote(),
+		[]
 	);
 	const relatedBlockElement = useBlockElement( thread.blockClientId );
 	const debouncedToggleBlockHighlight = useDebounce(
@@ -517,7 +518,7 @@ function Thread( {
 	};
 
 	const handleCommentSelect = () => {
-		setNewNoteFormState( 'closed' );
+		selectNote( undefined );
 		setSelectedThread( thread.id );
 		toggleBlockSpotlight( thread.blockClientId, true );
 		if ( !! thread.blockClientId ) {
@@ -528,7 +529,7 @@ function Thread( {
 
 	const unselectThread = () => {
 		setSelectedThread( null );
-		setNewNoteFormState( 'closed' );
+		selectNote( undefined );
 		toggleBlockSpotlight( thread.blockClientId, false );
 	};
 
@@ -556,14 +557,12 @@ function Thread( {
 
 	if (
 		thread.id === 'new-note-thread' &&
-		newNoteFormState === 'open' &&
+		selectedNote === 'new' &&
 		isFloating
 	) {
 		return (
 			<AddComment
 				onSubmit={ onAddReply }
-				newNoteFormState={ newNoteFormState }
-				setNewNoteFormState={ setNewNoteFormState }
 				commentSidebarRef={ commentSidebarRef }
 				reflowComments={ reflowComments }
 				isFloating={ isFloating }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -176,7 +176,7 @@ export function Comments( {
 				commentSidebarRef.current,
 				selectedNote === 'new' ? 'textarea' : undefined
 			);
-			// Clear meta to avoid re-triggering.
+			// Clear focus flag to avoid re-triggering.
 			selectNote( selectedNote );
 		}
 	}, [ noteFocused, selectedNote, selectNote, commentSidebarRef ] );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useState, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -35,8 +35,6 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
 
 function NotesSidebarContent( {
-	newNoteFormState,
-	setNewNoteFormState,
 	styles,
 	comments,
 	commentSidebarRef,
@@ -70,8 +68,6 @@ function NotesSidebarContent( {
 				onEditComment={ onEdit }
 				onAddReply={ onCreate }
 				onCommentDelete={ onDelete }
-				newNoteFormState={ newNoteFormState }
-				setNewNoteFormState={ setNewNoteFormState }
 				commentSidebarRef={ commentSidebarRef }
 				reflowComments={ reflowComments }
 				commentLastUpdated={ commentLastUpdated }
@@ -82,15 +78,12 @@ function NotesSidebarContent( {
 }
 
 function NotesSidebar( { postId } ) {
-	// Enum: 'closed' | 'creating' | 'open'
-	const [ newNoteFormState, setNewNoteFormState ] = useState( 'closed' );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
+	const { selectNote } = unlock( useDispatch( editorStore ) );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
-
-	const showFloatingSidebar = isLargeViewport;
 
 	const { clientId, blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
@@ -109,7 +102,12 @@ function NotesSidebar( { postId } ) {
 			isDistractionFree: get( 'core', 'distractionFree' ),
 		};
 	}, [] );
+	const selectedNote = useSelect(
+		( select ) => unlock( select( editorStore ) ).getSelectedNote(),
+		[]
+	);
 
+	const showFloatingSidebar = isLargeViewport;
 	const {
 		resultComments,
 		unresolvedSortedThreads,
@@ -118,8 +116,7 @@ function NotesSidebar( { postId } ) {
 	} = useBlockComments( postId );
 	useEnableFloatingSidebar(
 		showFloatingSidebar &&
-			( unresolvedSortedThreads.length > 0 ||
-				newNoteFormState !== 'closed' )
+			( unresolvedSortedThreads.length > 0 || selectedNote !== undefined )
 	);
 
 	// Get the global styles to set the background color of the sidebar.
@@ -153,7 +150,7 @@ function NotesSidebar( { postId } ) {
 			return;
 		}
 
-		setNewNoteFormState( ! currentThread ? 'open' : 'closed' );
+		selectNote( ! currentThread ? 'new' : undefined );
 		focusCommentThread(
 			currentThread?.id,
 			commentSidebarRef.current,
@@ -191,8 +188,6 @@ function NotesSidebar( { postId } ) {
 				>
 					<NotesSidebarContent
 						comments={ resultComments }
-						newNoteFormState={ newNoteFormState }
-						setNewNoteFormState={ setNewNoteFormState }
 						commentSidebarRef={ commentSidebarRef }
 					/>
 				</PluginSidebar>
@@ -208,8 +203,6 @@ function NotesSidebar( { postId } ) {
 				>
 					<NotesSidebarContent
 						comments={ unresolvedSortedThreads }
-						newNoteFormState={ newNoteFormState }
-						setNewNoteFormState={ setNewNoteFormState }
 						commentSidebarRef={ commentSidebarRef }
 						reflowComments={ reflowComments }
 						commentLastUpdated={ commentLastUpdated }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -150,11 +150,11 @@ function NotesSidebar( { postId } ) {
 			return;
 		}
 
-		selectNote( ! currentThread ? 'new' : undefined );
+		selectNote( currentThread ? currentThread.id : 'new' );
 		focusCommentThread(
 			currentThread?.id,
 			commentSidebarRef.current,
-			// Focus a comment thread when there's a selected block with a comment.
+			// Focus the textarea when creating a new note.
 			! currentThread ? 'textarea' : undefined
 		);
 		toggleBlockSpotlight( clientId, true );

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -108,9 +108,10 @@ export function focusCommentThread( commentId, container, additionalSelector ) {
 	}
 
 	// A thread without a commentId is a new comment thread.
-	const threadSelector = commentId
-		? `[role=treeitem][id="comment-thread-${ commentId }"]`
-		: '[role=treeitem]:not([id])';
+	const threadSelector =
+		commentId && commentId !== 'new'
+			? `[role=treeitem][id="comment-thread-${ commentId }"]`
+			: '[role=treeitem]:not([id])';
 	const selector = additionalSelector
 		? `${ threadSelector } ${ additionalSelector }`
 		: threadSelector;

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -651,11 +651,13 @@ export const restoreRevision =
  * Select a note by its ID, or clear the selection.
  *
  * @param {undefined|number|'new'} noteId The note ID to select, 'new' to open the new note form, or undefined to clear.
+ * @param {Object}                 [meta] Optional metadata for the selection.
  * @return {Object} Action object.
  */
-export function selectNote( noteId ) {
+export function selectNote( noteId, meta ) {
 	return {
 		type: 'SELECT_NOTE',
 		noteId,
+		meta,
 	};
 }

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -650,14 +650,15 @@ export const restoreRevision =
 /**
  * Select a note by its ID, or clear the selection.
  *
- * @param {undefined|number|'new'} noteId The note ID to select, 'new' to open the new note form, or undefined to clear.
- * @param {Object}                 [meta] Optional metadata for the selection.
+ * @param {undefined|number|'new'} noteId          The note ID to select, 'new' to open the new note form, or undefined to clear.
+ * @param {Object}                 [options]       Optional options for the selection.
+ * @param {boolean}                [options.focus] Whether to focus the selected note. Default false.
  * @return {Object} Action object.
  */
-export function selectNote( noteId, meta ) {
+export function selectNote( noteId, options = { focus: false } ) {
 	return {
 		type: 'SELECT_NOTE',
 		noteId,
-		meta,
+		options,
 	};
 }

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -646,3 +646,16 @@ export const restoreRevision =
 				id: 'editor-revision-restored',
 			} );
 	};
+
+/**
+ * Select a note by its ID, or clear the selection.
+ *
+ * @param {undefined|number|'new'} noteId The note ID to select, 'new' to open the new note form, or undefined to clear.
+ * @return {Object} Action object.
+ */
+export function selectNote( noteId ) {
+	return {
+		type: 'SELECT_NOTE',
+		noteId,
+	};
+}

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -354,3 +354,14 @@ export const getCurrentRevision = createRegistrySelector(
 		return revisions.find( ( r ) => r.id === revisionId ) ?? null;
 	}
 );
+
+/**
+ * Returns the currently selected note ID.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {undefined|number|'new'} The selected note ID, 'new' for the new note form, or undefined if none.
+ */
+export function getSelectedNote( state ) {
+	return state.selectedNote;
+}

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -374,5 +374,5 @@ export function getSelectedNote( state ) {
  * @return {boolean} Whether the selected note should be focused.
  */
 export function isNoteFocused( state ) {
-	return !! state.selectedNote?.meta?.focus;
+	return !! state.selectedNote?.options?.focus;
 }

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -363,5 +363,16 @@ export const getCurrentRevision = createRegistrySelector(
  * @return {undefined|number|'new'} The selected note ID, 'new' for the new note form, or undefined if none.
  */
 export function getSelectedNote( state ) {
-	return state.selectedNote;
+	return state.selectedNote?.noteId;
+}
+
+/**
+ * Returns whether the selected note should be focused.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the selected note should be focused.
+ */
+export function isNoteFocused( state ) {
+	return !! state.selectedNote?.meta?.focus;
 }

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -450,16 +450,16 @@ export function revisionId( state = null, action ) {
 }
 
 /**
- * Reducer returning the currently selected note ID.
+ * Reducer returning the currently selected note and its metadata.
  *
- * @param {undefined|number|'new'} state  Current state.
- * @param {Object}                 action Dispatched action.
- * @return {undefined|number|'new'} Updated state.
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ * @return {Object} Updated state.
  */
-export function selectedNote( state = undefined, action ) {
+export function selectedNote( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SELECT_NOTE':
-			return action.noteId;
+			return { noteId: action.noteId, meta: action.meta };
 	}
 	return state;
 }

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -449,6 +449,21 @@ export function revisionId( state = null, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the currently selected note ID.
+ *
+ * @param {undefined|number|'new'} state  Current state.
+ * @param {Object}                 action Dispatched action.
+ * @return {undefined|number|'new'} Updated state.
+ */
+export function selectedNote( state = undefined, action ) {
+	switch ( action.type ) {
+		case 'SELECT_NOTE':
+			return action.noteId;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -472,5 +487,6 @@ export default combineReducers( {
 	showStylebook,
 	canvasMinHeight,
 	revisionId,
+	selectedNote,
 	dataviews: dataviewsReducer,
 } );

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -450,7 +450,7 @@ export function revisionId( state = null, action ) {
 }
 
 /**
- * Reducer returning the currently selected note and its metadata.
+ * Reducer returning the currently selected note and its options.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
@@ -459,7 +459,7 @@ export function revisionId( state = null, action ) {
 export function selectedNote( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SELECT_NOTE':
-			return { noteId: action.noteId, meta: action.meta };
+			return { noteId: action.noteId, options: action.options };
 	}
 	return state;
 }

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -881,10 +881,15 @@ class BlockCommentUtils {
 					.getByRole( 'region', { name: 'Editor settings' } )
 					.getByRole( 'button', { name: 'Add note', exact: true } )
 					.click();
-				await this.#page
-					.getByRole( 'button', { name: 'Dismiss this notice' } )
-					.filter( { hasText: 'Note added.' } )
-					.click();
+				await expect(
+					this.#page
+						.getByRole( 'region', {
+							name: 'Editor settings',
+						} )
+						.getByRole( 'treeitem', {
+							name: `Note: ${ comment }`,
+						} )
+				).toBeVisible();
 			},
 			{ box: true }
 		);


### PR DESCRIPTION
## What?
PR introduces a new global state for `selectedNote`, along with an associated private action and selector. This is similar to the `selectBlock` action.

## Why?
The local state served us well initially, but it had limitations and blocked integration with other features, such as the Command Palette, Keyboard Shortcuts and RichText formats. It also required a lot of prop drilling.

_Most of the code is extracted from my local inline notes format branch._

## Todo(s)

- [x] Add action flag to move focus to the selected note.

## Testing Instructions
* CI checks are passing. We've good e2e tests coverage for the feature.
* Smoke test the floating note, confirm it works as before.

## Testing note focus via action

* Apply the patch from below and try adding a new note or selection exiting via the block toolbar. Focus should move as before.

```diff
diff --git a/packages/editor/src/components/collab-sidebar/index.js b/packages/editor/src/components/collab-sidebar/index.js
index 296e491a296..de830bca2e7 100644
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -150,13 +150,7 @@ function NotesSidebar( { postId } ) {
 			return;
 		}
 
-		selectNote( currentThread ? currentThread.id : 'new' );
-		focusCommentThread(
-			currentThread?.id,
-			commentSidebarRef.current,
-			// Focus the textarea when creating a new note.
-			! currentThread ? 'textarea' : undefined
-		);
+		selectNote( currentThread ? currentThread.id : 'new', { focus: true } );
 		toggleBlockSpotlight( clientId, true );
 	}
```