### PR TITLE
Fix colorpicker default behavior

### DIFF
--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -67,6 +67,11 @@ const UnconnectedColorPicker = (
 
 	const handleChange = useCallback(
 		( nextValue: Colord ) => {
+			// Handle invalid/empty colors by clearing the selection
+			if ( ! nextValue || ! nextValue.isValid() ) {
+				debouncedSetColor( '' );
+				return;
+			}
 			debouncedSetColor( nextValue.toHex() );
 		},
 		[ debouncedSetColor ]

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -68,7 +68,7 @@ const UnconnectedColorPicker = (
 	const handleChange = useCallback(
 		( nextValue: Colord ) => {
 			// Handle invalid/empty colors by clearing the selection
-			if ( ! nextValue || ! nextValue.isValid() ) {
+			if ( ! nextValue?.isValid() ) {
 				debouncedSetColor( '' );
 				return;
 			}

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -20,7 +20,8 @@ import InputControlPrefixWrapper from '../input-control/input-prefix-wrapper';
 
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const handleChange = ( nextValue: string | undefined ) => {
-		// Default to white when the input is empty or undefined
+		// When input is empty, default to white (#fff) to match the ColorPicker's
+		// defaultValue and ensure consistent behavior regardless of how the input is cleared.
 		if ( ! nextValue ) {
 			onChange( colord( '#fff' ) );
 			return;

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -20,10 +20,9 @@ import InputControlPrefixWrapper from '../input-control/input-prefix-wrapper';
 
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const handleChange = ( nextValue: string | undefined ) => {
-		// When input is empty, default to white (#fff) to match the ColorPicker's
-		// defaultValue and ensure consistent behavior regardless of how the input is cleared.
+		// When input is empty, pass an empty string to clear the color selection.
 		if ( ! nextValue ) {
-			onChange( colord( '#fff' ) );
+			onChange( colord( '' ) );
 			return;
 		}
 		const hexValue = nextValue.startsWith( '#' )

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -20,7 +20,9 @@ import InputControlPrefixWrapper from '../input-control/input-prefix-wrapper';
 
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const handleChange = ( nextValue: string | undefined ) => {
+		// Default to white when the input is empty or undefined
 		if ( ! nextValue ) {
+			onChange( colord( '#fff' ) );
 			return;
 		}
 		const hexValue = nextValue.startsWith( '#' )

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -20,7 +20,9 @@ import InputControlPrefixWrapper from '../input-control/input-prefix-wrapper';
 
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const handleChange = ( nextValue: string | undefined ) => {
-		// When input is empty, pass an empty string to clear the color selection.
+		// When input is empty, pass colord('') which creates an invalid Colord object.
+		// This is handled in component.tsx by setting the color to an empty string,
+		// representing "no color selected".
 		if ( ! nextValue ) {
 			onChange( colord( '' ) );
 			return;

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -95,7 +95,9 @@ describe( 'ColorPicker', () => {
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
 
-			expect( onChangeComplete ).toHaveBeenCalledTimes( 3 );
+			// Clearing the input triggers onChange once (to white),
+			// then typing triggers 3 more times
+			expect( onChangeComplete ).toHaveBeenCalledTimes( 4 );
 			expect( onChangeComplete ).toHaveBeenLastCalledWith(
 				legacyColorMatcher
 			);
@@ -126,8 +128,38 @@ describe( 'ColorPicker', () => {
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
 
-			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			// Clearing the input triggers onChange once (to white),
+			// then typing triggers 3 more times
+			expect( onChange ).toHaveBeenCalledTimes( 4 );
 			expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
+		} );
+
+		it( 'should default to white when hex input is cleared', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			const color = '#ff0000';
+
+			render(
+				<ColorPicker
+					onChange={ onChange }
+					color={ color }
+					enableAlpha={ false }
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			expect( formatSelector ).toBeVisible();
+
+			await user.selectOptions( formatSelector, 'hex' );
+
+			const hexInput = screen.getByRole( 'textbox' );
+			expect( hexInput ).toBeVisible();
+
+			// Clear the entire hex input at once
+			await user.clear( hexInput );
+
+			// Should default to white (#ffffff)
+			expect( onChange ).toHaveBeenCalledWith( '#ffffff' );
 		} );
 	} );
 

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -95,7 +95,7 @@ describe( 'ColorPicker', () => {
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
 
-			// Clearing the input triggers onChange once (to white),
+			// Clearing the input triggers onChange once (to empty string),
 			// then typing triggers 3 more times
 			expect( onChangeComplete ).toHaveBeenCalledTimes( 4 );
 			expect( onChangeComplete ).toHaveBeenLastCalledWith(
@@ -128,13 +128,13 @@ describe( 'ColorPicker', () => {
 			await user.clear( hexInput );
 			await user.type( hexInput, '1ab' );
 
-			// Clearing the input triggers onChange once (to white),
+			// Clearing the input triggers onChange once (to empty string),
 			// then typing triggers 3 more times
 			expect( onChange ).toHaveBeenCalledTimes( 4 );
 			expect( onChange ).toHaveBeenLastCalledWith( '#11aabb' );
 		} );
 
-		it( 'should default to white when hex input is cleared', async () => {
+		it( 'should clear the color when hex input is cleared', async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
 			const color = '#ff0000';
@@ -158,8 +158,8 @@ describe( 'ColorPicker', () => {
 			// Clear the entire hex input at once
 			await user.clear( hexInput );
 
-			// Should default to white (#ffffff)
-			expect( onChange ).toHaveBeenCalledWith( '#ffffff' );
+			// Should clear the color (pass empty string)
+			expect( onChange ).toHaveBeenCalledWith( '' );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

- #75243
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. component.tsx - Added validation logic
2. hex-input.tsx - Modified empty input handling


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/796290d0-5d7f-4571-8faa-1ee843fa90d1


<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

