### PR TITLE
Media Fields: Filter author field to only show authors

### DIFF
--- a/packages/media-fields/src/author/index.tsx
+++ b/packages/media-fields/src/author/index.tsx
@@ -28,6 +28,9 @@ const authorField: Partial< Field< MediaItem > > = {
 				'user',
 				{
 					per_page: -1,
+					who: 'authors',
+					_fields: 'id,name',
+					context: 'view',
 				}
 			) ) ?? [];
 		return authors.map( ( { id, name } ) => ( {


### PR DESCRIPTION
## What?

Applies the same improvement from #75298 to the `@wordpress/media-fields` package. The author field's `getEntityRecords` call was fetching all users, but it should only fetch users with authoring capabilities.

This adds:
- `who: 'authors'` — filters to only users who can author content
- `_fields: 'id,name'` — limits the response to only the fields we need
- `context: 'view'` — uses the view context for the request

Follow-up to the suggestion in https://github.com/WordPress/gutenberg/pull/75298#pullrequestreview-3766900282 by @t-hamano.

## Testing Instructions

<img width="954" height="82" alt="Screenshot 2026-02-08 at 10 37 41 pm" src="https://github.com/user-attachments/assets/c972c53e-e362-45cb-9f9e-6553cc1f97da" />


1. Enable the `Data Views: new media modal` experiment over at `/wp-admin/admin.php?page=gutenberg-experiments`
2. Create a user with `subscriber` role, and, if you like, some other users who have create post permissions.
3. Create a post and insert an Image block. Click on "Media Library" in the image placeholder to trigger the modal.
4. Filter the view by "Author". The author filter should not include the subscriber user

| Before | After |
|--------|--------|
| <img width="386" height="476" alt="Screenshot 2026-02-08 at 10 36 23 pm" src="https://github.com/user-attachments/assets/28224cb1-19e7-4b0f-a267-524e762adbd3" /> | <img width="356" height="444" alt="Screenshot 2026-02-08 at 10 41 06 pm" src="https://github.com/user-attachments/assets/466a3777-8361-4c2e-ac9a-e2e0d84bcd6d" /> | 




