### PR TITLE
Navigation link: fix resetting link from the tools panel

### DIFF
--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -176,12 +176,9 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				onDeselect={ () =>
 					setAttributes( {
 						url: undefined,
-						label: undefined,
 						id: undefined,
 						kind: undefined,
 						type: undefined,
-						opensInNewTab: false,
-						rel: undefined,
 					} )
 				}
 				isShownByDefault

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -173,7 +173,16 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 			<ToolsPanelItem
 				hasValue={ () => !! url }
 				label={ __( 'Link to' ) }
-				onDeselect={ () => setAttributes( { url: '' } ) }
+				onDeselect={ () =>
+					setAttributes( {
+						url: undefined,
+						label: undefined,
+						id: undefined,
+						kind: undefined,
+						type: undefined,
+						opensInNewTab: false,
+					} )
+				}
 				isShownByDefault
 			>
 				<LinkPicker

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -181,6 +181,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						kind: undefined,
 						type: undefined,
 						opensInNewTab: false,
+						rel: undefined,
 					} )
 				}
 				isShownByDefault


### PR DESCRIPTION
## What?
Resetting 'Link to' for the nav link (or submenu) block using the tools panel interface doesn't seem to have the desired effect.

## Why?
The code only resets the `url` attribute, but I think since the introduction of bindings (and a dynamic URL) for navigation links the `id` is the most important attribute, along with the `kind` and `type`. 

## How?
In this PR I've updated the attributes that are reset to `url`, `id`, `kind` and `type`. These are all the things that are used to determine the href of the link.

I did consider whether the reset logic should be closer to this other code:
https://github.com/WordPress/gutenberg/blob/e2d8385f01f5995cf69bdfb40b8b4d9c8015eed0/packages/block-library/src/navigation-link/edit.js#L274-L291

It would mean one `ToolsPanelItem` resetting the value of other `ToolsPanelItem`s (label, opens in new tab etc., pretty much all of them), which does feels wrong in some ways but right in others. If any reviewer knows how it should work, feel free to push a commit to change the attributes that are reset.

## Testing Instructions
1. Add a navigation block somewhere
2. Insert a nav link into the navigation block and link to a page (not a custom url)
3. Select the nav link, and from the tools panel in the sidebar click the little dropdown
4. Select 'Link to    RESET' from the dropdown
5. Observe that the link field is now unset

In trunk: The link isn't reset.

## Screenshots or screencast <!-- if applicable -->

#### Before

https://github.com/user-attachments/assets/5b21ef4c-4d7b-4d70-ad26-406d50db2efa

#### After

https://github.com/user-attachments/assets/07116d35-c20e-4a17-a746-adf37a5ea459

