### PR TITLE
DOM: stripHTML & safeHTML: Reject non-string values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59368,6 +59368,9 @@
 			"dependencies": {
 				"@wordpress/deprecated": "file:../deprecated"
 			},
+			"devDependencies": {
+				"@wordpress/rich-text": "file:../rich-text"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -369,7 +369,7 @@ Strips scripts and on\* attributes from HTML.
 
 _Parameters_
 
--   _html_ `string`: HTML to sanitize.
+-   _html_ `string|RichTextData`: HTML to sanitize.
 
 _Returns_
 

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -47,6 +47,9 @@
 	"dependencies": {
 		"@wordpress/deprecated": "file:../deprecated"
 	},
+	"devDependencies": {
+		"@wordpress/rich-text": "file:../rich-text"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/dom/src/dom/safe-html.js
+++ b/packages/dom/src/dom/safe-html.js
@@ -4,15 +4,24 @@
 import remove from './remove';
 
 /**
+ * Mock the RichTextData to avoid making the `dom` package depend on `rich-text`
+ *
+ * @typedef {Object} RichTextData
+ * @property {Function} toHTMLString Method used for duck typing
+ */
+
+/**
  * Strips scripts and on* attributes from HTML.
  *
- * @param {string} html HTML to sanitize.
+ * @param {string|RichTextData} html HTML to sanitize.
  *
  * @return {string} The sanitized HTML.
  */
 export default function safeHTML( html ) {
+	const htmlString = typeof html === 'string' ? html : castToString( html );
+
 	const { body } = document.implementation.createHTMLDocument( '' );
-	body.innerHTML = html;
+	body.innerHTML = htmlString;
 	const elements = body.getElementsByTagName( '*' );
 	let elementIndex = elements.length;
 
@@ -35,4 +44,21 @@ export default function safeHTML( html ) {
 	}
 
 	return body.innerHTML;
+}
+
+/**
+ * Coerce a non-string value into a string-like one. This appeases the type
+ * checker while actually guarding against accidental passing of a
+ * non-RichTextData value.
+ *
+ * @param {any} maybeRichText String-like rich text
+ *
+ * @return {string} TypeScript-normalized string-like value
+ */
+function castToString( maybeRichText ) {
+	if ( typeof maybeRichText.toHTMLString === 'function' ) {
+		return maybeRichText;
+	}
+
+	return '';
 }

--- a/packages/dom/src/dom/safe-html.js
+++ b/packages/dom/src/dom/safe-html.js
@@ -4,7 +4,7 @@
 import remove from './remove';
 
 /**
- * Mock the RichTextData to avoid making the `dom` package depend on `rich-text`
+ * Mock to avoid making the `dom` package depend on `rich-text`
  *
  * @typedef {Object} RichTextData
  * @property {Function} toHTMLString Method used for duck typing
@@ -51,7 +51,7 @@ export default function safeHTML( html ) {
  * checker while actually guarding against accidental passing of a
  * non-RichTextData value.
  *
- * @param {any} maybeRichText String-like rich text
+ * @param {any} maybeRichText Either string-like rich text, or an invalid value
  *
  * @return {string} TypeScript-normalized string-like value
  */

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -1,7 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+
+/**
  * Internal dependencies
  */
 import {
+	safeHTML,
 	isHorizontalEdge,
 	placeCaretAtHorizontalEdge,
 	isTextField,
@@ -21,6 +27,28 @@ describe( 'DOM', () => {
 
 	afterEach( () => {
 		parent.remove();
+	} );
+
+	describe( 'safeHTML', () => {
+		it( 'should strip scripts and on* attributes from strings', () => {
+			expect(
+				safeHTML( '<p>hi<script>alert()</script>, friend</p>' )
+			).toBe( '<p>hi, friend</p>' );
+		} );
+
+		it( 'should strip scripts and on* attributes from RichText values', () => {
+			expect(
+				safeHTML(
+					RichTextData.fromHTMLString(
+						'<p>hi<script>alert()</script>, friend</p>'
+					)
+				)
+			).toBe( '<p>hi, friend</p>' );
+		} );
+
+		it( 'should reject other values', () => {
+			expect( safeHTML( {} ) ).toBe( '' );
+		} );
 	} );
 
 	describe( 'isHorizontalEdge', () => {


### PR DESCRIPTION
## What?

_Note that rich text is considered "string-like"._

Guard against unintended uses of DOM functions by rejecting non-string-like inputs. For example, this prevents `safeHTML` and `stripHTML` from returning the string `[object Object]` if called with an object.

Some sleight of hand is needed in order to check for `RichTextData` values without adding RichText as a dependency of DOM.

## Testing instructions

Open the post editor, then in your browser console call `wp.dom.safeHTML` with the following inputs:

```js
wp.dom.safeHTML('<p>hi<script>alert()</script>, friend</p>')
// -> "<p>hi, friend</p>"
// unchanged behaviour

wp.dom.safeHTML(wp.richText.RichTextData.fromHTMLString('<p>hi<script>alert()</script>, friend</p>'))
// -> "<p>hi, friend</p>"
// unchanged behaviour

wp.dom.safeHTML({})
// before -> '[object Object]'
// after -> ''
```