### PR TITLE
DataViews: list and activity stories in contained width

### DIFF
--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -119,6 +119,7 @@ export const LayoutGrid = {
 export const LayoutList = {
 	render: LayoutListComponent,
 	args: {
+		fullWidth: false,
 		groupBy: false,
 		groupByLabel: true,
 		hasClickableItems: true,
@@ -129,6 +130,11 @@ export const LayoutList = {
 		backgroundColor: {
 			control: 'color',
 			description: 'Background color of the DataViews component',
+		},
+		fullWidth: {
+			control: 'boolean',
+			description:
+				'Whether to use full width or a contained layout (400px)',
 		},
 		groupBy: {
 			control: 'boolean',
@@ -157,6 +163,7 @@ export const LayoutList = {
 export const LayoutActivity = {
 	render: LayoutActivityComponent,
 	args: {
+		fullWidth: false,
 		groupBy: false,
 		groupByLabel: true,
 		hasClickableItems: true,
@@ -167,6 +174,11 @@ export const LayoutActivity = {
 		backgroundColor: {
 			control: 'color',
 			description: 'Background color of the DataViews component',
+		},
+		fullWidth: {
+			control: 'boolean',
+			description:
+				'Whether to use full width or a contained layout (400px)',
 		},
 		groupBy: {
 			control: 'boolean',

--- a/packages/dataviews/src/dataviews/stories/layout-activity.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-activity.tsx
@@ -580,6 +580,7 @@ export const orderEventActions: Action< OrderEvent >[] = [
 
 const LayoutActivityComponent = ( {
 	backgroundColor,
+	fullWidth = false,
 	hasClickableItems = true,
 	groupBy = true,
 	groupByLabel = true,
@@ -587,6 +588,7 @@ const LayoutActivityComponent = ( {
 	showMedia = true,
 }: {
 	backgroundColor?: string;
+	fullWidth?: boolean;
 	hasClickableItems?: boolean;
 	groupBy?: boolean;
 	groupByLabel?: boolean;
@@ -640,6 +642,7 @@ const LayoutActivityComponent = ( {
 		<div
 			style={
 				{
+					maxWidth: fullWidth ? undefined : '400px',
 					'--wp-dataviews-color-background': backgroundColor,
 				} as React.CSSProperties
 			}

--- a/packages/dataviews/src/dataviews/stories/layout-list.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-list.tsx
@@ -14,6 +14,7 @@ import { actions, data, fields, type SpaceObject } from './fixtures';
 
 export const LayoutTableComponent = ( {
 	backgroundColor,
+	fullWidth = false,
 	hasClickableItems = true,
 	groupBy = false,
 	groupByLabel = true,
@@ -21,6 +22,7 @@ export const LayoutTableComponent = ( {
 	showMedia = true,
 }: {
 	backgroundColor?: string;
+	fullWidth?: boolean;
 	hasClickableItems?: boolean;
 	groupBy?: boolean;
 	groupByLabel?: boolean;
@@ -63,6 +65,7 @@ export const LayoutTableComponent = ( {
 		<div
 			style={
 				{
+					maxWidth: fullWidth ? undefined : '400px',
 					'--wp-dataviews-color-background': backgroundColor,
 				} as React.CSSProperties
 			}


### PR DESCRIPTION
Display list and activity layout stories in contained width and allow…… full width via control

## What?

This PR updates the list and activity layout stories so that they are displayed in a contained width. There's a "full width" story control that enables full width as well.


https://github.com/user-attachments/assets/48bd80b4-755e-4bfc-8c8e-d10e32c4023c


## Why?

Because that's the main purpose of the layout. 

## How?

Restrict max width unless the full width control is enabled.

## Testing Instructions

Visit storybook and verify that it works as advertised.