### PR TITLE
Group Block: Fix preview display

### DIFF
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -43,7 +43,11 @@ export const settings = {
 				name: 'core/heading',
 				attributes: {
 					content: __( 'La Mancha' ),
-					textAlign: 'center',
+					style: {
+						typography: {
+							textAlign: 'center',
+						},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The textAlign attribute of the Heading block used in the Group block example has been moved to typography. #74383

The preview display had changed from before, so this fixes it.

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="293" height="322" alt="before" src="https://github.com/user-attachments/assets/52c7cd5e-2f5c-47e7-8023-4e0a1f072e4e" /> | <img width="293" height="322" alt="after" src="https://github.com/user-attachments/assets/251712a0-c45b-4d31-9a2c-58c5c1e0430b" /> |
