### PR TITLE
Real-time collaboration: Add global setting to enable real-time collaboration

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -771,6 +771,14 @@ _Returns_
 
 -   `boolean`: Whether new post and unsaved values exist.
 
+### isCollaborationEnabledForCurrentPost
+
+Returns whether the collaboration is enabled for the current post.
+
+_Returns_
+
+-   `boolean`: Whether collaboration is enabled.
+
 ### isCurrentPostPending
 
 Returns true if post is pending review.

--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -47,3 +47,53 @@ function gutenberg_rest_api_crdt_post_meta() {
 	);
 }
 add_action( 'init', 'gutenberg_rest_api_crdt_post_meta' );
+
+/**
+ * Registers the real-time collaboration setting.
+ */
+function gutenberg_register_real_time_collaboration_setting() {
+	$option_name = 'gutenberg_enable_real_time_collaboration';
+
+	register_setting(
+		'writing',
+		$option_name,
+		array(
+			'type'              => 'boolean',
+			'description'       => __( 'Enable Real-Time Collaboration', 'gutenberg' ),
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default'           => false,
+			'show_in_rest'      => true,
+		)
+	);
+
+	add_settings_field(
+		$option_name,
+		__( 'Collaboration', 'gutenberg' ),
+		function () use ( $option_name ) {
+			$option_value = get_option( $option_name );
+
+			?>
+			<label for="gutenberg_enable_real_time_collaboration">
+				<input name="gutenberg_enable_real_time_collaboration" type="checkbox" id="gutenberg_enable_real_time_collaboration" value="1" <?php checked( '1', $option_value ); ?>/>
+				<?php _e( 'Enable real-time collaboration', 'gutenberg' ); ?>
+			</label>
+			<?php
+		},
+		'writing'
+	);
+}
+add_action( 'admin_init', 'gutenberg_register_real_time_collaboration_setting' );
+
+/**
+ * Injects the real-time collaboration setting for the sync package.
+ */
+function gutenberg_inject_real_time_collaboration_setting() {
+	if ( get_option( 'gutenberg_enable_real_time_collaboration' ) ) {
+		wp_add_inline_script(
+			'wp-sync',
+			'window.__wpSyncEnabled = true;',
+			'after'
+		);
+	}
+}
+add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -26,6 +26,7 @@ function PostLockedModal() {
 	const hookName = 'core/editor/post-locked-modal-' + instanceId;
 	const { autosave, updatePostLock } = useDispatch( editorStore );
 	const {
+		isCollaborationEnabled,
 		isLocked,
 		isTakeover,
 		user,
@@ -34,22 +35,21 @@ function PostLockedModal() {
 		activePostLock,
 		postType,
 		previewLink,
-		supportsSync,
 	} = useSelect( ( select ) => {
 		const {
+			isCollaborationEnabledForCurrentPost,
 			isPostLocked,
 			isPostLockTakeover,
 			getPostLockUser,
 			getCurrentPostId,
-			getCurrentPostType,
 			getActivePostLock,
 			getEditedPostAttribute,
 			getEditedPostPreviewLink,
 			getEditorSettings,
 		} = select( editorStore );
-		const { getPostType, getEntityConfig } = select( coreStore );
-		const currentPostType = getCurrentPostType();
+		const { getPostType } = select( coreStore );
 		return {
+			isCollaborationEnabled: isCollaborationEnabledForCurrentPost(),
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),
 			user: getPostLockUser(),
@@ -58,9 +58,6 @@ function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
-			supportsSync: Boolean(
-				getEntityConfig( 'postType', currentPostType )?.syncConfig
-			),
 		};
 	}, [] );
 
@@ -155,8 +152,8 @@ function PostLockedModal() {
 	}
 
 	// Avoid sending the modal if sync is supported, but retain functionality around locks etc.
-	if ( supportsSync ) {
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		if ( isCollaborationEnabled ) {
 			return null;
 		}
 	}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1879,3 +1879,20 @@ export const getPostTypeLabel = createRegistrySelector(
 export function isPublishSidebarOpened( state ) {
 	return state.publishSidebarActive;
 }
+
+/**
+ * Returns whether the collaboration is enabled for the current post.
+ *
+ * @return {boolean} Whether collaboration is enabled.
+ */
+export const isCollaborationEnabledForCurrentPost = createRegistrySelector(
+	( select ) => ( state ) => {
+		const currentPostType = getCurrentPostType( state );
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			currentPostType
+		);
+
+		return Boolean( entityConfig?.syncConfig && window.__wpSyncEnabled );
+	}
+);

--- a/packages/sync/src/providers/index.ts
+++ b/packages/sync/src/providers/index.ts
@@ -41,12 +41,17 @@ export function getProviderCreators(): ProviderCreator[] {
 		return providerCreators;
 	}
 
+	// Check if real-time collaboration is enabled via WordPress setting.
+	if ( ! window.__wpSyncEnabled ) {
+		return [];
+	}
+
 	/**
 	 * Filter the available provider creators.
 	 */
 	const filteredProviderCreators: unknown = applyFilters(
 		'sync.providers',
-		[] // Replace `[]` with `getDefaultProviderCreators()` to enable sync.
+		getDefaultProviderCreators()
 	);
 
 	// If the returned value is not an array, ignore and set to empty array.

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -14,6 +14,13 @@ import type { Awareness } from 'y-protocols/awareness';
  */
 import type { WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE } from './config';
 
+/* globalThis */
+declare global {
+	interface Window {
+		__wpSyncEnabled?: string;
+	}
+}
+
 export type CRDTDoc = Y.Doc;
 export type AwarenessID = string;
 export type EntityID = string;


### PR DESCRIPTION
## What?

Add global setting to enable real-time collaboration.

See: https://github.com/WordPress/gutenberg/issues/74983


## Why?

A global setting provides an easy mechanism for users (and testers) to enable and disable real-time collaboration.

- If enabled, it will use the included default sync provider (but allow third-party code to inject an alternate provider [via a filter](https://github.com/WordPress/gutenberg/blob/cde3c2598cbe2529c47dee998fc402c8969b4e2c/packages/sync/src/providers/index.ts#L60)).
- If disabled (default), no sync providers will be available and the filter will not be applied. All collaboration features are disabled.


## How?

Add a boolean setting (Settings > Writing).

## Testing Instructions

1. Check out this branch.
2. Enable real-time collaboration: Settings > Writing > Enable real-time collaboration
3. Open a post in two browser tabs and observe updates being shared.

### Testing Instructions for Keyboard

1. Check out this branch.
2. Navigate to Settings > Writing > Enable real-time collaboration
3. Skip to main content
4. Tab to "Enable real-time collaboration" setting.
5. Spacebar to toggle setting.
6. Tab to "Save" button and submit form.
7. Open a post in two browser tabs and observe updates being shared.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c69dcb44-012f-4819-b1b3-3be1e727c3e1

