### PR TITLE
Playlist block: Remove border

### DIFF
--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -1,8 +1,6 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .wp-block-playlist {
-	border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-	border-radius: 2px;
 	padding: $grid-unit-20;
 
 	.wp-block-playlist__current-item {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the border around the playlist block.

## Why?
The playlist block doesn't need a border by default. Users can still add one if they want.

## How?
Remove CSS

## Testing Instructions
1. Enable experimental blocks
2. Add a playlist block
3. Confirm it has no border in the frontend
4. Add a border using block styles
5. Confirm you see the border in the frontend


## Screenshots or screencast <!-- if applicable -->
<img width="739" height="687" alt="Screenshot 2026-02-04 at 11 21 58" src="https://github.com/user-attachments/assets/ae464e89-570c-431b-81a9-9f02788be03d" />
