### PR TITLE
DataViews: externalize theme stylesheet

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The design tokens stylesheet (`@wordpress/theme/design-tokens.css`) is no longer embedded in the DataViews stylesheet. Applications using DataViews outside of WordPress must now explicitly include the design tokens stylesheet. See the README for installation instructions. [#74594](https://github.com/WordPress/gutenberg/pull/74594)
+
 ### Bug Fixes
 
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- The design tokens stylesheet (`@wordpress/theme/design-tokens.css`) is no longer embedded in the DataViews stylesheet. Applications using DataViews outside of WordPress must now explicitly include the design tokens stylesheet. See the README for installation instructions. [#74594](https://github.com/WordPress/gutenberg/pull/74594)
+- The design tokens stylesheet (`@wordpress/theme/design-tokens.css`) is no longer embedded in the DataViews stylesheet. Applications using DataViews outside of WordPress must now explicitly include the design tokens stylesheet. See the README for installation instructions. [#75182](https://github.com/WordPress/gutenberg/pull/75182)
 
 ### Bug Fixes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -16,13 +16,14 @@ npm install @wordpress/dataviews --save
 
 ## Stylesheet Dependencies
 
-As an implementation of the design system, these components depend on CSS custom properties defined by the `@wordpress/theme` package. In a WordPress admin page context, these are loaded automatically. For applications outside WordPress, you will need to install and include the design tokens stylesheet:
+DataViews depends on stylesheets from `@wordpress/components` and `@wordpress/theme`. In a WordPress admin page context, these are loaded automatically. For applications outside WordPress, you will need to include these stylesheets:
 
 ```bash
-npm install @wordpress/theme
+npm install @wordpress/components @wordpress/theme
 ```
 
 ```tsx
+import '@wordpress/components/build-style/style.css';
 import '@wordpress/theme/design-tokens.css';
 ```
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -14,6 +14,18 @@ Install the module
 npm install @wordpress/dataviews --save
 ```
 
+## Stylesheet Dependencies
+
+As an implementation of the design system, these components depend on CSS custom properties defined by the `@wordpress/theme` package. In a WordPress admin page context, these are loaded automatically. For applications outside WordPress, you will need to install and include the design tokens stylesheet:
+
+```bash
+npm install @wordpress/theme
+```
+
+```tsx
+import '@wordpress/theme/design-tokens.css';
+```
+
 ## `DataViews`
 
 <div class="callout callout-info">At <a href="https://wordpress.github.io/gutenberg/">WordPress Gutenberg's Storybook</a> there's an <a href="https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataviews--docs">example implementation of the Dataviews component</a>.</div>

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -1,5 +1,3 @@
-@use "@wordpress/theme/src/prebuilt/css/design-tokens.css" as *;
-
 @use "./dataviews/style.scss" as *;
 @use "./components/dataviews-bulk-actions/style.scss" as *;
 @use "./components/dataviews-filters/style.scss" as *;

--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -17,6 +17,7 @@ import fieldsLtr from '../package-styles/fields-ltr.lazy.scss?inline';
 import fieldsRtl from '../package-styles/fields-rtl.lazy.scss?inline';
 import mediaFieldsLtr from '../package-styles/media-fields-ltr.lazy.scss?inline';
 import mediaFieldsRtl from '../package-styles/media-fields-rtl.lazy.scss?inline';
+import theme from '../package-styles/theme.lazy.scss?inline';
 import ui from '../package-styles/ui.lazy.scss?inline';
 
 /**
@@ -60,8 +61,8 @@ const CONFIG = [
 	},
 	{
 		componentIdMatcher: /^dataviews-/,
-		ltr: [ componentsLtr, dataviewsLtr ],
-		rtl: [ componentsRtl, dataviewsRtl ],
+		ltr: [ theme, componentsLtr, dataviewsLtr ],
+		rtl: [ theme, componentsRtl, dataviewsRtl ],
 	},
 	{
 		componentIdMatcher: /^fields-/,

--- a/storybook/package-styles/theme.lazy.scss
+++ b/storybook/package-styles/theme.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/theme/src/prebuilt/css/design-tokens.css";


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/74594

## What?

Remove the `@wordpress/theme/design-tokens.css` stylesheet from dataviews.

## Why?

This can lead to duplication of the stylesheet the design tokens are already provided elsewhere in their application.

## How?

- Remove the stylesheet.
- Document the stylesheet dependencies for DataViews.

## Testing Instructions

- Load the site editor and smoke test that it works as before.
- Load the storybook and smoke test that it works as before.