### PR TITLE
Link Control: Validate on submit

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -629,6 +629,7 @@ function LinkControl( {
 							hideLabelFromVision={ ! showTextControl }
 							isEntity={ isEntity }
 							customValidity={ customValidity }
+							required={ showTextControl }
 							suffix={
 								<SearchSuffixControl
 									isEntity={ isEntity }

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -46,6 +46,7 @@ const LinkControlSearchInput = forwardRef(
 			suffix,
 			isEntity = false,
 			customValidity: customValidityProp,
+			required = false,
 		},
 		ref
 	) => {
@@ -148,9 +149,11 @@ const LinkControlSearchInput = forwardRef(
 						showInitialSuggestions
 					}
 					customValidity={ customValidityProp }
-					// Don't mark the field as required to avoid browser validation errors
-					// on blur. Validation is handled manually via onSubmit and handleSubmit.
-					required={ false }
+					// When required=false, validation is handled manually via onSubmit and handleSubmit.
+					// When required=true (e.g., in modals with text control), browser validation is used.
+					// Use markWhenOptional when required=true to suppress the "(Required)" indicator.
+					required={ required }
+					{ ...( required && { markWhenOptional: true } ) }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
 

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -148,11 +148,9 @@ const LinkControlSearchInput = forwardRef(
 						showInitialSuggestions
 					}
 					customValidity={ customValidityProp }
-					// Suppress the "(Required)" indicator that appears when validation
-					// is triggered. The field is still required for validation purposes,
-					// but we don't want to show the indicator as it looks cluttered
-					// in the link control UI.
-					markWhenOptional
+					// Don't mark the field as required to avoid browser validation errors
+					// on blur. Validation is handled manually via onSubmit and handleSubmit.
+					required={ false }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
 

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -46,7 +46,7 @@ const LinkControlSearchInput = forwardRef(
 			suffix,
 			isEntity = false,
 			customValidity: customValidityProp,
-			required = false,
+			required,
 		},
 		ref
 	) => {

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -153,7 +153,7 @@ const LinkControlSearchInput = forwardRef(
 					// When required=true (e.g., in modals with text control), browser validation is used.
 					// Use markWhenOptional when required=true to suppress the "(Required)" indicator.
 					required={ required }
-					{ ...( required && { markWhenOptional: true } ) }
+					markWhenOptional={ required }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -455,7 +455,7 @@ class URLInput extends Component {
 		const inputProps = {
 			id: inputId,
 			value,
-			required: true,
+			required: this.props.required ?? true,
 			type: 'text',
 			name: inputId,
 			autoComplete: 'off',

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -902,13 +902,13 @@ test.describe( 'Navigation block', () => {
 				await expect( linkControlSearch ).toBeFocused();
 			} );
 
-			await test.step( 'Should not show validation error when input is empty', async () => {
+			await test.step( 'Should not show validation error on blur when input is empty', async () => {
 				// Press tab twice to reach the "Create page" button
 				await pageUtils.pressKeys( 'Tab', { times: 2 } );
 
 				await expect(
 					page.getByText( 'Please fill out this field' )
-				).not.toBeVisible();
+				).toBeHidden();
 			} );
 
 			await test.step( 'Click Create Page button', async () => {
@@ -1311,11 +1311,12 @@ test.describe( 'Navigation block', () => {
 				);
 			} );
 
+			const linkPopover = navigation.getLinkPopover();
+
 			await test.step( 'Verify Link UI popover also reflects updated page URL', async () => {
 				// Open Link UI via keyboard shortcut
 				await pageUtils.pressKeys( 'primary+k' );
 
-				const linkPopover = navigation.getLinkPopover();
 				await expect( linkPopover ).toBeVisible();
 
 				// Click Edit button to see form fields
@@ -1339,7 +1340,6 @@ test.describe( 'Navigation block', () => {
 				// Open Link UI via keyboard shortcut
 				await pageUtils.pressKeys( 'primary+k' );
 
-				const linkPopover = navigation.getLinkPopover();
 				await expect( linkPopover ).toBeVisible();
 
 				// Click Edit button
@@ -1359,16 +1359,24 @@ test.describe( 'Navigation block', () => {
 
 				// Verify Link field becomes enabled
 				await expect( linkInput ).toBeEnabled();
-
-				// Cancel to preserve bound state for sidebar tests
-				await linkPopover
-					.getByRole( 'button', { name: 'Cancel' } )
-					.click();
-
-				// Pressing Escape closes the popover
-				await page.keyboard.press( 'Escape' );
-				await expect( linkPopover ).toBeHidden();
+				await expect( linkInput ).toBeFocused();
+				await expect( linkInput ).toHaveValue( '' );
 			} );
+
+			await test.step( 'Verify link field validates on blur in Link UI popover', async () => {
+				await page.keyboard.press( 'Tab' );
+
+				await expect(
+					page.getByText( 'Please fill out this field' )
+				).toBeVisible();
+			} );
+
+			// Cancel to preserve bound state for sidebar tests
+			await linkPopover.getByRole( 'button', { name: 'Cancel' } ).click();
+
+			// Pressing Escape closes the popover
+			await page.keyboard.press( 'Escape' );
+			await expect( linkPopover ).toBeHidden();
 		} );
 
 		test( 'existing links with id but no binding remain editable', async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -902,14 +902,22 @@ test.describe( 'Navigation block', () => {
 				await expect( linkControlSearch ).toBeFocused();
 			} );
 
+			await test.step( 'Should not show validation error when input is empty', async () => {
+				// Press tab twice to reach the "Create page" button
+				await pageUtils.pressKeys( 'Tab', { times: 2 } );
+
+				await expect(
+					page.getByText( 'Please fill out this field' )
+				).not.toBeVisible();
+			} );
+
 			await test.step( 'Click Create Page button', async () => {
 				// Find and click the "Create page" button
 				const createPageButton = page.getByRole( 'button', {
 					name: 'Create page',
 				} );
 				await expect( createPageButton ).toBeVisible();
-				// Press tab twice to reach the "Create page" button
-				await pageUtils.pressKeys( 'Tab', { times: 2 } );
+
 				// expect the "Create page" button to be focused
 				await expect( createPageButton ).toBeFocused();
 				await page.keyboard.press( 'Enter' );
@@ -1202,6 +1210,13 @@ test.describe( 'Navigation block', () => {
 				await expect( linkButton ).toContainText(
 					url.pathname.replace( /\/$/, '' )
 				);
+
+				// Verify help text
+				await expect(
+					settingsControls.getByText(
+						'Synced with the selected page.'
+					)
+				).toBeVisible();
 			} );
 
 			await test.step( 'Verify bound link works correctly on frontend', async () => {
@@ -1626,14 +1641,14 @@ test.describe( 'Navigation block', () => {
 
 				// With LinkControlInspector, unavailable entities show a button with error badge
 				const linkButton = settingsControls.getByRole( 'button', {
-					name: /Missing page/i,
+					name: /No link selected/i,
 				} );
 
 				// Button is enabled (can click to fix the link)
 				await expect( linkButton ).toBeEnabled();
 
-				// Button should show "Missing page" for unavailable entity
-				await expect( linkButton ).toContainText( 'Missing page' );
+				// Button should show "No link selected" for unavailable entity
+				await expect( linkButton ).toContainText( 'No link selected' );
 			} );
 
 			await test.step( 'Verify clicking button with error opens link control for fixing', async () => {
@@ -1642,7 +1657,7 @@ test.describe( 'Navigation block', () => {
 					.getByRole( 'tabpanel', { name: 'Settings' } );
 
 				const linkButton = settingsControls.getByRole( 'button', {
-					name: /Missing page/i,
+					name: /No link selected/i,
 				} );
 
 				// Click the button to open the link control and fix the link

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1210,13 +1210,6 @@ test.describe( 'Navigation block', () => {
 				await expect( linkButton ).toContainText(
 					url.pathname.replace( /\/$/, '' )
 				);
-
-				// Verify help text
-				await expect(
-					settingsControls.getByText(
-						'Synced with the selected page.'
-					)
-				).toBeVisible();
 			} );
 
 			await test.step( 'Verify bound link works correctly on frontend', async () => {
@@ -1649,14 +1642,14 @@ test.describe( 'Navigation block', () => {
 
 				// With LinkControlInspector, unavailable entities show a button with error badge
 				const linkButton = settingsControls.getByRole( 'button', {
-					name: /No link selected/i,
+					name: /Missing page/i,
 				} );
 
 				// Button is enabled (can click to fix the link)
 				await expect( linkButton ).toBeEnabled();
 
-				// Button should show "No link selected" for unavailable entity
-				await expect( linkButton ).toContainText( 'No link selected' );
+				// Button should show "Missing page" for unavailable entity
+				await expect( linkButton ).toContainText( 'Missing page' );
 			} );
 
 			await test.step( 'Verify clicking button with error opens link control for fixing', async () => {
@@ -1665,7 +1658,7 @@ test.describe( 'Navigation block', () => {
 					.getByRole( 'tabpanel', { name: 'Settings' } );
 
 				const linkButton = settingsControls.getByRole( 'button', {
-					name: /No link selected/i,
+					name: /Missing page/i,
 				} );
 
 				// Click the button to open the link control and fix the link


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/75185
When using the LinkControl component (e.g., in the Navigation block), clicking the "Create Page" button or other suggestion items triggers a validation error: "Please fill out this field." This occurs because:

1. The search input uses `ValidatedInputControl` with `required={true}`
2. When the user clicks any button/suggestion, the input loses focus (blurs)
3. `ControlWithError` marks blurred fields as "touched" 
4. Once touched, validation errors are displayed
5. The "Create Page" action is blocked by the validation error

This is problematic because the create page button is a **separate action** from link submission—it shouldn't trigger input validation.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Bug fix for UX error

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In https://github.com/WordPress/gutenberg/pull/75188, I tried adding a "prevent validation on blur" behavior to the validation input. In this PR, I'm not marking the link control search input as required, because in some instances, it is not required. For example, when you click the "Create Page" button, the field can be empty or have any text in it. We don't want to validate it or require it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
#### Test: No validation on blur
- Add new navigation link
- Focus should be on the search input
- Click "Create page" button
- You should move on to the Create Page step without seeing any validation error

#### Test: Validation on submit
- Type an invalid url like "testing it out"
- Press Enter
- Validation error should show
- Type something else in the url field, still invalid
- click the submit button 
- Validation error should show
- Fix it (use real url)
- Press enter, should submit correctly
- Retry with a click on the submit button, should work correctly

#### Test: No validation error when clicking a suggestion
- Add new navigation link
- Click suggestion
- Should create link

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
