### PR TITLE
Writing flow: appender focus should select block

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -50,7 +50,7 @@ export function useFocusHandler( clientId ) {
 
 				// If an inner block is focussed, that block is responsible for
 				// setting the selected block.
-				if ( ! isInsideRootBlock( node, event.target ) ) {
+				if ( ! isInsideRootBlock( node, event.target, true ) ) {
 					return;
 				}
 

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -18,15 +18,23 @@ export function isInSameBlock( a, b ) {
  * Returns true if an element is considered part of the block and not its inner
  * blocks or appender.
  *
- * @param {Element} blockElement Block container element.
- * @param {Element} element      Element.
+ * @param {Element} blockElement   Block container element.
+ * @param {Element} element        Element.
+ * @param {boolean} ignoreAppender Whether to ignore the appender.
  *
  * @return {boolean} Whether an element is considered part of the block and not
  *                   its inner blocks or appender.
  */
-export function isInsideRootBlock( blockElement, element ) {
+export function isInsideRootBlock(
+	blockElement,
+	element,
+	ignoreAppender = false
+) {
 	const parentBlock = element.closest(
-		[ BLOCK_SELECTOR, APPENDER_SELECTOR, BLOCK_APPENDER_CLASS ].join( ',' )
+		( ignoreAppender
+			? [ BLOCK_SELECTOR ]
+			: [ BLOCK_SELECTOR, APPENDER_SELECTOR, BLOCK_APPENDER_CLASS ]
+		).join( ',' )
 	);
 	return parentBlock === blockElement;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Just testing the waters with e2e tests.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
