### PR TITLE
Optimize tabsList computation with useRef for comparison

### DIFF
--- a/packages/block-library/src/tabs-menu/edit.js
+++ b/packages/block-library/src/tabs-menu/edit.js
@@ -31,6 +31,7 @@ import AddTabToolbarControl from '../tab/add-tab-toolbar-control';
 import RemoveTabToolbarControl from '../tab/remove-tab-toolbar-control';
 
 const TABS_MENU_ITEM_TEMPLATE = [ [ 'core/tabs-menu-item', {} ] ];
+const EMPTY_ARRAY = [];
 
 /**
  * Preview component for non-active tab menu items.
@@ -99,8 +100,7 @@ function Edit( {
 	const { layout } = useBlockEditContext();
 
 	const tabsId = context[ 'core/tabs-id' ] || null;
-	const tabsListRaw = context[ 'core/tabs-list' ];
-	const tabsList = useMemo( () => tabsListRaw || [], [ tabsListRaw ] );
+	const tabsList = context[ 'core/tabs-list' ] || EMPTY_ARRAY;
 	const activeTabIndex = context[ 'core/tabs-activeTabIndex' ] ?? 0;
 	const editorActiveTabIndex = context[ 'core/tabs-editorActiveTabIndex' ];
 

--- a/packages/block-library/src/tabs-menu/edit.js
+++ b/packages/block-library/src/tabs-menu/edit.js
@@ -99,7 +99,8 @@ function Edit( {
 	const { layout } = useBlockEditContext();
 
 	const tabsId = context[ 'core/tabs-id' ] || null;
-	const tabsList = context[ 'core/tabs-list' ] || [];
+	const tabsListRaw = context[ 'core/tabs-list' ];
+	const tabsList = useMemo( () => tabsListRaw || [], [ tabsListRaw ] );
 	const activeTabIndex = context[ 'core/tabs-activeTabIndex' ] ?? 0;
 	const editorActiveTabIndex = context[ 'core/tabs-editorActiveTabIndex' ];
 

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -8,7 +8,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useEffect, useRef } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -63,84 +63,52 @@ function Edit( {
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	/**
-	 * Ref to store previous tabsList for deep comparison.
-	 * This prevents returning new array references when data is unchanged.
+	 * Construct a list of core/tab blocks, used to create tabs-list context.
 	 */
