### PR TITLE
Prevent QuickEdit modal from being triggered in list layout via URL param

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -332,13 +332,16 @@ export default function PostList( { postType } ) {
 				getItemLevel={ getItemLevel }
 				defaultLayouts={ defaultLayouts }
 			/>
-			{ quickEdit && ! isLoadingData && selection.length > 0 && (
-				<QuickEditModal
-					postType={ postType }
-					postId={ selection }
-					closeModal={ closeQuickEditModal }
-				/>
-			) }
+			{ quickEdit &&
+				! isLoadingData &&
+				selection.length > 0 &&
+				view.type !== LAYOUT_LIST && (
+					<QuickEditModal
+						postType={ postType }
+						postId={ selection }
+						closeModal={ closeQuickEditModal }
+					/>
+				) }
 		</Page>
 	);
 }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/75173/

## What?

While the QuickEdit action is not available in the list layout, if the quickEdit url param is present is still possible to open the modal. This PR prevents the modal from opening in that situation.

## Why?

To offer a cohesive experience.

## How?

Check if view.type is different from layout list to open the modal.

## Testing Instructions

- Enable the QuickEdit experiment and visit Site Editor's Pages screen.
- With the list layout active, add `&quickEdit=true` and URL param.
- The expected result is that the modal should not be opened.

https://github.com/user-attachments/assets/1f1ce76d-a723-4872-8431-e529fa6536d0

