### PR TITLE
Filter navigation category patterns to only show in navigation-overlay template part context

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -12,11 +12,9 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
-import { privateApis } from '../../../private-apis';
+import { isNavigationOverlayContextKey } from '../../../store/private-keys';
 import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
 import { isFiltered } from '../../../store/utils';
-
-const { isNavigationOverlayContextKey } = unlock( privateApis );
 
 /**
  * Retrieves the block patterns inserter state.

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -35,6 +35,16 @@ const usePatternsState = (
 		() => ( { [ isFiltered ]: !! isQuick } ),
 		[ isQuick ]
 	);
+
+	// Check if we're editing a navigation-overlay template part.
+	// This information is passed through block editor settings to avoid
+	// cross-package dependencies.
+	const isWithinNavigationOverlayContext = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( blockEditorStore ) );
+		const settings = getSettings();
+		return settings.__experimentalIsNavigationOverlayContext ?? false;
+	}, [] );
+
 	const { patternCategories, patterns, userPatternCategories } = useSelect(
 		( select ) => {
 			const { getSettings, __experimentalGetAllowedPatterns } = unlock(
@@ -55,6 +65,19 @@ const usePatternsState = (
 		},
 		[ rootClientId, options ]
 	);
+
+	// Filter out patterns with "navigation" category unless we're in
+	// navigation-overlay template part context.
+	const filteredPatterns = useMemo( () => {
+		return patterns.filter( ( pattern ) => {
+			const hasNavigationCategory =
+				pattern.categories?.includes( 'navigation' );
+			if ( hasNavigationCategory && ! isWithinNavigationOverlayContext ) {
+				return false;
+			}
+			return true;
+		} );
+	}, [ patterns, isWithinNavigationOverlayContext ] );
 	const { getClosestAllowedInsertionPointForPattern } = unlock(
 		useSelect( blockEditorStore )
 	);
@@ -131,7 +154,7 @@ const usePatternsState = (
 		]
 	);
 
-	return [ patterns, allCategories, onClickPattern ];
+	return [ filteredPatterns, allCategories, onClickPattern ];
 };
 
 export default usePatternsState;

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -12,8 +12,11 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
+import { privateApis } from '../../../private-apis';
 import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
 import { isFiltered } from '../../../store/utils';
+
+const { isNavigationOverlayContextKey } = unlock( privateApis );
 
 /**
  * Retrieves the block patterns inserter state.
@@ -42,7 +45,7 @@ const usePatternsState = (
 	const isWithinNavigationOverlayContext = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( blockEditorStore ) );
 		const settings = getSettings();
-		return settings.__experimentalIsNavigationOverlayContext ?? false;
+		return settings[ isNavigationOverlayContextKey ] ?? false;
 	}, [] );
 
 	const { patternCategories, patterns, userPatternCategories } = useSelect(
@@ -68,6 +71,7 @@ const usePatternsState = (
 
 	// Filter out patterns with "navigation" category unless we're in
 	// navigation-overlay template part context.
+	// TO DO: create an api for patterns to decide in which context they should be shown.
 	const filteredPatterns = useMemo( () => {
 		return patterns.filter( ( pattern ) => {
 			const hasNavigationCategory =

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -45,6 +45,7 @@ import {
 	essentialFormatKey,
 	deviceTypeKey,
 	isIsolatedEditorKey,
+	isNavigationOverlayContextKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
@@ -118,6 +119,7 @@ lock( privateApis, {
 	essentialFormatKey,
 	deviceTypeKey,
 	isIsolatedEditorKey,
+	isNavigationOverlayContextKey,
 	useBlockElement,
 	useBlockElementRef,
 	LinkPicker,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -8,3 +8,6 @@ export const getMediaSelectKey = Symbol( 'getMediaSelect' );
 export const essentialFormatKey = Symbol( 'essentialFormat' );
 export const isIsolatedEditorKey = Symbol( 'isIsolatedEditor' );
 export const deviceTypeKey = Symbol( 'deviceTypeKey' );
+export const isNavigationOverlayContextKey = Symbol(
+	'isNavigationOverlayContext'
+);

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -131,6 +131,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		restBlockPatternCategories,
 		sectionRootClientId,
 		deviceType,
+		isNavigationOverlayContext,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -197,6 +198,14 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				restBlockPatternCategories: getBlockPatternCategories(),
 				sectionRootClientId: getSectionRootBlock(),
 				deviceType: getDeviceType(),
+				isNavigationOverlayContext:
+					postType === 'wp_template_part' && postId
+						? getEntityRecord(
+								'postType',
+								'wp_template_part',
+								postId
+						  )?.area === 'navigation-overlay'
+						: false,
 			};
 		},
 		[ postType, postId, isLargeViewport, renderingMode ]
@@ -389,6 +398,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				'wp_navigation',
 			].includes( postType ),
 			...( deviceType ? { [ deviceTypeKey ]: deviceType } : {} ),
+			__experimentalIsNavigationOverlayContext:
+				isNavigationOverlayContext,
 		};
 
 		return blockEditorSettings;
@@ -420,6 +431,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		editMediaEntity,
 		wrappedOnNavigateToEntityRecord,
 		deviceType,
+		isNavigationOverlayContext,
 	] );
 }
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -100,6 +100,7 @@ const {
 	getMediaSelectKey,
 	isIsolatedEditorKey,
 	deviceTypeKey,
+	isNavigationOverlayContextKey,
 } = unlock( privateApis );
 
 /**
@@ -398,8 +399,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				'wp_navigation',
 			].includes( postType ),
 			...( deviceType ? { [ deviceTypeKey ]: deviceType } : {} ),
-			__experimentalIsNavigationOverlayContext:
-				isNavigationOverlayContext,
+			[ isNavigationOverlayContextKey ]: isNavigationOverlayContext,
 		};
 
 		return blockEditorSettings;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Partially addresses <!-- #ISSUE-NUMBER or URL -->#75241

<!-- In a few words, what is the PR actually doing? -->

This PR filters patterns with the "navigation" category to only appear in the pattern inserter when editing a navigation-overlay template part.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Navigation overlay patterns are currently available globally in the pattern library/inserter. When these patterns are inserted outside of an overlay template part context, the overlay content appears as regular visible content, the Close button is non-functional, and users become confused about why the pattern doesn't work as expected.

## How?
<!-- How is your PR addressing the issue at the hand? What are the implementation details? -->

The implementation passes the navigation-overlay template part context through block editor settings from the editor package to the block-editor package. In `useBlockEditorSettings`, we check if the current post type is a template part with area "navigation-overlay" and pass this as `__experimentalIsNavigationOverlayContext` in the settings. The `usePatternsState` hook then reads this setting and filters out patterns with the "navigation" category unless we're in the navigation-overlay context.

This approach avoidd cross-package dependencies and passes context information through settings rather than accessing stores directly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a regular post or page in the editor.
2. Open the pattern inserter (regular or quick inserter).
3. Verify that navigation category patterns are NOT visible in the pattern list.
4. Navigate to edit a navigation-overlay template part 
5. Verify that navigation category patterns ARE now visible and can be inserted.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Non overlay template part|Overlay template part|
|-|-|
|<img width="1729" height="736" alt="Screenshot 2026-02-06 at 10 17 42" src="https://github.com/user-attachments/assets/e57612cc-6976-4719-a452-90f6da953e29" />|<img width="1728" height="755" alt="Screenshot 2026-02-06 at 10 18 04" src="https://github.com/user-attachments/assets/f00b2c55-38e8-4e91-b17e-876193e97dbf" />|


