### PR TITLE
ToggleControl: Prevent console warning for `__nextHasNoMarginBottom`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
+-   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).
 
 ### Enhancements
 

--- a/packages/components/src/toggle-control/index.tsx
+++ b/packages/components/src/toggle-control/index.tsx
@@ -28,6 +28,8 @@ function UnforwardedToggleControl(
 		className,
 		onChange,
 		disabled,
+		// Prevent passing to internal component.
+		__nextHasNoMarginBottom: _,
 		...additionalProps
 	}: WordPressComponentProps< ToggleControlProps, 'input', false >,
 	ref: ForwardedRef< HTMLInputElement >


### PR DESCRIPTION
## What?

Fixes an unintentional side effect of #74956 in which a "React does not recognize the `__nextHasNoMarginBottom` prop on a DOM element" warning is logged when a consumer is passing a `__nextHasNoMarginBottom` prop.

## Why?

This should not log a console warning, because consumers still use the prop for supporting multiple versions of WP.

## How?

Prevent the prop from being passed down to the internal DOM element, similar to how we handle this in other components.

## Testing Instructions

In Storybook, passing a `__nextHasNoMarginBottom` prop to `ToggleControl` should not log a console warning.