### PR TITLE
Fixed: Custom colors are now reflected in the editor for heading blocks.

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -17,12 +17,20 @@ import { generateAnchor, setAnchor } from './autogenerate-anchors';
 import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
 function HeadingEdit( props ) {
-	const { attributes, setAttributes, mergeBlocks, onReplace, clientId } =
-		props;
+	const {
+		attributes,
+		setAttributes,
+		mergeBlocks,
+		onReplace,
+		style,
+		clientId,
+	} = props;
 	useDeprecatedTextAlign( props );
 	const { content, level, placeholder, anchor } = attributes;
 	const tagName = 'h' + level;
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		style,
+	} );
 
 	const { canGenerateAnchors } = useSelect( ( select ) => {
 		const { getGlobalBlockCount, getSettings } = select( blockEditorStore );

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -20,11 +20,9 @@ function HeadingEdit( props ) {
 	const { attributes, setAttributes, mergeBlocks, onReplace, clientId } =
 		props;
 	useDeprecatedTextAlign( props );
-	const { style, content, level, placeholder, anchor } = attributes;
+	const { content, level, placeholder, anchor } = attributes;
 	const tagName = 'h' + level;
-	const blockProps = useBlockProps( {
-		style,
-	} );
+	const blockProps = useBlockProps();
 
 	const { canGenerateAnchors } = useSelect( ( select ) => {
 		const { getGlobalBlockCount, getSettings } = select( blockEditorStore );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75223


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page
2. Insert a heading block. 
3. You can confirm that custom colors are reflected in the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before


https://github.com/user-attachments/assets/61e652a6-f40d-411c-b5eb-a91eabfa674a



### After
https://github.com/user-attachments/assets/d188926f-87f0-40f4-9e5b-57f03fe4ab00

