### PR TITLE
Post Excerpt Block: Remove REST API filter for excerpt length in post excerpt block

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -104,9 +104,6 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 101 (one more than the max block setting of 100) to ensure
  * wp_trim_words can detect when trimming is needed and add the ellipsis.
  *
- * For REST API requests, the filter is added on 'rest_api_init'
- * because REST_REQUEST is not defined until 'parse_request'.
- *
  * @since 7.0.0
  *
  * @return int The excerpt length.
@@ -118,9 +115,3 @@ function block_core_post_excerpt_excerpt_length() {
 if ( is_admin() ) {
 	add_filter( 'excerpt_length', 'block_core_post_excerpt_excerpt_length', PHP_INT_MAX );
 }
-add_action(
-	'rest_api_init',
-	static function () {
-		add_filter( 'excerpt_length', 'block_core_post_excerpt_excerpt_length', PHP_INT_MAX );
-	}
-);


### PR DESCRIPTION
## What?
@xavier-lc has noticed that despite the excerpt is being showed correctly now in both Editor and Front-end the behaviour in the  REST-API is buggy. 

## Why?
#74140 introduced some changes in the admin checks, but also added a little bug.

## How?
Removing the filter to rest_api also fixes the problem. 

## Testing Instructions
1. Create two posts
2. Add content in the two posts, a good amount of words, 200 words at least
3. Add a manual excerpt to one of the two posts, be sure to add a good amount of text, 200 words at least
4. I recommend using TT3 theme
5. Now set the excerpt lenght to something like 70 words
6. Check if:
  1. In the frontend you see 70 words for the automatic excerpt
  2. In the backend you see 70 words for the automatic exceprt
  3. In an API call like: `curl -s -u 'your_api_creds' "http://localhost:8889/?rest_route=/wp/v2/posts/POST_NUMBER&context=edit&_fields=excerpt&excerpt_length=20" you see 70 words for the excerpt (THIS IS WHAT THIS FIX IS TARGETTING)
  4. In the front end you see 70 words for the manual excerpt
  5. In the backend you see 70 words for the manual excerpt
  5. In the API you see all the words you added to the excerpt in the manual exceprt (expected behaviour? it seems that limit doesn't affect in the API for manual excerpt, but this beyond our scope)
