### PR TITLE
Add timestamp when publishing next versions

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -367,6 +367,12 @@ async function publishPackagesToNpm( {
 		gitWorkingDirectoryPath
 	).revparse( [ '--short', 'HEAD' ] );
 
+	// Timestamp is the current time in `YYYYMMDDHHMM` format.
+	const timestamp = new Date()
+		.toISOString()
+		.replace( /[-:]/g, '' )
+		.substring( 0, 12 );
+
 	const yesFlag = interactive ? '' : '--yes';
 	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
 	if ( releaseType === 'next' ) {
@@ -375,7 +381,7 @@ async function publishPackagesToNpm( {
 		);
 
 		await command(
-			`npx lerna version pre${ minimumVersionBump } --preid next.v --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
+			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',


### PR DESCRIPTION
Repeated publishing of `next` versions is unreliable because we don't have the information we need to bump version like `next.v.0` to `next.v.1`. The `wp/next` branch is completely overwritten with `trunk` files before each publish, and the `next.v.0` version is overwritten with the version from `trunk`. Then the Lerna versioning always starts from `v.0`. And NPM publishing fails because the same version was already published.

The solution is to add timestamp to the version number. It's an increasing number that can be generated independently, without knowing the previous version.

The version string should now look like `11.0.1-next.v.202602061304.0+5a627da981`.

This is a followup to #74589 which removed commit hash from the version string, because commit hashes don't sort correctly: a newer version is not lexicographically "higher" than an old version. Causes problem when updating usages of `next` versions.
