### PR TITLE
Storybook: Preserve export order for stories

### DIFF
--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -207,8 +207,8 @@ export const parameters = {
 					if ( aIndex !== bIndex ) {
 						return aIndex - bIndex;
 					}
-					// Same index (both not in order list), sort alphabetically
-					return aSegment.localeCompare( bSegment );
+					// Same index (both not in order list), preserve export order
+					return 0;
 				}
 
 				// Same segment, descend into nested order
@@ -241,8 +241,8 @@ export const parameters = {
 				return aPriority - bPriority;
 			}
 
-			// Same priority, sort alphabetically by name
-			return a.name.localeCompare( b.name );
+			// Same priority, preserve export order
+			return 0;
 		},
 	},
 };


### PR DESCRIPTION
## What?

Fixes the story sort order in Storybook so they respect the export order (which is the default sorting).

## Why?

I unintentionally introduced a sorting behavior in #74672 where stories got sorted alphabetically. Originally, they were sorted by the order they were exported in the stories file. Alphabetical sorting is bad because it would ignore any intentional ordering by the story author, but most importantly it can sometimes make a story appear _above_ the "Default" story, making it appear like the default story in the Docs view.

## How?

Fix the sorting algo so it respects the export order when no custom ordering is specified.

## Testing Instructions

Check some components that this affects, for example `FormTokenField`.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="1958" height="1080" alt="CustomSelectControl docs, before" src="https://github.com/user-attachments/assets/e9d99e37-4883-4ec5-a795-f40f67c75705" />|<img width="1958" height="1080" alt="CustomSelectControl docs, after" src="https://github.com/user-attachments/assets/5d15a70f-cba0-4448-ae88-2004b0c2c51d" />|
