### PR TITLE
Widget Area: Disable renaming and visibility support

### DIFF
--- a/packages/edit-widgets/src/blocks/widget-area/block.json
+++ b/packages/edit-widgets/src/blocks/widget-area/block.json
@@ -17,6 +17,8 @@
 		"inserter": false,
 		"customClassName": false,
 		"reusable": false,
+		"renaming": false,
+		"visibility": false,
 		"__experimentalToolbar": false,
 		"__experimentalParentSelector": false,
 		"__experimentalDisableBlockOverlay": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

There are now shortcuts available for renaming and toggling block visibility. I noticed that these shortcuts worked unintentionally with the Widget Area block. These shortcuts are not what we'd expect.


https://github.com/user-attachments/assets/6447ef63-030a-46fe-bb65-31369b5649e3



## Testing Instructions

- Activate Twenty Twenty One
- Open Appearance > Widget
- Select one of the widget areas
- Run the shortcut to hide or rename the block. Nothing should happen.