### PR TITLE
DataForm: update panel trigger

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Enhancements
 
+- DataForm: Update trigger mechanism for panel layout. [#75290](https://github.com/WordPress/gutenberg/pull/75290)
 - DataViews: Add `onReset` prop to control view reset functionality from the view config dropdown. [#75093](https://github.com/WordPress/gutenberg/pull/75093)
 - DataForm: Add automatic field labeling - forms now automatically mark the minority of fields (required or optional) to reduce visual noise. [#74430](https://github.com/WordPress/gutenberg/pull/74430)
 - DataViews: Add details form layout validation. [#74996](https://github.com/WordPress/gutenberg/pull/74996)

--- a/packages/dataviews/src/components/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/index.tsx
@@ -34,7 +34,7 @@ const FORM_FIELD_LAYOUTS = [
 			<Stack
 				direction="column"
 				className="dataforms-layouts__wrapper"
-				gap="sm"
+				gap="md"
 			>
 				{ children }
 			</Stack>

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -17,9 +17,8 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import type {
-	FieldValidity,
+	FieldLayoutProps,
 	NormalizedForm,
-	NormalizedFormField,
 	NormalizedPanelLayout,
 	FormValidity,
 } from '../../../types';
@@ -83,12 +82,7 @@ function PanelDropdown< Item >( {
 	field,
 	onChange,
 	validity,
-}: {
-	data: Item;
-	field: NormalizedFormField;
-	onChange: ( value: any ) => void;
-	validity?: FieldValidity;
-} ) {
+}: FieldLayoutProps< Item > ) {
 	const [ touched, setTouched ] = useState( false );
 
 	const { fields } = useContext( DataFormContext );

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -28,6 +28,7 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
 import useReportValidity from '../../../hooks/use-report-validity';
+import getFirstValidationError from './utils/get-first-validation-error';
 
 function DropdownHeader( {
 	title,
@@ -86,7 +87,6 @@ function PanelDropdown< Item >( {
 	labelContent,
 	labelClassName,
 	showError,
-	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -99,10 +99,10 @@ function PanelDropdown< Item >( {
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
 	showError?: boolean;
-	errorMessage?: string;
 } ) {
 	const layout = field.layout as NormalizedPanelLayout;
 	const labelPosition = layout.labelPosition;
+	const errorMessage = getFirstValidationError( validity );
 
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -85,7 +85,6 @@ function PanelDropdown< Item >( {
 	touched,
 	labelContent,
 	labelClassName,
-	showError,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -95,7 +94,6 @@ function PanelDropdown< Item >( {
 	touched: boolean;
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
-	showError?: boolean;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
@@ -154,7 +152,9 @@ function PanelDropdown< Item >( {
 	if ( ! fieldDefinition ) {
 		return null;
 	}
+
 	const errorMessage = getFirstValidationError( validity );
+	const showError = touched && !! errorMessage;
 
 	return (
 		<div

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -11,9 +11,10 @@ import { __ } from '@wordpress/i18n';
 import { useMemo, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import {
-	useFocusOnMount,
-	useFocusReturn,
-	useMergeRefs,
+	// useFocusOnMount,
+	// useFocusReturn,
+	// useMergeRefs,
+	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
@@ -149,9 +150,9 @@ function PanelDropdown< Item >( {
 		[ popoverAnchor ]
 	);
 
-	const focusOnMountRef = useFocusOnMount( 'firstInputElement' );
-	const focusReturnRef = useFocusReturn();
-	const mergedRef = useMergeRefs( [ focusOnMountRef, focusReturnRef ] );
+	const [ dialogRef, dialogProps ] = useDialog( {
+		focusOnMount: 'firstInputElement',
+	} );
 
 	return (
 		<div
@@ -189,7 +190,7 @@ function PanelDropdown< Item >( {
 							title={ fieldLabel }
 							onClose={ onClose }
 						/>
-						<div ref={ mergedRef }>
+						<div ref={ dialogRef } { ...dialogProps }>
 							<DataFormLayout
 								data={ data }
 								form={ form }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -26,7 +26,6 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
 import useReportValidity from '../../../hooks/use-report-validity';
-import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 import DataFormContext from '../../dataform-context';
 
@@ -140,9 +139,6 @@ function PanelDropdown< Item >( {
 		return null;
 	}
 
-	const errorMessage = getFirstValidationError( validity );
-	const showError = touched && !! errorMessage;
-
 	return (
 		<div
 			ref={ setPopoverAnchor }
@@ -161,13 +157,13 @@ function PanelDropdown< Item >( {
 					<SummaryButton
 						data={ data }
 						field={ field }
+						validity={ validity }
+						touched={ touched }
 						summaryFields={ summaryFields }
 						fieldLabel={ fieldLabel }
 						disabled={ fieldDefinition.readOnly === true }
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
-						showError={ showError }
-						errorMessage={ errorMessage }
 					/>
 				) }
 				renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -186,11 +186,11 @@ function PanelDropdown< Item >( {
 				) }
 				renderContent={ ( { onClose } ) => (
 					<DropdownContentWithValidation touched={ touched }>
-						<DropdownHeader
-							title={ fieldLabel }
-							onClose={ onClose }
-						/>
 						<div ref={ dialogRef } { ...dialogProps }>
+							<DropdownHeader
+								title={ fieldLabel }
+								onClose={ onClose }
+							/>
 							<DataFormLayout
 								data={ data }
 								form={ form }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -168,7 +168,6 @@ function PanelDropdown< Item >( {
 						disabled={ fieldDefinition.readOnly === true }
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
-						aria-haspopup="dialog"
 						labelContent={ labelContent }
 						showError={ showError }
 						errorMessage={ errorMessage }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -170,6 +170,7 @@ function PanelDropdown< Item >( {
 						disabled={ fieldDefinition.readOnly === true }
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
+						aria-haspopup="dialog"
 						labelContent={ labelContent }
 						labelClassName={ labelClassName }
 						showError={ showError }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useContext, useMemo, useRef, useState } from '@wordpress/element';
+import { useMemo, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { __experimentalUseDialog as useDialog } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
@@ -25,8 +25,7 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
 import useReportValidity from '../../../hooks/use-report-validity';
-import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
-import DataFormContext from '../../dataform-context';
+import useFieldFromFormField from './utils/use-field-from-form-field';
 
 function DropdownHeader( {
 	title,
@@ -98,10 +97,9 @@ function PanelDropdown< Item >( {
 		} ),
 		[ popoverAnchor ]
 	);
-
-	const { fields } = useContext( DataFormContext );
-	const { fieldDefinition, fieldLabel, summaryFields } =
-		getFieldDefinitionAndSummaryFields( field, fields );
+	const [ dialogRef, dialogProps ] = useDialog( {
+		focusOnMount: 'firstInputElement',
+	} );
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -125,10 +123,8 @@ function PanelDropdown< Item >( {
 		return { [ field.id ]: validity };
 	}, [ validity, field ] );
 
-	const [ dialogRef, dialogProps ] = useDialog( {
-		focusOnMount: 'firstInputElement',
-	} );
-
+	const { fieldDefinition, fieldLabel, summaryFields } =
+		useFieldFromFormField( field );
 	if ( ! fieldDefinition ) {
 		return null;
 	}
@@ -151,10 +147,10 @@ function PanelDropdown< Item >( {
 					<SummaryButton
 						data={ data }
 						field={ field }
+						fieldLabel={ fieldLabel }
+						summaryFields={ summaryFields }
 						validity={ validity }
 						touched={ touched }
-						summaryFields={ summaryFields }
-						fieldLabel={ fieldLabel }
 						disabled={ fieldDefinition.readOnly === true }
 						onClick={ onToggle }
 						aria-expanded={ isOpen }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -10,7 +10,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useMemo, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
-import { useFocusOnMount } from '@wordpress/compose';
+import {
+	useFocusOnMount,
+	useFocusReturn,
+	useMergeRefs,
+} from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -146,6 +150,8 @@ function PanelDropdown< Item >( {
 	);
 
 	const focusOnMountRef = useFocusOnMount( 'firstInputElement' );
+	const focusReturnRef = useFocusReturn();
+	const mergedRef = useMergeRefs( [ focusOnMountRef, focusReturnRef ] );
 
 	return (
 		<div
@@ -183,7 +189,7 @@ function PanelDropdown< Item >( {
 							title={ fieldLabel }
 							onClose={ onClose }
 						/>
-						<div ref={ focusOnMountRef }>
+						<div ref={ mergedRef }>
 							<DataFormLayout
 								data={ data }
 								form={ form }

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -31,6 +31,7 @@ import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 import DataFormContext from '../../dataform-context';
 import getLabelClassName from './utils/get-label-classname';
+import getLabelContent from './utils/get-label-content';
 
 function DropdownHeader( {
 	title,
@@ -84,7 +85,6 @@ function PanelDropdown< Item >( {
 	validity,
 	onClose: onCloseCallback,
 	touched,
-	labelContent,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -92,7 +92,6 @@ function PanelDropdown< Item >( {
 	validity?: FieldValidity;
 	onClose?: () => void;
 	touched: boolean;
-	labelContent?: React.ReactNode;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
@@ -155,6 +154,7 @@ function PanelDropdown< Item >( {
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
 	const labelClassName = getLabelClassName( labelPosition, showError );
+	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 
 	return (
 		<div

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -83,16 +83,14 @@ function PanelDropdown< Item >( {
 	field,
 	onChange,
 	validity,
-	onClose: onCloseCallback,
-	touched,
 }: {
 	data: Item;
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
 	validity?: FieldValidity;
-	onClose?: () => void;
-	touched: boolean;
 } ) {
+	const [ touched, setTouched ] = useState( false );
+
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
 	const labelPosition = layout.labelPosition;
@@ -167,7 +165,7 @@ function PanelDropdown< Item >( {
 				focusOnMount={ false }
 				onToggle={ ( willOpen ) => {
 					if ( ! willOpen ) {
-						onCloseCallback?.();
+						setTouched( true );
 					}
 				} }
 				renderToggle={ ( { isOpen, onToggle } ) => (

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -19,7 +19,6 @@ import { Stack } from '@wordpress/ui';
 import type {
 	FieldLayoutProps,
 	NormalizedForm,
-	NormalizedPanelLayout,
 	FormValidity,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
@@ -82,19 +81,27 @@ function PanelDropdown< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const [ touched, setTouched ] = useState( false );
 
-	const { fields } = useContext( DataFormContext );
-	const layout = field.layout as NormalizedPanelLayout;
-
-	const { fieldDefinition, summaryFields } =
-		getFieldDefinitionAndSummaryFields( layout, field, fields );
-
-	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
-
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
 		null
 	);
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+
+	const { fields } = useContext( DataFormContext );
+	const { fieldDefinition, fieldLabel, summaryFields } =
+		getFieldDefinitionAndSummaryFields( field, fields );
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -117,19 +124,6 @@ function PanelDropdown< Item >( {
 
 		return { [ field.id ]: validity };
 	}, [ validity, field ] );
-
-	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps = useMemo(
-		() => ( {
-			// Anchor the popover to the middle of the entire row so that it doesn't
-			// move around when the label changes.
-			anchor: popoverAnchor,
-			placement: 'left-start',
-			offset: 36,
-			shift: true,
-		} ),
-		[ popoverAnchor ]
-	);
 
 	const [ dialogRef, dialogProps ] = useDialog( {
 		focusOnMount: 'firstInputElement',

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -29,7 +29,6 @@ import useReportValidity from '../../../hooks/use-report-validity';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 import DataFormContext from '../../dataform-context';
-import getLabelClassName from './utils/get-label-classname';
 import getLabelContent from './utils/get-label-content';
 
 function DropdownHeader( {
@@ -87,7 +86,6 @@ function PanelDropdown< Item >( {
 
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
-	const labelPosition = layout.labelPosition;
 
 	const { fieldDefinition, summaryFields } =
 		getFieldDefinitionAndSummaryFields( layout, field, fields );
@@ -145,7 +143,6 @@ function PanelDropdown< Item >( {
 
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
-	const labelClassName = getLabelClassName( labelPosition, showError );
 	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 
 	return (
@@ -173,7 +170,6 @@ function PanelDropdown< Item >( {
 						aria-expanded={ isOpen }
 						aria-haspopup="dialog"
 						labelContent={ labelContent }
-						labelClassName={ labelClassName }
 						showError={ showError }
 						errorMessage={ errorMessage }
 					/>

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -29,7 +29,6 @@ import useReportValidity from '../../../hooks/use-report-validity';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 import DataFormContext from '../../dataform-context';
-import getLabelContent from './utils/get-label-content';
 
 function DropdownHeader( {
 	title,
@@ -143,7 +142,6 @@ function PanelDropdown< Item >( {
 
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
-	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 
 	return (
 		<div
@@ -168,7 +166,6 @@ function PanelDropdown< Item >( {
 						disabled={ fieldDefinition.readOnly === true }
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
-						labelContent={ labelContent }
 						showError={ showError }
 						errorMessage={ errorMessage }
 					/>

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -30,6 +30,7 @@ import useReportValidity from '../../../hooks/use-report-validity';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 import DataFormContext from '../../dataform-context';
+import getLabelClassName from './utils/get-label-classname';
 
 function DropdownHeader( {
 	title,
@@ -84,7 +85,6 @@ function PanelDropdown< Item >( {
 	onClose: onCloseCallback,
 	touched,
 	labelContent,
-	labelClassName,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -93,7 +93,6 @@ function PanelDropdown< Item >( {
 	onClose?: () => void;
 	touched: boolean;
 	labelContent?: React.ReactNode;
-	labelClassName?: string;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
@@ -155,6 +154,7 @@ function PanelDropdown< Item >( {
 
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
+	const labelClassName = getLabelClassName( labelPosition, showError );
 
 	return (
 		<div

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useRef } from '@wordpress/element';
+import { useMemo, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
@@ -81,9 +81,12 @@ function PanelDropdown< Item >( {
 	labelPosition = 'side',
 	summaryFields,
 	fieldDefinition,
-	popoverAnchor,
 	onClose: onCloseCallback,
 	touched,
+	labelContent,
+	labelClassName,
+	showError,
+	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -92,11 +95,20 @@ function PanelDropdown< Item >( {
 	labelPosition: 'side' | 'top' | 'none';
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
-	popoverAnchor: HTMLElement | null;
 	onClose?: () => void;
 	touched: boolean;
+	labelContent?: React.ReactNode;
+	labelClassName?: string;
+	showError?: boolean;
+	errorMessage?: string;
 } ) {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
+
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
+		null
+	);
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -136,64 +148,71 @@ function PanelDropdown< Item >( {
 	const focusOnMountRef = useFocusOnMount( 'firstInputElement' );
 
 	return (
-		<Dropdown
-			contentClassName="dataforms-layouts-panel__field-dropdown"
-			popoverProps={ popoverProps }
-			focusOnMount={ false }
-			onToggle={ ( willOpen ) => {
-				if ( ! willOpen ) {
-					onCloseCallback?.();
-				}
-			} }
-			toggleProps={ {
-				size: 'compact',
-				variant: 'tertiary',
-				tooltipPosition: 'middle left',
-			} }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<SummaryButton
-					summaryFields={ summaryFields }
-					data={ data }
-					labelPosition={ labelPosition }
-					fieldLabel={ fieldLabel }
-					disabled={ fieldDefinition.readOnly === true }
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-				/>
-			) }
-			renderContent={ ( { onClose } ) => (
-				<DropdownContentWithValidation touched={ touched }>
-					<DropdownHeader title={ fieldLabel } onClose={ onClose } />
-					<div ref={ focusOnMountRef }>
-						<DataFormLayout
-							data={ data }
-							form={ form }
-							onChange={ onChange }
-							validity={ formValidity }
-						>
-							{ (
-								FieldLayout,
-								childField,
-								childFieldValidity,
-								markWhenOptional
-							) => (
-								<FieldLayout
-									key={ childField.id }
-									data={ data }
-									field={ childField }
-									onChange={ onChange }
-									hideLabelFromVision={
-										( form?.fields ?? [] ).length < 2
-									}
-									markWhenOptional={ markWhenOptional }
-									validity={ childFieldValidity }
-								/>
-							) }
-						</DataFormLayout>
-					</div>
-				</DropdownContentWithValidation>
-			) }
-		/>
+		<div
+			ref={ setPopoverAnchor }
+			className="dataforms-layouts-panel__field-dropdown-anchor"
+		>
+			<Dropdown
+				contentClassName="dataforms-layouts-panel__field-dropdown"
+				popoverProps={ popoverProps }
+				focusOnMount={ false }
+				onToggle={ ( willOpen ) => {
+					if ( ! willOpen ) {
+						onCloseCallback?.();
+					}
+				} }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<SummaryButton
+						summaryFields={ summaryFields }
+						data={ data }
+						labelPosition={ labelPosition }
+						fieldLabel={ fieldLabel }
+						disabled={ fieldDefinition.readOnly === true }
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+						labelContent={ labelContent }
+						labelClassName={ labelClassName }
+						showError={ showError }
+						errorMessage={ errorMessage }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<DropdownContentWithValidation touched={ touched }>
+						<DropdownHeader
+							title={ fieldLabel }
+							onClose={ onClose }
+						/>
+						<div ref={ focusOnMountRef }>
+							<DataFormLayout
+								data={ data }
+								form={ form }
+								onChange={ onChange }
+								validity={ formValidity }
+							>
+								{ (
+									FieldLayout,
+									childField,
+									childFieldValidity,
+									markWhenOptional
+								) => (
+									<FieldLayout
+										key={ childField.id }
+										data={ data }
+										field={ childField }
+										onChange={ onChange }
+										hideLabelFromVision={
+											( form?.fields ?? [] ).length < 2
+										}
+										markWhenOptional={ markWhenOptional }
+										validity={ childFieldValidity }
+									/>
+								) }
+							</DataFormLayout>
+						</div>
+					</DropdownContentWithValidation>
+				) }
+			/>
+		</div>
 	);
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -10,12 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useMemo, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
-import {
-	// useFocusOnMount,
-	// useFocusReturn,
-	// useMergeRefs,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { __experimentalUseDialog as useDialog } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -27,6 +22,7 @@ import type {
 	NormalizedFormField,
 	FormValidity,
 	NormalizedField,
+	NormalizedPanelLayout,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
@@ -83,7 +79,6 @@ function PanelDropdown< Item >( {
 	field,
 	onChange,
 	validity,
-	labelPosition = 'side',
 	summaryFields,
 	fieldDefinition,
 	onClose: onCloseCallback,
@@ -97,7 +92,6 @@ function PanelDropdown< Item >( {
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
 	validity?: FieldValidity;
-	labelPosition: 'side' | 'top' | 'none';
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	onClose?: () => void;
@@ -107,6 +101,9 @@ function PanelDropdown< Item >( {
 	showError?: boolean;
 	errorMessage?: string;
 } ) {
+	const layout = field.layout as NormalizedPanelLayout;
+	const labelPosition = layout.labelPosition;
+
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
 	// Use internal state instead of a ref to make sure that the component

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useRef, useState } from '@wordpress/element';
+import { useContext, useMemo, useRef, useState } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { __experimentalUseDialog as useDialog } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
@@ -20,15 +20,16 @@ import type {
 	FieldValidity,
 	NormalizedForm,
 	NormalizedFormField,
-	FormValidity,
-	NormalizedField,
 	NormalizedPanelLayout,
+	FormValidity,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
 import useReportValidity from '../../../hooks/use-report-validity';
 import getFirstValidationError from './utils/get-first-validation-error';
+import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
+import DataFormContext from '../../dataform-context';
 
 function DropdownHeader( {
 	title,
@@ -80,8 +81,6 @@ function PanelDropdown< Item >( {
 	field,
 	onChange,
 	validity,
-	summaryFields,
-	fieldDefinition,
 	onClose: onCloseCallback,
 	touched,
 	labelContent,
@@ -92,17 +91,18 @@ function PanelDropdown< Item >( {
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
 	validity?: FieldValidity;
-	summaryFields: NormalizedField< Item >[];
-	fieldDefinition: NormalizedField< Item >;
 	onClose?: () => void;
 	touched: boolean;
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
 	showError?: boolean;
 } ) {
+	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
 	const labelPosition = layout.labelPosition;
-	const errorMessage = getFirstValidationError( validity );
+
+	const { fieldDefinition, summaryFields } =
+		getFieldDefinitionAndSummaryFields( layout, field, fields );
 
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
@@ -150,6 +150,11 @@ function PanelDropdown< Item >( {
 	const [ dialogRef, dialogProps ] = useDialog( {
 		focusOnMount: 'firstInputElement',
 	} );
+
+	if ( ! fieldDefinition ) {
+		return null;
+	}
+	const errorMessage = getFirstValidationError( validity );
 
 	return (
 		<div

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -164,9 +164,9 @@ function PanelDropdown< Item >( {
 				} }
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<SummaryButton
-						summaryFields={ summaryFields }
 						data={ data }
-						labelPosition={ labelPosition }
+						field={ field }
+						summaryFields={ summaryFields }
 						fieldLabel={ fieldLabel }
 						disabled={ fieldDefinition.readOnly === true }
 						onClick={ onToggle }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -180,7 +180,6 @@ export default function FormPanelField< Item >( {
 				data={ data }
 				field={ field }
 				onChange={ onChange }
-				labelPosition={ labelPosition }
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
 				onClose={ handleClose }
@@ -199,7 +198,6 @@ export default function FormPanelField< Item >( {
 			field={ field }
 			onChange={ onChange }
 			validity={ validity }
-			labelPosition={ labelPosition }
 			summaryFields={ summaryFields }
 			fieldDefinition={ fieldDefinition }
 			onClose={ handleClose }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { BaseControl, Icon, Tooltip } from '@wordpress/components';
@@ -38,14 +33,8 @@ export default function FormPanelField< Item >( {
 	const [ touched, setTouched ] = useState( false );
 	const handleClose = () => setTouched( true );
 
-	const labelPosition = layout.labelPosition;
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
-	const labelClassName = clsx(
-		'dataforms-layouts-panel__field-label',
-		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`,
-		{ 'has-error': showError }
-	);
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
 	const labelContent = showError ? (
@@ -71,7 +60,6 @@ export default function FormPanelField< Item >( {
 				onClose={ handleClose }
 				touched={ touched }
 				labelContent={ labelContent }
-				labelClassName={ labelClassName }
 			/>
 		);
 	}
@@ -85,7 +73,6 @@ export default function FormPanelField< Item >( {
 			onClose={ handleClose }
 			touched={ touched }
 			labelContent={ labelContent }
-			labelClassName={ labelClassName }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -72,7 +72,6 @@ export default function FormPanelField< Item >( {
 				touched={ touched }
 				labelContent={ labelContent }
 				labelClassName={ labelClassName }
-				showError={ showError }
 			/>
 		);
 	}
@@ -87,7 +86,6 @@ export default function FormPanelField< Item >( {
 			touched={ touched }
 			labelContent={ labelContent }
 			labelClassName={ labelClassName }
-			showError={ showError }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -1,19 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { BaseControl, Icon, Tooltip } from '@wordpress/components';
-import { useState, useContext } from '@wordpress/element';
-import { error as errorIcon } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import type { FieldLayoutProps, NormalizedPanelLayout } from '../../../types';
-import DataFormContext from '../../dataform-context';
 import PanelModal from './modal';
 import PanelDropdown from './dropdown';
-import getFirstValidationError from './utils/get-first-validation-error';
-import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 
 export default function FormPanelField< Item >( {
 	data,
@@ -21,34 +16,10 @@ export default function FormPanelField< Item >( {
 	onChange,
 	validity,
 }: FieldLayoutProps< Item > ) {
-	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
-	const { fieldDefinition } = getFieldDefinitionAndSummaryFields(
-		layout,
-		field,
-		fields
-	);
 
-	// Track if the panel has been closed (touched) to only show errors after interaction.
 	const [ touched, setTouched ] = useState( false );
 	const handleClose = () => setTouched( true );
-
-	const errorMessage = getFirstValidationError( validity );
-	const showError = touched && !! errorMessage;
-	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
-
-	const labelContent = showError ? (
-		<Tooltip text={ errorMessage } placement="top">
-			<span className="dataforms-layouts-panel__field-label-error-content">
-				<Icon icon={ errorIcon } size={ 16 } />
-				<BaseControl.VisualLabel>
-					{ fieldLabel }
-				</BaseControl.VisualLabel>
-			</span>
-		</Tooltip>
-	) : (
-		<BaseControl.VisualLabel>{ fieldLabel }</BaseControl.VisualLabel>
-	);
 
 	if ( layout.openAs === 'modal' ) {
 		return (
@@ -59,7 +30,6 @@ export default function FormPanelField< Item >( {
 				validity={ validity }
 				onClose={ handleClose }
 				touched={ touched }
-				labelContent={ labelContent }
 			/>
 		);
 	}
@@ -72,7 +42,6 @@ export default function FormPanelField< Item >( {
 			validity={ validity }
 			onClose={ handleClose }
 			touched={ touched }
-			labelContent={ labelContent }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { Icon, Tooltip } from '@wordpress/components';
 import { useState, useContext } from '@wordpress/element';
 import { error as errorIcon } from '@wordpress/icons';
-import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -141,12 +140,6 @@ export default function FormPanelField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
 
-	// Use internal state instead of a ref to make sure that the component
-	// re-renders when the popover's anchor updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
-		null
-	);
-
 	// Track if the panel has been closed (touched) to only show errors after interaction.
 	const [ touched, setTouched ] = useState( false );
 	const handleClose = () => setTouched( true );
@@ -170,22 +163,17 @@ export default function FormPanelField< Item >( {
 
 	const labelContent = showError ? (
 		<Tooltip text={ errorMessage } placement="top">
-			<Stack
-				direction="row"
-				gap="sm"
-				className="dataforms-layouts-panel__field-label-error-content"
-				justify="flex-start"
-			>
+			<span className="dataforms-layouts-panel__field-label-error-content">
 				<Icon icon={ errorIcon } size={ 16 } />
-				<>{ fieldLabel }</>
-			</Stack>
+				<span>{ fieldLabel }</span>
+			</span>
 		</Tooltip>
 	) : (
 		fieldLabel
 	);
 
-	const renderedControl =
-		layout.openAs === 'modal' ? (
+	if ( layout.openAs === 'modal' ) {
+		return (
 			<PanelModal
 				data={ data }
 				field={ field }
@@ -195,76 +183,29 @@ export default function FormPanelField< Item >( {
 				fieldDefinition={ fieldDefinition }
 				onClose={ handleClose }
 				touched={ touched }
+				labelContent={ labelContent }
+				labelClassName={ labelClassName }
+				showError={ showError }
+				errorMessage={ errorMessage }
 			/>
-		) : (
-			<PanelDropdown
-				data={ data }
-				field={ field }
-				onChange={ onChange }
-				validity={ validity }
-				labelPosition={ labelPosition }
-				summaryFields={ summaryFields }
-				fieldDefinition={ fieldDefinition }
-				popoverAnchor={ popoverAnchor }
-				onClose={ handleClose }
-				touched={ touched }
-			/>
-		);
-
-	if ( labelPosition === 'top' ) {
-		return (
-			<Stack
-				direction="column"
-				className="dataforms-layouts-panel__field"
-			>
-				<div
-					className={ labelClassName }
-					style={ { paddingBottom: 0 } }
-				>
-					{ labelContent }
-				</div>
-				<div className="dataforms-layouts-panel__field-control">
-					{ renderedControl }
-				</div>
-			</Stack>
 		);
 	}
 
-	if ( labelPosition === 'none' ) {
-		return (
-			<Stack
-				direction="row"
-				gap="sm"
-				className="dataforms-layouts-panel__field dataforms-layouts-panel__field--label-position-none"
-			>
-				{ showError && (
-					<Tooltip text={ errorMessage } placement="top">
-						<Icon
-							className="dataforms-layouts-panel__field-label-error-content"
-							icon={ errorIcon }
-							size={ 16 }
-						/>
-					</Tooltip>
-				) }
-				<div className="dataforms-layouts-panel__field-control">
-					{ renderedControl }
-				</div>
-			</Stack>
-		);
-	}
-
-	// Defaults to label position side.
 	return (
-		<Stack
-			direction="row"
-			gap="sm"
-			ref={ setPopoverAnchor }
-			className="dataforms-layouts-panel__field"
-		>
-			<div className={ labelClassName }>{ labelContent }</div>
-			<div className="dataforms-layouts-panel__field-control">
-				{ renderedControl }
-			</div>
-		</Stack>
+		<PanelDropdown
+			data={ data }
+			field={ field }
+			onChange={ onChange }
+			validity={ validity }
+			labelPosition={ labelPosition }
+			summaryFields={ summaryFields }
+			fieldDefinition={ fieldDefinition }
+			onClose={ handleClose }
+			touched={ touched }
+			labelContent={ labelContent }
+			labelClassName={ labelClassName }
+			showError={ showError }
+			errorMessage={ errorMessage }
+		/>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -13,79 +13,12 @@ import { error as errorIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import type {
-	FieldLayoutProps,
-	NormalizedField,
-	NormalizedFormField,
-	NormalizedPanelLayout,
-} from '../../../types';
+import type { FieldLayoutProps, NormalizedPanelLayout } from '../../../types';
 import DataFormContext from '../../dataform-context';
-import PanelDropdown from './dropdown';
 import PanelModal from './modal';
-import { getSummaryFields } from '../get-summary-fields';
+import PanelDropdown from './dropdown';
 import getFirstValidationError from './utils/get-first-validation-error';
-
-const getFieldDefinition = < Item, >(
-	field: NormalizedFormField,
-	fields: NormalizedField< Item >[]
-) => {
-	const fieldDefinition = fields.find( ( _field ) => _field.id === field.id );
-
-	if ( ! fieldDefinition ) {
-		return fields.find( ( _field ) => {
-			if ( !! field.children ) {
-				const simpleChildren = field.children.filter(
-					( child ) => ! child.children
-				);
-
-				if ( simpleChildren.length === 0 ) {
-					return false;
-				}
-
-				return _field.id === simpleChildren[ 0 ].id;
-			}
-
-			return _field.id === field.id;
-		} );
-	}
-
-	return fieldDefinition;
-};
-
-/**
- * Determines the field definition and summary fields for a panel layout.
- *
- * Summary fields are determined with the following priority:
- * 1. Use layout.summary fields if they exist
- * 2. Fall back to the field definition that matches the form field's id
- * 3. If the form field id doesn't exist, pick the first child field
- * 4. If no field definition is found, return empty summary fields
- *
- * @param layout - The normalized panel layout configuration
- * @param field  - The form field to get definition for
- * @param fields - Array of normalized field definitions
- * @return Object containing fieldDefinition and summaryFields
- */
-const getFieldDefinitionAndSummaryFields = < Item, >(
-	layout: NormalizedPanelLayout,
-	field: NormalizedFormField,
-	fields: NormalizedField< Item >[]
-) => {
-	const summaryFields = getSummaryFields( layout.summary, fields );
-	const fieldDefinition = getFieldDefinition( field, fields );
-
-	if ( summaryFields.length === 0 ) {
-		return {
-			summaryFields: fieldDefinition ? [ fieldDefinition ] : [],
-			fieldDefinition,
-		};
-	}
-
-	return {
-		summaryFields,
-		fieldDefinition,
-	};
-};
+import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 
 export default function FormPanelField< Item >( {
 	data,
@@ -95,17 +28,15 @@ export default function FormPanelField< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
+	const { fieldDefinition } = getFieldDefinitionAndSummaryFields(
+		layout,
+		field,
+		fields
+	);
 
 	// Track if the panel has been closed (touched) to only show errors after interaction.
 	const [ touched, setTouched ] = useState( false );
 	const handleClose = () => setTouched( true );
-
-	const { fieldDefinition, summaryFields } =
-		getFieldDefinitionAndSummaryFields( layout, field, fields );
-
-	if ( ! fieldDefinition ) {
-		return null;
-	}
 
 	const labelPosition = layout.labelPosition;
 	const errorMessage = getFirstValidationError( validity );
@@ -137,8 +68,6 @@ export default function FormPanelField< Item >( {
 				field={ field }
 				onChange={ onChange }
 				validity={ validity }
-				summaryFields={ summaryFields }
-				fieldDefinition={ fieldDefinition }
 				onClose={ handleClose }
 				touched={ touched }
 				labelContent={ labelContent }
@@ -154,8 +83,6 @@ export default function FormPanelField< Item >( {
 			field={ field }
 			onChange={ onChange }
 			validity={ validity }
-			summaryFields={ summaryFields }
-			fieldDefinition={ fieldDefinition }
 			onClose={ handleClose }
 			touched={ touched }
 			labelContent={ labelContent }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Icon, Tooltip } from '@wordpress/components';
+import { BaseControl, Icon, Tooltip } from '@wordpress/components';
 import { useState, useContext } from '@wordpress/element';
 import { error as errorIcon } from '@wordpress/icons';
 
@@ -165,11 +165,13 @@ export default function FormPanelField< Item >( {
 		<Tooltip text={ errorMessage } placement="top">
 			<span className="dataforms-layouts-panel__field-label-error-content">
 				<Icon icon={ errorIcon } size={ 16 } />
-				<span>{ fieldLabel }</span>
+				<BaseControl.VisualLabel>
+					{ fieldLabel }
+				</BaseControl.VisualLabel>
 			</span>
 		</Tooltip>
 	) : (
-		fieldLabel
+		<BaseControl.VisualLabel>{ fieldLabel }</BaseControl.VisualLabel>
 	);
 
 	if ( layout.openAs === 'modal' ) {

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import type { FieldLayoutProps, NormalizedPanelLayout } from '../../../types';
@@ -18,9 +13,6 @@ export default function FormPanelField< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const layout = field.layout as NormalizedPanelLayout;
 
-	const [ touched, setTouched ] = useState( false );
-	const handleClose = () => setTouched( true );
-
 	if ( layout.openAs === 'modal' ) {
 		return (
 			<PanelModal
@@ -28,8 +20,6 @@ export default function FormPanelField< Item >( {
 				field={ field }
 				onChange={ onChange }
 				validity={ validity }
-				onClose={ handleClose }
-				touched={ touched }
 			/>
 		);
 	}
@@ -40,8 +30,6 @@ export default function FormPanelField< Item >( {
 			field={ field }
 			onChange={ onChange }
 			validity={ validity }
-			onClose={ handleClose }
-			touched={ touched }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -15,7 +15,6 @@ import { error as errorIcon } from '@wordpress/icons';
  */
 import type {
 	FieldLayoutProps,
-	FieldValidity,
 	NormalizedField,
 	NormalizedFormField,
 	NormalizedPanelLayout,
@@ -24,50 +23,7 @@ import DataFormContext from '../../dataform-context';
 import PanelDropdown from './dropdown';
 import PanelModal from './modal';
 import { getSummaryFields } from '../get-summary-fields';
-
-function getFirstValidationError(
-	validity: FieldValidity | undefined
-): string | undefined {
-	if ( ! validity ) {
-		return undefined;
-	}
-
-	const validityRules = Object.keys( validity ).filter(
-		( key ) => key !== 'children'
-	);
-
-	for ( const key of validityRules ) {
-		const rule = validity[ key as keyof Omit< FieldValidity, 'children' > ];
-		if ( rule === undefined ) {
-			continue;
-		}
-
-		if ( rule.type === 'invalid' ) {
-			if ( rule.message ) {
-				return rule.message;
-			}
-
-			// Provide default message for required validation (message is optional)
-			if ( key === 'required' ) {
-				return 'A required field is empty';
-			}
-
-			return 'Unidentified validation error';
-		}
-	}
-
-	// Check children recursively
-	if ( validity.children ) {
-		for ( const childValidity of Object.values( validity.children ) ) {
-			const childError = getFirstValidationError( childValidity );
-			if ( childError ) {
-				return childError;
-			}
-		}
-	}
-
-	return undefined;
-}
+import getFirstValidationError from './utils/get-first-validation-error';
 
 const getFieldDefinition = < Item, >(
 	field: NormalizedFormField,
@@ -180,6 +136,7 @@ export default function FormPanelField< Item >( {
 				data={ data }
 				field={ field }
 				onChange={ onChange }
+				validity={ validity }
 				summaryFields={ summaryFields }
 				fieldDefinition={ fieldDefinition }
 				onClose={ handleClose }
@@ -187,7 +144,6 @@ export default function FormPanelField< Item >( {
 				labelContent={ labelContent }
 				labelClassName={ labelClassName }
 				showError={ showError }
-				errorMessage={ errorMessage }
 			/>
 		);
 	}
@@ -205,7 +161,6 @@ export default function FormPanelField< Item >( {
 			labelContent={ labelContent }
 			labelClassName={ labelClassName }
 			showError={ showError }
-			errorMessage={ errorMessage }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -24,7 +24,7 @@ import type {
 	NormalizedForm,
 	NormalizedFormField,
 	NormalizedPanelLayout,
-	FieldValidity,
+	FieldLayoutProps,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
@@ -170,12 +170,7 @@ function PanelModal< Item >( {
 	field,
 	onChange,
 	validity,
-}: {
-	data: Item;
-	field: NormalizedFormField;
-	onChange: ( value: any ) => void;
-	validity?: FieldValidity;
-} ) {
+}: FieldLayoutProps< Item > ) {
 	const [ touched, setTouched ] = useState( false );
 
 	const { fields } = useContext( DataFormContext );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -35,6 +35,7 @@ import DataFormContext from '../../dataform-context';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 import getLabelClassName from './utils/get-label-classname';
+import getLabelContent from './utils/get-label-content';
 
 function ModalContent< Item >( {
 	data,
@@ -171,7 +172,6 @@ function PanelModal< Item >( {
 	validity,
 	onClose: onCloseCallback,
 	touched,
-	labelContent,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -179,7 +179,6 @@ function PanelModal< Item >( {
 	validity?: FieldValidity;
 	onClose?: () => void;
 	touched: boolean;
-	labelContent?: React.ReactNode;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
@@ -197,6 +196,7 @@ function PanelModal< Item >( {
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
 	const labelClassName = getLabelClassName( labelPosition, showError );
+	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 
 	const handleClose = () => {
 		setIsOpen( false );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -23,7 +23,6 @@ import type {
 	Field,
 	NormalizedForm,
 	NormalizedFormField,
-	NormalizedPanelLayout,
 	FieldLayoutProps,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
@@ -170,18 +169,15 @@ function PanelModal< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const [ touched, setTouched ] = useState( false );
 
-	const { fields } = useContext( DataFormContext );
-	const layout = field.layout as NormalizedPanelLayout;
-	const { fieldDefinition, summaryFields } =
-		getFieldDefinitionAndSummaryFields( layout, field, fields );
-
 	const [ isOpen, setIsOpen ] = useState( false );
+
+	const { fields } = useContext( DataFormContext );
+	const { fieldDefinition, fieldLabel, summaryFields } =
+		getFieldDefinitionAndSummaryFields( field, fields );
 
 	if ( ! fieldDefinition ) {
 		return null;
 	}
-
-	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
 	const handleClose = () => {
 		setIsOpen( false );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -199,9 +199,9 @@ function PanelModal< Item >( {
 	return (
 		<>
 			<SummaryButton
-				summaryFields={ summaryFields }
 				data={ data }
-				labelPosition={ labelPosition }
+				field={ field }
+				summaryFields={ summaryFields }
 				fieldLabel={ fieldLabel }
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -206,6 +206,7 @@ function PanelModal< Item >( {
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }
+				aria-haspopup="dialog"
 				labelContent={ labelContent }
 				labelClassName={ labelClassName }
 				showError={ showError }

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -170,16 +170,14 @@ function PanelModal< Item >( {
 	field,
 	onChange,
 	validity,
-	onClose: onCloseCallback,
-	touched,
 }: {
 	data: Item;
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
 	validity?: FieldValidity;
-	onClose?: () => void;
-	touched: boolean;
 } ) {
+	const [ touched, setTouched ] = useState( false );
+
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
 	const labelPosition = layout.labelPosition;
@@ -200,7 +198,7 @@ function PanelModal< Item >( {
 
 	const handleClose = () => {
 		setIsOpen( false );
-		onCloseCallback?.();
+		setTouched( true );
 	};
 
 	return (

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -23,7 +23,6 @@ import type {
 	Field,
 	NormalizedForm,
 	NormalizedFormField,
-	NormalizedField,
 	NormalizedPanelLayout,
 	FieldValidity,
 } from '../../../types';
@@ -34,6 +33,7 @@ import useFormValidity from '../../../hooks/use-form-validity';
 import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
 import getFirstValidationError from './utils/get-first-validation-error';
+import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 
 function ModalContent< Item >( {
 	data,
@@ -168,8 +168,6 @@ function PanelModal< Item >( {
 	field,
 	onChange,
 	validity,
-	summaryFields,
-	fieldDefinition,
 	onClose: onCloseCallback,
 	touched,
 	labelContent,
@@ -180,21 +178,26 @@ function PanelModal< Item >( {
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
 	validity?: FieldValidity;
-	summaryFields: NormalizedField< Item >[];
-	fieldDefinition: NormalizedField< Item >;
 	onClose?: () => void;
 	touched: boolean;
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
 	showError?: boolean;
 } ) {
+	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
 	const labelPosition = layout.labelPosition;
-	const errorMessage = getFirstValidationError( validity );
+	const { fieldDefinition, summaryFields } =
+		getFieldDefinitionAndSummaryFields( layout, field, fields );
 
 	const [ isOpen, setIsOpen ] = useState( false );
 
+	if ( ! fieldDefinition ) {
+		return null;
+	}
+
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
+	const errorMessage = getFirstValidationError( validity );
 
 	const handleClose = () => {
 		setIsOpen( false );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -34,7 +34,6 @@ import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
-import getLabelClassName from './utils/get-label-classname';
 import getLabelContent from './utils/get-label-content';
 
 function ModalContent< Item >( {
@@ -175,7 +174,6 @@ function PanelModal< Item >( {
 
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
-	const labelPosition = layout.labelPosition;
 	const { fieldDefinition, summaryFields } =
 		getFieldDefinitionAndSummaryFields( layout, field, fields );
 
@@ -188,7 +186,6 @@ function PanelModal< Item >( {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
-	const labelClassName = getLabelClassName( labelPosition, showError );
 	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 
 	const handleClose = () => {
@@ -208,7 +205,6 @@ function PanelModal< Item >( {
 				aria-expanded={ isOpen }
 				aria-haspopup="dialog"
 				labelContent={ labelContent }
-				labelClassName={ labelClassName }
 				showError={ showError }
 				errorMessage={ errorMessage }
 			/>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -34,6 +34,7 @@ import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
+import getLabelClassName from './utils/get-label-classname';
 
 function ModalContent< Item >( {
 	data,
@@ -171,7 +172,6 @@ function PanelModal< Item >( {
 	onClose: onCloseCallback,
 	touched,
 	labelContent,
-	labelClassName,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -180,7 +180,6 @@ function PanelModal< Item >( {
 	onClose?: () => void;
 	touched: boolean;
 	labelContent?: React.ReactNode;
-	labelClassName?: string;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
@@ -197,6 +196,7 @@ function PanelModal< Item >( {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
+	const labelClassName = getLabelClassName( labelPosition, showError );
 
 	const handleClose = () => {
 		setIsOpen( false );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -25,6 +25,7 @@ import type {
 	NormalizedFormField,
 	NormalizedField,
 	NormalizedPanelLayout,
+	FieldValidity,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
@@ -32,6 +33,7 @@ import SummaryButton from './summary-button';
 import useFormValidity from '../../../hooks/use-form-validity';
 import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
+import getFirstValidationError from './utils/get-first-validation-error';
 
 function ModalContent< Item >( {
 	data,
@@ -165,6 +167,7 @@ function PanelModal< Item >( {
 	data,
 	field,
 	onChange,
+	validity,
 	summaryFields,
 	fieldDefinition,
 	onClose: onCloseCallback,
@@ -172,11 +175,11 @@ function PanelModal< Item >( {
 	labelContent,
 	labelClassName,
 	showError,
-	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
+	validity?: FieldValidity;
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	onClose?: () => void;
@@ -184,10 +187,10 @@ function PanelModal< Item >( {
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
 	showError?: boolean;
-	errorMessage?: string;
 } ) {
 	const layout = field.layout as NormalizedPanelLayout;
 	const labelPosition = layout.labelPosition;
+	const errorMessage = getFirstValidationError( validity );
 
 	const [ isOpen, setIsOpen ] = useState( false );
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -32,7 +32,6 @@ import SummaryButton from './summary-button';
 import useFormValidity from '../../../hooks/use-form-validity';
 import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
-import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
 
 function ModalContent< Item >( {
@@ -183,8 +182,6 @@ function PanelModal< Item >( {
 	}
 
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
-	const errorMessage = getFirstValidationError( validity );
-	const showError = touched && !! errorMessage;
 
 	const handleClose = () => {
 		setIsOpen( false );
@@ -196,13 +193,13 @@ function PanelModal< Item >( {
 			<SummaryButton
 				data={ data }
 				field={ field }
+				validity={ validity }
+				touched={ touched }
 				summaryFields={ summaryFields }
 				fieldLabel={ fieldLabel }
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }
-				showError={ showError }
-				errorMessage={ errorMessage }
 			/>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -169,6 +169,10 @@ function PanelModal< Item >( {
 	fieldDefinition,
 	onClose: onCloseCallback,
 	touched,
+	labelContent,
+	labelClassName,
+	showError,
+	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -178,6 +182,10 @@ function PanelModal< Item >( {
 	fieldDefinition: NormalizedField< Item >;
 	onClose?: () => void;
 	touched: boolean;
+	labelContent?: React.ReactNode;
+	labelClassName?: string;
+	showError?: boolean;
+	errorMessage?: string;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -198,6 +206,10 @@ function PanelModal< Item >( {
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }
+				labelContent={ labelContent }
+				labelClassName={ labelClassName }
+				showError={ showError }
+				errorMessage={ errorMessage }
 			/>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -172,7 +172,6 @@ function PanelModal< Item >( {
 	touched,
 	labelContent,
 	labelClassName,
-	showError,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -182,7 +181,6 @@ function PanelModal< Item >( {
 	touched: boolean;
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
-	showError?: boolean;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
@@ -198,6 +196,7 @@ function PanelModal< Item >( {
 
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 	const errorMessage = getFirstValidationError( validity );
+	const showError = touched && !! errorMessage;
 
 	const handleClose = () => {
 		setIsOpen( false );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -24,6 +24,7 @@ import type {
 	NormalizedForm,
 	NormalizedFormField,
 	NormalizedField,
+	NormalizedPanelLayout,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
@@ -164,7 +165,6 @@ function PanelModal< Item >( {
 	data,
 	field,
 	onChange,
-	labelPosition,
 	summaryFields,
 	fieldDefinition,
 	onClose: onCloseCallback,
@@ -177,7 +177,6 @@ function PanelModal< Item >( {
 	data: Item;
 	field: NormalizedFormField;
 	onChange: ( value: any ) => void;
-	labelPosition: 'side' | 'top' | 'none';
 	summaryFields: NormalizedField< Item >[];
 	fieldDefinition: NormalizedField< Item >;
 	onClose?: () => void;
@@ -187,6 +186,9 @@ function PanelModal< Item >( {
 	showError?: boolean;
 	errorMessage?: string;
 } ) {
+	const layout = field.layout as NormalizedPanelLayout;
+	const labelPosition = layout.labelPosition;
+
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -34,7 +34,6 @@ import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
 import getFirstValidationError from './utils/get-first-validation-error';
 import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
-import getLabelContent from './utils/get-label-content';
 
 function ModalContent< Item >( {
 	data,
@@ -186,7 +185,6 @@ function PanelModal< Item >( {
 	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
-	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 
 	const handleClose = () => {
 		setIsOpen( false );
@@ -203,7 +201,6 @@ function PanelModal< Item >( {
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }
-				labelContent={ labelContent }
 				showError={ showError }
 				errorMessage={ errorMessage }
 			/>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -31,7 +31,7 @@ import SummaryButton from './summary-button';
 import useFormValidity from '../../../hooks/use-form-validity';
 import useReportValidity from '../../../hooks/use-report-validity';
 import DataFormContext from '../../dataform-context';
-import getFieldDefinitionAndSummaryFields from './utils/get-field-definition-and-summary-fields';
+import useFieldFromFormField from './utils/use-field-from-form-field';
 
 function ModalContent< Item >( {
 	data,
@@ -171,10 +171,8 @@ function PanelModal< Item >( {
 
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const { fields } = useContext( DataFormContext );
 	const { fieldDefinition, fieldLabel, summaryFields } =
-		getFieldDefinitionAndSummaryFields( field, fields );
-
+		useFieldFromFormField( field );
 	if ( ! fieldDefinition ) {
 		return null;
 	}
@@ -189,10 +187,10 @@ function PanelModal< Item >( {
 			<SummaryButton
 				data={ data }
 				field={ field }
+				fieldLabel={ fieldLabel }
+				summaryFields={ summaryFields }
 				validity={ validity }
 				touched={ touched }
-				summaryFields={ summaryFields }
-				fieldLabel={ fieldLabel }
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -203,7 +203,6 @@ function PanelModal< Item >( {
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
 				aria-expanded={ isOpen }
-				aria-haspopup="dialog"
 				labelContent={ labelContent }
 				showError={ showError }
 				errorMessage={ errorMessage }

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -144,9 +144,6 @@
 	overflow: hidden;
 
 	> * {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
 		min-width: 0;
 	}
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -13,14 +13,6 @@
 	border-radius: $radius-small;
 	isolation: isolate;
 
-	&::before {
-		content: "";
-		position: absolute;
-		inset: 0 (-$grid-unit-10);
-		border-radius: $radius-small;
-		z-index: -1;
-	}
-
 	&--label-side {
 		flex-direction: row;
 		gap: $grid-unit-10;
@@ -38,12 +30,12 @@
 	&:not([aria-disabled="true"]):hover {
 		color: var(--wp-admin-theme-color);
 
-		&::before {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		}
-
 		.dataforms-layouts-panel__field-trigger-icon {
 			opacity: 1;
+		}
+
+		.dataforms-layouts-panel__field-label {
+			color: var(--wp-admin-theme-color);
 		}
 	}
 
@@ -66,25 +58,14 @@
 	display: flex;
 	align-items: center;
 	align-self: center;
-	color: var(--wp-admin-theme-color);
+	fill: var(--wp-admin-theme-color);
 	flex: 0 0 auto;
 	opacity: 0;
-
-	&::after {
-		content: "";
-		position: absolute;
-		inset: 0 (-$grid-unit-10);
-		border-radius: $radius-small;
-	}
+	border-radius: var(--wpds-border-radius-xs);
 
 	&:focus-visible {
-		outline: none;
 		opacity: 1;
-
-		&::after {
-			outline: var(--wp-admin-theme-color, #007cba) solid 1.5px;
-			outline-offset: -1.5px;
-		}
+		outline: var(--wpds-border-width-focus) solid var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -27,7 +27,8 @@
 	}
 
 	&--label-top {
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: 1fr auto;
 	}
 
 	&--label-none {
@@ -150,6 +151,15 @@
 
 .dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-label {
 	width: 100%;
+}
+
+.dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-control {
+	grid-column: 1 / -1;
+}
+
+.dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-trigger-icon {
+	grid-row: 1;
+	grid-column: 2;
 }
 
 .dataforms-layouts-panel__field-dropdown .components-popover__content {

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -15,7 +15,7 @@
 
 	&--label-side {
 		flex-direction: row;
-		gap: $grid-unit-10;
+		gap: var(--wpds-dimension-gap-md);
 	}
 
 	&--label-top {

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -67,6 +67,7 @@
 	}
 
 	&:focus-visible {
+		outline: none;
 		width: auto;
 		overflow: visible;
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -83,6 +83,12 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
+	color: $gray-700;
+
+	.components-base-control__label {
+		display: inline;
+		margin-bottom: 0;
+	}
 
 	&--label-position-side {
 		align-self: center;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -44,6 +44,7 @@
 
 		.dataforms-layouts-panel__field-control {
 			color: $gray-700;
+			font-weight: var(--wpds-font-weight-regular);
 		}
 	}
 }
@@ -57,7 +58,6 @@
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-	align-self: center;
 	fill: var(--wp-admin-theme-color);
 	flex: 0 0 auto;
 	opacity: 0;
@@ -99,10 +99,6 @@
 		line-height: inherit;
 	}
 
-	&--label-position-side {
-		align-self: center;
-	}
-
 	&.has-error {
 		color: $alert-red;
 	}
@@ -123,13 +119,14 @@
 }
 
 .dataforms-layouts-panel__field-control {
-	align-self: center;
 	flex-grow: 1;
 	min-width: 0;
-	min-height: $grid-unit-40;
+	min-height: $grid-unit-30;
+	line-height: var(--wpds-font-line-height-md);
 	display: flex;
 	align-items: center;
 	overflow: hidden;
+	font-weight: var(--wpds-font-weight-medium);
 
 	> * {
 		min-width: 0;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -3,14 +3,8 @@
 @use "@wordpress/base-styles/z-index" as *;
 
 .dataforms-layouts-panel__field-trigger {
-	appearance: none;
-	background: none;
-	border: none;
-	padding: 0;
-	margin: 0;
-	font: inherit;
+	position: relative;
 	color: inherit;
-	text-align: start;
 	display: flex;
 	width: 100%;
 	min-height: $grid-unit-40;
@@ -29,11 +23,6 @@
 
 	&--label-none {
 		align-items: center;
-	}
-
-	&:focus-visible {
-		outline: var(--wp-admin-theme-color, #007cba) solid 1.5px;
-		outline-offset: -1.5px;
 	}
 
 	&:not([aria-disabled="true"]):hover {
@@ -56,12 +45,35 @@
 }
 
 .dataforms-layouts-panel__field-trigger-icon {
+	appearance: none;
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	cursor: pointer;
 	display: flex;
 	align-items: center;
 	color: var(--wp-admin-theme-color);
 	flex: 0 0 auto;
 	overflow: hidden;
 	width: 0;
+
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: $radius-small;
+	}
+
+	&:focus-visible {
+		width: auto;
+		overflow: visible;
+
+		&::after {
+			outline: var(--wp-admin-theme-color, #007cba) solid 1.5px;
+			outline-offset: -1.5px;
+		}
+	}
 }
 
 .dataforms-layouts-panel__field-dropdown-anchor {
@@ -98,6 +110,8 @@
 }
 
 .dataforms-layouts-panel__field-label-error-content {
+	position: relative;
+	z-index: 1;
 	cursor: help;
 	fill: $alert-red;
 	display: inline-flex;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -53,6 +53,7 @@
 	cursor: pointer;
 	display: flex;
 	align-items: center;
+	align-self: center;
 	color: var(--wp-admin-theme-color);
 	flex: 0 0 auto;
 	overflow: hidden;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -11,6 +11,15 @@
 	cursor: pointer;
 	align-items: flex-start;
 	border-radius: $radius-small;
+	isolation: isolate;
+
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0 (-$grid-unit-10);
+		border-radius: $radius-small;
+		z-index: -1;
+	}
 
 	&--label-side {
 		flex-direction: row;
@@ -26,8 +35,11 @@
 	}
 
 	&:not([aria-disabled="true"]):hover {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		color: var(--wp-admin-theme-color);
+
+		&::before {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		}
 
 		.dataforms-layouts-panel__field-trigger-icon {
 			width: auto;
@@ -62,7 +74,7 @@
 	&::after {
 		content: "";
 		position: absolute;
-		inset: 0;
+		inset: 0 (-$grid-unit-10);
 		border-radius: $radius-small;
 	}
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -138,6 +138,7 @@
 }
 
 .dataforms-layouts-panel__field-control {
+	align-self: center;
 	flex-grow: 1;
 	min-width: 0;
 	min-height: $grid-unit-40;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -48,6 +48,10 @@
 
 	&[aria-disabled="true"] {
 		cursor: default;
+
+		.dataforms-layouts-panel__field-control {
+			color: $gray-700;
+		}
 	}
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -42,8 +42,7 @@
 		}
 
 		.dataforms-layouts-panel__field-trigger-icon {
-			width: auto;
-			overflow: visible;
+			opacity: 1;
 		}
 	}
 
@@ -68,8 +67,7 @@
 	align-self: center;
 	color: var(--wp-admin-theme-color);
 	flex: 0 0 auto;
-	overflow: hidden;
-	width: 0;
+	opacity: 0;
 
 	&::after {
 		content: "";
@@ -80,8 +78,7 @@
 
 	&:focus-visible {
 		outline: none;
-		width: auto;
-		overflow: visible;
+		opacity: 1;
 
 		&::after {
 			outline: var(--wp-admin-theme-color, #007cba) solid 1.5px;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -63,6 +63,12 @@
 	opacity: 0;
 	border-radius: var(--wpds-border-radius-xs);
 
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+	}
+
 	&:focus-visible {
 		opacity: 1;
 		outline: var(--wpds-border-width-focus) solid var(--wp-admin-theme-color);

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -2,14 +2,76 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
-.dataforms-layouts-panel__field {
+.dataforms-layouts-panel__field-trigger {
+	appearance: none;
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	text-align: start;
+	display: flex;
 	width: 100%;
 	min-height: $grid-unit-40;
-	justify-content: flex-start !important;
-	align-items: flex-start !important;
+	cursor: pointer;
+	align-items: flex-start;
+	position: relative;
+	border-radius: $radius-small;
 
-	&--label-position-none {
-		align-items: center !important;
+	&--label-side {
+		flex-direction: row;
+		gap: $grid-unit-10;
+	}
+
+	&--label-top {
+		flex-direction: column;
+	}
+
+	&--label-none {
+		align-items: center;
+	}
+
+	&:focus-visible {
+		outline: var(--wp-admin-theme-color, #007cba) solid 1.5px;
+		outline-offset: -1.5px;
+	}
+
+	&:not([aria-disabled="true"]):hover {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		color: var(--wp-admin-theme-color);
+
+		.dataforms-layouts-panel__field-trigger-icon {
+			opacity: 1;
+		}
+	}
+
+	&[aria-disabled="true"] {
+		cursor: default;
+	}
+}
+
+.dataforms-layouts-panel__field-trigger-icon {
+	position: absolute;
+	right: $grid-unit-05;
+	top: 50%;
+	transform: translateY(-50%);
+	opacity: 0;
+	color: var(--wp-admin-theme-color);
+	display: flex;
+	align-items: center;
+
+	.dataforms-layouts-panel__field-trigger--label-top & {
+		top: 0;
+		transform: translateY(25%);
+	}
+}
+
+.dataforms-layouts-panel__field-dropdown-anchor {
+	width: 100%;
+
+	.components-dropdown {
+		width: 100%;
 	}
 }
 
@@ -34,6 +96,10 @@
 .dataforms-layouts-panel__field-label-error-content {
 	cursor: help;
 	fill: $alert-red;
+	display: inline-flex;
+	flex-direction: row;
+	align-items: center;
+	gap: $grid-unit-05;
 	svg {
 		fill: currentColor;
 	}
@@ -44,23 +110,6 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
-
-	.components-button {
-		max-width: 100%;
-		text-align: left;
-		white-space: normal;
-		text-wrap: balance; // Fallback for Safari.
-		text-wrap: pretty;
-		min-height: $button-size-compact;
-	}
-
-	&.components-button.is-link[aria-disabled="true"] {
-		text-decoration: none;
-	}
-
-	.components-dropdown {
-		max-width: 100%;
-	}
 }
 
 .dataforms-layouts-panel__field-dropdown .components-popover__content {
@@ -78,8 +127,4 @@
 
 .components-popover.components-dropdown__content.dataforms-layouts-panel__field-dropdown {
 	z-index: z-index(".components-popover.components-dropdown__content.dataforms-layouts-panel__field-dropdown");
-}
-
-.dataforms-layouts-panel__summary-button:empty {
-	min-width: $admin-sidebar-width;
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -80,7 +80,7 @@
 .dataforms-layouts-panel__field-label {
 	width: 38%;
 	flex-shrink: 0;
-	min-height: $grid-unit-40;
+	min-height: $grid-unit-30;
 	display: flex;
 	align-items: center;
 	line-height: $grid-unit-05 * 5;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -16,7 +16,6 @@
 	min-height: $grid-unit-40;
 	cursor: pointer;
 	align-items: flex-start;
-	position: relative;
 	border-radius: $radius-small;
 
 	&--label-side {
@@ -25,7 +24,7 @@
 	}
 
 	&--label-top {
-		flex-direction: column;
+		flex-wrap: wrap;
 	}
 
 	&--label-none {
@@ -42,7 +41,8 @@
 		color: var(--wp-admin-theme-color);
 
 		.dataforms-layouts-panel__field-trigger-icon {
-			opacity: 1;
+			width: auto;
+			overflow: visible;
 		}
 	}
 
@@ -52,19 +52,12 @@
 }
 
 .dataforms-layouts-panel__field-trigger-icon {
-	position: absolute;
-	right: $grid-unit-05;
-	top: 50%;
-	transform: translateY(-50%);
-	opacity: 0;
-	color: var(--wp-admin-theme-color);
 	display: flex;
 	align-items: center;
-
-	.dataforms-layouts-panel__field-trigger--label-top & {
-		top: 0;
-		transform: translateY(25%);
-	}
+	color: var(--wp-admin-theme-color);
+	flex: 0 0 auto;
+	overflow: hidden;
+	width: 0;
 }
 
 .dataforms-layouts-panel__field-dropdown-anchor {
@@ -88,6 +81,7 @@
 	.components-base-control__label {
 		display: inline;
 		margin-bottom: 0;
+		line-height: inherit;
 	}
 
 	&--label-position-side {
@@ -113,9 +107,22 @@
 
 .dataforms-layouts-panel__field-control {
 	flex-grow: 1;
+	min-width: 0;
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
+	overflow: hidden;
+
+	> * {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+}
+
+.dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-label {
+	width: 100%;
 }
 
 .dataforms-layouts-panel__field-dropdown .components-popover__content {

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -7,7 +7,7 @@
 	color: inherit;
 	display: flex;
 	width: 100%;
-	min-height: $grid-unit-40;
+	min-height: $grid-unit-30;
 	cursor: pointer;
 	align-items: flex-start;
 	border-radius: $radius-small;

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { Icon, Tooltip } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
 import { error as errorIcon, pencil } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ export default function SummaryButton< Item >( {
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
+	'aria-haspopup': ariaHasPopup,
 	labelContent,
 	labelClassName,
 	showError,
@@ -35,6 +37,7 @@ export default function SummaryButton< Item >( {
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;
+	'aria-haspopup'?: 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid';
 	labelContent?: React.ReactNode;
 	labelClassName?: string;
 	showError?: boolean;
@@ -44,6 +47,23 @@ export default function SummaryButton< Item >( {
 		'dataforms-layouts-panel__field-trigger',
 		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`
 	);
+
+	const controlId = useInstanceId(
+		SummaryButton,
+		'dataforms-layouts-panel__field-control'
+	);
+
+	const ariaLabel = showError
+		? sprintf(
+				// translators: %s: Field name.
+				_x( 'Edit %s (has errors)', 'field' ),
+				fieldLabel || ''
+		  )
+		: sprintf(
+				// translators: %s: Field name.
+				_x( 'Edit %s', 'field' ),
+				fieldLabel || ''
+		  );
 
 	return (
 		<div className={ className } aria-disabled={ disabled || undefined }>
@@ -57,7 +77,10 @@ export default function SummaryButton< Item >( {
 					</span>
 				</Tooltip>
 			) }
-			<span className="dataforms-layouts-panel__field-control">
+			<span
+				id={ `${ controlId }` }
+				className="dataforms-layouts-panel__field-control"
+			>
 				{ summaryFields.length > 1 ? (
 					<span
 						style={ {
@@ -94,12 +117,10 @@ export default function SummaryButton< Item >( {
 				<button
 					type="button"
 					className="dataforms-layouts-panel__field-trigger-icon"
-					aria-label={ sprintf(
-						// translators: %s: Field name.
-						_x( 'Edit %s', 'field' ),
-						fieldLabel || ''
-					) }
+					aria-label={ ariaLabel }
 					aria-expanded={ ariaExpanded }
+					aria-haspopup={ ariaHasPopup }
+					aria-describedby={ `${ controlId }` }
 					onClick={ onClick }
 				>
 					<Icon icon={ pencil } size={ 24 } />

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -15,36 +15,40 @@ import { useInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import type {
+	FieldValidity,
 	NormalizedField,
 	NormalizedFormField,
 	NormalizedPanelLayout,
 } from '../../../types';
 import getLabelClassName from './utils/get-label-classname';
 import getLabelContent from './utils/get-label-content';
+import getFirstValidationError from './utils/get-first-validation-error';
 
 export default function SummaryButton< Item >( {
 	data,
 	field,
+	validity,
+	touched,
 	summaryFields,
 	fieldLabel,
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
-	showError,
-	errorMessage,
 }: {
 	data: Item;
 	field: NormalizedFormField;
+	validity?: FieldValidity;
+	touched: boolean;
 	summaryFields: NormalizedField< Item >[];
 	fieldLabel?: string;
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;
-	showError?: boolean;
-	errorMessage?: string;
 } ) {
 	const labelPosition = ( field.layout as NormalizedPanelLayout )
 		.labelPosition;
+	const errorMessage = getFirstValidationError( validity );
+	const showError = touched && !! errorMessage;
 	const labelClassName = getLabelClassName( labelPosition, showError );
 	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 	const className = clsx(

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -29,7 +29,6 @@ export default function SummaryButton< Item >( {
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
-	'aria-haspopup': ariaHasPopup,
 	labelContent,
 	showError,
 	errorMessage,
@@ -41,7 +40,6 @@ export default function SummaryButton< Item >( {
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;
-	'aria-haspopup'?: 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid';
 	labelContent?: React.ReactNode;
 	showError?: boolean;
 	errorMessage?: string;
@@ -125,7 +123,7 @@ export default function SummaryButton< Item >( {
 					className="dataforms-layouts-panel__field-trigger-icon"
 					aria-label={ ariaLabel }
 					aria-expanded={ ariaExpanded }
-					aria-haspopup={ ariaHasPopup }
+					aria-haspopup="dialog"
 					aria-describedby={ `${ controlId }` }
 					onClick={ onClick }
 				>

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -19,6 +19,7 @@ import type {
 	NormalizedFormField,
 	NormalizedPanelLayout,
 } from '../../../types';
+import getLabelClassName from './utils/get-label-classname';
 
 export default function SummaryButton< Item >( {
 	data,
@@ -30,7 +31,6 @@ export default function SummaryButton< Item >( {
 	'aria-expanded': ariaExpanded,
 	'aria-haspopup': ariaHasPopup,
 	labelContent,
-	labelClassName,
 	showError,
 	errorMessage,
 }: {
@@ -43,12 +43,12 @@ export default function SummaryButton< Item >( {
 	'aria-expanded'?: boolean;
 	'aria-haspopup'?: 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid';
 	labelContent?: React.ReactNode;
-	labelClassName?: string;
 	showError?: boolean;
 	errorMessage?: string;
 } ) {
 	const labelPosition = ( field.layout as NormalizedPanelLayout )
 		.labelPosition;
+	const labelClassName = getLabelClassName( labelPosition, showError );
 	const className = clsx(
 		'dataforms-layouts-panel__field-trigger',
 		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -20,6 +20,7 @@ import type {
 	NormalizedPanelLayout,
 } from '../../../types';
 import getLabelClassName from './utils/get-label-classname';
+import getLabelContent from './utils/get-label-content';
 
 export default function SummaryButton< Item >( {
 	data,
@@ -29,7 +30,6 @@ export default function SummaryButton< Item >( {
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
-	labelContent,
 	showError,
 	errorMessage,
 }: {
@@ -40,13 +40,13 @@ export default function SummaryButton< Item >( {
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;
-	labelContent?: React.ReactNode;
 	showError?: boolean;
 	errorMessage?: string;
 } ) {
 	const labelPosition = ( field.layout as NormalizedPanelLayout )
 		.labelPosition;
 	const labelClassName = getLabelClassName( labelPosition, showError );
+	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 	const className = clsx(
 		'dataforms-layouts-panel__field-trigger',
 		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -1,92 +1,118 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
+import { error as errorIcon, pencil } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import type { NormalizedField } from '../../../types';
 
-function SummaryButton< Item >( {
-	summaryFields,
-	data,
-	labelPosition,
-	fieldLabel,
-	disabled,
-	onClick,
-	'aria-expanded': ariaExpanded,
-}: {
-	summaryFields: NormalizedField< Item >[];
-	data: Item;
-	labelPosition: 'side' | 'top' | 'none';
-	fieldLabel?: string;
-	disabled?: boolean;
-	onClick: () => void;
-	'aria-expanded'?: boolean;
-} ) {
+function SummaryButton< Item >(
+	{
+		summaryFields,
+		data,
+		labelPosition,
+		fieldLabel,
+		disabled,
+		onClick,
+		'aria-expanded': ariaExpanded,
+		labelContent,
+		labelClassName,
+		showError,
+		errorMessage,
+	}: {
+		summaryFields: NormalizedField< Item >[];
+		data: Item;
+		labelPosition: 'side' | 'top' | 'none';
+		fieldLabel?: string;
+		disabled?: boolean;
+		onClick: () => void;
+		'aria-expanded'?: boolean;
+		labelContent?: React.ReactNode;
+		labelClassName?: string;
+		showError?: boolean;
+		errorMessage?: string;
+	},
+	ref: React.Ref< HTMLButtonElement >
+) {
+	const className = clsx(
+		'dataforms-layouts-panel__field-trigger',
+		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`
+	);
+
 	return (
-		<Button
-			className="dataforms-layouts-panel__summary-button"
-			size="compact"
-			variant={
-				[ 'none', 'top' ].includes( labelPosition )
-					? 'link'
-					: 'tertiary'
-			}
-			aria-expanded={ ariaExpanded }
+		<button
+			ref={ ref }
+			type="button"
+			className={ className }
 			aria-label={ sprintf(
 				// translators: %s: Field name.
 				_x( 'Edit %s', 'field' ),
 				fieldLabel || ''
 			) }
-			onClick={ onClick }
-			disabled={ disabled }
-			accessibleWhenDisabled
-			style={
-				summaryFields.length > 1
-					? {
-							minHeight: 'auto',
-							height: 'auto',
-							alignItems: 'flex-start',
-					  }
-					: undefined
-			}
+			aria-expanded={ ariaExpanded }
+			aria-disabled={ disabled || undefined }
+			onClick={ disabled ? undefined : onClick }
 		>
-			{ summaryFields.length > 1 ? (
-				<div
-					style={ {
-						display: 'flex',
-						flexDirection: 'column',
-						alignItems: 'flex-start',
-						width: '100%',
-						gap: '2px',
-					} }
-				>
-					{ summaryFields.map( ( summaryField ) => (
-						<div
-							key={ summaryField.id }
-							style={ { width: '100%' } }
-						>
-							<summaryField.render
-								item={ data }
-								field={ summaryField }
-							/>
-						</div>
-					) ) }
-				</div>
-			) : (
-				summaryFields.map( ( summaryField ) => (
-					<summaryField.render
-						key={ summaryField.id }
-						item={ data }
-						field={ summaryField }
-					/>
-				) )
+			{ labelPosition !== 'none' && (
+				<span className={ labelClassName }>{ labelContent }</span>
 			) }
-		</Button>
+			{ labelPosition === 'none' && showError && (
+				<Tooltip text={ errorMessage } placement="top">
+					<span className="dataforms-layouts-panel__field-label-error-content">
+						<Icon icon={ errorIcon } size={ 16 } />
+					</span>
+				</Tooltip>
+			) }
+			<span className="dataforms-layouts-panel__field-control">
+				{ summaryFields.length > 1 ? (
+					<span
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'flex-start',
+							width: '100%',
+							gap: '2px',
+						} }
+					>
+						{ summaryFields.map( ( summaryField ) => (
+							<span
+								key={ summaryField.id }
+								style={ { width: '100%' } }
+							>
+								<summaryField.render
+									item={ data }
+									field={ summaryField }
+								/>
+							</span>
+						) ) }
+					</span>
+				) : (
+					summaryFields.map( ( summaryField ) => (
+						<summaryField.render
+							key={ summaryField.id }
+							item={ data }
+							field={ summaryField }
+						/>
+					) )
+				) }
+			</span>
+			{ ! disabled && (
+				<span className="dataforms-layouts-panel__field-trigger-icon">
+					<Icon icon={ pencil } size={ 24 } />
+				</span>
+			) }
+		</button>
 	);
 }
 
-export default SummaryButton;
+export default forwardRef( SummaryButton ) as typeof SummaryButton;

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -14,12 +14,16 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import type { NormalizedField } from '../../../types';
+import type {
+	NormalizedField,
+	NormalizedFormField,
+	NormalizedPanelLayout,
+} from '../../../types';
 
 export default function SummaryButton< Item >( {
-	summaryFields,
 	data,
-	labelPosition,
+	field,
+	summaryFields,
 	fieldLabel,
 	disabled,
 	onClick,
@@ -30,9 +34,9 @@ export default function SummaryButton< Item >( {
 	showError,
 	errorMessage,
 }: {
-	summaryFields: NormalizedField< Item >[];
 	data: Item;
-	labelPosition: 'side' | 'top' | 'none';
+	field: NormalizedFormField;
+	summaryFields: NormalizedField< Item >[];
 	fieldLabel?: string;
 	disabled?: boolean;
 	onClick: () => void;
@@ -43,6 +47,8 @@ export default function SummaryButton< Item >( {
 	showError?: boolean;
 	errorMessage?: string;
 } ) {
+	const labelPosition = ( field.layout as NormalizedPanelLayout )
+		.labelPosition;
 	const className = clsx(
 		'dataforms-layouts-panel__field-trigger',
 		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -27,20 +27,20 @@ import getFirstValidationError from './utils/get-first-validation-error';
 export default function SummaryButton< Item >( {
 	data,
 	field,
+	fieldLabel,
+	summaryFields,
 	validity,
 	touched,
-	summaryFields,
-	fieldLabel,
 	disabled,
 	onClick,
 	'aria-expanded': ariaExpanded,
 }: {
 	data: Item;
 	field: NormalizedFormField;
+	fieldLabel?: string;
+	summaryFields: NormalizedField< Item >[];
 	validity?: FieldValidity;
 	touched: boolean;
-	summaryFields: NormalizedField< Item >[];
-	fieldLabel?: string;
 	disabled?: boolean;
 	onClick: () => void;
 	'aria-expanded'?: boolean;

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import { Icon, Tooltip } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
-import { forwardRef } from '@wordpress/element';
 import { error as errorIcon, pencil } from '@wordpress/icons';
 
 /**
@@ -16,53 +15,38 @@ import { error as errorIcon, pencil } from '@wordpress/icons';
  */
 import type { NormalizedField } from '../../../types';
 
-function SummaryButton< Item >(
-	{
-		summaryFields,
-		data,
-		labelPosition,
-		fieldLabel,
-		disabled,
-		onClick,
-		'aria-expanded': ariaExpanded,
-		labelContent,
-		labelClassName,
-		showError,
-		errorMessage,
-	}: {
-		summaryFields: NormalizedField< Item >[];
-		data: Item;
-		labelPosition: 'side' | 'top' | 'none';
-		fieldLabel?: string;
-		disabled?: boolean;
-		onClick: () => void;
-		'aria-expanded'?: boolean;
-		labelContent?: React.ReactNode;
-		labelClassName?: string;
-		showError?: boolean;
-		errorMessage?: string;
-	},
-	ref: React.Ref< HTMLButtonElement >
-) {
+export default function SummaryButton< Item >( {
+	summaryFields,
+	data,
+	labelPosition,
+	fieldLabel,
+	disabled,
+	onClick,
+	'aria-expanded': ariaExpanded,
+	labelContent,
+	labelClassName,
+	showError,
+	errorMessage,
+}: {
+	summaryFields: NormalizedField< Item >[];
+	data: Item;
+	labelPosition: 'side' | 'top' | 'none';
+	fieldLabel?: string;
+	disabled?: boolean;
+	onClick: () => void;
+	'aria-expanded'?: boolean;
+	labelContent?: React.ReactNode;
+	labelClassName?: string;
+	showError?: boolean;
+	errorMessage?: string;
+} ) {
 	const className = clsx(
 		'dataforms-layouts-panel__field-trigger',
 		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`
 	);
 
 	return (
-		<button
-			ref={ ref }
-			type="button"
-			className={ className }
-			aria-label={ sprintf(
-				// translators: %s: Field name.
-				_x( 'Edit %s', 'field' ),
-				fieldLabel || ''
-			) }
-			aria-expanded={ ariaExpanded }
-			aria-disabled={ disabled || undefined }
-			onClick={ disabled ? undefined : onClick }
-		>
+		<div className={ className } aria-disabled={ disabled || undefined }>
 			{ labelPosition !== 'none' && (
 				<span className={ labelClassName }>{ labelContent }</span>
 			) }
@@ -107,12 +91,20 @@ function SummaryButton< Item >(
 				) }
 			</span>
 			{ ! disabled && (
-				<span className="dataforms-layouts-panel__field-trigger-icon">
+				<button
+					type="button"
+					className="dataforms-layouts-panel__field-trigger-icon"
+					aria-label={ sprintf(
+						// translators: %s: Field name.
+						_x( 'Edit %s', 'field' ),
+						fieldLabel || ''
+					) }
+					aria-expanded={ ariaExpanded }
+					onClick={ onClick }
+				>
 					<Icon icon={ pencil } size={ 24 } />
-				</span>
+				</button>
 			) }
-		</button>
+		</div>
 	);
 }
-
-export default forwardRef( SummaryButton ) as typeof SummaryButton;

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-field-definition-and-summary-fields.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-field-definition-and-summary-fields.ts
@@ -41,29 +41,31 @@ const getFieldDefinition = < Item >(
  * 3. If the form field id doesn't exist, pick the first child field
  * 4. If no field definition is found, return empty summary fields
  *
- * @param layout - The normalized panel layout configuration
  * @param field  - The form field to get definition for
  * @param fields - Array of normalized field definitions
- * @return Object containing fieldDefinition and summaryFields
+ * @return Object containing fieldDefinition, fieldLabel, and summaryFields
  */
 const getFieldDefinitionAndSummaryFields = < Item >(
-	layout: NormalizedPanelLayout,
 	field: NormalizedFormField,
 	fields: NormalizedField< Item >[]
 ) => {
+	const layout = field.layout as NormalizedPanelLayout;
 	const summaryFields = getSummaryFields( layout.summary, fields );
 	const fieldDefinition = getFieldDefinition( field, fields );
+	const fieldLabel = !! field.children ? field.label : fieldDefinition?.label;
 
 	if ( summaryFields.length === 0 ) {
 		return {
 			summaryFields: fieldDefinition ? [ fieldDefinition ] : [],
 			fieldDefinition,
+			fieldLabel,
 		};
 	}
 
 	return {
 		summaryFields,
 		fieldDefinition,
+		fieldLabel,
 	};
 };
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-field-definition-and-summary-fields.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-field-definition-and-summary-fields.ts
@@ -1,0 +1,70 @@
+import type {
+	NormalizedFormField,
+	NormalizedField,
+	NormalizedPanelLayout,
+} from '../../../../types';
+import { getSummaryFields } from '../../get-summary-fields';
+
+const getFieldDefinition = < Item >(
+	field: NormalizedFormField,
+	fields: NormalizedField< Item >[]
+) => {
+	const fieldDefinition = fields.find( ( _field ) => _field.id === field.id );
+
+	if ( ! fieldDefinition ) {
+		return fields.find( ( _field ) => {
+			if ( !! field.children ) {
+				const simpleChildren = field.children.filter(
+					( child ) => ! child.children
+				);
+
+				if ( simpleChildren.length === 0 ) {
+					return false;
+				}
+
+				return _field.id === simpleChildren[ 0 ].id;
+			}
+
+			return _field.id === field.id;
+		} );
+	}
+
+	return fieldDefinition;
+};
+
+/**
+ * Determines the field definition and summary fields for a panel layout.
+ *
+ * Summary fields are determined with the following priority:
+ * 1. Use layout.summary fields if they exist
+ * 2. Fall back to the field definition that matches the form field's id
+ * 3. If the form field id doesn't exist, pick the first child field
+ * 4. If no field definition is found, return empty summary fields
+ *
+ * @param layout - The normalized panel layout configuration
+ * @param field  - The form field to get definition for
+ * @param fields - Array of normalized field definitions
+ * @return Object containing fieldDefinition and summaryFields
+ */
+const getFieldDefinitionAndSummaryFields = < Item >(
+	layout: NormalizedPanelLayout,
+	field: NormalizedFormField,
+	fields: NormalizedField< Item >[]
+) => {
+	const summaryFields = getSummaryFields( layout.summary, fields );
+	const fieldDefinition = getFieldDefinition( field, fields );
+
+	if ( summaryFields.length === 0 ) {
+		return {
+			summaryFields: fieldDefinition ? [ fieldDefinition ] : [],
+			fieldDefinition,
+		};
+	}
+
+	return {
+		summaryFields,
+		fieldDefinition,
+	};
+};
+
+export default getFieldDefinitionAndSummaryFields;

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-first-validation-error.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-first-validation-error.ts
@@ -1,0 +1,47 @@
+import type { FieldValidity } from '../../../../types';
+
+function getFirstValidationError(
+	validity: FieldValidity | undefined
+): string | undefined {
+	if ( ! validity ) {
+		return undefined;
+	}
+
+	const validityRules = Object.keys( validity ).filter(
+		( key ) => key !== 'children'
+	);
+
+	for ( const key of validityRules ) {
+		const rule = validity[ key as keyof Omit< FieldValidity, 'children' > ];
+		if ( rule === undefined ) {
+			continue;
+		}
+
+		if ( rule.type === 'invalid' ) {
+			if ( rule.message ) {
+				return rule.message;
+			}
+
+			// Provide default message for required validation (message is optional)
+			if ( key === 'required' ) {
+				return 'A required field is empty';
+			}
+
+			return 'Unidentified validation error';
+		}
+	}
+
+	// Check children recursively
+	if ( validity.children ) {
+		for ( const childValidity of Object.values( validity.children ) ) {
+			const childError = getFirstValidationError( childValidity );
+			if ( childError ) {
+				return childError;
+			}
+		}
+	}
+
+	return undefined;
+}
+
+export default getFirstValidationError;

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-classname.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-classname.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import type { LabelPosition } from '../../../../types';
+
+function getLabelClassName( labelPosition: LabelPosition, showError: boolean ) {
+	return clsx(
+		'dataforms-layouts-panel__field-label',
+		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`,
+		{ 'has-error': showError }
+	);
+}
+
+export default getLabelClassName;

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-classname.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-classname.ts
@@ -4,7 +4,10 @@
 import clsx from 'clsx';
 import type { LabelPosition } from '../../../../types';
 
-function getLabelClassName( labelPosition: LabelPosition, showError: boolean ) {
+function getLabelClassName(
+	labelPosition: LabelPosition,
+	showError?: boolean
+) {
 	return clsx(
 		'dataforms-layouts-panel__field-label',
 		`dataforms-layouts-panel__field-label--label-position-${ labelPosition }`,

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { BaseControl, Icon, Tooltip } from '@wordpress/components';
+import { error as errorIcon } from '@wordpress/icons';
+
+function getLabelContent(
+	showError: boolean,
+	errorMessage?: string,
+	fieldLabel?: string
+) {
+	return showError ? (
+		<Tooltip text={ errorMessage } placement="top">
+			<span className="dataforms-layouts-panel__field-label-error-content">
+				<Icon icon={ errorIcon } size={ 16 } />
+				<BaseControl.VisualLabel>
+					{ fieldLabel }
+				</BaseControl.VisualLabel>
+			</span>
+		</Tooltip>
+	) : (
+		<BaseControl.VisualLabel>{ fieldLabel }</BaseControl.VisualLabel>
+	);
+}
+
+export default getLabelContent;

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
@@ -5,7 +5,7 @@ import { BaseControl, Icon, Tooltip } from '@wordpress/components';
 import { error as errorIcon } from '@wordpress/icons';
 
 function getLabelContent(
-	showError: boolean,
+	showError?: boolean,
 	errorMessage?: string,
 	fieldLabel?: string
 ) {

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/use-field-from-form-field.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/use-field-from-form-field.ts
@@ -1,9 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import type {
 	NormalizedFormField,
 	NormalizedField,
 	NormalizedPanelLayout,
 } from '../../../../types';
 import { getSummaryFields } from '../../get-summary-fields';
+import DataFormContext from '../../../dataform-context';
 
 const getFieldDefinition = < Item >(
 	field: NormalizedFormField,
@@ -41,14 +50,11 @@ const getFieldDefinition = < Item >(
  * 3. If the form field id doesn't exist, pick the first child field
  * 4. If no field definition is found, return empty summary fields
  *
- * @param field  - The form field to get definition for
- * @param fields - Array of normalized field definitions
+ * @param field The form field to get definition for
  * @return Object containing fieldDefinition, fieldLabel, and summaryFields
  */
-const getFieldDefinitionAndSummaryFields = < Item >(
-	field: NormalizedFormField,
-	fields: NormalizedField< Item >[]
-) => {
+function useFieldFromFormField( field: NormalizedFormField ) {
+	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedPanelLayout;
 	const summaryFields = getSummaryFields( layout.summary, fields );
 	const fieldDefinition = getFieldDefinition( field, fields );
@@ -67,6 +73,6 @@ const getFieldDefinitionAndSummaryFields = < Item >(
 		fieldDefinition,
 		fieldLabel,
 	};
-};
+}
 
-export default getFieldDefinitionAndSummaryFields;
+export default useFieldFromFormField;

--- a/packages/dataviews/src/components/dataform-layouts/regular/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/regular/style.scss
@@ -6,6 +6,11 @@
 	min-height: $grid-unit-40;
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
+
+	.components-base-control__label,
+	.components-input-control__label {
+		color: $gray-700;
+	}
 }
 
 .dataforms-layouts-regular__field-label {

--- a/packages/dataviews/src/components/dataform-layouts/regular/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/regular/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .dataforms-layouts-regular__field {

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -511,9 +511,9 @@ describe( 'DataForm component', () => {
 				/>
 			);
 
-			const titleField = screen.getByText( data.title );
+			const titleButton = fieldsSelector.title.view();
 			const user = await userEvent.setup();
-			await user.click( titleField );
+			await user.click( titleButton );
 			const titleEditField = screen.getByText(
 				'This is the Title Field'
 			);

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -25,35 +25,6 @@ const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
 const fieldsWithBulkEditSupport = [ 'status', 'date', 'author', 'discussion' ];
 
 export function QuickEditModal( { postType, postId, closeModal } ) {
-	// Before calling the onRequestClose callback, the modal introduces a animation delay
-	// that produces a visual glitch, see https://github.com/WordPress/gutenberg/pull/75173#pullrequestreview-3755585506
-	// Handling the ESC key and click-outside ourselves fixes it.
-	useEffect( () => {
-		const handleKeyDown = ( event ) => {
-			if ( event.key === 'Escape' || event.code === 'Escape' ) {
-				event.preventDefault();
-				event.stopPropagation();
-				closeModal?.();
-			}
-		};
-
-		const handleClickOutside = ( event ) => {
-			if (
-				event.target.classList.contains(
-					'dataviews-action-modal__quick-edit'
-				)
-			) {
-				closeModal?.();
-			}
-		};
-		document.addEventListener( 'keydown', handleKeyDown );
-		document.addEventListener( 'mousedown', handleClickOutside );
-		return () => {
-			document.removeEventListener( 'keydown', handleKeyDown );
-			document.removeEventListener( 'mousedown', handleClickOutside );
-		};
-	}, [ closeModal ] );
-
 	const isBulk = postId.length > 1;
 
 	const [ localEdits, setLocalEdits ] = useState( {} );
@@ -221,8 +192,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 		<Modal
 			overlayClassName="dataviews-action-modal__quick-edit"
 			__experimentalHideHeader
-			shouldCloseOnEsc={ false }
-			shouldCloseOnClickOutside={ false }
+			onRequestClose={ closeModal }
 		>
 			<div className="dataviews-action-modal__quick-edit-header">
 				<PostCardPanel

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -193,6 +193,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 			overlayClassName="dataviews-action-modal__quick-edit"
 			__experimentalHideHeader
 			onRequestClose={ closeModal }
+			focusOnMount="firstElement"
 		>
 			<div className="dataviews-action-modal__quick-edit-header">
 				<PostCardPanel

--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -93,10 +93,22 @@
 		max-width: 400px;
 		border-radius: $radius-large;
 		position: relative;
-		animation: none;
+		animation-name: none;
 
 		@media (prefers-reduced-motion: no-preference) {
-			animation: quick-edit-slide-in-right 0.2s ease-out;
+			animation-name: quick-edit-slide-in-right;
+			animation-duration: 0.2s;
+			animation-timing-function: ease-out;
+		}
+	}
+
+	&.is-animating-out .components-modal__frame {
+		animation-name: none;
+
+		@media (prefers-reduced-motion: no-preference) {
+			animation-name: quick-edit-slide-out-right;
+			animation-duration: 0.2s;
+			animation-timing-function: ease-out;
 		}
 	}
 
@@ -149,5 +161,14 @@
 	}
 	to {
 		transform: translateX(0);
+	}
+}
+
+@keyframes quick-edit-slide-out-right {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(100%);
 	}
 }

--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -115,7 +115,6 @@
 	}
 
 	.dataviews-action-modal__quick-edit-header {
-		margin-bottom: $grid-unit-20;
 		padding: $grid-unit-30 $grid-unit-30 0;
 	}
 
@@ -123,6 +122,7 @@
 		flex: 1;
 		min-height: 0;
 		overflow-y: auto;
+		padding-top: $grid-unit-20;
 
 		.dataforms-layouts__wrapper {
 			flex: 1;

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -113,10 +113,12 @@ test.describe( 'Page List', () => {
 			},
 			statusVisibility: {
 				performEdit: async ( page ) => {
-					const statusAndVisibility = page.getByLabel(
-						'Status & Visibility'
-					);
-					await statusAndVisibility.click();
+					const editButton = page.getByRole( 'button', {
+						name: 'Edit Status & Visibility',
+					} );
+					await editButton.locator( '..' ).hover();
+					await editButton.click();
+					const statusAndVisibility = editButton.locator( '..' );
 					const options = [
 						'Published',
 						'Draft',
@@ -142,17 +144,21 @@ test.describe( 'Page List', () => {
 					}
 				},
 				assertInitialState: async ( page ) => {
-					const statusAndVisibility = page.getByLabel(
-						'Status & Visibility'
-					);
+					const statusAndVisibility = page
+						.getByRole( 'button', {
+							name: 'Edit Status & Visibility',
+						} )
+						.locator( '..' );
 					await expect( statusAndVisibility ).toContainText(
 						'Published'
 					);
 				},
 				assertEditedState: async ( page ) => {
-					const statusAndVisibility = page.getByLabel(
-						'Status & Visibility'
-					);
+					const statusAndVisibility = page
+						.getByRole( 'button', {
+							name: 'Edit Status & Visibility',
+						} )
+						.locator( '..' );
 					await expect( statusAndVisibility ).toContainText(
 						'Private'
 					);
@@ -160,12 +166,17 @@ test.describe( 'Page List', () => {
 			},
 			author: {
 				assertInitialState: async ( page ) => {
-					const author = page.getByLabel( 'Author' );
+					const author = page
+						.getByRole( 'button', { name: 'Edit Author' } )
+						.locator( '..' );
 					await expect( author ).toContainText( 'admin' );
 				},
 				performEdit: async ( page ) => {
-					const author = page.getByLabel( 'Author' );
-					await author.click();
+					const editButton = page.getByRole( 'button', {
+						name: 'Edit Author',
+					} );
+					await editButton.locator( '..' ).hover();
+					await editButton.click();
 					const selectElement = page.locator(
 						'select:has(option[value="1"])'
 					);
@@ -174,21 +185,28 @@ test.describe( 'Page List', () => {
 					} );
 				},
 				assertEditedState: async ( page ) => {
-					const author = page.getByLabel( 'Edit Author' );
+					const author = page
+						.getByRole( 'button', { name: 'Edit Author' } )
+						.locator( '..' );
 					await expect( author ).toContainText( 'Test Author' );
 				},
 			},
 			date: {
 				assertInitialState: async ( page ) => {
-					const dateEl = page.getByLabel( 'Edit Date' );
+					const dateEl = page
+						.getByRole( 'button', { name: 'Edit Date' } )
+						.locator( '..' );
 					const date = new Date();
 					const yy = String( date.getFullYear() );
 
 					await expect( dateEl ).toContainText( yy );
 				},
 				performEdit: async ( page ) => {
-					const dateEl = page.getByLabel( 'Edit Date' );
-					await dateEl.click();
+					const editButton = page.getByRole( 'button', {
+						name: 'Edit Date',
+					} );
+					await editButton.locator( '..' ).hover();
+					await editButton.click();
 
 					// Wait for the datetime control to appear
 					const datetimeInput = page.locator(
@@ -213,18 +231,25 @@ test.describe( 'Page List', () => {
 				assertEditedState: async ( page ) => {
 					const date = new Date();
 					const yy = Number( date.getFullYear() );
-					const dateEl = page.getByLabel( 'Edit Date' );
+					const dateEl = page
+						.getByRole( 'button', { name: 'Edit Date' } )
+						.locator( '..' );
 					await expect( dateEl ).toContainText( String( yy + 1 ) );
 				},
 			},
 			slug: {
 				assertInitialState: async ( page ) => {
-					const slug = page.getByLabel( 'Edit Slug' );
+					const slug = page
+						.getByRole( 'button', { name: 'Edit Slug' } )
+						.locator( '..' );
 					await expect( slug ).toContainText( 'privacy-policy' );
 				},
 				performEdit: async ( page ) => {
-					const slug = page.getByLabel( 'Edit Slug' );
-					await slug.click();
+					const editButton = page.getByRole( 'button', {
+						name: 'Edit Slug',
+					} );
+					await editButton.locator( '..' ).hover();
+					await editButton.click();
 					await expect(
 						page.getByRole( 'link', {
 							name: 'http://localhost:8889/?',
@@ -235,12 +260,17 @@ test.describe( 'Page List', () => {
 			},
 			parent: {
 				assertInitialState: async ( page ) => {
-					const parent = page.getByLabel( 'Edit Parent' );
+					const parent = page
+						.getByRole( 'button', { name: 'Edit Parent' } )
+						.locator( '..' );
 					await expect( parent ).toContainText( 'None' );
 				},
 				performEdit: async ( page ) => {
-					const parent = page.getByLabel( 'Edit Parent' );
-					await parent.click();
+					const editButton = page.getByRole( 'button', {
+						name: 'Edit Parent',
+					} );
+					await editButton.locator( '..' ).hover();
+					await editButton.click();
 					await page
 						.getByLabel( 'Parent', { exact: true } )
 						.fill( 'Sample' );
@@ -250,7 +280,9 @@ test.describe( 'Page List', () => {
 						.click();
 				},
 				assertEditedState: async ( page ) => {
-					const parent = page.getByLabel( 'Edit Parent' );
+					const parent = page
+						.getByRole( 'button', { name: 'Edit Parent' } )
+						.locator( '..' );
 					await expect( parent ).toContainText( 'Sample Page' );
 				},
 			},
@@ -277,12 +309,19 @@ test.describe( 'Page List', () => {
 			// },
 			discussion: {
 				assertInitialState: async ( page ) => {
-					const discussion = page.getByLabel( 'Edit Discussion' );
+					const discussion = page
+						.getByRole( 'button', {
+							name: 'Edit Discussion',
+						} )
+						.locator( '..' );
 					await expect( discussion ).toContainText( 'Closed' );
 				},
 				performEdit: async ( page ) => {
-					const discussion = page.getByLabel( 'Edit Discussion' );
-					await discussion.click();
+					const editButton = page.getByRole( 'button', {
+						name: 'Edit Discussion',
+					} );
+					await editButton.locator( '..' ).hover();
+					await editButton.click();
 					await page
 						.getByLabel( 'Open', {
 							exact: true,
@@ -290,7 +329,11 @@ test.describe( 'Page List', () => {
 						.check();
 				},
 				assertEditedState: async ( page ) => {
-					const discussion = page.getByLabel( 'Edit Discussion' );
+					const discussion = page
+						.getByRole( 'button', {
+							name: 'Edit Discussion',
+						} )
+						.locator( '..' );
 					await expect( discussion ).toContainText( 'Comments only' );
 				},
 			},


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/73036

## What?

This PR updates the panel trigger so that the whole field is clickable, as opposed to only the field content.

## Why?

There's an issue with empty content right now: because the content is empty, the trigger is very small. [New designs](https://github.com/WordPress/gutenberg/pull/73036#issuecomment-3563915366) change the trigger to the whole field.

<img width="929" height="762" alt="Screenshot 2025-11-21 at 16 51 48" src="https://github.com/user-attachments/assets/e990a90a-6642-42e7-b96a-ca95ede54e43" />

## How?

- Update the SummaryButton to handle the label position.

## Testing Instructions

- Visit DataForm > Layout panel story locally (`npm install && npm run storybook:dev`).


https://github.com/user-attachments/assets/226c2c96-810c-44ff-84d8-6bc498f3b087



- Enable the QuickEdit experiment (Gutenberg > Experiments > QuickEdit) and visit the Site Editor's Pages screen. Open QuickEdit and interact with it.


https://github.com/user-attachments/assets/5204d6ab-b23b-40ad-a21d-116552b50dec

## Follow-ups

- Add panel layout option so that whether to always show the edit icon or not is configurable (see [designs](https://github.com/WordPress/gutenberg/pull/73036#issuecomment-3841398869)). 
- Template field. Explore solutions to better accomodate it in the QuickEdit form. For example, make it a whole custom button for the row, make it an action, etc.).
- https://github.com/WordPress/gutenberg/pull/75292
