### PR TITLE
Default all initial suggested results to 20 for navigation link ui

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -40,19 +40,19 @@ export function getSuggestionsQuery( type, kind ) {
 	switch ( type ) {
 		case 'post':
 		case 'page':
-			return { type: 'post', subtype: type };
+			return { type: 'post', subtype: type, perPage: 20 };
 		case 'category':
-			return { type: 'term', subtype: 'category' };
+			return { type: 'term', subtype: 'category', perPage: 20 };
 		case 'tag':
-			return { type: 'term', subtype: 'post_tag' };
+			return { type: 'term', subtype: 'post_tag', perPage: 20 };
 		case 'post_format':
-			return { type: 'post-format' };
+			return { type: 'post-format', perPage: 20 };
 		default:
 			if ( kind === 'taxonomy' ) {
-				return { type: 'term', subtype: type };
+				return { type: 'term', subtype: type, perPage: 20 };
 			}
 			if ( kind === 'post-type' ) {
-				return { type: 'post', subtype: type };
+				return { type: 'post', subtype: type, perPage: 20 };
 			}
 			return {
 				// for custom link which has no type

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -37,22 +37,25 @@ import { useEntityBinding } from '../shared/use-entity-binding';
  * @return {{ type?: string, subtype?: string }} Search query params.
  */
 export function getSuggestionsQuery( type, kind ) {
+	// How many results to show initially and per search.
+	const perPage = 20;
+
 	switch ( type ) {
 		case 'post':
 		case 'page':
-			return { type: 'post', subtype: type, perPage: 20 };
+			return { type: 'post', subtype: type, perPage };
 		case 'category':
-			return { type: 'term', subtype: 'category', perPage: 20 };
+			return { type: 'term', subtype: 'category', perPage };
 		case 'tag':
-			return { type: 'term', subtype: 'post_tag', perPage: 20 };
+			return { type: 'term', subtype: 'post_tag', perPage };
 		case 'post_format':
-			return { type: 'post-format', perPage: 20 };
+			return { type: 'post-format', perPage };
 		default:
 			if ( kind === 'taxonomy' ) {
-				return { type: 'term', subtype: type, perPage: 20 };
+				return { type: 'term', subtype: type, perPage };
 			}
 			if ( kind === 'post-type' ) {
-				return { type: 'post', subtype: type, perPage: 20 };
+				return { type: 'post', subtype: type, perPage };
 			}
 			return {
 				// for custom link which has no type
@@ -60,7 +63,7 @@ export function getSuggestionsQuery( type, kind ) {
 				initialSuggestionsSearchOptions: {
 					type: 'post',
 					subtype: 'page',
-					perPage: 20,
+					perPage,
 				},
 			};
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/68185

<!-- In a few words, what is the PR actually doing? -->
Defaults initial suggested results to 20 instead of 3.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consistency across components. The inline link editor has more than 3 default suggested results as well. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Increase navigation link ui suggestion queries to 20 instead of letting them default to 3.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a new navigation link using the link appender
- Initial suggested results (no search yet) will be up to 20 instead of only 3

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**

https://github.com/user-attachments/assets/bd353cf7-461c-4728-9554-8e3dda2612b8

**After**

https://github.com/user-attachments/assets/b418a9ab-7d03-49c5-9fdf-c34e18f7c972




