### PR TITLE
Post editor: iframe: check inserted rather than registered block versions

### DIFF
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -67,10 +67,7 @@ export function ExperimentalBlockCanvas( {
 					ref={ contentRef }
 					className="editor-styles-wrapper"
 					tabIndex={ -1 }
-					style={ {
-						height: '100%',
-						width: '100%',
-					} }
+					style={ { overflow: 'auto' } }
 				>
 					{ children }
 				</WritingFlow>

--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -67,7 +67,11 @@ export function ExperimentalBlockCanvas( {
 					ref={ contentRef }
 					className="editor-styles-wrapper"
 					tabIndex={ -1 }
-					style={ { overflow: 'auto' } }
+					style={ {
+						height: '100%',
+						width: '100%',
+						overflow: 'auto',
+					} }
 				>
 					{ children }
 				</WritingFlow>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -134,7 +134,7 @@ function useEditorStyles( settings ) {
 
 /**
  * @param {Object}  props
- * @param {boolean} props.isLegacy True when the editor canvas is not in an iframe.
+ * @param {boolean} props.isLegacy True for device previews where split view is disabled.
  */
 function MetaBoxesMain( { isLegacy } ) {
 	const [ isOpen, openHeight, hasAnyVisible ] = useSelect( ( select ) => {
@@ -602,11 +602,7 @@ function Layout( {
 						extraContent={
 							! isDistractionFree &&
 							showMetaBoxes && (
-								<MetaBoxesMain
-									isLegacy={
-										! shouldIframe || isDevicePreview
-									}
-								/>
+								<MetaBoxesMain isLegacy={ isDevicePreview } />
 							)
 						}
 					>

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -110,14 +110,13 @@
 	clear: both;
 }
 
-// Only when the split view is active the visual editor should allow shrinking and
-// its main size should be zero.
+// Only when the split view is active the visual editor should allow shrinking,
+// its main size should be zero, and overflow should be hidden so that the inner
+// container provides the scrollable viewport.
 .has-metaboxes .interface-interface-skeleton__content:has(.edit-post-meta-boxes-main) .editor-visual-editor {
 	flex-shrink: 1;
 	flex-basis: 0%;
-}
-
-.has-metaboxes .editor-visual-editor.is-iframed {
+	overflow: hidden;
 	isolation: isolate;
 }
 

--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -17,6 +17,10 @@ export function useShouldIframe() {
 	return useSelect( ( select ) => {
 		const { getEditorSettings, getCurrentPostType, getDeviceType } =
 			select( editorStore );
+		const { getClientIdsWithDescendants, getBlockName } =
+			select( blockEditorStore );
+		const { getBlockType } = select( blocksStore );
+
 		return (
 			// If the theme is block based and the Gutenberg plugin is active,
 			// we ALWAYS use the iframe for consistency across the post and site
@@ -29,11 +33,12 @@ export function useShouldIframe() {
 			getDeviceType() !== 'Desktop' ||
 			[ 'wp_template', 'wp_block' ].includes( getCurrentPostType() ) ||
 			unlock( select( blockEditorStore ) ).isZoomOut() ||
-			// Finally, still iframe the editor if all blocks are v3 (which means
-			// they are marked as iframe-compatible).
-			select( blocksStore )
-				.getBlockTypes()
-				.every( ( type ) => type.apiVersion >= 3 )
+			// Finally, still iframe the editor if all present blocks are v3
+			// (which means they are marked as iframe-compatible).
+			[ ...new Set( getClientIdsWithDescendants().map( getBlockName ) ) ]
+				.map( getBlockType )
+				.filter( Boolean )
+				.every( ( blockType ) => blockType.apiVersion >= 3 )
 		);
 	}, [] );
 }

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Should iframe', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should switch to non-iframe when a v2 block is added', async ( {
+		page,
+		editor,
+	} ) => {
+		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
+
+		// Initially, the editor should be iframed (all core blocks are v3).
+		await expect( iframe ).toBeVisible();
+
+		// Register a v2 block dynamically.
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/v2', {
+				apiVersion: 2,
+				title: 'Test V2 Block',
+				edit: () =>
+					window.wp.element.createElement( 'p', null, 'v2 block' ),
+				save: () => null,
+			} );
+		} );
+
+		// Insert the v2 block.
+		await editor.insertBlock( { name: 'test/v2' } );
+
+		// The editor should no longer be iframed.
+		await expect( iframe ).not.toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -17,21 +17,23 @@ test.describe( 'Should iframe', () => {
 		// Initially, the editor should be iframed (all core blocks are v3).
 		await expect( iframe ).toBeVisible();
 
-		// Register a v2 block dynamically.
 		await page.evaluate( () => {
-			window.wp.blocks.registerBlockType( 'test/v2', {
-				apiVersion: 2,
-				title: 'Test V2 Block',
+			window.wp.blocks.registerBlockType( 'test/v1', {
+				apiVersion: 1,
+				title: 'Test V1 Block',
 				edit: () =>
-					window.wp.element.createElement( 'p', null, 'v2 block' ),
+					window.wp.element.createElement( 'p', null, 'v1 block' ),
 				save: () => null,
 			} );
 		} );
 
-		// Insert the v2 block.
-		await editor.insertBlock( { name: 'test/v2' } );
+		// The editor should still be iframed.
+		await expect( iframe ).toBeVisible();
+
+		// Insert the v1 block.
+		await editor.insertBlock( { name: 'test/v1' } );
 
 		// The editor should no longer be iframed.
-		await expect( iframe ).not.toBeVisible();
+		await expect( iframe ).toBeHidden();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Alternative to #74042.

Rather than always enabling the iframe (post editor), check what blocks are inserted in the canvas rather than checking the registered blocks (what we currently do).

A slight downside is that it will remount the whole editor when inserting an incompatible blocks, but this should happen much more rarely than when we first added the iframe.

We could potentially add a notice somewhere that mentions that the editor is in a compatibility mode and there may be some issues, with a list of the block names causing the compatibility mode, though it doesn't seem ideal to show this to users.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Themes and plugins are used to having content appear in an iframe and often don't consider both iframed and non-iframe editors, which causes a lot of frustration when an editor suddenly switches to a non-iframed if the user installs a plugin with a API v1 or v2 block. For example: https://x.com/thekevingeary/status/1803760573718397081.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We check the blocks in the canvas rather than the blocks registered.

We also adjust the meta boxes for non iframe mode to be collapsed at the bottom, exactly the same as iframe mode so that there's no shift in layout.

## Testing Instructions

Activate a classic theme. Insert a v1 or v2 block. You can check the e2e test for an example:

```js
window.wp.blocks.registerBlockType( 'test/v1', {
  apiVersion: 1,
  title: 'Test V1 Block',
  edit: () =>
	  window.wp.element.createElement( 'p', null, 'v1 block' ),
  save: () => null,
} );
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


<video src="https://github.com/user-attachments/assets/e11195f4-426b-42b7-838b-d174744aa9de">


