### PR TITLE
Fix: Navigation Overlay Close Block: Add missing @since tag #75247

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/index.php
+++ b/packages/block-library/src/navigation-overlay-close/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/navigation-overlay-close` block on server.
  *
+ * @since 7.0.0
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the block content.


### PR DESCRIPTION
Changes Summary
Updated the docblock for 
render_block_core_navigation_overlay_close
 to include @since 7.0.0.