### PR TITLE
RichText: Avoid stale active formats when deleting the text

### DIFF
--- a/packages/rich-text/src/component/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/component/event-listeners/input-and-selection.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getActiveFormats } from '../../get-active-formats';
+import { isCollapsed } from '../../is-collapsed';
 import { updateFormats } from '../../update-formats';
 
 /**
@@ -88,12 +89,18 @@ export default ( props ) => ( element ) => {
 		const currentValue = createRecord();
 		const { start, activeFormats: oldActiveFormats = [] } = record.current;
 
+		// When a non-collapsed selection is deleted (not replaced with new
+		// text), the old active formats refer to the deleted content and
+		// should not be carried forward.
+		const isDelete =
+			! isCollapsed( record.current ) && currentValue.start <= start;
+
 		// Update the formats between the last and new caret position.
 		const change = updateFormats( {
 			value: currentValue,
 			start,
 			end: currentValue.start,
-			formats: oldActiveFormats,
+			formats: isDelete ? [] : oldActiveFormats,
 		} );
 
 		handleChange( change );

--- a/packages/rich-text/src/component/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/component/event-listeners/input-and-selection.js
@@ -92,7 +92,7 @@ export default ( props ) => ( element ) => {
 		// When a non-collapsed selection is deleted (not replaced with new
 		// text), the old active formats refer to the deleted content and
 		// should not be carried forward.
-		const isDelete =
+		const clearFormats =
 			! isCollapsed( record.current ) && currentValue.start <= start;
 
 		// Update the formats between the last and new caret position.
@@ -100,7 +100,7 @@ export default ( props ) => ( element ) => {
 			value: currentValue,
 			start,
 			end: currentValue.start,
-			formats: isDelete ? [] : oldActiveFormats,
+			formats: clearFormats ? [] : oldActiveFormats,
 		} );
 
 		handleChange( change );


### PR DESCRIPTION
## What?
Closes #16627.
Alternative to #70073. Uses `onInput` callback instead of delete event listener.

PR fixes an issue where RichText formats receive stale active formats, even when formatted text is no longer part of the value.

## Why?
See ##16627.

## Testing Instructions
1. Open a post or page.
2. Add a paragraph with text.
3. Select a section of the text and link it.
4. Fully select the linked text. Ensure that the preview popover is displayed.
5. Delete the text.
6. Confirm that the popover is no longer displayed.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/50489abe-fa51-4a7e-960c-b66633334fb2

**After**

https://github.com/user-attachments/assets/eeb371f4-8b27-4030-8285-1a36459639eb

