### PR TITLE
Notes: Introduce inline text note format

### DIFF
--- a/packages/editor/src/components/collab-sidebar/format.js
+++ b/packages/editor/src/components/collab-sidebar/format.js
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { comment as commentIcon } from '@wordpress/icons';
+import { isCollapsed } from '@wordpress/rich-text';
+import { store as interfaceStore } from '@wordpress/interface';
+
+/**
+ * Internal dependencies
+ */
+import { collabHistorySidebarName } from './constants';
+import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
+
+export const formatName = 'core/note';
+export const format = {
+	title: __( 'Note' ),
+	tagName: 'span',
+	className: 'wp-note',
+	attributes: {
+		'data-id': 'data-id',
+	},
+	edit: Edit,
+};
+
+function Edit( { value, isActive, activeAttributes } ) {
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { selectNote } = unlock( useDispatch( editorStore ) );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const { selectedNote } = useSelect( ( select ) => {
+		return {
+			selectedNote: unlock( select( editorStore ) ).getSelectedNote(),
+		};
+	}, [] );
+
+	if ( ! isActive && isCollapsed( value ) ) {
+		return null;
+	}
+
+	return (
+		<RichTextToolbarButton
+			name="unknown"
+			icon={ commentIcon }
+			title={ __( 'Note' ) }
+			onClick={ () => {
+				// @todo: Correctly handle multiple sidebars.
+				enableComplementaryArea( 'core', collabHistorySidebarName );
+				selectNote(
+					activeAttributes[ 'data-id' ]
+						? Number( activeAttributes[ 'data-id' ] )
+						: 'new',
+					{ focus: true }
+				);
+			} }
+			isActive={ isActive || selectedNote === 'new' }
+		/>
+	);
+}

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -26,6 +26,12 @@ import {
 import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as interfaceStore } from '@wordpress/interface';
+import {
+	RichTextData,
+	applyFormat,
+	create,
+	isCollapsed,
+} from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -174,8 +180,12 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { getCurrentPostId } = useSelect( editorStore );
-	const { getBlockAttributes, getSelectedBlockClientId } =
-		useSelect( blockEditorStore );
+	const {
+		getBlockAttributes,
+		getSelectedBlockClientId,
+		getSelectionStart,
+		getSelectionEnd,
+	} = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const onError = ( error ) => {
@@ -204,16 +214,48 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 				{ throwOnError: true }
 			);
 
+			if ( ! savedRecord?.id ) {
+				throw new Error( __( 'Failed to create the note.' ) );
+			}
+
+			const clientId = getSelectedBlockClientId();
+			const attributes = getBlockAttributes( clientId ) ?? {};
+			const start = getSelectionStart();
+			const end = getSelectionEnd();
+			const hasSelection = ! isCollapsed( {
+				start: start.offset,
+				end: end.offset,
+			} );
+			const newAttributes = {};
+			const record = attributes[ start.attributeKey ];
+
 			// If it's a main comment, update the block attributes with the comment id.
-			if ( ! parent && savedRecord?.id ) {
-				const clientId = getSelectedBlockClientId();
-				const metadata = getBlockAttributes( clientId )?.metadata;
-				updateBlockAttributes( clientId, {
-					metadata: {
-						...metadata,
-						noteId: savedRecord.id,
+			// Note: This doesn't work as well. Requires https://github.com/WordPress/gutenberg/pull/75147.
+			if ( ! parent && ! hasSelection ) {
+				newAttributes.metadata = {
+					...attributes.metadata,
+					noteId: savedRecord.id,
+				};
+			}
+
+			if ( hasSelection && record instanceof RichTextData ) {
+				const formatted = applyFormat(
+					create( { html: record } ),
+					{
+						type: 'core/note',
+						attributes: { 'data-id': String( savedRecord.id ) },
 					},
-				} );
+					start.offset,
+					end.offset
+				);
+
+				newAttributes[ start.attributeKey ] = new RichTextData(
+					formatted
+				);
+			}
+
+			if ( Object.keys( newAttributes ).length > 0 ) {
+				updateBlockAttributes( clientId, newAttributes );
 			}
 
 			createNotice(

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -10,6 +10,7 @@ import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { registerFormatType } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -33,6 +34,10 @@ import {
 import { focusCommentThread } from './utils';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
+import { formatName, format } from './format';
+
+// Register the note format.
+registerFormatType( formatName, format );
 
 function NotesSidebarContent( {
 	styles,


### PR DESCRIPTION
## What?
Requires #75147.
Alternative to #74852.

An early draft. Mostly a boilerplate for inline note format.

## Testing Instructions
1. Open a post or page.
2. Add paragraph or heading and text.
3. Select part of the text.
4. When the comment button appears. Click on it and add the note.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/48ac52e2-2316-4020-aad7-95cd484f53ec


