### PR TITLE
Pattern Editing and Navigation block: Show navigation controls in popover

### DIFF
--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -11,6 +11,9 @@ export const mayDisplayPatternEditingControlsKey = Symbol(
 export const blockEditingModeKey = Symbol( 'blockEditingMode' );
 export const blockBindingsKey = Symbol( 'blockBindings' );
 export const isPreviewModeKey = Symbol( 'isPreviewMode' );
+export const isInListViewBlockSupportTreeKey = Symbol(
+	'isInListViewBlockSupportTree'
+);
 
 export const DEFAULT_BLOCK_EDIT_CONTEXT = {
 	name: '',

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -17,6 +17,7 @@ import {
 	blockEditingModeKey,
 	blockBindingsKey,
 	isPreviewModeKey,
+	isInListViewBlockSupportTreeKey,
 } from './context';
 import { MultipleUsageWarning } from './multiple-usage-warning';
 import { PrivateBlockContext } from '../block-list/private-block-context';
@@ -53,6 +54,11 @@ export default function BlockEdit( {
 	const layoutSupport =
 		hasBlockSupport( name, 'layout', false ) ||
 		hasBlockSupport( name, '__experimentalLayout', false );
+	const parentBlockEditContext = useBlockEditContext();
+	const isInListViewBlockSupportTree =
+		!! parentBlockEditContext[ isInListViewBlockSupportTreeKey ] ||
+		hasBlockSupport( name, 'listView' ) ||
+		name === 'core/navigation';
 	const { originalBlockClientId } = useContext( PrivateBlockContext );
 
 	return (
@@ -77,6 +83,8 @@ export default function BlockEdit( {
 					[ blockEditingModeKey ]: blockEditingMode,
 					[ blockBindingsKey ]: bindings,
 					[ isPreviewModeKey ]: isPreviewMode,
+					[ isInListViewBlockSupportTreeKey ]:
+						isInListViewBlockSupportTree,
 				} ),
 				[
 					name,
@@ -91,6 +99,7 @@ export default function BlockEdit( {
 					blockEditingMode,
 					bindings,
 					isPreviewMode,
+					isInListViewBlockSupportTree,
 				]
 			) }
 		>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/blocks';
 import { __unstableMotion as motion } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,7 +23,8 @@ import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 import BlockStyles from '../block-styles';
-import { default as InspectorControls } from '../inspector-controls';
+import { ListViewContentPopover } from '../inspector-controls/list-view-content-popover';
+import InspectorControls from '../inspector-controls';
 import { default as InspectorControlsTabs } from '../inspector-controls-tabs';
 import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-controls-tabs';
 import InspectorControlsLastItem from '../inspector-controls/last-item';
@@ -314,6 +316,7 @@ const BlockInspectorSingleBlock = ( {
 	hasBlockStyles,
 	editedContentOnlySection,
 } ) => {
+	const listViewRef = useRef( null );
 	const hasMultipleTabs = availableTabs?.length > 1;
 	const hasParentChildBlockCards =
 		editedContentOnlySection &&
@@ -364,7 +367,8 @@ const BlockInspectorSingleBlock = ( {
 					) }
 					<ContentTab contentClientIds={ contentClientIds } />
 					<InspectorControls.Slot group="content" />
-					<InspectorControls.Slot group="list" />
+					<InspectorControls.Slot group="list" ref={ listViewRef } />
+					<ListViewContentPopover listViewRef={ listViewRef } />
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots blockName={ blockName } />
 					) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
@@ -16,7 +16,7 @@ import {
 } from '../inspector-controls';
 import { PrivateInspectorControlsAllowedBlocks } from '../inspector-controls/groups';
 
-const AdvancedControls = () => {
+const AdvancedControls = ( { initialOpen = false } ) => {
 	const fills = useSlotFills( InspectorAdvancedControls.slotName );
 	const privateFills = useSlotFills(
 		PrivateInspectorControlsAllowedBlocks.name
@@ -32,7 +32,7 @@ const AdvancedControls = () => {
 		<PanelBody
 			className="block-editor-block-inspector__advanced"
 			title={ __( 'Advanced' ) }
-			initialOpen={ false }
+			initialOpen={ initialOpen }
 		>
 			<InspectorControls.Slot group="advanced" />
 			<PrivateInspectorControlsAllowedBlocks.Slot />

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -17,6 +17,7 @@ import { TAB_SETTINGS, TAB_STYLES, TAB_LIST_VIEW, TAB_CONTENT } from './utils';
 import SettingsTab from './settings-tab';
 import StylesTab from './styles-tab';
 import ContentTab from './content-tab';
+import { ListViewContentPopover } from '../inspector-controls/list-view-content-popover';
 import InspectorControls from '../inspector-controls';
 import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
@@ -31,6 +32,7 @@ export default function InspectorControlsTabs( {
 	isSectionBlock,
 	contentClientIds,
 } ) {
+	const listViewRef = useRef( null );
 	const showIconLabels = useSelect( ( select ) => {
 		return select( preferencesStore ).get( 'core', 'showIconLabels' );
 	}, [] );
@@ -123,6 +125,18 @@ export default function InspectorControlsTabs( {
 						)
 					) }
 				</Tabs.TabList>
+				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>
+					<ContentTab
+						contentClientIds={ contentClientIds }
+						onSwitchToListView={ switchToListView }
+						hasListViewTab={ hasListViewTab }
+					/>
+					<InspectorControls.Slot group="content" />
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name } focusable={ false }>
+					<InspectorControls.Slot group="list" ref={ listViewRef } />
+					<ListViewContentPopover listViewRef={ listViewRef } />
+				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_SETTINGS.name } focusable={ false }>
 					<SettingsTab showAdvancedControls={ !! blockName } />
 				</Tabs.TabPanel>
@@ -134,17 +148,6 @@ export default function InspectorControlsTabs( {
 						isSectionBlock={ isSectionBlock }
 						contentClientIds={ contentClientIds }
 					/>
-				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>
-					<ContentTab
-						contentClientIds={ contentClientIds }
-						onSwitchToListView={ switchToListView }
-						hasListViewTab={ hasListViewTab }
-					/>
-					<InspectorControls.Slot group="content" />
-				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name } focusable={ false }>
-					<InspectorControls.Slot group="list" />
 				</Tabs.TabPanel>
 			</Tabs>
 		</div>

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -1,21 +1,40 @@
 /**
+ * WordPress dependencies
+ */
+import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import AdvancedControls from './advanced-controls-panel';
 import PositionControls from './position-controls-panel';
 import { default as InspectorControls } from '../inspector-controls';
+import groups from '../inspector-controls/groups';
 
-const SettingsTab = ( { showAdvancedControls = false } ) => (
-	<>
-		<InspectorControls.Slot />
-		<PositionControls />
-		<InspectorControls.Slot group="bindings" />
-		{ showAdvancedControls && (
-			<div>
-				<AdvancedControls />
-			</div>
-		) }
-	</>
-);
+const SettingsTab = ( { showAdvancedControls = false } ) => {
+	const defaultFills = useSlotFills( groups.default.name );
+	const positionFills = useSlotFills( groups.position.name );
+	const bindingsFills = useSlotFills( groups.bindings.name );
+
+	// Expand the advanced panel when there are no other fills
+	// in the settings tab.
+	const hasOtherFills =
+		!! defaultFills?.length ||
+		!! positionFills?.length ||
+		!! bindingsFills?.length;
+
+	return (
+		<>
+			<InspectorControls.Slot />
+			<PositionControls />
+			<InspectorControls.Slot group="bindings" />
+			{ showAdvancedControls && (
+				<div>
+					<AdvancedControls initialOpen={ ! hasOtherFills } />
+				</div>
+			) }
+		</>
+	);
+};
 
 export default SettingsTab;

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -16,8 +16,10 @@ import {
 	useBlockEditContext,
 	mayDisplayControlsKey,
 	mayDisplayPatternEditingControlsKey,
+	isInListViewBlockSupportTreeKey,
 } from '../block-edit/context';
 import groups from './groups';
+import { ListViewContentFill } from './list-view-content-popover';
 
 const PATTERN_EDITING_GROUPS = [ 'content', 'list' ];
 const TEMPLATE_PART_GROUPS = [ 'default', 'settings', 'advanced' ];
@@ -41,6 +43,7 @@ export default function InspectorControlsFill( {
 	}
 
 	const context = useBlockEditContext();
+
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );
@@ -71,6 +74,26 @@ export default function InspectorControlsFill( {
 		! context[ mayDisplayPatternEditingControlsKey ] &&
 		! context[ mayDisplayControlsKey ]
 	) {
+		return null;
+	}
+
+	// When inside a section with a parent that has ListView block support,
+	// content controls are rendered as part of the ListView via a popover.
+	if (
+		group === 'content' &&
+		!! context[ isInListViewBlockSupportTreeKey ] &&
+		!! context[ mayDisplayPatternEditingControlsKey ]
+	) {
+		if ( context[ mayDisplayControlsKey ] ) {
+			return (
+				<StyleProvider document={ document }>
+					<ListViewContentFill>{ children }</ListViewContentFill>
+				</StyleProvider>
+			);
+		}
+
+		// When using the ListView fill, only render controls for the selected
+		// block. Other blocks return `null`.
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/list-view-content-popover.js
+++ b/packages/block-editor/src/components/inspector-controls/list-view-content-popover.js
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createSlotFill,
+	Popover,
+	__experimentalUseSlotFills as useSlotFills,
+} from '@wordpress/components';
+import { useState, useLayoutEffect } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+/** @typedef {import('@wordpress/element').RefObject} RefObject */
+
+// Create private slot-fill for ListViewContentPanel
+const LIST_VIEW_CONTENT_PANEL_SLOT = Symbol( 'ListViewContentPopover' );
+const { Fill, Slot } = createSlotFill( LIST_VIEW_CONTENT_PANEL_SLOT );
+
+export { Fill as ListViewContentFill };
+
+// Hook to determine popover placement for inspector controls
+function useInspectorPopoverPlacement() {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					offset: 35,
+					resize: false,
+				},
+		  }
+		: {};
+}
+
+/**
+ * Displays a popover for the List View block inspector support.
+ * Blocks can use `<InspectorControls group="content">` to display their
+ * controls in this popover when inside a section with a parent that has
+ * List View block support. The routing is handled automatically by
+ * `InspectorControlsFill`.
+ *
+ * @param {Object}                 props
+ * @param {RefObject<HTMLElement>} props.listViewRef Ref to the List View slot for the block inspector.
+ */
+export function ListViewContentPopover( { listViewRef } ) {
+	const { popoverProps } = useInspectorPopoverPlacement();
+	const fills = useSlotFills( LIST_VIEW_CONTENT_PANEL_SLOT );
+	const hasFills = Boolean( fills && fills.length );
+
+	// Get both the selected client ID and the popover open state.
+	const { selectedClientId, isOpen } = useSelect( ( select ) => {
+		const { getSelectedBlockClientId } = select( blockEditorStore );
+		const privateSelectors = unlock( select( blockEditorStore ) );
+
+		return {
+			selectedClientId: getSelectedBlockClientId(),
+			isOpen: privateSelectors.isListViewContentPanelOpen(),
+		};
+	}, [] );
+
+	// Query DOM for the selected block row element in List View.
+	const [ anchorElement, setAnchorElement ] = useState( null );
+
+	useLayoutEffect( () => {
+		if ( ! selectedClientId || ! listViewRef?.current ) {
+			setAnchorElement( null );
+			return;
+		}
+
+		// Query for the block in list view to anchor the popover.
+		// Ensures the vertical positioning of the popover matches the
+		// selected block in List View.
+		const element = listViewRef.current.querySelector(
+			`[data-block="${ selectedClientId }"]`
+		);
+
+		setAnchorElement( element );
+	}, [ selectedClientId, listViewRef ] );
+
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { closeListViewContentPanel } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
+	// Only render when explicitly open.
+	if ( ! isOpen || ! hasFills || ! anchorElement ) {
+		return null;
+	}
+
+	// The slot rendered in the popover doesn't use `bubblesVirtually`, this has a downside
+	// that certain context providers (like `BlockEditContext`) are not available
+	// to fills.
+	// The upside is that it allows nested popovers to function correctly. If `bubblesVirtually`
+	// is set opening a nest popover triggers the `onFocusOutside` of this popover and closes it.
+	// Is there a solution that has no trade-offs?
+	return (
+		<Popover
+			{ ...( popoverProps ?? {} ) }
+			anchor={ anchorElement }
+			onClose={ closeListViewContentPanel }
+		>
+			<div style={ { width: '280px' } }>
+				<Slot />
+			</div>
+		</Popover>
+	);
+}

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
 import warning from '@wordpress/warning';
 import deprecated from '@wordpress/deprecated';
 
@@ -12,13 +13,10 @@ import BlockSupportToolsPanel from './block-support-tools-panel';
 import BlockSupportSlotContainer from './block-support-slot-container';
 import groups from './groups';
 
-export default function InspectorControlsSlot( {
-	__experimentalGroup,
-	group = 'default',
-	label,
-	fillProps,
-	...props
-} ) {
+function InspectorControlsSlot(
+	{ __experimentalGroup, group = 'default', label, fillProps, ...props },
+	ref
+) {
 	if ( __experimentalGroup ) {
 		deprecated(
 			'`__experimentalGroup` property in `InspectorControlsSlot`',
@@ -56,5 +54,14 @@ export default function InspectorControlsSlot( {
 		);
 	}
 
-	return <Slot { ...props } fillProps={ fillProps } bubblesVirtually />;
+	return (
+		<Slot
+			{ ...props }
+			ref={ ref }
+			fillProps={ fillProps }
+			bubblesVirtually
+		/>
+	);
 }
+
+export default forwardRef( InspectorControlsSlot );

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -453,3 +453,25 @@ export function toggleBlockSpotlight( clientId, hasBlockSpotlight ) {
 		hasBlockSpotlight,
 	};
 }
+
+/**
+ * Opens the list view content panel popover.
+ *
+ * @return {Object} Action object.
+ */
+export function openListViewContentPanel() {
+	return {
+		type: 'OPEN_LIST_VIEW_CONTENT_PANEL',
+	};
+}
+
+/**
+ * Closes the list view content panel popover.
+ *
+ * @return {Object} Action object.
+ */
+export function closeListViewContentPanel() {
+	return {
+		type: 'CLOSE_LIST_VIEW_CONTENT_PANEL',
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -950,3 +950,14 @@ export function isLockedBlock( state, clientId ) {
 		isRemoveLockedBlock( state, clientId )
 	);
 }
+
+/**
+ * Returns whether the list view content panel popover is open.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the popover is open.
+ */
+export function isListViewContentPanelOpen( state ) {
+	return state.listViewContentPanelOpen;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2172,6 +2172,30 @@ function listViewExpandRevision( state = 0, action ) {
 	return state;
 }
 
+/**
+ * Reducer tracking whether the list view content panel popover is open.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function listViewContentPanelOpen( state = false, action ) {
+	switch ( action.type ) {
+		case 'OPEN_LIST_VIEW_CONTENT_PANEL':
+			return true;
+
+		case 'CLOSE_LIST_VIEW_CONTENT_PANEL':
+			return false;
+
+		// Close when selection is cleared
+		case 'CLEAR_SELECTED_BLOCK':
+			return false;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2205,6 +2229,7 @@ const combinedReducers = combineReducers( {
 	hasBlockSpotlight,
 	openedListViewPanels,
 	listViewExpandRevision,
+	listViewContentPanelOpen,
 } );
 
 /**

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -391,7 +391,7 @@ export default function NavigationLinkEdit( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
+			<InspectorControls group="content">
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -158,6 +158,14 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 			?.home;
 	}, [] );
 
+	const blockEditingMode = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockEditingMode( clientId ),
+		[ clientId ]
+	);
+
+	const isContentOnly = blockEditingMode === 'contentOnly';
+
 	const preview = useLinkPreview( {
 		url,
 		title: linkTitle,
@@ -310,7 +318,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				hasValue={ () => !! description }
 				label={ __( 'Description' ) }
 				onDeselect={ () => setAttributes( { description: '' } ) }
-				isShownByDefault
+				isShownByDefault={ ! isContentOnly }
 			>
 				<TextareaControl
 					label={ __( 'Description' ) }
@@ -328,7 +336,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				hasValue={ () => !! rel }
 				label={ __( 'Rel attribute' ) }
 				onDeselect={ () => setAttributes( { rel: '' } ) }
-				isShownByDefault
+				isShownByDefault={ ! isContentOnly }
 			>
 				<TextControl
 					__next40pxDefaultSize

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -13,8 +13,8 @@ import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InnerBlocks,
-	useInnerBlocksProps,
 	InspectorControls,
+	useInnerBlocksProps,
 	RichText,
 	useBlockProps,
 	useBlockEditingMode,
@@ -333,7 +333,7 @@ export default function NavigationSubmenuEdit( {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
+			<InspectorControls group="content">
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -154,6 +154,10 @@ const MainContent = ( {
 		[ clientId ]
 	);
 
+	const { openListViewContentPanel } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
 	if ( currentMenuId && isNavigationMenuMissing ) {
@@ -191,6 +195,7 @@ const MainContent = ( {
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
 				additionalBlockContent={ AdditionalBlockContent }
+				onSelect={ openListViewContentPanel }
 			/>
 		</div>
 	);

--- a/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-list-view.spec.js
@@ -310,7 +310,7 @@ test.describe( 'Navigation block - List view editing', () => {
 
 		await expect(
 			blockSettings.getByRole( 'tab', {
-				name: 'Settings',
+				name: 'Content',
 				selected: true,
 			} )
 		).toBeVisible();
@@ -318,7 +318,7 @@ test.describe( 'Navigation block - List view editing', () => {
 		await expect(
 			blockSettings
 				.getByRole( 'tabpanel', {
-					name: 'Settings',
+					name: 'Content',
 				} )
 				.getByRole( 'heading', {
 					name: 'Settings',

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -739,7 +739,7 @@ test.describe( 'Navigation block', () => {
 
 				// With LinkControlInspector, check that link button shows the page info
 				const linkButton = page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
+					.getByRole( 'tabpanel', { name: 'Content' } )
 					.getByRole( 'button', { name: /Cat/i } );
 
 				// Wait for the Cat link to load in the button
@@ -752,7 +752,7 @@ test.describe( 'Navigation block', () => {
 				// Cat link is already selected from setup step, with entity loaded
 				// Verify sidebar shows Cat
 				inspectorNavigationLabel = page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
+					.getByRole( 'tabpanel', { name: 'Content' } )
 					.getByRole( 'textbox', {
 						name: 'Text',
 					} );
@@ -1197,7 +1197,7 @@ test.describe( 'Navigation block', () => {
 				await editor.openDocumentSettingsSidebar();
 				const settingsControls = page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tabpanel', { name: 'Settings' } );
+					.getByRole( 'tabpanel', { name: 'Content' } );
 
 				await expect( settingsControls ).toBeVisible();
 
@@ -1287,16 +1287,13 @@ test.describe( 'Navigation block', () => {
 
 				// Check that the link button now shows the updated URL
 				await editor.openDocumentSettingsSidebar();
-				const settingsControls = page
+				const contentControls = page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tabpanel', { name: 'Settings' } );
+					.getByRole( 'tabpanel', { name: 'Content' } );
 
-				const updatedLinkButton = settingsControls.getByRole(
-					'button',
-					{
-						name: /Link to:/,
-					}
-				);
+				const updatedLinkButton = contentControls.getByRole( 'button', {
+					name: /Link to:/,
+				} );
 
 				const updatedUrl = new URL( updatedPage.link );
 				await expect( updatedLinkButton ).toContainText(
@@ -1423,14 +1420,14 @@ test.describe( 'Navigation block', () => {
 			// Check the Inspector controls for the Nav Link block
 			// to verify the Link field is clickable (not locked in entity mode)
 			await editor.openDocumentSettingsSidebar();
-			const settingsControls = page
+			const contentControls = page
 				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tabpanel', { name: 'Settings' } );
+				.getByRole( 'tabpanel', { name: 'Content' } );
 
-			await expect( settingsControls ).toBeVisible();
+			await expect( contentControls ).toBeVisible();
 
 			// With LinkControlInspector, there's now a button instead of a textbox
-			const linkButton = settingsControls.getByRole( 'button', {
+			const linkButton = contentControls.getByRole( 'button', {
 				name: /test-page-1/i,
 			} );
 
@@ -1518,14 +1515,14 @@ test.describe( 'Navigation block', () => {
 
 			// Open sidebar to check Link field
 			await editor.openDocumentSettingsSidebar();
-			const settingsControls = page
+			const contentControls = page
 				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'tabpanel', { name: 'Settings' } );
+				.getByRole( 'tabpanel', { name: 'Content' } );
 
-			await expect( settingsControls ).toBeVisible();
+			await expect( contentControls ).toBeVisible();
 
 			// With LinkControlInspector, synced links show a button with the URL
-			const linkButton = settingsControls.getByRole( 'button', {
+			const linkButton = contentControls.getByRole( 'button', {
 				name: /Link to:/,
 			} );
 
@@ -1647,14 +1644,14 @@ test.describe( 'Navigation block', () => {
 
 				// Open document settings sidebar
 				await editor.openDocumentSettingsSidebar();
-				const settingsControls = page
+				const contentControls = page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tabpanel', { name: 'Settings' } );
+					.getByRole( 'tabpanel', { name: 'Content' } );
 
-				await expect( settingsControls ).toBeVisible();
+				await expect( contentControls ).toBeVisible();
 
 				// With LinkControlInspector, unavailable entities show a button with error badge
-				const linkButton = settingsControls.getByRole( 'button', {
+				const linkButton = contentControls.getByRole( 'button', {
 					name: /Missing page/i,
 				} );
 
@@ -1666,11 +1663,11 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Verify clicking button with error opens link control for fixing', async () => {
-				const settingsControls = page
+				const contentControls = page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'tabpanel', { name: 'Settings' } );
+					.getByRole( 'tabpanel', { name: 'Content' } );
 
-				const linkButton = settingsControls.getByRole( 'button', {
+				const linkButton = contentControls.getByRole( 'button', {
 					name: /Missing page/i,
 				} );
 
@@ -1697,12 +1694,9 @@ test.describe( 'Navigation block', () => {
 				await expect( linkPopover ).toBeHidden();
 
 				// Verify button now shows the new URL
-				const updatedLinkButton = settingsControls.getByRole(
-					'button',
-					{
-						name: /Link to:/,
-					}
-				);
+				const updatedLinkButton = contentControls.getByRole( 'button', {
+					name: /Link to:/,
+				} );
 				await expect( updatedLinkButton ).toContainText(
 					'example.com'
 				);
@@ -1767,7 +1761,7 @@ test.describe( 'Navigation block', () => {
 			await test.step( 'Open inspector and verify LinkPicker shows current page', async () => {
 				await editor.openDocumentSettingsSidebar();
 
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 				await expect( settingsControls ).toBeVisible();
 
 				// Verify the LinkPicker button shows the current page
@@ -1780,7 +1774,7 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Click LinkPicker button to open dropdown', async () => {
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -1812,7 +1806,7 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Verify LinkPicker now shows Test Page 2', async () => {
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -1852,7 +1846,7 @@ test.describe( 'Navigation block', () => {
 
 			await test.step( 'Open inspector LinkPicker and change to custom URL', async () => {
 				await editor.openDocumentSettingsSidebar();
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -1872,7 +1866,7 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Verify LinkPicker shows custom URL', async () => {
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -1911,7 +1905,7 @@ test.describe( 'Navigation block', () => {
 
 			await test.step( 'Open inspector LinkPicker and change to new custom URL', async () => {
 				await editor.openDocumentSettingsSidebar();
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -1932,7 +1926,7 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Verify LinkPicker shows new custom URL', async () => {
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -1961,7 +1955,7 @@ test.describe( 'Navigation block', () => {
 			await test.step( 'Open inspector and verify LinkPicker shows "Add link" button', async () => {
 				await editor.openDocumentSettingsSidebar();
 
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 				await expect( settingsControls ).toBeVisible();
 
 				// Verify button shows "Add link" text
@@ -1973,7 +1967,7 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Click LinkPicker button to open dropdown and add page link', async () => {
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -2000,7 +1994,7 @@ test.describe( 'Navigation block', () => {
 			} );
 
 			await test.step( 'Verify LinkPicker now shows the selected page', async () => {
-				const settingsControls = navigation.getSettingsControls();
+				const settingsControls = navigation.getContentControls();
 
 				const linkButton = settingsControls.getByRole( 'button', {
 					name: /Link to:/,
@@ -2062,10 +2056,10 @@ class Navigation {
 		} );
 	}
 
-	getSettingsControls() {
+	getContentControls() {
 		return this.page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'tabpanel', { name: 'Settings' } );
+			.getByRole( 'tabpanel', { name: 'Content' } );
 	}
 
 	async useBlockInserter() {


### PR DESCRIPTION
## What?
Another alternative to #75050 and #75042.

This should dovetail nicely with the experience in #75246

## Why?
In these PRs we're trying to make editing a navigation block easier when the block is in a contentOnly Template Part. The Pattern Editing project/feature proposes to make Template Parts contentOnly by default in 7.0.

## How?
In this PR nav link controls are shown in a popover when clicking the list view items. This is something we haven't tried yet, #75050 and #75042 both use different approaches (drilldown/different tab), so I thought I'd try it in this PR:

https://github.com/user-attachments/assets/4038db20-1ab3-4e14-8379-464c4e176a6d


### Code changes

- Updates the nav list and submenu blocks to use the `content` group for its inspector controls. When outside of a pattern this will make the block show the tools in the content tab (I might split this change out to a separate PR)
- Adds a new slotfill `ListViewContentPopover` that is only used internally in the block editor package. When a block uses the content group for its tools, is within a pattern or template part, and is part of a block hierarchy that has the List View support, then the tools will show in a popover when the block is selected in the List View.
- Implements the popover used for the above

## Testing Instructions
(assumes a theme like Twenty Twenty Five is in use)
1. Open a template like Blog Home
2. Select the header or footer
3. See that there are three tabs 'Content', 'List View' and 'Settings':
<img width="280" height="193" alt="Screenshot 2026-02-09 at 4 19 51 pm" src="https://github.com/user-attachments/assets/f1ced8ad-0fc2-44f6-8f7d-4256eb54a19d" />

4. Open the List View tab
5. You should see a List View dedicated to the Navigation Block
6. If there are none already, add one or more pages to the nav block using the appender in the sidebar
7. Select one of the Pages
8. See its controls appear in a popover:
<img width="590" height="382" alt="Screenshot 2026-02-09 at 4 24 28 pm" src="https://github.com/user-attachments/assets/cb8a92d9-bd15-466f-8003-1f8f3f8cbee7" />

9. Edit the block using the controls in the popover