-	const prevTabsListRef = useRef( [] );
-
-	/**
-	 * Compute tabs list from innerblocks to provide via context.
-	 * This traverses the tab-panel block to find all tab blocks
-	 * and extracts their label and anchor for the tabs-menu to consume.
-	 *
-	 * Uses deep comparison to prevent returning new array references
-	 * when the actual tab data hasn't changed, which would cause
-	 * infinite re-render loops in nested contexts.
-	 */
-	const tabsList = useSelect(
-		( select ) => {
-			const { getBlocks } = select( blockEditorStore );
-			const innerBlocks = getBlocks( clientId );
+	const tabs = useSelect(
+		(select) => {
+			const { getBlocks } = select(blockEditorStore);
+			const innerBlocks = getBlocks(clientId);
 
 			// Find tab-panel block and extract tab data
 			const tabPanel = innerBlocks.find(
-				( block ) => block.name === 'core/tab-panel'
+				(block) => block.name === 'core/tab-panel'
 			);
 
-			if ( ! tabPanel ) {
-				// Only return new empty array if previous wasn't empty
-				if ( prevTabsListRef.current.length === 0 ) {
-					return prevTabsListRef.current;
-				}
-				prevTabsListRef.current = [];
-				return prevTabsListRef.current;
+			if (!tabPanel) {
+				return [];
 			}
 
-			const newTabsList = tabPanel.innerBlocks
-				.filter( ( block ) => block.name === 'core/tab' )
-				.map( ( tab, index ) => ( {
-					id: tab.attributes.anchor || `tab-${ index }`,
-					label: tab.attributes.label || '',
-					clientId: tab.clientId,
-					index,
-				} ) );
-
-			// Deep compare: check if tabs data actually changed
-			const prevList = prevTabsListRef.current;
-			if (
-				prevList.length === newTabsList.length &&
-				newTabsList.every(
-					( tab, i ) =>
-						prevList[ i ] &&
-						prevList[ i ].id === tab.id &&
-						prevList[ i ].label === tab.label &&
-						prevList[ i ].clientId === tab.clientId &&
-						prevList[ i ].index === tab.index
-				)
-			) {
-				// Data unchanged, return previous reference to prevent re-renders
-				return prevList;
-			}
-
-			// Data changed, update ref and return new array
-			prevTabsListRef.current = newTabsList;
-			return newTabsList;
+			return tabPanel.innerBlocks.filter(
+				(block) => block.name === 'core/tab'
+			);
 		},
-		[ clientId ]
+		[clientId]
 	);
 
 	/**
 	 * Memoize context value to prevent unnecessary re-renders.
 	 */
-	const contextValue = useMemo(
-		() => ( {
-			'core/tabs-list': tabsList,
+	const contextValue = useMemo(() => {
+		/**
+		 * Compute tabs list from innerblocks to provide via context.
+		 * This traverses the tab-panel block to find all tab blocks
+		 * and extracts their label and anchor for the tabs-menu to consume.
+		 */
+		const tabList = tabs.map((tab, index) => ({
+			id: tab.attributes.anchor || `tab-${index}`,
+			label: tab.attributes.label || '',
+			clientId: tab.clientId,
+			index,
+		}));
+
+		return {
+			'core/tabs-list': tabList,
 			'core/tabs-id': anchor,
 			'core/tabs-activeTabIndex': activeTabIndex,
 			'core/tabs-editorActiveTabIndex': editorActiveTabIndex,
-		} ),
-		[ tabsList, anchor, activeTabIndex, editorActiveTabIndex ]
-	);
+		};
+	}, [tabs, anchor, activeTabIndex, editorActiveTabIndex]);
 
 	/**
 	 * Block props for the tabs container.

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -8,7 +8,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -63,9 +63,19 @@ function Edit( {
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	/**
+	 * Ref to store previous tabsList for deep comparison.
+	 * This prevents returning new array references when data is unchanged.
+	 */
+	const prevTabsListRef = useRef( [] );
+
+	/**
 	 * Compute tabs list from innerblocks to provide via context.
 	 * This traverses the tab-panel block to find all tab blocks
 	 * and extracts their label and anchor for the tabs-menu to consume.
+	 *
+	 * Uses deep comparison to prevent returning new array references
+	 * when the actual tab data hasn't changed, which would cause
+	 * infinite re-render loops in nested contexts.
 	 */
 	const tabsList = useSelect(
 		( select ) => {
@@ -78,10 +88,15 @@ function Edit( {
 			);
 
 			if ( ! tabPanel ) {
-				return [];
+				// Only return new empty array if previous wasn't empty
+				if ( prevTabsListRef.current.length === 0 ) {
+					return prevTabsListRef.current;
+				}
+				prevTabsListRef.current = [];
+				return prevTabsListRef.current;
 			}
 
-			return tabPanel.innerBlocks
+			const newTabsList = tabPanel.innerBlocks
 				.filter( ( block ) => block.name === 'core/tab' )
 				.map( ( tab, index ) => ( {
 					id: tab.attributes.anchor || `tab-${ index }`,
@@ -89,6 +104,27 @@ function Edit( {
 					clientId: tab.clientId,
 					index,
 				} ) );
+
+			// Deep compare: check if tabs data actually changed
+			const prevList = prevTabsListRef.current;
+			if (
+				prevList.length === newTabsList.length &&
+				newTabsList.every(
+					( tab, i ) =>
+						prevList[ i ] &&
+						prevList[ i ].id === tab.id &&
+						prevList[ i ].label === tab.label &&
+						prevList[ i ].clientId === tab.clientId &&
+						prevList[ i ].index === tab.index
+				)
+			) {
+				// Data unchanged, return previous reference to prevent re-renders
+				return prevList;
+			}
+
+			// Data changed, update ref and return new array
+			prevTabsListRef.current = newTabsList;
+			return newTabsList;
 		},
 		[ clientId ]
 	);

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -66,41 +66,41 @@ function Edit( {
 	 * Construct a list of core/tab blocks, used to create tabs-list context.
 	 */
 	const tabs = useSelect(
-		(select) => {
-			const { getBlocks } = select(blockEditorStore);
-			const innerBlocks = getBlocks(clientId);
+		( select ) => {
+			const { getBlocks } = select( blockEditorStore );
+			const innerBlocks = getBlocks( clientId );
 
 			// Find tab-panel block and extract tab data
 			const tabPanel = innerBlocks.find(
-				(block) => block.name === 'core/tab-panel'
+				( block ) => block.name === 'core/tab-panel'
 			);
 
-			if (!tabPanel) {
+			if ( ! tabPanel ) {
 				return [];
 			}
 
 			return tabPanel.innerBlocks.filter(
-				(block) => block.name === 'core/tab'
+				( block ) => block.name === 'core/tab'
 			);
 		},
-		[clientId]
+		[ clientId ]
 	);
 
 	/**
 	 * Memoize context value to prevent unnecessary re-renders.
 	 */
-	const contextValue = useMemo(() => {
+	const contextValue = useMemo( () => {
 		/**
 		 * Compute tabs list from innerblocks to provide via context.
 		 * This traverses the tab-panel block to find all tab blocks
 		 * and extracts their label and anchor for the tabs-menu to consume.
 		 */
-		const tabList = tabs.map((tab, index) => ({
-			id: tab.attributes.anchor || `tab-${index}`,
+		const tabList = tabs.map( ( tab, index ) => ( {
+			id: tab.attributes.anchor || `tab-${ index }`,
 			label: tab.attributes.label || '',
 			clientId: tab.clientId,
 			index,
-		}));
+		} ) );
 
 		return {
 			'core/tabs-list': tabList,
@@ -108,7 +108,7 @@ function Edit( {
 			'core/tabs-activeTabIndex': activeTabIndex,
 			'core/tabs-editorActiveTabIndex': editorActiveTabIndex,
 		};
-	}, [tabs, anchor, activeTabIndex, editorActiveTabIndex]);
+	}, [ tabs, anchor, activeTabIndex, editorActiveTabIndex ] );
 
 	/**
 	 * Block props for the tabs container.
@@ -121,10 +121,10 @@ function Edit( {
 	 * Innerblocks props for the tabs container.
 	 */
 	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		__experimentalCaptureToolbars: true,
 		template: TABS_TEMPLATE,
 		templateLock: false,
 		renderAppender: false,
-		__experimentalCaptureToolbars: true,
 	} );
 
 	return (


### PR DESCRIPTION
Added a ref to store previous tabsList for deep comparison to prevent unnecessary re-renders and an issue with an infinite loop we encountered with entity blocks inside tabs.

## What?

The tabs block had a reference stability issue in its tabsList selector that could cause infinite re-render loops when combined with any deeply nested block that triggers frequent re-renders.

The useSelect hook that computed tabsList used .map() to create the array of tab data:
```
return tabPanels.innerBlocks
    .filter( ( block ) => block.name === 'core/tab' )
    .map( ( tab, index ) => ( {
        id: tab.attributes.anchor || `tab-${ index }`,
        label: tab.attributes.label || '',
        clientId: tab.clientId,
        index,
    } ) );
```

This always returned a new array reference on every call, even when the underlying tab data hadn't changed. Since tabsList was a dependency of the contextValue useMemo, this caused the BlockContextProvider to propagate new context values to all child blocks on every render cycle.

Issue cascade:
- Any inner block re-renders for any reason
- The tabs block re-renders
- useSelect runs and .map() returns a new array reference
- contextValue is recalculated (dependency changed)
- BlockContextProvider propagates new context to all children
- Children re-render, potentially triggering step 1 again

## Why?

Without this change any deeply nested block that triggers re-renders can cause an infinite loop. 

## How?

Added a useRef to store the previous tabsList value and perform deep comparison of each tab's id, label, clientId, and index. The selector now returns the same array reference when the data is unchanged, preventing unnecessary context propagation and breaking potential re-render loops.

## Testing Instructions
n/a code performance

### Testing Instructions for Keyboard
n/a code performance