### PR TITLE
Fix awareness timeout documentation unit

### DIFF
--- a/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
+++ b/lib/experimental/sync/class-gutenberg-http-polling-sync-server.php
@@ -18,7 +18,7 @@ class Gutenberg_HTTP_Polling_Sync_Server {
 	const REST_NAMESPACE = 'wp/v2/sync';
 
 	/**
-	 * Awareness timeout in milliseconds. Clients that haven't updated
+	 * Awareness timeout in seconds. Clients that haven't updated
 	 * their awareness state within this time are considered disconnected.
 	 */
 	const AWARENESS_TIMEOUT_IN_S = 30; // 30 seconds


### PR DESCRIPTION
Updated awareness timeout constant documentation to reflect seconds instead of milliseconds.

## What?
Minor comment update to reflect functionality.