### PR TITLE
Real-time collaboration: Update 'sync.providers' filter inline comments

### DIFF
--- a/packages/sync/src/providers/index.ts
+++ b/packages/sync/src/providers/index.ts
@@ -42,11 +42,11 @@ export function getProviderCreators(): ProviderCreator[] {
 	}
 
 	/**
-	 * Filter the
+	 * Filter the available provider creators.
 	 */
 	const filteredProviderCreators: unknown = applyFilters(
 		'sync.providers',
-		[] // Replace with `getDefaultProviderCreators()` to enable sync
+		[] // Replace `[]` with `getDefaultProviderCreators()` to enable sync.
 	);
 
 	// If the returned value is not an array, ignore and set to empty array.


### PR DESCRIPTION
## What?
A minor follow-up to #72183.

PR updates `sync.providers` filter inline comments:

* Finish the doc-block comment text.
* Clarify that the empty array needs to be replaced.

## Testing Instructions
None. Check that changes make sense.
