### PR TITLE
DataViews: Hide table headers when nothing is returned.

### DIFF
--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -430,111 +430,120 @@ function ViewTable< Item >( {
 						<PropertiesSection showLabel={ false } />
 					</Popover>
 				) }
-				<thead onContextMenu={ handleHeaderContextMenu }>
-					<tr className="dataviews-view-table__row">
-						{ hasBulkActions && (
-							<th
-								className="dataviews-view-table__checkbox-column"
-								scope="col"
-								onContextMenu={ handleHeaderContextMenu }
-							>
-								<BulkSelectionCheckbox
-									selection={ selection }
-									onChangeSelection={ onChangeSelection }
-									data={ data }
-									actions={ actions }
-									getItemId={ getItemId }
-								/>
-							</th>
-						) }
-						{ hasPrimaryColumn && (
-							<th scope="col">
-								{ titleField && (
-									<ColumnHeaderMenu
-										ref={ headerMenuRef(
-											titleField.id,
-											0
-										) }
-										fieldId={ titleField.id }
-										view={ view }
-										fields={ fields }
-										onChangeView={ onChangeView }
-										onHide={ onHide }
-										setOpenedFilter={ setOpenedFilter }
-										canMove={ false }
-										canInsertLeft={
-											isRtl
-												? view.layout?.enableMoving ??
-												  true
-												: false
-										}
-										canInsertRight={
-											isRtl
-												? false
-												: view.layout?.enableMoving ??
-												  true
-										}
-									/>
-								) }
-							</th>
-						) }
-						{ columns.map( ( column, index ) => {
-							// Explicit picks the supported styles.
-							const { width, maxWidth, minWidth, align } =
-								view.layout?.styles?.[ column ] ?? {};
-							const canInsertOrMove =
-								view.layout?.enableMoving ?? true;
-							return (
+				{ ( hasData || isLoading ) && (
+					<thead onContextMenu={ handleHeaderContextMenu }>
+						<tr className="dataviews-view-table__row">
+							{ hasBulkActions && (
 								<th
-									key={ column }
-									style={ {
-										width,
-										maxWidth,
-										minWidth,
-										textAlign: align,
-									} }
-									aria-sort={
-										view.sort?.direction &&
-										view.sort?.field === column
-											? sortValues[ view.sort.direction ]
-											: undefined
-									}
+									className="dataviews-view-table__checkbox-column"
 									scope="col"
+									onContextMenu={ handleHeaderContextMenu }
 								>
-									<ColumnHeaderMenu
-										ref={ headerMenuRef( column, index ) }
-										fieldId={ column }
-										view={ view }
-										fields={ fields }
-										onChangeView={ onChangeView }
-										onHide={ onHide }
-										setOpenedFilter={ setOpenedFilter }
-										canMove={ canInsertOrMove }
-										canInsertLeft={ canInsertOrMove }
-										canInsertRight={ canInsertOrMove }
+									<BulkSelectionCheckbox
+										selection={ selection }
+										onChangeSelection={ onChangeSelection }
+										data={ data }
+										actions={ actions }
+										getItemId={ getItemId }
 									/>
 								</th>
-							);
-						} ) }
-						{ !! actions?.length && (
-							<th
-								className={ clsx(
-									'dataviews-view-table__actions-column',
-									{
-										'dataviews-view-table__actions-column--sticky':
-											true,
-										'dataviews-view-table__actions-column--stuck':
-											! isHorizontalScrollEnd,
-									}
-								) }
-							>
-								<span className="dataviews-view-table-header">
-									{ __( 'Actions' ) }
-								</span>
-							</th>
-						) }
-					</tr>
-				</thead>
+							) }
+							{ hasPrimaryColumn && (
+								<th scope="col">
+									{ titleField && (
+										<ColumnHeaderMenu
+											ref={ headerMenuRef(
+												titleField.id,
+												0
+											) }
+											fieldId={ titleField.id }
+											view={ view }
+											fields={ fields }
+											onChangeView={ onChangeView }
+											onHide={ onHide }
+											setOpenedFilter={ setOpenedFilter }
+											canMove={ false }
+											canInsertLeft={
+												isRtl
+													? view.layout
+															?.enableMoving ??
+													  true
+													: false
+											}
+											canInsertRight={
+												isRtl
+													? false
+													: view.layout
+															?.enableMoving ??
+													  true
+											}
+										/>
+									) }
+								</th>
+							) }
+							{ columns.map( ( column, index ) => {
+								// Explicit picks the supported styles.
+								const { width, maxWidth, minWidth, align } =
+									view.layout?.styles?.[ column ] ?? {};
+								const canInsertOrMove =
+									view.layout?.enableMoving ?? true;
+								return (
+									<th
+										key={ column }
+										style={ {
+											width,
+											maxWidth,
+											minWidth,
+											textAlign: align,
+										} }
+										aria-sort={
+											view.sort?.direction &&
+											view.sort?.field === column
+												? sortValues[
+														view.sort.direction
+												  ]
+												: undefined
+										}
+										scope="col"
+									>
+										<ColumnHeaderMenu
+											ref={ headerMenuRef(
+												column,
+												index
+											) }
+											fieldId={ column }
+											view={ view }
+											fields={ fields }
+											onChangeView={ onChangeView }
+											onHide={ onHide }
+											setOpenedFilter={ setOpenedFilter }
+											canMove={ canInsertOrMove }
+											canInsertLeft={ canInsertOrMove }
+											canInsertRight={ canInsertOrMove }
+										/>
+									</th>
+								);
+							} ) }
+							{ !! actions?.length && (
+								<th
+									className={ clsx(
+										'dataviews-view-table__actions-column',
+										{
+											'dataviews-view-table__actions-column--sticky':
+												true,
+											'dataviews-view-table__actions-column--stuck':
+												! isHorizontalScrollEnd,
+										}
+									) }
+								>
+									<span className="dataviews-view-table-header">
+										{ __( 'Actions' ) }
+									</span>
+								</th>
+							) }
+						</tr>
+					</thead>
+				) }
 				{ /* Render grouped data if groupBy is specified */ }
 				{ hasData && groupField && dataByGroup ? (
 					Array.from( dataByGroup.entries() ).map(


### PR DESCRIPTION

## What?
Closes: {none yet, experiment}

## Why?

Previously, table headers were always rendered regardless of data state. This created an awkward empty state where column headers sat above a "No results" message. This PR hides the headers when we have no data.

## How?
- Hides table headers in the table layout when there is no data and the component is not in a loading state
- Headers remain visible during loading transitions, preventing flickering when searching/filtering


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="995" height="532" alt="Screenshot 2026-02-06 at 11 50 54 AM" src="https://github.com/user-attachments/assets/1759fa08-a815-4206-afc5-d2aea0c1ea34" />|<img width="996" height="510" alt="Screenshot 2026-02-06 at 11 50 40 AM" src="https://github.com/user-attachments/assets/17e441a7-f4c5-4496-a76e-cb1666ae6c60" />|

### Video

https://github.com/user-attachments/assets/a51099c6-49b8-4e32-a625-17ed2095fc76


