### PR TITLE
Notes: Pressing Escape should cancel adding a note

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -77,6 +77,12 @@ function CommentForm( {
 					) {
 						event.target.parentNode.requestSubmit();
 					}
+
+					if ( event.key === 'Escape' ) {
+						event.preventDefault();
+						// Passing event for reply forms.
+						onCancel( event );
+					}
 				} }
 			/>
 			<HStack spacing="2" justify="flex-end" wrap>


### PR DESCRIPTION
## What?
Related #72868.

A minor QoL improvement PR. Allows canceling, adding a new note, or replying by pressing the Escape key.

## Testing Instructions
1. Open a post or page
2. Insert a heading block.
3. Open a new note form.
4. Press the Escape key.
5. Confirm that the note form is closed, and focus returns to the block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/64f9f9a5-0020-470b-b40a-d4a1a8592578

