### PR TITLE
Link Control: Prevent link validation on blur

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -270,21 +270,6 @@ function LinkControl( {
 		};
 	}, [] );
 
-	// Trigger validation display when customValidity becomes invalid.
-	// This effect runs after React has applied the customValidity state update
-	// and ControlWithError's useEffect has set the native validity on the input.
-	useEffect( () => {
-		if ( customValidity?.type === 'invalid' ) {
-			const inputElement = searchInputRef.current;
-			if (
-				inputElement &&
-				typeof inputElement.reportValidity === 'function'
-			) {
-				inputElement.reportValidity();
-			}
-		}
-	}, [ customValidity ] );
-
 	const hasLinkValue = value?.url?.trim()?.length > 0;
 
 	/**

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -153,11 +153,10 @@ const LinkControlSearchInput = forwardRef(
 					// but we don't want to show the indicator as it looks cluttered
 					// in the link control UI.
 					markWhenOptional
-					// Prevent blur from triggering validation in ControlWithError.
-					// For LinkControl, validation should only occur on submit, not on blur.
-					onBlur={ ( event ) => {
-						event.stopPropagation();
-					} }
+					// Prevent validation from showing on blur. For LinkControl,
+					// validation should only occur on submit, not on blur, since
+					// blur can happen when clicking suggestions or the create page button.
+					validateOnBlur={ false }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
 

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -153,6 +153,11 @@ const LinkControlSearchInput = forwardRef(
 					// but we don't want to show the indicator as it looks cluttered
 					// in the link control UI.
 					markWhenOptional
+					// Prevent blur from triggering validation in ControlWithError.
+					// For LinkControl, validation should only occur on submit, not on blur.
+					onBlur={ ( event ) => {
+						event.stopPropagation();
+					} }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -486,31 +486,23 @@ class URLInput extends Component {
 			...( markWhenOptional !== undefined && {
 				markWhenOptional,
 			} ),
+			// Allow parent to control whether validation shows on blur
+			...( this.props.validateOnBlur !== undefined && {
+				validateOnBlur: this.props.validateOnBlur,
+			} ),
 		};
 
 		if ( renderControl ) {
 			return renderControl( controlProps, inputProps, loading );
 		}
 
-		const handleBlurCapture = ( event ) => {
-			// If a custom onBlur handler is provided, call it during capture phase.
-			// This allows the parent to control blur behavior (e.g., stop propagation
-			// to prevent validation from triggering on blur) before the event reaches
-			// ControlWithError's onBlur handler.
-			if ( this.props.onBlur ) {
-				this.props.onBlur( event );
-			}
-		};
-
 		return (
 			<BaseControl __nextHasNoMarginBottom { ...controlProps }>
-				<div onBlurCapture={ handleBlurCapture }>
-					<ValidatedInputControl
-						{ ...inputProps }
-						{ ...validationProps }
-						__next40pxDefaultSize
-					/>
-				</div>
+				<ValidatedInputControl
+					{ ...inputProps }
+					{ ...validationProps }
+					__next40pxDefaultSize
+				/>
 				{ loading && <Spinner /> }
 			</BaseControl>
 		);

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -492,13 +492,25 @@ class URLInput extends Component {
 			return renderControl( controlProps, inputProps, loading );
 		}
 
+		const handleBlurCapture = ( event ) => {
+			// If a custom onBlur handler is provided, call it during capture phase.
+			// This allows the parent to control blur behavior (e.g., stop propagation
+			// to prevent validation from triggering on blur) before the event reaches
+			// ControlWithError's onBlur handler.
+			if ( this.props.onBlur ) {
+				this.props.onBlur( event );
+			}
+		};
+
 		return (
 			<BaseControl __nextHasNoMarginBottom { ...controlProps }>
-				<ValidatedInputControl
-					{ ...inputProps }
-					{ ...validationProps }
-					__next40pxDefaultSize
-				/>
+				<div onBlurCapture={ handleBlurCapture }>
+					<ValidatedInputControl
+						{ ...inputProps }
+						{ ...validationProps }
+						__next40pxDefaultSize
+					/>
+				</div>
 				{ loading && <Spinner /> }
 			</BaseControl>
 		);

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Validated form controls (private API): Add `validateOnBlur` prop to control whether validation errors show on blur. When `false`, errors only show on submit or when `customValidity` is explicitly set ([#75188](https://github.com/WordPress/gutenberg/pull/75188)).
+
 ### Bug Fixes
 
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used.

--- a/packages/components/src/validated-form-controls/components/input-control.tsx
+++ b/packages/components/src/validated-form-controls/components/input-control.tsx
@@ -16,6 +16,7 @@ const UnforwardedValidatedInputControl = (
 		required,
 		customValidity,
 		markWhenOptional,
+		validateOnBlur,
 		...restProps
 	}: Omit<
 		React.ComponentProps< typeof InputControl >,
@@ -32,6 +33,7 @@ const UnforwardedValidatedInputControl = (
 			required={ required }
 			markWhenOptional={ markWhenOptional }
 			customValidity={ customValidity }
+			validateOnBlur={ validateOnBlur }
 			getValidityTarget={ () => validityTargetRef.current }
 		>
 			<InputControl

--- a/packages/components/src/validated-form-controls/components/types.ts
+++ b/packages/components/src/validated-form-controls/components/types.ts
@@ -10,6 +10,12 @@ export type ValidatedControlProps = {
 	 */
 	markWhenOptional?: boolean;
 	/**
+	 * Whether to show validation errors when the field blurs.
+	 * When false, errors only show on submit or when customValidity is set.
+	 * @default true
+	 */
+	validateOnBlur?: boolean;
+	/**
 	 * Show a custom message based on the validation status.
 	 *
 	 * - When `type` is `invalid`, the message will be applied to the underlying element using the

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -60,6 +60,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		markWhenOptional,
 		customValidity,
 		getValidityTarget,
+		validateOnBlur = true,
 		children,
 	}: {
 		/**
@@ -75,6 +76,13 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		 * A function that returns the actual element on which the validity data should be applied.
 		 */
 		getValidityTarget: () => ValidityTarget | null | undefined;
