### PR TITLE
Slot: fix ref forwarding

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).
--   `createSlotFill`: fix ref forwarding ([#75274](https://github.com/WordPress/gutenberg/pull/75274))
+-   `createSlotFill`: fix ref forwarding ([#75274](https://github.com/WordPress/gutenberg/pull/75274)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).
+-   `createSlotFill`: fix ref forwarding ([#75274](https://github.com/WordPress/gutenberg/pull/75274))
 
 ### Enhancements
 

--- a/packages/components/src/slot-fill/index.tsx
+++ b/packages/components/src/slot-fill/index.tsx
@@ -64,9 +64,18 @@ export function createSlotFill( key: SlotKey ) {
 	);
 	FillComponent.displayName = `${ baseName }Fill`;
 
-	const SlotComponent = (
-		props: DistributiveOmit< SlotComponentProps, 'name' >
-	) => <Slot name={ key } { ...props } />;
+	// Wrap SlotComponent with forwardRef to support ref forwarding
+	const SlotComponent = forwardRef(
+		(
+			props: DistributiveOmit< SlotComponentProps, 'name' >,
+			ref: ForwardedRef< any >
+		) => <Slot name={ key } ref={ ref } { ...props } />
+	) as React.ForwardRefExoticComponent<
+		DistributiveOmit< SlotComponentProps, 'name' > &
+			React.RefAttributes< any >
+	> & {
+		__unstableName: SlotKey;
+	};
 	SlotComponent.displayName = `${ baseName }Slot`;
 	/**
 	 * @deprecated 6.8.0

--- a/packages/components/src/slot-fill/test/index.js
+++ b/packages/components/src/slot-fill/test/index.js
@@ -4,6 +4,11 @@
 import { render, screen, within } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { createRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { createSlotFill, Provider as SlotFillProvider } from '../';
@@ -81,5 +86,55 @@ describe( 'createSlotFill', () => {
 		expect(
 			within( pageSidebar ).queryByText( 'Post Section' )
 		).not.toBeInTheDocument();
+	} );
+
+	test( 'should forward ref to the slot when using bubblesVirtually', () => {
+		const TestSlotFill = createSlotFill( 'TestRefSlot' );
+		const ref = createRef();
+
+		render(
+			<SlotFillProvider>
+				<TestSlotFill.Fill>
+					<p>Content</p>
+				</TestSlotFill.Fill>
+				<TestSlotFill.Slot bubblesVirtually ref={ ref } />
+			</SlotFillProvider>
+		);
+
+		expect( ref.current ).not.toBeNull();
+		expect( ref.current.tagName ).toBe( 'DIV' );
+	} );
+
+	test( 'should support callback refs with bubblesVirtually', () => {
+		const TestSlotFill = createSlotFill( 'TestCallbackRefSlot' );
+		const callbackRef = jest.fn();
+
+		render(
+			<SlotFillProvider>
+				<TestSlotFill.Fill>
+					<p>Content</p>
+				</TestSlotFill.Fill>
+				<TestSlotFill.Slot bubblesVirtually ref={ callbackRef } />
+			</SlotFillProvider>
+		);
+
+		expect( callbackRef ).toHaveBeenCalled();
+		expect( callbackRef.mock.calls[ 0 ][ 0 ].tagName ).toBe( 'DIV' );
+	} );
+
+	test( 'should forward ref without bubblesVirtually (ref stays null for fragment-based slot)', () => {
+		const TestSlotFill = createSlotFill( 'TestRefSlotBase' );
+		const ref = createRef();
+
+		render(
+			<SlotFillProvider>
+				<TestSlotFill.Fill>
+					<p>Content</p>
+				</TestSlotFill.Fill>
+				<TestSlotFill.Slot ref={ ref } />
+			</SlotFillProvider>
+		);
+
+		expect( ref.current ).toBeNull();
 	} );
 } );

--- a/packages/components/src/slot-fill/test/index.js
+++ b/packages/components/src/slot-fill/test/index.js
@@ -105,23 +105,6 @@ describe( 'createSlotFill', () => {
 		expect( ref.current.tagName ).toBe( 'DIV' );
 	} );
 
-	test( 'should support callback refs with bubblesVirtually', () => {
-		const TestSlotFill = createSlotFill( 'TestCallbackRefSlot' );
-		const callbackRef = jest.fn();
-
-		render(
-			<SlotFillProvider>
-				<TestSlotFill.Fill>
-					<p>Content</p>
-				</TestSlotFill.Fill>
-				<TestSlotFill.Slot bubblesVirtually ref={ callbackRef } />
-			</SlotFillProvider>
-		);
-
-		expect( callbackRef ).toHaveBeenCalled();
-		expect( callbackRef.mock.calls[ 0 ][ 0 ].tagName ).toBe( 'DIV' );
-	} );
-
 	test( 'should forward ref without bubblesVirtually (ref stays null for fragment-based slot)', () => {
 		const TestSlotFill = createSlotFill( 'TestRefSlotBase' );
 		const ref = createRef();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Extracted from #75194

## What?
From the implementation here, we can see that the Slot component looks like it is supposed to support refs thanks to the use of `forwardRef`:
https://github.com/WordPress/gutenberg/blob/62cd30e9441d9613d14a8e59017515b619581e2e/packages/components/src/slot-fill/index.tsx#L33-L46

However, when calling `createSlotFill`, that component is wrapped in another that doesn't forward refs, and that means consumers can't use refs with slots:
https://github.com/WordPress/gutenberg/blob/62cd30e9441d9613d14a8e59017515b619581e2e/packages/components/src/slot-fill/index.tsx#L67-L70

## How?
This PR fixes the issue by using forwardRef on the component that `createSlotFill` returns as well.

## Testing Instructions
Some unit tests are added, I checked they fail in trunk.

1. Render a slot somewhere that uses `bubblesVirtually`
2. Try attaching a ref
3. Observe the ref returns null in trunk, but works in this PR