### PR TITLE
Prevent fatal error when the inline CSS duotone variable is an array

### DIFF
--- a/backport-changelog/7.0/10883.md
+++ b/backport-changelog/7.0/10883.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10883
+
+* https://github.com/WordPress/gutenberg/pull/75283

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -452,6 +452,10 @@ class WP_Duotone_Gutenberg {
 	 * @return string The slug of the duotone preset or an empty string if no slug is found.
 	 */
 	private static function get_slug_from_attribute( $duotone_attr ) {
+		if ( ! is_string( $duotone_attr ) ) {
+			return '';
+		}
+
 		// Uses Branch Reset Groups `(?|…)` to return one capture group.
 		preg_match( '/(?|var:preset\|duotone\|(\S+)|var\(--wp--preset--duotone--(\S+)\))/', $duotone_attr, $matches );
 
@@ -465,6 +469,10 @@ class WP_Duotone_Gutenberg {
 	 * @return bool True if the duotone preset present and valid.
 	 */
 	private static function is_preset( $duotone_attr ) {
+		if ( ! is_string( $duotone_attr ) ) {
+			return false;
+		}
+
 		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
@@ -809,6 +817,11 @@ class WP_Duotone_Gutenberg {
 				continue;
 			}
 			// If it has a duotone filter preset, save the block name and the preset slug.
+			// Only process if it's a string (preset reference), not an array (custom colors).
+			if ( ! is_string( $duotone_attr ) ) {
+				continue;
+			}
+
 			$slug = self::get_slug_from_attribute( $duotone_attr );
 
 			if ( $slug && $slug !== $duotone_attr ) {

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -448,8 +448,8 @@ class WP_Duotone_Gutenberg {
 	 * var:preset|duotone|blue-orange
 	 * var(--wp--preset--duotone--blue-orange)
 	 *
-	 * @param string $duotone_attr The duotone attribute from a block.
-	 * @return string The slug of the duotone preset or an empty string if no slug is found.
+	 * @param string|string[] $duotone_attr The duotone attribute from a block.
+	 * @return string The slug of the duotone preset or an empty string if no slug is found (including when an array was passed).
 	 */
 	private static function get_slug_from_attribute( $duotone_attr ) {
 		if ( ! is_string( $duotone_attr ) ) {
@@ -465,7 +465,7 @@ class WP_Duotone_Gutenberg {
 	/**
 	 * Check if we have a valid duotone preset.
 	 *
-	 * @param string $duotone_attr The duotone attribute from a block.
+	 * @param string|string[] $duotone_attr The duotone attribute from a block.
 	 * @return bool True if the duotone preset present and valid.
 	 */
 	private static function is_preset( $duotone_attr ) {

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -94,6 +94,8 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 			'pipe-slug-no-value'              => array( 'var:preset|duotone|', '' ),
 			'css-var-spaces'                  => array( 'var(--wp--preset--duotone--    ', '' ),
 			'pipe-slug-spaces'                => array( 'var:preset|duotone|  ', '' ),
+			'array-of-colors'                 => array( array( '#000000', '#ffffff' ), '' ),
+			'empty-array'                     => array( array(), '' ),
 		);
 	}
 
@@ -115,6 +117,8 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 			'css-var-invalid-slug-chars'      => array( 'var(--wp--preset--duotone--.)', false ),
 			'css-var-missing-end-parenthesis' => array( 'var(--wp--preset--duotone--blue-orange', false ),
 			'invalid'                         => array( 'not a valid attribute', false ),
+			'array-of-colors'                 => array( array( '#000000', '#ffffff' ), false ),
+			'empty-array'                     => array( array(), false ),
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I've encountered fatal errors on the `get_slug_from_attribute` function when the `$duotone_attr` is an array:

```
Fatal error: Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in /var/www/html/wp-content/plugins/gutenberg/lib/class-wp-duotone-gutenberg.php:456
Stack trace:
#0 /var/www/html/wp-content/plugins/gutenberg/lib/class-wp-duotone-gutenberg.php(456): preg_match('/(?|var:preset\\...', Array, NULL)
#1 /var/www/html/wp-content/plugins/gutenberg/lib/class-wp-duotone-gutenberg.php(812): WP_Duotone_Gutenberg::get_slug_from_attribute(Array)
#2 /var/www/html/wp-includes/class-wp-hook.php(341): WP_Duotone_Gutenberg::set_global_style_block_names('')
#3 /var/www/html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters(NULL, Array)
#4 /var/www/html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#5 /var/www/html/wp-settings.php(774): do_action('wp_loaded')
#6 /var/www/html/wp-config.php(148): require_once('/var/www/html/w...')
#7 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...')
#8 /var/www/html/wp-blog-header.php(13): require_once('/var/www/html/w...')
#9 /var/www/html/index.php(17): require('/var/www/html/w...')
#10 {main}
  thrown in /var/www/html/wp-content/plugins/gutenberg/lib/class-wp-duotone-gutenberg.php on line 456
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR fixes that by checking whether the `$duotone_attr` is a string, which is the usual scenario.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Checkout to this branch
2. On your local `gutenberg` directory: `npx wp-env start`
3. `npm run dev`
4. Go to http://localhost:8888/wp-admin/theme-install.php?browse=popular
5. Click on `Upload Theme`
6. Upload this zip file: [test-theme.zip](https://github.com/user-attachments/files/25129544/test-theme.zip). It contains a test theme with an array value for duotone
7. Click on `Install Now`.
8. Click on `Activate`.
9. Checkout to `trunk`
10. Reload http://localhost:8888/wp-admin/themes.php
11. Check that you get the fatal error:

<img width="2834" height="1567" alt="image" src="https://github.com/user-attachments/assets/616b9bcb-b940-4dba-947a-7b19de32d537" />

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
