### PR TITLE
Accordion block: Add list view support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Displays a foldable layout that groups content in collapsible sections. ([Source
 -	**Name:** core/accordion
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -55,7 +55,8 @@
 				"fontSize": true
 			}
 		},
-		"contentRole": true
+		"contentRole": true,
+		"listView": true
 	},
 	"attributes": {
 		"iconPosition": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #75270

This is a very simple PR (just a one-line change), but the UX change is sizeable for the accordion block. (Kudos @talldan for the idea)

It proposes opting-in to the list view support, so that the list view tab can be used for rerranging and adding items to the accordion.

## Why?

In previous work last year in #72052, the PR from @t-hamano was intended to help improve the ability to add and edit accordions in content only mode.

There's been considerable progress on content-only pattern editing since then, and the introduction of the list view support. Opting-in achieves a couple of things here:

* It prevents any of the Accordion's children from appearing in the Content tab on a pattern/section, which significantly helps reduce the visual noise on that tab
* It opens up the List View for more easily helping folks rearrange accordion items, and potentially add additional items

Note: this behaviour affects Accordions inserted straight into post content, too, as it'll now default to the List tab. I'm not too sure how this change will be received, but it arguable makes it easier to work with the nested nature of the block. But I'll be keen to see how folks feel about it. The intention with this PR is to try it out, and see what we think.

## How?

* Simply opt-in to the list view support, and let the feature do its thing

## Testing Instructions

Here's some quick block markup for the accordion:

<details>

<summary>Accordion block markup</summary>

```html
<!-- wp:accordion -->
<div role="group" class="wp-block-accordion"><!-- wp:accordion-item -->
<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion title 1</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
<!-- /wp:accordion-heading -->

<!-- wp:accordion-panel -->
<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
<p>A paragraph within the accordion panel</p>
<!-- /wp:paragraph --></div>
<!-- /wp:accordion-panel --></div>
<!-- /wp:accordion-item -->

<!-- wp:accordion-item -->
<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion title 2</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
<!-- /wp:accordion-heading -->

<!-- wp:accordion-panel -->
<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
<p>A paragraph within the accordion panel</p>
<!-- /wp:paragraph --></div>
<!-- /wp:accordion-panel --></div>
<!-- /wp:accordion-item -->

<!-- wp:accordion-item -->
<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion title 3</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
<!-- /wp:accordion-heading -->

<!-- wp:accordion-panel -->
<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
<p>A paragraph within the accordion panel</p>
<!-- /wp:paragraph --></div>
<!-- /wp:accordion-panel --></div>
<!-- /wp:accordion-item --></div>
<!-- /wp:accordion -->
```

</details>

1. Go to add a pattern to a post, page or template, and click Edit Section
2. Add this markup in there (or create your own accordions)
3. Then click to Exit the section
4. Note that the Accordion will only show at the root level in the content tab, however:
5. You'll still be able to rearrange and edit Accordions (and add new items) from the List view tab
6. Go to edit a post or page normally and insert an Accordion block as usual. Note that there is now a list view tab, and see how it feels

## Screenshots or screencast <!-- if applicable -->

In the post editor

<img width="1112" height="791" alt="image" src="https://github.com/user-attachments/assets/e1d90c31-b973-4063-92a7-7f6c33882d17" />

Within a pattern (note that this simplifies the Content panel considerably compared to previously):

https://github.com/user-attachments/assets/706d6ff5-84fd-4dde-b96a-806fc6ab3344