+		/**
+		 * Whether to show validation errors when the field blurs.
+		 * When false, errors only show on submit or when customValidity is set.
+		 *
+		 * @default true
+		 */
+		validateOnBlur?: boolean;
 		/**
 		 * The control component to apply validation to.
 		 *
@@ -224,6 +232,12 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 	// Mark blurred fields as touched.
 	const onBlur = ( event: React.FocusEvent< HTMLDivElement > ) => {
 		if ( isTouched ) {
+			return;
+		}
+
+		// If validateOnBlur is false, don't mark the field as touched on blur.
+		// This prevents validation errors from showing when the field loses focus.
+		if ( ! validateOnBlur ) {
 			return;
 		}
 

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -205,15 +205,26 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 				setErrorMessage( validityTarget?.validationMessage );
 
 				setStatusMessage( undefined );
+
+				// Mark field as touched when consumer explicitly sets an invalid state.
+				// This ensures validation errors show even when validateOnBlur={false},
+				// since explicit validation (like on submit) should trigger error display.
+				setIsTouched( true );
 				break;
 			}
 		}
 	}, [ customValidity, getValidityTarget ] );
 
-	// Show messages if field has been touched (i.e. has blurred at least once),
+	// Show messages if field has been touched (i.e. has blurred at least once and validateOnBlur is true),
 	// or validation has been triggered by the consumer/user.
 	useEffect( (): ReturnType< React.EffectCallback > => {
 		if ( ! isTouched || showMessage ) {
+			return;
+		}
+
+		// If validateOnBlur is false, only show messages when explicitly triggered
+		// (via customValidity or invalid event), not just because the field was touched.
+		if ( ! validateOnBlur && ! customValidity?.type ) {
 			return;
 		}
 
@@ -227,17 +238,11 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		}
 
 		setShowMessage( true );
-	}, [ isTouched, customValidity?.type, showMessage ] );
+	}, [ isTouched, customValidity?.type, showMessage, validateOnBlur ] );
 
 	// Mark blurred fields as touched.
 	const onBlur = ( event: React.FocusEvent< HTMLDivElement > ) => {
 		if ( isTouched ) {
-			return;
-		}
-
-		// If validateOnBlur is false, don't mark the field as touched on blur.
-		// This prevents validation errors from showing when the field loses focus.
-		if ( ! validateOnBlur ) {
 			return;
 		}
 
@@ -248,7 +253,6 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 			! event.currentTarget.contains( event.relatedTarget )
 		) {
 			setIsTouched( true );
-			getValidityTarget()?.setAttribute( VALIDITY_VISIBLE_ATTRIBUTE, '' );
 		}
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/75185
When using the LinkControl component (e.g., in the Navigation block), clicking the "Create Page" button or other suggestion items triggers a validation error: "Please fill out this field." This occurs because:

1. The search input uses `ValidatedInputControl` with `required={true}`
2. When the user clicks any button/suggestion, the input loses focus (blurs)
3. `ControlWithError` marks blurred fields as "touched" 
4. Once touched, validation errors are displayed
5. The "Create Page" action is blocked by the validation error

This is problematic because the create page button is a **separate action** from link submission—it shouldn't trigger input validation.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I looked at two different approaches. One that avoids modifying the components package, and one that adds a `validateOnBlur` prop to the `ValidatedControlProps` component.

### Approach 1: Event Interception in Block-Editor (Initial Fix - no need to touch components package)

See commit https://github.com/WordPress/gutenberg/pull/75188/commits/09bc8e512b8aa2cf0563c94502f879be63ad3b48 for implementation.

**Implementation:**
- Wrapped `ValidatedInputControl` in a div with `onBlurCapture`
- Parent component (`LinkControlSearchInput`) passed an `onBlur` handler that called `event.stopPropagation()`
- This prevented the blur event from reaching `ControlWithError`'s `onBlur` handler

**Code:**
```jsx
// url-input/index.js
<div onBlurCapture={handleBlurCapture}>
  <ValidatedInputControl {...props} />
</div>

// search-input.js
<URLInput
  onBlur={(event) => {
    event.stopPropagation();
  }}
/>
```

**Pros:**
- ✅ Fixes the issue without touching components package
- ✅ Uses React event capture phase to intercept before `ControlWithError`
- ✅ Parent controls behavior via callback

**Cons:**
- ❌ Requires an extra wrapper div
- ❌ Relies on event manipulation (stopPropagation)
- ❌ Not reusable—other consumers would need to implement the same workaround
- ❌ Couples the solution to DOM event flow rather than intent
- ❌ Less self-documenting—intent unclear from code

### Approach 2: Add a `validateOnBlur` Prop to `ValidatedControlProps` (Current Solution)

**Implementation:**
- Added `validateOnBlur` prop to `ValidatedControlProps` (defaults to `true`)
- Updated `ControlWithError` to skip marking field as touched when `validateOnBlur={false}`
- Passed through `ValidatedInputControl` → `ControlWithError`
- `LinkControlSearchInput` uses `<URLInput validateOnBlur={false} />`

**Pros:**
- ✅ **Reusable**: Any component using `ValidatedInputControl` can opt out of blur validation
- ✅ **Self-documenting**: `validateOnBlur={false}` clearly expresses intent
- ✅ **Backward compatible**: Defaults to `true`, existing behavior unchanged
- ✅ **Clean DOM**: No wrapper divs needed
- ✅ **No event manipulation**: Works at the logic level, not DOM level
- ✅ **Follows React patterns**: Props control behavior, not event interception
- ✅ **Extensible**: Other form validation scenarios can use this prop

**Cons:**
- ⚠️ Requires changes to components package (but improves the API for all consumers)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add new navigation link
- Focus should be on the search input
- Click "Create page" button
- You should move on to the Create Page step without seeing any validation error

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
