### PR TITLE
Fix duplicate content when navigation overlay is open and nav has non-link inner blocks

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -796,16 +796,8 @@ class WP_Navigation_Block_Renderer {
 				$toggle_aria_label_close,
 				$close_button_directives,
 				$toggle_close_button_content
-			);
-		}
-
-		// When using a custom overlay, wrap the default nav content so it can be hidden
-		// when the overlay is open (avoiding duplicate menu + e.g. buttons). Unwrapped
-		// content is shown on desktop; overlay is shown when menu is open.
-		$responsive_container_inner_content = $inner_blocks_html;
-		if ( $has_custom_overlay && ! empty( $inner_blocks_html ) ) {
-			$responsive_container_inner_content = '<div class="wp-block-navigation__default-content">' . $inner_blocks_html . '</div>';
-		}
+		);
+	}
 
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
@@ -821,7 +813,7 @@ class WP_Navigation_Block_Renderer {
 					</div>
 				</div>',
 			esc_attr( $modal_unique_id ),
-			$responsive_container_inner_content,
+			$inner_blocks_html,
 			$toggle_aria_label_open,
 			$toggle_aria_label_close,
 			esc_attr( trim( implode( ' ', $responsive_container_classes ) ) ),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -796,8 +796,8 @@ class WP_Navigation_Block_Renderer {
 				$toggle_aria_label_close,
 				$close_button_directives,
 				$toggle_close_button_content
-		);
-	}
+			);
+		}
 
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -799,6 +799,14 @@ class WP_Navigation_Block_Renderer {
 			);
 		}
 
+		// When using a custom overlay, wrap the default nav content so it can be hidden
+		// when the overlay is open (avoiding duplicate menu + e.g. buttons). Unwrapped
+		// content is shown on desktop; overlay is shown when menu is open.
+		$responsive_container_inner_content = $inner_blocks_html;
+		if ( $has_custom_overlay && ! empty( $inner_blocks_html ) ) {
+			$responsive_container_inner_content = '<div class="wp-block-navigation__default-content">' . $inner_blocks_html . '</div>';
+		}
+
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
 				<div class="%5$s" %7$s id="%1$s" %11$s>
@@ -813,7 +821,7 @@ class WP_Navigation_Block_Renderer {
 					</div>
 				</div>',
 			esc_attr( $modal_unique_id ),
-			$inner_blocks_html,
+			$responsive_container_inner_content,
 			$toggle_aria_label_open,
 			$toggle_aria_label_close,
 			esc_attr( trim( implode( ' ', $responsive_container_classes ) ) ),

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -686,11 +686,11 @@ button.wp-block-navigation-item__content {
 		}
 
 		// When menu is open with custom overlay, hide all default content (nav + any sibling
-		// blocks e.g. buttons) and show overlay. Using .wp-block-navigation__default-content
-		// ensures the entire default block is hidden, not just the ul container.
+		// blocks e.g. buttons) and show overlay. Hide every direct child except the overlay
+		// container so no extra wrapper markup is needed.
 		&.is-menu-open {
 			.wp-block-navigation__responsive-container-content {
-				.wp-block-navigation__default-content {
+				> *:not(.wp-block-navigation__overlay-container) {
 					display: none;
 				}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -685,11 +685,12 @@ button.wp-block-navigation-item__content {
 			max-width: none;
 		}
 
-		// When menu is open with custom overlay, hide default navigation and show overlay.
+		// When menu is open with custom overlay, hide all default content (nav + any sibling
+		// blocks e.g. buttons) and show overlay. Using .wp-block-navigation__default-content
+		// ensures the entire default block is hidden, not just the ul container.
 		&.is-menu-open {
 			.wp-block-navigation__responsive-container-content {
-				// Hides the content of the non-overlay navigation.
-				> .wp-block-navigation__container {
+				.wp-block-navigation__default-content {
 					display: none;
 				}
 


### PR DESCRIPTION
## What

Fixes #75179. Prevents duplicate rendering of non-link inner blocks (e.g. buttons) when a custom navigation overlay is open.

## Why

When the overlay is open, only the nav list was hidden in CSS; sibling blocks in the default content (such as buttons) stayed visible. The same content was therefore shown twice—once in the default area and once inside the overlay.

## How

No new markup. When the overlay is open, CSS hides every direct child of the responsive container content except the overlay container (using a direct-child `:not()` selector). The selector is wrapped in `:where()` so specificity stays minimal and themes can override if needed. Desktop continues to show the default content; overlay view shows only the overlay.

## Testing instructions

1. Enable the "Customizable navigation overlays" experiment (Gutenberg Experiments).
2. Add a Navigation block and assign a menu.
3. Create an overlay from the default template (Overlay panel → Create overlay).
4. Insert a Button block _**inside**_ the Navigation block (as a sibling to the link items).
5. Save and view the front.
6. **Desktop:** Confirm the nav (links + button) appears in the header.
7. **Mobile / narrow viewport:** Open the overlay (menu icon); confirm only one instance of the button appears (no duplicate).
8. Toggle the overlay closed and open again; confirm no duplicate content.
