### PR TITLE
Real-time collaboration: Explicitly wp_update_post() during autosave

### DIFF
--- a/lib/experimental/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/experimental/class-gutenberg-rest-autosaves-controller.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Autosaves_Controller class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Controller which provides REST endpoint for autosaves.
+ * This overrides the core WP_REST_Autosaves_Controller to add support for
+ * real-time collaboration fixes on draft posts.
+ *
+ * @see WP_REST_Autosaves_Controller
+ */
+class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
+
+	/**
+	 * Parent post controller.
+	 *
+	 * Stored separately because the parent class property is private.
+	 *
+	 * @var WP_REST_Controller
+	 */
+	private $gutenberg_parent_controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $parent_post_type Post type of the parent.
+	 */
+	public function __construct( $parent_post_type ) {
+		parent::__construct( $parent_post_type );
+
+		$post_type_object  = get_post_type_object( $parent_post_type );
+		$parent_controller = $post_type_object->get_rest_controller();
+
+		if ( ! $parent_controller ) {
+			$parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
+		}
+
+		$this->gutenberg_parent_controller = $parent_controller;
+	}
+
+	/**
+	 * Creates, updates or deletes an autosave revision.
+	 *
+	 * This overrides the parent method to add support for real-time
+	 * collaboration on draft posts. When RTC is enabled for a post type,
+	 * all users' autosaves on drafts update the post directly instead of
+	 * creating separate autosave revisions per user.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		if ( ! defined( 'WP_RUN_CORE_TESTS' ) && ! defined( 'DOING_AUTOSAVE' ) ) {
+			define( 'DOING_AUTOSAVE', true );
+		}
+
+		$post = $this->get_parent( $request['id'] );
+
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$prepared_post     = $this->gutenberg_parent_controller->prepare_item_for_database( $request );
+		$prepared_post->ID = $post->ID;
+		$user_id           = get_current_user_id();
+
+		// We need to check post lock to ensure the original author didn't leave their browser tab open.
+		if ( ! function_exists( 'wp_check_post_lock' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/post.php';
+		}
+
+		$post_lock = wp_check_post_lock( $post->ID );
+		$is_draft  = 'draft' === $post->post_status || 'auto-draft' === $post->post_status;
+
+		$is_real_time_collaboration_enabled = true;
+
+		if ( $is_real_time_collaboration_enabled && $is_draft ) {
+			/*
+			 * In the context of RTC, we don't care if a user has the post lock or is
+			 * the original author when `$is_draft` is true. In both cases, update the
+			 * post content directly instead of creating an autosave revision.
+			 *
+			 * Otherwise:
+			 * - Autosaves from the original author (if they have the post lock) will become
+			 *   part of the saved post content automatically.
+			 * - Autosaves from other users are applied to a post revision.
+			 * - If any user reloads a post, they see the content from the author's
+			 *   autosave as it's applied direcly to the document via wp_update_post().
+			 *   All other users are treated differently and their autosaved edits won't
+			 *   be applied to the post.
+			 *
+			 * This change ensures the behavior is consistent for all users as post lock
+			 * is not relevant in the context of RTC.
+			 *
+			 * Note that autosaves for other post statuses are still separated per-user,
+			 * because this wp_update_post() conditional is the only place where there is
+			 * an autosave distinction based on author and post lock status.
+			 */
+			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
+		} elseif ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock ) {
+			/*
+			 * Draft posts for the same author: autosaving updates the post and does not create a revision.
+			 * Convert the post object to an array and add slashes, wp_update_post() expects escaped array.
+			 */
+			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
+		} else {
+			// Non-draft posts: create or update the post autosave. Pass the meta data.
+			$autosave_id = $this->create_post_autosave( (array) $prepared_post, (array) $request->get_param( 'meta' ) );
+		}
+
+		if ( is_wp_error( $autosave_id ) ) {
+			return $autosave_id;
+		}
+
+		$autosave = get_post( $autosave_id );
+		$request->set_param( 'context', 'edit' );
+
+		$response = $this->prepare_item_for_response( $autosave, $request );
+		$response = rest_ensure_response( $response );
+
+		return $response;
+	}
+}

--- a/lib/experimental/sync/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/experimental/sync/class-gutenberg-rest-autosaves-controller.php
@@ -17,8 +17,7 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 	/**
 	 * Parent post controller.
 	 *
-	 * Stored separately because the parent class property is private.
-	 *
+	 * @since 5.0.0
 	 * @var WP_REST_Controller
 	 */
 	private $gutenberg_parent_controller;
