### PR TITLE
Navigation Link: Go to page link and edit page for inspector sidebar

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -63,6 +63,10 @@ import {
 } from './components/block-list/use-block-props/use-block-refs';
 import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
+import {
+	isHashLink,
+	isRelativePath,
+} from './components/link-control/is-url-like';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -122,4 +126,6 @@ lock( privateApis, {
 	useBlockElementRef,
 	LinkPicker,
 	useRemoteUrlData,
+	isHashLink,
+	isRelativePath,
 } );

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -245,6 +245,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						attributes.kind === 'post-type' &&
 						onNavigateToEntityRecord && (
 							<Button
+								size="compact"
 								variant="secondary"
 								onClick={ () => {
 									onNavigateToEntityRecord( {
@@ -263,6 +264,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						) }
 					{ isViewableUrl && (
 						<Button
+							size="compact"
 							variant="secondary"
 							href={ viewUrl }
 							target="_blank"

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -178,6 +178,11 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	const viewUrl =
 		isViewableUrl && url.startsWith( '/' ) && homeUrl ? homeUrl + url : url;
 
+	const entityTypeName = getEntityTypeName(
+		attributes.type,
+		attributes.kind
+	);
+
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
@@ -230,9 +235,8 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 			{ url && (
 				<HStack
 					className="navigation-link-to__actions"
-					alignment="stretch"
-					expanded
-					justify="stretch"
+					alignment="left"
+					justify="left"
 					style={ { gridColumn: '1 / -1' } }
 				>
 					{ hasUrlBinding &&
@@ -253,10 +257,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 								{ sprintf(
 									/* translators: %s: entity type (e.g., "page", "post", "category") */
 									__( 'Edit %s' ),
-									getEntityTypeName(
-										attributes.type,
-										attributes.kind
-									)
+									entityTypeName
 								) }
 							</Button>
 						) }
@@ -270,12 +271,11 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 							__next40pxDefaultSize
 						>
 							{ sprintf(
-								/* translators: %s: entity type (e.g., "page", "post", "category") */
+								/* translators: %s: entity type (e.g., "page", "post", "category") or "site" for external links */
 								__( 'View %s' ),
-								getEntityTypeName(
-									attributes.type,
-									attributes.kind
-								)
+								entityTypeName !== 'item'
+									? entityTypeName
+									: __( 'site' )
 							) }
 						</Button>
 					) }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -2,17 +2,23 @@
  * WordPress dependencies
  */
 import {
+	Button,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalHStack as HStack,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import {
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -139,6 +145,12 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		[ entityRecord?.featured_media ]
 	);
 
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+		[]
+	);
+
 	const preview = useLinkPreview( {
 		url,
 		title: linkTitle,
@@ -197,6 +209,59 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 					help={ helpText ? helpText : undefined }
 				/>
 			</ToolsPanelItem>
+
+			{ url && (
+				<HStack
+					className="navigation-link-to__actions"
+					alignment="stretch"
+					expanded
+					justify="stretch"
+					style={ { gridColumn: '1 / -1' } }
+				>
+					{ hasUrlBinding &&
+						isBoundEntityAvailable &&
+						entityRecord?.id &&
+						attributes.kind === 'post-type' &&
+						onNavigateToEntityRecord && (
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									onNavigateToEntityRecord( {
+										postId: entityRecord.id,
+										postType: attributes.type,
+									} );
+								} }
+								__next40pxDefaultSize
+							>
+								{ sprintf(
+									/* translators: %s: entity type (e.g., "page", "post", "category") */
+									__( 'Edit %s' ),
+									getEntityTypeName(
+										attributes.type,
+										attributes.kind
+									)
+								) }
+							</Button>
+						) }
+					<Button
+						variant="minimal"
+						href={ url }
+						target="_blank"
+						icon={ external }
+						iconPosition="right"
+						__next40pxDefaultSize
+					>
+						{ sprintf(
+							/* translators: %s: entity type (e.g., "page", "post", "category") */
+							__( 'View %s' ),
+							getEntityTypeName(
+								attributes.type,
+								attributes.kind
+							)
+						) }
+					</Button>
+				</HStack>
+			) }
 
 			<ToolsPanelItem
 				hasValue={ () => !! opensInNewTab }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -31,7 +31,9 @@ import { useLinkPreview } from './use-link-preview';
 import { useIsInvalidLink } from './use-is-invalid-link';
 import { unlock } from '../../lock-unlock';
 
-const { LinkPicker } = unlock( blockEditorPrivateApis );
+const { LinkPicker, isHashLink, isRelativePath } = unlock(
+	blockEditorPrivateApis
+);
 
 /**
  * Get a human-readable entity type name.
@@ -151,6 +153,11 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		[]
 	);
 
+	const homeUrl = useSelect( ( select ) => {
+		return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+			?.home;
+	}, [] );
+
 	const preview = useLinkPreview( {
 		url,
 		title: linkTitle,
@@ -160,6 +167,16 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		hasBinding: hasUrlBinding,
 		isEntityAvailable: isBoundEntityAvailable,
 	} );
+
+	// Check if URL is viewable (not hash link or other relative path like ./ or ../)
+	const isViewableUrl =
+		url &&
+		( ! isHashLink( url ) ||
+			( isRelativePath( url ) && ! url.startsWith( '/' ) ) );
+
+	// Construct full URL for viewing (prepend home URL for absolute paths starting with /)
+	const viewUrl =
+		isViewableUrl && url.startsWith( '/' ) && homeUrl ? homeUrl + url : url;
 
 	return (
 		<ToolsPanel
@@ -243,23 +260,25 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 								) }
 							</Button>
 						) }
-					<Button
-						variant="minimal"
-						href={ url }
-						target="_blank"
-						icon={ external }
-						iconPosition="right"
-						__next40pxDefaultSize
-					>
-						{ sprintf(
-							/* translators: %s: entity type (e.g., "page", "post", "category") */
-							__( 'View %s' ),
-							getEntityTypeName(
-								attributes.type,
-								attributes.kind
-							)
-						) }
-					</Button>
+					{ isViewableUrl && (
+						<Button
+							variant="secondary"
+							href={ viewUrl }
+							target="_blank"
+							icon={ external }
+							iconPosition="right"
+							__next40pxDefaultSize
+						>
+							{ sprintf(
+								/* translators: %s: entity type (e.g., "page", "post", "category") */
+								__( 'View %s' ),
+								getEntityTypeName(
+									attributes.type,
+									attributes.kind
+								)
+							) }
+						</Button>
+					) }
 				</HStack>
 			) }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Helps address https://github.com/WordPress/gutenberg/issues/71759 and https://github.com/WordPress/gutenberg/issues/72623


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Give a means to view the page and edit the page from the navigation link inspector sidebar. At the moment, if you want to edit or publish a draft page to resolve the draft page not showing on the frontpage, you hav to go back to the page list and find it. This gives a route to more quickly publish or navigate to your page. The View link also gives the ability to check your page route for confidence.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add edit and page links to the sidebar under the Link to section.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Check navigation links in inspector sidebar
- Internal entity bound pages will show "Edit {entity type}"
- External full links will show "View 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
<img width="481" height="303" alt="Edit page and View page links" src="https://github.com/user-attachments/assets/6998f6dd-071c-436d-ae3f-9e73a7efc73e" />
