### PR TITLE
wp-env: fix status command

### DIFF
--- a/packages/env/lib/commands/status.js
+++ b/packages/env/lib/commands/status.js
@@ -70,7 +70,7 @@ module.exports = async function status( { spinner, debug, json } ) {
 	}
 
 	// Detect and get runtime.
-	const runtimeName = detectRuntime( config.workDirectoryPath );
+	const runtimeName = await detectRuntime( config.workDirectoryPath );
 	const runtime = getRuntime( runtimeName );
 
 	// Get status from runtime.


### PR DESCRIPTION
## What?

As of #75057, `detectRuntime` has been changed to an async function and now returns a Promise, so `await` is required.

```bash
$ npm run wp-env status

> gutenberg@22.5.0 wp-env
> wp-env status

✖ Unknown runtime: [object Promise]
Error: Unknown runtime: [object Promise]
    at getRuntime (/home/t-hamano/projects/_core-dev/gutenberg/packages/env/lib/runtime/index.js:30:9)
    at status (/home/t-hamano/projects/_core-dev/gutenberg/packages/env/lib/commands/status.js:74:18)
```

## Testing Instructions

Run `npm run wp-env status`