### PR TITLE
Real-time Collaboration: Remove disconnected users from Awareness

### DIFF
--- a/packages/core-data/src/awareness/awareness-state.ts
+++ b/packages/core-data/src/awareness/awareness-state.ts
@@ -165,6 +165,8 @@ export abstract class AwarenessState<
 
 		this.hasSetupRun = true;
 
+		this.onSetUp();
+
 		this.on(
 			'change',
 			( { added, removed, updated }: AwarenessStateChange ) => {
@@ -186,8 +188,6 @@ export abstract class AwarenessState<
 				this.updateSubscribers();
 			}
 		);
-
-		this.onSetUp();
 	};
 
 	/**

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -5,6 +5,7 @@ import * as Y from 'yjs';
 import * as encoding from 'lib0/encoding';
 import * as decoding from 'lib0/decoding';
 import type { Awareness } from 'y-protocols/awareness';
+import { removeAwarenessStates } from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
 
 /**
@@ -162,14 +163,21 @@ function processAwarenessUpdate(
 		}
 	} );
 
-	if ( added.size + updated.size + removed.size > 0 ) {
+	if ( added.size + updated.size > 0 ) {
 		awareness.emit( 'change', [
 			{
 				added: Array.from( added ),
 				updated: Array.from( updated ),
-				removed: Array.from( removed ),
 			},
 		] );
+	}
+
+	if ( removed.size > 0 ) {
+		removeAwarenessStates(
+			awareness,
+			Array.from( removed ),
+			POLLING_MANAGER_ORIGIN
+		);
 	}
 }
 


### PR DESCRIPTION
## What?

Disconnected users should be removed from the default provider's awareness state.

## Why?

It's important to always keep the awareness state updated. Any client that disconnects should be removed from the awareness state, and should not be left behind.

## How?

The default provider wasn't correctly updating the clients that should be removed. It was only emitting a change, but not actually making a change to the awareness which is what it should be doing.

## Testing Instructions

1. Enable the default provider
2. Open up two browser sessions
3. Make changes in both of em
4. Ensure the collaborator list shows one person in each session
5. Close one session
6. Wait a few seconds and watch the list vanish as no one else is collaborating.
7. Previously, it would keep enabling and disabling the other user.

### Testing Instructions for Keyboard

N/A
