### PR TITLE
Quick edit: Make footer sticky

### DIFF
--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -8,7 +8,6 @@ import { DataForm } from '@wordpress/dataviews';
 import {
 	Button,
 	Modal,
-	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
@@ -233,10 +232,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 					hideActions
 				/>
 			</div>
-			<VStack
-				spacing={ 4 }
-				className="dataviews-action-modal__quick-edit-content"
-			>
+			<div className="dataviews-action-modal__quick-edit-content">
 				{ hasFinishedResolution && (
 					<DataForm
 						data={ { ...record, ...localEdits } }
@@ -245,23 +241,23 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 						onChange={ onChange }
 					/>
 				) }
-				<HStack className="dataviews-action-modal__quick-edit-footer">
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						onClick={ closeModal }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						onClick={ onSave }
-					>
-						{ __( 'Done' ) }
-					</Button>
-				</HStack>
-			</VStack>
+			</div>
+			<HStack className="dataviews-action-modal__quick-edit-footer">
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ closeModal }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ onSave }
+				>
+					{ __( 'Done' ) }
+				</Button>
+			</HStack>
 		</Modal>
 	);
 }

--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -86,10 +86,6 @@
 	justify-content: flex-end;
 	align-items: stretch;
 
-	.dataviews-action-modal__quick-edit-header {
-		margin-bottom: $grid-unit-20;
-	}
-
 	.components-modal__frame {
 		margin: $grid-unit-20 $grid-unit-20 $grid-unit-20 0;
 		height: calc(100% - #{$grid-unit-20 * 2});
@@ -107,18 +103,38 @@
 	.components-modal__content {
 		display: flex;
 		flex-direction: column;
-		height: 100%;
+		overflow: hidden;
+		padding: 0;
+
+		> * {
+			display: flex;
+			flex-direction: column;
+			flex: 1;
+			min-height: 0;
+		}
+	}
+
+	.dataviews-action-modal__quick-edit-header {
+		margin-bottom: $grid-unit-20;
+		padding: $grid-unit-30 $grid-unit-30 0;
 	}
 
 	.dataviews-action-modal__quick-edit-content {
-		flex-grow: 1;
-		display: flex;
-		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+
+		.dataforms-layouts__wrapper {
+			flex: 1;
+			padding: 0 $grid-unit-30 $grid-unit-05; // Horizontal + bottom space for focus ring
+		}
 	}
 
 	.dataviews-action-modal__quick-edit-footer {
-		margin-top: auto;
-		padding-top: $grid-unit-20;
+		position: sticky;
+		bottom: 0;
+		flex-shrink: 0;
+		padding: $grid-unit-20 $grid-unit-30 $grid-unit-30;
 
 		.components-button {
 			flex: 1;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Quick edit: Make footer sticky

## Testing Instructions
1. In site editor go to pages and trigger `quick edit`
2. The footer should be sticky at the bottom





|Before|After|
|-|-|
|<img width="1015" height="738" alt="Screenshot 2026-02-06 at 4 52 46 PM" src="https://github.com/user-attachments/assets/dfb524cd-a3e0-4a90-9454-71f9b0dbe25a" />|<img width="1015" height="738" alt="Screenshot 2026-02-06 at 4 52 42 PM" src="https://github.com/user-attachments/assets/5f7d7a88-7422-48ba-bed0-d1d4f7f419c4" />|


### If the form was bigger


https://github.com/user-attachments/assets/58cbc1ef-443b-46c8-a429-be0192110d90

