### PR TITLE
Fields: Fix `authorField` query

### DIFF
--- a/packages/fields/src/fields/author/index.tsx
+++ b/packages/fields/src/fields/author/index.tsx
@@ -28,6 +28,9 @@ const authorField: Field< BasePostWithEmbeddedAuthor > = {
 				'user',
 				{
 					per_page: -1,
+					who: 'authors',
+					_fields: 'id,name',
+					context: 'view',
 				}
 			) ) ?? [];
 		return authors.map( ( { id, name } ) => ( {

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -307,6 +307,7 @@ test.describe( 'Page List', () => {
 				firstName: 'Test',
 				lastName: 'Author',
 				password: '1',
+				roles: [ 'author' ],
 			} );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed that in site editor in page the `author field` fetches all users. This is wrong since not all users can be authors.
This PR fixes that.

## Testing Instructions
1. Create a user with `subscriber` role
2. Go to site editor in pages
3. Add `author` filter-> the subscriber should not be among the available options
4. Quick edit (GB experiment) a page-> the subscriber should not be among the available options

