### PR TITLE
Link Control: Validate on submit

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -629,7 +629,6 @@ function LinkControl( {
 							hideLabelFromVision={ ! showTextControl }
 							isEntity={ isEntity }
 							customValidity={ customValidity }
-							required={ showTextControl }
 							suffix={
 								<SearchSuffixControl
 									isEntity={ isEntity }

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -46,7 +46,6 @@ const LinkControlSearchInput = forwardRef(
 			suffix,
 			isEntity = false,
 			customValidity: customValidityProp,
-			required,
 		},
 		ref
 	) => {
@@ -149,11 +148,10 @@ const LinkControlSearchInput = forwardRef(
 						showInitialSuggestions
 					}
 					customValidity={ customValidityProp }
-					// When required=false, validation is handled manually via onSubmit and handleSubmit.
-					// When required=true (e.g., in modals with text control), browser validation is used.
-					// Use markWhenOptional when required=true to suppress the "(Required)" indicator.
-					required={ required }
-					markWhenOptional={ required }
+					// Validation is handled manually via onSubmit and handleSubmit. We may be able to rely
+					// on browser validation when enhancements land to base level components:
+					// https://github.com/WordPress/gutenberg/pull/75188#issuecomment-3861757260
+					required={ false }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1329,6 +1329,10 @@ test.describe( 'Navigation block', () => {
 				await expect( linkPopover ).toBeHidden();
 			} );
 
+			const linkInput = linkPopover.getByRole( 'combobox', {
+				name: 'Link',
+			} );
+
 			await test.step( 'Verify unsync button works in Link UI popover', async () => {
 				// Open Link UI via keyboard shortcut
 				await pageUtils.pressKeys( 'primary+k' );
@@ -1339,10 +1343,6 @@ test.describe( 'Navigation block', () => {
 				await linkPopover
 					.getByRole( 'button', { name: 'Edit' } )
 					.click();
-
-				const linkInput = linkPopover.getByRole( 'combobox', {
-					name: 'Link',
-				} );
 
 				// Find and click unsync button
 				const unsyncButton = linkPopover.getByRole( 'button', {
@@ -1356,11 +1356,24 @@ test.describe( 'Navigation block', () => {
 				await expect( linkInput ).toHaveValue( '' );
 			} );
 
-			await test.step( 'Verify link field validates on blur in Link UI popover', async () => {
+			await test.step( 'Verify link field validates on submit in Link UI popover', async () => {
+				await page.keyboard.type( 'invalid url string' );
+
 				await page.keyboard.press( 'Tab' );
 
+				// Verify validation error is not shown on blur
 				await expect(
 					page.getByText( 'Please fill out this field' )
+				).toBeHidden();
+
+				// Go back to the link input and press enter to submit
+				await pageUtils.pressKeys( 'Shift+Tab' );
+				await expect( linkInput ).toBeFocused();
+				await page.keyboard.press( 'Enter' );
+
+				// Verify validation error is shown
+				await expect(
+					page.getByText( 'Please enter a valid URL.' )
 				).toBeVisible();
 			} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #75267

Simplifies LinkControl validation by removing the `required` prop and hardcoding manual validation behavior, so we have full control of when validation happens.

## Why?

#75267 attempted to fix validation happening on blur by removing the default link control view from being a required field (in some cases, it's not a required field), but preserved it as a required field when editing a link. In that case, it truly is a required field. However, it still caused UX issues by validation showing up on blur.

1. **Premature validation issues**: Setting `required={true}` (when `showTextControl` was true) caused validation to trigger on blur and when clicking link suggestions, creating a poor UX with flashing error messages.
3. **Brand new API**: The `required` prop was only added 2 days ago, so it's safe to remove.
4. **Unnecessary abstraction**: Since the value is always `false`, passing it as a prop adds complexity without benefit.

## How?

**LinkControlSearchInput (`search-input.js`):**
- Removed `required` parameter entirely (no longer part of the API)
- Hardcoded `required={ false }` in the URLInput call
- Removed `markWhenOptional` prop (not needed when field isn't required)

**LinkControl (`index.js`):**
- Removed `required={ showTextControl }` prop passing
**Result:** Validation is now consistently handled manually via `onSubmit` and `handleSubmit`, preventing premature validation on blur or when selecting suggestions.

## Testing Instructions

### Editing existing links
1. Add a Navigation Link with a valid URL
2. Edit the link by clicking on it
3. Clear the URL field
4. Blur the field
5. ✅ **Expected:** No validation error on blur
6. ✅ **Expected:** Empty input should have dimmed "Apply" button
7. Make sure you cannot submit an empty value 
8. Type an invalid url in the field, like "Testing it out"
9. Press Enter
10. ✅ **Expected:** Validation prevents submission (manual validation works)
11. Search for a pagfe
12. Select a page suggestion
13. ✅ **Expected:** There should not be a flash of a validation error


## Screenshots or screencast

**Before**

https://github.com/user-attachments/assets/11ffd5fb-f756-4af8-9488-88e05437c910

**After**

https://github.com/user-attachments/assets/7a428e59-25d3-40e7-806f-3fb6dbea190c

