### PR TITLE
Docs: Remove private GitHub team links in repository management

### DIFF
--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -156,9 +156,9 @@ If you’d like a template to follow:
 
 Two GitHub teams are used in the project.
 
--   [Gutenberg Core](https://github.com/orgs/WordPress/teams/gutenberg-core): A team composed of people that are actively involved in the project: attending meetings regularly, participating in triage sessions, performing reviews regularly, working on features and bug fixes and performing plugin and npm releases.
+-   Gutenberg Core: A team composed of people that are actively involved in the project: attending meetings regularly, participating in triage sessions, performing reviews regularly, working on features and bug fixes and performing plugin and npm releases.
 
--   [Gutenberg](https://github.com/orgs/WordPress/teams/gutenberg): A team composed of contributors with at least 2–3 meaningful contributions to the project.
+-   Gutenberg: A team composed of contributors with at least 2–3 meaningful contributions to the project.
 
 If you meet this criterion of several meaningful contributions having been accepted into the repository and would like to be added to the Gutenberg team, feel free to ask in the [#core-editor Slack channel](https://make.wordpress.org/chat/).
 


### PR DESCRIPTION
Fixes #75162

Removes links to private GitHub team pages and keeps team names as plain text.