@@ -26,11 +25,15 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 	/**
 	 * Constructor.
 	 *
+	 * @since 5.0.0
+	 *
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
 		parent::__construct( $parent_post_type );
 
+		// Create an instance of the parent post type controller that is accessible
+		// by this extended class.
 		$post_type_object  = get_post_type_object( $parent_post_type );
 		$parent_controller = $post_type_object->get_rest_controller();
 
@@ -44,15 +47,13 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 	/**
 	 * Creates, updates or deletes an autosave revision.
 	 *
-	 * This overrides the parent method to add support for real-time
-	 * collaboration on draft posts. When RTC is enabled for a post type,
-	 * all users' autosaves on drafts update the post directly instead of
-	 * creating separate autosave revisions per user.
+	 * @since 5.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+
 		if ( ! defined( 'WP_RUN_CORE_TESTS' ) && ! defined( 'DOING_AUTOSAVE' ) ) {
 			define( 'DOING_AUTOSAVE', true );
 		}
@@ -75,32 +76,34 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 		$post_lock = wp_check_post_lock( $post->ID );
 		$is_draft  = 'draft' === $post->post_status || 'auto-draft' === $post->post_status;
 
-		$is_real_time_collaboration_enabled = true;
+		/**
+		 * In the context of real-time collaboration, all peers are effectively
+		 * authors and we don't want to vary behavior based on whether they are the
+		 * original author. Always target an autosave revision.
+		 *
+		 * This avoids the following issue when real-time collaboration is enabled:
+		 *
+		 * - Autosaves from the original author (if they have the post lock) will
+		 *   target the saved post.
+		 *
+		 * - Autosaves from other users are applied to a post revision.
+		 *
+		 * - If any user reloads a post, they load changes from the author's autosave.
+		 *
+		 * - The saved post has now diverged from the persisted CRDT document. The
+		 *   content (and/or title or excerpt) are now "ahead" of the persisted CRDT
+		 *   document.
+		 *
+		 * - When the persisted CRDT document is loaded, a diff is computed against
+		 *   the saved post. This diff is then applied to the in-memory CRDT
+		 *   document, which can lead to duplicate inserts or deletions.
+		 *
+		 * Load the real-time collaboration setting and, when enabled, ensure that an
+		 * an autosave revision is always targeted.
+		 */
+		$is_collaboration_enabled = get_option( 'gutenberg_enable_real_time_collaboration' );
 
