### PR TITLE
Block Library: Fix Spotify embed whitespace with percentage dimensions

### DIFF
--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -124,6 +124,73 @@ describe( 'utils', () => {
 				existingClassNames
 			);
 		} );
+
+		it( 'should not add aspect ratio classes when iframe width is a percentage (e.g., Spotify embeds)', () => {
+			// Spotify embeds use width="100%" which shouldn't be used for aspect ratio calculation
+			const html = '<iframe width="100%" height="352"></iframe>';
+			const existingClassNames = 'wp-block-embed';
+			// Should not add aspect ratio classes because width is a percentage
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				existingClassNames
+			);
+		} );
+
+		it( 'should not add aspect ratio classes when iframe height is a percentage', () => {
+			const html = '<iframe width="640" height="100%"></iframe>';
+			const existingClassNames = 'wp-block-embed';
+			// Should not add aspect ratio classes because height is a percentage
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				existingClassNames
+			);
+		} );
+
+		it( 'should remove existing aspect ratio classes when iframe width is a percentage', () => {
+			const html = '<iframe width="100%" height="352"></iframe>';
+			const existingClassNames =
+				'wp-block-embed wp-embed-aspect-21-9 wp-has-aspect-ratio';
+			// Should remove the incorrect aspect ratio classes
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				'wp-block-embed'
+			);
+		} );
+
+		it( 'should apply vertical aspect ratio when iframe has percentage width with very large height', () => {
+			// Prevent layout break with extremely large heights
+			const html = '<iframe width="100%" height="4000"></iframe>';
+			const existingClassNames = 'wp-block-embed';
+			// Should apply constraining 9:16 aspect ratio to prevent breaking layout
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				'wp-block-embed wp-embed-aspect-9-16 wp-has-aspect-ratio'
+			);
+		} );
+
+		it( 'should apply vertical aspect ratio when iframe has percentage height with very large width', () => {
+			const html = '<iframe width="2000" height="100%"></iframe>';
+			const existingClassNames = 'wp-block-embed';
+			// Should apply constraining aspect ratio
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				'wp-block-embed wp-embed-aspect-9-16 wp-has-aspect-ratio'
+			);
+		} );
+
+		it( 'should not add aspect ratio classes when both iframe width and height are percentage with different values and have ratio higher than 2.43', () => {
+			const html = '<iframe width="100%" height="25%"></iframe>';
+			const existingClassNames = 'wp-block-embed';
+			// Should not add aspect ratio classes because both dimensions are percentage and ratio is higher than 2.43
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				existingClassNames
+			);
+		} );
+
+		it( 'should add aspect ratio classes when both iframe width and height are percentage with same values', () => {
+			const html = '<iframe width="100%" height="100%"></iframe>';
+			const existingClassNames =
+				'wp-block-embed wp-embed-aspect-1-1 wp-has-aspect-ratio';
+			// Should add aspect ratio classes because both dimensions are percentage
+			expect( getClassNames( html, existingClassNames, true ) ).toEqual(
+				existingClassNames
+			);
+		} );
 	} );
 	describe( 'hasInlineResponsivePadding', () => {
 		it( 'should return true when HTML contains padding-bottom percentage', () => {

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -239,7 +239,50 @@ export function getClassNames(
 
 	// If we have a fixed aspect iframe, and it's a responsive embed block.
 	if ( iframe && iframe.height && iframe.width ) {
-		const aspectRatio = ( iframe.width / iframe.height ).toFixed( 2 );
+		// Skip aspect ratio calculation if width or height is a percentage (e.g., Spotify embeds use "100%").
+		const widthAttr = iframe.getAttribute( 'width' );
+		const heightAttr = iframe.getAttribute( 'height' );
+		const hasPercentageWidth = widthAttr && widthAttr.includes( '%' );
+		const hasPercentageHeight = heightAttr && heightAttr.includes( '%' );
+
+		// If the embed has percentage-based dimensions, we generally want to skip adding aspect ratio classes, because the embed should already be responsive. However, if only one of the dimensions is percentage-based and the other is a fixed size that is very large, we should add aspect ratio classes to prevent it from breaking the layout.
+		// also if both dimensions are percentage-based, we should add aspect ratio classes to prevent layout issues.
+		if (
+			( hasPercentageWidth || hasPercentageHeight ) &&
+			! ( hasPercentageWidth && hasPercentageHeight )
+		) {
+			// If width is percentage with a reasonable fixed height (e.g., Spotify: 100% x 352px),
+			// skip aspect ratio to let it render naturally. But if height is very large (>800px),
+			// apply a constraining aspect ratio to prevent breaking the layout.
+			const numericHeight = parseFloat( heightAttr );
+			const numericWidth = parseFloat( widthAttr );
+
+			// Check if we have an unreasonably large dimension that needs constraining
+			const hasLargeHeight =
+				hasPercentageWidth &&
+				! isNaN( numericHeight ) &&
+				numericHeight > 800;
+			const hasLargeWidth =
+				hasPercentageHeight &&
+				! isNaN( numericWidth ) &&
+				numericWidth > 800;
+
+			if ( hasLargeHeight || hasLargeWidth ) {
+				// Apply a vertical aspect ratio (9:16) to constrain the oversized embed
+				return clsx(
+					removeAspectRatioClasses( existingClassNames ),
+					'wp-embed-aspect-9-16',
+					'wp-has-aspect-ratio'
+				);
+			}
+
+			// For normal percentage embeds (like Spotify), skip aspect ratio
+			return removeAspectRatioClasses( existingClassNames );
+		}
+		const aspectRatio = (
+			parseFloat( iframe.width ) / parseFloat( iframe.height )
+		).toFixed( 2 );
+
 		// Given the actual aspect ratio, find the widest ratio to support it.
 		for (
 			let ratioIndex = 0;

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -245,15 +245,11 @@ export function getClassNames(
 		const hasPercentageWidth = widthAttr && widthAttr.includes( '%' );
 		const hasPercentageHeight = heightAttr && heightAttr.includes( '%' );
 
-		// If the embed has percentage-based dimensions, we generally want to skip adding aspect ratio classes, because the embed should already be responsive. However, if only one of the dimensions is percentage-based and the other is a fixed size that is very large, we should add aspect ratio classes to prevent it from breaking the layout.
-		// also if both dimensions are percentage-based, we should add aspect ratio classes to prevent layout issues.
-		if (
-			( hasPercentageWidth || hasPercentageHeight ) &&
-			! ( hasPercentageWidth && hasPercentageHeight )
-		) {
-			// If width is percentage with a reasonable fixed height (e.g., Spotify: 100% x 352px),
-			// skip aspect ratio to let it render naturally. But if height is very large (>800px),
-			// apply a constraining aspect ratio to prevent breaking the layout.
+		// Handle embeds with percentage-based dimensions.
+		// If only one dimension is a percentage, we handle it specially.
+		// If both dimensions are percentages, we fall through to calculate the ratio.
+		if ( hasPercentageWidth !== hasPercentageHeight ) {
+			// Only one dimension is a percentage. Check if the fixed dimension is unreasonably large.
 			const numericHeight = parseFloat( heightAttr );
 			const numericWidth = parseFloat( widthAttr );
 


### PR DESCRIPTION
## What?

Closes #51212

Fixes Spotify embed blocks showing excessive whitespace below playlists and albums.

## Why?
Spotify embeds use `width="100%"` instead of numeric values. The `getClassNames()` function was calculating aspect ratios using `iframe.width / iframe.height`, which with percentage widths resulted in incorrect calculations (e.g., `100 / 352`) that applied wrong aspect ratio classes like `wp-embed-aspect-21-9`, causing the whitespace.

## How?
The fix detects percentage-based width/height attributes and handles them appropriately:

**For normal embeds** (percentage dimension with height ≤800px):
- Skips aspect ratio calculation
- Allows natural rendering without whitespace
- Typical Spotify use case: `width="100%"` `height="352"`

**For edge cases** (percentage dimension with height >800px):
- Applies constraining 9:16 vertical aspect ratio
- Prevents potential layout breaks from unusually large dimensions

### Technical Details
- Uses `getAttribute()` for reliable string detection (more robust than property access)
- Threshold of 800px balances normal embed sizes (150-600px) vs. problematic ones
- Only affects embeds with percentage dimensions; all other blocks unchanged

## Testing Instructions
1. Create a new post
2. Add Spotify embed block
3. Paste a Spotify playlist URL (e.g., `https://open.spotify.com/playlist/37i9dQZEVXbMWDif5SCBJq`)
4. Verify: No extra whitespace below the embed
5. Verify: Playlist displays with artwork and tracklist without squishing


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/4a02bb8b-5dfd-4637-8df5-c64e1ad23f5c


### After  

https://github.com/user-attachments/assets/27bc2ea4-e0a7-433d-80ce-d2fb201535e1




