### PR TITLE
Media Modal Experiment: Update preview size to be a little smaller

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -200,6 +200,9 @@ export function MediaUploadModal( {
 		page: 1,
 		perPage: 20,
 		filters: [],
+		layout: {
+			previewSize: 170,
+		},
 	} ) );
 
 	// Build query args based on view properties, similar to PostList


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #73085

Reduce the default grid preview size of the experimental media modal's grid layout.

## Why?

Raised in testing feedback in #73085, that the default size we were going with was a little too large for browsing lots of media all at once. If we make it slightly smaller, more results can fit in a view at one time. It's still possible for users to adjust the preview size in the settings dropdown, of course.

Note: this is just a quick PR, it doesn't address the gap between items which was also raised as feedback in testing. That's a separate matter to look into in DataViews.

## How?

Add a default preview size of 170, to match the second stop of the view config settings. (it matches the hard-coded value defined here in dataviews layouts):

https://github.com/WordPress/gutenberg/blob/d2197b794c594cd71c5e2c93f7307d26e6434cc7/packages/dataviews/src/components/dataviews-layouts/grid/preview-size-picker.tsx#L19-L22

## Testing Instructions

Enable the experimental media modal in the Gutenberg experiment settings:

<img width="982" height="71" alt="image" src="https://github.com/user-attachments/assets/af49692d-3988-4fd5-847a-4652ac00466d" />

Go to add a featured image to a post or page
Note that with this PR applied, there should be a slightly smaller preview size, but it should still be possible to adjust the size in the dropdown settings

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="2546" height="1970" alt="image" src="https://github.com/user-attachments/assets/c5c4ea85-dc14-4af2-9781-34ca7ba22d93" /> | <img width="2546" height="1964" alt="image" src="https://github.com/user-attachments/assets/a8c5bb3d-0979-4e4b-b2d0-eda51769f10d" /> |