### PR TITLE
Workflows: Ignore icons manifest for manual backports

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -18,6 +18,7 @@ on:
             - '!packages/block-serialization-default-parser/**'
             - '!packages/widgets/**'
             - '!packages/e2e-tests/**'
+            - '!packages/icons/src/manifest.php'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.


### PR DESCRIPTION
## What?
This is a follow-up to #74943.

Adds `packages/icons/src/manifest.php` to the ignored paths for manual backports. The WP build process will handle syncing. See https://github.com/WordPress/wordpress-develop/pull/10795.

## Testing Instructions
Confirm that the ignore pattern is correct. Testing these changes without merging the workflow is difficult.