### PR TITLE
DataForm Regular layout: label always uppercase

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- DataForm: Fix label case and color for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 - DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- DataForm: Fix label case and color for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)
+- DataForm: Fix label case for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 - DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)

--- a/packages/dataviews/src/components/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/regular/index.tsx
@@ -98,7 +98,9 @@ export default function FormRegularField< Item >( {
 						`dataforms-layouts-regular__field-label--label-position-${ labelPosition }`
 					) }
 				>
-					{ fieldDefinition.label }
+					<BaseControl.VisualLabel>
+						{ fieldDefinition.label }
+					</BaseControl.VisualLabel>
 				</div>
 				<div className="dataforms-layouts-regular__field-control">
 					{ fieldDefinition.readOnly === true ? (

--- a/packages/dataviews/src/components/dataform-layouts/regular/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/regular/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .dataforms-layouts-regular__field {
@@ -5,6 +6,11 @@
 	min-height: $grid-unit-40;
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
+
+	.components-base-control__label,
+	.components-input-control__label {
+		color: $gray-700;
+	}
 }
 
 .dataforms-layouts-regular__field-label {
@@ -18,6 +24,10 @@
 
 	&--label-position-side {
 		align-self: center;
+	}
+
+	.components-base-control__label {
+		margin-bottom: 0;
 	}
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/regular/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/regular/style.scss
@@ -1,4 +1,3 @@
-@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .dataforms-layouts-regular__field {
@@ -6,11 +5,6 @@
 	min-height: $grid-unit-40;
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
-
-	.components-base-control__label,
-	.components-input-control__label {
-		color: $gray-700;
-	}
 }
 
 .dataforms-layouts-regular__field-label {


### PR DESCRIPTION
## What?

This PR addresses two things:

- the side-label in the regular layout was not uppercase, now it is
- it changes the label color so that it matches the incoming changes for panel layout at [#75290](https://github.com/WordPress/gutenberg/pull/75290)
 
## Why?

The label should be consistent because forms can render fields using any layout.

## How?

- Use BaseControl.VisualLabel for uppercase consistency, like regular top label + panel layout do.
- Add styles for the label color.

## Testing Instructions

- Visit DataForm > Regular layouc story locally (`npm install && npm run storybook:dev`).



https://github.com/user-attachments/assets/62e2cf3e-408f-4877-986c-0bf24d840cf2



- Enable the QuickEdit experiment (Gutenberg > Experiments > QuickEdit) and visit the Site Editor's Pages screen. Open QuickEdit. Note that the changes to the label for panel layout will land at [#75290](https://github.com/WordPress/gutenberg/pull/75290)

<img width="432" height="908" alt="Screenshot 2026-02-06 at 13 53 14" src="https://github.com/user-attachments/assets/696454e7-788d-405c-b519-42efced956ad" />

