### PR TITLE
Block Editor: The insertBlock(s) actions should receive the same arguments

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1313,6 +1313,7 @@ _Parameters_
 -   _index_ `?number`: Index at which block should be inserted.
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
 -   _updateSelection_ `?boolean`: If true block selection will be updated. If false, block selection will not change. Defaults to true.
+-   _initialPosition_ `0|-1|null`: Initial focus position. Setting it to null prevent focusing the inserted block.
 -   _meta_ `?Object`: Optional Meta values to be passed to the action object.
 
 _Returns_

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking Change
+### Bug Fixes
 
 -   Store: `insertBlock` - the meta argument is now the 6th argument of the action, the 5th argument is `initialPosition` ([#75197](https://github.com/WordPress/gutenberg/pull/75197)).
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Store: `insertBlock` - the meta argument is now the 6th argument of the action, the 5th argument is `initialPosition` ([#75197](https://github.com/WordPress/gutenberg/pull/75197)).
+
 ## 15.12.0 (2026-01-29)
 
 ## 15.11.0 (2026-01-16)

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -129,6 +129,7 @@ function InserterMenu( {
 				insertionIndex,
 				destinationRootClientId,
 				true,
+				0,
 				{ source: 'inserter_menu' }
 			);
 		},

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -517,11 +517,12 @@ export function moveBlockToPosition(
  * Only allowed blocks are inserted. The action may fail silently for blocks that are not allowed or if
  * a templateLock is active on the block list.
  *
- * @param {Object}   block           Block object to insert.
- * @param {?number}  index           Index at which block should be inserted.
- * @param {?string}  rootClientId    Optional root client ID of block list on which to insert.
- * @param {?boolean} updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to true.
- * @param {?Object}  meta            Optional Meta values to be passed to the action object.
+ * @param {Object}    block           Block object to insert.
+ * @param {?number}   index           Index at which block should be inserted.
+ * @param {?string}   rootClientId    Optional root client ID of block list on which to insert.
+ * @param {?boolean}  updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to true.
+ * @param {0|-1|null} initialPosition Initial focus position. Setting it to null prevent focusing the inserted block.
+ * @param {?Object}   meta            Optional Meta values to be passed to the action object.
  *
  * @return {Object} Action object.
  */
@@ -530,6 +531,7 @@ export function insertBlock(
 	index,
 	rootClientId,
 	updateSelection,
+	initialPosition,
 	meta
 ) {
 	return insertBlocks(
@@ -537,7 +539,7 @@ export function insertBlock(
 		index,
 		rootClientId,
 		updateSelection,
-		0,
+		initialPosition,
 		meta
 	);
 }


### PR DESCRIPTION
## What?
Closes #18562.

The `insertBlock` is just a wrapper around `insertBlocks` actions, but it wasn't possible to prevent focusing on the block. PR updates the `insertBlock` argument to match the action it wraps around.

I think this was just overlooked in the original PR #28191.

## Testing Instructions
1. Open a post or page and run the actions from below.

Should log a warning:

```js
wp.data.dispatch( 'core/block-editor' ).insertBlock( wp.blocks.createBlock( 'core/image' ), 1, '', true, {} );
```

Should prevent focus:

```js
wp.data.dispatch( 'core/block-editor' ).insertBlock( wp.blocks.createBlock( 'core/image' ), 1, '', true, null );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="1182" height="124" alt="CleanShot 2026-02-04 at 13 59 00" src="https://github.com/user-attachments/assets/a0a3ca23-395a-4ec8-bebc-43073c5a3044" />
