### PR TITLE
TimePicker: Add minYear prop and Invalid Date guard

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#75343](https://github.com/WordPress/gutenberg/pull/75343)).
--   `TimePicker`: Fix Invalid Date errors by implementing ISO 8601 compliant year formatting. Years below 1000 are now properly zero-padded (e.g., year 999 becomes "0999") to ensure reliable date parsing ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
+-   `TimePicker`: Prevent Invalid Date from propagating via `onChange` when date fields are cleared ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#75343](https://github.com/WordPress/gutenberg/pull/75343)).
--   `TimePicker`: Fix Invalid Date propagation that caused critical errors when clearing date fields during post scheduling ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
+-   `TimePicker`: Fix Invalid Date errors by implementing ISO 8601 compliant year formatting. Years below 1000 are now properly zero-padded (e.g., year 999 becomes "0999") to ensure reliable date parsing ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).
@@ -13,7 +13,7 @@
 
 ### Enhancements
 
--   `TimePicker`, `DateTimePicker`: Add `minYear` prop to control minimum selectable year (defaults to 1000) ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
+-   `TimePicker`, `DateTimePicker`: Add `minYear` prop to control minimum selectable year. Defaults to 1, enabling support for historical dates. Post scheduling continues to restrict dates to the current year and future via the `minYear` prop ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
 -   Improve visual emphasis of the selected item in the ToggleGroupControl component ([#75138](https://github.com/WordPress/gutenberg/pull/75138)).
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#75343](https://github.com/WordPress/gutenberg/pull/75343)).
+-   `TimePicker`: Fix Invalid Date propagation that caused critical errors when clearing date fields during post scheduling ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).
@@ -12,6 +13,7 @@
 
 ### Enhancements
 
+-   `TimePicker`, `DateTimePicker`: Add `minYear` prop to control minimum selectable year (defaults to 1000) ([#75285](https://github.com/WordPress/gutenberg/pull/75285)).
 -   Improve visual emphasis of the selected item in the ToggleGroupControl component ([#75138](https://github.com/WordPress/gutenberg/pull/75138)).
 
 ### Internal

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -92,17 +92,15 @@ The day that the week should start on. 0 for Sunday, 1 for Monday, etc.
 
 ### `minYear`: `number`
 
-The minimum year that can be selected in the date fields. This prop helps prevent invalid dates from being created.
-
-**Important:** Internally, the component enforces a minimum of 1000 for the year field regardless of the `minYear` value provided. This is because years below 1000 cannot be reliably parsed by moment.js (used internally) and would cause deprecation warnings or parsing errors.
+The minimum year that can be selected in the year input field.
 
 - Required: No
-- Default: `1000`
+- Default: `1`
 
 **Usage examples:**
 
 ```jsx
-// Default behavior - allows years from 1000 onwards
+// Default behavior - allows years from 1 onwards
 <DateTimePicker
 	currentDate={ date }
 	onChange={ setDate }

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -89,3 +89,29 @@ The day that the week should start on. 0 for Sunday, 1 for Monday, etc.
 
 - Required: No
 - Default: 0
+
+### `minYear`: `number`
+
+The minimum year that can be selected in the date fields. This prop helps prevent invalid dates from being created.
+
+**Important:** Internally, the component enforces a minimum of 1000 for the year field regardless of the `minYear` value provided. This is because years below 1000 cannot be reliably parsed by moment.js (used internally) and would cause deprecation warnings or parsing errors.
+
+- Required: No
+- Default: `1000`
+
+**Usage examples:**
+
+```jsx
+// Default behavior - allows years from 1000 onwards
+<DateTimePicker
+	currentDate={ date }
+	onChange={ setDate }
+/>
+
+// For post scheduling - restrict to current year and future only
+<DateTimePicker
+	currentDate={ date }
+	onChange={ setDate }
+	minYear={ new Date().getFullYear() }
+/>
+```

--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -30,7 +30,7 @@ function UnforwardedDateTimePicker(
 		onChange,
 		events,
 		startOfWeek,
-		minYear = 1000,
+		minYear = 1,
 	}: DateTimePickerProps,
 	ref: ForwardedRef< any >
 ) {

--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -30,6 +30,7 @@ function UnforwardedDateTimePicker(
 		onChange,
 		events,
 		startOfWeek,
+		minYear,
 	}: DateTimePickerProps,
 	ref: ForwardedRef< any >
 ) {
@@ -41,6 +42,7 @@ function UnforwardedDateTimePicker(
 					onChange={ onChange }
 					is12Hour={ is12Hour }
 					dateOrder={ dateOrder }
+					minYear={ minYear }
 				/>
 				<DatePicker
 					currentDate={ currentDate }

--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -30,7 +30,7 @@ function UnforwardedDateTimePicker(
 		onChange,
 		events,
 		startOfWeek,
-		minYear,
+		minYear = 1000,
 	}: DateTimePickerProps,
 	ref: ForwardedRef< any >
 ) {

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -128,13 +128,13 @@ export function TimePicker( {
 			// We can safely assume value is a number if target is valid.
 			const numberValue = Number( value );
 
-			// Sanity check for year values - reject unreasonably small years
+			// Confidence check for year values - reject unreasonably small years
 			// that would create dates moment can't parse properly
 			if ( method === 'year' && numberValue < 1000 ) {
 				return;
 			}
 
-			// Sanity check for day values - must be positive
+			// Confidence check for day values - must be positive
 			if ( method === 'date' && numberValue < 1 ) {
 				return;
 			}

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -127,13 +127,9 @@ export function TimePicker( {
 
 	const buildNumberControlChangeCallback = ( method: 'date' | 'year' ) => {
 		const callback: InputChangeCallback = ( value, { event } ) => {
+			// validateInputElementTarget checks event.target.validity.valid,
+			// which catches empty values via the 'required' attribute
 			if ( ! validateInputElementTarget( event ) ) {
-				return;
-			}
-
-			// Ignore empty values - they can occur during user interaction
-			// before browser constraint validation coerces to min value
-			if ( value === '' || value === null || value === undefined ) {
 				return;
 			}
 

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -40,20 +40,6 @@ import { TimeInput } from './time-input';
 const VALID_DATE_ORDERS = [ 'dmy', 'mdy', 'ymd' ];
 
 /**
- * Minimum year that can be reliably parsed by moment.js and Date().
- *
- * Years below 1000 cause moment.js (used internally by setInConfiguredTimezone)
- * to emit deprecation warnings and fall back to unreliable js Date() parsing.
- * This constant is used as:
- * - The default value for the minYear prop
- * - An internal guard to prevent Invalid Date propagation
- *
- * Even if consumers pass minYear={1}, dates with years < 1000 are blocked
- * internally to prevent moment.js issues.
- */
-const MIN_SUPPORTED_YEAR = 1000;
-
-/**
  * TimePicker is a React component that renders a clock for time selection.
  *
  * ```jsx
@@ -79,7 +65,7 @@ export function TimePicker( {
 	onChange,
 	dateOrder: dateOrderProp,
 	hideLabelFromVision = false,
-	minYear = MIN_SUPPORTED_YEAR,
+	minYear = 1,
 }: TimePickerProps ) {
 	const [ date, setDate ] = useState( () =>
 		// Truncate the date at the minutes, see: #15495.
@@ -122,12 +108,8 @@ export function TimePicker( {
 	);
 
 	const updateDate = ( newDate: Date ) => {
+		// Guard against Invalid Date propagation.
 		if ( newDate instanceof Date && ! Number.isFinite( newDate.getTime() ) ) {
-			return;
-		}
-
-		// Guard against years below MIN_SUPPORTED_YEAR to prevent Invalid Date propagation.
-		if ( newDate.getFullYear() < MIN_SUPPORTED_YEAR ) {
 			return;
 		}
 
@@ -143,13 +125,8 @@ export function TimePicker( {
 				return;
 			}
 
-		// We can safely assume value is a number if target is valid.
-		const numberValue = Number( value );
-
-		// Prevent years below MIN_SUPPORTED_YEAR to guard against Invalid Date.
-		if ( method === 'year' && numberValue < MIN_SUPPORTED_YEAR ) {
-			return;
-		}
+			// We can safely assume value is a number if target is valid.
+			const numberValue = Number( value );
 
 			// Internal date is UTC-normalized, but the field should be updated
 			// as if in the configured timezone.

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -65,6 +65,7 @@ export function TimePicker( {
 	onChange,
 	dateOrder: dateOrderProp,
 	hideLabelFromVision = false,
+	minYear = 1000,
 }: TimePickerProps ) {
 	const [ date, setDate ] = useState( () =>
 		// Truncate the date at the minutes, see: #15495.
@@ -120,24 +121,14 @@ export function TimePicker( {
 				return;
 			}
 
-			// Ignore empty values (they produce 0 which creates invalid dates)
+			// Ignore empty values - they can occur during user interaction
+			// before browser constraint validation coerces to min value
 			if ( value === '' || value === null || value === undefined ) {
 				return;
 			}
 
 			// We can safely assume value is a number if target is valid.
 			const numberValue = Number( value );
-
-			// Confidence check for year values - reject unreasonably small years
-			// that would create dates moment can't parse properly
-			if ( method === 'year' && numberValue < 1000 ) {
-				return;
-			}
-
-			// Confidence check for day values - must be positive
-			if ( method === 'date' && numberValue < 1 ) {
-				return;
-			}
 
 			// Internal date is UTC-normalized, but the field should be updated
 			// as if in the configured timezone.
@@ -212,7 +203,7 @@ export function TimePicker( {
 			__next40pxDefaultSize
 			value={ year }
 			step={ 1 }
-			min={ 1 }
+			min={ minYear }
 			max={ 9999 }
 			required
 			spinControls="none"

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -111,6 +111,16 @@ export function TimePicker( {
 		if ( ! Number.isFinite( newDate.getTime() ) ) {
 			return;
 		}
+
+		// Guard against years below 1000 that moment.js cannot parse reliably.
+		// Even if a consumer passes minYear={1}, the browser will enforce it
+		// but moment.js (used internally by setInConfiguredTimezone) will emit
+		// deprecation warnings and fall back to unreliable js Date() parsing.
+		// This prevents those dates from reaching onChange.
+		if ( newDate.getFullYear() < 1000 ) {
+			return;
+		}
+
 		setDate( newDate );
 		onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
 	};
@@ -129,6 +139,14 @@ export function TimePicker( {
 
 			// We can safely assume value is a number if target is valid.
 			const numberValue = Number( value );
+
+			// Prevent years below 1000 from reaching setInConfiguredTimezone.
+			// Even if minYear allows lower values, moment.js (used internally)
+			// cannot parse dates with years < 1000 reliably and will emit
+			// deprecation warnings.
+			if ( method === 'year' && numberValue < 1000 ) {
+				return;
+			}
 
 			// Internal date is UTC-normalized, but the field should be updated
 			// as if in the configured timezone.

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -106,22 +106,45 @@ export function TimePicker( {
 		[ date ]
 	);
 
+	const updateDate = ( newDate: Date ) => {
+		if ( ! Number.isFinite( newDate.getTime() ) ) {
+			return;
+		}
+		setDate( newDate );
+		onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
+	};
+
 	const buildNumberControlChangeCallback = ( method: 'date' | 'year' ) => {
 		const callback: InputChangeCallback = ( value, { event } ) => {
 			if ( ! validateInputElementTarget( event ) ) {
 				return;
 			}
 
+			// Ignore empty values (they produce 0 which creates invalid dates)
+			if ( value === '' || value === null || value === undefined ) {
+				return;
+			}
+
 			// We can safely assume value is a number if target is valid.
 			const numberValue = Number( value );
+
+			// Sanity check for year values - reject unreasonably small years
+			// that would create dates moment can't parse properly
+			if ( method === 'year' && numberValue < 1000 ) {
+				return;
+			}
+
+			// Sanity check for day values - must be positive
+			if ( method === 'date' && numberValue < 1 ) {
+				return;
+			}
 
 			// Internal date is UTC-normalized, but the field should be updated
 			// as if in the configured timezone.
 			const newDate = setInConfiguredTimezone( date, {
 				[ method ]: numberValue,
 			} );
-			setDate( newDate );
-			onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
+			updateDate( newDate );
 		};
 		return callback;
 	};
@@ -136,8 +159,7 @@ export function TimePicker( {
 			hours: newHours,
 			minutes: newMinutes,
 		} );
-		setDate( newDate );
-		onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
+		updateDate( newDate );
 	};
 
 	const dayField = (
@@ -175,8 +197,7 @@ export function TimePicker( {
 					const newDate = setInConfiguredTimezone( date, {
 						month: Number( value ) - 1,
 					} );
-					setDate( newDate );
-					onChange?.( formatDate( TIMEZONELESS_FORMAT, newDate ) );
+					updateDate( newDate );
 				} }
 			/>
 		</MonthSelectWrapper>

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -109,7 +109,10 @@ export function TimePicker( {
 
 	const updateDate = ( newDate: Date ) => {
 		// Guard against Invalid Date propagation.
-		if ( newDate instanceof Date && ! Number.isFinite( newDate.getTime() ) ) {
+		if (
+			newDate instanceof Date &&
+			! Number.isFinite( newDate.getTime() )
+		) {
 			return;
 		}
 

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -40,6 +40,20 @@ import { TimeInput } from './time-input';
 const VALID_DATE_ORDERS = [ 'dmy', 'mdy', 'ymd' ];
 
 /**
+ * Minimum year that can be reliably parsed by moment.js and Date().
+ *
+ * Years below 1000 cause moment.js (used internally by setInConfiguredTimezone)
+ * to emit deprecation warnings and fall back to unreliable js Date() parsing.
+ * This constant is used as:
+ * - The default value for the minYear prop
+ * - An internal guard to prevent Invalid Date propagation
+ *
+ * Even if consumers pass minYear={1}, dates with years < 1000 are blocked
+ * internally to prevent moment.js issues.
+ */
+const MIN_SUPPORTED_YEAR = 1000;
+
+/**
  * TimePicker is a React component that renders a clock for time selection.
  *
  * ```jsx
@@ -65,7 +79,7 @@ export function TimePicker( {
 	onChange,
 	dateOrder: dateOrderProp,
 	hideLabelFromVision = false,
-	minYear = 1000,
+	minYear = MIN_SUPPORTED_YEAR,
 }: TimePickerProps ) {
 	const [ date, setDate ] = useState( () =>
 		// Truncate the date at the minutes, see: #15495.
@@ -108,16 +122,12 @@ export function TimePicker( {
 	);
 
 	const updateDate = ( newDate: Date ) => {
-		if ( ! Number.isFinite( newDate.getTime() ) ) {
+		if ( newDate instanceof Date && ! Number.isFinite( newDate.getTime() ) ) {
 			return;
 		}
 
-		// Guard against years below 1000 that moment.js cannot parse reliably.
-		// Even if a consumer passes minYear={1}, the browser will enforce it
-		// but moment.js (used internally by setInConfiguredTimezone) will emit
-		// deprecation warnings and fall back to unreliable js Date() parsing.
-		// This prevents those dates from reaching onChange.
-		if ( newDate.getFullYear() < 1000 ) {
+		// Guard against years below MIN_SUPPORTED_YEAR to prevent Invalid Date propagation.
+		if ( newDate.getFullYear() < MIN_SUPPORTED_YEAR ) {
 			return;
 		}
 
@@ -133,16 +143,13 @@ export function TimePicker( {
 				return;
 			}
 
-			// We can safely assume value is a number if target is valid.
-			const numberValue = Number( value );
+		// We can safely assume value is a number if target is valid.
+		const numberValue = Number( value );
 
-			// Prevent years below 1000 from reaching setInConfiguredTimezone.
-			// Even if minYear allows lower values, moment.js (used internally)
-			// cannot parse dates with years < 1000 reliably and will emit
-			// deprecation warnings.
-			if ( method === 'year' && numberValue < 1000 ) {
-				return;
-			}
+		// Prevent years below MIN_SUPPORTED_YEAR to guard against Invalid Date.
+		if ( method === 'year' && numberValue < MIN_SUPPORTED_YEAR ) {
+			return;
+		}
 
 			// Internal date is UTC-normalized, but the field should be updated
 			// as if in the configured timezone.

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -638,10 +638,11 @@ describe( 'TimePicker', () => {
 		it( 'should not call onChange when year is cleared and blurred', async () => {
 			const user = userEvent.setup();
 			const onChangeSpy = jest.fn();
+			const year = '1986';
 
 			render(
 				<TimePicker
-					currentTime="1986-10-18T11:00:00"
+					currentTime={ `${ year }-10-18T11:00:00` }
 					onChange={ onChangeSpy }
 					is12Hour
 				/>
@@ -659,6 +660,8 @@ describe( 'TimePicker', () => {
 			// should prevent onChange from being called.
 			const callCountAfterClear = onChangeSpy.mock.calls.length;
 			expect( callCountAfterClear ).toBe( initialCallCount ); // No new calls made
+
+			expect( yearInput ).toHaveValue( year );
 		} );
 
 		it( 'should not call onChange with an invalid date when day is cleared and month is changed', async () => {
@@ -686,7 +689,9 @@ describe( 'TimePicker', () => {
 			// should have properly formatted dates without "NaN" or "Invalid".
 			onChangeSpy.mock.calls.forEach( ( call ) => {
 				const dateString = call[ 0 ];
-				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
+				expect( dateString ).toMatch(
+					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
+				);
 				expect( dateString ).not.toContain( 'NaN' );
 				expect( dateString ).not.toContain( 'Invalid' );
 			} );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -650,14 +650,15 @@ describe( 'TimePicker', () => {
 			const yearInput = screen.getByLabelText( 'Year' );
 			const initialCallCount = onChangeSpy.mock.calls.length;
 
-			// Clear the year field
+			// Clear the year field and blur
 			await user.clear( yearInput );
-			// Blur the field (tab away)
 			await user.keyboard( '{Tab}' );
 
-			// onChange should not be called when the year is cleared
-			// because it would produce an invalid date
-			expect( onChangeSpy ).toHaveBeenCalledTimes( initialCallCount );
+			// Verify onChange was not called with an invalid date.
+			// Clearing the year would create an Invalid Date, so our guard
+			// should prevent onChange from being called.
+			const callCountAfterClear = onChangeSpy.mock.calls.length;
+			expect( callCountAfterClear ).toBe( initialCallCount ); // No new calls made
 		} );
 
 		it( 'should not call onChange with an invalid date when day is cleared and month is changed', async () => {
@@ -677,10 +678,12 @@ describe( 'TimePicker', () => {
 
 			// Clear the day field
 			await user.clear( dayInput );
-			// Change the month
+			// Change the month (this would create an invalid date if day is 0)
 			await user.selectOptions( monthInput, '12' );
 
-			// All onChange calls should have valid date strings
+			// Verify that if onChange was called, it only received valid date strings.
+			// Our guard should prevent invalid dates from being emitted, so any calls
+			// should have properly formatted dates without "NaN" or "Invalid".
 			onChangeSpy.mock.calls.forEach( ( call ) => {
 				const dateString = call[ 0 ];
 				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -649,19 +649,22 @@ describe( 'TimePicker', () => {
 
 			const yearInput = screen.getByLabelText( 'Year' );
 
-			// Clear the year field and blur
-			await user.clear( yearInput );
-			await user.keyboard( '{Tab}' );
+		// Clear the year field and blur
+		await user.clear( yearInput );
+		await user.keyboard( '{Tab}' );
 
-			// When the year is cleared, the browser may coerce to minYear.
-			// If onChange is called, it should only emit valid date strings.
-			onChangeSpy.mock.calls.forEach( ( call ) => {
-				const dateString = call[ 0 ];
-				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
-				expect( dateString ).not.toContain( 'NaN' );
-				expect( dateString ).not.toContain( 'Invalid' );
-			} );
+		// Verify the input field value after browser coercion
+		expect( yearInput ).toHaveValue( 1000 );
+
+		// When the year is cleared, the browser may coerce to minYear.
+		// If onChange is called, it should only emit valid date strings.
+		onChangeSpy.mock.calls.forEach( ( call ) => {
+			const dateString = call[ 0 ];
+			expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
+			expect( dateString ).not.toContain( 'NaN' );
+			expect( dateString ).not.toContain( 'Invalid' );
 		} );
+	} );
 
 		it( 'should not call onChange with an invalid date when day is cleared and month is changed', async () => {
 			const user = userEvent.setup();
@@ -678,23 +681,26 @@ describe( 'TimePicker', () => {
 			const dayInput = screen.getByLabelText( 'Day' );
 			const monthInput = screen.getByLabelText( 'Month' );
 
-			// Clear the day field
-			await user.clear( dayInput );
-			// Change the month (this would create an invalid date if day is 0)
-			await user.selectOptions( monthInput, '12' );
+		// Clear the day field
+		await user.clear( dayInput );
+		// Change the month (this would create an invalid date if day is 0)
+		await user.selectOptions( monthInput, '12' );
 
-			// Verify that if onChange was called, it only received valid date strings.
-			// Our guard should prevent invalid dates from being emitted, so any calls
-			// should have properly formatted dates without "NaN" or "Invalid".
-			onChangeSpy.mock.calls.forEach( ( call ) => {
-				const dateString = call[ 0 ];
-				expect( dateString ).toMatch(
-					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
-				);
-				expect( dateString ).not.toContain( 'NaN' );
-				expect( dateString ).not.toContain( 'Invalid' );
-			} );
+		// Verify the input field value after browser coercion
+		expect( dayInput ).toHaveValue( 1 );
+
+		// Verify that if onChange was called, it only received valid date strings.
+		// Our guard should prevent invalid dates from being emitted, so any calls
+		// should have properly formatted dates without "NaN" or "Invalid".
+		onChangeSpy.mock.calls.forEach( ( call ) => {
+			const dateString = call[ 0 ];
+			expect( dateString ).toMatch(
+				/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
+			);
+			expect( dateString ).not.toContain( 'NaN' );
+			expect( dateString ).not.toContain( 'Invalid' );
 		} );
+	} );
 
 		it( 'should handle years below 1000 when minYear allows them without moment.js warnings', async () => {
 			const user = userEvent.setup();
@@ -712,18 +718,23 @@ describe( 'TimePicker', () => {
 
 			const yearInput = screen.getByLabelText( 'Year' );
 
-			// Clear the year field and blur - browser will coerce to minYear (1)
-			await user.clear( yearInput );
-			await user.keyboard( '{Tab}' );
+		// Clear the year field and blur - browser will coerce to minYear (1)
+		await user.clear( yearInput );
+		await user.keyboard( '{Tab}' );
 
-			// Verify that if onChange was called, it only received valid date strings
-			// without triggering moment.js warnings
-			onChangeSpy.mock.calls.forEach( ( call ) => {
-				const dateString = call[ 0 ];
-				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
-				expect( dateString ).not.toContain( 'NaN' );
-				expect( dateString ).not.toContain( 'Invalid' );
-			} );
+		// Verify the input field value after browser coercion to minYear
+		expect( yearInput ).toHaveValue( 1 );
+
+		// Our internal guard should prevent years < 1000 from propagating,
+		// so onChange should NOT have been called with the year 1
+		// Verify that if onChange was called, it only received valid date strings
+		// without triggering moment.js warnings
+		onChangeSpy.mock.calls.forEach( ( call ) => {
+			const dateString = call[ 0 ];
+			expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
+			expect( dateString ).not.toContain( 'NaN' );
+			expect( dateString ).not.toContain( 'Invalid' );
 		} );
+	} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -695,5 +695,35 @@ describe( 'TimePicker', () => {
 				expect( dateString ).not.toContain( 'Invalid' );
 			} );
 		} );
+
+		it( 'should handle years below 1000 when minYear allows them without moment.js warnings', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			// Set minYear to 1, which browser will enforce but moment.js may struggle with
+			render(
+				<TimePicker
+					currentTime="1986-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+					is12Hour
+				/>
+			);
+
+			const yearInput = screen.getByLabelText( 'Year' );
+
+			// Clear the year field and blur - browser will coerce to minYear (1)
+			await user.clear( yearInput );
+			await user.keyboard( '{Tab}' );
+
+			// Verify that if onChange was called, it only received valid date strings
+			// without triggering moment.js warnings
+			onChangeSpy.mock.calls.forEach( ( call ) => {
+				const dateString = call[ 0 ];
+				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
+				expect( dateString ).not.toContain( 'NaN' );
+				expect( dateString ).not.toContain( 'Invalid' );
+			} );
+		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -635,26 +635,26 @@ describe( 'TimePicker', () => {
 	} );
 
 	describe( 'Invalid date handling', () => {
-		it( 'should not emit invalid dates when year is cleared and blurred', async () => {
-			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+	it( 'should not emit invalid dates when year is cleared and blurred', async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = jest.fn();
 
-			render(
-				<TimePicker
-					currentTime="1986-10-18T11:00:00"
-					onChange={ onChangeSpy }
-					is12Hour
-				/>
-			);
+		render(
+			<TimePicker
+				currentTime="1986-10-18T11:00:00"
+				onChange={ onChangeSpy }
+				is12Hour
+			/>
+		);
 
-			const yearInput = screen.getByLabelText( 'Year' );
+		const yearInput = screen.getByLabelText( 'Year' );
 
 		// Clear the year field and blur
 		await user.clear( yearInput );
 		await user.keyboard( '{Tab}' );
 
 		// Verify the input field value after browser coercion
-		expect( yearInput ).toHaveValue( 1000 );
+		expect( yearInput ).toHaveValue( 1 );
 
 		// When the year is cleared, the browser may coerce to minYear.
 		// If onChange is called, it should only emit valid date strings.
@@ -702,21 +702,20 @@ describe( 'TimePicker', () => {
 		} );
 	} );
 
-		it( 'should handle years below 1000 when minYear allows them without moment.js warnings', async () => {
-			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+	it( 'should handle years below 1000 when minYear allows them', async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = jest.fn();
 
-			// Set minYear to 1, which browser will enforce but moment.js may struggle with
-			render(
-				<TimePicker
-					currentTime="1986-10-18T11:00:00"
-					onChange={ onChangeSpy }
-					minYear={ 1 }
-					is12Hour
-				/>
-			);
+		render(
+			<TimePicker
+				currentTime="1986-10-18T11:00:00"
+				onChange={ onChangeSpy }
+				minYear={ 1 }
+				is12Hour
+			/>
+		);
 
-			const yearInput = screen.getByLabelText( 'Year' );
+		const yearInput = screen.getByLabelText( 'Year' );
 
 		// Clear the year field and blur - browser will coerce to minYear (1)
 		await user.clear( yearInput );
@@ -725,10 +724,7 @@ describe( 'TimePicker', () => {
 		// Verify the input field value after browser coercion to minYear
 		expect( yearInput ).toHaveValue( 1 );
 
-		// Our internal guard should prevent years < 1000 from propagating,
-		// so onChange should NOT have been called with the year 1
 		// Verify that if onChange was called, it only received valid date strings
-		// without triggering moment.js warnings
 		onChangeSpy.mock.calls.forEach( ( call ) => {
 			const dateString = call[ 0 ];
 			expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
@@ -736,5 +732,123 @@ describe( 'TimePicker', () => {
 			expect( dateString ).not.toContain( 'Invalid' );
 		} );
 	} );
+	} );
+
+	describe( 'Years below 1000 support', () => {
+		it( 'should handle year 999 with zero-padded output', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="0999-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+				/>
+			);
+
+		const yearInput = screen.getByLabelText( 'Year' );
+
+		// Verify input displays human-readable year (not zero-padded)
+		expect( yearInput ).toHaveValue( 999 );
+
+		// Change to year 500
+		await user.clear( yearInput );
+		await user.type( yearInput, '500' );
+		await user.keyboard( '{Tab}' );
+
+		// Verify onChange emits zero-padded ISO 8601 format
+		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+		expect( lastCall[ 0 ] ).toMatch( /^0500-10-18T/ );
+		expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
+		} );
+
+		it( 'should handle year 1 with zero-padded output', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="0001-01-01T12:00:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+				/>
+			);
+
+		const yearInput = screen.getByLabelText( 'Year' );
+
+		// Verify input displays human-readable year (not zero-padded)
+		expect( yearInput ).toHaveValue( 1 );
+
+		// Change to year 99
+		await user.clear( yearInput );
+		await user.type( yearInput, '99' );
+		await user.keyboard( '{Tab}' );
+
+		// Verify input displays human-readable year
+		expect( yearInput ).toHaveValue( 99 );
+
+		// Verify onChange emits zero-padded ISO 8601 format
+		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+		expect( lastCall[ 0 ] ).toMatch( /^0099-01-01T/ );
+		} );
+
+	it( 'should allow years below 1000 when minYear permits', async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = jest.fn();
+
+		render(
+			<TimePicker
+				currentTime="1986-10-18T11:00:00"
+				onChange={ onChangeSpy }
+				minYear={ 1 }
+			/>
+		);
+
+		const yearInput = screen.getByLabelText( 'Year' );
+
+		// Type year 500 - should be allowed
+		await user.clear( yearInput );
+		await user.type( yearInput, '500' );
+		await user.keyboard( '{Tab}' );
+
+		// Verify input displays human-readable year (not zero-padded)
+		expect( yearInput ).toHaveValue( 500 );
+
+		// Verify onChange was called with zero-padded ISO 8601 format
+		expect( onChangeSpy ).toHaveBeenCalled();
+		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+		expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
+	} );
+
+		it( 'should handle year 500 correctly', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="0500-06-15T09:30:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+				/>
+			);
+
+		const yearInput = screen.getByLabelText( 'Year' );
+
+		// Verify input displays human-readable year (not zero-padded)
+		expect( yearInput ).toHaveValue( 500 );
+
+		// Change to year 750
+		await user.clear( yearInput );
+		await user.type( yearInput, '750' );
+		await user.keyboard( '{Tab}' );
+
+		// Verify input displays human-readable year
+		expect( yearInput ).toHaveValue( 750 );
+
+		// Verify onChange emits zero-padded ISO 8601 format
+		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+		expect( lastCall[ 0 ] ).toMatch( /^0750-06-15T/ );
+		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -635,36 +635,38 @@ describe( 'TimePicker', () => {
 	} );
 
 	describe( 'Invalid date handling', () => {
-	it( 'should not emit invalid dates when year is cleared and blurred', async () => {
-		const user = userEvent.setup();
-		const onChangeSpy = jest.fn();
+		it( 'should not emit invalid dates when year is cleared and blurred', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
 
-		render(
-			<TimePicker
-				currentTime="1986-10-18T11:00:00"
-				onChange={ onChangeSpy }
-				is12Hour
-			/>
-		);
+			render(
+				<TimePicker
+					currentTime="1986-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					is12Hour
+				/>
+			);
 
-		const yearInput = screen.getByLabelText( 'Year' );
+			const yearInput = screen.getByLabelText( 'Year' );
 
-		// Clear the year field and blur
-		await user.clear( yearInput );
-		await user.keyboard( '{Tab}' );
+			// Clear the year field and blur
+			await user.clear( yearInput );
+			await user.keyboard( '{Tab}' );
 
-		// Verify the input field value after browser coercion
-		expect( yearInput ).toHaveValue( 1 );
+			// Verify the input field value after browser coercion
+			expect( yearInput ).toHaveValue( 1 );
 
-		// When the year is cleared, the browser may coerce to minYear.
-		// If onChange is called, it should only emit valid date strings.
-		onChangeSpy.mock.calls.forEach( ( call ) => {
-			const dateString = call[ 0 ];
-			expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
-			expect( dateString ).not.toContain( 'NaN' );
-			expect( dateString ).not.toContain( 'Invalid' );
+			// When the year is cleared, the browser may coerce to minYear.
+			// If onChange is called, it should only emit valid date strings.
+			onChangeSpy.mock.calls.forEach( ( call ) => {
+				const dateString = call[ 0 ];
+				expect( dateString ).toMatch(
+					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
+				);
+				expect( dateString ).not.toContain( 'NaN' );
+				expect( dateString ).not.toContain( 'Invalid' );
+			} );
 		} );
-	} );
 
 		it( 'should not call onChange with an invalid date when day is cleared and month is changed', async () => {
 			const user = userEvent.setup();
@@ -681,57 +683,59 @@ describe( 'TimePicker', () => {
 			const dayInput = screen.getByLabelText( 'Day' );
 			const monthInput = screen.getByLabelText( 'Month' );
 
-		// Clear the day field
-		await user.clear( dayInput );
-		// Change the month (this would create an invalid date if day is 0)
-		await user.selectOptions( monthInput, '12' );
+			// Clear the day field
+			await user.clear( dayInput );
+			// Change the month (this would create an invalid date if day is 0)
+			await user.selectOptions( monthInput, '12' );
 
-		// Verify the input field value after browser coercion
-		expect( dayInput ).toHaveValue( 1 );
+			// Verify the input field value after browser coercion
+			expect( dayInput ).toHaveValue( 1 );
 
-		// Verify that if onChange was called, it only received valid date strings.
-		// Our guard should prevent invalid dates from being emitted, so any calls
-		// should have properly formatted dates without "NaN" or "Invalid".
-		onChangeSpy.mock.calls.forEach( ( call ) => {
-			const dateString = call[ 0 ];
-			expect( dateString ).toMatch(
-				/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
+			// Verify that if onChange was called, it only received valid date strings.
+			// Our guard should prevent invalid dates from being emitted, so any calls
+			// should have properly formatted dates without "NaN" or "Invalid".
+			onChangeSpy.mock.calls.forEach( ( call ) => {
+				const dateString = call[ 0 ];
+				expect( dateString ).toMatch(
+					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
+				);
+				expect( dateString ).not.toContain( 'NaN' );
+				expect( dateString ).not.toContain( 'Invalid' );
+			} );
+		} );
+
+		it( 'should handle years below 1000 when minYear allows them', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="1986-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+					is12Hour
+				/>
 			);
-			expect( dateString ).not.toContain( 'NaN' );
-			expect( dateString ).not.toContain( 'Invalid' );
+
+			const yearInput = screen.getByLabelText( 'Year' );
+
+			// Clear the year field and blur - browser will coerce to minYear (1)
+			await user.clear( yearInput );
+			await user.keyboard( '{Tab}' );
+
+			// Verify the input field value after browser coercion to minYear
+			expect( yearInput ).toHaveValue( 1 );
+
+			// Verify that if onChange was called, it only received valid date strings
+			onChangeSpy.mock.calls.forEach( ( call ) => {
+				const dateString = call[ 0 ];
+				expect( dateString ).toMatch(
+					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
+				);
+				expect( dateString ).not.toContain( 'NaN' );
+				expect( dateString ).not.toContain( 'Invalid' );
+			} );
 		} );
-	} );
-
-	it( 'should handle years below 1000 when minYear allows them', async () => {
-		const user = userEvent.setup();
-		const onChangeSpy = jest.fn();
-
-		render(
-			<TimePicker
-				currentTime="1986-10-18T11:00:00"
-				onChange={ onChangeSpy }
-				minYear={ 1 }
-				is12Hour
-			/>
-		);
-
-		const yearInput = screen.getByLabelText( 'Year' );
-
-		// Clear the year field and blur - browser will coerce to minYear (1)
-		await user.clear( yearInput );
-		await user.keyboard( '{Tab}' );
-
-		// Verify the input field value after browser coercion to minYear
-		expect( yearInput ).toHaveValue( 1 );
-
-		// Verify that if onChange was called, it only received valid date strings
-		onChangeSpy.mock.calls.forEach( ( call ) => {
-			const dateString = call[ 0 ];
-			expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
-			expect( dateString ).not.toContain( 'NaN' );
-			expect( dateString ).not.toContain( 'Invalid' );
-		} );
-	} );
 	} );
 
 	describe( 'Years below 1000 support', () => {
@@ -747,23 +751,24 @@ describe( 'TimePicker', () => {
 				/>
 			);
 
-		const yearInput = screen.getByLabelText( 'Year' );
+			const yearInput = screen.getByLabelText( 'Year' );
 
-		// Verify input displays human-readable year (not zero-padded)
-		expect( yearInput ).toHaveValue( 999 );
+			// Verify input displays human-readable year (not zero-padded)
+			expect( yearInput ).toHaveValue( 999 );
 
-		// Change to year 500
-		await user.clear( yearInput );
-		await user.type( yearInput, '500' );
-		await user.keyboard( '{Tab}' );
+			// Change to year 500
+			await user.clear( yearInput );
+			await user.type( yearInput, '500' );
+			await user.keyboard( '{Tab}' );
 
-		// Verify input displays human-readable year
-		expect( yearInput ).toHaveValue( 500 );
+			// Verify input displays human-readable year
+			expect( yearInput ).toHaveValue( 500 );
 
-		// Verify onChange emits zero-padded ISO 8601 format
-		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-		expect( lastCall[ 0 ] ).toMatch( /^0500-10-18T/ );
-		expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
+			// Verify onChange emits zero-padded ISO 8601 format
+			const lastCall =
+				onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+			expect( lastCall[ 0 ] ).toMatch( /^0500-10-18T/ );
+			expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
 		} );
 
 		it( 'should handle year 1 with zero-padded output', async () => {
@@ -778,54 +783,56 @@ describe( 'TimePicker', () => {
 				/>
 			);
 
-		const yearInput = screen.getByLabelText( 'Year' );
+			const yearInput = screen.getByLabelText( 'Year' );
 
-		// Verify input displays human-readable year (not zero-padded)
-		expect( yearInput ).toHaveValue( 1 );
+			// Verify input displays human-readable year (not zero-padded)
+			expect( yearInput ).toHaveValue( 1 );
 
-		// Change to year 99
-		await user.clear( yearInput );
-		await user.type( yearInput, '99' );
-		await user.keyboard( '{Tab}' );
+			// Change to year 99
+			await user.clear( yearInput );
+			await user.type( yearInput, '99' );
+			await user.keyboard( '{Tab}' );
 
-		// Verify input displays human-readable year
-		expect( yearInput ).toHaveValue( 99 );
+			// Verify input displays human-readable year
+			expect( yearInput ).toHaveValue( 99 );
 
-		// Verify onChange emits zero-padded ISO 8601 format
-		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-		expect( lastCall[ 0 ] ).toMatch( /^0099-01-01T/ );
+			// Verify onChange emits zero-padded ISO 8601 format
+			const lastCall =
+				onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+			expect( lastCall[ 0 ] ).toMatch( /^0099-01-01T/ );
 		} );
 
-	it( 'should allow years below 1000 when minYear permits', async () => {
-		const user = userEvent.setup();
-		const onChangeSpy = jest.fn();
+		it( 'should allow years below 1000 when minYear permits', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
 
-		render(
-			<TimePicker
-				currentTime="1986-10-18T11:00:00"
-				onChange={ onChangeSpy }
-				minYear={ 1 }
-			/>
-		);
+			render(
+				<TimePicker
+					currentTime="1986-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+				/>
+			);
 
-		const yearInput = screen.getByLabelText( 'Year' );
+			const yearInput = screen.getByLabelText( 'Year' );
 
-		// Verify initial input displays correctly
-		expect( yearInput ).toHaveValue( 1986 );
+			// Verify initial input displays correctly
+			expect( yearInput ).toHaveValue( 1986 );
 
-		// Type year 500 - should be allowed
-		await user.clear( yearInput );
-		await user.type( yearInput, '500' );
-		await user.keyboard( '{Tab}' );
+			// Type year 500 - should be allowed
+			await user.clear( yearInput );
+			await user.type( yearInput, '500' );
+			await user.keyboard( '{Tab}' );
 
-		// Verify input displays human-readable year (not zero-padded)
-		expect( yearInput ).toHaveValue( 500 );
+			// Verify input displays human-readable year (not zero-padded)
+			expect( yearInput ).toHaveValue( 500 );
 
-		// Verify onChange was called with zero-padded ISO 8601 format
-		expect( onChangeSpy ).toHaveBeenCalled();
-		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-		expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
-	} );
+			// Verify onChange was called with zero-padded ISO 8601 format
+			expect( onChangeSpy ).toHaveBeenCalled();
+			const lastCall =
+				onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+			expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
+		} );
 
 		it( 'should handle year 500 correctly', async () => {
 			const user = userEvent.setup();
@@ -839,22 +846,23 @@ describe( 'TimePicker', () => {
 				/>
 			);
 
-		const yearInput = screen.getByLabelText( 'Year' );
+			const yearInput = screen.getByLabelText( 'Year' );
 
-		// Verify input displays human-readable year (not zero-padded)
-		expect( yearInput ).toHaveValue( 500 );
+			// Verify input displays human-readable year (not zero-padded)
+			expect( yearInput ).toHaveValue( 500 );
 
-		// Change to year 750
-		await user.clear( yearInput );
-		await user.type( yearInput, '750' );
-		await user.keyboard( '{Tab}' );
+			// Change to year 750
+			await user.clear( yearInput );
+			await user.type( yearInput, '750' );
+			await user.keyboard( '{Tab}' );
 
-		// Verify input displays human-readable year
-		expect( yearInput ).toHaveValue( 750 );
+			// Verify input displays human-readable year
+			expect( yearInput ).toHaveValue( 750 );
 
-		// Verify onChange emits zero-padded ISO 8601 format
-		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-		expect( lastCall[ 0 ] ).toMatch( /^0750-06-15T/ );
+			// Verify onChange emits zero-padded ISO 8601 format
+			const lastCall =
+				onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+			expect( lastCall[ 0 ] ).toMatch( /^0750-06-15T/ );
 		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -635,33 +635,32 @@ describe( 'TimePicker', () => {
 	} );
 
 	describe( 'Invalid date handling', () => {
-		it( 'should not call onChange when year is cleared and blurred', async () => {
+		it( 'should not emit invalid dates when year is cleared and blurred', async () => {
 			const user = userEvent.setup();
 			const onChangeSpy = jest.fn();
-			const year = '1986';
 
 			render(
 				<TimePicker
-					currentTime={ `${ year }-10-18T11:00:00` }
+					currentTime="1986-10-18T11:00:00"
 					onChange={ onChangeSpy }
 					is12Hour
 				/>
 			);
 
 			const yearInput = screen.getByLabelText( 'Year' );
-			const initialCallCount = onChangeSpy.mock.calls.length;
 
 			// Clear the year field and blur
 			await user.clear( yearInput );
 			await user.keyboard( '{Tab}' );
 
-			// Verify onChange was not called with an invalid date.
-			// Clearing the year would create an Invalid Date, so our guard
-			// should prevent onChange from being called.
-			const callCountAfterClear = onChangeSpy.mock.calls.length;
-			expect( callCountAfterClear ).toBe( initialCallCount ); // No new calls made
-
-			expect( yearInput ).toHaveValue( year );
+			// When the year is cleared, the browser may coerce to minYear.
+			// If onChange is called, it should only emit valid date strings.
+			onChangeSpy.mock.calls.forEach( ( call ) => {
+				const dateString = call[ 0 ];
+				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
+				expect( dateString ).not.toContain( 'NaN' );
+				expect( dateString ).not.toContain( 'Invalid' );
+			} );
 		} );
 
 		it( 'should not call onChange with an invalid date when day is cleared and month is changed', async () => {

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -757,6 +757,9 @@ describe( 'TimePicker', () => {
 		await user.type( yearInput, '500' );
 		await user.keyboard( '{Tab}' );
 
+		// Verify input displays human-readable year
+		expect( yearInput ).toHaveValue( 500 );
+
 		// Verify onChange emits zero-padded ISO 8601 format
 		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
 		expect( lastCall[ 0 ] ).toMatch( /^0500-10-18T/ );
@@ -806,6 +809,9 @@ describe( 'TimePicker', () => {
 		);
 
 		const yearInput = screen.getByLabelText( 'Year' );
+
+		// Verify initial input displays correctly
+		expect( yearInput ).toHaveValue( 1986 );
 
 		// Type year 500 - should be allowed
 		await user.clear( yearInput );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -633,4 +633,60 @@ describe( 'TimePicker', () => {
 			expect( outputDate ).not.toContain( 'Invalid' );
 		} );
 	} );
+
+	describe( 'Invalid date handling', () => {
+		it( 'should not call onChange when year is cleared and blurred', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="1986-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					is12Hour
+				/>
+			);
+
+			const yearInput = screen.getByLabelText( 'Year' );
+			const initialCallCount = onChangeSpy.mock.calls.length;
+
+			// Clear the year field
+			await user.clear( yearInput );
+			// Blur the field (tab away)
+			await user.keyboard( '{Tab}' );
+
+			// onChange should not be called when the year is cleared
+			// because it would produce an invalid date
+			expect( onChangeSpy ).toHaveBeenCalledTimes( initialCallCount );
+		} );
+
+		it( 'should not call onChange with an invalid date when day is cleared and month is changed', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="1986-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					is12Hour
+				/>
+			);
+
+			const dayInput = screen.getByLabelText( 'Day' );
+			const monthInput = screen.getByLabelText( 'Month' );
+
+			// Clear the day field
+			await user.clear( dayInput );
+			// Change the month
+			await user.selectOptions( monthInput, '12' );
+
+			// All onChange calls should have valid date strings
+			onChangeSpy.mock.calls.forEach( ( call ) => {
+				const dateString = call[ 0 ];
+				expect( dateString ).toMatch( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/ );
+				expect( dateString ).not.toContain( 'NaN' );
+				expect( dateString ).not.toContain( 'Invalid' );
+			} );
+		} );
+	} );
 } );

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -38,8 +38,13 @@ export type TimePickerProps = {
 	hideLabelFromVision?: boolean;
 
 	/**
-	 * The minimum year that can be selected. Defaults to 1000 to prevent
-	 * dates that moment.js cannot parse reliably.
+	 * The minimum year that can be selected.
+	 *
+	 * Defaults to MIN_SUPPORTED_YEAR (1000) because years below this value
+	 * cannot be reliably parsed by moment.js (used internally). Even if a
+	 * lower minYear value is provided, the component will internally block
+	 * years < 1000 to prevent Invalid Date propagation and moment.js
+	 * deprecation warnings.
 	 *
 	 * @default 1000
 	 */

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -36,6 +36,14 @@ export type TimePickerProps = {
 	 * @default false
 	 */
 	hideLabelFromVision?: boolean;
+
+	/**
+	 * The minimum year that can be selected. Defaults to 1000 to prevent
+	 * dates that moment.js cannot parse reliably.
+	 *
+	 * @default 1000
+	 */
+	minYear?: number;
 };
 
 export type TimeInputValue = {

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -38,15 +38,9 @@ export type TimePickerProps = {
 	hideLabelFromVision?: boolean;
 
 	/**
-	 * The minimum year that can be selected.
+	 * The minimum year that can be selected in the year input field.
 	 *
-	 * Defaults to MIN_SUPPORTED_YEAR (1000) because years below this value
-	 * cannot be reliably parsed by moment.js (used internally). Even if a
-	 * lower minYear value is provided, the component will internally block
-	 * years < 1000 to prevent Invalid Date propagation and moment.js
-	 * deprecation warnings.
-	 *
-	 * @default 1000
+	 * @default 1
 	 */
 	minYear?: number;
 };

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -6,7 +6,7 @@ import { parseISO, endOfMonth, startOfMonth } from 'date-fns';
 /**
  * WordPress dependencies
  */
-import { getSettings } from '@wordpress/date';
+import { getDate, getSettings } from '@wordpress/date';
 import { _x } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -94,6 +94,11 @@ export function PrivatePostSchedule( {
 			.join( '' ) // Reverse the string and test for "a" not followed by a slash.
 	);
 
+	// Get the current year in the site's timezone to use as the minimum schedulable year.
+	// We use getDate() instead of new Date() to ensure we respect the WordPress site's
+	// configured timezone rather than the browser/system timezone.
+	const currentSiteYear = getDate().getFullYear();
+
 	return (
 		<PrivatePublishDateTimePicker
 			currentDate={ postDate }
@@ -103,7 +108,7 @@ export function PrivatePostSchedule( {
 				/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
 				_x( 'dmy', 'date order' )
 			}
-			minYear={ new Date().getFullYear() }
+			minYear={ currentSiteYear }
 			events={ events }
 			onMonthPreviewed={ ( date ) =>
 				setPreviewedMonth( parseISO( date ) )

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -103,6 +103,7 @@ export function PrivatePostSchedule( {
 				/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
 				_x( 'dmy', 'date order' )
 			}
+			minYear={ new Date().getFullYear() }
 			events={ events }
 			onMonthPreviewed={ ( date ) =>
 				setPreviewedMonth( parseISO( date ) )

--- a/test/e2e/specs/editor/various/datepicker.spec.js
+++ b/test/e2e/specs/editor/various/datepicker.spec.js
@@ -40,7 +40,7 @@ TIMEZONES.forEach( ( timezone ) => {
 			).toHaveText( 'Immediately' );
 		} );
 
-		test( 'should show the publishing date if the date is in the past', async ( {
+		test( 'should not allow scheduling to a past year', async ( {
 			page,
 		} ) => {
 			const datepicker = page.getByRole( 'button', {
@@ -48,18 +48,26 @@ TIMEZONES.forEach( ( timezone ) => {
 			} );
 			await datepicker.click();
 
-			// Change the publishing date to a year in the future.
-			await page
+			const yearInput = page
 				.getByRole( 'group', { name: 'Date' } )
-				.getByRole( 'spinbutton', { name: 'Year' } )
-				.click();
+				.getByRole( 'spinbutton', { name: 'Year' } );
+
+			// Get the current year value
+			const currentYear = await yearInput.inputValue();
+
+			// Try to decrease the year
+			await yearInput.click();
 			await page.keyboard.press( 'ArrowDown' );
+
+			// The year should remain at the current year (cannot go to past)
+			await expect( yearInput ).toHaveValue( currentYear );
+
 			await page.keyboard.press( 'Escape' );
 
-			// The expected date format will be "Sep 26, 2018 11:52 pm".
+			// Since the date hasn't changed from current, it should still show "Immediately"
 			await expect(
 				page.getByRole( 'button', { name: 'Change date' } )
-			).toContainText( /^[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
+			).toHaveText( 'Immediately' );
 		} );
 
 		test( 'should show the publishing date if the date is in the future', async ( {


### PR DESCRIPTION
## What?

Adds a `minYear` prop to `TimePicker` and `DateTimePicker`, and adds an Invalid Date guard to prevent `onChange` from emitting invalid dates when fields are cleared.

## Why?

Follows up on #75343 which fixed the core ISO 8601 year-padding bug.

With that fix in place, the `TimePicker` can now safely support years below 1000. This PR:

1. **Exposes a `minYear` prop** so consumers can control the minimum allowed year. Defaults to `1`, enabling historical dates.
2. **Restricts post scheduling** to the current year and forward via `minYear={ new Date().getFullYear() }`.
3. **Guards against Invalid Date propagation** — when fields are cleared or cross-field validation produces an invalid date (e.g., Day=31 + February), `onChange` is no longer called with invalid values.

## How?

- Adds `updateDate()` wrapper around `setDate`/`onChange` with a `Number.isFinite()` check to catch Invalid Date before propagation.
- Adds `minYear` prop to `TimePickerProps` and `DateTimePickerProps` (default: `1`), passed through to the year input's `min` attribute.
- Sets `minYear={ new Date().getFullYear() }` in `PostSchedule` to restrict scheduling to current/future years.

## Testing Instructions

### Unit Tests
```bash
# All date-time tests
npm run test:unit -- packages/components/src/date-time/

# Just the new tests
npm run test:unit -- packages/components/src/date-time/time/test/index.tsx -t "Invalid date handling"
npm run test:unit -- packages/components/src/date-time/time/test/index.tsx -t "Years below 1000"
```

### Manual: Invalid Date Guard
1. Open a post and reveal the date/time picker
2. Clear the Day field completely
3. Change the Month dropdown
4. **Expected**: No JavaScript errors, no Invalid Date values

### Manual: minYear in Post Scheduling
1. Open a post's publish panel → click "Immediately"
2. Try to set the year below the current year using the input spinner
3. **Expected**: The year input does not go below the current year