-		if ( $is_real_time_collaboration_enabled && $is_draft ) {
-			/*
-			 * In the context of RTC, we don't care if a user has the post lock or is
-			 * the original author when `$is_draft` is true. In both cases, update the
-			 * post content directly instead of creating an autosave revision.
-			 *
-			 * Otherwise:
-			 * - Autosaves from the original author (if they have the post lock) will become
-			 *   part of the saved post content automatically.
-			 * - Autosaves from other users are applied to a post revision.
-			 * - If any user reloads a post, they see the content from the author's
-			 *   autosave as it's applied direcly to the document via wp_update_post().
-			 *   All other users are treated differently and their autosaved edits won't
-			 *   be applied to the post.
-			 *
-			 * This change ensures the behavior is consistent for all users as post lock
-			 * is not relevant in the context of RTC.
-			 *
-			 * Note that autosaves for other post statuses are still separated per-user,
-			 * because this wp_update_post() conditional is the only place where there is
-			 * an autosave distinction based on author and post lock status.
-			 */
-			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
-		} elseif ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock ) {
+		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*
 			 * Draft posts for the same author: autosaving updates the post and does not create a revision.
 			 * Convert the post object to an array and add slashes, wp_update_post() expects escaped array.

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -118,45 +118,6 @@ function gutenberg_add_crdt_meta_on_autosave( WP_REST_Response $response, WP_Pos
 		return $response;
 	}
 
-	if ( 'revision' === $post->post_type ) {
-		$base_post_id = $post->post_parent;
-		$is_draft     = 'draft' === $post->post_status || 'auto-draft' === $post->post_status;
-
-		if ( $base_post_id && $is_draft ) {
-			/*
-			 * Fix for autosave behavior in WordPress:
-			 * https://github.com/WordPress/wordpress-develop/blob/6.9.1/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L233-L244
-			 *
-			 * In the context of RTC, we don't care if a user has the post lock or is
-			 * the original author when `$is_draft` is true. In both cases, update the
-			 * post content directly instead of creating an autosave revision.
-			 *
-			 * Otherwise:
-			 * - Autosaves from the original author (if they have the post lock) will become
-			 *   part of the saved post content automatically.
-			 * - Autosaves from other users are applied to a post revision.
-			 * - If any user reloads a post, they see the content from the author's
-			 *   autosave as it's applied direcly to the document via wp_update_post().
-			 *   All other users are treated differently and their autosaved edits won't
-			 *   be applied to the post.
-			 *
-			 * This change ensures the behavior is consistent for all users as post lock
-			 * is not relevant in the context of RTC.
-			 *
-			 * Note that autosaves for other post statuses are still separated per-user,
-			 * because this wp_update_post() conditional is the only place where there is
-			 * an autosave distinction based on author and post lock status.
-			 */
-			wp_update_post(
-				array(
-					'ID'           => $base_post_id,
-					'post_content' => $post->post_content,
-				),
-				true
-			);
-		}
-	}
-
 	// Get the persisted CRDT meta from the request.
 	$meta  = $request->get_param( 'meta' );
 	$key   = '_crdt_document'; // Must match the key registered in gutenberg_rest_api_crdt_post_meta().
@@ -176,3 +137,24 @@ function gutenberg_add_crdt_meta_on_autosave( WP_REST_Response $response, WP_Pos
 	return $response;
 }
 add_filter( 'rest_prepare_autosave', 'gutenberg_add_crdt_meta_on_autosave', 10, 3 );
+
+/**
+ * Overrides the default REST controller for autosaves to fix real-time
+ * collaboration on draft posts.
+ *
+ * When RTC is enabled, draft autosaves from all users update the post directly
+ * instead of creating per-user autosave revisions depending on post lock and
+ * assigned author.
+ *
+ * Only overrides when autosave_rest_controller_class is not explicitly set,
+ * i.e. when WP_REST_Autosaves_Controller would be used by default. Post types
+ * with their own specialized autosave controller (e.g. templates) are left alone.
+ */
+function gutenberg_override_autosaves_rest_controller( $args, $post_type ) {
+	if ( empty( $args['autosave_rest_controller_class'] ) ) {
+		$args['autosave_rest_controller_class'] = 'Gutenberg_REST_Autosaves_Controller';
+	}
+	return $args;
+}
+
+add_filter( 'register_post_type_args', 'gutenberg_override_autosaves_rest_controller', 10, 2 );

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -99,46 +99,6 @@ function gutenberg_inject_real_time_collaboration_setting() {
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 
 /**
- * Saves CRDT post meta on autosave requests. Autosaves are sometimes applied to
- * the post itself instead of a revision:
- *
- * https://github.com/WordPress/wordpress-develop/blob/dc62ecbc345ca1b8d1801eca794d71755b7568f1/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L235-L244
- *
- * When this happens, the special post meta handling in `create_post_autosave` is
- * not called. We do it manually in this filter before the response is returned.
- *
- * @param WP_REST_Response $response The response object.
- * @param WP_Post          $post     The post object.
- * @param WP_REST_Request  $request  The request object.
- * @return WP_REST_Response Modified response object.
- */
-function gutenberg_add_crdt_meta_on_autosave( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) {
-	// Ensure that this is an autosave request.
-	if ( ! defined( 'DOING_AUTOSAVE' ) || true !== constant( 'DOING_AUTOSAVE' ) ) {
-		return $response;
-	}
-
-	// Get the persisted CRDT meta from the request.
-	$meta  = $request->get_param( 'meta' );
-	$key   = '_crdt_document'; // Must match the key registered in gutenberg_rest_api_crdt_post_meta().
-	$value = $meta[ $key ] ?? '';
-
-	if ( empty( $value ) ) {
-		return $response;
-	}
-
-	update_post_meta( $post->ID, $key, $value );
-
-	// Update the response.
-	$data         = $response->get_data();
-	$data['meta'] = array_merge( $data['meta'] ?? array(), array( $key => $value ) );
-	$response->set_data( $data );
-
-	return $response;
-}
-add_filter( 'rest_prepare_autosave', 'gutenberg_add_crdt_meta_on_autosave', 10, 3 );
-
-/**
  * Overrides the default REST controller for autosaves to fix real-time
  * collaboration on draft posts.
  *

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -118,6 +118,45 @@ function gutenberg_add_crdt_meta_on_autosave( WP_REST_Response $response, WP_Pos
 		return $response;
 	}
 
+	if ( 'revision' === $post->post_type ) {
+		$base_post_id = $post->post_parent;
+		$is_draft     = 'draft' === $post->post_status || 'auto-draft' === $post->post_status;
+
+		if ( $base_post_id && $is_draft ) {
+			/*
+			 * Fix for autosave behavior in WordPress:
+			 * https://github.com/WordPress/wordpress-develop/blob/6.9.1/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L233-L244
+			 *
+			 * In the context of RTC, we don't care if a user has the post lock or is
+			 * the original author when `$is_draft` is true. In both cases, update the
+			 * post content directly instead of creating an autosave revision.
+			 *
+			 * Otherwise:
+			 * - Autosaves from the original author (if they have the post lock) will become
+			 *   part of the saved post content automatically.
+			 * - Autosaves from other users are applied to a post revision.
+			 * - If any user reloads a post, they see the content from the author's
+			 *   autosave as it's applied direcly to the document via wp_update_post().
+			 *   All other users are treated differently and their autosaved edits won't
+			 *   be applied to the post.
+			 *
+			 * This change ensures the behavior is consistent for all users as post lock
+			 * is not relevant in the context of RTC.
+			 *
+			 * Note that autosaves for other post statuses are still separated per-user,
+			 * because this wp_update_post() conditional is the only place where there is
+			 * an autosave distinction based on author and post lock status.
+			 */
+			wp_update_post(
+				array(
+					'ID'           => $base_post_id,
+					'post_content' => $post->post_content,
+				),
+				true
+			);
+		}
+	}
+
 	// Get the persisted CRDT meta from the request.
 	$meta  = $request->get_param( 'meta' );
 	$key   = '_crdt_document'; // Must match the key registered in gutenberg_rest_api_crdt_post_meta().

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -150,11 +150,11 @@ add_filter( 'rest_prepare_autosave', 'gutenberg_add_crdt_meta_on_autosave', 10, 
  * i.e. when WP_REST_Autosaves_Controller would be used by default. Post types
  * with their own specialized autosave controller (e.g. templates) are left alone.
  */
-function gutenberg_override_autosaves_rest_controller( $args, $post_type ) {
+function gutenberg_override_autosaves_rest_controller( $args ) {
 	if ( empty( $args['autosave_rest_controller_class'] ) ) {
 		$args['autosave_rest_controller_class'] = 'Gutenberg_REST_Autosaves_Controller';
 	}
 	return $args;
 }
 
-add_filter( 'register_post_type_args', 'gutenberg_override_autosaves_rest_controller', 10, 2 );
+add_filter( 'register_post_type_args', 'gutenberg_override_autosaves_rest_controller', 10, 1 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -78,6 +78,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';
 	require_once __DIR__ . '/rest-api.php';
 
+	// Experimental autosaves controller override for real-time collaboration.
+	require_once __DIR__ . '/experimental/class-gutenberg-rest-autosaves-controller.php';
+
 	require_once __DIR__ . '/experimental/rest-api.php';
 	require_once __DIR__ . '/experimental/kses-allowed-html.php';
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -79,7 +79,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/rest-api.php';
 
 	// Experimental autosaves controller override for real-time collaboration.
-	require_once __DIR__ . '/experimental/class-gutenberg-rest-autosaves-controller.php';
+	require_once __DIR__ . '/experimental/sync/class-gutenberg-rest-autosaves-controller.php';
 
 	require_once __DIR__ . '/experimental/rest-api.php';
 	require_once __DIR__ . '/experimental/kses-allowed-html.php';

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -644,19 +644,6 @@ export const saveEntityRecord =
 						...autosavePost,
 						...record,
 					};
-					// Additionally call the entity-specific pre-persist handler, since
-					// autosaves can target the actual persisted entity in some cases.
-					if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-						if ( entityConfig.__unstablePrePersist ) {
-							data = {
-								...data,
-								...entityConfig.__unstablePrePersist(
-									persistedRecord,
-									data
-								),
-							};
-						}
-					}
 					data = Object.keys( data ).reduce(
 						( acc, key ) => {
 							if (


### PR DESCRIPTION
## What?

This PR fixes a behavior in real-time collaboration that caused apparent data loss to collaborators who were not the original author depending on original author and post lock, which is unexpected behavior in the context of RTC.

## How?

Fix for [this particular autosave behavior](https://github.com/WordPress/wordpress-develop/blob/6.9.1/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L233-L244) in WordPress.

In the context of RTC, we don't care if a user has the post lock or is the original author when `$is_draft` is true. In both cases, ~update the post content directly instead of creating an autosave revision~ create an autosave revision.

Otherwise:
- Autosaves from the original author (if they have the post lock) will become part of the saved post content automatically.
- Autosaves from other users are applied to a post revision.
- If any user reloads a post, they see the content from the author's autosave as it's applied direcly to the document via wp_update_post(). All other users are treated differently and their autosaved edits won't be applied to the post.

This change ensures the behavior is consistent for all users as post lock is not relevant in the context of RTC.

## Testing Instructions

The original issue can be reproduced following these steps:

1. Create a new post, add a title, and content, and save draft.
2. Join with a second user (it can’t be the same user) and add content.
3. Do nothing else for the second user. Do not save manually.
4. Wait until an autosave occurs for the second user.
5. Close the page for the first user.
6. Edit the post again in the same browser as the first user.
7. The content added by the second user is removed as soon as the first browser loads.
8. You will see a message in the first browser about a “more recent autosave” clicking to view that will show a blank autosave.

In this PR, on step 6, the content from the second user will not be removed from the post. To test:

1. Check out this PR.
2. Edit [this line](https://github.com/WordPress/gutenberg/blob/48ce44dac7981eb730079563a3a2975b89840fac/packages/sync/src/providers/index.ts#L49) per the comment to enable syncing
3. Follow the steps above.