### PR TITLE
Embed: Add clear both to prevent float wrapping issues

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -30,6 +30,7 @@
 
 .wp-block-embed {
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
+	clear: both; // Ensure embeds clear floated elements to prevent layout issues.
 
 	// Supply caption styles to embeds, even if the theme hasn't opted in.
 	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/75152
Adds `clear: both` to the embed block's frontend styles to fix layout issues when mixing aligned and non-aligned embed blocks.

## Why?
When an embed block is aligned left, subsequent embed blocks with default alignment (none) would float up and wrap around the aligned embed instead of appearing below it. This creates an undesirable layout where embeds overlap or stack horizontally instead of vertically.

The editor styles already included `clear: both`, but the frontend styles were missing this property, causing inconsistent behavior between the editor and frontend.

## How?
Added `clear: both` to the `.wp-block-embed` rule in `packages/block-library/src/embed/style.scss`. This ensures that embed blocks clear any preceding floated elements (including other aligned embeds), preventing wrapping behavior.

## Testing Instructions
1. Create a new post/page
2. Add an embed block (e.g., YouTube)
3. Align it to the left using the alignment controls
4. Add another embed block below it with default alignment (no alignment)
5. Verify that the second embed appears below the first one, not wrapping around it
6. Test with right alignment as well
7. Save and view on the frontend to ensure the fix applies there too

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/e661b58e-6b2c-4725-9295-0913becabd7d

After:

<img width="2538" height="1188" alt="image" src="https://github.com/user-attachments/assets/be3af030-39f9-4c5b-ae7e-aff78f115ba9" />
