### PR TITLE
Block Support: Allow serialization skipping for ariaLabel

### DIFF
--- a/backport-changelog/7.0/10861.md
+++ b/backport-changelog/7.0/10861.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10861
+
+* https://github.com/WordPress/gutenberg/pull/75192

--- a/lib/block-supports/aria-label.php
+++ b/lib/block-supports/aria-label.php
@@ -42,7 +42,10 @@ function gutenberg_apply_aria_label_support( $block_type, $block_attributes ) {
 	}
 
 	$has_aria_label_support = block_has_support( $block_type, array( 'ariaLabel' ), false );
-	if ( ! $has_aria_label_support ) {
+	if (
+		! $has_aria_label_support ||
+		wp_should_skip_block_supports_serialization( $block_type, 'ariaLabel' )
+	) {
 		return array();
 	}
 

--- a/packages/block-editor/src/hooks/aria-label.js
+++ b/packages/block-editor/src/hooks/aria-label.js
@@ -5,6 +5,11 @@ import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
+ * Internal dependencies
+ */
+import { shouldSkipSerialization } from './utils';
+
+/**
  * Filters registered block settings, extending attributes with ariaLabel using aria-label
  * of the first node.
  *
@@ -42,7 +47,10 @@ export function addAttribute( settings ) {
  * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( extraProps, blockType, attributes ) {
-	if ( hasBlockSupport( blockType, 'ariaLabel' ) ) {
+	if (
+		hasBlockSupport( blockType, 'ariaLabel' ) &&
+		! shouldSkipSerialization( blockType, 'ariaLabel', 'ariaLabel' )
+	) {
 		extraProps[ 'aria-label' ] =
 			attributes.ariaLabel === '' ? null : attributes.ariaLabel;
 	}

--- a/phpunit/block-supports/aria-label-test.php
+++ b/phpunit/block-supports/aria-label-test.php
@@ -44,13 +44,13 @@ class WP_Block_Supports_Aria_Label_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that position block support works as expected.
+	 * Tests that aria-label block support works as expected.
 	 *
 	 * @dataProvider data_aria_label_block_support
 	 *
 	 * @param boolean|array $support Aria label block support configuration.
 	 * @param string        $value   Aria label value for attribute object.
-	 * @param array         $expected       Expected aria label block support styles.
+	 * @param array         $expected Expected aria-label attributes.
 	 */
 	public function test_gutenberg_apply_aria_label_support( $support, $value, $expected ) {
 		$block_type  = self::register_aria_label_block_with_support(
@@ -77,6 +77,13 @@ class WP_Block_Supports_Aria_Label_Test extends WP_UnitTestCase {
 			),
 			'aria-label attribute is not applied if block does not support it' => array(
 				'support'  => false,
+				'value'    => 'Label',
+				'expected' => array(),
+			),
+			'aria-label attribute is not applied when serialization is skipped' => array(
+				'support'  => array(
+					'__experimentalSkipSerialization' => true,
+				),
 				'value'    => 'Label',
 				'expected' => array(),
 			),

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -260,7 +260,14 @@
 				},
 				"ariaLabel": {
 					"description": "ARIA-labels let you define an accessible label for elements. This property allows enabling the definition of an aria-label for the block, without exposing a UI field.",
-					"type": "boolean",
+					"oneOf": [
+						{
+							"type": "boolean"
+						},
+						{
+							"type": "object"
+						}
+					],
 					"default": false
 				},
 				"className": {


### PR DESCRIPTION
Related to #71227

## What?

I found that there is a need to skip serializing `ariaLabel` block support and apply `aria-label` to the inner element rather than the block wrapper. For example, the in-progress Icon block requires the `aria-label` attribute to be applied to the inner `svg` element.

## Testing Instructions

- modify the Group block as follows to skip serialization:
  ```diff
  diff --git a/packages/block-library/src/group/block.json b/packages/block-library/src/group/block.json
  index e83fb60d31f..ac235387eee 100644
  --- a/packages/block-library/src/group/block.json
  +++ b/packages/block-library/src/group/block.json
  @@ -23,7 +23,9 @@
                  "__experimentalSettings": true,
                  "align": [ "wide", "full" ],
                  "anchor": true,
  -               "ariaLabel": true,
  +               "ariaLabel": {
  +                       "__experimentalSkipSerialization": true
  +               },
                  "html": false,
                  "background": {
                          "backgroundImage": true,
  ```
- Insert a Group block.
- Currently, the `ariaLabel` block support does not provide a UI, so use the sample code to update the `aria-label` attribute:
  ```javascript
  const blocks = wp.data.select( 'core/block-editor' ).getBlocks();
  if ( blocks.length ) {
  	const firstBlock = blocks[ 0 ];
  	wp.data
  		.dispatch( 'core/block-editor' )
  		.updateBlockAttributes( firstBlock.clientId, { ariaLabel: 'My Aria label' } );
  }
  ```
- Open the code editor, and the block wrapper div doesn't have the `aria-label` attribute.
  ```html
  <!-- wp:group {"ariaLabel":"My Aria label"} -->
  <div class="wp-block-group"></div>
  <!-- /wp:group -->
  ```
- Open the front end, and the block wrapper div doesn't have the `aria-label` attribute.