### PR TITLE
Real-time collaboration: Make the collaborators presense button translatable

### DIFF
--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -4,6 +4,7 @@ import {
 	privateApis,
 	type PostEditorAwarenessState,
 } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
 
 import { Avatar } from './avatar';
 import { CollaboratorsList } from './list';
@@ -64,7 +65,11 @@ export function CollaboratorsPresence( {
 				onClick={ () => setIsPopoverVisible( ! isPopoverVisible ) }
 				isPressed={ isPopoverVisible }
 				ref={ setPopoverAnchor }
-				aria-label={ `Collaborators list, ${ otherActiveUsers.length } online` }
+				aria-label={ sprintf(
+					// translators: %d: number of online collaborators.
+					__( 'Collaborators list, %d online' ),
+					otherActiveUsers.length
+				) }
 			>
 				{ visibleUsers.map( ( userState ) => (
 					<Avatar


### PR DESCRIPTION
## What?
This is a follow-up to #75065.

PR makes `aria-label` in `CollaboratorsPresence` component translatable.

## Testing Instructions
It's a minor fix. Just wraps text into translation functions.
