### PR TITLE
iAPI Docs: Add client-side navigation guide under "Core Concepts"

### DIFF
--- a/docs/reference-guides/interactivity-api/core-concepts/README.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/README.md
@@ -9,3 +9,5 @@ This section provides some guides on important concepts and mental models relate
 3. **[Server-side rendering: Processing directives on the server](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md):** The Interactivity API allows WordPress to use server-side rendering to create interactive and state-aware HTML, smoothly connected with client-side features while maintaining performance and SEO benefits.
 
 4. **[Using TypeScript](/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md):** This guide will walk you through the process of using TypeScript with Interactivity API stores, covering everything from basic type definitions to advanced techniques for handling complex store structures.
+
+5. **[Client-Side Navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md):** This guide explains how to use the `@wordpress/interactivity-router` package to implement client-side navigation, enabling faster page transitions by updating only the parts of the page that change.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -24,17 +24,25 @@ This approach offers several benefits:
 
 ## Getting started with the Interactivity Router
 
-The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. To use it in your interactive blocks, you need to:
+The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. If you are starting a new project, the easiest way to get set up is using the [`@wordpress/create-block-interactive-template`](https://www.npmjs.com/package/@wordpress/create-block-interactive-template) scaffolding tool, which creates a block with the Interactivity API already configured:
 
-1. **Add the dependency**: Ensure `@wordpress/interactivity-router` is listed as a dependency for your script module.
-2. **Define router regions**: Mark the HTML elements that should be updated during navigation.
-3. **Trigger navigation**: Use the `actions.navigate()` function to navigate programmatically.
+```bash
+npx @wordpress/create-block@latest my-interactive-block --template @wordpress/create-block-interactive-template
+```
+
+If you already have an interactive block and want to add client-side navigation, you need to:
+
+1. **Add the router dependency**: Add `@wordpress/interactivity-router` as a dependency of your block's script module. This is typically done by dynamically importing the package in your `view.js` file (as shown in the examples below), which ensures it is only loaded when needed.
+2. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
+3. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
 
 For detailed API documentation, see the [`@wordpress/interactivity-router` package README](/packages/interactivity-router/README.md).
 
 ### Setting up router regions
 
-First, define router regions in your block's markup:
+Router regions are the parts of your page that the router will update during client-side navigation. You mark them with the `data-wp-router-region` directive, which takes a unique ID as its value. When navigation occurs, the router matches regions on the current page with regions on the target page by their IDs and replaces their content — leaving everything outside router regions untouched.
+
+Define a router region in your block's markup by adding `data-wp-router-region` alongside `data-wp-interactive`:
 
 ```php
 // render.php
@@ -54,7 +62,20 @@ First, define router regions in your block's markup:
 
 ### Implementing navigation
 
-Use `navigate()` to handle link clicks:
+To trigger client-side navigation, you define an **action** in your block's store and connect it to a DOM event using an Interactivity API directive. Actions are functions defined inside `store()` that handle user interactions — similar to event handlers in other frameworks. When connected to an element through a directive like `data-wp-on--click`, the action runs whenever that event fires.
+
+Here's how to implement a link that navigates client-side. First, the HTML in your block's `render.php` connects the link's click event to the `navigateTo` action:
+
+```html
+<a
+    data-wp-on--click="actions.navigateTo"
+    href="/page-2/"
+>
+    Go to Page 2
+</a>
+```
+
+Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
 
 ```js
 // view.js
@@ -74,20 +95,25 @@ store( 'myPlugin', {
 } );
 ```
 
-```html
-<a
-    data-wp-on--click="actions.navigateTo"
-    href="/page-2/"
->
-    Go to Page 2
-</a>
-```
-
 _Note: The `withSyncEvent()` wrapper is required for actions that need to call synchronous event methods like `event.preventDefault()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details._
 
 ### Implementing prefetching
 
-Use `prefetch()` to load pages before navigation:
+The router also provides a `prefetch()` function that fetches a page and stores it in an internal cache without performing navigation. By prefetching pages before the user clicks, subsequent navigations feel instant because the content is already available.
+
+A common pattern is to prefetch a page when the user hovers over a link, and navigate when they click. You can combine both behaviors on the same element using two directives — `data-wp-on--mouseenter` for prefetching and `data-wp-on--click` for navigation:
+
+```html
+<a
+    data-wp-on--mouseenter="actions.prefetchPage"
+    data-wp-on--click="actions.navigateTo"
+    href="/page-2/"
+>
+    Hover to prefetch, click to navigate
+</a>
+```
+
+The corresponding actions in `view.js` handle each event:
 
 ```js
 // view.js
@@ -114,19 +140,11 @@ store( 'myPlugin', {
 } );
 ```
 
-```html
-<a
-    data-wp-on--mouseenter="actions.prefetchPage"
-    data-wp-on--click="actions.navigateTo"
-    href="/page-2/"
->
-    Hover to prefetch, click to navigate
-</a>
-```
-
 ### Complete example: Pagination
 
-Here's a complete example implementing client-side pagination:
+This example brings together router regions, navigation, and prefetching to implement client-side pagination for a list of posts.
+
+The block queries posts for the current page and renders them inside a router region. Pagination links at the bottom allow the user to move between pages. When the user hovers over a "Previous" or "Next" link, the target page is prefetched. When they click, the router navigates client-side — replacing only the content inside the router region without a full page reload. After navigation, the page scrolls smoothly to the top.
 
 **PHP (render.php):**
 ```php

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -426,7 +426,7 @@ const { state } = store( 'myPlugin', {
 } );
 ```
 
-For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md#subscribing-to-server-state-and-context) guide.
 
 ### Overriding cached pages
 
@@ -1020,7 +1020,7 @@ These functions are reactive. When used inside a callback or derived state gette
 
 This is different from the regular `state` and `getContext()`, which return the client-side state and context. As explained above, existing client-side values are not overwritten during navigation, so `state` and `getContext()` will keep reflecting whatever the client had before navigating. Use `getServerState()` and `getServerContext()` when you need to react to the values that the server sent for the new page.
 
-For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md#subscribing-to-server-state-and-context) guide.
 
 ### Putting it all together: the navigation flow
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -4,6 +4,32 @@ Client-side navigation is a technique that allows navigation between pages witho
 
 The Interactivity API provides client-side navigation through the `@wordpress/interactivity-router` package. This package enables you to implement region-based navigation, where only specific parts of your page are updated when navigating between URLs.
 
+## Table of contents
+
+- [How client-side navigation works](#how-client-side-navigation-works)
+- [Getting started with the Interactivity Router](#getting-started-with-the-interactivity-router)
+    - [Setting up router regions](#setting-up-router-regions)
+    - [Implementing navigation](#implementing-navigation)
+    - [Implementing prefetching](#implementing-prefetching)
+    - [Complete example: Pagination](#complete-example-pagination)
+- [More advanced use cases](#more-advanced-use-cases)
+    - [Adding new regions on navigation](#adding-new-regions-on-navigation)
+    - [Handling server state updates](#handling-server-state-updates)
+    - [Overriding cached pages](#overriding-cached-pages)
+    - [Using custom HTML](#using-custom-html)
+    - [Managing browser history](#managing-browser-history)
+    - [Changing the timeout](#changing-the-timeout)
+    - [Handling fetch errors](#handling-fetch-errors)
+    - [Disabling client-side navigation on certain pages](#disabling-client-side-navigation-on-certain-pages)
+    - [Disabling navigation feedback](#disabling-navigation-feedback)
+- [The Interactivity Router in depth](#the-interactivity-router-in-depth)
+    - [The page cache](#the-page-cache)
+    - [Router regions](#router-regions)
+    - [CSS handling](#css-handling)
+    - [Script module handling](#script-module-handling)
+    - [Server state and context](#server-state-and-context)
+    - [Putting it all together: the navigation flow](#putting-it-all-together-the-navigation-flow)
+
 ## How client-side navigation works
 
 When a user triggers a navigation (for example, by clicking a link), the Interactivity Router:

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -326,7 +326,9 @@ When navigating from Page 1 to Page 2, the modal region is created and appended 
 
 ### Handling server state updates
 
-During client-side navigation, the client-side state persists while the server provides new state for the target page. Use `getServerState()` and `getServerContext()` to react specifically to server-provided values.
+During client-side navigation, the client-side state persists while the server provides new state for the target page. In some cases, you may want parts of your client state to stay in sync with what the server provides for each page — for example, updating a product count that changes across pages, or resetting an "expanded" flag based on the new page's context.
+
+Use `getServerState()` and `getServerContext()` to react specifically to server-provided values and selectively update the client state in a callback:
 
 ```js
 import {
@@ -343,11 +345,12 @@ const { state } = store( 'myPlugin', {
             const serverContext = getServerContext();
             const context = getContext();
 
-            // Update client state with server values selectively.
+            // Keep the product count in sync with the server across navigations.
             if ( serverState.productCount !== undefined ) {
                 state.productCount = serverState.productCount;
             }
 
+            // Reset the expanded state based on the new page's context.
             if ( serverContext.isExpanded !== undefined ) {
                 context.isExpanded = serverContext.isExpanded;
             }

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -11,7 +11,7 @@ The Interactivity API supports two navigation modes:
 
 ## How client-side navigation works
 
-When a user triggers a navigation (for example, by clicking a link), the Interactivity Router:
+When a user triggers a navigation, for example, by clicking a link that has a `data-wp-on--click` directive that calls `actions.navigate()`, the Interactivity Router:
 
 1. **Fetches the new page**: The router requests the HTML of the destination URL.
 2. **Parses the response**: It extracts the relevant regions, styles, scripts, and server-rendered data from the fetched HTML.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -2,7 +2,9 @@
 
 Client-side navigation is a technique that allows navigation between pages without requiring a full page reload. Instead of the browser fetching an entirely new HTML document from the server, client-side navigation fetches the new page's content and updates only the parts of the DOM that have changed. This results in faster, smoother page transitions and a more app-like user experience.
 
-The Interactivity API provides client-side navigation through the `@wordpress/interactivity-router` package. This package enables you to implement region-based navigation, where only specific parts of your page are updated when navigating between URLs.
+The Interactivity API provides client-side navigation through the `@wordpress/interactivity-router` package. The central concept is the **router region**: a section of your page that the router knows how to update during navigation. You mark these sections with the `data-wp-router-region` directive, and when the user navigates to a new URL, the router fetches the destination page and replaces only the content inside matching regions — leaving everything else on the page untouched.
+
+This is known as **region-based client-side navigation**, and it is the recommended approach for implementing client-side navigation in WordPress. There is also an experimental **full-page client-side navigation** mode, which treats the entire `<body>` element as a single region — effectively updating the whole page content without a traditional reload. Full-page navigation is covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
 
 ## Table of contents
 
@@ -29,6 +31,7 @@ The Interactivity API provides client-side navigation through the `@wordpress/in
     - [Script module handling](#script-module-handling)
     - [Server state and context](#server-state-and-context)
     - [Putting it all together: the navigation flow](#putting-it-all-together-the-navigation-flow)
+- [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental)
 
 ## How client-side navigation works
 
@@ -972,3 +975,20 @@ A subtle but important detail: users don't always wait for navigation to complet
 When `navigate()` is called, the router remembers the target URL. If another `navigate()` call comes in before the first completes, the router updates its target and the first navigation is abandoned. When the first navigation's fetch completes, it checks whether its URL is still the current target — if not, it simply returns without rendering.
 
 This ensures that rapid clicking through multiple links doesn't cause visual glitches or render stale content. Only the most recent navigation completes.
+
+## Full-page client-side navigation (experimental)
+
+Full-page client-side navigation is an experimental feature that extends the region-based approach described throughout this guide. Instead of requiring you to define individual router regions, full-page navigation treats the entire `<body>` element as a single region — effectively replacing all page content during navigation.
+
+This feature is only available in the Gutenberg plugin and must be enabled manually. To activate it, go to **Admin Panel > Gutenberg > Experiments** and check the **"Interactivity API: Full-page client-side navigation"** option.
+
+Once enabled, this mode automatically intercepts all link clicks and hover events on the page, triggering client-side navigation and prefetching without you needing to write any custom action handlers. It is available through a separate entry point in the router package:
+
+```js
+import '@wordpress/interactivity-router/full-page';
+```
+
+Full-page client-side navigation is essentially a special case of region-based navigation where there is only one region covering the whole page. Because it replaces all content, **every block on the page must be compatible with client-side navigation** — meaning all interactive blocks must use the Interactivity API (not jQuery or other libraries). See [Block compatibility](#block-compatibility) for details on how to declare block compatibility.
+
+> [!WARNING]
+> This feature is experimental and still under active development. It may not work correctly in all scenarios. If you try it out, please report any issues you encounter in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues). Contributions are also welcome!

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -38,8 +38,6 @@ If you already have an interactive block and want to add client-side navigation,
 2. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
 3. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
 
-For detailed API documentation, see the [`@wordpress/interactivity-router` package README](/packages/interactivity-router/README.md).
-
 ### Setting up router regions
 
 Router regions are the parts of your page that the router will update during client-side navigation. You mark them with the `data-wp-router-region` directive, which takes a unique ID as its value. When navigation occurs, the router matches regions on the current page with regions on the target page by their IDs and replaces their content — leaving everything outside router regions untouched.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -6,39 +6,6 @@ The Interactivity API provides client-side navigation through the `@wordpress/in
 
 This is known as **region-based client-side navigation**, and it is the recommended approach for implementing client-side navigation in WordPress. There is also an experimental **full-page client-side navigation** mode, which treats the entire `<body>` element as a single region — effectively updating the whole page content without a traditional reload. Full-page navigation is covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
 
-## Table of contents
-
-- [How client-side navigation works](#how-client-side-navigation-works)
-- [Getting started with the Interactivity Router](#getting-started-with-the-interactivity-router)
-    - [Setting up router regions](#setting-up-router-regions)
-    - [Implementing navigation](#implementing-navigation)
-    - [Implementing prefetching](#implementing-prefetching)
-    - [Complete example: Pagination](#complete-example-pagination)
-- [Block compatibility](#block-compatibility)
-    - [The `supports.interactivity` field](#the-supportsinteractivity-field)
-    - [Non-interactive blocks](#non-interactive-blocks)
-    - [Interactive blocks using the Interactivity API](#interactive-blocks-using-the-interactivity-api)
-    - [Interactive blocks using other libraries](#interactive-blocks-using-other-libraries)
-- [More advanced use cases](#more-advanced-use-cases)
-    - [Adding new regions on navigation](#adding-new-regions-on-navigation)
-    - [Handling server state updates](#handling-server-state-updates)
-    - [Overriding cached pages](#overriding-cached-pages)
-    - [Using custom HTML](#using-custom-html)
-    - [Managing browser history](#managing-browser-history)
-    - [Changing the timeout](#changing-the-timeout)
-    - [Handling fetch errors](#handling-fetch-errors)
-    - [Disabling client-side navigation on certain pages](#disabling-client-side-navigation-on-certain-pages)
-    - [Disabling navigation feedback](#disabling-navigation-feedback)
-    - [Subscribing to page changes](#subscribing-to-page-changes)
-- [The Interactivity Router in depth](#the-interactivity-router-in-depth)
-    - [The page cache](#the-page-cache)
-    - [Router regions](#router-regions)
-    - [CSS handling](#css-handling)
-    - [Script module handling](#script-module-handling)
-    - [Server state and context](#server-state-and-context)
-    - [Putting it all together: the navigation flow](#putting-it-all-together-the-navigation-flow)
-- [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental)
-
 ## How client-side navigation works
 
 When a user triggers a navigation (for example, by clicking a link), the Interactivity Router:

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -879,11 +879,9 @@ When the router fetches a new page, it extracts both types of server data:
 
 When navigation renders the new page, the server-provided data needs to merge with the existing client-side state. This merge follows specific rules:
 
-For global state, the new server state is deeply merged with the existing state. Properties from the server overwrite existing properties with the same path, but properties that exist only on the client are preserved. This allows client-side code to have modified the state (for example, incrementing a counter) while still receiving updates from the server for other properties.
+For global state, the server state does not overwrite existing client state properties. During navigation, only properties that don't already exist on the client are added. Existing client-side properties are preserved as-is. If you need the client state to reflect server changes during navigation, you must use `getServerState()` to subscribe to server state updates and then manually update the client state accordingly.
 
-For local context, the behavior depends on the region. When a region is updated, its new context (from the server) replaces the region's previous context. However, because the Interactivity API tracks both "server context" and "client context" separately, your code can choose whether to use the server-provided values or preserve client modifications.
-
-<!-- IMAGE: Diagram showing state merge. Left box shows "Existing Client State" with properties {a: 1, b: 2, c: 3}. Right box shows "New Server State" with properties {a: 10, d: 4}. Arrow points to "Merged Result" showing {a: 10, b: 2, c: 3, d: 4}. Caption explains that 'a' was overwritten by server, 'b' and 'c' preserved from client, 'd' added from server. -->
+For local context, the behavior is similar. The server context and client context are tracked separately by the Interactivity API. During navigation, the server context is updated with the values from the new page, but the client context is not automatically overwritten. You can use `getServerContext()` to read the server-provided values or `getContext()` to read the client-side values, and decide which one to use in your code.
 
 **Subscribing to server data changes**
 
@@ -894,7 +892,7 @@ The Interactivity API provides two functions for accessing server-provided data 
 
 These functions are reactive. When used inside a callback or derived state getter, they automatically set up a subscription. When navigation occurs and new server data arrives, any code using these functions will re-run with the new values.
 
-This is different from the regular `state` and `getContext()`, which reflect the current merged state including any client-side modifications. Use `getServerState()` and `getServerContext()` when you specifically need to react to what the server sent, regardless of client modifications.
+This is different from the regular `state` and `getContext()`, which return the client-side state and context. As explained above, existing client-side values are not overwritten during navigation, so `state` and `getContext()` will keep reflecting whatever the client had before navigating. Use `getServerState()` and `getServerContext()` when you need to react to the values that the server sent for the new page.
 
 For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -430,7 +430,7 @@ For more details, see the [Understanding global state, local context, and derive
 
 ### Overriding cached pages
 
-By default, once a page is cached, subsequent navigations use the cached version. Use the `force` option to re-fetch a page even if it's cached:
+By default, once a page is stored in the router's internal in-memory cache, subsequent navigations use the cached version without making a new network request. Use the `force` option to bypass the router's cache and re-fetch the page from the server:
 
 ```js
 // Force re-fetch with navigate().

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -583,14 +583,6 @@ add_action( 'wp', function() {
             array( 'clientNavigationDisabled' => true )
         );
     }
-
-    // Disable on admin-like pages.
-    if ( is_page( 'dashboard' ) ) {
-        wp_interactivity_config(
-            'core/router',
-            array( 'clientNavigationDisabled' => true )
-        );
-    }
 } );
 ```
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -432,7 +432,7 @@ const { state } = store( 'myPlugin', {
 } );
 ```
 
-For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
 
 ### Overriding cached pages
 
@@ -1042,7 +1042,7 @@ These functions are reactive. When used inside a callback or derived state gette
 
 This is different from the regular `state` and `getContext()`, which return the client-side state and context. As explained above, existing client-side values are not overwritten during navigation, so `state` and `getContext()` will keep reflecting whatever the client had before navigating. Use `getServerState()` and `getServerContext()` when you need to react to the values that the server sent for the new page.
 
-For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
 
 ### Putting it all together: the navigation flow
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -22,438 +22,6 @@ This approach offers several benefits:
 - **Smooth transitions**: No flash of white screen between pages; transitions feel instant and app-like.
 - **SEO-friendly**: Since the server still renders complete HTML pages, search engines can crawl your site normally.
 
-### In depth
-
-This section provides a detailed technical explanation of how client-side navigation works internally. If you're primarily interested in practical usage, you can skip ahead to [Getting started with the Interactivity Router](#getting-started-with-the-interactivity-router).
-
-Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your interactive blocks.
-
-#### The page cache
-
-At the heart of the Interactivity API router is a page cache—a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
-
-The cache uses a normalized version of the URL as its key. This normalization strips away the domain and any hash fragments, keeping only the pathname and query parameters. For example, `https://example.com/products/?category=shoes#details` becomes `/products/?category=shoes`. This ensures that navigations to the same logical page (regardless of how the URL was constructed) share the same cache entry.
-
-Each entry in the cache stores not just the fetched HTML, but a fully processed page representation containing:
-
-- **Virtual DOM trees** for each router region found in the page
-- **Style sheet references** needed by the page
-- **Script module information** for JavaScript that should be loaded
-- **The page title** for updating the document title
-- **Server state** that was embedded in the page by WordPress
-
-<!-- IMAGE: Diagram showing the page cache structure. A box labeled "Page Cache" contains multiple entries, each showing a URL path (like "/products/", "/about/", "/contact/") mapped to a "Page Object" containing icons for vDOM, styles, scripts, title, and state. Arrows show how navigate() and prefetch() interact with this cache. -->
-
-An important detail is that the cache stores promises rather than resolved values. When a fetch begins, the router immediately stores the pending promise in the cache. This means that if multiple calls to `prefetch()` or `navigate()` target the same URL simultaneously (for example, if a user rapidly hovers over multiple links pointing to the same page), only one network request is made. All callers receive the same promise and wait for the same result.
-
-Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit—the page is already prepared and ready to render.
-
-If you need to force a fresh fetch (for example, after submitting a form that changes the page's content), you can use the `force: true` option with `navigate()` or `prefetch()`. This bypasses the cache check and fetches the page anew, replacing the existing cache entry with the fresh content.
-
-#### Router regions
-
-Router regions are the sections of your page that the router knows how to update during client-side navigation. They act as boundaries that tell the router "this is the content that should change when navigating between pages."
-
-**Defining router regions**
-
-You define a router region by adding the `data-wp-router-region` attribute to an element. The element must also be interactive (either having `data-wp-interactive` directly, or being a descendant of an element with `data-wp-interactive`).
-
-The attribute value serves as a unique identifier for that region. You can specify it in two ways:
-
-1. As a simple string:
-   ```html
-   <div
-       data-wp-interactive="myPlugin"
-       data-wp-router-region="main-content"
-   >
-       <!-- Region content -->
-   </div>
-   ```
-
-2. As a JSON object (when you need the `attachTo` feature, explained later):
-   ```html
-   <div
-       data-wp-interactive="myPlugin"
-       data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
-   >
-       <!-- Region content -->
-   </div>
-   ```
-
-The region ID must be unique within a single page and consistent across pages that share the same region. For example, if both your "Products" page and "Product Detail" page have a sidebar, and you want that sidebar to update during navigation, both pages should define a region with the same ID (e.g., `"myPlugin/sidebar"`).
-
-<!-- IMAGE: Side-by-side comparison of two pages. Page A shows a layout with header, main content area (highlighted and labeled "data-wp-router-region='main'"), and sidebar. Page B shows a similar layout with the same regions highlighted. Arrows between them show how regions with matching IDs correspond to each other. -->
-
-**Requirements for router regions**
-
-For a router region to function correctly, it must meet these requirements:
-
-1. **Must be inside an interactive scope**: The element with `data-wp-router-region` must either have `data-wp-interactive` itself, or be nested inside an element that does. This is because the router relies on the Interactivity API's directive processing to handle the region content.
-
-2. **Must have a unique ID**: No two regions on the same page should share the same ID. If they do, the router won't know which region to update.
-
-3. **Should include `data-wp-interactive` on nested regions**: When you place a router region inside another interactive element, always include the `data-wp-interactive` attribute on the region element itself:
-
-```html
-<!-- Correct: The region element has data-wp-interactive -->
-<div data-wp-interactive="myPlugin">
-    <div
-        data-wp-interactive="myPlugin"
-        data-wp-router-region="sidebar"
-    >
-        <!-- Sidebar content -->
-    </div>
-</div>
-
-<!-- Incorrect: This region may not update properly -->
-<div data-wp-interactive="myPlugin">
-    <div data-wp-router-region="sidebar">
-        <!-- This won't work reliably! -->
-    </div>
-</div>
-```
-
-**How regions are processed during page fetch**
-
-When the router fetches a new page (either through `prefetch()` or as part of `navigate()`), it processes the HTML to extract and prepare all router regions. This happens in several steps:
-
-First, the router parses the fetched HTML into a document structure using the browser's built-in HTML parser. This gives it a complete DOM tree to work with, just as if the page had been loaded normally.
-
-Next, the router scans this document for all elements that have both `data-wp-interactive` and `data-wp-router-region` attributes. For each region found, it extracts the region ID and checks whether the region is nested inside another region. Only top-level regions are processed directly; nested regions are handled as part of their parent's content.
-
-For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion—not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
-
-<!-- IMAGE: Flowchart showing the region processing pipeline. Starting with "Fetched HTML" (showing raw HTML code), an arrow leads to "Parse HTML" (DOM tree icon), then to "Find Regions" (highlighting regions in the tree), then to "Convert to vDOM" (showing a simplified tree structure), and finally to "Store in Cache" (the cache icon from earlier). -->
-
-Finally, each region's virtual DOM is stored in the page cache entry, indexed by its region ID. The cache entry now contains a map of region IDs to their corresponding virtual DOM trees.
-
-**How regions are rendered during navigation**
-
-When `navigate()` is called and the target page has been successfully fetched (or was already cached), the router needs to update the current page to show the new content. This rendering process is carefully orchestrated to be efficient and avoid visual glitches.
-
-The router begins by examining which regions exist in the current page and which exist in the target page. Based on this comparison, three different scenarios can occur:
-
-**Scenario 1: Region exists on both pages (update)**
-
-This is the most common case. When a region with a given ID exists on both the current page and the target page, the router updates the existing region with the new content.
-
-Rather than simply replacing the entire region's HTML (which would destroy any internal state and cause a jarring visual transition), the router uses a virtual DOM diffing algorithm. This algorithm compares the current region's virtual DOM with the new region's virtual DOM and calculates the minimum set of changes needed to transform one into the other.
-
-For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements—rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
-
-<!-- IMAGE: Before/after comparison showing region update. Left side shows "Current Page" with a region containing items A, B, C (each in a box). Right side shows "Target Page" with items A, D, C. In the middle, arrows show that A and C stay in place while B transforms into D. Caption: "The diffing algorithm minimizes DOM changes." -->
-
-**Scenario 2: Region exists only on the target page with `attachTo` (create)**
-
-Sometimes a page contains a region that doesn't exist on the current page—for example, a modal dialog that only appears on certain pages. If this region has the `attachTo` property specified, the router will dynamically create it.
-
-The `attachTo` property contains a CSS selector that identifies where in the current page the new region should be appended. When the router encounters such a region, it:
-
-1. Finds the element matching the `attachTo` selector in the current page
-2. Creates new DOM elements for the region
-3. Appends these elements to the matched parent
-4. Renders the region's virtual DOM into the newly created elements
-
-This allows content that exists on one page but not another to appear smoothly during navigation, without requiring the target element to exist in advance.
-
-**Scenario 3: Region exists only on the current page (remove)**
-
-When a region exists on the current page but not on the target page, it means that content is no longer needed. The router handles this by setting the region's content to empty, effectively clearing it from the display.
-
-If the region was dynamically created via `attachTo` during a previous navigation, the entire region element is removed from the DOM. If it was part of the original page structure, the element remains but its content is cleared.
-
-<!-- IMAGE: Three-panel diagram showing the three scenarios. Panel 1 "Update": Same-shaped regions on both pages with a refresh arrow. Panel 2 "Create": Region with attachTo appears from the target page and gets inserted into current page's body. Panel 3 "Remove": Region fades out/disappears from current page. -->
-
-**What happens to HTML outside router regions?**
-
-An important detail to understand is that HTML outside of router regions remains completely untouched during client-side navigation. The router only modifies the content inside the regions it manages—everything else in the DOM stays exactly as it was.
-
-This means that if you have static elements like a site header, footer, or navigation menu that aren't wrapped in a router region, they won't change when the user navigates between pages. This can be intentional (for elements that truly are the same across all pages) or it can be a source of confusion if you expect those elements to update.
-
-However, there's an important exception: **interactive elements outside router regions can still react to global state changes**. If you have an interactive block outside any router region, with directives that use `getServerState()` to read global state, these directives will automatically re-evaluate when navigation brings in new server state.
-
-For example, consider a shopping cart icon in the header that displays the number of items:
-
-```html
-<!-- This header is NOT inside a router region -->
-<header data-wp-interactive="myShop">
-    <div class="cart-icon">
-        <span data-wp-text="state.cartCount"></span> items
-    </div>
-</header>
-
-<!-- This is the router region that updates during navigation -->
-<main
-    data-wp-interactive="myShop"
-    data-wp-router-region="myShop/content"
->
-    <!-- Page content -->
-</main>
-```
-
-If `state.cartCount` comes from the regular client-side state, the cart icon will not update during navigation—even if the new page has a different cart count in its server state. The header, while being interactive, is outside any router region, so it's not re-rendered.
-
-But if you use `getServerState()` instead:
-
-```js
-const { state } = store( 'myShop', {
-    state: {
-        get cartCount() {
-            // This reacts to server state changes during navigation
-            return getServerState().cartCount;
-        },
-    },
-} );
-```
-
-Now the cart icon will update whenever navigation brings in a new `cartCount` value from the server, even though the header itself is outside any router region. This is because `getServerState()` creates a reactive subscription to server-provided state, which is updated during every navigation.
-
-This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region.
-
-#### CSS handling
-
-One of the trickier aspects of client-side navigation is managing CSS style sheets. Different pages may require different styles, and the router must ensure that the correct styles are active for each page—without causing flashes of unstyled content or breaking the CSS cascade order.
-
-**The challenge of CSS cascade order**
-
-CSS rules are applied in a specific order, and when two rules have the same specificity, the one that appears later in the document "wins." This means that the order of `<link>` and `<style>` elements in your HTML matters. If the router simply appended new style sheets to the end of the document, it could inadvertently change which rules take precedence, causing visual bugs.
-
-Consider this example: Page A has style sheets [base.css, theme.css], and Page B has [base.css, components.css, theme.css]. If the user navigates from A to B, the router needs to insert components.css between base.css and theme.css—not at the end. Otherwise, any rules in theme.css that are meant to override components.css would stop working.
-
-**How styles are extracted and prepared**
-
-When the router fetches a page, it extracts all style-related elements: both `<link rel="stylesheet">` tags and inline `<style>` blocks. Each style element is identified by a combination of its attributes (for `<link>` tags, primarily the `href`) or its content hash (for inline `<style>` blocks).
-
-The router then compares the extracted styles with those already present in the current page's document. Styles fall into three categories:
-
-1. **Already present**: The style sheet is already loaded in the current page. No action needed during preparation.
-2. **New**: The style sheet doesn't exist in the current page. It needs to be added.
-3. **No longer needed**: The style sheet is in the current page but not in the target page. It will be disabled during navigation.
-
-**Preloading new styles without applying them**
-
-For new style sheets, the router faces a dilemma: it needs to ensure the styles are fully loaded before showing the new page content (to prevent flash of unstyled content), but it doesn't want to apply them yet (because the user is still viewing the current page).
-
-The solution is to add new `<link>` elements with their `media` attribute set to a value that prevents them from applying. The router uses `media="preload"`, which tells the browser "this style sheet applies to no media types"—effectively disabling it while still allowing the browser to download and parse it.
-
-When a `<link>` element is added this way, the browser begins downloading the CSS file immediately. The router tracks when each style sheet finishes loading by listening for the `load` event. This allows it to wait until all new styles are ready before proceeding with navigation.
-
-<!-- IMAGE: Timeline diagram showing style preloading. At t=0, "Prefetch starts" and a link element with media="preload" is added. Browser download begins (shown as a progress bar). At t=200ms, download completes and "load event fires". The styles remain inactive (grayed out) until navigation actually occurs. -->
-
-**Maintaining cascade order with the Shortest Common Supersequence algorithm**
-
-When inserting new style sheets, the router must preserve the correct cascade order. It accomplishes this using an algorithm based on finding the Shortest Common Supersequence (SCS) of two sequences.
-
-Given the current page's style sheets (sequence X) and the target page's style sheets (sequence Y), the SCS algorithm finds the shortest sequence that contains both X and Y as subsequences while preserving their internal order. This tells the router exactly where to insert new elements and which existing elements to keep.
-
-For example:
-- Current page styles (X): [A, C, D]
-- Target page styles (Y): [A, B, C, E]
-- Shortest Common Supersequence: [A, B, C, D, E]
-
-The algorithm then determines: keep A and C in place, insert B between A and C, keep D after C, and insert E at the end.
-
-<!-- IMAGE: Visual representation of the SCS algorithm. Two rows show the "Current" sequence [A, C, D] and "Target" sequence [A, B, C, E]. Below them, the "Merged (SCS)" sequence shows [A, B, C, D, E] with color coding: A and C in blue (shared), B and E in green (inserted), D in gray (will be disabled). Arrows show how elements from both sequences map to the merged result. -->
-
-This approach ensures that:
-- Style sheets that appear in both pages remain in their correct relative order
-- New style sheets are inserted at the proper position to maintain cascade correctness
-- The minimum number of DOM operations is performed
-
-**Activating and deactivating styles during navigation**
-
-When `navigate()` actually renders the new page, the router toggles style sheets on and off:
-
-- **Activating styles**: For each style sheet that belongs to the target page, the router removes the `media="preload"` override (or restores the original `media` attribute if one was specified). This causes the browser to apply those styles.
-
-- **Deactivating styles**: For each style sheet that was in the current page but not the target page, the router sets `media="preload"`. This disables the styles without removing the element from the DOM.
-
-By keeping deactivated style elements in the DOM (rather than removing them), the router can quickly reactivate them if the user navigates back. The styles are already loaded and parsed; they just need to be enabled.
-
-#### Script module handling
-
-Modern WordPress blocks often use JavaScript modules (ES modules) for their interactive behavior. The router must ensure that when navigating to a new page, any JavaScript modules required by that page are loaded and executed.
-
-**Identifying modules for client-side navigation**
-
-Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. To distinguish which modules should be loaded, WordPress uses a special data attribute:
-
-```html
-<script
-    type="module"
-    src="/wp-content/plugins/my-plugin/view.js"
-    data-wp-router-options='{"loadOnClientNavigation": true}'
-></script>
-```
-
-When the router fetches a page, it scans for all `<script type="module">` elements that have this attribute with `loadOnClientNavigation` set to `true`. These are the modules it will preload and execute.
-
-**Processing the import map**
-
-Modern JavaScript uses import maps to resolve bare module specifiers (like `@wordpress/interactivity`) to actual URLs. WordPress generates an import map that tells the browser where to find each module:
-
-```html
-<script type="importmap">
-{
-    "imports": {
-        "@wordpress/interactivity": "/wp-includes/js/dist/interactivity.min.js",
-        "@wordpress/interactivity-router": "/wp-includes/js/dist/interactivity-router.min.js"
-    }
-}
-</script>
-```
-
-When the router fetches a new page, it extracts the import map from that page and merges any new mappings with the current page's import map. This ensures that modules can resolve their dependencies correctly even when navigating between pages that have different sets of scripts.
-
-**Preloading modules and their dependencies**
-
-Preloading script modules is more complex than preloading styles because modules can import other modules. A single entry-point module might depend on dozens of other modules, which might depend on dozens more.
-
-To handle this, the router performs a recursive dependency resolution:
-
-1. It fetches the source code of each entry-point module
-2. It parses the source to find all `import` statements
-3. For each import, it resolves the module specifier using the import map
-4. It recursively fetches and parses each dependency
-5. This continues until all modules in the dependency tree have been fetched
-
-The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again—the browser already has it cached.
-
-<!-- IMAGE: Tree diagram showing module dependency resolution. At the top, "view.js" (the entry point). Arrows lead down to its dependencies: "@wordpress/interactivity" and "./components/modal.js". The interactivity module is shown grayed out with a note "Already loaded - skip". The modal.js module has its own dependencies branching below it. Each node shows whether it needs to be fetched or can be skipped. -->
-
-**Handling the import timing**
-
-An important subtlety is that module code shouldn't execute until navigation actually happens. The router needs to have the module code ready (to avoid delays during navigation), but it shouldn't run that code while the user is still viewing the current page.
-
-The router accomplishes this by transforming the fetched modules. It rewrites the source code to use blob URLs (data embedded directly in the URL) and caches these transformed modules. When navigation occurs, the router uses dynamic `import()` to execute the cached modules.
-
-Because the browser's module system caches modules by URL, importing the same blob URL multiple times returns the same module instance. This ensures that each module is only executed once, even if multiple code paths try to import it.
-
-**Module execution during navigation**
-
-When `navigate()` renders the new page, it imports all the modules that were preloaded for that page:
-
-```js
-// Simplified conceptual view of what happens
-for (const moduleInfo of page.scriptModules) {
-    await import(moduleInfo.blobUrl);
-}
-```
-
-Each module's top-level code runs, which typically includes calls to `store()` to register actions, callbacks, and state. Because the Interactivity API's store is global and additive, these registrations merge with existing store definitions from the initial page load.
-
-#### Server state and context
-
-WordPress blocks often need data from the server—configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: global state and local context. During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
-
-**How server data is embedded in pages**
-
-When WordPress renders a page with interactive blocks, it embeds server-provided data in special `<script>` tags:
-
-```html
-<!-- Global state -->
-<script type="application/json" id="wp-script-module-data-@wordpress/interactivity">
-{
-    "state": {
-        "myPlugin":{
-            "cartItemCount": 3,
-            "userLoggedIn": true
-        }
-    }
-}
-</script>
-```
-
-Local context is embedded directly in the `data-wp-context` attribute of elements:
-
-```html
-<div
-    data-wp-interactive="myPlugin"
-    data-wp-context='{ "productId": 42, "inStock": true }'
->
-    <!-- Block content -->
-</div>
-```
-
-**Extracting state and context during fetch**
-
-When the router fetches a new page, it extracts both types of server data:
-
-1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content. This state is stored in the page cache entry.
-
-2. **Local context**: Context values are embedded in the virtual DOM representation of each router region. When a region's HTML is converted to vDOM, the `data-wp-context` attributes are preserved and will be processed during rendering.
-
-**Merging server data during navigation**
-
-When navigation renders the new page, the server-provided data needs to merge with the existing client-side state. This merge follows specific rules:
-
-For global state, the new server state is deeply merged with the existing state. Properties from the server overwrite existing properties with the same path, but properties that exist only on the client are preserved. This allows client-side code to have modified the state (for example, incrementing a counter) while still receiving updates from the server for other properties.
-
-For local context, the behavior depends on the region. When a region is updated, its new context (from the server) replaces the region's previous context. However, because the Interactivity API tracks both "server context" and "client context" separately, your code can choose whether to use the server-provided values or preserve client modifications.
-
-<!-- IMAGE: Diagram showing state merge. Left box shows "Existing Client State" with properties {a: 1, b: 2, c: 3}. Right box shows "New Server State" with properties {a: 10, d: 4}. Arrow points to "Merged Result" showing {a: 10, b: 2, c: 3, d: 4}. Caption explains that 'a' was overwritten by server, 'b' and 'c' preserved from client, 'd' added from server. -->
-
-**Subscribing to server data changes**
-
-The Interactivity API provides two functions for accessing server-provided data that updates during navigation:
-
-- `getServerState()`: Returns the global state as provided by the server for the current page
-- `getServerContext()`: Returns the local context as provided by the server for the current element
-
-These functions are reactive. When used inside a callback or derived state getter, they automatically set up a subscription. When navigation occurs and new server data arrives, any code using these functions will re-run with the new values.
-
-This is different from the regular `state` and `getContext()`, which reflect the current merged state including any client-side modifications. Use `getServerState()` and `getServerContext()` when you specifically need to react to what the server sent, regardless of client modifications.
-
-For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
-
-#### Putting it all together: the navigation flow
-
-Now that we've examined each component, let's trace through a complete navigation to see how they work together.
-
-**Phase 1: Prefetch (optional but recommended)**
-
-When the user hovers over a link, your code might call `prefetch()`:
-
-1. The router normalizes the URL and checks the page cache
-2. If not cached, it begins fetching the HTML
-3. The fetched HTML is parsed into a document
-4. Router regions are extracted and converted to virtual DOM
-5. Style sheets are compared with current page; new ones are added with `media="preload"`
-6. Script modules are identified, dependencies resolved, and source code fetched
-7. Server state is extracted
-8. The fully processed page is stored in the cache
-9. The function returns (the page is now ready for instant navigation)
-
-**Phase 2: Navigate**
-
-When the user clicks the link and your code calls `navigate()`:
-
-1. The router checks if client navigation is disabled; if so, falls back to full page load
-2. If not already prefetched, the fetch process from Phase 1 runs now
-3. The router waits for the page to be ready (fetch complete, styles loaded)
-4. A loading indicator may appear if the wait exceeds a threshold (400ms)
-5. Script modules for the new page are imported and executed
-6. The rendering phase begins (wrapped in a batch for efficiency):
-   - Server state is merged with client state
-   - Each router region is updated with its new virtual DOM
-   - Regions with `attachTo` that don't exist are created and appended
-   - Styles are activated/deactivated as needed
-   - The document title is updated
-7. Browser history is updated (pushState or replaceState)
-8. Screen reader announcement is made for accessibility
-9. If the URL has a hash, the page scrolls to that element
-10. Navigation is complete
-
-<!-- IMAGE: Flowchart showing complete navigation flow. Starts with "User hovers link" flowing to "prefetch()" which branches through the prefetch steps. Then "User clicks link" leads to "navigate()" which shows the navigation steps in sequence. Key decision points are shown as diamonds (e.g., "In cache?", "Styles loaded?"). The flow ends at "Navigation complete" with a checkmark. -->
-
-**Race condition protection**
-
-A subtle but important detail: users don't always wait for navigation to complete before clicking another link. The router handles this gracefully.
-
-When `navigate()` is called, the router remembers the target URL. If another `navigate()` call comes in before the first completes, the router updates its target and the first navigation is abandoned. When the first navigation's fetch completes, it checks whether its URL is still the current target—if not, it simply returns without rendering.
-
-This ensures that rapid clicking through multiple links doesn't cause visual glitches or render stale content. Only the most recent navigation completes.
-
 ## Getting started with the Interactivity Router
 
 The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. To use it in your interactive blocks, you need to:
@@ -949,3 +517,435 @@ Use cases for disabling feedback:
 - **Silent updates**: Background refreshes where you don't want to draw attention.
 - **Custom loading UI**: When you're implementing your own loading indicators.
 - **Custom accessibility**: When you're providing your own screen reader announcements.
+
+
+
+## The Interactivity Router in depth
+
+This section provides a detailed technical explanation of how client-side navigation works internally. Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your interactive blocks.
+
+### The page cache
+
+At the heart of the Interactivity API router is a page cache—a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
+
+The cache uses a normalized version of the URL as its key. This normalization strips away the domain and any hash fragments, keeping only the pathname and query parameters. For example, `https://example.com/products/?category=shoes#details` becomes `/products/?category=shoes`. This ensures that navigations to the same logical page (regardless of how the URL was constructed) share the same cache entry.
+
+Each entry in the cache stores not just the fetched HTML, but a fully processed page representation containing:
+
+- **Virtual DOM trees** for each router region found in the page
+- **Style sheet references** needed by the page
+- **Script module information** for JavaScript that should be loaded
+- **The page title** for updating the document title
+- **Server state** that was embedded in the page by WordPress
+
+<!-- IMAGE: Diagram showing the page cache structure. A box labeled "Page Cache" contains multiple entries, each showing a URL path (like "/products/", "/about/", "/contact/") mapped to a "Page Object" containing icons for vDOM, styles, scripts, title, and state. Arrows show how navigate() and prefetch() interact with this cache. -->
+
+An important detail is that the cache stores promises rather than resolved values. When a fetch begins, the router immediately stores the pending promise in the cache. This means that if multiple calls to `prefetch()` or `navigate()` target the same URL simultaneously (for example, if a user rapidly hovers over multiple links pointing to the same page), only one network request is made. All callers receive the same promise and wait for the same result.
+
+Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit—the page is already prepared and ready to render.
+
+If you need to force a fresh fetch (for example, after submitting a form that changes the page's content), you can use the `force: true` option with `navigate()` or `prefetch()`. This bypasses the cache check and fetches the page anew, replacing the existing cache entry with the fresh content.
+
+### Router regions
+
+Router regions are the sections of your page that the router knows how to update during client-side navigation. They act as boundaries that tell the router "this is the content that should change when navigating between pages."
+
+**Defining router regions**
+
+You define a router region by adding the `data-wp-router-region` attribute to an element. The element must also be interactive (either having `data-wp-interactive` directly, or being a descendant of an element with `data-wp-interactive`).
+
+The attribute value serves as a unique identifier for that region. You can specify it in two ways:
+
+1. As a simple string:
+   ```html
+   <div
+       data-wp-interactive="myPlugin"
+       data-wp-router-region="main-content"
+   >
+       <!-- Region content -->
+   </div>
+   ```
+
+2. As a JSON object (when you need the `attachTo` feature, explained later):
+   ```html
+   <div
+       data-wp-interactive="myPlugin"
+       data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
+   >
+       <!-- Region content -->
+   </div>
+   ```
+
+The region ID must be unique within a single page and consistent across pages that share the same region. For example, if both your "Products" page and "Product Detail" page have a sidebar, and you want that sidebar to update during navigation, both pages should define a region with the same ID (e.g., `"myPlugin/sidebar"`).
+
+<!-- IMAGE: Side-by-side comparison of two pages. Page A shows a layout with header, main content area (highlighted and labeled "data-wp-router-region='main'"), and sidebar. Page B shows a similar layout with the same regions highlighted. Arrows between them show how regions with matching IDs correspond to each other. -->
+
+**Requirements for router regions**
+
+For a router region to function correctly, it must meet these requirements:
+
+1. **Must be inside an interactive scope**: The element with `data-wp-router-region` must either have `data-wp-interactive` itself, or be nested inside an element that does. This is because the router relies on the Interactivity API's directive processing to handle the region content.
+
+2. **Must have a unique ID**: No two regions on the same page should share the same ID. If they do, the router won't know which region to update.
+
+3. **Should include `data-wp-interactive` on nested regions**: When you place a router region inside another interactive element, always include the `data-wp-interactive` attribute on the region element itself:
+
+```html
+<!-- Correct: The region element has data-wp-interactive -->
+<div data-wp-interactive="myPlugin">
+    <div
+        data-wp-interactive="myPlugin"
+        data-wp-router-region="sidebar"
+    >
+        <!-- Sidebar content -->
+    </div>
+</div>
+
+<!-- Incorrect: This region may not update properly -->
+<div data-wp-interactive="myPlugin">
+    <div data-wp-router-region="sidebar">
+        <!-- This won't work reliably! -->
+    </div>
+</div>
+```
+
+**How regions are processed during page fetch**
+
+When the router fetches a new page (either through `prefetch()` or as part of `navigate()`), it processes the HTML to extract and prepare all router regions. This happens in several steps:
+
+First, the router parses the fetched HTML into a document structure using the browser's built-in HTML parser. This gives it a complete DOM tree to work with, just as if the page had been loaded normally.
+
+Next, the router scans this document for all elements that have both `data-wp-interactive` and `data-wp-router-region` attributes. For each region found, it extracts the region ID and checks whether the region is nested inside another region. Only top-level regions are processed directly; nested regions are handled as part of their parent's content.
+
+For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion—not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
+
+<!-- IMAGE: Flowchart showing the region processing pipeline. Starting with "Fetched HTML" (showing raw HTML code), an arrow leads to "Parse HTML" (DOM tree icon), then to "Find Regions" (highlighting regions in the tree), then to "Convert to vDOM" (showing a simplified tree structure), and finally to "Store in Cache" (the cache icon from earlier). -->
+
+Finally, each region's virtual DOM is stored in the page cache entry, indexed by its region ID. The cache entry now contains a map of region IDs to their corresponding virtual DOM trees.
+
+**How regions are rendered during navigation**
+
+When `navigate()` is called and the target page has been successfully fetched (or was already cached), the router needs to update the current page to show the new content. This rendering process is carefully orchestrated to be efficient and avoid visual glitches.
+
+The router begins by examining which regions exist in the current page and which exist in the target page. Based on this comparison, three different scenarios can occur:
+
+**Scenario 1: Region exists on both pages (update)**
+
+This is the most common case. When a region with a given ID exists on both the current page and the target page, the router updates the existing region with the new content.
+
+Rather than simply replacing the entire region's HTML (which would destroy any internal state and cause a jarring visual transition), the router uses a virtual DOM diffing algorithm. This algorithm compares the current region's virtual DOM with the new region's virtual DOM and calculates the minimum set of changes needed to transform one into the other.
+
+For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements—rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
+
+<!-- IMAGE: Before/after comparison showing region update. Left side shows "Current Page" with a region containing items A, B, C (each in a box). Right side shows "Target Page" with items A, D, C. In the middle, arrows show that A and C stay in place while B transforms into D. Caption: "The diffing algorithm minimizes DOM changes." -->
+
+**Scenario 2: Region exists only on the target page with `attachTo` (create)**
+
+Sometimes a page contains a region that doesn't exist on the current page—for example, a modal dialog that only appears on certain pages. If this region has the `attachTo` property specified, the router will dynamically create it.
+
+The `attachTo` property contains a CSS selector that identifies where in the current page the new region should be appended. When the router encounters such a region, it:
+
+1. Finds the element matching the `attachTo` selector in the current page
+2. Creates new DOM elements for the region
+3. Appends these elements to the matched parent
+4. Renders the region's virtual DOM into the newly created elements
+
+This allows content that exists on one page but not another to appear smoothly during navigation, without requiring the target element to exist in advance.
+
+**Scenario 3: Region exists only on the current page (remove)**
+
+When a region exists on the current page but not on the target page, it means that content is no longer needed. The router handles this by setting the region's content to empty, effectively clearing it from the display.
+
+If the region was dynamically created via `attachTo` during a previous navigation, the entire region element is removed from the DOM. If it was part of the original page structure, the element remains but its content is cleared.
+
+<!-- IMAGE: Three-panel diagram showing the three scenarios. Panel 1 "Update": Same-shaped regions on both pages with a refresh arrow. Panel 2 "Create": Region with attachTo appears from the target page and gets inserted into current page's body. Panel 3 "Remove": Region fades out/disappears from current page. -->
+
+**What happens to HTML outside router regions?**
+
+An important detail to understand is that HTML outside of router regions remains completely untouched during client-side navigation. The router only modifies the content inside the regions it manages—everything else in the DOM stays exactly as it was.
+
+This means that if you have static elements like a site header, footer, or navigation menu that aren't wrapped in a router region, they won't change when the user navigates between pages. This can be intentional (for elements that truly are the same across all pages) or it can be a source of confusion if you expect those elements to update.
+
+However, there's an important exception: **interactive elements outside router regions can still react to global state changes**. If you have an interactive block outside any router region, with directives that use `getServerState()` to read global state, these directives will automatically re-evaluate when navigation brings in new server state.
+
+For example, consider a shopping cart icon in the header that displays the number of items:
+
+```html
+<!-- This header is NOT inside a router region -->
+<header data-wp-interactive="myShop">
+    <div class="cart-icon">
+        <span data-wp-text="state.cartCount"></span> items
+    </div>
+</header>
+
+<!-- This is the router region that updates during navigation -->
+<main
+    data-wp-interactive="myShop"
+    data-wp-router-region="myShop/content"
+>
+    <!-- Page content -->
+</main>
+```
+
+If `state.cartCount` comes from the regular client-side state, the cart icon will not update during navigation—even if the new page has a different cart count in its server state. The header, while being interactive, is outside any router region, so it's not re-rendered.
+
+But if you use `getServerState()` instead:
+
+```js
+const { state } = store( 'myShop', {
+    state: {
+        get cartCount() {
+            // This reacts to server state changes during navigation
+            return getServerState().cartCount;
+        },
+    },
+} );
+```
+
+Now the cart icon will update whenever navigation brings in a new `cartCount` value from the server, even though the header itself is outside any router region. This is because `getServerState()` creates a reactive subscription to server-provided state, which is updated during every navigation.
+
+This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region.
+
+### CSS handling
+
+One of the trickier aspects of client-side navigation is managing CSS style sheets. Different pages may require different styles, and the router must ensure that the correct styles are active for each page—without causing flashes of unstyled content or breaking the CSS cascade order.
+
+**The challenge of CSS cascade order**
+
+CSS rules are applied in a specific order, and when two rules have the same specificity, the one that appears later in the document "wins." This means that the order of `<link>` and `<style>` elements in your HTML matters. If the router simply appended new style sheets to the end of the document, it could inadvertently change which rules take precedence, causing visual bugs.
+
+Consider this example: Page A has style sheets [base.css, theme.css], and Page B has [base.css, components.css, theme.css]. If the user navigates from A to B, the router needs to insert components.css between base.css and theme.css—not at the end. Otherwise, any rules in theme.css that are meant to override components.css would stop working.
+
+**How styles are extracted and prepared**
+
+When the router fetches a page, it extracts all style-related elements: both `<link rel="stylesheet">` tags and inline `<style>` blocks. Each style element is identified by a combination of its attributes (for `<link>` tags, primarily the `href`) or its content hash (for inline `<style>` blocks).
+
+The router then compares the extracted styles with those already present in the current page's document. Styles fall into three categories:
+
+1. **Already present**: The style sheet is already loaded in the current page. No action needed during preparation.
+2. **New**: The style sheet doesn't exist in the current page. It needs to be added.
+3. **No longer needed**: The style sheet is in the current page but not in the target page. It will be disabled during navigation.
+
+**Preloading new styles without applying them**
+
+For new style sheets, the router faces a dilemma: it needs to ensure the styles are fully loaded before showing the new page content (to prevent flash of unstyled content), but it doesn't want to apply them yet (because the user is still viewing the current page).
+
+The solution is to add new `<link>` elements with their `media` attribute set to a value that prevents them from applying. The router uses `media="preload"`, which tells the browser "this style sheet applies to no media types"—effectively disabling it while still allowing the browser to download and parse it.
+
+When a `<link>` element is added this way, the browser begins downloading the CSS file immediately. The router tracks when each style sheet finishes loading by listening for the `load` event. This allows it to wait until all new styles are ready before proceeding with navigation.
+
+<!-- IMAGE: Timeline diagram showing style preloading. At t=0, "Prefetch starts" and a link element with media="preload" is added. Browser download begins (shown as a progress bar). At t=200ms, download completes and "load event fires". The styles remain inactive (grayed out) until navigation actually occurs. -->
+
+**Maintaining cascade order with the Shortest Common Supersequence algorithm**
+
+When inserting new style sheets, the router must preserve the correct cascade order. It accomplishes this using an algorithm based on finding the Shortest Common Supersequence (SCS) of two sequences.
+
+Given the current page's style sheets (sequence X) and the target page's style sheets (sequence Y), the SCS algorithm finds the shortest sequence that contains both X and Y as subsequences while preserving their internal order. This tells the router exactly where to insert new elements and which existing elements to keep.
+
+For example:
+- Current page styles (X): [A, C, D]
+- Target page styles (Y): [A, B, C, E]
+- Shortest Common Supersequence: [A, B, C, D, E]
+
+The algorithm then determines: keep A and C in place, insert B between A and C, keep D after C, and insert E at the end.
+
+<!-- IMAGE: Visual representation of the SCS algorithm. Two rows show the "Current" sequence [A, C, D] and "Target" sequence [A, B, C, E]. Below them, the "Merged (SCS)" sequence shows [A, B, C, D, E] with color coding: A and C in blue (shared), B and E in green (inserted), D in gray (will be disabled). Arrows show how elements from both sequences map to the merged result. -->
+
+This approach ensures that:
+- Style sheets that appear in both pages remain in their correct relative order
+- New style sheets are inserted at the proper position to maintain cascade correctness
+- The minimum number of DOM operations is performed
+
+**Activating and deactivating styles during navigation**
+
+When `navigate()` actually renders the new page, the router toggles style sheets on and off:
+
+- **Activating styles**: For each style sheet that belongs to the target page, the router removes the `media="preload"` override (or restores the original `media` attribute if one was specified). This causes the browser to apply those styles.
+
+- **Deactivating styles**: For each style sheet that was in the current page but not the target page, the router sets `media="preload"`. This disables the styles without removing the element from the DOM.
+
+By keeping deactivated style elements in the DOM (rather than removing them), the router can quickly reactivate them if the user navigates back. The styles are already loaded and parsed; they just need to be enabled.
+
+### Script module handling
+
+Modern WordPress blocks often use JavaScript modules (ES modules) for their interactive behavior. The router must ensure that when navigating to a new page, any JavaScript modules required by that page are loaded and executed.
+
+**Identifying modules for client-side navigation**
+
+Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. To distinguish which modules should be loaded, WordPress uses a special data attribute:
+
+```html
+<script
+    type="module"
+    src="/wp-content/plugins/my-plugin/view.js"
+    data-wp-router-options='{"loadOnClientNavigation": true}'
+></script>
+```
+
+When the router fetches a page, it scans for all `<script type="module">` elements that have this attribute with `loadOnClientNavigation` set to `true`. These are the modules it will preload and execute.
+
+**Processing the import map**
+
+Modern JavaScript uses import maps to resolve bare module specifiers (like `@wordpress/interactivity`) to actual URLs. WordPress generates an import map that tells the browser where to find each module:
+
+```html
+<script type="importmap">
+{
+    "imports": {
+        "@wordpress/interactivity": "/wp-includes/js/dist/interactivity.min.js",
+        "@wordpress/interactivity-router": "/wp-includes/js/dist/interactivity-router.min.js"
+    }
+}
+</script>
+```
+
+When the router fetches a new page, it extracts the import map from that page and merges any new mappings with the current page's import map. This ensures that modules can resolve their dependencies correctly even when navigating between pages that have different sets of scripts.
+
+**Preloading modules and their dependencies**
+
+Preloading script modules is more complex than preloading styles because modules can import other modules. A single entry-point module might depend on dozens of other modules, which might depend on dozens more.
+
+To handle this, the router performs a recursive dependency resolution:
+
+1. It fetches the source code of each entry-point module
+2. It parses the source to find all `import` statements
+3. For each import, it resolves the module specifier using the import map
+4. It recursively fetches and parses each dependency
+5. This continues until all modules in the dependency tree have been fetched
+
+The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again—the browser already has it cached.
+
+<!-- IMAGE: Tree diagram showing module dependency resolution. At the top, "view.js" (the entry point). Arrows lead down to its dependencies: "@wordpress/interactivity" and "./components/modal.js". The interactivity module is shown grayed out with a note "Already loaded - skip". The modal.js module has its own dependencies branching below it. Each node shows whether it needs to be fetched or can be skipped. -->
+
+**Handling the import timing**
+
+An important subtlety is that module code shouldn't execute until navigation actually happens. The router needs to have the module code ready (to avoid delays during navigation), but it shouldn't run that code while the user is still viewing the current page.
+
+The router accomplishes this by transforming the fetched modules. It rewrites the source code to use blob URLs (data embedded directly in the URL) and caches these transformed modules. When navigation occurs, the router uses dynamic `import()` to execute the cached modules.
+
+Because the browser's module system caches modules by URL, importing the same blob URL multiple times returns the same module instance. This ensures that each module is only executed once, even if multiple code paths try to import it.
+
+**Module execution during navigation**
+
+When `navigate()` renders the new page, it imports all the modules that were preloaded for that page:
+
+```js
+// Simplified conceptual view of what happens
+for (const moduleInfo of page.scriptModules) {
+    await import(moduleInfo.blobUrl);
+}
+```
+
+Each module's top-level code runs, which typically includes calls to `store()` to register actions, callbacks, and state. Because the Interactivity API's store is global and additive, these registrations merge with existing store definitions from the initial page load.
+
+### Server state and context
+
+WordPress blocks often need data from the server—configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: global state and local context. During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
+
+**How server data is embedded in pages**
+
+When WordPress renders a page with interactive blocks, it embeds server-provided data in special `<script>` tags:
+
+```html
+<!-- Global state -->
+<script type="application/json" id="wp-script-module-data-@wordpress/interactivity">
+{
+    "state": {
+        "myPlugin":{
+            "cartItemCount": 3,
+            "userLoggedIn": true
+        }
+    }
+}
+</script>
+```
+
+Local context is embedded directly in the `data-wp-context` attribute of elements:
+
+```html
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-context='{ "productId": 42, "inStock": true }'
+>
+    <!-- Block content -->
+</div>
+```
+
+**Extracting state and context during fetch**
+
+When the router fetches a new page, it extracts both types of server data:
+
+1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content. This state is stored in the page cache entry.
+
+2. **Local context**: Context values are embedded in the virtual DOM representation of each router region. When a region's HTML is converted to vDOM, the `data-wp-context` attributes are preserved and will be processed during rendering.
+
+**Merging server data during navigation**
+
+When navigation renders the new page, the server-provided data needs to merge with the existing client-side state. This merge follows specific rules:
+
+For global state, the new server state is deeply merged with the existing state. Properties from the server overwrite existing properties with the same path, but properties that exist only on the client are preserved. This allows client-side code to have modified the state (for example, incrementing a counter) while still receiving updates from the server for other properties.
+
+For local context, the behavior depends on the region. When a region is updated, its new context (from the server) replaces the region's previous context. However, because the Interactivity API tracks both "server context" and "client context" separately, your code can choose whether to use the server-provided values or preserve client modifications.
+
+<!-- IMAGE: Diagram showing state merge. Left box shows "Existing Client State" with properties {a: 1, b: 2, c: 3}. Right box shows "New Server State" with properties {a: 10, d: 4}. Arrow points to "Merged Result" showing {a: 10, b: 2, c: 3, d: 4}. Caption explains that 'a' was overwritten by server, 'b' and 'c' preserved from client, 'd' added from server. -->
+
+**Subscribing to server data changes**
+
+The Interactivity API provides two functions for accessing server-provided data that updates during navigation:
+
+- `getServerState()`: Returns the global state as provided by the server for the current page
+- `getServerContext()`: Returns the local context as provided by the server for the current element
+
+These functions are reactive. When used inside a callback or derived state getter, they automatically set up a subscription. When navigation occurs and new server data arrives, any code using these functions will re-run with the new values.
+
+This is different from the regular `state` and `getContext()`, which reflect the current merged state including any client-side modifications. Use `getServerState()` and `getServerContext()` when you specifically need to react to what the server sent, regardless of client modifications.
+
+For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+
+### Putting it all together: the navigation flow
+
+Now that we've examined each component, let's trace through a complete navigation to see how they work together.
+
+**Phase 1: Prefetch (optional but recommended)**
+
+When the user hovers over a link, your code might call `prefetch()`:
+
+1. The router normalizes the URL and checks the page cache
+2. If not cached, it begins fetching the HTML
+3. The fetched HTML is parsed into a document
+4. Router regions are extracted and converted to virtual DOM
+5. Style sheets are compared with current page; new ones are added with `media="preload"`
+6. Script modules are identified, dependencies resolved, and source code fetched
+7. Server state is extracted
+8. The fully processed page is stored in the cache
+9. The function returns (the page is now ready for instant navigation)
+
+**Phase 2: Navigate**
+
+When the user clicks the link and your code calls `navigate()`:
+
+1. The router checks if client navigation is disabled; if so, falls back to full page load
+2. If not already prefetched, the fetch process from Phase 1 runs now
+3. The router waits for the page to be ready (fetch complete, styles loaded)
+4. A loading indicator may appear if the wait exceeds a threshold (400ms)
+5. Script modules for the new page are imported and executed
+6. The rendering phase begins (wrapped in a batch for efficiency):
+   - Server state is merged with client state
+   - Each router region is updated with its new virtual DOM
+   - Regions with `attachTo` that don't exist are created and appended
+   - Styles are activated/deactivated as needed
+   - The document title is updated
+7. Browser history is updated (pushState or replaceState)
+8. Screen reader announcement is made for accessibility
+9. If the URL has a hash, the page scrolls to that element
+10. Navigation is complete
+
+<!-- IMAGE: Flowchart showing complete navigation flow. Starts with "User hovers link" flowing to "prefetch()" which branches through the prefetch steps. Then "User clicks link" leads to "navigate()" which shows the navigation steps in sequence. Key decision points are shown as diamonds (e.g., "In cache?", "Styles loaded?"). The flow ends at "Navigation complete" with a checkmark. -->
+
+**Race condition protection**
+
+A subtle but important detail: users don't always wait for navigation to complete before clicking another link. The router handles this gracefully.
+
+When `navigate()` is called, the router remembers the target URL. If another `navigate()` call comes in before the first completes, the router updates its target and the first navigation is abandoned. When the first navigation's fetch completes, it checks whether its URL is still the current target—if not, it simply returns without rendering.
+
+This ensures that rapid clicking through multiple links doesn't cause visual glitches or render stale content. Only the most recent navigation completes.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -111,7 +111,7 @@ Here's how to implement a link that navigates client-side. First, the HTML in yo
 ```
 
 > [!NOTE]
-> This element must be placed inside an element with the `data-wp-interactive="myPlugin"` directive (like the router region defined above), so the directive knows which store namespace to look up the action in. Alternatively, you can specify the namespace explicitly in the directive value itself: `data-wp-on--click="myPlugin::actions.navigateTo"`. For more details on how namespaces work, see the [Interactivity API Reference](/docs/reference-guides/interactivity-api/api-reference.md).
+> This element must be placed inside an element with the `data-wp-interactive="myPlugin"` directive (like the router region defined above), so the directive knows which store namespace to look up the action in. Alternatively, you can specify the namespace explicitly in the directive value itself: `data-wp-on--click="myPlugin::actions.navigateTo"`. For more details on how namespaces work, see the [Interactivity API Reference](/docs/reference-guides/interactivity-api/directives-and-store.md).
 
 Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -311,6 +311,32 @@ WordPress does not currently disable client-side navigation automatically when a
 
 ## More advanced use cases
 
+### Handling scroll and focus
+
+The router does not automatically manage scroll position or focus after navigation — this is the responsibility of the action that calls `actions.navigate()`. After a client-side navigation completes, the page will remain at its current scroll position and the focus will stay on the element that triggered the navigation (or be lost if that element was removed during the region update).
+
+You should handle scroll and focus explicitly in your navigation action. For example, to scroll to the top after navigation:
+
+```js
+store( 'myPlugin', {
+    actions: {
+        navigateTo: withSyncEvent( function* ( event ) {
+            event.preventDefault();
+
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.navigate( event.target.href );
+
+            // Scroll to top after navigation.
+            window.scrollTo( { top: 0, behavior: 'smooth' } );
+        } ),
+    },
+} );
+```
+
+For accessibility, consider moving focus to a meaningful element after navigation, such as the main content area or a heading, so keyboard and screen reader users know where they are on the new page.
+
 ### Adding new regions on navigation
 
 Sometimes you need UI elements — like modals, sidebars, or notification panels — that only appear on certain pages. With regular router regions, a region must already exist on the current page to be updated during navigation. The `attachTo` option solves this by letting you define regions that are dynamically created and inserted into the DOM when navigating to a page where they exist, even if they weren't present on the original page.
@@ -576,7 +602,7 @@ When `clientNavigationDisabled` is `true`:
 ### Disabling navigation feedback
 
 The Interactivity API router includes built-in feedback during navigation:
-- **Loading animation**: A progress bar that appears during navigation.
+- **Loading animation**: A progress bar that appears at the top of the page during navigation. The bar appears after a short delay (400ms) if navigation hasn't completed yet.
 - **Screen reader announcements**: Accessibility announcements for navigation progress.
 
 In some cases, you may want to disable these:

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -14,6 +14,11 @@ This is known as **region-based client-side navigation**, and it is the recommen
     - [Implementing navigation](#implementing-navigation)
     - [Implementing prefetching](#implementing-prefetching)
     - [Complete example: Pagination](#complete-example-pagination)
+- [Block compatibility](#block-compatibility)
+    - [The `supports.interactivity` field](#the-supportsinteractivity-field)
+    - [Non-interactive blocks](#non-interactive-blocks)
+    - [Interactive blocks using the Interactivity API](#interactive-blocks-using-the-interactivity-api)
+    - [Interactive blocks using other libraries](#interactive-blocks-using-other-libraries)
 - [More advanced use cases](#more-advanced-use-cases)
     - [Adding new regions on navigation](#adding-new-regions-on-navigation)
     - [Handling server state updates](#handling-server-state-updates)
@@ -255,6 +260,100 @@ store( 'myPagination', {
     },
 } );
 ```
+
+## Block compatibility
+
+For client-side navigation to work correctly, the blocks inside a router region need to be compatible with it. A block is compatible when it can be re-rendered by the router without breaking its functionality. This primarily depends on how the block handles interactivity.
+
+Blocks declare their compatibility with client-side navigation through the `supports.interactivity` field in their `block.json` file. This information tells WordPress whether a block can safely participate in region-based navigation.
+
+### The `supports.interactivity` field
+
+The `supports.interactivity` field in `block.json` can be set as a boolean or as an object with two sub-properties:
+
+- **`interactive`** (`boolean`, default: `false`): Indicates whether the block uses Interactivity API directives.
+- **`clientNavigation`** (`boolean`, default: `false`): Indicates whether the block is compatible with client-side navigation.
+
+Setting `supports.interactivity` to `true` is a shorthand for setting both `interactive` and `clientNavigation` to `true`:
+
+```json
+{
+    "supports": {
+        "interactivity": true
+    }
+}
+```
+
+This is equivalent to:
+
+```json
+{
+    "supports": {
+        "interactivity": {
+            "clientNavigation": true,
+            "interactive": true
+        }
+    }
+}
+```
+
+The `clientNavigation` property is the key to compatibility. Set it to `true` only if:
+
+- The block is **not interactive** (it renders only static HTML), or
+- The block **is interactive and uses the Interactivity API** for all its client-side behavior.
+
+Set it to `false` (or leave it unset) if the block is interactive but uses vanilla JavaScript, jQuery, or any other JavaScript framework or library other than the Interactivity API.
+
+### Non-interactive blocks
+
+Blocks that render only static HTML — with no JavaScript-driven interactivity — are inherently compatible with client-side navigation. Since they have no client-side state to manage or event listeners to re-attach, they can be safely re-rendered by the router at any time.
+
+For these blocks, set only `clientNavigation` to `true`:
+
+```json
+{
+    "supports": {
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}
+```
+
+Examples of non-interactive blocks include the Paragraph, Heading, Image, and List blocks. Even though they don't use Interactivity API directives, they are fully compatible with client-side navigation because their output is purely static HTML.
+
+### Interactive blocks using the Interactivity API
+
+Blocks that use the Interactivity API for their client-side behavior are compatible with client-side navigation. The Interactivity API's directive system integrates with the router, so interactive state, event handlers, and reactive bindings are properly preserved or re-initialized when regions are updated during navigation.
+
+For these blocks, set both properties to `true` (or use the shorthand):
+
+```json
+{
+    "supports": {
+        "interactivity": true
+    }
+}
+```
+
+### Interactive blocks using other libraries
+
+Blocks that use vanilla JavaScript, jQuery, or other JavaScript frameworks for interactivity are **not compatible** with client-side navigation. When the router replaces a region's content, any event listeners attached via these libraries are lost, and the block's JavaScript will not re-initialize for the new content.
+
+For these blocks, leave `supports.interactivity` at its default value (`false`) or explicitly set `clientNavigation` to `false`:
+
+```json
+{
+    "supports": {
+        "interactivity": {
+            "clientNavigation": false
+        }
+    }
+}
+```
+
+> [!IMPORTANT]
+> If a block that is not compatible with client-side navigation is detected inside a router region, WordPress may automatically disable client-side navigation on that page to prevent broken behavior. For example, the Query block's enhanced pagination checks for incompatible blocks and falls back to full page reloads when they are found.
 
 ## More advanced use cases
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -77,8 +77,9 @@ Here's how to implement a link that navigates client-side. First, the HTML in yo
 </a>
 ```
 
-> [!NOTE]
-> This element must be placed inside an element with the `data-wp-interactive="myPlugin"` directive (like the router region defined above), so the directive knows which store namespace to look up the action in. Alternatively, you can specify the namespace explicitly in the directive value itself: `data-wp-on--click="myPlugin::actions.navigateTo"`. For more details on how namespaces work, see the [Interactivity API Reference](/docs/reference-guides/interactivity-api/directives-and-store.md).
+<div class="callout callout-info">
+This element must be placed inside an element with the <code>data-wp-interactive="myPlugin"</code> directive (like the router region defined above), so the directive knows which store namespace to look up the action in. Alternatively, you can specify the namespace explicitly in the directive value itself: <code>data-wp-on--click="myPlugin::actions.navigateTo"</code>. For more details on how namespaces work, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/">Interactivity API Reference</a>.
+</div>
 
 Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
 
@@ -100,8 +101,9 @@ store( 'myPlugin', {
 } );
 ```
 
-> [!NOTE]
-> The `withSyncEvent()` wrapper is required for actions that need to call synchronous event methods like `event.preventDefault()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details.
+<div class="callout callout-info">
+The <code>withSyncEvent()</code> wrapper is required for actions that need to call synchronous event methods like <code>event.preventDefault()</code>. See the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/#withsyncevent">withSyncEvent() documentation</a> for details.
+</div>
 
 ### Implementing prefetching
 
@@ -320,8 +322,9 @@ For these blocks, leave `supports.interactivity` at its default value (`false`) 
 }
 ```
 
-> [!IMPORTANT]
-> If a block that is not compatible with client-side navigation is detected inside a router region, WordPress may automatically disable client-side navigation on that page to prevent broken behavior. For example, the Query block's enhanced pagination checks for incompatible blocks and falls back to full page reloads when they are found.
+<div class="callout callout-warning">
+If a block that is not compatible with client-side navigation is detected inside a router region, WordPress may automatically disable client-side navigation on that page to prevent broken behavior. For example, the Query block's enhanced pagination checks for incompatible blocks and falls back to full page reloads when they are found.
+</div>
 
 ## More advanced use cases
 
@@ -443,8 +446,9 @@ yield actions.navigate( '/products/', { force: true } );
 yield actions.prefetch( '/products/', { force: true } );
 ```
 
-> [!IMPORTANT]
-> If you're using `force: true` to refresh a page after a mutation (POST, PUT, DELETE request), make sure the mutation has completed before navigating:
+<div class="callout callout-warning">
+If you're using <code>force: true</code> to refresh a page after a mutation (POST, PUT, DELETE request), make sure the mutation has completed before navigating:
+</div>
 
 ```js
 store( 'myPlugin', {
@@ -1102,5 +1106,6 @@ import '@wordpress/interactivity-router/full-page';
 
 Full-page client-side navigation is essentially a special case of region-based navigation where there is only one region covering the whole page. Because it replaces all content, **every block on the page must be compatible with client-side navigation** — meaning all interactive blocks must use the Interactivity API (not jQuery or other libraries). See [Block compatibility](#block-compatibility) for details on how to declare block compatibility.
 
-> [!WARNING]
-> This feature is experimental and still under active development. It may not work correctly in all scenarios. If you try it out, please report any issues you encounter in the [Gutenberg GitHub repository](https://github.com/WordPress/gutenberg/issues). Contributions are also welcome!
+<div class="callout callout-alert">
+This feature is experimental and still under active development. It may not work correctly in all scenarios. If you try it out, please report any issues you encounter in the <a href="https://github.com/WordPress/gutenberg/issues">Gutenberg GitHub repository</a>. Contributions are also welcome!
+</div>

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -6,8 +6,8 @@ The Interactivity API provides client-side navigation through the `@wordpress/in
 
 The Interactivity API supports two navigation modes:
 
-- **Region-based client-side navigation** — The recommended approach for implementing client-side navigation in WordPress.
-- **Full-page client-side navigation** _(experimental)_ — Treats the entire `<body>` element as a single region, effectively updating the whole page content without a traditional reload. Covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
+-   **Region-based client-side navigation** — The recommended approach for implementing client-side navigation in WordPress.
+-   **Full-page client-side navigation** _(experimental)_ — Treats the entire `<body>` element as a single region, effectively updating the whole page content without a traditional reload. Covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
 
 ## How client-side navigation works
 
@@ -22,10 +22,10 @@ When a user triggers a navigation, for example, by clicking a link that has a `d
 
 This approach offers several benefits:
 
-- **Improved performance**: Only the changed parts of the page are updated, reducing data transfer and DOM manipulation.
-- **Preserved state**: Client-side state (global state, local context) is preserved across navigations.
-- **Smooth transitions**: No flash of white screen between pages; transitions feel instant and app-like.
-- **SEO-friendly**: Since the server still renders complete HTML pages, search engines can crawl your site normally.
+-   **Improved performance**: Only the changed parts of the page are updated, reducing data transfer and DOM manipulation.
+-   **Preserved state**: Client-side state (global state, local context) is preserved across navigations.
+-   **Smooth transitions**: No flash of white screen between pages; transitions feel instant and app-like.
+-   **SEO-friendly**: Since the server still renders complete HTML pages, search engines can crawl your site normally.
 
 ## Getting started with the Interactivity Router
 
@@ -70,12 +70,7 @@ To trigger client-side navigation, you define an **action** in your block's stor
 Here's how to implement a link that navigates client-side. First, the HTML in your block's `render.php` connects the link's click event to the `navigateTo` action:
 
 ```html
-<a
-    data-wp-on--click="actions.navigateTo"
-    href="/page-2/"
->
-    Go to Page 2
-</a>
+<a data-wp-on--click="actions.navigateTo" href="/page-2/"> Go to Page 2 </a>
 ```
 
 Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
@@ -85,16 +80,16 @@ Then, in your `view.js`, you define the `navigateTo` action. It prevents the bro
 import { store, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPlugin', {
-    actions: {
-        navigateTo: withSyncEvent( function* ( event ) {
-            event.preventDefault();
+	actions: {
+		navigateTo: withSyncEvent( function* ( event ) {
+			event.preventDefault();
 
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.navigate( event.target.href );
-        } ),
-    },
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
+		} ),
+	},
 } );
 ```
 
@@ -110,11 +105,11 @@ A common pattern is to prefetch a page when the user hovers over a link, and nav
 
 ```html
 <a
-    data-wp-on--mouseenter="actions.prefetchPage"
-    data-wp-on--click="actions.navigateTo"
-    href="/page-2/"
+	data-wp-on--mouseenter="actions.prefetchPage"
+	data-wp-on--click="actions.navigateTo"
+	href="/page-2/"
 >
-    Hover to prefetch, click to navigate
+	Hover to prefetch, click to navigate
 </a>
 ```
 
@@ -125,23 +120,23 @@ The corresponding actions in `view.js` handle each event:
 import { store, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPlugin', {
-    actions: {
-        prefetchPage: function* ( event ) {
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.prefetch( event.target.href );
-        },
+	actions: {
+		prefetchPage: function* ( event ) {
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.prefetch( event.target.href );
+		},
 
-        navigateTo: withSyncEvent( function* ( event ) {
-            event.preventDefault();
+		navigateTo: withSyncEvent( function* ( event ) {
+			event.preventDefault();
 
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.navigate( event.target.href );
-        } ),
-    },
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
+		} ),
+	},
 } );
 ```
 
@@ -152,6 +147,7 @@ This example brings together router regions, navigation, and prefetching to impl
 The block queries posts for the current page and renders them inside a router region. Pagination links at the bottom allow the user to move between pages. When the user hovers over a "Previous" or "Next" link, the target page is prefetched. When they click, the router navigates client-side — replacing only the content inside the router region without a full page reload. After navigation, the page scrolls smoothly to the top.
 
 **PHP (render.php):**
+
 ```php
 <?php
 $current_page = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
@@ -201,30 +197,31 @@ $query = new WP_Query( array(
 ```
 
 **JavaScript (view.js):**
+
 ```js
 import { store, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPagination', {
-    actions: {
-        prefetch: function* ( event ) {
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.prefetch( event.target.href );
-        },
+	actions: {
+		prefetch: function* ( event ) {
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.prefetch( event.target.href );
+		},
 
-        navigate: withSyncEvent( function* ( event ) {
-            event.preventDefault();
+		navigate: withSyncEvent( function* ( event ) {
+			event.preventDefault();
 
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.navigate( event.target.href );
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
 
-            // Scroll to top after navigation.
-            window.scrollTo( { top: 0, behavior: 'smooth' } );
-        } ),
-    },
+			// Scroll to top after navigation.
+			window.scrollTo( { top: 0, behavior: 'smooth' } );
+		} ),
+	},
 } );
 ```
 
@@ -238,16 +235,16 @@ Blocks declare their compatibility with client-side navigation through the `supp
 
 The `supports.interactivity` field in `block.json` can be set as a boolean or as an object with two sub-properties:
 
-- **`interactive`** (`boolean`, default: `false`): Indicates whether the block uses Interactivity API directives.
-- **`clientNavigation`** (`boolean`, default: `false`): Indicates whether the block is compatible with client-side navigation.
+-   **`interactive`** (`boolean`, default: `false`): Indicates whether the block uses Interactivity API directives.
+-   **`clientNavigation`** (`boolean`, default: `false`): Indicates whether the block is compatible with client-side navigation.
 
 Setting `supports.interactivity` to `true` is a shorthand for setting both `interactive` and `clientNavigation` to `true`:
 
 ```json
 {
-    "supports": {
-        "interactivity": true
-    }
+	"supports": {
+		"interactivity": true
+	}
 }
 ```
 
@@ -255,19 +252,19 @@ This is equivalent to:
 
 ```json
 {
-    "supports": {
-        "interactivity": {
-            "clientNavigation": true,
-            "interactive": true
-        }
-    }
+	"supports": {
+		"interactivity": {
+			"clientNavigation": true,
+			"interactive": true
+		}
+	}
 }
 ```
 
 The `clientNavigation` property is the key to compatibility. Set it to `true` only if:
 
-- The block is **not interactive** (it renders only static HTML), or
-- The block **is interactive and uses the Interactivity API** for all its client-side behavior.
+-   The block is **not interactive** (it renders only static HTML), or
+-   The block **is interactive and uses the Interactivity API** for all its client-side behavior.
 
 Set it to `false` (or leave it unset) if the block is interactive but uses vanilla JavaScript, jQuery, or any other JavaScript framework or library other than the Interactivity API.
 
@@ -279,11 +276,11 @@ For these blocks, set only `clientNavigation` to `true`:
 
 ```json
 {
-    "supports": {
-        "interactivity": {
-            "clientNavigation": true
-        }
-    }
+	"supports": {
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
 }
 ```
 
@@ -297,11 +294,11 @@ For these blocks, leave `supports.interactivity` at its default value (`false`) 
 
 ```json
 {
-    "supports": {
-        "interactivity": {
-            "clientNavigation": false
-        }
-    }
+	"supports": {
+		"interactivity": {
+			"clientNavigation": false
+		}
+	}
 }
 ```
 
@@ -319,19 +316,19 @@ You should handle scroll and focus explicitly in your navigation action. For exa
 
 ```js
 store( 'myPlugin', {
-    actions: {
-        navigateTo: withSyncEvent( function* ( event ) {
-            event.preventDefault();
+	actions: {
+		navigateTo: withSyncEvent( function* ( event ) {
+			event.preventDefault();
 
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.navigate( event.target.href );
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
 
-            // Scroll to top after navigation.
-            window.scrollTo( { top: 0, behavior: 'smooth' } );
-        } ),
-    },
+			// Scroll to top after navigation.
+			window.scrollTo( { top: 0, behavior: 'smooth' } );
+		} ),
+	},
 } );
 ```
 
@@ -345,15 +342,15 @@ Sometimes you need UI elements — like modals, sidebars, or notification panels
 
 ```html
 <div
-    data-wp-interactive="myPlugin"
-    data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
+	data-wp-interactive="myPlugin"
+	data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
 >
-    <div class="modal-overlay">
-        <div class="modal-content">
-            <h2>Modal Title</h2>
-            <p>Modal content here...</p>
-        </div>
-    </div>
+	<div class="modal-overlay">
+		<div class="modal-content">
+			<h2>Modal Title</h2>
+			<p>Modal content here...</p>
+		</div>
+	</div>
 </div>
 ```
 
@@ -362,6 +359,7 @@ The `attachTo` value is a CSS selector. When navigating to this page from a page
 **Example: Modal that appears on navigation**
 
 _Page without modal (page-1.php):_
+
 ```php
 <div
     data-wp-interactive="myPlugin"
@@ -378,6 +376,7 @@ _Page without modal (page-1.php):_
 ```
 
 _Page with modal (page-2.php):_
+
 ```php
 <div
     data-wp-interactive="myPlugin"
@@ -414,30 +413,30 @@ Use `getServerState()` and `getServerContext()` to react specifically to server-
 
 ```js
 import {
-    store,
-    getContext,
-    getServerState,
-    getServerContext,
+	store,
+	getContext,
+	getServerState,
+	getServerContext,
 } from '@wordpress/interactivity';
 
 const { state } = store( 'myPlugin', {
-    callbacks: {
-        syncWithServer() {
-            const serverState = getServerState();
-            const serverContext = getServerContext();
-            const context = getContext();
+	callbacks: {
+		syncWithServer() {
+			const serverState = getServerState();
+			const serverContext = getServerContext();
+			const context = getContext();
 
-            // Keep the product count in sync with the server across navigations.
-            if ( serverState.productCount !== undefined ) {
-                state.productCount = serverState.productCount;
-            }
+			// Keep the product count in sync with the server across navigations.
+			if ( serverState.productCount !== undefined ) {
+				state.productCount = serverState.productCount;
+			}
 
-            // Reset the expanded state based on the new page's context.
-            if ( serverContext.isExpanded !== undefined ) {
-                context.isExpanded = serverContext.isExpanded;
-            }
-        },
-    },
+			// Reset the expanded state based on the new page's context.
+			if ( serverContext.isExpanded !== undefined ) {
+				context.isExpanded = serverContext.isExpanded;
+			}
+		},
+	},
 } );
 ```
 
@@ -461,18 +460,18 @@ If you're using <code>force: true</code> to refresh a page after a mutation (POS
 
 ```js
 store( 'myPlugin', {
-    actions: {
-        deleteAndRefresh: function* () {
-            // Wait for the deletion to complete.
-            yield fetch( '/api/items/123', { method: 'DELETE' } );
+	actions: {
+		deleteAndRefresh: function* () {
+			// Wait for the deletion to complete.
+			yield fetch( '/api/items/123', { method: 'DELETE' } );
 
-            // Now refresh the page to show updated data.
-            const { actions } = yield import(
-                '@wordpress/interactivity-router'
-            );
-            yield actions.navigate( window.location.href, { force: true } );
-        },
-    },
+			// Now refresh the page to show updated data.
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( window.location.href, { force: true } );
+		},
+	},
 } );
 ```
 
@@ -498,9 +497,10 @@ yield actions.prefetch( '/custom-page/', {
 ```
 
 This is useful for:
-- Optimistic UI updates where you construct the expected HTML before the server responds.
-- Offline scenarios where you provide cached or fallback content.
-- Testing and development.
+
+-   Optimistic UI updates where you construct the expected HTML before the server responds.
+-   Offline scenarios where you provide cached or fallback content.
+-   Testing and development.
 
 ### Managing browser history
 
@@ -515,9 +515,10 @@ yield actions.navigate( '/page-2/', { replace: true } );
 ```
 
 Use `replace: true` when:
-- Implementing redirects where the original URL shouldn't be in history.
-- Updating query parameters for filtering/sorting where each change shouldn't be a separate history entry.
-- Implementing infinite scroll where you update the URL but don't want each page to be a separate history entry.
+
+-   Implementing redirects where the original URL shouldn't be in history.
+-   Updating query parameters for filtering/sorting where each change shouldn't be a separate history entry.
+-   Implementing infinite scroll where you update the URL but don't want each page to be a separate history entry.
 
 ### Changing the timeout
 
@@ -539,33 +540,33 @@ If you need custom error handling (for example, showing an error message instead
 
 ```js
 store( 'myPlugin', {
-    actions: {
-        navigateWithCustomErrorHandling: withSyncEvent( function* ( event ) {
-            event.preventDefault();
-            const url = event.target.href;
+	actions: {
+		navigateWithCustomErrorHandling: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+			const url = event.target.href;
 
-            try {
-                // Fetch the page manually.
-                const response = yield fetch( url );
+			try {
+				// Fetch the page manually.
+				const response = yield fetch( url );
 
-                if ( ! response.ok ) {
-                    // Handle HTTP errors.
-                    state.error = `Error: ${response.status}`;
-                    return;
-                }
+				if ( ! response.ok ) {
+					// Handle HTTP errors.
+					state.error = `Error: ${ response.status }`;
+					return;
+				}
 
-                const html = yield response.text();
+				const html = yield response.text();
 
-                // Navigate using the fetched HTML.
-                const { actions } = yield import(
-                    '@wordpress/interactivity-router'
-                );
-                yield actions.navigate( url, { html } );
-            } catch ( error ) {
-                state.error = 'Network error. Please check your connection.';
-            }
-        } ),
-    },
+				// Navigate using the fetched HTML.
+				const { actions } = yield import(
+					'@wordpress/interactivity-router'
+				);
+				yield actions.navigate( url, { html } );
+			} catch ( error ) {
+				state.error = 'Network error. Please check your connection.';
+			}
+		} ),
+	},
 } );
 ```
 
@@ -587,15 +588,17 @@ add_action( 'wp', function() {
 ```
 
 When `clientNavigationDisabled` is `true`:
-- `actions.navigate()` triggers a full page reload.
-- `actions.prefetch()` does nothing.
-- Navigating from another page to this page forces a reload.
+
+-   `actions.navigate()` triggers a full page reload.
+-   `actions.prefetch()` does nothing.
+-   Navigating from another page to this page forces a reload.
 
 ### Disabling navigation feedback
 
 The Interactivity API router includes built-in feedback during navigation:
-- **Loading animation**: A progress bar that appears at the top of the page during navigation. The bar appears after a short delay (400ms) if navigation hasn't completed yet.
-- **Screen reader announcements**: Accessibility announcements for navigation progress.
+
+-   **Loading animation**: A progress bar that appears at the top of the page during navigation. The bar appears after a short delay (400ms) if navigation hasn't completed yet.
+-   **Screen reader announcements**: Accessibility announcements for navigation progress.
 
 In some cases, you may want to disable these:
 
@@ -614,9 +617,10 @@ yield actions.navigate( '/page/', {
 ```
 
 Use cases for disabling feedback:
-- **Silent updates**: Background refreshes where you don't want to draw attention.
-- **Custom loading UI**: When you're implementing your own loading indicators.
-- **Custom accessibility**: When you're providing your own screen reader announcements.
+
+-   **Silent updates**: Background refreshes where you don't want to draw attention.
+-   **Custom loading UI**: When you're implementing your own loading indicators.
+-   **Custom accessibility**: When you're providing your own screen reader announcements.
 
 ### Subscribing to page changes
 
@@ -628,18 +632,18 @@ import { watch, store } from '@wordpress/interactivity';
 
 // Store-wide subscription.
 watch( () => {
-    const { state } = store( 'core/router' );
-    sendAnalyticsPageView( state.url );
+	const { state } = store( 'core/router' );
+	sendAnalyticsPageView( state.url );
 } );
 
 // Element-based subscription: <div data-wp-watch="callbacks.sendPageView">
 store( 'myPlugin', {
-    callbacks: {
-        sendPageView() {
-            const { state } = store( 'core/router' );
-            sendAnalyticsPageView( state.url );
-        },
-    },
+	callbacks: {
+		sendPageView() {
+			const { state } = store( 'core/router' );
+			sendAnalyticsPageView( state.url );
+		},
+	},
 } );
 ```
 
@@ -655,11 +659,11 @@ The cache uses a normalized version of the URL as its key. This normalization st
 
 Each entry in the cache stores not just the fetched HTML, but a fully processed page representation containing:
 
-- **Virtual DOM trees** for each router region found in the page
-- **Style sheet references** needed by the page
-- **Script module information** for JavaScript that should be loaded
-- **The page title** for updating the document title
-- **Server state** that was embedded in the page by WordPress
+-   **Virtual DOM trees** for each router region found in the page
+-   **Style sheet references** needed by the page
+-   **Script module information** for JavaScript that should be loaded
+-   **The page title** for updating the document title
+-   **Server state** that was embedded in the page by WordPress
 
 An important detail is that the cache stores promises rather than resolved values. When a fetch begins, the router immediately stores the pending promise in the cache. This means that if multiple calls to `prefetch()` or `navigate()` target the same URL simultaneously (for example, if a user rapidly hovers over multiple links pointing to the same page), only one network request is made. All callers receive the same promise and wait for the same result.
 
@@ -674,7 +678,9 @@ const { actions } = store( 'myPlugin', {
 		*submitForm() {
 			yield fetch( '/wp-json/my-plugin/v1/submit', {
 				method: 'POST',
-				body: JSON.stringify( { /* form data */ } ),
+				body: JSON.stringify( {
+					/* form data */
+				} ),
 			} );
 			// Navigate to the same page, bypassing the cache
 			// to reflect the updated content.
@@ -695,24 +701,25 @@ You define a router region by adding the `data-wp-router-region` attribute to an
 The attribute value serves as a unique identifier for that region. You can specify it in two ways:
 
 1. As a simple string:
-   ```html
-   <div
-       data-wp-interactive="myPlugin"
-       data-wp-router-region="myPlugin/main-content"
-   >
-       <!-- Region content -->
-   </div>
-   ```
+
+    ```html
+    <div
+    	data-wp-interactive="myPlugin"
+    	data-wp-router-region="myPlugin/main-content"
+    >
+    	<!-- Region content -->
+    </div>
+    ```
 
 2. As a JSON object (when you need to pass other options):
-   ```html
-   <div
-       data-wp-interactive="myPlugin"
-       data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
-   >
-       <!-- Region content -->
-   </div>
-   ```
+    ```html
+    <div
+    	data-wp-interactive="myPlugin"
+    	data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
+    >
+    	<!-- Region content -->
+    </div>
+    ```
 
 The region ID must be unique within a single page and consistent across pages that share the same region. For example, if both your "Products" page and "Product Detail" page have a sidebar, and you want that sidebar to update during navigation, both pages should define a region with the same ID (e.g., `"myPlugin/sidebar"`).
 
@@ -729,19 +736,19 @@ For a router region to function correctly, it must meet these requirements:
 ```html
 <!-- Correct: The region element has data-wp-interactive -->
 <div data-wp-interactive="myPlugin">
-    <div
-        data-wp-interactive="myPlugin"
-        data-wp-router-region="myPlugin/sidebar"
-    >
-        <!-- Sidebar content -->
-    </div>
+	<div
+		data-wp-interactive="myPlugin"
+		data-wp-router-region="myPlugin/sidebar"
+	>
+		<!-- Sidebar content -->
+	</div>
 </div>
 
 <!-- Incorrect: This region may not update properly -->
 <div data-wp-interactive="myPlugin">
-    <div data-wp-router-region="myPlugin/sidebar">
-        <!-- This won't work reliably! -->
-    </div>
+	<div data-wp-router-region="myPlugin/sidebar">
+		<!-- This won't work reliably! -->
+	</div>
 </div>
 ```
 
@@ -803,17 +810,14 @@ For example, consider a shopping cart icon in the header that displays the numbe
 ```html
 <!-- This header is NOT inside a router region -->
 <header data-wp-interactive="myShop">
-    <div class="cart-icon">
-        <span data-wp-text="state.cartCount"></span> items
-    </div>
+	<div class="cart-icon">
+		<span data-wp-text="state.cartCount"></span> items
+	</div>
 </header>
 
 <!-- This is the router region that updates during navigation -->
-<main
-    data-wp-interactive="myShop"
-    data-wp-router-region="myShop/content"
->
-    <!-- Page content -->
+<main data-wp-interactive="myShop" data-wp-router-region="myShop/content">
+	<!-- Page content -->
 </main>
 ```
 
@@ -823,12 +827,12 @@ But if you use `getServerState()` instead:
 
 ```js
 const { state } = store( 'myShop', {
-    state: {
-        get cartCount() {
-            // This reacts to server state changes during navigation.
-            return getServerState().cartCount;
-        },
-    },
+	state: {
+		get cartCount() {
+			// This reacts to server state changes during navigation.
+			return getServerState().cartCount;
+		},
+	},
 } );
 ```
 
@@ -871,24 +875,26 @@ When inserting new style sheets, the router must preserve the correct cascade or
 Given the current page's style sheets (sequence X) and the target page's style sheets (sequence Y), the SCS algorithm finds the shortest sequence that contains both X and Y as subsequences while preserving their internal order. This tells the router exactly where to insert new elements and which existing elements to keep.
 
 For example:
-- Current page styles (X): [A, C, D]
-- Target page styles (Y): [A, B, C, E]
-- Shortest Common Supersequence: [A, B, C, D, E]
+
+-   Current page styles (X): [A, C, D]
+-   Target page styles (Y): [A, B, C, E]
+-   Shortest Common Supersequence: [A, B, C, D, E]
 
 The algorithm then determines: keep A and C in place, insert B between A and C, keep D after C, and insert E at the end.
 
 This approach ensures that:
-- Style sheets that appear in both pages remain in their correct relative order
-- New style sheets are inserted at the proper position to maintain cascade correctness
-- The minimum number of DOM operations is performed
+
+-   Style sheets that appear in both pages remain in their correct relative order
+-   New style sheets are inserted at the proper position to maintain cascade correctness
+-   The minimum number of DOM operations is performed
 
 **Activating and deactivating styles during navigation**
 
 When `navigate()` actually renders the new page, the router toggles style sheets on and off:
 
-- **Activating styles**: For each style sheet that belongs to the target page, the router removes the `media="preload"` override (or restores the original `media` attribute if one was specified). This causes the browser to apply those styles.
+-   **Activating styles**: For each style sheet that belongs to the target page, the router removes the `media="preload"` override (or restores the original `media` attribute if one was specified). This causes the browser to apply those styles.
 
-- **Deactivating styles**: For each style sheet that was in the current page but not the target page, the router sets `media="preload"`. This disables the styles without removing the element from the DOM.
+-   **Deactivating styles**: For each style sheet that was in the current page but not the target page, the router sets `media="preload"`. This disables the styles without removing the element from the DOM.
 
 By keeping deactivated style elements in the DOM (rather than removing them), the router can quickly reactivate them if the user navigates back. The styles are already loaded and parsed; they just need to be enabled.
 
@@ -902,9 +908,9 @@ Not all script modules should be loaded during client-side navigation. Some modu
 
 ```html
 <script
-    type="module"
-    src="/wp-content/plugins/my-plugin/view.js"
-    data-wp-router-options='{"loadOnClientNavigation": true}'
+	type="module"
+	src="/wp-content/plugins/my-plugin/view.js"
+	data-wp-router-options='{"loadOnClientNavigation": true}'
 ></script>
 ```
 
@@ -916,12 +922,12 @@ Modern JavaScript uses import maps to resolve bare module specifiers (like `@wor
 
 ```html
 <script type="importmap">
-{
-    "imports": {
-        "@wordpress/interactivity": "/wp-includes/js/dist/interactivity.min.js",
-        "@wordpress/interactivity-router": "/wp-includes/js/dist/interactivity-router.min.js"
-    }
-}
+	{
+		"imports": {
+			"@wordpress/interactivity": "/wp-includes/js/dist/interactivity.min.js",
+			"@wordpress/interactivity-router": "/wp-includes/js/dist/interactivity-router.min.js"
+		}
+	}
 </script>
 ```
 
@@ -955,8 +961,8 @@ When `navigate()` renders the new page, it imports all the script modules that w
 
 ```js
 // Simplified conceptual view of what happens.
-for (const moduleInfo of page.scriptModules) {
-    await import(moduleInfo.blobUrl);
+for ( const moduleInfo of page.scriptModules ) {
+	await import( moduleInfo.blobUrl );
 }
 ```
 
@@ -974,15 +980,18 @@ When WordPress renders a page with interactive blocks, it embeds server-provided
 
 ```html
 <!-- Global state -->
-<script type="application/json" id="wp-script-module-data-@wordpress/interactivity">
-{
-    "state": {
-        "myPlugin":{
-            "cartItemCount": 3,
-            "userLoggedIn": true
-        }
-    }
-}
+<script
+	type="application/json"
+	id="wp-script-module-data-@wordpress/interactivity"
+>
+	{
+		"state": {
+			"myPlugin": {
+				"cartItemCount": 3,
+				"userLoggedIn": true
+			}
+		}
+	}
 </script>
 ```
 
@@ -990,10 +999,10 @@ Local context is embedded directly in the `data-wp-context` attribute of element
 
 ```html
 <div
-    data-wp-interactive="myPlugin"
-    data-wp-context='{ "productId": 42, "inStock": true }'
+	data-wp-interactive="myPlugin"
+	data-wp-context='{ "productId": 42, "inStock": true }'
 >
-    <!-- Block content -->
+	<!-- Block content -->
 </div>
 ```
 
@@ -1053,8 +1062,8 @@ After navigation:
 
 The Interactivity API provides two functions for accessing server-provided data that updates during navigation:
 
-- `getServerState()`: Returns the global state as provided by the server for the current page
-- `getServerContext()`: Returns the local context as provided by the server for the current element
+-   `getServerState()`: Returns the global state as provided by the server for the current page
+-   `getServerContext()`: Returns the local context as provided by the server for the current element
 
 These functions are reactive. When used inside a callback or derived state getter, they automatically set up a subscription. When navigation occurs and new server data arrives, any code using these functions will re-run with the new values.
 
@@ -1090,11 +1099,11 @@ When `navigate()` is called (for example, on link click):
 4. A loading indicator may appear if the wait exceeds a threshold (400ms).
 5. Script modules for the new page are imported and executed.
 6. The rendering phase begins (wrapped in a batch for efficiency):
-   - Server state is merged with client state.
-   - Each router region is updated with its new virtual DOM.
-   - Regions with `attachTo` that don't exist are created and appended.
-   - Styles are activated/deactivated as needed.
-   - The document title is updated.
+    - Server state is merged with client state.
+    - Each router region is updated with its new virtual DOM.
+    - Regions with `attachTo` that don't exist are created and appended.
+    - Styles are activated/deactivated as needed.
+    - The document title is updated.
 7. Browser history is updated (pushState or replaceState).
 8. Screen reader announcement is made for accessibility.
 9. If the URL has a hash, the page scrolls to that element.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -22,61 +22,41 @@ This approach offers several benefits:
 - **Smooth transitions**: No flash of white screen between pages; transitions feel instant and app-like.
 - **SEO-friendly**: Since the server still renders complete HTML pages, search engines can crawl your site normally.
 
-## Getting started with the Interactivity Router
+### In depth
 
-The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. To use it in your interactive blocks, you need to:
+This section explains the client-side navigation algorithm in more detail. You can skip to [Using the Interactivity API router](#using-the-interactivity-api-router) if you're more interested in practical usage.
 
-1. **Add the dependency**: Ensure `@wordpress/interactivity-router` is listed as a dependency for your script module.
-2. **Define router regions**: Mark the HTML elements that should be updated during navigation.
-3. **Trigger navigation**: Use the `actions.navigate()` function to navigate programmatically.
+#### Router regions
 
-### Dynamic imports for optimal performance
+Router regions are the fundamental building blocks of client-side navigation. They define which parts of the page should be updated during navigation.
 
-The recommended pattern is to import the router package dynamically to reduce the initial JavaScript bundle size. The router is only loaded when navigation is actually needed:
+**How router regions are defined:**
 
-```js
-import { store, withSyncEvent } from '@wordpress/interactivity';
+Router regions are defined using the `data-wp-router-region` directive. The value can be either:
 
-store( 'myPlugin', {
-	actions: {
-		// Use withSyncEvent because we need to call preventDefault().
-		goToPage: withSyncEvent( function* ( event ) {
-			event.preventDefault();
-
-			// Dynamically import the router when needed.
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.navigate( event.target.href );
-		} ),
-	},
-} );
-```
-
-_Note: Actions that need to call synchronous event methods like `event.preventDefault()` must wrap the handler with `withSyncEvent()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details._
-
-## Defining router regions
-
-Router regions are sections of your page that will be updated during client-side navigation. You define them using the `data-wp-router-region` directive.
-
-### Basic usage
-
-To create a router region, add the `data-wp-router-region` directive to an element that also has `data-wp-interactive`:
-
-```html
-<div
+1. A simple string ID:
+   ```html
+   <div
 	data-wp-interactive="myPlugin"
 	data-wp-router-region="main-content"
->
-	<!-- This content will be replaced during navigation -->
-	<h1>Page Title</h1>
-	<p>Page content goes here...</p>
-</div>
-```
+   >
+	<!-- Region content -->
+   </div>
+   ```
 
-The value of `data-wp-router-region` must be a unique identifier for that region. When navigating to a new page, the router will find regions with matching IDs and replace their content.
+2. A JSON object with `id` and optional `attachTo` property:
+   ```html
+   <div
+	data-wp-interactive="myPlugin"
+	data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
+   >
+	<!-- Region content -->
+   </div>
+   ```
 
-### Requirements for router regions
+The region ID must be unique within the page and consistent across pages that share the same region.
+
+**Where router regions can appear:**
 
 For a router region to work correctly:
 
@@ -103,309 +83,225 @@ For a router region to work correctly:
 </div>
 ```
 
-### How regions are matched during navigation
+**How regions are handled:**
 
-When navigating between pages, the router compares regions:
+_During fetch (`prefetch()` or `navigate()`):_
 
-- **Region exists on both pages**: The content is updated with the new page's content.
-- **Region exists only on the new page (without `attachTo`)**: The region is not added to the DOM.
-- **Region exists only on the new page (with `attachTo`)**: The region is created and appended to the specified parent.
-- **Region exists only on the current page**: The region is removed from the DOM.
+1. **Regions are identified**: The router scans the fetched HTML for all elements with `data-wp-router-region`.
+2. **Regions are converted to virtual DOM**: Each region's HTML (including the region element itself) is converted into a virtual DOM representation. This means directives on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
+3. **Regions are cached**: Each region is stored in the page cache with its corresponding ID.
 
-## Using the navigate action
+_On `navigate()`:_
 
-The `navigate` action is the primary way to trigger client-side navigation programmatically.
+1. **Regions are located in the current page**: The router finds all existing regions by their IDs.
+2. **Existing regions are updated**: If a region exists in both the current page and the target page, its content is updated with the new virtual DOM using Preact's diffing algorithm.
+3. **New regions with `attachTo` are created**: If a region exists in the target page but not the current page, and it has an `attachTo` selector, the region is created and appended to the specified element.
+4. **Orphaned regions are removed**: Regions that exist only in the current page are removed from the DOM.
 
-### Basic navigation
+#### CSS handling
+
+The router carefully manages style sheets during navigation to ensure pages are styled correctly while minimizing network requests and avoiding flash of unstyled content.
+
+**On `prefetch()`:**
+
+1. **Styles are extracted**: The router extracts all `<link rel="stylesheet">` and `<style>` elements from the fetched HTML.
+2. **Styles are compared**: Extracted styles are compared with those already present in the current page.
+3. **New styles are added**: Style sheets that don't exist in the current page are added to the document with `media="not all"` (for `<link>` elements) so they are loaded but not applied yet. The router uses a [Shortest Common Supersequence](https://en.wikipedia.org/wiki/Shortest_common_supersequence) algorithm to add new style sheets while preserving CSS cascade order.
+4. **Styles are recorded**: Both existing and newly added styles related to this page are recorded for later activation.
+
+**On `navigate()`:**
+
+1. **Styles are toggled**: The router enables or disables style sheets based on whether they belong to the page being navigated to:
+   - Styles needed by the new page have their `media` attribute restored (enabled).
+   - Styles not needed by the new page have their `media` attribute set to `not all` (disabled).
+
+This approach ensures that:
+- Style sheets are only loaded once, even if multiple pages use them.
+- CSS cascade order is maintained correctly.
+- Styles are ready before the page renders, preventing flash of unstyled content.
+
+#### Script module handling
+
+Script modules (ES modules loaded via `<script type="module">`) are managed to ensure all necessary JavaScript is available for the new page's interactive features.
+
+**On `prefetch()`:**
+
+1. **Script modules are located**: The router identifies script modules in the fetched HTML that should be loaded during client-side navigation. These are marked with `data-wp-router-options='{"loadOnClientNavigation": true}'`.
+2. **Import map is processed**: The import map from the fetched page is parsed to resolve module dependencies.
+3. **Modules are fetched and cached**: Script modules and their dependencies are fetched and cached by the browser's module system.
+
+**On `navigate()`:**
+
+1. **Cached modules are imported**: The router imports the cached script modules using dynamic `import()`.
+2. **Modules are evaluated**: Each module is evaluated, initializing any stores or callbacks it contains.
+3. **Deduplication is automatic**: Because modules are cached by the browser, importing the same module multiple times returns the cached version, ensuring each module is only evaluated once.
+
+#### Server state and context
+
+Server-rendered state and context are preserved and synchronized during navigation to maintain consistency between server and client.
+
+**On `prefetch()`:**
+
+1. **Global state is extracted**: Server state (from `wp_interactivity_state()`) is extracted from the fetched HTML.
+2. **Local context is extracted**: Context values (from `data-wp-context` attributes) are extracted as part of each router region's virtual DOM.
+3. **Data is cached**: Both state and context are stored in the page cache.
+
+**On `navigate()`:**
+
+1. **State and context are merged**: The server-provided state and context from the target page are merged with the existing client state.
+2. **Reactive updates occur**: Components subscribed to the state or context will automatically re-render.
+3. **Use `getServerState()` and `getServerContext()`**: To react to server-provided changes specifically, use these functions in your callbacks. See the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide for details.
+
+## Getting started with the Interactivity Router
+
+The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. To use it in your interactive blocks, you need to:
+
+1. **Add the dependency**: Ensure `@wordpress/interactivity-router` is listed as a dependency for your script module.
+2. **Define router regions**: Mark the HTML elements that should be updated during navigation.
+3. **Trigger navigation**: Use the `actions.navigate()` function to navigate programmatically.
+
+### Setting up router regions
+
+First, define router regions in your block's markup:
+
+```php
+// render.php
+<div
+    <?php echo get_block_wrapper_attributes(); ?>
+    data-wp-interactive="myPlugin"
+    data-wp-router-region="myPlugin/posts-list"
+>
+    <?php foreach ( $posts as $post ) : ?>
+        <article>
+            <h2><?php echo esc_html( $post->post_title ); ?></h2>
+            <p><?php echo esc_html( $post->post_excerpt ); ?></p>
+        </article>
+    <?php endforeach; ?>
+</div>
+```
+
+### Implementing navigation
+
+Use `navigate()` to handle link clicks:
 
 ```js
+// view.js
 import { store, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPlugin', {
-	actions: {
-		handleLinkClick: withSyncEvent( function* ( event ) {
-			event.preventDefault();
+    actions: {
+        navigateTo: withSyncEvent( function* ( event ) {
+            event.preventDefault();
 
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.navigate( event.target.href );
-		} ),
-	},
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.navigate( event.target.href );
+        } ),
+    },
 } );
 ```
 
 ```html
 <a
-	data-wp-on--click="actions.handleLinkClick"
-	href="/another-page/"
+    data-wp-on--click="actions.navigateTo"
+    href="/page-2/"
 >
-	Go to another page
+    Go to Page 2
 </a>
 ```
 
-### Navigation options
+_Note: The `withSyncEvent()` wrapper is required for actions that need to call synchronous event methods like `event.preventDefault()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details._
 
-The `navigate` function accepts an optional second parameter with configuration options:
+### Implementing prefetching
 
-```js
-yield actions.navigate( href, {
-	force: false, // Re-fetch even if the page is cached
-	replace: false, // Replace current history entry instead of adding new one
-	timeout: 10000, // Abort navigation after this many milliseconds
-	loadingAnimation: true, // Show loading animation during navigation
-	screenReaderAnnouncement: true, // Announce navigation to screen readers
-	html: null, // Provide HTML directly instead of fetching
-} );
-```
-
-#### Option details
-
-| Option                     | Type    | Default | Description                                                       |
-| -------------------------- | ------- | ------- | ----------------------------------------------------------------- |
-| `force`                    | boolean | `false` | Force re-fetching the page even if it's already cached            |
-| `replace`                  | boolean | `false` | Replace the current browser history entry instead of adding a new one |
-| `timeout`                  | number  | `10000` | Maximum time (in ms) to wait for the navigation before aborting   |
-| `loadingAnimation`         | boolean | `true`  | Whether to show the loading animation during navigation           |
-| `screenReaderAnnouncement` | boolean | `true`  | Whether to announce navigation status to screen readers           |
-| `html`                     | string  | `null`  | HTML string to use instead of fetching from the URL               |
-
-### Example: Navigation with custom options
+Use `prefetch()` to load pages before navigation:
 
 ```js
+// view.js
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
 store( 'myPlugin', {
-	actions: {
-		navigateWithReplace: withSyncEvent( function* ( event ) {
-			event.preventDefault();
+    actions: {
+        prefetchPage: function* ( event ) {
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.prefetch( event.target.href );
+        },
 
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
+        navigateTo: withSyncEvent( function* ( event ) {
+            event.preventDefault();
 
-			// Replace history entry and use a shorter timeout.
-			yield actions.navigate( event.target.href, {
-				replace: true,
-				timeout: 5000,
-			} );
-		} ),
-	},
-} );
-```
-
-## Prefetching pages
-
-Prefetching allows you to load a page's content before the user actually navigates to it. This makes subsequent navigation feel instant.
-
-### Basic prefetching
-
-```js
-store( 'myPlugin', {
-	actions: {
-		*prefetchPage( event ) {
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.prefetch( event.target.href );
-		},
-	},
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.navigate( event.target.href );
+        } ),
+    },
 } );
 ```
 
 ```html
 <a
-	data-wp-on--mouseenter="actions.prefetchPage"
-	data-wp-on--click="actions.handleLinkClick"
-	href="/another-page/"
+    data-wp-on--mouseenter="actions.prefetchPage"
+    data-wp-on--click="actions.navigateTo"
+    href="/page-2/"
 >
-	Hover to prefetch
+    Hover to prefetch, click to navigate
 </a>
 ```
 
-### Prefetch options
+### Complete example: Pagination
 
-| Option  | Type    | Default | Description                                           |
-| ------- | ------- | ------- | ----------------------------------------------------- |
-| `force` | boolean | `false` | Force re-fetching even if the page is already cached  |
-| `html`  | string  | `null`  | HTML string to use instead of fetching from the URL   |
-
-### Example: Prefetch on hover with force reload
-
-```js
-store( 'myPlugin', {
-	actions: {
-		*prefetchFresh( event ) {
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			// Always fetch fresh content, ignore cache.
-			yield actions.prefetch( event.target.href, { force: true } );
-		},
-	},
-} );
-```
-
-## Router state
-
-The Interactivity Router exposes reactive state that you can use in your directives:
-
-```js
-const { state } = store( 'core/router', {
-	state: {
-		url: window.location.href,
-		navigation: {
-			hasStarted: false,
-			hasFinished: false,
-		},
-	},
-} );
-```
-
-### Available state properties
-
-| Property                    | Type    | Description                                     |
-| --------------------------- | ------- | ----------------------------------------------- |
-| `state.url`                 | string  | The current URL, synchronized with browser location |
-| `state.navigation.hasStarted`  | boolean | `true` when a navigation has started            |
-| `state.navigation.hasFinished` | boolean | `true` when a navigation has completed          |
-
-### Example: Showing a loading indicator
-
-```html
-<div data-wp-interactive="myPlugin">
-	<div
-		data-wp-class--is-loading="state.navigation.hasStarted"
-		data-wp-class--is-loaded="state.navigation.hasFinished"
-	>
-		<span data-wp-bind--hidden="!state.navigation.hasStarted">
-			Loading...
-		</span>
-		<!-- Page content -->
-	</div>
-</div>
-```
-
-```css
-.is-loading {
-	opacity: 0.5;
-	pointer-events: none;
-}
-```
-
-## Dynamic regions with attachTo
-
-The `attachTo` property allows you to create regions that can be dynamically added to any part of the DOM, even if they don't exist on the initial page. This is useful for elements like modals, overlays, or sidebars that appear only on certain pages.
-
-### Using attachTo
-
-Instead of a simple string ID, pass a JSON object with `id` and `attachTo` properties:
-
-```html
-<div
-	data-wp-interactive="myPlugin"
-	data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
->
-	<div class="modal">
-		<!-- Modal content -->
-	</div>
-</div>
-```
-
-The `attachTo` value is a CSS selector pointing to the parent element where the region should be appended.
-
-### How attachTo works
-
-- If the region with `attachTo` exists on the new page but not the current page, it is created and appended to the element matching the `attachTo` selector.
-- If the region exists on both pages, the content is updated (and `attachTo` is ignored).
-- If the region exists on the current page but not the new page, it is removed from the DOM.
-- If the region with `attachTo` is present on the initial page load, it is treated as a regular region (the `attachTo` property is ignored for the initial page).
-
-### Example: Modal that appears on navigation
-
-**Page 1 (no modal):**
-```html
-<div data-wp-interactive="myPlugin" data-wp-router-region="main">
-	<h1>Page without modal</h1>
-	<a
-		data-wp-on--click="actions.navigate"
-		href="/page-with-modal/"
-	>
-		Open page with modal
-	</a>
-</div>
-```
-
-**Page 2 (with modal):**
-```html
-<div data-wp-interactive="myPlugin" data-wp-router-region="main">
-	<h1>Page with modal</h1>
-</div>
-
-<!-- Modal region that will be appended to body -->
-<div
-	data-wp-interactive="myPlugin"
-	data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
->
-	<div class="modal-overlay">
-		<div class="modal-content">
-			<h2>I'm a modal!</h2>
-			<a
-				data-wp-on--click="actions.navigate"
-				href="/page-without-modal/"
-			>
-				Close
-			</a>
-		</div>
-	</div>
-</div>
-```
-
-When navigating from Page 1 to Page 2, the modal region is created and appended to `body`. When navigating back to Page 1, the modal is removed.
-
-## Practical examples
-
-### Example 1: Simple pagination
-
-This example shows how to implement client-side pagination for a list of posts.
+Here's a complete example implementing client-side pagination:
 
 **PHP (render.php):**
 ```php
 <?php
-$current_page = isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1;
-$posts = new WP_Query( array(
-	'paged' => $current_page,
-	'posts_per_page' => 5,
+$current_page = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
+$query = new WP_Query( array(
+    'paged'          => $current_page,
+    'posts_per_page' => 5,
 ) );
 ?>
 
 <div
-	data-wp-interactive="myPagination"
-	data-wp-router-region="posts-list"
+    <?php echo get_block_wrapper_attributes(); ?>
+    data-wp-interactive="myPagination"
+    data-wp-router-region="myPagination/posts"
 >
-	<ul class="posts-list">
-		<?php while ( $posts->have_posts() ) : $posts->the_post(); ?>
-			<li><?php the_title(); ?></li>
-		<?php endwhile; ?>
-	</ul>
+    <ul class="posts-list">
+        <?php while ( $query->have_posts() ) : $query->the_post(); ?>
+            <li>
+                <a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+            </li>
+        <?php endwhile; wp_reset_postdata(); ?>
+    </ul>
 
-	<nav class="pagination">
-		<?php if ( $current_page > 1 ) : ?>
-			<a
-				data-wp-on--click="actions.navigate"
-				href="?paged=<?php echo $current_page - 1; ?>"
-			>
-				Previous
-			</a>
-		<?php endif; ?>
+    <nav class="pagination">
+        <?php if ( $current_page > 1 ) : ?>
+            <a
+                data-wp-on--mouseenter="actions.prefetch"
+                data-wp-on--click="actions.navigate"
+                href="?paged=<?php echo $current_page - 1; ?>"
+            >
+                &larr; Previous
+            </a>
+        <?php endif; ?>
 
-		<?php if ( $posts->max_num_pages > $current_page ) : ?>
-			<a
-				data-wp-on--click="actions.navigate"
-				href="?paged=<?php echo $current_page + 1; ?>"
-			>
-				Next
-			</a>
-		<?php endif; ?>
-	</nav>
+        <span>Page <?php echo $current_page; ?></span>
+
+        <?php if ( $query->max_num_pages > $current_page ) : ?>
+            <a
+                data-wp-on--mouseenter="actions.prefetch"
+                data-wp-on--click="actions.navigate"
+                href="?paged=<?php echo $current_page + 1; ?>"
+            >
+                Next &rarr;
+            </a>
+        <?php endif; ?>
+    </nav>
 </div>
 ```
 
@@ -414,400 +310,340 @@ $posts = new WP_Query( array(
 import { store, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPagination', {
-	actions: {
-		navigate: withSyncEvent( function* ( event ) {
-			event.preventDefault();
+    actions: {
+        prefetch: function* ( event ) {
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.prefetch( event.target.href );
+        },
 
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.navigate( event.target.href );
+        navigate: withSyncEvent( function* ( event ) {
+            event.preventDefault();
 
-			// Scroll to top after navigation.
-			window.scrollTo( { top: 0, behavior: 'smooth' } );
-		} ),
-	},
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.navigate( event.target.href );
+
+            // Scroll to top after navigation.
+            window.scrollTo( { top: 0, behavior: 'smooth' } );
+        } ),
+    },
 } );
 ```
 
-### Example 2: Tab-based navigation with state preservation
+## More advanced use cases
 
-This example demonstrates tabs where the active tab content loads via client-side navigation while preserving local state.
+### Adding new regions on navigation
 
-**PHP (render.php):**
-```php
-<?php
-$active_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'overview';
-$base_url = get_permalink();
-?>
+The `attachTo` option allows router regions to be dynamically added to the DOM when navigating to a page where they exist, even if they weren't present on the original page. This is useful for modals, sidebars, or other UI elements that appear only on certain pages.
 
-<div
-	data-wp-interactive="myTabs"
-	data-wp-router-region="tabbed-content"
-	data-wp-context='{ "lastVisited": "" }'
->
-	<nav class="tabs-nav">
-		<a
-			data-wp-on--click="actions.switchTab"
-			data-wp-class--active="<?php echo $active_tab === 'overview' ? 'true' : 'false'; ?>"
-			href="<?php echo esc_url( add_query_arg( 'tab', 'overview', $base_url ) ); ?>"
-		>
-			Overview
-		</a>
-		<a
-			data-wp-on--click="actions.switchTab"
-			data-wp-class--active="<?php echo $active_tab === 'details' ? 'true' : 'false'; ?>"
-			href="<?php echo esc_url( add_query_arg( 'tab', 'details', $base_url ) ); ?>"
-		>
-			Details
-		</a>
-		<a
-			data-wp-on--click="actions.switchTab"
-			data-wp-class--active="<?php echo $active_tab === 'reviews' ? 'true' : 'false'; ?>"
-			href="<?php echo esc_url( add_query_arg( 'tab', 'reviews', $base_url ) ); ?>"
-		>
-			Reviews
-		</a>
-	</nav>
-
-	<div class="tab-content">
-		<?php if ( $active_tab === 'overview' ) : ?>
-			<h2>Overview</h2>
-			<p>Product overview content...</p>
-		<?php elseif ( $active_tab === 'details' ) : ?>
-			<h2>Details</h2>
-			<p>Product details content...</p>
-		<?php else : ?>
-			<h2>Reviews</h2>
-			<p>Product reviews content...</p>
-		<?php endif; ?>
-	</div>
-
-	<p data-wp-text="state.visitMessage"></p>
-</div>
-```
-
-**JavaScript (view.js):**
-```js
-import { store, getContext, withSyncEvent } from '@wordpress/interactivity';
-
-const { state } = store( 'myTabs', {
-	state: {
-		get visitMessage() {
-			const { lastVisited } = getContext();
-			return lastVisited
-				? `You previously visited: ${ lastVisited }`
-				: 'Welcome!';
-		},
-	},
-	actions: {
-		switchTab: withSyncEvent( function* ( event ) {
-			event.preventDefault();
-
-			// Update context before navigation (this persists).
-			const context = getContext();
-			const currentUrl = new URL( window.location.href );
-			context.lastVisited =
-				currentUrl.searchParams.get( 'tab' ) || 'overview';
-
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.navigate( event.target.href );
-		} ),
-	},
-} );
-```
-
-### Example 3: Infinite scroll
-
-This example shows how to implement infinite scroll loading.
-
-**PHP (render.php):**
-```php
-<?php
-$page = isset( $_GET['page'] ) ? (int) $_GET['page'] : 1;
-$items = get_items_for_page( $page );
-$has_more = has_more_items( $page );
-$next_url = add_query_arg( 'page', $page + 1, get_permalink() );
-
-wp_interactivity_state( 'myInfiniteScroll', array(
-	'hasMore' => $has_more,
-	'nextUrl' => $next_url,
-	'isLoading' => false,
-) );
-?>
-
-<div
-	data-wp-interactive="myInfiniteScroll"
-	data-wp-router-region="infinite-list"
->
-	<ul class="items-list">
-		<?php foreach ( $items as $item ) : ?>
-			<li><?php echo esc_html( $item['title'] ); ?></li>
-		<?php endforeach; ?>
-	</ul>
-
-	<div
-		data-wp-bind--hidden="!state.hasMore"
-		data-wp-watch="callbacks.observeLoadMore"
-	>
-		<span data-wp-bind--hidden="!state.isLoading">Loading more...</span>
-		<button
-			data-wp-on--click="actions.loadMore"
-			data-wp-bind--disabled="state.isLoading"
-		>
-			Load More
-		</button>
-	</div>
-</div>
-```
-
-**JavaScript (view.js):**
-```js
-import { store, getElement } from '@wordpress/interactivity';
-
-const { state } = store( 'myInfiniteScroll', {
-	actions: {
-		*loadMore() {
-			if ( state.isLoading || ! state.hasMore ) {
-				return;
-			}
-
-			state.isLoading = true;
-
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.navigate( state.nextUrl, {
-				// Replace history so back button works correctly.
-				replace: true,
-			} );
-
-			state.isLoading = false;
-		},
-	},
-	callbacks: {
-		observeLoadMore() {
-			const { ref } = getElement();
-
-			// Use Intersection Observer for automatic loading.
-			const observer = new IntersectionObserver(
-				( entries ) => {
-					if ( entries[ 0 ].isIntersecting ) {
-						store( 'myInfiniteScroll' ).actions.loadMore();
-					}
-				},
-				{ rootMargin: '100px' }
-			);
-
-			observer.observe( ref );
-
-			// Cleanup function.
-			return () => observer.disconnect();
-		},
-	},
-} );
-```
-
-### Example 4: Handling navigation errors
-
-This example demonstrates proper error handling during navigation.
-
-```js
-import { store, withSyncEvent } from '@wordpress/interactivity';
-
-const { state } = store( 'myPlugin', {
-	state: {
-		error: null,
-		isNavigating: false,
-	},
-	actions: {
-		navigate: withSyncEvent( function* ( event ) {
-			event.preventDefault();
-			state.error = null;
-			state.isNavigating = true;
-
-			try {
-				const { actions } = yield import(
-					'@wordpress/interactivity-router'
-				);
-				yield actions.navigate( event.target.href, {
-					timeout: 5000,
-				} );
-			} catch ( error ) {
-				state.error = 'Navigation failed. Please try again.';
-				console.error( 'Navigation error:', error );
-			} finally {
-				state.isNavigating = false;
-			}
-		} ),
-	},
-} );
-```
+**Defining a region with `attachTo`:**
 
 ```html
-<div data-wp-interactive="myPlugin">
-	<div
-		data-wp-bind--hidden="!state.error"
-		class="error-message"
-		data-wp-text="state.error"
-	></div>
-
-	<a
-		data-wp-on--click="actions.navigate"
-		data-wp-class--is-loading="state.isNavigating"
-		href="/another-page/"
-	>
-		Navigate
-	</a>
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
+>
+    <div class="modal-overlay">
+        <div class="modal-content">
+            <h2>Modal Title</h2>
+            <p>Modal content here...</p>
+        </div>
+    </div>
 </div>
 ```
 
-## Disabling client-side navigation
+The `attachTo` value is a CSS selector. When navigating to this page from a page without this region, the region will be created and appended to the element matching the selector.
 
-There are scenarios where you may need to disable client-side navigation and force a full page reload. The Interactivity API provides a configuration option for this.
+**Example: Modal that appears on navigation**
 
-### Using wp_interactivity_config
-
-In PHP, use `wp_interactivity_config()` to disable client-side navigation:
-
+_Page without modal (page-1.php):_
 ```php
-// Disable client navigation for this page.
-wp_interactivity_config(
-	'core/router',
-	array( 'clientNavigationDisabled' => true )
-);
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-router-region="myPlugin/content"
+>
+    <h1>Page 1</h1>
+    <a
+        data-wp-on--click="actions.navigate"
+        href="/page-with-modal/"
+    >
+        Open page with modal
+    </a>
+</div>
 ```
 
-When `clientNavigationDisabled` is set to `true`:
+_Page with modal (page-2.php):_
+```php
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-router-region="myPlugin/content"
+>
+    <h1>Page 2</h1>
+    <a
+        data-wp-on--click="actions.navigate"
+        href="/page-without-modal/"
+    >
+        Close modal
+    </a>
+</div>
 
-- Calls to `actions.navigate()` will trigger a full page reload instead of client-side navigation.
-- Calls to `actions.prefetch()` will do nothing.
-- If a user navigates to a page with this configuration, the router will force a page reload.
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
+>
+    <div class="modal-overlay">
+        <div class="modal-content">
+            <h2>I'm a modal!</h2>
+        </div>
+    </div>
+</div>
+```
 
-### Use cases for disabling client navigation
+When navigating from Page 1 to Page 2, the modal region is created and appended to `<body>`. When navigating back to Page 1, the modal is automatically removed.
 
-- **Plugin incompatibility**: When third-party plugins require full page reloads.
-- **Complex state resets**: When you need to ensure all JavaScript state is completely reset.
-- **Admin pages**: When the full WordPress admin experience is needed.
-- **Specific page types**: When certain pages have special requirements that conflict with client-side navigation.
+### Handling server state updates
 
-## Synchronizing with server data
-
-When using client-side navigation, the global state and local context are preserved on the client. However, the server may provide updated data for each page. The Interactivity API provides `getServerState()` and `getServerContext()` functions to help synchronize client state with server-provided data.
-
-_Please, visit the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide to learn more about `getServerState()` and `getServerContext()`._
-
-### Example: Updating state after navigation
+During client-side navigation, the client-side state persists while the server provides new state for the target page. Use `getServerState()` and `getServerContext()` to react specifically to server-provided values.
 
 ```js
 import {
-	store,
-	getContext,
-	getServerState,
-	getServerContext,
+    store,
+    getContext,
+    getServerState,
+    getServerContext,
 } from '@wordpress/interactivity';
 
 const { state } = store( 'myPlugin', {
-	callbacks: {
-		// This callback watches for server state changes.
-		syncWithServer() {
-			const serverState = getServerState();
-			const serverContext = getServerContext();
-			const context = getContext();
+    callbacks: {
+        syncWithServer() {
+            const serverState = getServerState();
+            const serverContext = getServerContext();
+            const context = getContext();
 
-			// Selectively update what you need from the server.
-			if ( serverState.pageTitle ) {
-				state.pageTitle = serverState.pageTitle;
-			}
+            // Update client state with server values selectively.
+            if ( serverState.productCount !== undefined ) {
+                state.productCount = serverState.productCount;
+            }
 
-			if ( serverContext.itemCount !== undefined ) {
-				context.itemCount = serverContext.itemCount;
-			}
-		},
-	},
+            if ( serverContext.isExpanded !== undefined ) {
+                context.isExpanded = serverContext.isExpanded;
+            }
+        },
+    },
 } );
 ```
 
-## Best practices
+For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
 
-### 1. Keep regions focused
+### Overriding cached pages
 
-Define router regions around the content that actually changes between pages. Avoid wrapping the entire page in a single region.
+By default, once a page is cached, subsequent navigations use the cached version. Use the `force` option to re-fetch a page even if it's cached:
 
-```html
-<!-- Good: Specific regions for changing content -->
-<header data-wp-interactive="myTheme" data-wp-router-region="header">
-	<nav><!-- Navigation that might show active states --></nav>
-</header>
+```js
+// Force re-fetch with navigate()
+yield actions.navigate( '/products/', { force: true } );
 
-<main data-wp-interactive="myTheme" data-wp-router-region="main-content">
-	<!-- Main content that changes between pages -->
-</main>
-
-<!-- Avoid: One giant region -->
-<body data-wp-interactive="myTheme" data-wp-router-region="everything">
-	<!-- This defeats the purpose of partial updates -->
-</body>
+// Force re-fetch with prefetch()
+yield actions.prefetch( '/products/', { force: true } );
 ```
 
-### 2. Use consistent region IDs
-
-Ensure region IDs are consistent across all pages where they should be updated. Use namespaced IDs to avoid conflicts.
-
-```html
-<!-- Good: Namespaced, descriptive IDs -->
-<div data-wp-router-region="myPlugin/product-list">...</div>
-<div data-wp-router-region="myPlugin/sidebar">...</div>
-
-<!-- Avoid: Generic IDs that might conflict -->
-<div data-wp-router-region="content">...</div>
-<div data-wp-router-region="sidebar">...</div>
-```
-
-### 3. Prefetch strategically
-
-Prefetch pages that users are likely to visit, but avoid prefetching everything. Good candidates for prefetching include:
-
-- Links on hover (most common pattern)
-- "Next" links in pagination
-- Primary navigation items on viewport visibility
+**Important:** If you're using `force: true` to refresh a page after a mutation (POST, PUT, DELETE request), make sure the mutation has completed before navigating:
 
 ```js
 store( 'myPlugin', {
-	actions: {
-		*prefetchOnHover( event ) {
-			const { actions } = yield import(
-				'@wordpress/interactivity-router'
-			);
-			yield actions.prefetch( event.target.href );
-		},
-	},
+    actions: {
+        deleteAndRefresh: function* () {
+            // Wait for the deletion to complete.
+            yield fetch( '/api/items/123', { method: 'DELETE' } );
+
+            // Now refresh the page to show updated data.
+            const { actions } = yield import(
+                '@wordpress/interactivity-router'
+            );
+            yield actions.navigate( window.location.href, { force: true } );
+        },
+    },
 } );
 ```
 
-### 4. Handle loading states gracefully
+### Using custom HTML
 
-Always provide visual feedback during navigation. Use the router's built-in state or manage your own loading indicators.
+Instead of fetching a page from a URL, you can provide HTML directly using the `html` option:
 
-### 5. Test back/forward navigation
+```js
+// Navigate with custom HTML
+yield actions.navigate( '/custom-page/', {
+    html: `
+        <div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/content">
+            <h1>Custom Content</h1>
+            <p>This HTML was provided directly, not fetched.</p>
+        </div>
+    `,
+} );
 
-Ensure your interactive blocks work correctly when users use browser back/forward buttons. The router automatically handles caching, but your state management should account for these navigation patterns.
+// Prefetch with custom HTML
+yield actions.prefetch( '/custom-page/', {
+    html: customHtmlString,
+} );
+```
 
-### 6. Consider accessibility
+This is useful for:
+- Optimistic UI updates where you construct the expected HTML before the server responds.
+- Offline scenarios where you provide cached or fallback content.
+- Testing and development.
 
-The router provides screen reader announcements by default. Keep this enabled unless you have a specific reason to disable it and are providing your own accessibility handling.
+### Managing browser history
 
-## Conclusion
+By default, `navigate()` adds a new entry to the browser's session history using `pushState`. Use the `replace` option to replace the current history entry instead:
 
-Client-side navigation with the Interactivity API provides a powerful way to create faster, more responsive WordPress sites while maintaining the benefits of server-side rendering. By using router regions to define what changes between pages, prefetching to anticipate user navigation, and proper state management, you can create experiences that feel instant and app-like.
+```js
+// Default behavior: adds new history entry (pushState)
+yield actions.navigate( '/page-2/' );
 
-Key takeaways:
+// Replace current history entry (replaceState)
+yield actions.navigate( '/page-2/', { replace: true } );
+```
 
-- Use `data-wp-router-region` to mark content that should be updated during navigation.
-- Import the router dynamically with `yield import('@wordpress/interactivity-router')` to minimize initial bundle size.
-- Use `actions.navigate()` for programmatic navigation and `actions.prefetch()` for preloading.
-- Leverage `state.navigation.hasStarted` and `state.navigation.hasFinished` for loading states.
-- Use `attachTo` for regions that should be dynamically injected into the DOM.
-- Consider using `getServerState()` and `getServerContext()` to synchronize with server-provided data after navigation.
+Use `replace: true` when:
+- Implementing redirects where the original URL shouldn't be in history.
+- Updating query parameters for filtering/sorting where each change shouldn't be a separate history entry.
+- Implementing infinite scroll where you update the URL but don't want each page to be a separate history entry.
+
+### Changing the timeout
+
+Navigation will abort if it takes too long. The default timeout is 10 seconds. Use the `timeout` option to change this:
+
+```js
+// Shorter timeout for faster failure
+yield actions.navigate( '/page/', { timeout: 5000 } );
+
+// Longer timeout for slow connections
+yield actions.navigate( '/page/', { timeout: 30000 } );
+```
+
+### Handling fetch errors
+
+When navigation fails (network error, timeout, or server error), the router automatically falls back to a full page reload. You can implement custom error handling by catching errors from `navigate()`:
+
+```js
+store( 'myPlugin', {
+    state: {
+        error: null,
+    },
+    actions: {
+        navigateSafely: withSyncEvent( function* ( event ) {
+            event.preventDefault();
+            state.error = null;
+
+            try {
+                const { actions } = yield import(
+                    '@wordpress/interactivity-router'
+                );
+                yield actions.navigate( event.target.href, {
+                    timeout: 5000,
+                } );
+            } catch ( error ) {
+                state.error = 'Navigation failed. Please try again.';
+                console.error( 'Navigation error:', error );
+
+                // Optionally fall back to full page navigation:
+                // window.location.href = event.target.href;
+            }
+        } ),
+    },
+} );
+```
+
+For more control, you can fetch and process pages manually:
+
+```js
+store( 'myPlugin', {
+    actions: {
+        navigateWithCustomErrorHandling: withSyncEvent( function* ( event ) {
+            event.preventDefault();
+            const url = event.target.href;
+
+            try {
+                // Fetch the page manually.
+                const response = yield fetch( url );
+
+                if ( ! response.ok ) {
+                    // Handle HTTP errors.
+                    state.error = `Error: ${response.status}`;
+                    return;
+                }
+
+                const html = yield response.text();
+
+                // Navigate using the fetched HTML.
+                const { actions } = yield import(
+                    '@wordpress/interactivity-router'
+                );
+                yield actions.navigate( url, { html } );
+            } catch ( error ) {
+                state.error = 'Network error. Please check your connection.';
+            }
+        } ),
+    },
+} );
+```
+
+### Disabling client-side navigation on certain pages
+
+Some pages may require a full page reload instead of client-side navigation. Use `wp_interactivity_config()` to disable client navigation:
+
+```php
+// In your theme's functions.php or a plugin
+add_action( 'wp', function() {
+    // Disable on specific page templates.
+    if ( is_page_template( 'template-complex.php' ) ) {
+        wp_interactivity_config(
+            'core/router',
+            array( 'clientNavigationDisabled' => true )
+        );
+    }
+
+    // Disable on admin-like pages.
+    if ( is_page( 'dashboard' ) ) {
+        wp_interactivity_config(
+            'core/router',
+            array( 'clientNavigationDisabled' => true )
+        );
+    }
+} );
+```
+
+When `clientNavigationDisabled` is `true`:
+- `actions.navigate()` triggers a full page reload.
+- `actions.prefetch()` does nothing.
+- Navigating from another page to this page forces a reload.
+
+### Disabling navigation feedback
+
+The Interactivity API router includes built-in feedback during navigation:
+- **Loading animation**: A progress bar that appears during navigation.
+- **Screen reader announcements**: Accessibility announcements for navigation progress.
+
+In some cases, you may want to disable these:
+
+```js
+// Disable loading animation (for instant-feeling updates)
+yield actions.navigate( '/page/', { loadingAnimation: false } );
+
+// Disable screen reader announcements (when providing custom announcements)
+yield actions.navigate( '/page/', { screenReaderAnnouncement: false } );
+
+// Disable both
+yield actions.navigate( '/page/', {
+    loadingAnimation: false,
+    screenReaderAnnouncement: false,
+} );
+```
+
+Use cases for disabling feedback:
+- **Silent updates**: Background refreshes where you don't want to draw attention.
+- **Custom loading UI**: When you're implementing your own loading indicators.
+- **Custom accessibility**: When you're providing your own screen reader announcements.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -164,6 +164,52 @@ If the region was dynamically created via `attachTo` during a previous navigatio
 
 <!-- IMAGE: Three-panel diagram showing the three scenarios. Panel 1 "Update": Same-shaped regions on both pages with a refresh arrow. Panel 2 "Create": Region with attachTo appears from the target page and gets inserted into current page's body. Panel 3 "Remove": Region fades out/disappears from current page. -->
 
+**What happens to HTML outside router regions?**
+
+An important detail to understand is that HTML outside of router regions remains completely untouched during client-side navigation. The router only modifies the content inside the regions it manages—everything else in the DOM stays exactly as it was.
+
+This means that if you have static elements like a site header, footer, or navigation menu that aren't wrapped in a router region, they won't change when the user navigates between pages. This can be intentional (for elements that truly are the same across all pages) or it can be a source of confusion if you expect those elements to update.
+
+However, there's an important exception: **interactive elements outside router regions can still react to global state changes**. If you have an interactive block outside any router region, with directives that use `getServerState()` to read global state, these directives will automatically re-evaluate when navigation brings in new server state.
+
+For example, consider a shopping cart icon in the header that displays the number of items:
+
+```html
+<!-- This header is NOT inside a router region -->
+<header data-wp-interactive="myShop">
+    <div class="cart-icon">
+        <span data-wp-text="state.cartCount"></span> items
+    </div>
+</header>
+
+<!-- This is the router region that updates during navigation -->
+<main
+    data-wp-interactive="myShop"
+    data-wp-router-region="myShop/content"
+>
+    <!-- Page content -->
+</main>
+```
+
+If `state.cartCount` comes from the regular client-side state, the cart icon will not update during navigation—even if the new page has a different cart count in its server state. The header, while being interactive, is outside any router region, so it's not re-rendered.
+
+But if you use `getServerState()` instead:
+
+```js
+const { state } = store( 'myShop', {
+    state: {
+        get cartCount() {
+            // This reacts to server state changes during navigation
+            return getServerState().cartCount;
+        },
+    },
+} );
+```
+
+Now the cart icon will update whenever navigation brings in a new `cartCount` value from the server, even though the header itself is outside any router region. This is because `getServerState()` creates a reactive subscription to server-provided state, which is updated during every navigation.
+
+This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region.
+
 #### CSS handling
 
 One of the trickier aspects of client-side navigation is managing CSS style sheets. Different pages may require different styles, and the router must ensure that the correct styles are active for each page—without causing flashes of unstyled content or breaking the CSS cascade order.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -671,6 +671,10 @@ Place this callback on an element that is always present in the DOM (like a site
 </div>
 ```
 
+<div class="callout callout-info">
+The <code>state.url</code> approach has a known limitation: when navigating with <code>force: true</code> to the same URL, the callback won't re-run because the URL value doesn't actually change. A more explicit API for subscribing to navigation events will be provided in the future.
+</div>
+
 ## The Interactivity Router in depth
 
 This section provides a detailed technical explanation of how client-side navigation works internally. Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your interactive blocks.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -929,43 +929,43 @@ For more details, see the [Understanding global state, local context, and derive
 
 Now that we've examined each component, let's trace through a complete navigation to see how they work together.
 
-**Phase 1: Prefetch (optional but recommended)**
+#### Phase 1: Prefetch (optional but recommended)
 
 When the user hovers over a link, your code might call `prefetch()`:
 
-1. The router normalizes the URL and checks the page cache
-2. If not cached, it begins fetching the HTML
-3. The fetched HTML is parsed into a document
-4. Router regions are extracted and converted to virtual DOM
-5. Style sheets are compared with current page; new ones are added with `media="preload"`
-6. Script modules are identified, dependencies resolved, and source code fetched
-7. Server state is extracted
-8. The fully processed page is stored in the cache
-9. The function returns (the page is now ready for instant navigation)
+1. The router normalizes the URL and checks the page cache.
+2. If not cached, it begins fetching the HTML.
+3. The fetched HTML is parsed into a document.
+4. Router regions are extracted and converted to virtual DOM.
+5. Style sheets are compared with current page; new ones are added with `media="preload"`.
+6. Script modules are identified, dependencies resolved, and source code fetched.
+7. Server state is extracted.
+8. The fully processed page is stored in the cache.
+9. The function returns (the page is now ready for instant navigation).
 
-**Phase 2: Navigate**
+#### Phase 2: Navigate
 
 When the user clicks the link and your code calls `navigate()`:
 
-1. The router checks if client navigation is disabled; if so, falls back to full page load
-2. If not already prefetched, the fetch process from Phase 1 runs now
-3. The router waits for the page to be ready (fetch complete, styles loaded)
-4. A loading indicator may appear if the wait exceeds a threshold (400ms)
-5. Script modules for the new page are imported and executed
+1. The router checks if client navigation is disabled; if so, falls back to full page load.
+2. If not already prefetched, the fetch process from Phase 1 runs now.
+3. The router waits for the page to be ready (fetch complete, styles loaded).
+4. A loading indicator may appear if the wait exceeds a threshold (400ms).
+5. Script modules for the new page are imported and executed.
 6. The rendering phase begins (wrapped in a batch for efficiency):
-   - Server state is merged with client state
-   - Each router region is updated with its new virtual DOM
-   - Regions with `attachTo` that don't exist are created and appended
-   - Styles are activated/deactivated as needed
-   - The document title is updated
-7. Browser history is updated (pushState or replaceState)
-8. Screen reader announcement is made for accessibility
-9. If the URL has a hash, the page scrolls to that element
-10. Navigation is complete
+   - Server state is merged with client state.
+   - Each router region is updated with its new virtual DOM.
+   - Regions with `attachTo` that don't exist are created and appended.
+   - Styles are activated/deactivated as needed.
+   - The document title is updated.
+7. Browser history is updated (pushState or replaceState).
+8. Screen reader announcement is made for accessibility.
+9. If the URL has a hash, the page scrolls to that element.
+10. Navigation is complete.
 
 <!-- IMAGE: Flowchart showing complete navigation flow. Starts with "User hovers link" flowing to "prefetch()" which branches through the prefetch steps. Then "User clicks link" leads to "navigate()" which shows the navigation steps in sequence. Key decision points are shown as diamonds (e.g., "In cache?", "Styles loaded?"). The flow ends at "Navigation complete" with a checkmark. -->
 
-**Race condition protection**
+#### Race condition protection
 
 A subtle but important detail: users don't always wait for navigation to complete before clicking another link. The router handles this gracefully.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -37,11 +37,12 @@ npx @wordpress/create-block@latest my-interactive-block --template @wordpress/cr
 
 If you already have an interactive block and want to add client-side navigation, you need to:
 
-1. **Add the router dependency**: Add `@wordpress/interactivity-router` as a dependency of your block's script module. This is typically done by dynamically importing the package in your `view.js` file (as shown in the examples below), which ensures it is only loaded when needed.
-2. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
-3. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
+1. **Mark your script module as compatible with client-side navigation**: Ensure your block's `block.json` declares interactivity support (e.g., `"supports": { "interactivity": true }`) so that WordPress automatically marks its script module for loading during client-side navigation. See [Ensuring script modules load during navigation](#ensuring-script-modules-load-during-navigation) for details.
+2. **Add the router dependency**: Add `@wordpress/interactivity-router` as a dependency of your block's script module. This is typically done by dynamically importing the package in your `view.js` file (as shown in the examples below), which ensures it is only loaded when needed.
+3. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
+4. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
 
-## Using client-side navigation in Classic themes
+### Using client-side navigation in Classic themes
 
 Client-side navigation is not limited to blocks — you can also use it in classic PHP themes by adding the Interactivity API directives directly in your theme's template files and processing them with `wp_interactivity_process_directives()`, as explained in the [Server-side rendering](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md#processing-directives-in-classic-themes) guide. Instead of relying on a block's `block.json` to declare script module dependencies, you register and enqueue your script module manually, taking into account that the `@wordpress/interactivity-router` module should be dynamically imported:
 
@@ -63,7 +64,45 @@ add_action( 'wp_enqueue_scripts', function () {
 } );
 ```
 
+Since classic themes don't use `block.json`, you must also register your script module for client-side navigation explicitly using `add_client_navigation_support_to_script_module()`. Without this, the router will not load your script module when navigating to a page that needs it. See [Ensuring script modules load during navigation](#ensuring-script-modules-load-during-navigation) for details.
+
 The rest of the guide — router regions, prefetching, navigation options — applies in exactly the same way regardless of whether you are working with a block or a classic theme.
+
+### Ensuring script modules load during navigation
+
+During client-side navigation, the router needs to know which script modules should be loaded on the new page. It identifies them by looking for a `data-wp-router-options` attribute on the `<script>` tag with `loadOnClientNavigation` set to `true`. Without this attribute, the router will not load the script module during client-side navigation, and the block's interactivity will not work on the new page.
+
+For **blocks**, this attribute is added automatically when the block declares interactivity support in its `block.json`. Either of these configurations will work:
+
+```json
+{
+	"supports": {
+		"interactivity": true
+	}
+}
+```
+
+```json
+{
+	"supports": {
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}
+```
+
+If your block's `block.json` already includes one of these, no additional setup is needed — WordPress handles the rest.
+
+For **classic themes** and other script modules registered outside of `block.json`, the attribute is not added automatically. You must register your script module for client-side navigation explicitly using `add_client_navigation_support_to_script_module()`:
+
+```php
+wp_interactivity()->add_client_navigation_support_to_script_module(
+    'my-theme/navigation'
+);
+```
+
+Without this, the router will not load your script module when navigating to a page that needs it.
 
 ### Setting up router regions
 
@@ -865,7 +904,7 @@ The Interactivity API uses [script modules](https://make.wordpress.org/core/2024
 
 **Identifying script modules for client-side navigation**
 
-Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. To distinguish which modules should be loaded, WordPress uses a special data attribute:
+Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. As described in the [Getting started](#getting-started-with-the-interactivity-router) and [Classic themes](#using-client-side-navigation-in-classic-themes) sections, WordPress uses the `data-wp-router-options` attribute to mark which script modules should be loaded during navigation:
 
 ```html
 <script

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -506,7 +506,7 @@ Use `replace: true` when:
 
 ### Changing the timeout
 
-Navigation will abort if it takes too long. The default timeout is 10 seconds. Use the `timeout` option to change this:
+If navigation takes too long, the router falls back to a traditional full-page load. The default timeout is 10 seconds. Use the `timeout` option to change this:
 
 ```js
 // Shorter timeout for faster failure.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -582,7 +582,7 @@ The attribute value serves as a unique identifier for that region. You can speci
    ```html
    <div
        data-wp-interactive="myPlugin"
-       data-wp-router-region="main-content"
+       data-wp-router-region="myPlugin/main-content"
    >
        <!-- Region content -->
    </div>
@@ -592,7 +592,7 @@ The attribute value serves as a unique identifier for that region. You can speci
    ```html
    <div
        data-wp-interactive="myPlugin"
-       data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
+       data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
    >
        <!-- Region content -->
    </div>
@@ -617,7 +617,7 @@ For a router region to function correctly, it must meet these requirements:
 <div data-wp-interactive="myPlugin">
     <div
         data-wp-interactive="myPlugin"
-        data-wp-router-region="sidebar"
+        data-wp-router-region="myPlugin/sidebar"
     >
         <!-- Sidebar content -->
     </div>
@@ -625,7 +625,7 @@ For a router region to function correctly, it must meet these requirements:
 
 <!-- Incorrect: This region may not update properly -->
 <div data-wp-interactive="myPlugin">
-    <div data-wp-router-region="sidebar">
+    <div data-wp-router-region="myPlugin/sidebar">
         <!-- This won't work reliably! -->
     </div>
 </div>

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -75,6 +75,9 @@ Here's how to implement a link that navigates client-side. First, the HTML in yo
 </a>
 ```
 
+> [!NOTE]
+> This element must be placed inside an element with the `data-wp-interactive="myPlugin"` directive (like the router region defined above), so the directive knows which store namespace to look up the action in. Alternatively, you can specify the namespace explicitly in the directive value itself: `data-wp-on--click="myPlugin::actions.navigateTo"`. For more details on how namespaces work, see the [Interactivity API Reference](/docs/reference-guides/interactivity-api/api-reference.md).
+
 Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
 
 ```js

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -682,8 +682,6 @@ Each entry in the cache stores not just the fetched HTML, but a fully processed 
 - **The page title** for updating the document title
 - **Server state** that was embedded in the page by WordPress
 
-<!-- IMAGE: Diagram showing the page cache structure. A box labeled "Page Cache" contains multiple entries, each showing a URL path (like "/products/", "/about/", "/contact/") mapped to a "Page Object" containing icons for vDOM, styles, scripts, title, and state. Arrows show how navigate() and prefetch() interact with this cache. -->
-
 An important detail is that the cache stores promises rather than resolved values. When a fetch begins, the router immediately stores the pending promise in the cache. This means that if multiple calls to `prefetch()` or `navigate()` target the same URL simultaneously (for example, if a user rapidly hovers over multiple links pointing to the same page), only one network request is made. All callers receive the same promise and wait for the same result.
 
 Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit — the page is already prepared and ready to render.
@@ -721,8 +719,6 @@ The attribute value serves as a unique identifier for that region. You can speci
    ```
 
 The region ID must be unique within a single page and consistent across pages that share the same region. For example, if both your "Products" page and "Product Detail" page have a sidebar, and you want that sidebar to update during navigation, both pages should define a region with the same ID (e.g., `"myPlugin/sidebar"`).
-
-<!-- IMAGE: Side-by-side comparison of two pages. Page A shows a layout with header, main content area (highlighted and labeled "data-wp-router-region='main'"), and sidebar. Page B shows a similar layout with the same regions highlighted. Arrows between them show how regions with matching IDs correspond to each other. -->
 
 **Requirements for router regions**
 
@@ -763,8 +759,6 @@ Next, the router scans this document for all elements that have both `data-wp-in
 
 For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion — not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
 
-<!-- IMAGE: Flowchart showing the region processing pipeline. Starting with "Fetched HTML" (showing raw HTML code), an arrow leads to "Parse HTML" (DOM tree icon), then to "Find Regions" (highlighting regions in the tree), then to "Convert to vDOM" (showing a simplified tree structure), and finally to "Store in Cache" (the cache icon from earlier). -->
-
 Finally, each region's virtual DOM is stored in the page cache entry, indexed by its region ID. The cache entry now contains a map of region IDs to their corresponding virtual DOM trees.
 
 **How regions are rendered during navigation**
@@ -780,8 +774,6 @@ This is the most common case. When a region with a given ID exists on both the c
 Rather than simply replacing the entire region's HTML (which would destroy any internal state and cause a jarring visual transition), the router uses a virtual DOM diffing algorithm. This algorithm compares the current region's virtual DOM with the new region's virtual DOM and calculates the minimum set of changes needed to transform one into the other.
 
 For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements — rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
-
-<!-- IMAGE: Before/after comparison showing region update. Left side shows "Current Page" with a region containing items A, B, C (each in a box). Right side shows "Target Page" with items A, D, C. In the middle, arrows show that A and C stay in place while B transforms into D. Caption: "The diffing algorithm minimizes DOM changes." -->
 
 **Scenario 2: Region exists only on the target page with `attachTo` (create)**
 
@@ -801,8 +793,6 @@ This allows content that exists on one page but not another to appear smoothly d
 When a region exists on the current page but not on the target page, it means that content is no longer needed. The router handles this by setting the region's content to empty, effectively clearing it from the display.
 
 If the region was dynamically created via `attachTo` during a previous navigation, the entire region element is removed from the DOM. If it was part of the original page structure, the element remains but its content is cleared.
-
-<!-- IMAGE: Three-panel diagram showing the three scenarios. Panel 1 "Update": Same-shaped regions on both pages with a refresh arrow. Panel 2 "Create": Region with attachTo appears from the target page and gets inserted into current page's body. Panel 3 "Remove": Region fades out/disappears from current page. -->
 
 **What happens to HTML outside router regions?**
 
@@ -878,8 +868,6 @@ The solution is to add new `<link>` elements with their `media` attribute set to
 
 When a `<link>` element is added this way, the browser begins downloading the CSS file immediately. The router tracks when each style sheet finishes loading by listening for the `load` event. This allows it to wait until all new styles are ready before proceeding with navigation.
 
-<!-- IMAGE: Timeline diagram showing style preloading. At t=0, "Prefetch starts" and a link element with media="preload" is added. Browser download begins (shown as a progress bar). At t=200ms, download completes and "load event fires". The styles remain inactive (grayed out) until navigation actually occurs. -->
-
 **Maintaining cascade order with the Shortest Common Supersequence algorithm**
 
 When inserting new style sheets, the router must preserve the correct cascade order. It accomplishes this using an algorithm based on finding the Shortest Common Supersequence (SCS) of two sequences.
@@ -892,8 +880,6 @@ For example:
 - Shortest Common Supersequence: [A, B, C, D, E]
 
 The algorithm then determines: keep A and C in place, insert B between A and C, keep D after C, and insert E at the end.
-
-<!-- IMAGE: Visual representation of the SCS algorithm. Two rows show the "Current" sequence [A, C, D] and "Target" sequence [A, B, C, E]. Below them, the "Merged (SCS)" sequence shows [A, B, C, D, E] with color coding: A and C in blue (shared), B and E in green (inserted), D in gray (will be disabled). Arrows show how elements from both sequences map to the merged result. -->
 
 This approach ensures that:
 - Style sheets that appear in both pages remain in their correct relative order
@@ -958,8 +944,6 @@ To handle this, the router performs a recursive dependency resolution:
 5. This continues until all modules in the dependency tree have been fetched
 
 The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again — the browser already has it cached.
-
-<!-- IMAGE: Tree diagram showing module dependency resolution. At the top, "view.js" (the entry point). Arrows lead down to its dependencies: "@wordpress/interactivity" and "./components/modal.js". The interactivity module is shown grayed out with a note "Already loaded - skip". The modal.js module has its own dependencies branching below it. Each node shows whether it needs to be fetched or can be skipped. -->
 
 **Handling the import timing**
 
@@ -1081,8 +1065,6 @@ When the user clicks the link and your code calls `navigate()`:
 8. Screen reader announcement is made for accessibility.
 9. If the URL has a hash, the page scrolls to that element.
 10. Navigation is complete.
-
-<!-- IMAGE: Flowchart showing complete navigation flow. Starts with "User hovers link" flowing to "prefetch()" which branches through the prefetch steps. Then "User clicks link" leads to "navigate()" which shows the navigation steps in sequence. Key decision points are shown as diamonds (e.g., "In cache?", "Styles loaded?"). The flow ends at "Navigation complete" with a checkmark. -->
 
 #### Race condition protection
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -41,18 +41,38 @@ If you already have an interactive block and want to add client-side navigation,
 2. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
 3. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
 
+Client-side navigation is not limited to blocks — you can also use it in classic PHP themes by adding the Interactivity API directives directly in your theme's template files and processing them with `wp_interactivity_process_directives()`, as explained in the [Server-side rendering](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md#processing-directives-in-classic-themes). Instead of relying on a block's `block.json` to declare script module dependencies, you register and enqueue your script module manually, taking into account that the `@wordpress/interactivity-router` module should be dynamically imported:
+
+```php
+// functions.php
+add_action( 'wp_enqueue_scripts', function () {
+    wp_register_script_module(
+        'my-theme/navigation',
+        get_template_directory_uri() . '/assets/navigation.js',
+        array(
+			'@wordpress/interactivity',
+			array(
+				'id'     => '@wordpress/interactivity-router',
+				'import' => 'dynamic',
+			),
+		)
+    );
+    wp_enqueue_script_module( 'my-theme/navigation' );
+} );
+```
+
+The rest of the guide — router regions, prefetching, navigation options — applies in exactly the same way regardless of whether you are working with a block or a classic theme.
+
 ### Setting up router regions
 
 A router region is a section of your page that the router updates during client-side navigation. You define one by adding both `data-wp-router-region` and `data-wp-interactive` to the same element — both directives are required at this moment.
 
 The `data-wp-router-region` directive takes a unique ID as its value. When navigation occurs, the router matches regions on the current page with regions on the target page by their IDs and replaces their content — leaving everything outside router regions untouched. Each region ID must be unique within a page; if two regions share the same ID, the router won't know which one to update.
 
-Here's a basic router region in a block's markup:
+Here's a basic router region:
 
 ```php
-// render.php
 <div
-    <?php echo get_block_wrapper_attributes(); ?>
     data-wp-interactive="myPlugin"
     data-wp-router-region="myPlugin/posts-list"
 >
@@ -108,15 +128,15 @@ Note that the router region still needs its own `data-wp-interactive` directive,
 
 ### Implementing navigation
 
-To trigger client-side navigation, you define an **action** in your block's store and connect it to a DOM event using an Interactivity API directive. Actions are functions defined inside `store()` that handle user interactions — similar to event handlers in other frameworks. When connected to an element through a directive like `data-wp-on--click`, the action runs whenever that event fires.
+To trigger client-side navigation, you define an **action** in your store and connect it to a DOM event using an Interactivity API directive. Actions are functions defined inside `store()` that handle user interactions — similar to event handlers in other frameworks. When connected to an element through a directive like `data-wp-on--click`, the action runs whenever that event fires.
 
-Here's how to implement a link that navigates client-side. First, the HTML in your block's `render.php` connects the link's click event to the `navigateTo` action:
+Here's how to implement a link that navigates client-side. First, the HTML connects the link's click event to the `navigateTo` action:
 
 ```html
 <a data-wp-on--click="actions.navigateTo" href="/page-2/"> Go to Page 2 </a>
 ```
 
-Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
+Then, in your script module, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
 
 ```js
 // view.js
@@ -156,7 +176,7 @@ A common pattern is to prefetch a page when the user hovers over a link, and nav
 </a>
 ```
 
-The corresponding actions in `view.js` handle each event:
+The corresponding actions in the script module handle each event:
 
 ```js
 // view.js
@@ -187,9 +207,9 @@ store( 'myPlugin', {
 
 This example brings together router regions, navigation, and prefetching to implement client-side pagination for a list of posts.
 
-The block queries posts for the current page and renders them inside a router region. Pagination links at the bottom allow the user to move between pages. When the user hovers over a "Previous" or "Next" link, the target page is prefetched. When they click, the router navigates client-side — replacing only the content inside the router region without a full page reload. After navigation, the page scrolls smoothly to the top.
+The PHP template queries posts for the current page and renders them inside a router region. Pagination links at the bottom allow the user to move between pages. When the user hovers over a "Previous" or "Next" link, the target page is prefetched. When they click, the router navigates client-side — replacing only the content inside the router region without a full page reload. After navigation, the page scrolls smoothly to the top.
 
-**PHP (render.php):**
+**PHP:**
 
 ```php
 <?php
@@ -201,7 +221,6 @@ $query = new WP_Query( array(
 ?>
 
 <div
-    <?php echo get_block_wrapper_attributes(); ?>
     data-wp-interactive="myPagination"
     data-wp-router-region="myPagination/posts"
 >
@@ -239,7 +258,7 @@ $query = new WP_Query( array(
 </div>
 ```
 
-**JavaScript (view.js):**
+**JavaScript:**
 
 ```js
 import { store, withSyncEvent } from '@wordpress/interactivity';
@@ -738,7 +757,7 @@ An important detail to understand is that HTML outside of router regions remains
 
 This means that if you have static elements like a site header, footer, or navigation menu that aren't wrapped in a router region, they won't change when the user navigates between pages. This can be intentional (for elements that truly are the same across all pages) or it can be a source of confusion if you expect those elements to update.
 
-However, there's an important exception: **interactive elements outside router regions can still react to global state changes**. If you have an interactive block outside any router region, with directives that use `getServerState()` to read global state, these directives will automatically re-evaluate when navigation brings in new server state.
+However, there's an important exception: **interactive elements outside router regions can still react to global state changes**. If you have an interactive element outside any router region, with directives that use `getServerState()` to read global state, these directives will automatically re-evaluate when navigation brings in new server state.
 
 For example, consider a shopping cart icon in the header that displays the number of items:
 
@@ -773,7 +792,7 @@ const { state } = store( 'myShop', {
 
 Now the cart icon will update whenever navigation brings in a new `cartCount` value from the server, even though the header itself is outside any router region. This is because `getServerState()` creates a reactive subscription to server-provided state, which is updated during every navigation.
 
-This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region. However, `getServerState()` can also be used to synchronize the `state` of interactive blocks inside router regions, as described in the [Handling server state updates](#handling-server-state-updates) section.
+This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region. However, `getServerState()` can also be used to synchronize the `state` of interactive elements inside router regions, as described in the [Handling server state updates](#handling-server-state-updates) section.
 
 ### CSS handling
 
@@ -835,7 +854,7 @@ By keeping deactivated style elements in the DOM (rather than removing them), th
 
 ### Script module handling
 
-Interactive blocks use [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) for their interactive behavior. The router must ensure that when navigating to a new page, any script modules required by that page are loaded and executed.
+The Interactivity API uses [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) for interactive behavior. The router must ensure that when navigating to a new page, any script modules required by that page are loaded and executed.
 
 **Identifying script modules for client-side navigation**
 
@@ -905,13 +924,13 @@ Each script module's top-level code runs, which typically includes calls to `sto
 
 ### Server state and context
 
-Interactive blocks often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: [global state and local context](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md).
+Interactive elements often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: [global state and local context](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md).
 
 During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
 
 **How server data is embedded in pages**
 
-When WordPress renders a page with interactive blocks, it embeds server-provided data in special `<script>` tags:
+When WordPress renders a page with interactive elements, it embeds server-provided data in special `<script>` tags:
 
 ```html
 <!-- Global state -->
@@ -937,7 +956,7 @@ Local context is embedded directly in the `data-wp-context` attribute of element
 	data-wp-interactive="myPlugin"
 	data-wp-context='{ "productId": 42, "inStock": true }'
 >
-	<!-- Block content -->
+	<!-- Content -->
 </div>
 ```
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -43,9 +43,11 @@ If you already have an interactive block and want to add client-side navigation,
 
 ### Setting up router regions
 
-Router regions are the parts of your page that the router will update during client-side navigation. You mark them with the `data-wp-router-region` directive, which takes a unique ID as its value. When navigation occurs, the router matches regions on the current page with regions on the target page by their IDs and replaces their content — leaving everything outside router regions untouched.
+A router region is a section of your page that the router updates during client-side navigation. You define one by adding both `data-wp-router-region` and `data-wp-interactive` to the same element — both directives are required at this moment.
 
-Define a router region in your block's markup by adding `data-wp-router-region` alongside `data-wp-interactive`:
+The `data-wp-router-region` directive takes a unique ID as its value. When navigation occurs, the router matches regions on the current page with regions on the target page by their IDs and replaces their content — leaving everything outside router regions untouched. Each region ID must be unique within a page; if two regions share the same ID, the router won't know which one to update.
+
+Here's a basic router region in a block's markup:
 
 ```php
 // render.php
@@ -60,6 +62,47 @@ Define a router region in your block's markup by adding `data-wp-router-region` 
             <p><?php echo esc_html( $post->post_excerpt ); ?></p>
         </article>
     <?php endforeach; ?>
+</div>
+```
+
+#### Where to place router regions
+
+Router regions can be placed anywhere on the page. Their behavior depends on where they sit relative to other interactive elements and other router regions:
+
+**As a standalone element** — When a router region is not inside any existing `data-wp-interactive` element, it serves a dual role: it is the interactive boundary (since it carries `data-wp-interactive`) _and_ its content is updated during navigation:
+
+```html
+<div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/content">
+	<!-- Interactive boundary + navigable region -->
+	<p data-wp-text="state.message">Hello</p>
+</div>
+```
+
+**Inside an interactive element** — When a router region is nested inside an element that already has `data-wp-interactive`, the region becomes part of that element's virtual DOM. The parent interactive element stays untouched during navigation, but the region's content is updated:
+
+```html
+<div data-wp-interactive="myPlugin">
+	<h1>This heading is never updated during navigation</h1>
+
+	<div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/posts">
+		<!-- This content is updated during navigation -->
+	</div>
+</div>
+```
+
+Note that the router region still needs its own `data-wp-interactive` directive, even though it is already inside one.
+
+**Inside another router region** — When a router region is nested inside another router region, it becomes part of the parent region. The parent region is updated as a single unit during navigation; the nested region is not processed independently:
+
+```html
+<div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/main">
+	<!-- This inner region is part of "myPlugin/main" -->
+	<div
+		data-wp-interactive="myPlugin"
+		data-wp-router-region="myPlugin/sidebar"
+	>
+		<!-- Updated together with the parent region -->
+	</div>
 </div>
 ```
 
@@ -696,7 +739,7 @@ Router regions are the sections of your page that the router knows how to update
 
 **Defining router regions**
 
-You define a router region by adding the `data-wp-router-region` attribute to an element. The element must also be interactive (either having `data-wp-interactive` directly, or being a descendant of an element with `data-wp-interactive`).
+You define a router region by adding the `data-wp-router-region` attribute to an element alongside `data-wp-interactive` (as described in [Setting up router regions](#setting-up-router-regions) above).
 
 The attribute value serves as a unique identifier for that region. You can specify it in two ways:
 
@@ -722,35 +765,6 @@ The attribute value serves as a unique identifier for that region. You can speci
     ```
 
 The region ID must be unique within a single page and consistent across pages that share the same region. For example, if both your "Products" page and "Product Detail" page have a sidebar, and you want that sidebar to update during navigation, both pages should define a region with the same ID (e.g., `"myPlugin/sidebar"`).
-
-**Requirements for router regions**
-
-For a router region to function correctly, it must meet these requirements:
-
-1. **Must be inside an interactive scope**: The element with `data-wp-router-region` must either have `data-wp-interactive` itself, or be nested inside an element that does. This is because the router relies on the Interactivity API's directive processing to handle the region content.
-
-2. **Must have a unique ID**: No two regions on the same page should share the same ID. If they do, the router won't know which region to update.
-
-3. **Should include `data-wp-interactive` on nested regions**: When you place a router region inside another interactive element, always include the `data-wp-interactive` attribute on the region element itself:
-
-```html
-<!-- Correct: The region element has data-wp-interactive -->
-<div data-wp-interactive="myPlugin">
-	<div
-		data-wp-interactive="myPlugin"
-		data-wp-router-region="myPlugin/sidebar"
-	>
-		<!-- Sidebar content -->
-	</div>
-</div>
-
-<!-- Incorrect: This region may not update properly -->
-<div data-wp-interactive="myPlugin">
-	<div data-wp-router-region="myPlugin/sidebar">
-		<!-- This won't work reliably! -->
-	</div>
-</div>
-```
 
 **How regions are processed during page fetch**
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -30,6 +30,8 @@ The `@wordpress/interactivity-router` package is bundled with WordPress Core sin
 2. **Define router regions**: Mark the HTML elements that should be updated during navigation.
 3. **Trigger navigation**: Use the `actions.navigate()` function to navigate programmatically.
 
+For detailed API documentation, see the [`@wordpress/interactivity-router` package README](/packages/interactivity-router/README.md).
+
 ### Setting up router regions
 
 First, define router regions in your block's markup:

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -1,0 +1,813 @@
+# Client-Side Navigation
+
+Client-side navigation is a technique that allows navigation between pages without requiring a full page reload. Instead of the browser fetching an entirely new HTML document from the server, client-side navigation fetches the new page's content and updates only the parts of the DOM that have changed. This results in faster, smoother page transitions and a more app-like user experience.
+
+The Interactivity API provides client-side navigation through the `@wordpress/interactivity-router` package. This package enables you to implement region-based navigation, where only specific parts of your page are updated when navigating between URLs.
+
+## How client-side navigation works
+
+When a user triggers a navigation (for example, by clicking a link), the Interactivity Router:
+
+1. **Fetches the new page**: The router requests the HTML of the destination URL.
+2. **Parses the response**: It extracts the relevant regions, styles, scripts, and server-rendered data from the fetched HTML.
+3. **Updates the DOM**: Only the content within designated "router regions" is replaced with the new content.
+4. **Updates browser history**: A new entry is added to the browser's session history (or replaces the current entry if specified).
+5. **Loads necessary assets**: Any new styles or script modules required by the new page are loaded before rendering.
+6. **Handles accessibility**: Screen reader announcements are made to indicate navigation progress.
+
+This approach offers several benefits:
+
+- **Improved performance**: Only the changed parts of the page are updated, reducing data transfer and DOM manipulation.
+- **Preserved state**: Client-side state (global state, local context) is preserved across navigations.
+- **Smooth transitions**: No flash of white screen between pages; transitions feel instant and app-like.
+- **SEO-friendly**: Since the server still renders complete HTML pages, search engines can crawl your site normally.
+
+## Getting started with the Interactivity Router
+
+The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. To use it in your interactive blocks, you need to:
+
+1. **Add the dependency**: Ensure `@wordpress/interactivity-router` is listed as a dependency for your script module.
+2. **Define router regions**: Mark the HTML elements that should be updated during navigation.
+3. **Trigger navigation**: Use the `actions.navigate()` function to navigate programmatically.
+
+### Dynamic imports for optimal performance
+
+The recommended pattern is to import the router package dynamically to reduce the initial JavaScript bundle size. The router is only loaded when navigation is actually needed:
+
+```js
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
+store( 'myPlugin', {
+	actions: {
+		// Use withSyncEvent because we need to call preventDefault().
+		goToPage: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+
+			// Dynamically import the router when needed.
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
+		} ),
+	},
+} );
+```
+
+_Note: Actions that need to call synchronous event methods like `event.preventDefault()` must wrap the handler with `withSyncEvent()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details._
+
+## Defining router regions
+
+Router regions are sections of your page that will be updated during client-side navigation. You define them using the `data-wp-router-region` directive.
+
+### Basic usage
+
+To create a router region, add the `data-wp-router-region` directive to an element that also has `data-wp-interactive`:
+
+```html
+<div
+	data-wp-interactive="myPlugin"
+	data-wp-router-region="main-content"
+>
+	<!-- This content will be replaced during navigation -->
+	<h1>Page Title</h1>
+	<p>Page content goes here...</p>
+</div>
+```
+
+The value of `data-wp-router-region` must be a unique identifier for that region. When navigating to a new page, the router will find regions with matching IDs and replace their content.
+
+### Requirements for router regions
+
+For a router region to work correctly:
+
+1. **Must be inside an interactive element**: The element with `data-wp-router-region` must either have `data-wp-interactive` or be a descendant of an element with `data-wp-interactive`.
+
+2. **Must have a unique ID**: The region ID must be unique within the page and consistent across pages that should share the same region.
+
+3. **Nested regions should include `data-wp-interactive`**: When adding `data-wp-router-region` to a child element inside a parent with `data-wp-interactive`, always include `data-wp-interactive` on the child element as well.
+
+```html
+<!-- Correct: Region has data-wp-interactive -->
+<div data-wp-interactive="myPlugin">
+	<div
+		data-wp-interactive="myPlugin"
+		data-wp-router-region="sidebar"
+	>
+		<!-- Sidebar content -->
+	</div>
+</div>
+
+<!-- Incorrect: Region without data-wp-interactive won't be updated -->
+<div data-wp-router-region="sidebar">
+	<!-- This won't work! -->
+</div>
+```
+
+### How regions are matched during navigation
+
+When navigating between pages, the router compares regions:
+
+- **Region exists on both pages**: The content is updated with the new page's content.
+- **Region exists only on the new page (without `attachTo`)**: The region is not added to the DOM.
+- **Region exists only on the new page (with `attachTo`)**: The region is created and appended to the specified parent.
+- **Region exists only on the current page**: The region is removed from the DOM.
+
+## Using the navigate action
+
+The `navigate` action is the primary way to trigger client-side navigation programmatically.
+
+### Basic navigation
+
+```js
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
+store( 'myPlugin', {
+	actions: {
+		handleLinkClick: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
+		} ),
+	},
+} );
+```
+
+```html
+<a
+	data-wp-on--click="actions.handleLinkClick"
+	href="/another-page/"
+>
+	Go to another page
+</a>
+```
+
+### Navigation options
+
+The `navigate` function accepts an optional second parameter with configuration options:
+
+```js
+yield actions.navigate( href, {
+	force: false, // Re-fetch even if the page is cached
+	replace: false, // Replace current history entry instead of adding new one
+	timeout: 10000, // Abort navigation after this many milliseconds
+	loadingAnimation: true, // Show loading animation during navigation
+	screenReaderAnnouncement: true, // Announce navigation to screen readers
+	html: null, // Provide HTML directly instead of fetching
+} );
+```
+
+#### Option details
+
+| Option                     | Type    | Default | Description                                                       |
+| -------------------------- | ------- | ------- | ----------------------------------------------------------------- |
+| `force`                    | boolean | `false` | Force re-fetching the page even if it's already cached            |
+| `replace`                  | boolean | `false` | Replace the current browser history entry instead of adding a new one |
+| `timeout`                  | number  | `10000` | Maximum time (in ms) to wait for the navigation before aborting   |
+| `loadingAnimation`         | boolean | `true`  | Whether to show the loading animation during navigation           |
+| `screenReaderAnnouncement` | boolean | `true`  | Whether to announce navigation status to screen readers           |
+| `html`                     | string  | `null`  | HTML string to use instead of fetching from the URL               |
+
+### Example: Navigation with custom options
+
+```js
+store( 'myPlugin', {
+	actions: {
+		navigateWithReplace: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+
+			// Replace history entry and use a shorter timeout.
+			yield actions.navigate( event.target.href, {
+				replace: true,
+				timeout: 5000,
+			} );
+		} ),
+	},
+} );
+```
+
+## Prefetching pages
+
+Prefetching allows you to load a page's content before the user actually navigates to it. This makes subsequent navigation feel instant.
+
+### Basic prefetching
+
+```js
+store( 'myPlugin', {
+	actions: {
+		*prefetchPage( event ) {
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.prefetch( event.target.href );
+		},
+	},
+} );
+```
+
+```html
+<a
+	data-wp-on--mouseenter="actions.prefetchPage"
+	data-wp-on--click="actions.handleLinkClick"
+	href="/another-page/"
+>
+	Hover to prefetch
+</a>
+```
+
+### Prefetch options
+
+| Option  | Type    | Default | Description                                           |
+| ------- | ------- | ------- | ----------------------------------------------------- |
+| `force` | boolean | `false` | Force re-fetching even if the page is already cached  |
+| `html`  | string  | `null`  | HTML string to use instead of fetching from the URL   |
+
+### Example: Prefetch on hover with force reload
+
+```js
+store( 'myPlugin', {
+	actions: {
+		*prefetchFresh( event ) {
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			// Always fetch fresh content, ignore cache.
+			yield actions.prefetch( event.target.href, { force: true } );
+		},
+	},
+} );
+```
+
+## Router state
+
+The Interactivity Router exposes reactive state that you can use in your directives:
+
+```js
+const { state } = store( 'core/router', {
+	state: {
+		url: window.location.href,
+		navigation: {
+			hasStarted: false,
+			hasFinished: false,
+		},
+	},
+} );
+```
+
+### Available state properties
+
+| Property                    | Type    | Description                                     |
+| --------------------------- | ------- | ----------------------------------------------- |
+| `state.url`                 | string  | The current URL, synchronized with browser location |
+| `state.navigation.hasStarted`  | boolean | `true` when a navigation has started            |
+| `state.navigation.hasFinished` | boolean | `true` when a navigation has completed          |
+
+### Example: Showing a loading indicator
+
+```html
+<div data-wp-interactive="myPlugin">
+	<div
+		data-wp-class--is-loading="state.navigation.hasStarted"
+		data-wp-class--is-loaded="state.navigation.hasFinished"
+	>
+		<span data-wp-bind--hidden="!state.navigation.hasStarted">
+			Loading...
+		</span>
+		<!-- Page content -->
+	</div>
+</div>
+```
+
+```css
+.is-loading {
+	opacity: 0.5;
+	pointer-events: none;
+}
+```
+
+## Dynamic regions with attachTo
+
+The `attachTo` property allows you to create regions that can be dynamically added to any part of the DOM, even if they don't exist on the initial page. This is useful for elements like modals, overlays, or sidebars that appear only on certain pages.
+
+### Using attachTo
+
+Instead of a simple string ID, pass a JSON object with `id` and `attachTo` properties:
+
+```html
+<div
+	data-wp-interactive="myPlugin"
+	data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
+>
+	<div class="modal">
+		<!-- Modal content -->
+	</div>
+</div>
+```
+
+The `attachTo` value is a CSS selector pointing to the parent element where the region should be appended.
+
+### How attachTo works
+
+- If the region with `attachTo` exists on the new page but not the current page, it is created and appended to the element matching the `attachTo` selector.
+- If the region exists on both pages, the content is updated (and `attachTo` is ignored).
+- If the region exists on the current page but not the new page, it is removed from the DOM.
+- If the region with `attachTo` is present on the initial page load, it is treated as a regular region (the `attachTo` property is ignored for the initial page).
+
+### Example: Modal that appears on navigation
+
+**Page 1 (no modal):**
+```html
+<div data-wp-interactive="myPlugin" data-wp-router-region="main">
+	<h1>Page without modal</h1>
+	<a
+		data-wp-on--click="actions.navigate"
+		href="/page-with-modal/"
+	>
+		Open page with modal
+	</a>
+</div>
+```
+
+**Page 2 (with modal):**
+```html
+<div data-wp-interactive="myPlugin" data-wp-router-region="main">
+	<h1>Page with modal</h1>
+</div>
+
+<!-- Modal region that will be appended to body -->
+<div
+	data-wp-interactive="myPlugin"
+	data-wp-router-region='{ "id": "myPlugin/modal", "attachTo": "body" }'
+>
+	<div class="modal-overlay">
+		<div class="modal-content">
+			<h2>I'm a modal!</h2>
+			<a
+				data-wp-on--click="actions.navigate"
+				href="/page-without-modal/"
+			>
+				Close
+			</a>
+		</div>
+	</div>
+</div>
+```
+
+When navigating from Page 1 to Page 2, the modal region is created and appended to `body`. When navigating back to Page 1, the modal is removed.
+
+## Practical examples
+
+### Example 1: Simple pagination
+
+This example shows how to implement client-side pagination for a list of posts.
+
+**PHP (render.php):**
+```php
+<?php
+$current_page = isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1;
+$posts = new WP_Query( array(
+	'paged' => $current_page,
+	'posts_per_page' => 5,
+) );
+?>
+
+<div
+	data-wp-interactive="myPagination"
+	data-wp-router-region="posts-list"
+>
+	<ul class="posts-list">
+		<?php while ( $posts->have_posts() ) : $posts->the_post(); ?>
+			<li><?php the_title(); ?></li>
+		<?php endwhile; ?>
+	</ul>
+
+	<nav class="pagination">
+		<?php if ( $current_page > 1 ) : ?>
+			<a
+				data-wp-on--click="actions.navigate"
+				href="?paged=<?php echo $current_page - 1; ?>"
+			>
+				Previous
+			</a>
+		<?php endif; ?>
+
+		<?php if ( $posts->max_num_pages > $current_page ) : ?>
+			<a
+				data-wp-on--click="actions.navigate"
+				href="?paged=<?php echo $current_page + 1; ?>"
+			>
+				Next
+			</a>
+		<?php endif; ?>
+	</nav>
+</div>
+```
+
+**JavaScript (view.js):**
+```js
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
+store( 'myPagination', {
+	actions: {
+		navigate: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
+
+			// Scroll to top after navigation.
+			window.scrollTo( { top: 0, behavior: 'smooth' } );
+		} ),
+	},
+} );
+```
+
+### Example 2: Tab-based navigation with state preservation
+
+This example demonstrates tabs where the active tab content loads via client-side navigation while preserving local state.
+
+**PHP (render.php):**
+```php
+<?php
+$active_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'overview';
+$base_url = get_permalink();
+?>
+
+<div
+	data-wp-interactive="myTabs"
+	data-wp-router-region="tabbed-content"
+	data-wp-context='{ "lastVisited": "" }'
+>
+	<nav class="tabs-nav">
+		<a
+			data-wp-on--click="actions.switchTab"
+			data-wp-class--active="<?php echo $active_tab === 'overview' ? 'true' : 'false'; ?>"
+			href="<?php echo esc_url( add_query_arg( 'tab', 'overview', $base_url ) ); ?>"
+		>
+			Overview
+		</a>
+		<a
+			data-wp-on--click="actions.switchTab"
+			data-wp-class--active="<?php echo $active_tab === 'details' ? 'true' : 'false'; ?>"
+			href="<?php echo esc_url( add_query_arg( 'tab', 'details', $base_url ) ); ?>"
+		>
+			Details
+		</a>
+		<a
+			data-wp-on--click="actions.switchTab"
+			data-wp-class--active="<?php echo $active_tab === 'reviews' ? 'true' : 'false'; ?>"
+			href="<?php echo esc_url( add_query_arg( 'tab', 'reviews', $base_url ) ); ?>"
+		>
+			Reviews
+		</a>
+	</nav>
+
+	<div class="tab-content">
+		<?php if ( $active_tab === 'overview' ) : ?>
+			<h2>Overview</h2>
+			<p>Product overview content...</p>
+		<?php elseif ( $active_tab === 'details' ) : ?>
+			<h2>Details</h2>
+			<p>Product details content...</p>
+		<?php else : ?>
+			<h2>Reviews</h2>
+			<p>Product reviews content...</p>
+		<?php endif; ?>
+	</div>
+
+	<p data-wp-text="state.visitMessage"></p>
+</div>
+```
+
+**JavaScript (view.js):**
+```js
+import { store, getContext, withSyncEvent } from '@wordpress/interactivity';
+
+const { state } = store( 'myTabs', {
+	state: {
+		get visitMessage() {
+			const { lastVisited } = getContext();
+			return lastVisited
+				? `You previously visited: ${ lastVisited }`
+				: 'Welcome!';
+		},
+	},
+	actions: {
+		switchTab: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+
+			// Update context before navigation (this persists).
+			const context = getContext();
+			const currentUrl = new URL( window.location.href );
+			context.lastVisited =
+				currentUrl.searchParams.get( 'tab' ) || 'overview';
+
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( event.target.href );
+		} ),
+	},
+} );
+```
+
+### Example 3: Infinite scroll
+
+This example shows how to implement infinite scroll loading.
+
+**PHP (render.php):**
+```php
+<?php
+$page = isset( $_GET['page'] ) ? (int) $_GET['page'] : 1;
+$items = get_items_for_page( $page );
+$has_more = has_more_items( $page );
+$next_url = add_query_arg( 'page', $page + 1, get_permalink() );
+
+wp_interactivity_state( 'myInfiniteScroll', array(
+	'hasMore' => $has_more,
+	'nextUrl' => $next_url,
+	'isLoading' => false,
+) );
+?>
+
+<div
+	data-wp-interactive="myInfiniteScroll"
+	data-wp-router-region="infinite-list"
+>
+	<ul class="items-list">
+		<?php foreach ( $items as $item ) : ?>
+			<li><?php echo esc_html( $item['title'] ); ?></li>
+		<?php endforeach; ?>
+	</ul>
+
+	<div
+		data-wp-bind--hidden="!state.hasMore"
+		data-wp-watch="callbacks.observeLoadMore"
+	>
+		<span data-wp-bind--hidden="!state.isLoading">Loading more...</span>
+		<button
+			data-wp-on--click="actions.loadMore"
+			data-wp-bind--disabled="state.isLoading"
+		>
+			Load More
+		</button>
+	</div>
+</div>
+```
+
+**JavaScript (view.js):**
+```js
+import { store, getElement } from '@wordpress/interactivity';
+
+const { state } = store( 'myInfiniteScroll', {
+	actions: {
+		*loadMore() {
+			if ( state.isLoading || ! state.hasMore ) {
+				return;
+			}
+
+			state.isLoading = true;
+
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.navigate( state.nextUrl, {
+				// Replace history so back button works correctly.
+				replace: true,
+			} );
+
+			state.isLoading = false;
+		},
+	},
+	callbacks: {
+		observeLoadMore() {
+			const { ref } = getElement();
+
+			// Use Intersection Observer for automatic loading.
+			const observer = new IntersectionObserver(
+				( entries ) => {
+					if ( entries[ 0 ].isIntersecting ) {
+						store( 'myInfiniteScroll' ).actions.loadMore();
+					}
+				},
+				{ rootMargin: '100px' }
+			);
+
+			observer.observe( ref );
+
+			// Cleanup function.
+			return () => observer.disconnect();
+		},
+	},
+} );
+```
+
+### Example 4: Handling navigation errors
+
+This example demonstrates proper error handling during navigation.
+
+```js
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
+const { state } = store( 'myPlugin', {
+	state: {
+		error: null,
+		isNavigating: false,
+	},
+	actions: {
+		navigate: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+			state.error = null;
+			state.isNavigating = true;
+
+			try {
+				const { actions } = yield import(
+					'@wordpress/interactivity-router'
+				);
+				yield actions.navigate( event.target.href, {
+					timeout: 5000,
+				} );
+			} catch ( error ) {
+				state.error = 'Navigation failed. Please try again.';
+				console.error( 'Navigation error:', error );
+			} finally {
+				state.isNavigating = false;
+			}
+		} ),
+	},
+} );
+```
+
+```html
+<div data-wp-interactive="myPlugin">
+	<div
+		data-wp-bind--hidden="!state.error"
+		class="error-message"
+		data-wp-text="state.error"
+	></div>
+
+	<a
+		data-wp-on--click="actions.navigate"
+		data-wp-class--is-loading="state.isNavigating"
+		href="/another-page/"
+	>
+		Navigate
+	</a>
+</div>
+```
+
+## Disabling client-side navigation
+
+There are scenarios where you may need to disable client-side navigation and force a full page reload. The Interactivity API provides a configuration option for this.
+
+### Using wp_interactivity_config
+
+In PHP, use `wp_interactivity_config()` to disable client-side navigation:
+
+```php
+// Disable client navigation for this page.
+wp_interactivity_config(
+	'core/router',
+	array( 'clientNavigationDisabled' => true )
+);
+```
+
+When `clientNavigationDisabled` is set to `true`:
+
+- Calls to `actions.navigate()` will trigger a full page reload instead of client-side navigation.
+- Calls to `actions.prefetch()` will do nothing.
+- If a user navigates to a page with this configuration, the router will force a page reload.
+
+### Use cases for disabling client navigation
+
+- **Plugin incompatibility**: When third-party plugins require full page reloads.
+- **Complex state resets**: When you need to ensure all JavaScript state is completely reset.
+- **Admin pages**: When the full WordPress admin experience is needed.
+- **Specific page types**: When certain pages have special requirements that conflict with client-side navigation.
+
+## Synchronizing with server data
+
+When using client-side navigation, the global state and local context are preserved on the client. However, the server may provide updated data for each page. The Interactivity API provides `getServerState()` and `getServerContext()` functions to help synchronize client state with server-provided data.
+
+_Please, visit the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide to learn more about `getServerState()` and `getServerContext()`._
+
+### Example: Updating state after navigation
+
+```js
+import {
+	store,
+	getContext,
+	getServerState,
+	getServerContext,
+} from '@wordpress/interactivity';
+
+const { state } = store( 'myPlugin', {
+	callbacks: {
+		// This callback watches for server state changes.
+		syncWithServer() {
+			const serverState = getServerState();
+			const serverContext = getServerContext();
+			const context = getContext();
+
+			// Selectively update what you need from the server.
+			if ( serverState.pageTitle ) {
+				state.pageTitle = serverState.pageTitle;
+			}
+
+			if ( serverContext.itemCount !== undefined ) {
+				context.itemCount = serverContext.itemCount;
+			}
+		},
+	},
+} );
+```
+
+## Best practices
+
+### 1. Keep regions focused
+
+Define router regions around the content that actually changes between pages. Avoid wrapping the entire page in a single region.
+
+```html
+<!-- Good: Specific regions for changing content -->
+<header data-wp-interactive="myTheme" data-wp-router-region="header">
+	<nav><!-- Navigation that might show active states --></nav>
+</header>
+
+<main data-wp-interactive="myTheme" data-wp-router-region="main-content">
+	<!-- Main content that changes between pages -->
+</main>
+
+<!-- Avoid: One giant region -->
+<body data-wp-interactive="myTheme" data-wp-router-region="everything">
+	<!-- This defeats the purpose of partial updates -->
+</body>
+```
+
+### 2. Use consistent region IDs
+
+Ensure region IDs are consistent across all pages where they should be updated. Use namespaced IDs to avoid conflicts.
+
+```html
+<!-- Good: Namespaced, descriptive IDs -->
+<div data-wp-router-region="myPlugin/product-list">...</div>
+<div data-wp-router-region="myPlugin/sidebar">...</div>
+
+<!-- Avoid: Generic IDs that might conflict -->
+<div data-wp-router-region="content">...</div>
+<div data-wp-router-region="sidebar">...</div>
+```
+
+### 3. Prefetch strategically
+
+Prefetch pages that users are likely to visit, but avoid prefetching everything. Good candidates for prefetching include:
+
+- Links on hover (most common pattern)
+- "Next" links in pagination
+- Primary navigation items on viewport visibility
+
+```js
+store( 'myPlugin', {
+	actions: {
+		*prefetchOnHover( event ) {
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+			yield actions.prefetch( event.target.href );
+		},
+	},
+} );
+```
+
+### 4. Handle loading states gracefully
+
+Always provide visual feedback during navigation. Use the router's built-in state or manage your own loading indicators.
+
+### 5. Test back/forward navigation
+
+Ensure your interactive blocks work correctly when users use browser back/forward buttons. The router automatically handles caching, but your state management should account for these navigation patterns.
+
+### 6. Consider accessibility
+
+The router provides screen reader announcements by default. Keep this enabled unless you have a specific reason to disable it and are providing your own accessibility handling.
+
+## Conclusion
+
+Client-side navigation with the Interactivity API provides a powerful way to create faster, more responsive WordPress sites while maintaining the benefits of server-side rendering. By using router regions to define what changes between pages, prefetching to anticipate user navigation, and proper state management, you can create experiences that feel instant and app-like.
+
+Key takeaways:
+
+- Use `data-wp-router-region` to mark content that should be updated during navigation.
+- Import the router dynamically with `yield import('@wordpress/interactivity-router')` to minimize initial bundle size.
+- Use `actions.navigate()` for programmatic navigation and `actions.prefetch()` for preloading.
+- Leverage `state.navigation.hasStarted` and `state.navigation.hasFinished` for loading states.
+- Use `attachTo` for regions that should be dynamically injected into the DOM.
+- Consider using `getServerState()` and `getServerContext()` to synchronize with server-provided data after navigation.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -95,7 +95,8 @@ store( 'myPlugin', {
 } );
 ```
 
-_Note: The `withSyncEvent()` wrapper is required for actions that need to call synchronous event methods like `event.preventDefault()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details._
+> [!NOTE]
+> The `withSyncEvent()` wrapper is required for actions that need to call synchronous event methods like `event.preventDefault()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/directives-and-store.md#withsyncevent) for details.
 
 ### Implementing prefetching
 
@@ -340,7 +341,8 @@ yield actions.navigate( '/products/', { force: true } );
 yield actions.prefetch( '/products/', { force: true } );
 ```
 
-**Important:** If you're using `force: true` to refresh a page after a mutation (POST, PUT, DELETE request), make sure the mutation has completed before navigating:
+> [!IMPORTANT]
+> If you're using `force: true` to refresh a page after a mutation (POST, PUT, DELETE request), make sure the mutation has completed before navigating:
 
 ```js
 store( 'myPlugin', {

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -443,9 +443,9 @@ const { state } = store( 'myPlugin', {
 
 For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md#subscribing-to-server-state-and-context) guide.
 
-### Overriding cached pages
+### Overriding router's internal in-memory cached pages
 
-By default, once a page is stored in the router's internal in-memory cache, subsequent navigations use the cached version without making a new network request. Use the `force` option to bypass the router's cache and re-fetch the page from the server:
+By default, once a page is stored in the router's internal in-memory cache, subsequent navigations use the cached version without making a new network request. Use the `force` option to bypass the router's internal in-memory cache and re-fetch the page from the server:
 
 ```js
 // Force re-fetch with navigate().
@@ -677,11 +677,11 @@ The <code>state.url</code> approach has a known limitation: when navigating with
 
 ## The Interactivity Router in depth
 
-This section provides a detailed technical explanation of how client-side navigation works internally. Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your interactive blocks.
+This section provides a detailed technical explanation of how client-side navigation works internally. Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your code.
 
-### The page cache
+### The internal page cache
 
-At the heart of the Interactivity API router is a page cache — a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
+At the heart of the Interactivity API router is an internal in-memory page cache — a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
 
 The cache uses a normalized version of the URL as its key. This normalization strips away the domain and any hash fragments, keeping only the pathname and query parameters. For example, `https://example.com/products/?category=shoes#details` becomes `/products/?category=shoes`. This ensures that navigations to the same logical page (regardless of how the URL was constructed) share the same cache entry.
 
@@ -698,6 +698,23 @@ An important detail is that the cache stores promises rather than resolved value
 Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit — the page is already prepared and ready to render.
 
 If you need to force a fresh fetch (for example, after submitting a form that changes the page's content), you can use the `force: true` option with `navigate()` or `prefetch()`. This bypasses the cache check and fetches the page anew, replacing the existing cache entry with the fresh content.
+
+```js
+// Force a fresh fetch after a form submission.
+const { actions } = store( 'myPlugin', {
+	actions: {
+		*submitForm() {
+			yield fetch( '/wp-json/my-plugin/v1/submit', {
+				method: 'POST',
+				body: JSON.stringify( { /* form data */ } ),
+			} );
+			// Navigate to the same page, bypassing the cache
+			// to reflect the updated content.
+			yield navigate( window.location.href, { force: true } );
+		},
+	},
+} );
+```
 
 ### Router regions
 
@@ -719,7 +736,7 @@ The attribute value serves as a unique identifier for that region. You can speci
    </div>
    ```
 
-2. As a JSON object (when you need the `attachTo` feature, explained later):
+2. As a JSON object (when you need to pass other options):
    ```html
    <div
        data-wp-interactive="myPlugin"
@@ -768,7 +785,7 @@ First, the router parses the fetched HTML into a document structure using the br
 
 Next, the router scans this document for all elements that have both `data-wp-interactive` and `data-wp-router-region` attributes. For each region found, it extracts the region ID and checks whether the region is nested inside another region. Only top-level regions are processed directly; nested regions are handled as part of their parent's content.
 
-For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion — not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
+For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently by the Interactivity API. Importantly, the region element itself is included in this conversion — not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
 
 Finally, each region's virtual DOM is stored in the page cache entry, indexed by its region ID. The cache entry now contains a map of region IDs to their corresponding virtual DOM trees.
 
@@ -849,7 +866,7 @@ const { state } = store( 'myShop', {
 
 Now the cart icon will update whenever navigation brings in a new `cartCount` value from the server, even though the header itself is outside any router region. This is because `getServerState()` creates a reactive subscription to server-provided state, which is updated during every navigation.
 
-This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region.
+This pattern is useful for global UI elements that need to stay synchronized with server data across navigations, without requiring them to be inside a router region. However, `getServerState()` can also be used to synchronize the `state` of interactive blocks inside router regions, as described in the [Handling server state updates](#handling-server-state-updates) section.
 
 ### CSS handling
 
@@ -909,9 +926,9 @@ By keeping deactivated style elements in the DOM (rather than removing them), th
 
 ### Script module handling
 
-Modern WordPress blocks often use JavaScript modules (ES modules) for their interactive behavior. The router must ensure that when navigating to a new page, any JavaScript modules required by that page are loaded and executed.
+Interactive blocks use [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) for their interactive behavior. The router must ensure that when navigating to a new page, any script modules required by that page are loaded and executed.
 
-**Identifying modules for client-side navigation**
+**Identifying script modules for client-side navigation**
 
 Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. To distinguish which modules should be loaded, WordPress uses a special data attribute:
 
@@ -940,33 +957,33 @@ Modern JavaScript uses import maps to resolve bare module specifiers (like `@wor
 </script>
 ```
 
-When the router fetches a new page, it extracts the import map from that page and merges any new mappings with the current page's import map. This ensures that modules can resolve their dependencies correctly even when navigating between pages that have different sets of scripts.
+When the router fetches a new page, it extracts the import map from that page and merges any new mappings with the current page's import map. This ensures that script modules can resolve their dependencies correctly even when navigating between pages that have different sets of scripts.
 
-**Preloading modules and their dependencies**
+**Preloading script modules and their dependencies**
 
-Preloading script modules is more complex than preloading styles because modules can import other modules. A single entry-point module might depend on dozens of other modules, which might depend on dozens more.
+Preloading script modules is more complex than preloading styles because script modules can import other script modules. A single entry-point module might depend on dozens of other script modules, which might depend on dozens more.
 
 To handle this, the router performs a recursive dependency resolution:
 
-1. It fetches the source code of each entry-point module
+1. It fetches the source code of each entry-point script module
 2. It parses the source to find all `import` statements
-3. For each import, it resolves the module specifier using the import map
+3. For each import, it resolves the script module specifier using the import map
 4. It recursively fetches and parses each dependency
-5. This continues until all modules in the dependency tree have been fetched
+5. This continues until all script modules in the dependency tree have been fetched
 
-The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again — the browser already has it cached.
+The router is smart about avoiding redundant work. If a script module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again — the browser already has it cached.
 
 **Handling the import timing**
 
-An important subtlety is that module code shouldn't execute until navigation actually happens. The router needs to have the module code ready (to avoid delays during navigation), but it shouldn't run that code while the user is still viewing the current page.
+An important subtlety is that script module code shouldn't execute until navigation actually happens. The router needs to have the script module code ready (to avoid delays during navigation), but it shouldn't run that code while the user is still viewing the current page.
 
-The router accomplishes this by transforming the fetched modules. It rewrites the source code to use blob URLs (data embedded directly in the URL) and caches these transformed modules. When navigation occurs, the router uses dynamic `import()` to execute the cached modules.
+The router accomplishes this by transforming the fetched script modules. It rewrites the source code to use blob URLs (data embedded directly in the URL) and caches these transformed script modules. When navigation occurs, the router uses dynamic `import()` to execute the cached script modules.
 
-Because the browser's module system caches modules by URL, importing the same blob URL multiple times returns the same module instance. This ensures that each module is only executed once, even if multiple code paths try to import it.
+Because the browser's module system caches script modules by URL, importing the same blob URL multiple times returns the same module instance. This ensures that each script module is only executed once, even if multiple code paths try to import it.
 
-**Module execution during navigation**
+**Script module execution during navigation**
 
-When `navigate()` renders the new page, it imports all the modules that were preloaded for that page:
+When `navigate()` renders the new page, it imports all the script modules that were preloaded for that page:
 
 ```js
 // Simplified conceptual view of what happens.
@@ -975,11 +992,13 @@ for (const moduleInfo of page.scriptModules) {
 }
 ```
 
-Each module's top-level code runs, which typically includes calls to `store()` to register actions, callbacks, and state. Because the Interactivity API's store is global and additive, these registrations merge with existing store definitions from the initial page load.
+Each script module's top-level code runs, which typically includes calls to `store()` to register actions, callbacks, and state. Because the Interactivity API's store is global and additive, these registrations merge with existing store definitions from the initial page load.
 
 ### Server state and context
 
-WordPress blocks often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: global state and local context. During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
+Interactive blocks often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: [global state and local context](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md).
+
+During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
 
 **How server data is embedded in pages**
 
@@ -1014,7 +1033,7 @@ Local context is embedded directly in the `data-wp-context` attribute of element
 
 When the router fetches a new page, it extracts both types of server data:
 
-1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content. This state is stored in the page cache entry.
+1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content. This state is stored in the internal in-memory page cache entry.
 
 2. **Local context**: Context values are embedded in the virtual DOM representation of each router region. When a region's HTML is converted to vDOM, the `data-wp-context` attributes are preserved and will be processed during rendering.
 
@@ -1024,7 +1043,43 @@ When navigation renders the new page, the server-provided data may need to merge
 
 For **global state**, the merge works as follows: properties that already exist on the client are left untouched, and only new properties (those that don't exist on the client yet) are added from the server data. If you need the client state to reflect server changes during navigation, use `getServerState()` to subscribe to the server-provided values and update the client state yourself.
 
+```
+Server state from the initial page:
+  { "totalResults": 120, "isFiltersOpen": false }
+
+Before navigation (User opened the filters, modifying client state):
+  getServerState()  → { "totalResults": 120, "isFiltersOpen": false }
+  state             → { "totalResults": 120, "isFiltersOpen": true }
+
+Server state from the new page:
+  { "totalResults": 85, "sortOrder": "date" }
+
+After navigation:
+  getServerState()  → { "totalResults": 85, "sortOrder": "date" }
+  state             → { "totalResults": 120, "isFiltersOpen": true, "sortOrder": "date" }
+```
+
+`totalResults` stays at `120` in `state` because it already existed on the client. `isFiltersOpen` is also preserved. `sortOrder` is added because it didn't exist on the client yet. Meanwhile, `getServerState()` always reflects exactly what the server sent for the new page.
+
 For **local context**, the behavior follows the same principle. The Interactivity API tracks server context and client context separately. During navigation, the server context is updated with the values from the new page, but the client context remains unchanged. Use `getServerContext()` to read the server-provided values and `getContext()` to read the client-side values, choosing whichever is appropriate for your use case.
+
+```
+Server context from the initial page:
+  { "isAvailable": true, "isLiked": false }
+
+Before navigation (User has liked the item, modifying client context):
+  getServerContext() → { "isAvailable": true, "isLiked": false }
+  getContext()       → { "isAvailable": true, "isLiked": true }
+
+Server context from the new page:
+  { "isAvailable": false, "discount": 15 }
+
+After navigation:
+  getServerContext() → { "isAvailable": false, "discount": 15 }
+  getContext()       → { "isAvailable": true, "isLiked": true, "discount": 15 }
+```
+
+`isAvailable` stays `true` in `getContext()` because it already existed on the client. `isLiked` is also preserved. `discount` is added because it didn't exist on the client yet. Meanwhile, `getServerContext()` always reflects exactly what the server sent for the new page.
 
 **Subscribing to server data changes**
 
@@ -1045,21 +1100,21 @@ Now that we've examined each component, let's trace through a complete navigatio
 
 #### Phase 1: Prefetch (optional but recommended)
 
-When the user hovers over a link, your code might call `prefetch()`:
+When `prefetch()` is called (for example, on link hover):
 
 1. The router normalizes the URL and checks the page cache.
 2. If not cached, it begins fetching the HTML.
 3. The fetched HTML is parsed into a document.
 4. Router regions are extracted and converted to virtual DOM.
-5. Style sheets are compared with current page; new ones are added with `media="preload"`.
-6. Script modules are identified, dependencies resolved, and source code fetched.
+5. Style sheets are compared with the previously loaded ones; new ones are added with `media="preload"`.
+6. Script modules are identified and compared with the previously loaded ones; new ones have their dependencies resolved and source code fetched.
 7. Server state is extracted.
 8. The fully processed page is stored in the cache.
 9. The function returns (the page is now ready for instant navigation).
 
 #### Phase 2: Navigate
 
-When the user clicks the link and your code calls `navigate()`:
+When `navigate()` is called (for example, on link click):
 
 1. The router checks if client navigation is disabled; if so, falls back to full page load.
 2. If not already prefetched, the fetch process from Phase 1 runs now.
@@ -1089,7 +1144,7 @@ This ensures that rapid clicking through multiple links doesn't cause visual gli
 
 Full-page client-side navigation is an experimental feature that extends the region-based approach described throughout this guide. Instead of requiring you to define individual router regions, full-page navigation treats the entire `<body>` element as a single region — effectively replacing all page content during navigation.
 
-This feature is only available in the Gutenberg plugin and must be enabled manually. To activate it, go to **Admin Panel > Gutenberg > Experiments** and check the **"Interactivity API: Full-page client-side navigation"** option.
+This feature is only available in the Gutenberg plugin and must be enabled manually. To activate it, go to **WP Admin > Gutenberg > Experiments** and check the **"Interactivity API: Full-page client-side navigation"** option.
 
 Once enabled, this mode automatically intercepts all link clicks and hover events on the page, triggering client-side navigation and prefetching without you needing to write any custom action handlers. It is available through a separate entry point in the router package:
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -257,7 +257,7 @@ store( 'myPagination', {
 
 ### Adding new regions on navigation
 
-The `attachTo` option allows router regions to be dynamically added to the DOM when navigating to a page where they exist, even if they weren't present on the original page. This is useful for modals, sidebars, or other UI elements that appear only on certain pages.
+Sometimes you need UI elements — like modals, sidebars, or notification panels — that only appear on certain pages. With regular router regions, a region must already exist on the current page to be updated during navigation. The `attachTo` option solves this by letting you define regions that are dynamically created and inserted into the DOM when navigating to a page where they exist, even if they weren't present on the original page.
 
 **Defining a region with `attachTo`:**
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -642,8 +642,6 @@ Place this callback on an element that is always present in the DOM (like a site
 </div>
 ```
 
-The router also exposes `state.navigation.hasStarted` and `state.navigation.hasFinished` properties if you need to track the navigation lifecycle more granularly — for example, to show custom loading indicators or to time how long navigations take.
-
 ## The Interactivity Router in depth
 
 This section provides a detailed technical explanation of how client-side navigation works internally. Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your interactive blocks.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -77,10 +77,6 @@ Here's how to implement a link that navigates client-side. First, the HTML in yo
 </a>
 ```
 
-<div class="callout callout-info">
-This element must be placed inside an element with the <code>data-wp-interactive="myPlugin"</code> directive (like the router region defined above), so the directive knows which store namespace to look up the action in. Alternatively, you can specify the namespace explicitly in the directive value itself: <code>data-wp-on--click="myPlugin::actions.navigateTo"</code>. For more details on how namespaces work, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-and-store/">Interactivity API Reference</a>.
-</div>
-
 Then, in your `view.js`, you define the `navigateTo` action. It prevents the browser's default full-page navigation and uses the router's `navigate()` function instead:
 
 ```js

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -416,38 +416,9 @@ yield actions.navigate( '/page/', { timeout: 30000 } );
 
 ### Handling fetch errors
 
-When navigation fails (network error, timeout, or server error), the router automatically falls back to a full page reload. You can implement custom error handling by catching errors from `navigate()`:
+When navigation fails (network error, timeout, or server error), the router automatically falls back to a full page reload. This means you cannot catch fetch errors from `navigate()` directly — the browser takes over before your code has a chance to handle them.
 
-```js
-store( 'myPlugin', {
-    state: {
-        error: null,
-    },
-    actions: {
-        navigateSafely: withSyncEvent( function* ( event ) {
-            event.preventDefault();
-            state.error = null;
-
-            try {
-                const { actions } = yield import(
-                    '@wordpress/interactivity-router'
-                );
-                yield actions.navigate( event.target.href, {
-                    timeout: 5000,
-                } );
-            } catch ( error ) {
-                state.error = 'Navigation failed. Please try again.';
-                console.error( 'Navigation error:', error );
-
-                // Optionally fall back to full page navigation:
-                // window.location.href = event.target.href;
-            }
-        } ),
-    },
-} );
-```
-
-For more control, you can fetch and process pages manually:
+If you need custom error handling (for example, showing an error message instead of reloading), you can fetch the page manually, handle any errors yourself, and then pass the fetched HTML to `navigate()` using the `html` option:
 
 ```js
 store( 'myPlugin', {

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -24,133 +24,389 @@ This approach offers several benefits:
 
 ### In depth
 
-This section explains the client-side navigation algorithm in more detail. You can skip to [Using the Interactivity API router](#using-the-interactivity-api-router) if you're more interested in practical usage.
+This section provides a detailed technical explanation of how client-side navigation works internally. If you're primarily interested in practical usage, you can skip ahead to [Getting started with the Interactivity Router](#getting-started-with-the-interactivity-router).
+
+Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your interactive blocks.
+
+#### The page cache
+
+At the heart of the Interactivity API router is a page cache—a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
+
+The cache uses a normalized version of the URL as its key. This normalization strips away the domain and any hash fragments, keeping only the pathname and query parameters. For example, `https://example.com/products/?category=shoes#details` becomes `/products/?category=shoes`. This ensures that navigations to the same logical page (regardless of how the URL was constructed) share the same cache entry.
+
+Each entry in the cache stores not just the fetched HTML, but a fully processed page representation containing:
+
+- **Virtual DOM trees** for each router region found in the page
+- **Style sheet references** needed by the page
+- **Script module information** for JavaScript that should be loaded
+- **The page title** for updating the document title
+- **Server state** that was embedded in the page by WordPress
+
+<!-- IMAGE: Diagram showing the page cache structure. A box labeled "Page Cache" contains multiple entries, each showing a URL path (like "/products/", "/about/", "/contact/") mapped to a "Page Object" containing icons for vDOM, styles, scripts, title, and state. Arrows show how navigate() and prefetch() interact with this cache. -->
+
+An important detail is that the cache stores promises rather than resolved values. When a fetch begins, the router immediately stores the pending promise in the cache. This means that if multiple calls to `prefetch()` or `navigate()` target the same URL simultaneously (for example, if a user rapidly hovers over multiple links pointing to the same page), only one network request is made. All callers receive the same promise and wait for the same result.
+
+Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit—the page is already prepared and ready to render.
+
+If you need to force a fresh fetch (for example, after submitting a form that changes the page's content), you can use the `force: true` option with `navigate()` or `prefetch()`. This bypasses the cache check and fetches the page anew, replacing the existing cache entry with the fresh content.
 
 #### Router regions
 
-Router regions are the fundamental building blocks of client-side navigation. They define which parts of the page should be updated during navigation.
+Router regions are the sections of your page that the router knows how to update during client-side navigation. They act as boundaries that tell the router "this is the content that should change when navigating between pages."
 
-**How router regions are defined:**
+**Defining router regions**
 
-Router regions are defined using the `data-wp-router-region` directive. The value can be either:
+You define a router region by adding the `data-wp-router-region` attribute to an element. The element must also be interactive (either having `data-wp-interactive` directly, or being a descendant of an element with `data-wp-interactive`).
 
-1. A simple string ID:
+The attribute value serves as a unique identifier for that region. You can specify it in two ways:
+
+1. As a simple string:
    ```html
    <div
-	data-wp-interactive="myPlugin"
-	data-wp-router-region="main-content"
+       data-wp-interactive="myPlugin"
+       data-wp-router-region="main-content"
    >
-	<!-- Region content -->
+       <!-- Region content -->
    </div>
    ```
 
-2. A JSON object with `id` and optional `attachTo` property:
+2. As a JSON object (when you need the `attachTo` feature, explained later):
    ```html
    <div
-	data-wp-interactive="myPlugin"
-	data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
+       data-wp-interactive="myPlugin"
+       data-wp-router-region='{ "id": "my-modal", "attachTo": "body" }'
    >
-	<!-- Region content -->
+       <!-- Region content -->
    </div>
    ```
 
-The region ID must be unique within the page and consistent across pages that share the same region.
+The region ID must be unique within a single page and consistent across pages that share the same region. For example, if both your "Products" page and "Product Detail" page have a sidebar, and you want that sidebar to update during navigation, both pages should define a region with the same ID (e.g., `"myPlugin/sidebar"`).
 
-**Where router regions can appear:**
+<!-- IMAGE: Side-by-side comparison of two pages. Page A shows a layout with header, main content area (highlighted and labeled "data-wp-router-region='main'"), and sidebar. Page B shows a similar layout with the same regions highlighted. Arrows between them show how regions with matching IDs correspond to each other. -->
 
-For a router region to work correctly:
+**Requirements for router regions**
 
-1. **Must be inside an interactive element**: The element with `data-wp-router-region` must either have `data-wp-interactive` or be a descendant of an element with `data-wp-interactive`.
+For a router region to function correctly, it must meet these requirements:
 
-2. **Must have a unique ID**: The region ID must be unique within the page and consistent across pages that should share the same region.
+1. **Must be inside an interactive scope**: The element with `data-wp-router-region` must either have `data-wp-interactive` itself, or be nested inside an element that does. This is because the router relies on the Interactivity API's directive processing to handle the region content.
 
-3. **Nested regions should include `data-wp-interactive`**: When adding `data-wp-router-region` to a child element inside a parent with `data-wp-interactive`, always include `data-wp-interactive` on the child element as well.
+2. **Must have a unique ID**: No two regions on the same page should share the same ID. If they do, the router won't know which region to update.
+
+3. **Should include `data-wp-interactive` on nested regions**: When you place a router region inside another interactive element, always include the `data-wp-interactive` attribute on the region element itself:
 
 ```html
-<!-- Correct: Region has data-wp-interactive -->
+<!-- Correct: The region element has data-wp-interactive -->
 <div data-wp-interactive="myPlugin">
-	<div
-		data-wp-interactive="myPlugin"
-		data-wp-router-region="sidebar"
-	>
-		<!-- Sidebar content -->
-	</div>
+    <div
+        data-wp-interactive="myPlugin"
+        data-wp-router-region="sidebar"
+    >
+        <!-- Sidebar content -->
+    </div>
 </div>
 
-<!-- Incorrect: Region without data-wp-interactive won't be updated -->
-<div data-wp-router-region="sidebar">
-	<!-- This won't work! -->
+<!-- Incorrect: This region may not update properly -->
+<div data-wp-interactive="myPlugin">
+    <div data-wp-router-region="sidebar">
+        <!-- This won't work reliably! -->
+    </div>
 </div>
 ```
 
-**How regions are handled:**
+**How regions are processed during page fetch**
 
-_During fetch (`prefetch()` or `navigate()`):_
+When the router fetches a new page (either through `prefetch()` or as part of `navigate()`), it processes the HTML to extract and prepare all router regions. This happens in several steps:
 
-1. **Regions are identified**: The router scans the fetched HTML for all elements with `data-wp-router-region`.
-2. **Regions are converted to virtual DOM**: Each region's HTML (including the region element itself) is converted into a virtual DOM representation. This means directives on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
-3. **Regions are cached**: Each region is stored in the page cache with its corresponding ID.
+First, the router parses the fetched HTML into a document structure using the browser's built-in HTML parser. This gives it a complete DOM tree to work with, just as if the page had been loaded normally.
 
-_On `navigate()`:_
+Next, the router scans this document for all elements that have both `data-wp-interactive` and `data-wp-router-region` attributes. For each region found, it extracts the region ID and checks whether the region is nested inside another region. Only top-level regions are processed directly; nested regions are handled as part of their parent's content.
 
-1. **Regions are located in the current page**: The router finds all existing regions by their IDs.
-2. **Existing regions are updated**: If a region exists in both the current page and the target page, its content is updated with the new virtual DOM using Preact's diffing algorithm.
-3. **New regions with `attachTo` are created**: If a region exists in the target page but not the current page, and it has an `attachTo` selector, the region is created and appended to the specified element.
-4. **Orphaned regions are removed**: Regions that exist only in the current page are removed from the DOM.
+For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion—not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
+
+<!-- IMAGE: Flowchart showing the region processing pipeline. Starting with "Fetched HTML" (showing raw HTML code), an arrow leads to "Parse HTML" (DOM tree icon), then to "Find Regions" (highlighting regions in the tree), then to "Convert to vDOM" (showing a simplified tree structure), and finally to "Store in Cache" (the cache icon from earlier). -->
+
+Finally, each region's virtual DOM is stored in the page cache entry, indexed by its region ID. The cache entry now contains a map of region IDs to their corresponding virtual DOM trees.
+
+**How regions are rendered during navigation**
+
+When `navigate()` is called and the target page has been successfully fetched (or was already cached), the router needs to update the current page to show the new content. This rendering process is carefully orchestrated to be efficient and avoid visual glitches.
+
+The router begins by examining which regions exist in the current page and which exist in the target page. Based on this comparison, three different scenarios can occur:
+
+**Scenario 1: Region exists on both pages (update)**
+
+This is the most common case. When a region with a given ID exists on both the current page and the target page, the router updates the existing region with the new content.
+
+Rather than simply replacing the entire region's HTML (which would destroy any internal state and cause a jarring visual transition), the router uses a virtual DOM diffing algorithm. This algorithm compares the current region's virtual DOM with the new region's virtual DOM and calculates the minimum set of changes needed to transform one into the other.
+
+For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements—rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
+
+<!-- IMAGE: Before/after comparison showing region update. Left side shows "Current Page" with a region containing items A, B, C (each in a box). Right side shows "Target Page" with items A, D, C. In the middle, arrows show that A and C stay in place while B transforms into D. Caption: "The diffing algorithm minimizes DOM changes." -->
+
+**Scenario 2: Region exists only on the target page with `attachTo` (create)**
+
+Sometimes a page contains a region that doesn't exist on the current page—for example, a modal dialog that only appears on certain pages. If this region has the `attachTo` property specified, the router will dynamically create it.
+
+The `attachTo` property contains a CSS selector that identifies where in the current page the new region should be appended. When the router encounters such a region, it:
+
+1. Finds the element matching the `attachTo` selector in the current page
+2. Creates new DOM elements for the region
+3. Appends these elements to the matched parent
+4. Renders the region's virtual DOM into the newly created elements
+
+This allows content that exists on one page but not another to appear smoothly during navigation, without requiring the target element to exist in advance.
+
+**Scenario 3: Region exists only on the current page (remove)**
+
+When a region exists on the current page but not on the target page, it means that content is no longer needed. The router handles this by setting the region's content to empty, effectively clearing it from the display.
+
+If the region was dynamically created via `attachTo` during a previous navigation, the entire region element is removed from the DOM. If it was part of the original page structure, the element remains but its content is cleared.
+
+<!-- IMAGE: Three-panel diagram showing the three scenarios. Panel 1 "Update": Same-shaped regions on both pages with a refresh arrow. Panel 2 "Create": Region with attachTo appears from the target page and gets inserted into current page's body. Panel 3 "Remove": Region fades out/disappears from current page. -->
 
 #### CSS handling
 
-The router carefully manages style sheets during navigation to ensure pages are styled correctly while minimizing network requests and avoiding flash of unstyled content.
+One of the trickier aspects of client-side navigation is managing CSS style sheets. Different pages may require different styles, and the router must ensure that the correct styles are active for each page—without causing flashes of unstyled content or breaking the CSS cascade order.
 
-**On `prefetch()`:**
+**The challenge of CSS cascade order**
 
-1. **Styles are extracted**: The router extracts all `<link rel="stylesheet">` and `<style>` elements from the fetched HTML.
-2. **Styles are compared**: Extracted styles are compared with those already present in the current page.
-3. **New styles are added**: Style sheets that don't exist in the current page are added to the document with `media="not all"` (for `<link>` elements) so they are loaded but not applied yet. The router uses a [Shortest Common Supersequence](https://en.wikipedia.org/wiki/Shortest_common_supersequence) algorithm to add new style sheets while preserving CSS cascade order.
-4. **Styles are recorded**: Both existing and newly added styles related to this page are recorded for later activation.
+CSS rules are applied in a specific order, and when two rules have the same specificity, the one that appears later in the document "wins." This means that the order of `<link>` and `<style>` elements in your HTML matters. If the router simply appended new style sheets to the end of the document, it could inadvertently change which rules take precedence, causing visual bugs.
 
-**On `navigate()`:**
+Consider this example: Page A has style sheets [base.css, theme.css], and Page B has [base.css, components.css, theme.css]. If the user navigates from A to B, the router needs to insert components.css between base.css and theme.css—not at the end. Otherwise, any rules in theme.css that are meant to override components.css would stop working.
 
-1. **Styles are toggled**: The router enables or disables style sheets based on whether they belong to the page being navigated to:
-   - Styles needed by the new page have their `media` attribute restored (enabled).
-   - Styles not needed by the new page have their `media` attribute set to `not all` (disabled).
+**How styles are extracted and prepared**
+
+When the router fetches a page, it extracts all style-related elements: both `<link rel="stylesheet">` tags and inline `<style>` blocks. Each style element is identified by a combination of its attributes (for `<link>` tags, primarily the `href`) or its content hash (for inline `<style>` blocks).
+
+The router then compares the extracted styles with those already present in the current page's document. Styles fall into three categories:
+
+1. **Already present**: The style sheet is already loaded in the current page. No action needed during preparation.
+2. **New**: The style sheet doesn't exist in the current page. It needs to be added.
+3. **No longer needed**: The style sheet is in the current page but not in the target page. It will be disabled during navigation.
+
+**Preloading new styles without applying them**
+
+For new style sheets, the router faces a dilemma: it needs to ensure the styles are fully loaded before showing the new page content (to prevent flash of unstyled content), but it doesn't want to apply them yet (because the user is still viewing the current page).
+
+The solution is to add new `<link>` elements with their `media` attribute set to a value that prevents them from applying. The router uses `media="preload"`, which tells the browser "this style sheet applies to no media types"—effectively disabling it while still allowing the browser to download and parse it.
+
+When a `<link>` element is added this way, the browser begins downloading the CSS file immediately. The router tracks when each style sheet finishes loading by listening for the `load` event. This allows it to wait until all new styles are ready before proceeding with navigation.
+
+<!-- IMAGE: Timeline diagram showing style preloading. At t=0, "Prefetch starts" and a link element with media="preload" is added. Browser download begins (shown as a progress bar). At t=200ms, download completes and "load event fires". The styles remain inactive (grayed out) until navigation actually occurs. -->
+
+**Maintaining cascade order with the Shortest Common Supersequence algorithm**
+
+When inserting new style sheets, the router must preserve the correct cascade order. It accomplishes this using an algorithm based on finding the Shortest Common Supersequence (SCS) of two sequences.
+
+Given the current page's style sheets (sequence X) and the target page's style sheets (sequence Y), the SCS algorithm finds the shortest sequence that contains both X and Y as subsequences while preserving their internal order. This tells the router exactly where to insert new elements and which existing elements to keep.
+
+For example:
+- Current page styles (X): [A, C, D]
+- Target page styles (Y): [A, B, C, E]
+- Shortest Common Supersequence: [A, B, C, D, E]
+
+The algorithm then determines: keep A and C in place, insert B between A and C, keep D after C, and insert E at the end.
+
+<!-- IMAGE: Visual representation of the SCS algorithm. Two rows show the "Current" sequence [A, C, D] and "Target" sequence [A, B, C, E]. Below them, the "Merged (SCS)" sequence shows [A, B, C, D, E] with color coding: A and C in blue (shared), B and E in green (inserted), D in gray (will be disabled). Arrows show how elements from both sequences map to the merged result. -->
 
 This approach ensures that:
-- Style sheets are only loaded once, even if multiple pages use them.
-- CSS cascade order is maintained correctly.
-- Styles are ready before the page renders, preventing flash of unstyled content.
+- Style sheets that appear in both pages remain in their correct relative order
+- New style sheets are inserted at the proper position to maintain cascade correctness
+- The minimum number of DOM operations is performed
+
+**Activating and deactivating styles during navigation**
+
+When `navigate()` actually renders the new page, the router toggles style sheets on and off:
+
+- **Activating styles**: For each style sheet that belongs to the target page, the router removes the `media="preload"` override (or restores the original `media` attribute if one was specified). This causes the browser to apply those styles.
+
+- **Deactivating styles**: For each style sheet that was in the current page but not the target page, the router sets `media="preload"`. This disables the styles without removing the element from the DOM.
+
+By keeping deactivated style elements in the DOM (rather than removing them), the router can quickly reactivate them if the user navigates back. The styles are already loaded and parsed; they just need to be enabled.
 
 #### Script module handling
 
-Script modules (ES modules loaded via `<script type="module">`) are managed to ensure all necessary JavaScript is available for the new page's interactive features.
+Modern WordPress blocks often use JavaScript modules (ES modules) for their interactive behavior. The router must ensure that when navigating to a new page, any JavaScript modules required by that page are loaded and executed.
 
-**On `prefetch()`:**
+**Identifying modules for client-side navigation**
 
-1. **Script modules are located**: The router identifies script modules in the fetched HTML that should be loaded during client-side navigation. These are marked with `data-wp-router-options='{"loadOnClientNavigation": true}'`.
-2. **Import map is processed**: The import map from the fetched page is parsed to resolve module dependencies.
-3. **Modules are fetched and cached**: Script modules and their dependencies are fetched and cached by the browser's module system.
+Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. To distinguish which modules should be loaded, WordPress uses a special data attribute:
 
-**On `navigate()`:**
+```html
+<script
+    type="module"
+    src="/wp-content/plugins/my-plugin/view.js"
+    data-wp-router-options='{"loadOnClientNavigation": true}'
+></script>
+```
 
-1. **Cached modules are imported**: The router imports the cached script modules using dynamic `import()`.
-2. **Modules are evaluated**: Each module is evaluated, initializing any stores or callbacks it contains.
-3. **Deduplication is automatic**: Because modules are cached by the browser, importing the same module multiple times returns the cached version, ensuring each module is only evaluated once.
+When the router fetches a page, it scans for all `<script type="module">` elements that have this attribute with `loadOnClientNavigation` set to `true`. These are the modules it will preload and execute.
+
+**Processing the import map**
+
+Modern JavaScript uses import maps to resolve bare module specifiers (like `@wordpress/interactivity`) to actual URLs. WordPress generates an import map that tells the browser where to find each module:
+
+```html
+<script type="importmap">
+{
+    "imports": {
+        "@wordpress/interactivity": "/wp-includes/js/dist/interactivity.min.js",
+        "@wordpress/interactivity-router": "/wp-includes/js/dist/interactivity-router.min.js"
+    }
+}
+</script>
+```
+
+When the router fetches a new page, it extracts the import map from that page and merges any new mappings with the current page's import map. This ensures that modules can resolve their dependencies correctly even when navigating between pages that have different sets of scripts.
+
+**Preloading modules and their dependencies**
+
+Preloading script modules is more complex than preloading styles because modules can import other modules. A single entry-point module might depend on dozens of other modules, which might depend on dozens more.
+
+To handle this, the router performs a recursive dependency resolution:
+
+1. It fetches the source code of each entry-point module
+2. It parses the source to find all `import` statements
+3. For each import, it resolves the module specifier using the import map
+4. It recursively fetches and parses each dependency
+5. This continues until all modules in the dependency tree have been fetched
+
+The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again—the browser already has it cached.
+
+<!-- IMAGE: Tree diagram showing module dependency resolution. At the top, "view.js" (the entry point). Arrows lead down to its dependencies: "@wordpress/interactivity" and "./components/modal.js". The interactivity module is shown grayed out with a note "Already loaded - skip". The modal.js module has its own dependencies branching below it. Each node shows whether it needs to be fetched or can be skipped. -->
+
+**Handling the import timing**
+
+An important subtlety is that module code shouldn't execute until navigation actually happens. The router needs to have the module code ready (to avoid delays during navigation), but it shouldn't run that code while the user is still viewing the current page.
+
+The router accomplishes this by transforming the fetched modules. It rewrites the source code to use blob URLs (data embedded directly in the URL) and caches these transformed modules. When navigation occurs, the router uses dynamic `import()` to execute the cached modules.
+
+Because the browser's module system caches modules by URL, importing the same blob URL multiple times returns the same module instance. This ensures that each module is only executed once, even if multiple code paths try to import it.
+
+**Module execution during navigation**
+
+When `navigate()` renders the new page, it imports all the modules that were preloaded for that page:
+
+```js
+// Simplified conceptual view of what happens
+for (const moduleInfo of page.scriptModules) {
+    await import(moduleInfo.blobUrl);
+}
+```
+
+Each module's top-level code runs, which typically includes calls to `store()` to register actions, callbacks, and state. Because the Interactivity API's store is global and additive, these registrations merge with existing store definitions from the initial page load.
 
 #### Server state and context
 
-Server-rendered state and context are preserved and synchronized during navigation to maintain consistency between server and client.
+WordPress blocks often need data from the server—configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: global state and local context. During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
 
-**On `prefetch()`:**
+**How server data is embedded in pages**
 
-1. **Global state is extracted**: Server state (from `wp_interactivity_state()`) is extracted from the fetched HTML.
-2. **Local context is extracted**: Context values (from `data-wp-context` attributes) are extracted as part of each router region's virtual DOM.
-3. **Data is cached**: Both state and context are stored in the page cache.
+When WordPress renders a page with interactive blocks, it embeds server-provided data in special `<script>` tags:
 
-**On `navigate()`:**
+```html
+<!-- Global state -->
+<script type="application/json" id="wp-script-module-data-@wordpress/interactivity">
+{
+    "state": {
+        "myPlugin":{
+            "cartItemCount": 3,
+            "userLoggedIn": true
+        }
+    }
+}
+</script>
+```
 
-1. **State and context are merged**: The server-provided state and context from the target page are merged with the existing client state.
-2. **Reactive updates occur**: Components subscribed to the state or context will automatically re-render.
-3. **Use `getServerState()` and `getServerContext()`**: To react to server-provided changes specifically, use these functions in your callbacks. See the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide for details.
+Local context is embedded directly in the `data-wp-context` attribute of elements:
+
+```html
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-context='{ "productId": 42, "inStock": true }'
+>
+    <!-- Block content -->
+</div>
+```
+
+**Extracting state and context during fetch**
+
+When the router fetches a new page, it extracts both types of server data:
+
+1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content. This state is stored in the page cache entry.
+
+2. **Local context**: Context values are embedded in the virtual DOM representation of each router region. When a region's HTML is converted to vDOM, the `data-wp-context` attributes are preserved and will be processed during rendering.
+
+**Merging server data during navigation**
+
+When navigation renders the new page, the server-provided data needs to merge with the existing client-side state. This merge follows specific rules:
+
+For global state, the new server state is deeply merged with the existing state. Properties from the server overwrite existing properties with the same path, but properties that exist only on the client are preserved. This allows client-side code to have modified the state (for example, incrementing a counter) while still receiving updates from the server for other properties.
+
+For local context, the behavior depends on the region. When a region is updated, its new context (from the server) replaces the region's previous context. However, because the Interactivity API tracks both "server context" and "client context" separately, your code can choose whether to use the server-provided values or preserve client modifications.
+
+<!-- IMAGE: Diagram showing state merge. Left box shows "Existing Client State" with properties {a: 1, b: 2, c: 3}. Right box shows "New Server State" with properties {a: 10, d: 4}. Arrow points to "Merged Result" showing {a: 10, b: 2, c: 3, d: 4}. Caption explains that 'a' was overwritten by server, 'b' and 'c' preserved from client, 'd' added from server. -->
+
+**Subscribing to server data changes**
+
+The Interactivity API provides two functions for accessing server-provided data that updates during navigation:
+
+- `getServerState()`: Returns the global state as provided by the server for the current page
+- `getServerContext()`: Returns the local context as provided by the server for the current element
+
+These functions are reactive. When used inside a callback or derived state getter, they automatically set up a subscription. When navigation occurs and new server data arrives, any code using these functions will re-run with the new values.
+
+This is different from the regular `state` and `getContext()`, which reflect the current merged state including any client-side modifications. Use `getServerState()` and `getServerContext()` when you specifically need to react to what the server sent, regardless of client modifications.
+
+For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+
+#### Putting it all together: the navigation flow
+
+Now that we've examined each component, let's trace through a complete navigation to see how they work together.
+
+**Phase 1: Prefetch (optional but recommended)**
+
+When the user hovers over a link, your code might call `prefetch()`:
+
+1. The router normalizes the URL and checks the page cache
+2. If not cached, it begins fetching the HTML
+3. The fetched HTML is parsed into a document
+4. Router regions are extracted and converted to virtual DOM
+5. Style sheets are compared with current page; new ones are added with `media="preload"`
+6. Script modules are identified, dependencies resolved, and source code fetched
+7. Server state is extracted
+8. The fully processed page is stored in the cache
+9. The function returns (the page is now ready for instant navigation)
+
+**Phase 2: Navigate**
+
+When the user clicks the link and your code calls `navigate()`:
+
+1. The router checks if client navigation is disabled; if so, falls back to full page load
+2. If not already prefetched, the fetch process from Phase 1 runs now
+3. The router waits for the page to be ready (fetch complete, styles loaded)
+4. A loading indicator may appear if the wait exceeds a threshold (400ms)
+5. Script modules for the new page are imported and executed
+6. The rendering phase begins (wrapped in a batch for efficiency):
+   - Server state is merged with client state
+   - Each router region is updated with its new virtual DOM
+   - Regions with `attachTo` that don't exist are created and appended
+   - Styles are activated/deactivated as needed
+   - The document title is updated
+7. Browser history is updated (pushState or replaceState)
+8. Screen reader announcement is made for accessibility
+9. If the URL has a hash, the page scrolls to that element
+10. Navigation is complete
+
+<!-- IMAGE: Flowchart showing complete navigation flow. Starts with "User hovers link" flowing to "prefetch()" which branches through the prefetch steps. Then "User clicks link" leads to "navigate()" which shows the navigation steps in sequence. Key decision points are shown as diamonds (e.g., "In cache?", "Styles loaded?"). The flow ends at "Navigation complete" with a checkmark. -->
+
+**Race condition protection**
+
+A subtle but important detail: users don't always wait for navigation to complete before clicking another link. The router handles this gracefully.
+
+When `navigate()` is called, the router remembers the target URL. If another `navigate()` call comes in before the first completes, the router updates its target and the first navigation is abandoned. When the first navigation's fetch completes, it checks whether its URL is still the current target—if not, it simply returns without rendering.
+
+This ensures that rapid clicking through multiple links doesn't cause visual glitches or render stale content. Only the most recent navigation completes.
 
 ## Getting started with the Interactivity Router
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -778,6 +778,8 @@ For each top-level region, the router converts the HTML into a virtual DOM (vDOM
 
 Finally, each region's virtual DOM is stored in the page cache entry, indexed by its region ID. The cache entry now contains a map of region IDs to their corresponding virtual DOM trees.
 
+Beyond processing regions, the router also extracts the page's CSS stylesheets and JavaScript script modules during this step. New stylesheets that haven't been loaded yet are added to the document in a disabled state so the browser can begin downloading them without applying them. Similarly, new script modules are identified and their dependency trees are resolved and fetched. These assets are prepared in advance so that when navigation actually renders the new content, all necessary styles and scripts are ready. The details of how styles and script modules are handled are covered in the [CSS handling](#css-handling) and [Script module handling](#script-module-handling) sections below.
+
 **How regions are rendered during navigation**
 
 When `navigate()` is called and the target page has been successfully fetched (or was already cached), the router needs to update the current page to show the new content. This rendering process is carefully orchestrated to be efficient and avoid visual glitches.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -35,16 +35,27 @@ The `@wordpress/interactivity-router` package is bundled with WordPress Core sin
 npx @wordpress/create-block@latest my-interactive-block --template @wordpress/create-block-interactive-template
 ```
 
-If you already have an interactive block and want to add client-side navigation, you need to:
+Whether you are working with a block or a classic theme, adding client-side navigation involves the same steps:
 
-1. **Mark your script module as compatible with client-side navigation**: Ensure your block's `block.json` declares interactivity support (e.g., `"supports": { "interactivity": true }`) so that WordPress automatically marks its script module for loading during client-side navigation. See [Ensuring script modules load during navigation](#ensuring-script-modules-load-during-navigation) for details.
-2. **Add the router dependency**: Add `@wordpress/interactivity-router` as a dependency of your block's script module. This is typically done by dynamically importing the package in your `view.js` file (as shown in the examples below), which ensures it is only loaded when needed.
+1. **Add the router dependency**: Add `@wordpress/interactivity-router` as a dependency of your script module.
+2. **Ensure your script module loads during navigation**: Mark your script module so the router knows to load it on new pages.
 3. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
-4. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
+4. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically.
 
-### Using client-side navigation in Classic themes
+Steps 1 and 2 differ depending on whether you are working with a block or a classic theme, and are covered right below. Steps 3 and 4 are the same regardless of your setup.
 
-Client-side navigation is not limited to blocks — you can also use it in classic PHP themes by adding the Interactivity API directives directly in your theme's template files and processing them with `wp_interactivity_process_directives()`, as explained in the [Server-side rendering](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md#processing-directives-in-classic-themes) guide. Instead of relying on a block's `block.json` to declare script module dependencies, you register and enqueue your script module manually, taking into account that the `@wordpress/interactivity-router` module should be dynamically imported:
+### Adding the router dependency
+
+The `@wordpress/interactivity-router` module should be added as a dynamic dependency so it is only fetched when needed.
+
+For **blocks**, this is done by dynamically importing the package in your `view.js` file. The block build tooling (`wp-scripts`) detects the dynamic import and registers the PHP-side dependency automatically:
+
+```js
+const { actions } = yield import( '@wordpress/interactivity-router' );
+yield actions.navigate( url );
+```
+
+For **classic themes**, instead of relying on a block's `block.json`, you register and enqueue your script module manually in PHP, listing `@wordpress/interactivity-router` as a dynamic dependency. You also add the Interactivity API directives directly in your theme's template files and process them with `wp_interactivity_process_directives()`, as explained in the [Server-side rendering](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md#processing-directives-in-classic-themes) guide.
 
 ```php
 // functions.php
@@ -63,10 +74,6 @@ add_action( 'wp_enqueue_scripts', function () {
     wp_enqueue_script_module( 'my-theme/navigation' );
 } );
 ```
-
-Since classic themes don't use `block.json`, you must also register your script module for client-side navigation explicitly using `add_client_navigation_support_to_script_module()`. Without this, the router will not load your script module when navigating to a page that needs it. See [Ensuring script modules load during navigation](#ensuring-script-modules-load-during-navigation) for details.
-
-The rest of the guide — router regions, prefetching, navigation options — applies in exactly the same way regardless of whether you are working with a block or a classic theme.
 
 ### Ensuring script modules load during navigation
 
@@ -904,7 +911,7 @@ The Interactivity API uses [script modules](https://make.wordpress.org/core/2024
 
 **Identifying script modules for client-side navigation**
 
-Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. As described in the [Getting started](#getting-started-with-the-interactivity-router) and [Classic themes](#using-client-side-navigation-in-classic-themes) sections, WordPress uses the `data-wp-router-options` attribute to mark which script modules should be loaded during navigation:
+Not all script modules should be loaded during client-side navigation. Some modules might be for admin functionality, or for features that only apply on initial page load. As described in the [Getting started](#getting-started-with-the-interactivity-router) section, WordPress uses the `data-wp-router-options` attribute to mark which script modules should be loaded during navigation:
 
 ```html
 <script

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -356,7 +356,7 @@ const { state } = store( 'myPlugin', {
 } );
 ```
 
-For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
 
 ### Overriding cached pages
 
@@ -920,7 +920,7 @@ These functions are reactive. When used inside a callback or derived state gette
 
 This is different from the regular `state` and `getContext()`, which return the client-side state and context. As explained above, existing client-side values are not overwritten during navigation, so `state` and `getContext()` will keep reflecting whatever the client had before navigating. Use `getServerState()` and `getServerContext()` when you need to react to the values that the server sent for the new page.
 
-For more details, see the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
+For more details, see the [Understanding global state, local context, and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md#subscribing-to-server-state-and-context) guide.
 
 ### Putting it all together: the navigation flow
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -268,87 +268,6 @@ store( 'myPagination', {
 } );
 ```
 
-## Block compatibility
-
-For client-side navigation to work correctly, the blocks inside a router region need to be compatible with it. A block is compatible when it can be re-rendered by the router without breaking its functionality. This primarily depends on how the block handles interactivity.
-
-Blocks declare their compatibility with client-side navigation through the `supports.interactivity` field in their `block.json` file. This information tells WordPress whether a block can safely participate in region-based navigation.
-
-### The `supports.interactivity` field
-
-The `supports.interactivity` field in `block.json` can be set as a boolean or as an object with two sub-properties:
-
--   **`interactive`** (`boolean`, default: `false`): Indicates whether the block uses Interactivity API directives.
--   **`clientNavigation`** (`boolean`, default: `false`): Indicates whether the block is compatible with client-side navigation.
-
-Setting `supports.interactivity` to `true` is a shorthand for setting both `interactive` and `clientNavigation` to `true`:
-
-```json
-{
-	"supports": {
-		"interactivity": true
-	}
-}
-```
-
-This is equivalent to:
-
-```json
-{
-	"supports": {
-		"interactivity": {
-			"clientNavigation": true,
-			"interactive": true
-		}
-	}
-}
-```
-
-The `clientNavigation` property is the key to compatibility. Set it to `true` only if:
-
--   The block is **not interactive** (it renders only static HTML), or
--   The block **is interactive and uses the Interactivity API** for all its client-side behavior.
-
-Set it to `false` (or leave it unset) if the block is interactive but uses vanilla JavaScript, jQuery, or any other JavaScript framework or library other than the Interactivity API.
-
-### Non-interactive blocks
-
-Blocks that render only static HTML — with no JavaScript-driven interactivity — are inherently compatible with client-side navigation. Since they have no client-side state to manage or event listeners to re-attach, they can be safely re-rendered by the router at any time.
-
-For these blocks, set only `clientNavigation` to `true`:
-
-```json
-{
-	"supports": {
-		"interactivity": {
-			"clientNavigation": true
-		}
-	}
-}
-```
-
-Examples of non-interactive blocks include the Paragraph, Heading, Image, and List blocks. Even though they don't use Interactivity API directives, they are fully compatible with client-side navigation because their output is purely static HTML.
-
-### Interactive blocks using other libraries
-
-Blocks that use vanilla JavaScript, jQuery, or other JavaScript frameworks for interactivity are **not compatible** with client-side navigation. When the router replaces a region's content, any event listeners attached via these libraries are lost, and the block's JavaScript will not re-initialize for the new content.
-
-For these blocks, leave `supports.interactivity` at its default value (`false`) or explicitly set `clientNavigation` to `false`:
-
-```json
-{
-	"supports": {
-		"interactivity": {
-			"clientNavigation": false
-		}
-	}
-}
-```
-
-<div class="callout callout-warning">
-WordPress does not currently disable client-side navigation automatically when an incompatible block is detected inside a router region. However, blocks can check for incompatible descendants and disable it manually. For example, the Query block's enhanced pagination detects incompatible inner blocks and sets <code>clientNavigationDisabled</code> to <code>true</code> using <code>wp_interactivity_config()</code>, which causes the router to fall back to full page reloads. See <a href="#disabling-client-side-navigation-on-certain-pages">Disabling client-side navigation on certain pages</a> for details on <code>clientNavigationDisabled</code>.
-</div>
-
 ## More advanced use cases
 
 ### Handling scroll and focus
@@ -1145,7 +1064,7 @@ Once enabled, this mode automatically intercepts all link clicks and hover event
 import '@wordpress/interactivity-router/full-page';
 ```
 
-Full-page client-side navigation is essentially a special case of region-based navigation where there is only one region covering the whole page. Because it replaces all content, **every block on the page must be compatible with client-side navigation** — meaning all interactive blocks must use the Interactivity API (not jQuery or other libraries). See [Block compatibility](#block-compatibility) for details on how to declare block compatibility.
+Full-page client-side navigation is essentially a special case of region-based navigation where there is only one region covering the whole page. Because it replaces all content, **every interactive element on the page must use the Interactivity API** (not jQuery or other libraries) for client-side navigation to work correctly.
 
 <div class="callout callout-alert">
 This feature is experimental and still under active development. It may not work correctly in all scenarios. If you try it out, please report any issues you encounter in the <a href="https://github.com/WordPress/gutenberg/issues">Gutenberg GitHub repository</a>. Contributions are also welcome!

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -620,52 +620,28 @@ Use cases for disabling feedback:
 
 ### Subscribing to page changes
 
-When using client-side navigation, traditional page load events (like `DOMContentLoaded` or `load`) don't fire because the browser isn't performing a full page reload. If you need to run code after each navigation — for example, to send analytics events or update third-party widgets — you can subscribe to the router's reactive state.
-
-The `core/router` store exposes a reactive `state.url` property that updates every time a client-side navigation occurs. By reading this value inside a callback, you create a reactive subscription that re-runs whenever the URL changes.
-
-There is one subtlety to be aware of: the `@wordpress/interactivity-router` module is loaded asynchronously, so `state.url` is initially `undefined`. When the router module is finally imported, `state.url` is set to the current page URL — but this is not an actual navigation, just the initial value being populated. To avoid sending a spurious page view in either case, compare against the previous URL and only react to actual changes:
+The `core/router` store exposes a reactive `state.url` property that updates every time a client-side navigation occurs. By reading this value inside a `data-wp-watch` or `watch` callbacks, you create a reactive subscription that re-runs whenever the URL changes.
 
 ```js
 // view.js
-import { store } from '@wordpress/interactivity';
+import { watch, store } from '@wordpress/interactivity';
 
-const routerStore = store( 'core/router' );
+// Store-wide subscription.
+watch( () => {
+    const { state } = store( 'core/router' );
+    sendAnalyticsPageView( state.url );
+} );
 
-// Track the previous URL so we only react to actual navigations.
-let previousUrl = window.location.href;
-
-store( 'myAnalytics', {
+// Element-based subscription: <div data-wp-watch="callbacks.sendPageView">
+store( 'myPlugin', {
     callbacks: {
-        onPageChange() {
-            // Reading state.url creates a reactive subscription.
-            const url = routerStore.state.url;
-
-            // Skip if the router hasn't loaded yet or if the URL
-            // hasn't actually changed (e.g., initial router load).
-            if ( url && url !== previousUrl ) {
-                previousUrl = url;
-                sendAnalyticsPageView( url );
-            }
+        sendPageView() {
+            const { state } = store( 'core/router' );
+            sendAnalyticsPageView( state.url );
         },
     },
 } );
 ```
-
-Place this callback on an element that is always present in the DOM (like a site header or a persistent wrapper) using the `data-wp-watch` directive:
-
-```html
-<div
-    data-wp-interactive="myAnalytics"
-    data-wp-watch="callbacks.onPageChange"
->
-    <!-- Site content -->
-</div>
-```
-
-<div class="callout callout-info">
-The <code>state.url</code> approach has a known limitation: when navigating with <code>force: true</code> to the same URL, the callback won't re-run because the URL value doesn't actually change. A more explicit API for subscribing to navigation events will be provided in the future.
-</div>
 
 ## The Interactivity Router in depth
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -440,6 +440,80 @@ _Page with modal (page-2.php):_
 
 When navigating from Page 1 to Page 2, the modal region is created and appended to `<body>`. When navigating back to Page 1, the modal is automatically removed.
 
+### Preserving elements with `data-wp-key`
+
+During client-side navigation, the router uses Preact's reconciliation algorithm to update the content inside router regions. This algorithm relies on heuristics to efficiently match elements between the current and target pages. These heuristics work well for most cases, but they can fail under certain conditions — for example, when two elements have the same type and position on different pages but use different directives. In such cases, the algorithm may incorrectly treat them as the same element, leading to corrupted state or broken behavior.
+
+To prevent this, you can use the `data-wp-key` directive to give elements a stable, explicit identity. When the reconciliation algorithm encounters keyed elements, it matches them by key instead of relying on heuristics. Elements with matching keys are updated in place, preserving their internal state: focus, scroll position, CSS animations, form input values, and any JavaScript references to the DOM node. Unmatched elements are cleanly removed or created as needed.
+
+Keys are especially important in two scenarios:
+
+1. **Lists that change across pages** — such as paginated posts, filtered results, or sorted tables.
+2. **Regions whose structure differs between pages** — for example, a region that contains a sidebar on one page but not on another, or pages that render different blocks in the same region.
+
+Without keys, the reconciliation heuristics may incorrectly match unrelated elements that happen to share the same type and position. In the best case this causes unnecessary DOM recreation; in the worst case it can corrupt element state or produce broken markup — for example, applying one element's directives to a completely different element.
+
+With keys based on a stable identifier, the algorithm can match elements by identity instead of relying on heuristics. This ensures that each element is correctly identified across navigations.
+
+**PHP:**
+
+```php
+<div
+    data-wp-interactive="myPagination"
+    data-wp-router-region="myPagination/posts"
+>
+    <ul>
+        <?php while ( $query->have_posts() ) : $query->the_post(); ?>
+            <li data-wp-key="post-<?php echo get_the_ID(); ?>">
+                <a href="<?php the_permalink(); ?>">
+                    <?php the_title(); ?>
+                </a>
+            </li>
+        <?php endwhile; wp_reset_postdata(); ?>
+    </ul>
+</div>
+```
+
+Each `<li>` is keyed by the post ID. If the user navigates from one page of results to another and a post appears on both pages, the router reuses the existing DOM node for that post rather than destroying and recreating it.
+
+Keys are equally useful for non-list elements. If a router region renders structurally different content on different pages, keying the top-level sections helps the algorithm tell them apart:
+
+```php
+<div
+    data-wp-interactive="myPlugin"
+    data-wp-router-region="myPlugin/content"
+>
+    <?php if ( is_product_page() ) : ?>
+        <section data-wp-key="product-detail">
+            <!-- Product detail layout -->
+        </section>
+    <?php else : ?>
+        <section data-wp-key="product-list">
+            <!-- Product list layout -->
+        </section>
+    <?php endif; ?>
+</div>
+```
+
+Without keys, navigating between these two pages would cause the algorithm to patch the product-detail `<section>` into the product-list `<section>` (or vice versa) by position, potentially corrupting their internal state. With distinct keys, the algorithm recognizes they are different elements and cleanly replaces one with the other.
+
+#### Choosing good key values
+
+A key should be:
+
+-   **Stable**: The same item should always produce the same key, regardless of its position in the list.
+-   **Unique among siblings**: No two sibling elements should share the same key. Keys only need to be unique within their parent, not globally.
+
+Use data-derived identifiers whenever possible — post IDs, term IDs, or any value that uniquely identifies the item. Avoid using array indices as keys, because indices change when items are reordered, added, or removed, which defeats the purpose of keying.
+
+```html
+<!-- Good: stable, data-derived key -->
+<li data-wp-key="post-42">...</li>
+
+<!-- Bad: index-based key (changes when items shift) -->
+<li data-wp-key="item-0">...</li>
+```
+
 ### Handling server state updates
 
 During client-side navigation, the client-side state persists while the server provides new state for the target page. In some cases, you may want parts of your client state to stay in sync with what the server provides for each page — for example, updating a product count that changes across pages, or resetting an "expanded" flag based on the new page's context.
@@ -784,6 +858,8 @@ This is the most common case. When a region with a given ID exists on both the c
 Rather than simply replacing the entire region's HTML (which would destroy any internal state and cause a jarring visual transition), the router uses a virtual DOM diffing algorithm. This algorithm compares the current region's virtual DOM with the new region's virtual DOM and calculates the minimum set of changes needed to transform one into the other.
 
 For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements — rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
+
+The reconciliation algorithm relies on heuristics that can fail when elements share the same type and position but represent different things. You can use the `data-wp-key` directive to give elements a stable identity, ensuring they are correctly matched across navigations. See [Preserving elements with `data-wp-key`](#preserving-elements-with-data-wp-key) for details.
 
 **Scenario 2: Region exists only on the target page with `attachTo` (create)**
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -29,6 +29,7 @@ This is known as **region-based client-side navigation**, and it is the recommen
     - [Handling fetch errors](#handling-fetch-errors)
     - [Disabling client-side navigation on certain pages](#disabling-client-side-navigation-on-certain-pages)
     - [Disabling navigation feedback](#disabling-navigation-feedback)
+    - [Subscribing to page changes](#subscribing-to-page-changes)
 - [The Interactivity Router in depth](#the-interactivity-router-in-depth)
     - [The page cache](#the-page-cache)
     - [Router regions](#router-regions)
@@ -645,7 +646,52 @@ Use cases for disabling feedback:
 - **Custom loading UI**: When you're implementing your own loading indicators.
 - **Custom accessibility**: When you're providing your own screen reader announcements.
 
+### Subscribing to page changes
 
+When using client-side navigation, traditional page load events (like `DOMContentLoaded` or `load`) don't fire because the browser isn't performing a full page reload. If you need to run code after each navigation — for example, to send analytics events or update third-party widgets — you can subscribe to the router's reactive state.
+
+The `core/router` store exposes a reactive `state.url` property that updates every time a client-side navigation occurs. By reading this value inside a callback, you create a reactive subscription that re-runs whenever the URL changes.
+
+There is one subtlety to be aware of: the `@wordpress/interactivity-router` module is loaded asynchronously, so `state.url` is initially `undefined`. When the router module is finally imported, `state.url` is set to the current page URL — but this is not an actual navigation, just the initial value being populated. To avoid sending a spurious page view in either case, compare against the previous URL and only react to actual changes:
+
+```js
+// view.js
+import { store } from '@wordpress/interactivity';
+
+const routerStore = store( 'core/router' );
+
+// Track the previous URL so we only react to actual navigations.
+let previousUrl = window.location.href;
+
+store( 'myAnalytics', {
+    callbacks: {
+        onPageChange() {
+            // Reading state.url creates a reactive subscription.
+            const url = routerStore.state.url;
+
+            // Skip if the router hasn't loaded yet or if the URL
+            // hasn't actually changed (e.g., initial router load).
+            if ( url && url !== previousUrl ) {
+                previousUrl = url;
+                sendAnalyticsPageView( url );
+            }
+        },
+    },
+} );
+```
+
+Place this callback on an element that is always present in the DOM (like a site header or a persistent wrapper) using the `data-wp-watch` directive:
+
+```html
+<div
+    data-wp-interactive="myAnalytics"
+    data-wp-watch="callbacks.onPageChange"
+>
+    <!-- Site content -->
+</div>
+```
+
+The router also exposes `state.navigation.hasStarted` and `state.navigation.hasFinished` properties if you need to track the navigation lifecycle more granularly — for example, to show custom loading indicators or to time how long navigations take.
 
 ## The Interactivity Router in depth
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -317,7 +317,7 @@ For these blocks, leave `supports.interactivity` at its default value (`false`) 
 ```
 
 <div class="callout callout-warning">
-If a block that is not compatible with client-side navigation is detected inside a router region, WordPress may automatically disable client-side navigation on that page to prevent broken behavior. For example, the Query block's enhanced pagination checks for incompatible blocks and falls back to full page reloads when they are found.
+WordPress does not currently disable client-side navigation automatically when an incompatible block is detected inside a router region. However, blocks can check for incompatible descendants and disable it manually. For example, the Query block's enhanced pagination detects incompatible inner blocks and sets <code>clientNavigationDisabled</code> to <code>true</code> using <code>wp_interactivity_config()</code>, which causes the router to fall back to full page reloads. See <a href="#disabling-client-side-navigation-on-certain-pages">Disabling client-side navigation on certain pages</a> for details on <code>clientNavigationDisabled</code>.
 </div>
 
 ## More advanced use cases

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -286,20 +286,6 @@ For these blocks, set only `clientNavigation` to `true`:
 
 Examples of non-interactive blocks include the Paragraph, Heading, Image, and List blocks. Even though they don't use Interactivity API directives, they are fully compatible with client-side navigation because their output is purely static HTML.
 
-### Interactive blocks using the Interactivity API
-
-Blocks that use the Interactivity API for their client-side behavior are compatible with client-side navigation. The Interactivity API's directive system integrates with the router, so interactive state, event handlers, and reactive bindings are properly preserved or re-initialized when regions are updated during navigation.
-
-For these blocks, set both properties to `true` (or use the shorthand):
-
-```json
-{
-    "supports": {
-        "interactivity": true
-    }
-}
-```
-
 ### Interactive blocks using other libraries
 
 Blocks that use vanilla JavaScript, jQuery, or other JavaScript frameworks for interactivity are **not compatible** with client-side navigation. When the router replaces a region's content, any event listeners attached via these libraries are lost, and the block's JavaScript will not re-initialize for the new content.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -4,7 +4,10 @@ Client-side navigation is a technique that allows navigation between pages witho
 
 The Interactivity API provides client-side navigation through the `@wordpress/interactivity-router` package. The central concept is the **router region**: a section of your page that the router knows how to update during navigation. You mark these sections with the `data-wp-router-region` directive, and when the user navigates to a new URL, the router fetches the destination page and replaces only the content inside matching regions — leaving everything else on the page untouched.
 
-This is known as **region-based client-side navigation**, and it is the recommended approach for implementing client-side navigation in WordPress. There is also an experimental **full-page client-side navigation** mode, which treats the entire `<body>` element as a single region — effectively updating the whole page content without a traditional reload. Full-page navigation is covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
+The Interactivity API supports two navigation modes:
+
+- **Region-based client-side navigation** — The recommended approach for implementing client-side navigation in WordPress.
+- **Full-page client-side navigation** _(experimental)_ — Treats the entire `<body>` element as a single region, effectively updating the whole page content without a traditional reload. Covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
 
 ## How client-side navigation works
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -903,11 +903,11 @@ When the router fetches a new page, it extracts both types of server data:
 
 **Merging server data during navigation**
 
-When navigation renders the new page, the server-provided data needs to merge with the existing client-side state. This merge follows specific rules:
+When navigation renders the new page, the server-provided data may need to merge with the existing client-side state, depending on the use case. The key principle here is that **client-side state is never automatically overwritten by the server**. This design ensures that any changes your JavaScript code has made to the state (such as user preferences, UI toggles, or form input) are preserved across navigations.
 
-For global state, the server state does not overwrite existing client state properties. During navigation, only properties that don't already exist on the client are added. Existing client-side properties are preserved as-is. If you need the client state to reflect server changes during navigation, you must use `getServerState()` to subscribe to server state updates and then manually update the client state accordingly.
+For **global state**, the merge works as follows: properties that already exist on the client are left untouched, and only new properties (those that don't exist on the client yet) are added from the server data. If you need the client state to reflect server changes during navigation, use `getServerState()` to subscribe to the server-provided values and update the client state yourself.
 
-For local context, the behavior is similar. The server context and client context are tracked separately by the Interactivity API. During navigation, the server context is updated with the values from the new page, but the client context is not automatically overwritten. You can use `getServerContext()` to read the server-provided values or `getContext()` to read the client-side values, and decide which one to use in your code.
+For **local context**, the behavior follows the same principle. The Interactivity API tracks server context and client context separately. During navigation, the server context is updated with the values from the new page, but the client context remains unchanged. Use `getServerContext()` to read the server-provided values and `getContext()` to read the client-side values, choosing whichever is appropriate for your use case.
 
 **Subscribing to server data changes**
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -41,7 +41,9 @@ If you already have an interactive block and want to add client-side navigation,
 2. **Define router regions**: Mark the HTML elements that should be updated during navigation using the `data-wp-router-region` attribute.
 3. **Trigger navigation**: Use the router's `actions.navigate()` function to navigate programmatically when the user interacts with your block.
 
-Client-side navigation is not limited to blocks — you can also use it in classic PHP themes by adding the Interactivity API directives directly in your theme's template files and processing them with `wp_interactivity_process_directives()`, as explained in the [Server-side rendering](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md#processing-directives-in-classic-themes). Instead of relying on a block's `block.json` to declare script module dependencies, you register and enqueue your script module manually, taking into account that the `@wordpress/interactivity-router` module should be dynamically imported:
+## Using client-side navigation in Classic themes
+
+Client-side navigation is not limited to blocks — you can also use it in classic PHP themes by adding the Interactivity API directives directly in your theme's template files and processing them with `wp_interactivity_process_directives()`, as explained in the [Server-side rendering](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md#processing-directives-in-classic-themes) guide. Instead of relying on a block's `block.json` to declare script module dependencies, you register and enqueue your script module manually, taking into account that the `@wordpress/interactivity-router` module should be dynamically imported:
 
 ```php
 // functions.php
@@ -89,46 +91,52 @@ Here's a basic router region:
 
 Router regions can be placed anywhere on the page. Their behavior depends on where they sit relative to other interactive elements and other router regions:
 
-**As a standalone element** — When a router region is not inside any existing `data-wp-interactive` element, it serves a dual role: it is the interactive boundary (since it carries `data-wp-interactive`) _and_ its content is updated during navigation:
+-   **As a standalone element** — When a router region is not inside any existing `data-wp-interactive` element, it serves a dual role: it is the interactive boundary (since it also contains `data-wp-interactive`) _and_ its content is updated during navigation:
 
-```html
-<div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/content">
-	<!-- Interactive boundary + navigable region -->
-	<p data-wp-text="state.message">Hello</p>
-</div>
-```
+    ```html
+    <div
+    	data-wp-interactive="myPlugin"
+    	data-wp-router-region="myPlugin/content"
+    >
+    	<!-- Interactive boundary + navigable region -->
+    	<p data-wp-text="state.message">Hello</p>
+    </div>
+    ```
 
-**Inside an interactive element** — When a router region is nested inside an element that already has `data-wp-interactive`, the region becomes part of that element's virtual DOM. The parent interactive element stays untouched during navigation, but the region's content is updated:
+-   **Inside an interactive element** — When a router region is nested inside an element that already has `data-wp-interactive`, the region becomes part of that element's interactivity. The parent interactive element stays untouched during navigation, but the region's content is updated:
 
-```html
-<div data-wp-interactive="myPlugin">
-	<h1>This heading is never updated during navigation</h1>
+    ```html
+    <div data-wp-interactive="myPlugin">
+    	<h1>This heading is never updated during navigation</h1>
 
-	<div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/posts">
-		<!-- This content is updated during navigation -->
-	</div>
-</div>
-```
+    	<div
+    		data-wp-interactive="myPlugin"
+    		data-wp-router-region="myPlugin/posts"
+    	>
+    		<!-- This content is updated during navigation -->
+    	</div>
+    </div>
+    ```
 
-Note that the router region still needs its own `data-wp-interactive` directive, even though it is already inside one.
+    Note that the router region still needs its own `data-wp-interactive` directive, even though it is already inside one.
 
-**Inside another router region** — When a router region is nested inside another router region, it becomes part of the parent region. The parent region is updated as a single unit during navigation; the nested region is not processed independently:
+-   **Inside another router region** — When a router region is nested inside another router region, it becomes part of the parent region. The parent region is updated as a single unit during navigation; the nested region is not processed independently:
 
-```html
-<div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/main">
-	<!-- This inner region is part of "myPlugin/main" -->
-	<div
-		data-wp-interactive="myPlugin"
-		data-wp-router-region="myPlugin/sidebar"
-	>
-		<!-- Updated together with the parent region -->
-	</div>
-</div>
-```
+    ```html
+    <div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/main">
+    	<!-- This inner region is part of "myPlugin/main" -->
+    	<div
+    		data-wp-interactive="myPlugin"
+    		data-wp-router-region="myPlugin/sidebar"
+    	>
+    		<!-- Updated together with the parent region -->
+    	</div>
+    </div>
+    ```
 
 ### Implementing navigation
 
-To trigger client-side navigation, you define an **action** in your store and connect it to a DOM event using an Interactivity API directive. Actions are functions defined inside `store()` that handle user interactions — similar to event handlers in other frameworks. When connected to an element through a directive like `data-wp-on--click`, the action runs whenever that event fires.
+To trigger client-side navigation, you define an **action** in your store and connect it to a DOM event using an Interactivity API directive. Actions are functions defined inside `store()` that handle user interactions. When connected to an element through a directive like `data-wp-on--click`, the action runs whenever that event fires.
 
 Here's how to implement a link that navigates client-side. First, the HTML connects the link's click event to the `navigateTo` action:
 
@@ -162,7 +170,7 @@ The <code>withSyncEvent()</code> wrapper is required for actions that need to ca
 
 ### Implementing prefetching
 
-The router also provides a `prefetch()` function that fetches a page and stores it in an internal cache without performing navigation. By prefetching pages before the user clicks, subsequent navigations feel instant because the content is already available.
+The router also provides a `prefetch()` function that fetches a page and stores it in an internal in-memory cache without performing navigation. By prefetching pages before the user clicks, subsequent navigations feel instant because the content is already available.
 
 A common pattern is to prefetch a page when the user hovers over a link, and navigate when they click. You can combine both behaviors on the same element using two directives — `data-wp-on--mouseenter` for prefetching and `data-wp-on--click` for navigation:
 
@@ -444,7 +452,7 @@ store( 'myPlugin', {
 	actions: {
 		deleteAndRefresh: function* () {
 			// Wait for the deletion to complete.
-			yield fetch( '/api/items/123', { method: 'DELETE' } );
+			yield fetch( '/wp-json/wp/v2/posts/123', { method: 'DELETE' } );
 
 			// Now refresh the page to show updated data.
 			const { actions } = yield import(
@@ -477,11 +485,7 @@ yield actions.prefetch( '/custom-page/', {
 } );
 ```
 
-This is useful for:
-
--   Optimistic UI updates where you construct the expected HTML before the server responds.
--   Offline scenarios where you provide cached or fallback content.
--   Testing and development.
+This is useful when you need to control the `fetch` request yourself.
 
 ### Managing browser history
 
@@ -497,7 +501,6 @@ yield actions.navigate( '/page-2/', { replace: true } );
 
 Use `replace: true` when:
 
--   Implementing redirects where the original URL shouldn't be in history.
 -   Updating query parameters for filtering/sorting where each change shouldn't be a separate history entry.
 -   Implementing infinite scroll where you update the URL but don't want each page to be a separate history entry.
 
@@ -578,7 +581,7 @@ When `clientNavigationDisabled` is `true`:
 
 The Interactivity API router includes built-in feedback during navigation:
 
--   **Loading animation**: A progress bar that appears at the top of the page during navigation. The bar appears after a short delay (400ms) if navigation hasn't completed yet.
+-   **Loading animation**: A progress bar that appears at the top of the page during navigation. The bar appears after a short delay (400ms) if navigation hasn't completed yet. This 400ms delay is introduced to avoid showing the animation if the page has been sucessfully prefetched or in very fast connections.
 -   **Screen reader announcements**: Accessibility announcements for navigation progress.
 
 In some cases, you may want to disable these:
@@ -628,13 +631,17 @@ store( 'myPlugin', {
 } );
 ```
 
+<div class="callout callout-info">
+The `core/router` store and `state.url` are available and populated on page load, so there's no need to import the `@wordpress/interactivity-router` package to access them.
+</div>
+
 ## The Interactivity Router in depth
 
 This section provides a detailed technical explanation of how client-side navigation works internally. Understanding these internals can help you debug issues, optimize performance, and make informed decisions about how to structure your code.
 
-### The internal page cache
+### The internal in-memory page cache
 
-At the heart of the Interactivity API router is an internal in-memory page cache — a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
+At the heart of the Interactivity API router is an internal in-memory page cache — a simple store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
 
 The cache uses a normalized version of the URL as its key. This normalization strips away the domain and any hash fragments, keeping only the pathname and query parameters. For example, `https://example.com/products/?category=shoes#details` becomes `/products/?category=shoes`. This ensures that navigations to the same logical page (regardless of how the URL was constructed) share the same cache entry.
 
@@ -802,7 +809,7 @@ One of the trickier aspects of client-side navigation is managing CSS style shee
 
 CSS rules are applied in a specific order, and when two rules have the same specificity, the one that appears later in the document "wins." This means that the order of `<link>` and `<style>` elements in your HTML matters. If the router simply appended new style sheets to the end of the document, it could inadvertently change which rules take precedence, causing visual bugs.
 
-Consider this example: Page A has style sheets [base.css, theme.css], and Page B has [base.css, components.css, theme.css]. If the user navigates from A to B, the router needs to insert components.css between base.css and theme.css — not at the end. Otherwise, any rules in theme.css that are meant to override components.css would stop working.
+Consider this example: Page A has style sheets `base.css` and `theme.css`, and Page B has `base.css`, `components.css` and `theme.css`. If the user navigates from A to B, the router needs to insert `components.css` between `base.css` and `theme.css` — not at the end. Otherwise, any rules in `theme.css` that are meant to override `components.css` would stop working.
 
 **How styles are extracted and prepared**
 
@@ -854,7 +861,7 @@ By keeping deactivated style elements in the DOM (rather than removing them), th
 
 ### Script module handling
 
-The Interactivity API uses [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) for interactive behavior. The router must ensure that when navigating to a new page, any script modules required by that page are loaded and executed.
+The Interactivity API uses [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) for interactive behavior. The router must ensure that when navigating to a new page, the required script modules are loaded and executed.
 
 **Identifying script modules for client-side navigation**
 
@@ -924,7 +931,7 @@ Each script module's top-level code runs, which typically includes calls to `sto
 
 ### Server state and context
 
-Interactive elements often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: [global state and local context](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md).
+Interactive elements often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides three mechanisms for this: [global state, local context and config](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md).
 
 During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
 
@@ -942,6 +949,10 @@ When WordPress renders a page with interactive elements, it embeds server-provid
 		"state": {
 			"myPlugin": {
 				"cartItemCount": 3,
+			}
+		}
+		"config": {
+			"myPlugin": {
 				"userLoggedIn": true
 			}
 		}
@@ -960,13 +971,15 @@ Local context is embedded directly in the `data-wp-context` attribute of element
 </div>
 ```
 
-**Extracting state and context during fetch**
+**Extracting state, context and config during fetch**
 
-When the router fetches a new page, it extracts both types of server data:
+When the router fetches a new page, it extracts these types of server data:
 
-1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content. This state is stored in the internal in-memory page cache entry.
+1. **Global state**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content to extrat its `state` property. This state comes from `wp_interactivity_state` is stored in the internal in-memory page cache entry.
 
 2. **Local context**: Context values are embedded in the virtual DOM representation of each router region. When a region's HTML is converted to vDOM, the `data-wp-context` attributes are preserved and will be processed during rendering.
+
+3. **Config**: The router finds the `<script type="application/json">` element with ID `wp-script-module-data-@wordpress/interactivity` and parses its JSON content to extrat its `config` property. This configuration comes from `wp_interactivity_config` and is stored in the internal in-memory page cache entry.
 
 **Merging server data during navigation**
 
@@ -1051,17 +1064,17 @@ When `navigate()` is called (for example, on link click):
 2. If not already prefetched, the fetch process from Phase 1 runs now.
 3. The router waits for the page to be ready (fetch complete, styles loaded).
 4. A loading indicator may appear if the wait exceeds a threshold (400ms).
-5. Script modules for the new page are imported and executed.
-6. The rendering phase begins (wrapped in a batch for efficiency):
+5. The rendering phase begins (wrapped in a batch for efficiency):
+    - Script modules for the new page are executed.
     - Server state is merged with client state.
     - Each router region is updated with its new virtual DOM.
     - Regions with `attachTo` that don't exist are created and appended.
     - Styles are activated/deactivated as needed.
     - The document title is updated.
-7. Browser history is updated (pushState or replaceState).
-8. Screen reader announcement is made for accessibility.
-9. If the URL has a hash, the page scrolls to that element.
-10. Navigation is complete.
+6. Browser history is updated (pushState or replaceState).
+7. Screen reader announcement is made for accessibility.
+8. If the URL has a hash, the page scrolls to that element.
+9. Navigation is complete.
 
 #### Race condition protection
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -949,7 +949,7 @@ When the router fetches a new page, it extracts the import map from that page an
 
 **Preloading script modules and their dependencies**
 
-Preloading script modules is more complex than preloading styles because script modules can import other script modules. A single entry-point module might depend on dozens of other script modules, which might depend on dozens more.
+Preloading script modules requires resolving their full dependency tree, since a single entry-point module might depend on dozens of other script modules, which might depend on dozens more.
 
 To handle this, the router performs a recursive dependency resolution:
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -366,10 +366,10 @@ For more details, see the [Understanding global state, local context, and derive
 By default, once a page is cached, subsequent navigations use the cached version. Use the `force` option to re-fetch a page even if it's cached:
 
 ```js
-// Force re-fetch with navigate()
+// Force re-fetch with navigate().
 yield actions.navigate( '/products/', { force: true } );
 
-// Force re-fetch with prefetch()
+// Force re-fetch with prefetch().
 yield actions.prefetch( '/products/', { force: true } );
 ```
 
@@ -398,7 +398,7 @@ store( 'myPlugin', {
 Instead of fetching a page from a URL, you can provide HTML directly using the `html` option:
 
 ```js
-// Navigate with custom HTML
+// Navigate with custom HTML.
 yield actions.navigate( '/custom-page/', {
     html: `
         <div data-wp-interactive="myPlugin" data-wp-router-region="myPlugin/content">
@@ -408,7 +408,7 @@ yield actions.navigate( '/custom-page/', {
     `,
 } );
 
-// Prefetch with custom HTML
+// Prefetch with custom HTML.
 yield actions.prefetch( '/custom-page/', {
     html: customHtmlString,
 } );
@@ -424,10 +424,10 @@ This is useful for:
 By default, `navigate()` adds a new entry to the browser's session history using `pushState`. Use the `replace` option to replace the current history entry instead:
 
 ```js
-// Default behavior: adds new history entry (pushState)
+// Default behavior: adds new history entry (pushState).
 yield actions.navigate( '/page-2/' );
 
-// Replace current history entry (replaceState)
+// Replace current history entry (replaceState).
 yield actions.navigate( '/page-2/', { replace: true } );
 ```
 
@@ -441,10 +441,10 @@ Use `replace: true` when:
 Navigation will abort if it takes too long. The default timeout is 10 seconds. Use the `timeout` option to change this:
 
 ```js
-// Shorter timeout for faster failure
+// Shorter timeout for faster failure.
 yield actions.navigate( '/page/', { timeout: 5000 } );
 
-// Longer timeout for slow connections
+// Longer timeout for slow connections.
 yield actions.navigate( '/page/', { timeout: 30000 } );
 ```
 
@@ -491,7 +491,7 @@ store( 'myPlugin', {
 Some pages may require a full page reload instead of client-side navigation. Use `wp_interactivity_config()` to disable client navigation:
 
 ```php
-// In your theme's functions.php or a plugin
+// In your theme's functions.php or a plugin.
 add_action( 'wp', function() {
     // Disable on specific page templates.
     if ( is_page_template( 'template-complex.php' ) ) {
@@ -525,13 +525,13 @@ The Interactivity API router includes built-in feedback during navigation:
 In some cases, you may want to disable these:
 
 ```js
-// Disable loading animation (for instant-feeling updates)
+// Disable loading animation (for instant-feeling updates).
 yield actions.navigate( '/page/', { loadingAnimation: false } );
 
-// Disable screen reader announcements (when providing custom announcements)
+// Disable screen reader announcements (when providing custom announcements).
 yield actions.navigate( '/page/', { screenReaderAnnouncement: false } );
 
-// Disable both
+// Disable both.
 yield actions.navigate( '/page/', {
     loadingAnimation: false,
     screenReaderAnnouncement: false,
@@ -551,7 +551,7 @@ This section provides a detailed technical explanation of how client-side naviga
 
 ### The page cache
 
-At the heart of the Interactivity API router is a page cache—a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
+At the heart of the Interactivity API router is a page cache — a simple in-memory store that maps URLs to their processed page representations. When you call `prefetch()` or `navigate()`, the router first checks this cache to see if the target page has already been fetched and processed.
 
 The cache uses a normalized version of the URL as its key. This normalization strips away the domain and any hash fragments, keeping only the pathname and query parameters. For example, `https://example.com/products/?category=shoes#details` becomes `/products/?category=shoes`. This ensures that navigations to the same logical page (regardless of how the URL was constructed) share the same cache entry.
 
@@ -567,7 +567,7 @@ Each entry in the cache stores not just the fetched HTML, but a fully processed 
 
 An important detail is that the cache stores promises rather than resolved values. When a fetch begins, the router immediately stores the pending promise in the cache. This means that if multiple calls to `prefetch()` or `navigate()` target the same URL simultaneously (for example, if a user rapidly hovers over multiple links pointing to the same page), only one network request is made. All callers receive the same promise and wait for the same result.
 
-Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit—the page is already prepared and ready to render.
+Once a page is in the cache, it remains there for the duration of the browser session. Subsequent navigations to that URL will use the cached version instantly, without any network request. This is why client-side navigation feels so fast after the initial visit — the page is already prepared and ready to render.
 
 If you need to force a fresh fetch (for example, after submitting a form that changes the page's content), you can use the `force: true` option with `navigate()` or `prefetch()`. This bypasses the cache check and fetches the page anew, replacing the existing cache entry with the fresh content.
 
@@ -642,7 +642,7 @@ First, the router parses the fetched HTML into a document structure using the br
 
 Next, the router scans this document for all elements that have both `data-wp-interactive` and `data-wp-router-region` attributes. For each region found, it extracts the region ID and checks whether the region is nested inside another region. Only top-level regions are processed directly; nested regions are handled as part of their parent's content.
 
-For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion—not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
+For each top-level region, the router converts the HTML into a virtual DOM (vDOM) representation. The virtual DOM is a lightweight JavaScript object structure that mirrors the actual DOM but can be compared and manipulated much more efficiently. Importantly, the region element itself is included in this conversion — not just its children. This means that attributes on the region element, such as `data-wp-context`, will also be processed and updated during navigation.
 
 <!-- IMAGE: Flowchart showing the region processing pipeline. Starting with "Fetched HTML" (showing raw HTML code), an arrow leads to "Parse HTML" (DOM tree icon), then to "Find Regions" (highlighting regions in the tree), then to "Convert to vDOM" (showing a simplified tree structure), and finally to "Store in Cache" (the cache icon from earlier). -->
 
@@ -660,13 +660,13 @@ This is the most common case. When a region with a given ID exists on both the c
 
 Rather than simply replacing the entire region's HTML (which would destroy any internal state and cause a jarring visual transition), the router uses a virtual DOM diffing algorithm. This algorithm compares the current region's virtual DOM with the new region's virtual DOM and calculates the minimum set of changes needed to transform one into the other.
 
-For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements—rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
+For example, if a product list region contains 10 products on the current page and 10 different products on the new page, the diffing algorithm might determine that it only needs to update the text content and image sources within the existing list item elements — rather than destroying and recreating all 10 items from scratch. This preserves DOM state (like scroll position within the region, or focus state) and produces smoother visual transitions.
 
 <!-- IMAGE: Before/after comparison showing region update. Left side shows "Current Page" with a region containing items A, B, C (each in a box). Right side shows "Target Page" with items A, D, C. In the middle, arrows show that A and C stay in place while B transforms into D. Caption: "The diffing algorithm minimizes DOM changes." -->
 
 **Scenario 2: Region exists only on the target page with `attachTo` (create)**
 
-Sometimes a page contains a region that doesn't exist on the current page—for example, a modal dialog that only appears on certain pages. If this region has the `attachTo` property specified, the router will dynamically create it.
+Sometimes a page contains a region that doesn't exist on the current page — for example, a modal dialog that only appears on certain pages. If this region has the `attachTo` property specified, the router will dynamically create it.
 
 The `attachTo` property contains a CSS selector that identifies where in the current page the new region should be appended. When the router encounters such a region, it:
 
@@ -687,7 +687,7 @@ If the region was dynamically created via `attachTo` during a previous navigatio
 
 **What happens to HTML outside router regions?**
 
-An important detail to understand is that HTML outside of router regions remains completely untouched during client-side navigation. The router only modifies the content inside the regions it manages—everything else in the DOM stays exactly as it was.
+An important detail to understand is that HTML outside of router regions remains completely untouched during client-side navigation. The router only modifies the content inside the regions it manages — everything else in the DOM stays exactly as it was.
 
 This means that if you have static elements like a site header, footer, or navigation menu that aren't wrapped in a router region, they won't change when the user navigates between pages. This can be intentional (for elements that truly are the same across all pages) or it can be a source of confusion if you expect those elements to update.
 
@@ -712,7 +712,7 @@ For example, consider a shopping cart icon in the header that displays the numbe
 </main>
 ```
 
-If `state.cartCount` comes from the regular client-side state, the cart icon will not update during navigation—even if the new page has a different cart count in its server state. The header, while being interactive, is outside any router region, so it's not re-rendered.
+If `state.cartCount` comes from the regular client-side state, the cart icon will not update during navigation — even if the new page has a different cart count in its server state. The header, while being interactive, is outside any router region, so it's not re-rendered.
 
 But if you use `getServerState()` instead:
 
@@ -720,7 +720,7 @@ But if you use `getServerState()` instead:
 const { state } = store( 'myShop', {
     state: {
         get cartCount() {
-            // This reacts to server state changes during navigation
+            // This reacts to server state changes during navigation.
             return getServerState().cartCount;
         },
     },
@@ -733,13 +733,13 @@ This pattern is useful for global UI elements that need to stay synchronized wit
 
 ### CSS handling
 
-One of the trickier aspects of client-side navigation is managing CSS style sheets. Different pages may require different styles, and the router must ensure that the correct styles are active for each page—without causing flashes of unstyled content or breaking the CSS cascade order.
+One of the trickier aspects of client-side navigation is managing CSS style sheets. Different pages may require different styles, and the router must ensure that the correct styles are active for each page — without causing flashes of unstyled content or breaking the CSS cascade order.
 
 **The challenge of CSS cascade order**
 
 CSS rules are applied in a specific order, and when two rules have the same specificity, the one that appears later in the document "wins." This means that the order of `<link>` and `<style>` elements in your HTML matters. If the router simply appended new style sheets to the end of the document, it could inadvertently change which rules take precedence, causing visual bugs.
 
-Consider this example: Page A has style sheets [base.css, theme.css], and Page B has [base.css, components.css, theme.css]. If the user navigates from A to B, the router needs to insert components.css between base.css and theme.css—not at the end. Otherwise, any rules in theme.css that are meant to override components.css would stop working.
+Consider this example: Page A has style sheets [base.css, theme.css], and Page B has [base.css, components.css, theme.css]. If the user navigates from A to B, the router needs to insert components.css between base.css and theme.css — not at the end. Otherwise, any rules in theme.css that are meant to override components.css would stop working.
 
 **How styles are extracted and prepared**
 
@@ -755,7 +755,7 @@ The router then compares the extracted styles with those already present in the 
 
 For new style sheets, the router faces a dilemma: it needs to ensure the styles are fully loaded before showing the new page content (to prevent flash of unstyled content), but it doesn't want to apply them yet (because the user is still viewing the current page).
 
-The solution is to add new `<link>` elements with their `media` attribute set to a value that prevents them from applying. The router uses `media="preload"`, which tells the browser "this style sheet applies to no media types"—effectively disabling it while still allowing the browser to download and parse it.
+The solution is to add new `<link>` elements with their `media` attribute set to a value that prevents them from applying. The router uses `media="preload"`, which tells the browser "this style sheet applies to no media types" — effectively disabling it while still allowing the browser to download and parse it.
 
 When a `<link>` element is added this way, the browser begins downloading the CSS file immediately. The router tracks when each style sheet finishes loading by listening for the `load` event. This allows it to wait until all new styles are ready before proceeding with navigation.
 
@@ -838,7 +838,7 @@ To handle this, the router performs a recursive dependency resolution:
 4. It recursively fetches and parses each dependency
 5. This continues until all modules in the dependency tree have been fetched
 
-The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again—the browser already has it cached.
+The router is smart about avoiding redundant work. If a module has already been loaded by the initial page (it appears in the initial import map), the router doesn't fetch it again — the browser already has it cached.
 
 <!-- IMAGE: Tree diagram showing module dependency resolution. At the top, "view.js" (the entry point). Arrows lead down to its dependencies: "@wordpress/interactivity" and "./components/modal.js". The interactivity module is shown grayed out with a note "Already loaded - skip". The modal.js module has its own dependencies branching below it. Each node shows whether it needs to be fetched or can be skipped. -->
 
@@ -855,7 +855,7 @@ Because the browser's module system caches modules by URL, importing the same bl
 When `navigate()` renders the new page, it imports all the modules that were preloaded for that page:
 
 ```js
-// Simplified conceptual view of what happens
+// Simplified conceptual view of what happens.
 for (const moduleInfo of page.scriptModules) {
     await import(moduleInfo.blobUrl);
 }
@@ -865,7 +865,7 @@ Each module's top-level code runs, which typically includes calls to `store()` t
 
 ### Server state and context
 
-WordPress blocks often need data from the server—configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: global state and local context. During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
+WordPress blocks often need data from the server — configuration values, content from the database, user preferences, and more. The Interactivity API provides two mechanisms for this: global state and local context. During client-side navigation, this server-provided data needs to be extracted from the new page and made available to the client-side code.
 
 **How server data is embedded in pages**
 
@@ -969,6 +969,6 @@ When the user clicks the link and your code calls `navigate()`:
 
 A subtle but important detail: users don't always wait for navigation to complete before clicking another link. The router handles this gracefully.
 
-When `navigate()` is called, the router remembers the target URL. If another `navigate()` call comes in before the first completes, the router updates its target and the first navigation is abandoned. When the first navigation's fetch completes, it checks whether its URL is still the current target—if not, it simply returns without rendering.
+When `navigate()` is called, the router remembers the target URL. If another `navigate()` call comes in before the first completes, the router updates its target and the first navigation is abandoned. When the first navigation's fetch completes, it checks whether its URL is still the current target — if not, it simply returns without rendering.
 
 This ensures that rapid clicking through multiple links doesn't cause visual glitches or render stale content. Only the most recent navigation completes.

--- a/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md
@@ -745,6 +745,8 @@ By using derived state, you create a more maintainable and less error-prone code
 
 Interactivity API offers a region-based navigation feature that dynamically replaces a part of the page without a full page reload. The [Query block](/docs/reference-guides/core-blocks.md#query-loop) natively supports this feature when the `Force page reload` toggle is disabled. Developers can use the same functionality in custom blocks by calling [`actions.navigate()`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity-router/#actions) from the [`@wordpress/interactivity-router`](https://github.com/WordPress/gutenberg/tree/trunk/packages/interactivity-router) script module.
 
+_Please, visit the [Client-Side Navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md) guide to learn more about how to use the Interactivity Router and implement client-side navigation in your blocks._
+
 When using region-based navigation, it's crucial to ensure that your interactive blocks stay in sync with the server-provided global state and local context. By default, the Interactivity API will never overwrite the global state or local context with the server-provided values. The Interactivity API provides two functions to help manage this synchronization: [`getServerState()`](/docs/reference-guides/interactivity-api/directives-and-store.md#getserverstate) and [`getServerContext()`](/docs/reference-guides/interactivity-api/directives-and-store.md#getservercontext).
 
 ### `getServerState()`

--- a/docs/reference-guides/interactivity-api/iapi-about.md
+++ b/docs/reference-guides/interactivity-api/iapi-about.md
@@ -168,10 +168,12 @@ The API works out of the box with standard block-building tools like [`wp-script
 The Interactivity API comes with built-in primitives for adding client-side navigation to your site. This functionality is completely optional, but it opens the possibility to create these user experiences without having to opt out of the WordPress rendering system.
 
 <div class="callout callout-info">
-  Full-page client-side navigation with the Interactivity API is still a work in progress (see <a href="https://github.com/WordPress/gutenberg/issues/60951">#60951</a>). Still, it is expected that all the interactive blocks will have to use the Interactivity API to enable full-page client-side navigation with the Interactivity API. Only in this case, the Interactivity API won't be fully compatible with other libraries (such as jQuery). 
+  Full-page client-side navigation with the Interactivity API is still a work in progress (see <a href="https://github.com/WordPress/gutenberg/issues/60951">#60951</a>). Still, it is expected that all the interactive blocks will have to use the Interactivity API to enable full-page client-side navigation with the Interactivity API. Only in this case, the Interactivity API won't be fully compatible with other libraries (such as jQuery).
 </div>
 
 It also pairs very well with the [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions/) allowing developers to animate page transitions easily.
+
+_Please, visit the [Client-Side Navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md) guide to learn more about how to use the Interactivity Router and implement client-side navigation in your blocks._
 
 ## Why a standard?
 

--- a/docs/reference-guides/interactivity-api/iapi-about.md
+++ b/docs/reference-guides/interactivity-api/iapi-about.md
@@ -167,12 +167,6 @@ The API works out of the box with standard block-building tools like [`wp-script
 
 The Interactivity API comes with built-in primitives for adding client-side navigation to your site. This functionality is completely optional, but it opens the possibility to create these user experiences without having to opt out of the WordPress rendering system.
 
-<div class="callout callout-info">
-  Full-page client-side navigation with the Interactivity API is still a work in progress (see <a href="https://github.com/WordPress/gutenberg/issues/60951">#60951</a>). Still, it is expected that all the interactive blocks will have to use the Interactivity API to enable full-page client-side navigation with the Interactivity API. Only in this case, the Interactivity API won't be fully compatible with other libraries (such as jQuery).
-</div>
-
-It also pairs very well with the [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions/) allowing developers to animate page transitions easily.
-
 _Please, visit the [Client-Side Navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md) guide to learn more about how to use the Interactivity Router and implement client-side navigation in your blocks._
 
 ## Why a standard?

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -7,6 +7,10 @@ The package defines an Interactivity API store with the `core/router` namespace,
 The `@wordpress/interactivity-router` package was [introduced in WordPress Core in v6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/). This means this package is already bundled in Core in any version of WordPress higher than v6.5.
 
 <div class="callout callout-info">
+    For a comprehensive guide on how client-side navigation works, including getting started, block compatibility, and advanced use cases, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation/">Client-Side Navigation guide</a>.
+</div>
+
+<div class="callout callout-info">
     Check the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/">Interactivity API Reference docs in the Block Editor handbook</a> to learn more about the Interactivity API.
 </div>
 


### PR DESCRIPTION
## What?

Adds a "Core Concepts" guide for the Interactivity Router.

## Why?

The Interactivity Router, while being documented in the README, lacked an in-depth explanation about how it works.

## How?

The document follows this structure:
- Client-Side Navigation
  - How client-side navigation works
  - Getting started with the Interactivity Router
      - Setting up router regions
    - Implementing navigation
    - Implementing prefetching
    - Complete example: Pagination
  - Block compatibility
      - The `supports.interactivity` field
    - Non-interactive blocks
    - Interactive blocks using the Interactivity API
    - Interactive blocks using other libraries
  - More advanced use cases
      - Adding new regions on navigation
    - Handling server state updates
    - Overriding cached pages
    - Using custom HTML
    - Managing browser history
    - Changing the timeout
    - Handling fetch errors
    - Disabling client-side navigation on certain pages
    - Disabling navigation feedback
    - Subscribing to page changes
  - The Interactivity Router in depth
      - The page cache
    - Router regions
    - CSS handling
    - Script module handling
    - Server state and context
    - Putting it all together: the navigation flow
      - Phase 1: Prefetch (optional but recommended)
      - Phase 2: Navigate
      - Race condition protection
  - Full-page client-side navigation (experimental)