### PR TITLE
Publishing packages: fix next timestamp

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -370,8 +370,8 @@ async function publishPackagesToNpm( {
 	// Timestamp is the current time in `YYYYMMDDHHMM` format.
 	const timestamp = new Date()
 		.toISOString()
-		.replace( /[-:]/g, '' )
-		.substring( 0, 12 );
+		.substring( 0, 16 )
+		.replace( /[-:T]/g, '' );
 
 	const yesFlag = interactive ? '' : '--yes';
 	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';


### PR DESCRIPTION
A little fixup for #75293 -- the timestamp was wrong, as it didn't remove the `T` letter. The published packages have version:
```
11.0.1-next.v.20260206T143.0
```
This PR fixes that. First cut the seconds and milliseconds by taking the first 16 characters. That produces
```
2026-02-06T16:26
```
after removing the `:08.212Z` suffix. And then remove the `-`s, `:`s and `T`s.
