### PR TITLE
Template Style Variations (Exploration/POC)

### DIFF
--- a/lib/class-wp-base-themes-registry-gutenberg.php
+++ b/lib/class-wp-base-themes-registry-gutenberg.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Base Themes Registry.
+ *
+ * Provides a registry for base themes that can be used with style variations.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Class for managing registered base themes.
+ *
+ * Base themes define a complete theme.json configuration that can replace
+ * the current theme's theme.json when a style variation specifies one.
+ * This allows style variations to completely override the theme foundation.
+ *
+ */
+class WP_Base_Themes_Registry_Gutenberg {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var WP_Base_Themes_Registry_Gutenberg|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registered base themes.
+	 *
+	 * @var array
+	 */
+	private $registered_base_themes = array();
+
+	/**
+	 * Gets the singleton instance.
+	 *
+		 *
+	 * @return WP_Base_Themes_Registry_Gutenberg
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Private constructor to prevent direct instantiation.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Registers a base theme.
+	 *
+		 *
+	 * @param string $id   Unique identifier for the base theme (e.g., 'plugin//base-name').
+	 * @param array  $args {
+	 *     Arguments for the base theme.
+	 *
+	 *     @type string $title Human-readable title for the base theme.
+	 *     @type array  $data  The full theme.json-compatible data.
+	 * }
+	 * @return bool True on success, false on failure.
+	 */
+	public function register( $id, $args ) {
+		if ( empty( $id ) || ! is_string( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Base theme ID must be a non-empty string.', 'gutenberg' ),
+				'Gutenberg'
+			);
+			return false;
+		}
+
+		if ( $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: base theme ID */
+				sprintf( __( 'Base theme "%s" is already registered.', 'gutenberg' ), $id ),
+				'Gutenberg'
+			);
+			return false;
+		}
+
+		$defaults = array(
+			'title' => '',
+			'data'  => array(),
+		);
+
+		$base_theme = wp_parse_args( $args, $defaults );
+
+		// Ensure data has a version.
+		if ( ! isset( $base_theme['data']['version'] ) ) {
+			$base_theme['data']['version'] = WP_Theme_JSON_Gutenberg::LATEST_SCHEMA;
+		}
+
+		$this->registered_base_themes[ $id ] = $base_theme;
+
+		return true;
+	}
+
+	/**
+	 * Unregisters a base theme.
+	 *
+		 *
+	 * @param string $id The base theme ID to unregister.
+	 * @return bool True on success, false if the base theme was not registered.
+	 */
+	public function unregister( $id ) {
+		if ( ! $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: base theme ID */
+				sprintf( __( 'Base theme "%s" is not registered.', 'gutenberg' ), $id ),
+				'Gutenberg'
+			);
+			return false;
+		}
+
+		unset( $this->registered_base_themes[ $id ] );
+		return true;
+	}
+
+	/**
+	 * Gets a registered base theme by ID.
+	 *
+		 *
+	 * @param string $id The base theme ID.
+	 * @return array|null The base theme data, or null if not registered.
+	 */
+	public function get_registered( $id ) {
+		if ( ! $this->is_registered( $id ) ) {
+			return null;
+		}
+		return $this->registered_base_themes[ $id ];
+	}
+
+	/**
+	 * Gets all registered base themes.
+	 *
+		 *
+	 * @return array All registered base themes.
+	 */
+	public function get_all_registered() {
+		return $this->registered_base_themes;
+	}
+
+	/**
+	 * Checks if a base theme is registered.
+	 *
+		 *
+	 * @param string $id The base theme ID.
+	 * @return bool True if registered, false otherwise.
+	 */
+	public function is_registered( $id ) {
+		return isset( $this->registered_base_themes[ $id ] );
+	}
+}

--- a/lib/class-wp-rest-base-themes-controller-gutenberg.php
+++ b/lib/class-wp-rest-base-themes-controller-gutenberg.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * REST API: Base Themes Controller.
+ *
+ * Provides REST API endpoints for registered base themes.
+ *
+ * @package gutenberg
+ * @subpackage REST_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * REST API controller for registered base themes.
+ *
+ */
+class WP_REST_Base_Themes_Controller_Gutenberg extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 *
+		 */
+	public function __construct() {
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'base-themes';
+	}
+
+	/**
+	 * Registers the routes for the controller.
+	 *
+		 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_\-\/]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'description'       => __( 'The base theme ID.', 'gutenberg' ),
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read base themes.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return true;
+		}
+
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_cannot_read_base_themes',
+			__( 'Sorry, you are not allowed to access base themes.', 'gutenberg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read a base theme.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Retrieves all registered base themes.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$registry    = WP_Base_Themes_Registry_Gutenberg::get_instance();
+		$base_themes = $registry->get_all_registered();
+
+		$response = array();
+
+		foreach ( $base_themes as $id => $base_theme ) {
+			// Add the ID to the base theme data for prepare_item_for_response.
+			$base_theme['id'] = $id;
+			$item             = $this->prepare_item_for_response( $base_theme, $request );
+			$response[]       = $this->prepare_response_for_collection( $item );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Retrieves a single registered base theme.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object or WP_Error.
+	 */
+	public function get_item( $request ) {
+		$id       = $request['id'];
+		$registry = WP_Base_Themes_Registry_Gutenberg::get_instance();
+
+		// URL decode the ID.
+		$id = urldecode( $id );
+
+		$base_theme = $registry->get_registered( $id );
+
+		if ( ! $base_theme ) {
+			return new WP_Error(
+				'rest_base_theme_not_found',
+				__( 'Base theme not found.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Add the ID to the base theme data for prepare_item_for_response.
+		$base_theme['id'] = $id;
+
+		return $this->prepare_item_for_response( $base_theme, $request );
+	}
+
+	/**
+	 * Prepares a base theme for response.
+	 *
+		 *
+	 * @param array           $item    The base theme data including 'id'.
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$id     = $item['id'];
+
+		$data = array();
+
+		if ( rest_is_field_included( 'id', $fields ) ) {
+			$data['id'] = $id;
+		}
+
+		if ( rest_is_field_included( 'title', $fields ) ) {
+			$data['title'] = $item['title'];
+		}
+
+		if ( rest_is_field_included( 'settings', $fields ) ) {
+			$data['settings'] = isset( $item['data']['settings'] ) ? $item['data']['settings'] : new stdClass();
+		}
+
+		if ( rest_is_field_included( 'styles', $fields ) ) {
+			$data['styles'] = isset( $item['data']['styles'] ) ? $item['data']['styles'] : new stdClass();
+		}
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, urlencode( $id ) ) ),
+			),
+		);
+
+		$response->add_links( $links );
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves the query params for collections.
+	 *
+		 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
+	}
+
+	/**
+	 * Retrieves the base theme schema.
+	 *
+		 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'base-theme',
+			'type'       => 'object',
+			'properties' => array(
+				'id'       => array(
+					'description' => __( 'Unique identifier for the base theme.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'title'    => array(
+					'description' => __( 'The title of the base theme.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'settings' => array(
+					'description' => __( 'Global settings for the base theme.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'styles'   => array(
+					'description' => __( 'Global styles for the base theme.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/lib/class-wp-rest-style-variations-controller-gutenberg.php
+++ b/lib/class-wp-rest-style-variations-controller-gutenberg.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * REST API: Style Variations Controller.
+ *
+ * Provides REST API endpoints for registered style variations.
+ *
+ * @package gutenberg
+ * @subpackage REST_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * REST API controller for registered style variations.
+ *
+ */
+class WP_REST_Style_Variations_Controller_Gutenberg extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 *
+		 */
+	public function __construct() {
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'style-variations';
+	}
+
+	/**
+	 * Registers the routes for the controller.
+	 *
+		 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_\-\/]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'description'       => __( 'The style variation ID.', 'gutenberg' ),
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read style variations.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return true;
+		}
+
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_cannot_read_style_variations',
+			__( 'Sorry, you are not allowed to access style variations.', 'gutenberg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to read a style variation.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Retrieves all registered style variations.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$registry   = WP_Style_Variations_Registry_Gutenberg::get_instance();
+		$variations = $registry->get_all_registered();
+
+		$response = array();
+
+		foreach ( $variations as $id => $variation ) {
+			// Add the ID to the variation data for prepare_item_for_response.
+			$variation['id'] = $id;
+			$item            = $this->prepare_item_for_response( $variation, $request );
+			$response[]      = $this->prepare_response_for_collection( $item );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Retrieves a single registered style variation.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object or WP_Error.
+	 */
+	public function get_item( $request ) {
+		$id       = $request['id'];
+		$registry = WP_Style_Variations_Registry_Gutenberg::get_instance();
+
+		// URL decode the ID.
+		$id = urldecode( $id );
+
+		$variation = $registry->get_registered( $id );
+
+		if ( ! $variation ) {
+			return new WP_Error(
+				'rest_style_variation_not_found',
+				__( 'Style variation not found.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Add the ID to the variation data for prepare_item_for_response.
+		$variation['id'] = $id;
+
+		return $this->prepare_item_for_response( $variation, $request );
+	}
+
+	/**
+	 * Prepares a style variation for response.
+	 *
+		 *
+	 * @param array           $item    The variation data including 'id'.
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$id     = $item['id'];
+
+		$data = array();
+
+		if ( rest_is_field_included( 'id', $fields ) ) {
+			$data['id'] = $id;
+		}
+
+		if ( rest_is_field_included( 'title', $fields ) ) {
+			$data['title'] = $item['title'];
+		}
+
+		if ( rest_is_field_included( 'settings', $fields ) ) {
+			$data['settings'] = isset( $item['data']['settings'] ) ? $item['data']['settings'] : new stdClass();
+		}
+
+		if ( rest_is_field_included( 'styles', $fields ) ) {
+			$data['styles'] = isset( $item['data']['styles'] ) ? $item['data']['styles'] : new stdClass();
+		}
+
+		if ( rest_is_field_included( 'base_theme', $fields ) ) {
+			$data['base_theme'] = $item['base_theme'];
+		}
+
+		if ( rest_is_field_included( 'source', $fields ) ) {
+			$data['source'] = $item['source'];
+		}
+
+		// Include the post_id if a wp_global_styles post exists for this variation.
+		if ( rest_is_field_included( 'post_id', $fields ) ) {
+			$post_id         = gutenberg_get_variation_post_id( $id );
+			$data['post_id'] = $post_id ? $post_id : null;
+		}
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, urlencode( $id ) ) ),
+			),
+		);
+
+		$response->add_links( $links );
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves the query params for collections.
+	 *
+		 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
+	}
+
+	/**
+	 * Retrieves the style variation schema.
+	 *
+		 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'style-variation',
+			'type'       => 'object',
+			'properties' => array(
+				'id'         => array(
+					'description' => __( 'Unique identifier for the style variation.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'title'      => array(
+					'description' => __( 'The title of the style variation.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'settings'   => array(
+					'description' => __( 'Global settings for the style variation.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'styles'     => array(
+					'description' => __( 'Global styles for the style variation.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'base_theme' => array(
+					'description' => __( 'The ID of the base theme to use with this variation.', 'gutenberg' ),
+					'type'        => array( 'string', 'null' ),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'source'     => array(
+					'description' => __( 'The source of the style variation.', 'gutenberg' ),
+					'type'        => 'string',
+					'enum'        => array( 'theme', 'plugin', 'custom' ),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'post_id'    => array(
+					'description' => __( 'The wp_global_styles post ID if user customizations exist for this variation.', 'gutenberg' ),
+					'type'        => array( 'integer', 'null' ),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/lib/class-wp-style-variations-registry-gutenberg.php
+++ b/lib/class-wp-style-variations-registry-gutenberg.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Style Variations Registry.
+ *
+ * Provides a registry for style variations that can be associated with templates.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Class for managing registered style variations.
+ *
+ * Style variations define a set of global styles (settings and/or styles)
+ * that can be associated with specific templates. When a template has an
+ * associated style variation, that variation's styles are used instead of
+ * the global user styles.
+ *
+ */
+class WP_Style_Variations_Registry_Gutenberg {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var WP_Style_Variations_Registry_Gutenberg|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registered style variations.
+	 *
+	 * @var array
+	 */
+	private $registered_variations = array();
+
+	/**
+	 * Gets the singleton instance.
+	 *
+		 *
+	 * @return WP_Style_Variations_Registry_Gutenberg
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Private constructor to prevent direct instantiation.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Registers a style variation.
+	 *
+		 *
+	 * @param string $id   Unique identifier for the variation (e.g., 'theme//variation-name').
+	 * @param array  $args {
+	 *     Arguments for the style variation.
+	 *
+	 *     @type string $title      Human-readable title for the variation.
+	 *     @type array  $data       The theme.json-compatible data (settings, styles).
+	 *     @type string $base_theme Optional. ID of a registered base theme to use instead of current theme's theme.json.
+	 *     @type string $source     Optional. Source of the variation ('theme', 'plugin', 'custom'). Default 'custom'.
+	 * }
+	 * @return bool True on success, false on failure.
+	 */
+	public function register( $id, $args ) {
+		if ( empty( $id ) || ! is_string( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Style variation ID must be a non-empty string.', 'gutenberg' ),
+				'Gutenberg'
+			);
+			return false;
+		}
+
+		if ( $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: style variation ID */
+				sprintf( __( 'Style variation "%s" is already registered.', 'gutenberg' ), $id ),
+				'Gutenberg'
+			);
+			return false;
+		}
+
+		$defaults = array(
+			'title'      => '',
+			'data'       => array(),
+			'base_theme' => null,
+			'source'     => 'custom',
+		);
+
+		$variation = wp_parse_args( $args, $defaults );
+
+		// Ensure data has a version.
+		if ( ! isset( $variation['data']['version'] ) ) {
+			$variation['data']['version'] = WP_Theme_JSON_Gutenberg::LATEST_SCHEMA;
+		}
+
+		$this->registered_variations[ $id ] = $variation;
+
+		return true;
+	}
+
+	/**
+	 * Unregisters a style variation.
+	 *
+		 *
+	 * @param string $id The variation ID to unregister.
+	 * @return bool True on success, false if the variation was not registered.
+	 */
+	public function unregister( $id ) {
+		if ( ! $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: style variation ID */
+				sprintf( __( 'Style variation "%s" is not registered.', 'gutenberg' ), $id ),
+				'Gutenberg'
+			);
+			return false;
+		}
+
+		unset( $this->registered_variations[ $id ] );
+		return true;
+	}
+
+	/**
+	 * Gets a registered style variation by ID.
+	 *
+		 *
+	 * @param string $id The variation ID.
+	 * @return array|null The variation data, or null if not registered.
+	 */
+	public function get_registered( $id ) {
+		if ( ! $this->is_registered( $id ) ) {
+			return null;
+		}
+		return $this->registered_variations[ $id ];
+	}
+
+	/**
+	 * Gets all registered style variations.
+	 *
+		 *
+	 * @return array All registered variations.
+	 */
+	public function get_all_registered() {
+		return $this->registered_variations;
+	}
+
+	/**
+	 * Checks if a style variation is registered.
+	 *
+		 *
+	 * @param string $id The variation ID.
+	 * @return bool True if registered, false otherwise.
+	 */
+	public function is_registered( $id ) {
+		return isset( $this->registered_variations[ $id ] );
+	}
+}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -479,6 +479,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					'terms'    => $stylesheet,
 				),
 			),
+			// Exclude style variation posts - they have their own meta-based lookup.
+			// These posts are linked to variations, not to the default global styles.
+			'meta_query'             => array(
+				array(
+					'key'     => defined( 'GUTENBERG_VARIATION_SOURCE_META_KEY' ) ? GUTENBERG_VARIATION_SOURCE_META_KEY : '_wp_source_variation_id',
+					'compare' => 'NOT EXISTS',
+				),
+			),
 		);
 
 		$global_style_query = new WP_Query();
@@ -619,6 +627,199 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		$result->merge( static::get_user_data() );
+		return $result;
+	}
+
+	/**
+	 * Returns theme data using an optional base theme instead of the current theme.
+	 *
+	 * This method is used when a style variation specifies a base theme
+	 * that should replace the current theme's theme.json.
+	 *
+		 *
+	 * @param string|null $base_theme_id Optional. The ID of a registered base theme.
+	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
+	 */
+	public static function get_theme_data_with_base( $base_theme_id = null ) {
+		if ( empty( $base_theme_id ) ) {
+			return static::get_theme_data();
+		}
+
+		$registry   = WP_Base_Themes_Registry_Gutenberg::get_instance();
+		$base_theme = $registry->get_registered( $base_theme_id );
+
+		if ( ! $base_theme ) {
+			return static::get_theme_data();
+		}
+
+		// Create theme JSON from base theme data.
+		$base_theme_json = new WP_Theme_JSON_Gutenberg( $base_theme['data'], 'theme' );
+
+		/*
+		 * We want the presets and settings declared in the base theme
+		 * to override the ones declared via theme supports.
+		 */
+		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
+		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
+		$with_theme_supports->merge( $base_theme_json );
+
+		return $with_theme_supports;
+	}
+
+	/**
+	 * Returns user data from a specific global styles post.
+	 *
+	 * This method is used when a template has an associated style variation
+	 * and we need to use that variation's post as the user layer.
+	 *
+		 *
+	 * @param int $post_id The global styles post ID.
+	 * @return WP_Theme_JSON_Gutenberg Entity that holds user data from the specified post.
+	 */
+	public static function get_user_data_from_post( $post_id ) {
+		$config = array();
+		$post   = get_post( $post_id );
+
+		if ( ! $post || 'wp_global_styles' !== $post->post_type ) {
+			return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
+		}
+
+		$decoded_data = json_decode( $post->post_content, true );
+
+		$json_decoding_error = json_last_error();
+		if ( JSON_ERROR_NONE !== $json_decoding_error ) {
+			return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
+		}
+
+		// Verify the isGlobalStylesUserThemeJSON flag for safety, then accept the data.
+		// Variation posts created via gutenberg_get_or_create_variation_post() include
+		// this flag. Accept data both with and without the flag for variation posts
+		// (which are always created through controlled code paths).
+		if ( is_array( $decoded_data ) ) {
+			unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
+			$config = $decoded_data;
+		}
+
+		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
+		$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+
+		return $theme_json->get_theme_json();
+	}
+
+	/**
+	 * Returns user data from a registered style variation.
+	 *
+	 * This method is used when a template has an associated style variation
+	 * by string ID, and we need to use that variation's data as the user layer.
+	 *
+		 *
+	 * @param string $variation_id The registered style variation ID.
+	 * @return WP_Theme_JSON_Gutenberg Entity that holds user data from the variation.
+	 */
+	public static function get_user_data_from_registered_variation( $variation_id ) {
+		$config = array();
+
+		// Get the variation from the registry.
+		if ( ! class_exists( 'WP_Style_Variations_Registry_Gutenberg' ) ) {
+			return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
+		}
+
+		$registry  = WP_Style_Variations_Registry_Gutenberg::get_instance();
+		$variation = $registry->get_registered( $variation_id );
+
+		if ( ! $variation || empty( $variation['data'] ) ) {
+			return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
+		}
+
+		$config = $variation['data'];
+
+		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
+		$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+
+		return $theme_json->get_theme_json();
+	}
+
+	/**
+	 * Returns the merged data for a specific template.
+	 *
+	 * If the template has an associated style variation, that variation's
+	 * styles are used as the user layer. If the variation has an associated
+	 * wp_global_styles post (with user edits), that post's data is used.
+	 * Otherwise, the registered variation's data is used.
+	 *
+	 * Merge order: Core -> Blocks -> Theme (or Base Theme) -> User (variation post OR registered variation OR global)
+	 *
+		 *
+	 * @param string $template_id The template ID (e.g., 'theme//single').
+	 * @param string $origin      Optional. To what level should we merge data.
+	 * @return WP_Theme_JSON_Gutenberg
+	 */
+	public static function get_merged_data_for_template( $template_id, $origin = 'custom' ) {
+		// Check if the experiment is enabled.
+		if ( ! function_exists( 'gutenberg_is_experiment_enabled' ) || ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+			return static::get_merged_data( $origin );
+		}
+
+		// Get the template's style variation ID (now a string ID like 'demo//dark-mode').
+		$variation_id = null;
+		if ( function_exists( 'gutenberg_get_template_style_variation_id' ) ) {
+			$variation_id = gutenberg_get_template_style_variation_id( $template_id );
+		}
+
+		// If no variation, fall back to normal merge.
+		if ( ! $variation_id ) {
+			return static::get_merged_data( $origin );
+		}
+
+		// Check if there's a wp_global_styles post for this variation.
+		$variation_post_id = null;
+		if ( $variation_id && function_exists( 'gutenberg_get_variation_post_id' ) ) {
+			$variation_post_id = gutenberg_get_variation_post_id( $variation_id );
+		}
+
+		// Get the variation from the registry to check for base_theme.
+		$base_theme_id = null;
+		if ( class_exists( 'WP_Style_Variations_Registry_Gutenberg' ) ) {
+			$registry  = WP_Style_Variations_Registry_Gutenberg::get_instance();
+			$variation = $registry->get_registered( $variation_id );
+			if ( $variation && ! empty( $variation['base_theme'] ) ) {
+				$base_theme_id = $variation['base_theme'];
+			}
+		}
+
+		// Build merged data with template-specific layers.
+		$result = new WP_Theme_JSON_Gutenberg();
+		$result->merge( static::get_core_data() );
+
+		if ( 'default' === $origin ) {
+			return $result;
+		}
+
+		$result->merge( static::get_block_data() );
+
+		if ( 'blocks' === $origin ) {
+			return $result;
+		}
+
+		// Use base theme if specified, otherwise use current theme.
+		if ( $base_theme_id ) {
+			$result->merge( static::get_theme_data_with_base( $base_theme_id ) );
+		} else {
+			$result->merge( static::get_theme_data() );
+		}
+
+		if ( 'theme' === $origin ) {
+			return $result;
+		}
+
+		// Use template-specific user data.
+		// Priority: variation post (user edits) > registered variation data.
+		if ( $variation_post_id ) {
+			$result->merge( static::get_user_data_from_post( $variation_post_id ) );
+		} else {
+			$result->merge( static::get_user_data_from_registered_variation( $variation_id ) );
+		}
+
 		return $result;
 	}
 

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php
@@ -135,6 +135,33 @@ class Gutenberg_REST_Templates_Controller_7_0 extends WP_REST_Templates_Controll
 			 */
 			true
 		);
+
+		// Endpoint to create/get the variation post for a template.
+		// Note: experiment check is done in the callback to ensure route is always registered.
+		// Uses a separate route base to avoid conflicts with the greedy template ID pattern.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '-variation-post/(?P<id>.+)',
+			array(
+				'args' => array(
+					'id'           => array(
+						'description'       => __( 'The id of a template' ),
+						'type'              => 'string',
+						'sanitize_callback' => array( $this, '_sanitize_template_id' ),
+					),
+					'variation_id' => array(
+						'description' => __( 'The style variation ID. If provided, this is used instead of looking up the variation from template meta. This allows creating variation posts for non-customized templates.' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'ensure_variation_post' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+			),
+			true
+		);
 	}
 
 	/**
@@ -275,6 +302,21 @@ class Gutenberg_REST_Templates_Controller_7_0 extends WP_REST_Templates_Controll
 			}
 		}
 
+		// Template style variation support (experimental).
+		// Templates link to style variations by ID. The variation's wp_global_styles post
+		// (if any) is looked up by the variation ID, not stored on the template.
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+			if ( rest_is_field_included( 'style_variation', $fields ) ) {
+				$data['style_variation'] = null;
+				if ( $template->wp_id ) {
+					$variation_id = get_post_meta( $template->wp_id, GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY, true );
+					if ( $variation_id ) {
+						$data['style_variation'] = $variation_id;
+					}
+				}
+			}
+		}
+
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
@@ -409,5 +451,164 @@ class Gutenberg_REST_Templates_Controller_7_0 extends WP_REST_Templates_Controll
 
 		// Fail-safe to return a string should the original source ever fall through.
 		return '';
+	}
+
+	/**
+	 * Retrieves the template's schema, conforming to JSON Schema.
+	 *
+	 * Extends parent schema to add style_variation field when experiment is enabled.
+	 *
+		 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		// Add style_variation field if experiment is enabled.
+		// The variation's wp_global_styles post is looked up by variation ID, not stored on template.
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+			$schema['properties']['style_variation'] = array(
+				'description' => __( 'The registered style variation ID associated with this template.', 'gutenberg' ),
+				'type'        => array( 'string', 'null' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
+			);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Prepares a single template for update.
+	 *
+	 * Extends parent to handle style_variation field.
+	 *
+		 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return stdClass Changes to pass to wp_update_post.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$changes = parent::prepare_item_for_database( $request );
+
+		// Handle style_variation field if experiment is enabled.
+		// Use has_param() instead of isset() because isset() returns false for null values,
+		// and we need to detect when the user explicitly sets style_variation to null (to unset it).
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) && $request->has_param( 'style_variation' ) ) {
+			// Store the style_variation in meta via a custom property.
+			$changes->meta_input = isset( $changes->meta_input ) ? $changes->meta_input : array();
+			if ( null === $request['style_variation'] || '' === $request['style_variation'] ) {
+				// Set to empty to trigger deletion.
+				$changes->meta_input[ GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY ] = '';
+			} else {
+				$changes->meta_input[ GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY ] = sanitize_text_field( $request['style_variation'] );
+			}
+		}
+
+		return $changes;
+	}
+
+	/**
+	 * Updates a single template.
+	 *
+	 * Extends parent to handle style_variation meta changes.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_item( $request ) {
+		$response = parent::update_item( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		// Handle style_variation removal.
+		// Use has_param() instead of isset() because isset() returns false for null values,
+		// and we need to detect when the user explicitly sets style_variation to null (to unset it).
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) && $request->has_param( 'style_variation' ) ) {
+			$new_variation_id = $request['style_variation'];
+			$template         = get_block_template( $request['id'], $this->post_type );
+
+			if ( $template && $template->wp_id ) {
+				// If variation is removed (null or empty), delete the meta.
+				if ( null === $new_variation_id || '' === $new_variation_id ) {
+					delete_post_meta( $template->wp_id, GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY );
+				}
+			}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Creates or returns the wp_global_styles post for a style variation.
+	 *
+	 * The variation can be identified either from:
+	 * 1. The variation_id parameter passed in the request body (preferred)
+	 * 2. The template's style_variation meta (fallback for backwards compatibility)
+	 *
+	 * There is ONE post per variation, shared by all templates using that variation.
+	 *
+		 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function ensure_variation_post( $request ) {
+		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+			return new WP_Error(
+				'rest_feature_disabled',
+				__( 'Template style variations feature is not enabled.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// First, try to get variation_id from the request body.
+		// This allows creating a variation post even for non-customized templates.
+		$variation_id = isset( $request['variation_id'] ) ? sanitize_text_field( $request['variation_id'] ) : null;
+
+		// If no variation_id in request, fall back to looking it up from template meta.
+		if ( ! $variation_id ) {
+			$template = get_block_template( $request['id'], $this->post_type );
+
+			if ( ! $template ) {
+				return new WP_Error(
+					'rest_template_not_found',
+					__( 'No templates exist with that id.', 'gutenberg' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			if ( ! $template->wp_id ) {
+				return new WP_Error(
+					'rest_template_not_customized',
+					__( 'Template must be customized before creating a variation post, or pass variation_id in the request.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$variation_id = get_post_meta( $template->wp_id, GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY, true );
+		}
+
+		if ( ! $variation_id ) {
+			return new WP_Error(
+				'rest_no_variation',
+				__( 'No variation_id provided and template does not have a style variation assigned.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Get or create the variation post. This is shared by all templates using this variation.
+		$post_id = gutenberg_get_or_create_variation_post( $variation_id );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		return rest_ensure_response(
+			array(
+				'post_id'      => $post_id,
+				'variation_id' => $variation_id,
+			)
+		);
 	}
 }

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -76,6 +76,11 @@ add_filter( 'default_wp_template_part_areas', 'gutenberg_register_overlay_templa
  * WordPress core only adds this link for block themes with theme.json support.
  * This filter extends that functionality to all themes.
  *
+ * Additionally, this filter ensures the link points to the correct global styles post.
+ * WordPress core's WP_Theme_JSON_Resolver may return a template style variation post
+ * instead of the default global styles post. We use WP_Theme_JSON_Resolver_Gutenberg
+ * which has the fix to exclude variation posts from the default query.
+ *
  * @param WP_REST_Response $response The response object.
  * @param WP_Theme         $theme    Theme object used to create response.
  * @return WP_REST_Response Modified response object.
@@ -86,20 +91,17 @@ function gutenberg_rest_theme_global_styles_link_rel_7_0( $response, $theme ) {
 		return $response;
 	}
 
-	// Check if the link already exists (WordPress core adds it for block themes).
-	$all_links = $response->get_links();
-	if ( isset( $all_links['https://api.w.org/user-global-styles'] ) ) {
-		return $response;
-	}
-
-	// Get or create the global styles post ID for this theme.
-	// Now that we've removed the theme.json check, this works for all themes.
+	// Get or create the global styles post ID for this theme using Gutenberg's resolver.
+	// This ensures we get the correct default global styles post, not a variation post.
 	$global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	if ( ! $global_styles_id ) {
 		return $response;
 	}
 
-	// Add the wp:user-global-styles link.
+	// Remove any existing link that core may have added (it might point to wrong post).
+	$response->remove_link( 'https://api.w.org/user-global-styles' );
+
+	// Add the wp:user-global-styles link with the correct post ID.
 	$response->add_link(
 		'https://api.w.org/user-global-styles',
 		rest_url( 'wp/v2/global-styles/' . $global_styles_id )

--- a/lib/experimental/demo-template-style-variations.php
+++ b/lib/experimental/demo-template-style-variations.php
@@ -1,0 +1,372 @@
+<?php
+/**
+ * Demo Template Style Variations.
+ *
+ * This file registers sample base themes and style variations for testing
+ * the template style variations feature. It's only loaded when the
+ * experiment is enabled.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Registers demo base themes and style variations.
+ *
+ */
+function gutenberg_register_demo_template_style_variations() {
+	// Only register if the experiment is enabled.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+		return;
+	}
+
+	// Register a minimal base theme.
+	gutenberg_register_base_theme(
+		'demo//minimal',
+		array(
+			'title' => __( 'Minimal Base', 'gutenberg' ),
+			'data'  => array(
+				'version'  => 3,
+				'settings' => array(
+					'color'      => array(
+						'palette' => array(
+							array(
+								'slug'  => 'primary',
+								'color' => '#2271b1',
+								'name'  => __( 'Primary', 'gutenberg' ),
+							),
+							array(
+								'slug'  => 'secondary',
+								'color' => '#6c757d',
+								'name'  => __( 'Secondary', 'gutenberg' ),
+							),
+							array(
+								'slug'  => 'background',
+								'color' => '#ffffff',
+								'name'  => __( 'Background', 'gutenberg' ),
+							),
+							array(
+								'slug'  => 'foreground',
+								'color' => '#1a1a1a',
+								'name'  => __( 'Foreground', 'gutenberg' ),
+							),
+						),
+					),
+					'typography' => array(
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'system',
+								'fontFamily' => '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif',
+								'name'       => __( 'System Font', 'gutenberg' ),
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'color' => array(
+						'background' => '#ffffff',
+						'text'       => '#1a1a1a',
+					),
+				),
+			),
+		)
+	);
+
+	// Register a dark base theme.
+	// Uses very distinctive fonts (Courier New, Georgia) to make it obvious
+	// when the base theme override is active.
+	gutenberg_register_base_theme(
+		'demo//dark-base',
+		array(
+			'title' => __( 'Dark Base', 'gutenberg' ),
+			'data'  => array(
+				'version'  => 3,
+				'settings' => array(
+					'color'      => array(
+						'palette' => array(
+							array(
+								'slug'  => 'primary',
+								'color' => '#60a5fa',
+								'name'  => __( 'Primary', 'gutenberg' ),
+							),
+							array(
+								'slug'  => 'secondary',
+								'color' => '#94a3b8',
+								'name'  => __( 'Secondary', 'gutenberg' ),
+							),
+							array(
+								'slug'  => 'background',
+								'color' => '#0f172a',
+								'name'  => __( 'Background', 'gutenberg' ),
+							),
+							array(
+								'slug'  => 'foreground',
+								'color' => '#f1f5f9',
+								'name'  => __( 'Foreground', 'gutenberg' ),
+							),
+						),
+					),
+					'typography' => array(
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'dark-base-mono',
+								'fontFamily' => '"Courier New", Courier, monospace',
+								'name'       => __( 'Dark Base Mono', 'gutenberg' ),
+							),
+							array(
+								'slug'       => 'dark-base-serif',
+								'fontFamily' => 'Georgia, "Times New Roman", Times, serif',
+								'name'       => __( 'Dark Base Serif', 'gutenberg' ),
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'color'      => array(
+						'background' => '#0f172a',
+						'text'       => '#f1f5f9',
+					),
+					'typography' => array(
+						'fontFamily' => 'Georgia, "Times New Roman", Times, serif',
+					),
+				),
+			),
+		)
+	);
+
+	// Register a dark mode style variation.
+	gutenberg_register_style_variation(
+		'demo//dark-mode',
+		array(
+			'title'      => __( 'Dark Mode', 'gutenberg' ),
+			'base_theme' => 'demo//dark-base',
+			'source'     => 'plugin',
+			'data'       => array(
+				'version' => 3,
+				'styles'  => array(
+					'color'    => array(
+						'background' => '#1a1a1a',
+						'text'       => '#f5f5f5',
+					),
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text' => '#93c5fd',
+							),
+							':hover' => array(
+								'color' => array(
+									'text' => '#60a5fa',
+								),
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+
+	// Register a high contrast style variation.
+	gutenberg_register_style_variation(
+		'demo//high-contrast',
+		array(
+			'title'  => __( 'High Contrast', 'gutenberg' ),
+			'source' => 'plugin',
+			'data'   => array(
+				'version' => 3,
+				'styles'  => array(
+					'color'    => array(
+						'background' => '#000000',
+						'text'       => '#ffffff',
+					),
+					'elements' => array(
+						'link'    => array(
+							'color'  => array(
+								'text' => '#ffff00',
+							),
+							':hover' => array(
+								'color'      => array(
+									'text' => '#ffffff',
+								),
+								'typography' => array(
+									'textDecoration' => 'underline',
+								),
+							),
+						),
+						'heading' => array(
+							'color' => array(
+								'text' => '#ffffff',
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+
+	// Register a warm style variation.
+	gutenberg_register_style_variation(
+		'demo//warm',
+		array(
+			'title'      => __( 'Warm Tones', 'gutenberg' ),
+			'base_theme' => 'demo//minimal',
+			'source'     => 'plugin',
+			'data'       => array(
+				'version' => 3,
+				'styles'  => array(
+					'color'    => array(
+						'background' => '#fef7ed',
+						'text'       => '#451a03',
+					),
+					'elements' => array(
+						'link'    => array(
+							'color'  => array(
+								'text' => '#c2410c',
+							),
+							':hover' => array(
+								'color' => array(
+									'text' => '#9a3412',
+								),
+							),
+						),
+						'heading' => array(
+							'color' => array(
+								'text' => '#7c2d12',
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+
+	// Register a cool style variation.
+	gutenberg_register_style_variation(
+		'demo//cool',
+		array(
+			'title'  => __( 'Cool Tones', 'gutenberg' ),
+			'source' => 'plugin',
+			'data'   => array(
+				'version' => 3,
+				'styles'  => array(
+					'color'    => array(
+						'background' => '#f0f9ff',
+						'text'       => '#0c4a6e',
+					),
+					'elements' => array(
+						'link'    => array(
+							'color'  => array(
+								'text' => '#0284c7',
+							),
+							':hover' => array(
+								'color' => array(
+									'text' => '#0369a1',
+								),
+							),
+						),
+						'heading' => array(
+							'color' => array(
+								'text' => '#075985',
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+add_action( 'init', 'gutenberg_register_demo_template_style_variations', 20 );
+
+/**
+ * Registers a demo "Campaign Landing Page" template and assigns it a style variation.
+ *
+ * The template is registered via register_block_template(), and a wp_template post
+ * is created so the style variation association (stored as post meta) is persisted.
+ */
+function gutenberg_register_demo_campaign_template() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+		return;
+	}
+
+	$template_content = <<<BLOCKS
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+<!-- wp:cover {"overlayColor":"primary","minHeight":400,"isDark":true} -->
+<div class="wp-block-cover is-dark" style="min-height:400px"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
+<!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center">Your Campaign Headline</h1>
+<!-- /wp:heading -->
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">A compelling subtitle that captures the essence of your campaign.</p>
+<!-- /wp:paragraph -->
+</div></div>
+<!-- /wp:cover -->
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">
+<!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Get Started</a></div>
+<!-- /wp:button -->
+</div>
+<!-- /wp:buttons -->
+</main>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+BLOCKS;
+
+	register_block_template(
+		'gutenberg//campaign-landing-page',
+		array(
+			'title'       => __( 'Campaign Landing Page', 'gutenberg' ),
+			'description' => __( 'A landing page template for marketing campaigns.', 'gutenberg' ),
+			'content'     => $template_content,
+			'post_types'  => array( 'page' ),
+		)
+	);
+
+	// Create a wp_template post so the style variation meta can be stored.
+	// The REST API reads the variation ID from post meta, which requires a post to exist.
+	$existing = get_posts(
+		array(
+			'post_type'      => 'wp_template',
+			'post_status'    => array( 'publish', 'auto-draft', 'draft' ),
+			'name'           => 'campaign-landing-page',
+			'posts_per_page' => 1,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'wp_theme',
+					'field'    => 'name',
+					'terms'    => get_stylesheet(),
+				),
+			),
+		)
+	);
+
+	if ( ! empty( $existing ) ) {
+		return;
+	}
+
+	$post_id = wp_insert_post(
+		array(
+			'post_type'    => 'wp_template',
+			'post_status'  => 'publish',
+			'post_title'   => __( 'Campaign Landing Page', 'gutenberg' ),
+			'post_name'    => 'campaign-landing-page',
+			'post_content' => $template_content,
+			'meta_input'   => array(
+				GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY => 'demo//warm',
+			),
+		),
+		true
+	);
+
+	if ( ! is_wp_error( $post_id ) ) {
+		wp_set_object_terms( $post_id, get_stylesheet(), 'wp_theme' );
+	}
+}
+
+add_action( 'init', 'gutenberg_register_demo_campaign_template', 21 );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -233,6 +233,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-template-style-variations',
+		__( 'Template Style Variations', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables associating templates with specific style variations, allowing different templates to use different global styles configurations.', 'gutenberg' ),
+			'id'    => 'gutenberg-template-style-variations',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -412,3 +412,54 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 function gutenberg_get_theme_directory_pattern_slugs() {
 	return WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }
+
+/**
+ * Returns the stylesheet for a specific template, considering any associated style variation.
+ *
+ * If the template has an associated style variation, that variation's styles are used.
+ * If the variation specifies a base theme, that is used instead of the current theme's theme.json.
+ *
+ *
+ * @param string $template_id The template ID (e.g., 'theme//single').
+ * @param array  $types       Types of styles to load. Optional.
+ *                            See {@see 'WP_Theme_JSON::get_stylesheet'} for all valid types.
+ *                            If empty, will load: 'variables', 'presets', 'styles'.
+ *
+ * @return string Stylesheet.
+ */
+function gutenberg_get_global_stylesheet_for_template( $template_id, $types = array() ) {
+	// Check if the experiment is enabled.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+		return gutenberg_get_global_stylesheet( $types );
+	}
+
+	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data_for_template( $template_id );
+	$tree = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
+
+	if ( empty( $types ) ) {
+		$types = array( 'variables', 'presets', 'styles' );
+	}
+
+	/*
+	 * Enable base layout styles only mode for classic themes without theme.json.
+	 */
+	$options = array();
+	if ( ! wp_is_block_theme() && ! wp_theme_has_theme_json() ) {
+		$options['base_layout_styles'] = true;
+	}
+
+	$styles_variables = '';
+	if ( in_array( 'variables', $types, true ) ) {
+		$origins          = array( 'default', 'theme', 'custom' );
+		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins, $options );
+		$types            = array_diff( $types, array( 'variables' ) );
+	}
+
+	$styles_rest = '';
+	if ( ! empty( $types ) ) {
+		$origins     = array( 'default', 'theme', 'custom' );
+		$styles_rest = $tree->get_stylesheet( $types, $origins, $options );
+	}
+
+	return $styles_variables . $styles_rest;
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -76,6 +76,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';
+	require_once __DIR__ . '/class-wp-rest-style-variations-controller-gutenberg.php';
+	require_once __DIR__ . '/class-wp-rest-base-themes-controller-gutenberg.php';
 	require_once __DIR__ . '/rest-api.php';
 
 	require_once __DIR__ . '/experimental/rest-api.php';
@@ -148,6 +150,11 @@ require __DIR__ . '/script-loader.php';
 require __DIR__ . '/global-styles-and-settings.php';
 require __DIR__ . '/class-wp-theme-json-data-gutenberg.php';
 require __DIR__ . '/class-wp-theme-json-gutenberg.php';
+
+// Template style variations registries (must load before resolver).
+require __DIR__ . '/class-wp-style-variations-registry-gutenberg.php';
+require __DIR__ . '/class-wp-base-themes-registry-gutenberg.php';
+
 require __DIR__ . '/class-wp-theme-json-resolver-gutenberg.php';
 require __DIR__ . '/class-wp-theme-json-schema-gutenberg.php';
 require __DIR__ . '/class-wp-duotone-gutenberg.php';
@@ -206,4 +213,10 @@ require __DIR__ . '/overlay-patterns.php';
 if ( gutenberg_is_experiment_enabled( 'gutenberg-svg-icon-registry' ) ) {
 	require __DIR__ . '/experimental/class-wp-icons-registry.php';
 	require __DIR__ . '/experimental/class-wp-rest-icons-controller.php';
+}
+
+// Template style variations (only load when experiment is enabled).
+if ( gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+	require __DIR__ . '/template-style-variations.php';
+	require __DIR__ . '/experimental/demo-template-style-variations.php';
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -47,3 +47,35 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-svg-icon-registry' ) ) {
 	}
 	add_action( 'rest_api_init', 'gutenberg_register_icon_controller_endpoints' );
 }
+
+/**
+ * Registers the Style Variations REST API routes.
+ *
+ * Only registered when the template style variations experiment is enabled.
+ *
+ */
+function gutenberg_register_style_variations_controller_endpoints() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+		return;
+	}
+
+	$style_variations_controller = new WP_REST_Style_Variations_Controller_Gutenberg();
+	$style_variations_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_style_variations_controller_endpoints' );
+
+/**
+ * Registers the Base Themes REST API routes.
+ *
+ * Only registered when the template style variations experiment is enabled.
+ *
+ */
+function gutenberg_register_base_themes_controller_endpoints() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) ) {
+		return;
+	}
+
+	$base_themes_controller = new WP_REST_Base_Themes_Controller_Gutenberg();
+	$base_themes_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_base_themes_controller_endpoints' );

--- a/lib/script-loader.php
+++ b/lib/script-loader.php
@@ -42,7 +42,26 @@ function gutenberg_enqueue_global_styles() {
 	 */
 	add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 
-	$stylesheet = gutenberg_get_global_stylesheet();
+	/*
+	 * Check if template style variations are enabled and we have a current template.
+	 * If so, use template-specific styles.
+	 */
+	$stylesheet = '';
+	if (
+		function_exists( 'gutenberg_is_experiment_enabled' ) &&
+		gutenberg_is_experiment_enabled( 'gutenberg-template-style-variations' ) &&
+		function_exists( 'gutenberg_get_current_template_id' )
+	) {
+		$template_id = gutenberg_get_current_template_id();
+		if ( $template_id ) {
+			$stylesheet = gutenberg_get_global_stylesheet_for_template( $template_id );
+		}
+	}
+
+	// Fall back to default stylesheet if no template-specific one.
+	if ( empty( $stylesheet ) ) {
+		$stylesheet = gutenberg_get_global_stylesheet();
+	}
 
 	/*
 	 * For block themes, merge Customizer's custom CSS into the global styles stylesheet

--- a/lib/template-style-variations.php
+++ b/lib/template-style-variations.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Template Style Variations API.
+ *
+ * Public functions for working with template-specific style variations.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * The meta key used to store the style variation ID on templates.
+ */
+define( 'GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY', '_wp_style_variation_id' );
+
+/**
+ * The meta key used to identify which variation a wp_global_styles post belongs to.
+ * This creates a one-to-one relationship between variations and their style posts.
+ */
+define( 'GUTENBERG_VARIATION_SOURCE_META_KEY', '_wp_source_variation_id' );
+
+/**
+ * Registers a style variation.
+ *
+ *
+ * @param string $id   Unique identifier for the variation (e.g., 'theme//variation-name').
+ * @param array  $args {
+ *     Arguments for the style variation.
+ *
+ *     @type string $title      Human-readable title for the variation.
+ *     @type array  $data       The theme.json-compatible data (settings, styles).
+ *     @type string $base_theme Optional. ID of a registered base theme.
+ *     @type string $source     Optional. Source of the variation ('theme', 'plugin', 'custom').
+ * }
+ * @return bool True on success, false on failure.
+ */
+function gutenberg_register_style_variation( $id, $args ) {
+	return WP_Style_Variations_Registry_Gutenberg::get_instance()->register( $id, $args );
+}
+
+/**
+ * Unregisters a style variation.
+ *
+ *
+ * @param string $id The variation ID to unregister.
+ * @return bool True on success, false on failure.
+ */
+function gutenberg_unregister_style_variation( $id ) {
+	return WP_Style_Variations_Registry_Gutenberg::get_instance()->unregister( $id );
+}
+
+/**
+ * Registers a base theme.
+ *
+ *
+ * @param string $id   Unique identifier for the base theme.
+ * @param array  $args {
+ *     Arguments for the base theme.
+ *
+ *     @type string $title Human-readable title for the base theme.
+ *     @type array  $data  The full theme.json-compatible data.
+ * }
+ * @return bool True on success, false on failure.
+ */
+function gutenberg_register_base_theme( $id, $args ) {
+	return WP_Base_Themes_Registry_Gutenberg::get_instance()->register( $id, $args );
+}
+
+/**
+ * Unregisters a base theme.
+ *
+ *
+ * @param string $id The base theme ID to unregister.
+ * @return bool True on success, false on failure.
+ */
+function gutenberg_unregister_base_theme( $id ) {
+	return WP_Base_Themes_Registry_Gutenberg::get_instance()->unregister( $id );
+}
+
+/**
+ * Gets the style variation ID associated with a template.
+ *
+ *
+ * @param string $template_id The template ID (e.g., 'theme//single').
+ * @return string|null The registered style variation ID, or null if none.
+ */
+function gutenberg_get_template_style_variation_id( $template_id ) {
+	// Parse the template ID to get the slug.
+	$parts = explode( '//', $template_id, 2 );
+	$slug  = isset( $parts[1] ) ? $parts[1] : $template_id;
+	$theme = isset( $parts[0] ) ? $parts[0] : get_stylesheet();
+
+	// Find the template post.
+	$template_posts = get_posts(
+		array(
+			'post_type'      => 'wp_template',
+			'post_status'    => array( 'publish', 'auto-draft' ),
+			'name'           => $slug,
+			'posts_per_page' => 1,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'wp_theme',
+					'field'    => 'name',
+					'terms'    => array( $theme, get_template() ),
+				),
+			),
+		)
+	);
+
+	if ( empty( $template_posts ) ) {
+		return null;
+	}
+
+	$template_post = $template_posts[0];
+	$variation_id  = get_post_meta( $template_post->ID, GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY, true );
+
+	return $variation_id ? $variation_id : null;
+}
+
+/**
+ * Determines the current template being rendered on the frontend.
+ *
+ *
+ * @return string|null The template ID, or null if not determinable.
+ */
+function gutenberg_get_current_template_id() {
+	global $_wp_current_template_id;
+
+	if ( ! empty( $_wp_current_template_id ) ) {
+		return $_wp_current_template_id;
+	}
+
+	// Fallback: try to determine from the queried template.
+	if ( ! is_admin() && function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+		$template_slug = '';
+
+		if ( is_front_page() && is_home() ) {
+			$template_slug = 'home';
+		} elseif ( is_front_page() ) {
+			$template_slug = 'front-page';
+		} elseif ( is_home() ) {
+			$template_slug = 'home';
+		} elseif ( is_singular() ) {
+			$template_slug = 'single';
+		} elseif ( is_archive() ) {
+			$template_slug = 'archive';
+		} elseif ( is_search() ) {
+			$template_slug = 'search';
+		} elseif ( is_404() ) {
+			$template_slug = '404';
+		} else {
+			$template_slug = 'index';
+		}
+
+		return get_stylesheet() . '//' . $template_slug;
+	}
+
+	return null;
+}
+
+/**
+ * Registers the template style variation meta for templates.
+ *
+ */
+function gutenberg_register_template_style_variation_meta() {
+	// Register the variation ID meta (string ID like "demo//dark-mode").
+	// This links a template to a registered style variation.
+	register_post_meta(
+		'wp_template',
+		GUTENBERG_TEMPLATE_STYLE_VARIATION_META_KEY,
+		array(
+			'type'              => 'string',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'auth_callback'     => function () {
+				return current_user_can( 'edit_theme_options' );
+			},
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+}
+
+add_action( 'init', 'gutenberg_register_template_style_variation_meta' );
+
+/**
+ * Registers theme style variations into the style variations registry.
+ *
+ * Reads style variation JSON files from the active theme's styles/ directory
+ * and registers them so they appear in the template style variation picker.
+ *
+ */
+function gutenberg_register_theme_style_variations() {
+	$theme_variations = WP_Theme_JSON_Resolver_Gutenberg::get_style_variations( 'theme' );
+	foreach ( $theme_variations as $theme_variation ) {
+		if ( empty( $theme_variation['title'] ) ) {
+			continue;
+		}
+		$variation_id = 'theme//' . sanitize_title( $theme_variation['title'] );
+		if ( WP_Style_Variations_Registry_Gutenberg::get_instance()->is_registered( $variation_id ) ) {
+			continue;
+		}
+		gutenberg_register_style_variation(
+			$variation_id,
+			array(
+				'title'  => $theme_variation['title'],
+				'source' => 'theme',
+				'data'   => array(
+					'version'  => 3,
+					'settings' => isset( $theme_variation['settings'] ) ? $theme_variation['settings'] : array(),
+					'styles'   => isset( $theme_variation['styles'] ) ? $theme_variation['styles'] : array(),
+				),
+			)
+		);
+	}
+}
+add_action( 'init', 'gutenberg_register_theme_style_variations', 10 );
+
+/**
+ * Gets the wp_global_styles post ID for a style variation.
+ *
+ * Looks up the post by querying for the _wp_source_variation_id meta.
+ * There should be at most one wp_global_styles post per variation.
+ *
+ *
+ * @param string $variation_id The style variation ID (e.g., 'demo//dark-mode').
+ * @return int|null The wp_global_styles post ID, or null if none exists.
+ */
+function gutenberg_get_variation_post_id( $variation_id ) {
+	if ( empty( $variation_id ) ) {
+		return null;
+	}
+
+	$posts = get_posts(
+		array(
+			'post_type'      => 'wp_global_styles',
+			'post_status'    => array( 'publish', 'draft' ),
+			'posts_per_page' => 1,
+			'meta_query'     => array(
+				array(
+					'key'   => GUTENBERG_VARIATION_SOURCE_META_KEY,
+					'value' => $variation_id,
+				),
+			),
+		)
+	);
+
+	if ( empty( $posts ) ) {
+		return null;
+	}
+
+	return (int) $posts[0]->ID;
+}
+
+/**
+ * Creates or gets the wp_global_styles post for a style variation.
+ *
+ * If a wp_global_styles post already exists for this variation, returns its ID.
+ * Otherwise, creates a new post initialized with the registered variation's data.
+ *
+ * There is ONE post per variation, shared by all templates using that variation.
+ *
+ *
+ * @param string $variation_id The registered style variation ID.
+ * @return int|WP_Error The wp_global_styles post ID, or WP_Error on failure.
+ */
+function gutenberg_get_or_create_variation_post( $variation_id ) {
+	// Check if a post already exists for this variation.
+	$existing_post_id = gutenberg_get_variation_post_id( $variation_id );
+	if ( $existing_post_id ) {
+		return $existing_post_id;
+	}
+
+	// Get the registered variation data.
+	$registry  = WP_Style_Variations_Registry_Gutenberg::get_instance();
+	$variation = $registry->get_registered( $variation_id );
+
+	if ( ! $variation ) {
+		return new WP_Error(
+			'variation_not_found',
+			/* translators: %s: variation ID */
+			sprintf( __( 'Style variation "%s" is not registered.', 'gutenberg' ), $variation_id )
+		);
+	}
+
+	// Create the global styles post.
+	$post_data = array(
+		'post_type'    => 'wp_global_styles',
+		'post_status'  => 'publish',
+		'post_title'   => $variation['title'],
+		'post_content' => wp_json_encode(
+			array(
+				'version'                     => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'isGlobalStylesUserThemeJSON' => true,
+				'settings'                    => isset( $variation['data']['settings'] ) ? $variation['data']['settings'] : new stdClass(),
+				'styles'                      => isset( $variation['data']['styles'] ) ? $variation['data']['styles'] : new stdClass(),
+			)
+		),
+		'post_name'    => sanitize_title( 'wp-global-styles-' . $variation_id ),
+	);
+
+	$post_id = wp_insert_post( $post_data, true );
+
+	if ( is_wp_error( $post_id ) ) {
+		return $post_id;
+	}
+
+	// Store the source variation ID on the post. This links the post to the variation.
+	update_post_meta( $post_id, GUTENBERG_VARIATION_SOURCE_META_KEY, $variation_id );
+
+	// Store the base theme if present.
+	if ( ! empty( $variation['base_theme'] ) ) {
+		update_post_meta( $post_id, '_wp_base_theme_id', $variation['base_theme'] );
+	}
+
+	// Note: We intentionally do NOT assign the wp_theme taxonomy to variation posts.
+	// Variation posts are identified by their _wp_source_variation_id meta.
+	// Assigning the theme taxonomy would cause get_user_data_from_wp_global_styles()
+	// to return the variation post instead of the default global styles post.
+
+	return $post_id;
+}

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1039,6 +1039,40 @@ export function receiveDefaultTemplateId( query, templateId ) {
 }
 
 /**
+ * Returns an action object used in signalling that registered style variations have been received.
+ * Ignored from documentation as it's internal to the data store.
+ *
+ * @ignore
+ *
+ * @param {Array} variations The registered style variations.
+ *
+ * @return {Object} Action object.
+ */
+export function __experimentalReceiveRegisteredStyleVariations( variations ) {
+	return {
+		type: 'RECEIVE_REGISTERED_STYLE_VARIATIONS',
+		variations,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that base themes have been received.
+ * Ignored from documentation as it's internal to the data store.
+ *
+ * @ignore
+ *
+ * @param {Array} baseThemes The base themes.
+ *
+ * @return {Object} Action object.
+ */
+export function __experimentalReceiveBaseThemes( baseThemes ) {
+	return {
+		type: 'RECEIVE_BASE_THEMES',
+		baseThemes,
+	};
+}
+
+/**
  * Action triggered to receive revision items.
  *
  * @param {string}        kind            Kind of the received entity record revisions.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -660,6 +660,38 @@ export function editorAssets( state = null, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing registered style variations (experimental).
+ *
+ * @param {Array}  state  Current state.
+ * @param {Object} action Action object.
+ *
+ * @return {Array} Updated state.
+ */
+export function registeredStyleVariations( state = [], action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_REGISTERED_STYLE_VARIATIONS':
+			return action.variations;
+	}
+	return state;
+}
+
+/**
+ * Reducer managing base themes (experimental).
+ *
+ * @param {Array}  state  Current state.
+ * @param {Object} action Action object.
+ *
+ * @return {Array} Updated state.
+ */
+export function baseThemes( state = [], action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_BASE_THEMES':
+			return action.baseThemes;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	users,
 	currentTheme,
@@ -682,4 +714,6 @@ export default combineReducers( {
 	registeredPostMeta,
 	editorSettings,
 	editorAssets,
+	registeredStyleVariations,
+	baseThemes,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1254,3 +1254,39 @@ export const getEditorAssets =
 		} );
 		dispatch.receiveEditorAssets( assets );
 	};
+
+/**
+ * Requests registered style variations from the REST API (experimental).
+ */
+export const __experimentalGetRegisteredStyleVariations =
+	() =>
+	async ( { dispatch } ) => {
+		try {
+			const variations = await apiFetch( {
+				path: '/wp/v2/style-variations',
+			} );
+			dispatch.__experimentalReceiveRegisteredStyleVariations(
+				variations
+			);
+		} catch {
+			// Silently fail if the endpoint doesn't exist (experiment not enabled).
+			dispatch.__experimentalReceiveRegisteredStyleVariations( [] );
+		}
+	};
+
+/**
+ * Requests base themes from the REST API (experimental).
+ */
+export const __experimentalGetBaseThemes =
+	() =>
+	async ( { dispatch } ) => {
+		try {
+			const baseThemes = await apiFetch( {
+				path: '/wp/v2/base-themes',
+			} );
+			dispatch.__experimentalReceiveBaseThemes( baseThemes );
+		} catch {
+			// Silently fail if the endpoint doesn't exist (experiment not enabled).
+			dispatch.__experimentalReceiveBaseThemes( [] );
+		}
+	};

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -52,6 +52,25 @@ export interface State {
 	registeredPostMeta: Record< string, Object >;
 	editorSettings: Record< string, any > | null;
 	editorAssets: Record< string, any > | null;
+	registeredStyleVariations: Array< RegisteredStyleVariation >;
+	baseThemes: Array< BaseTheme >;
+}
+
+export interface RegisteredStyleVariation {
+	id: string;
+	title: string;
+	settings?: Object;
+	styles?: Object;
+	base_theme?: string | null;
+	source?: string;
+	post_id?: number | null;
+}
+
+export interface BaseTheme {
+	id: string;
+	title: string;
+	settings?: Object;
+	styles?: Object;
 }
 
 type EntityRecordKey = string | number;
@@ -1595,3 +1614,29 @@ export const getRevision = createSelector(
 		];
 	}
 );
+
+/**
+ * Returns the registered style variations (experimental).
+ *
+ * @param state Data state.
+ *
+ * @return The registered style variations.
+ */
+export function __experimentalGetRegisteredStyleVariations(
+	state: State
+): Array< RegisteredStyleVariation > {
+	return state.registeredStyleVariations;
+}
+
+/**
+ * Returns the base themes (experimental).
+ *
+ * @param state Data state.
+ *
+ * @return The base themes.
+ */
+export function __experimentalGetBaseThemes(
+	state: State
+): Array< BaseTheme > {
+	return state.baseThemes;
+}

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -9,7 +9,11 @@ import {
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
-import { generateGlobalStyles } from '@wordpress/global-styles-engine';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+	generateGlobalStyles,
+	mergeGlobalStyles,
+} from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -21,6 +25,86 @@ import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { useGlobalStyles } = unlock( editorPrivateApis );
+
+/**
+ * Look up a template's style variation data directly from core-data.
+ * Called outside the TemplateStyleVariationProvider context, so it performs
+ * its own lookup. When the variation has a wp_global_styles post with user
+ * edits, the post data is returned; otherwise registered data is used.
+ *
+ * @param {string|null} templateId The template ID to look up.
+ * @return {Object} Object with variation styles and settings.
+ */
+function useTemplateStyleVariationLookup( templateId ) {
+	return useSelect(
+		( select ) => {
+			if ( ! templateId ) {
+				return {
+					variationStyles: null,
+					variationSettings: null,
+				};
+			}
+
+			const { getEditedEntityRecord } = select( coreStore );
+			const template = getEditedEntityRecord(
+				'postType',
+				'wp_template',
+				templateId
+			);
+
+			const variationId = template?.style_variation || null;
+
+			if ( ! variationId ) {
+				return {
+					variationStyles: null,
+					variationSettings: null,
+				};
+			}
+
+			// Look up variation data from the registry.
+			const getRegisteredVariations =
+				select( coreStore ).__experimentalGetRegisteredStyleVariations;
+			if ( typeof getRegisteredVariations !== 'function' ) {
+				return {
+					variationStyles: null,
+					variationSettings: null,
+				};
+			}
+
+			const variations = getRegisteredVariations() || [];
+			const variation = variations.find( ( v ) => v.id === variationId );
+			if ( ! variation ) {
+				return {
+					variationStyles: null,
+					variationSettings: null,
+				};
+			}
+
+			// If the variation has a wp_global_styles post, use its
+			// (potentially user-edited) data instead of registered defaults.
+			if ( variation.post_id ) {
+				const postRecord = getEditedEntityRecord(
+					'root',
+					'globalStyles',
+					variation.post_id
+				);
+				if ( postRecord?.settings || postRecord?.styles ) {
+					return {
+						variationStyles: postRecord.styles || null,
+						variationSettings: postRecord.settings || null,
+					};
+				}
+			}
+
+			// Fall back to registered data.
+			return {
+				variationStyles: variation.styles || null,
+				variationSettings: variation.settings || null,
+			};
+		},
+		[ templateId ]
+	);
+}
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
@@ -38,7 +122,7 @@ function useNavigateToPreviousEntityRecord() {
 	return goBack;
 }
 
-export function useSpecificEditorSettings() {
+export function useSpecificEditorSettings( resolvedTemplateId = null ) {
 	const { query } = useLocation();
 	const { canvas = 'view' } = query;
 	const [ onNavigateToEntityRecord, initialBlockSelection ] =
@@ -53,6 +137,11 @@ export function useSpecificEditorSettings() {
 	 */
 	const { merged: mergedConfig } = useGlobalStyles();
 
+	// Look up the template's style variation directly (outside the context provider).
+	// This uses post data (user edits) when available, falling back to registered data.
+	const { variationStyles, variationSettings } =
+		useTemplateStyleVariationLookup( resolvedTemplateId );
+
 	const { settings, currentPostIsTrashed } = useSelect( ( select ) => {
 		const { getSettings } = select( editSiteStore );
 		const { getCurrentPostAttribute } = select( editorStore );
@@ -66,11 +155,22 @@ export function useSpecificEditorSettings() {
 	const onNavigateToPreviousEntityRecord =
 		useNavigateToPreviousEntityRecord();
 
+	// Merge variation styles/settings into the config if a variation is assigned.
+	const effectiveMergedConfig = useMemo( () => {
+		if ( ! variationStyles && ! variationSettings ) {
+			return mergedConfig;
+		}
+		return mergeGlobalStyles( mergedConfig, {
+			styles: variationStyles || {},
+			settings: variationSettings || {},
+		} );
+	}, [ mergedConfig, variationStyles, variationSettings ] );
+
 	const [ globalStyles, globalSettings ] = useMemo( () => {
-		return generateGlobalStyles( mergedConfig, [], {
+		return generateGlobalStyles( effectiveMergedConfig, [], {
 			disableRootPadding: false,
 		} );
-	}, [ mergedConfig ] );
+	}, [ effectiveMergedConfig ] );
 
 	const defaultEditorSettings = useMemo( () => {
 		// Preserve non-global styles from settings.styles (e.g., editor styles from add_editor_style)

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -33,6 +33,8 @@ import CanvasLoader from '../canvas-loader';
 import { unlock } from '../../lock-unlock';
 import { useSpecificEditorSettings } from '../block-editor/use-site-editor-settings';
 import PluginTemplateSettingPanel from '../plugin-template-setting-panel';
+import TemplateStyleVariationPanel from '../template-style-variation-panel';
+import TemplateStyleVariationProvider from '../template-style-variation-provider';
 import { isPreviewingTheme } from '../../utils/is-previewing-theme';
 import SaveButton from '../save-button';
 import SavePanel from '../save-panel';
@@ -143,7 +145,17 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 		'edit-site-editor__loading-progress'
 	);
 
-	const settings = useSpecificEditorSettings();
+	// Determine the resolved template ID for style variation context.
+	// When editing a page with its template, postId is the resolved template ID.
+	// When editing a template directly, postId is the template ID.
+	let resolvedTemplateIdForSettings = null;
+	if ( postType === 'wp_template' ) {
+		resolvedTemplateIdForSettings = postId;
+	} else if ( postWithTemplate ) {
+		resolvedTemplateIdForSettings = postId;
+	}
+
+	const settings = useSpecificEditorSettings( resolvedTemplateIdForSettings );
 	const { initialBlockSelection, ...editorSettings } = settings;
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
@@ -211,7 +223,9 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	return ! isBlockBasedTheme && isHomeRoute ? (
 		<SitePreview />
 	) : (
-		<>
+		<TemplateStyleVariationProvider
+			resolvedTemplateId={ resolvedTemplateIdForSettings }
+		>
 			<EditorKeyboardShortcutsRegister />
 			{ isEditMode && <BlockKeyboardShortcuts /> }
 			{ ! isReady ? <CanvasLoader id={ loadingProgressId } /> : null }
@@ -236,7 +250,10 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 					onActionPerformed={ onActionPerformed }
 					extraSidebarPanels={
 						! postWithTemplate && (
-							<PluginTemplateSettingPanel.Slot />
+							<>
+								<PluginTemplateSettingPanel.Slot />
+								<TemplateStyleVariationPanel />
+							</>
 						)
 					}
 				>
@@ -300,6 +317,6 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 					<SiteEditorMoreMenu />
 				</Editor>
 			) }
-		</>
+		</TemplateStyleVariationProvider>
 	);
 }

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -25,6 +25,10 @@ import {
 	store as coreStore,
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import {
+	mergeGlobalStyles,
+	generateGlobalStyles,
+} from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -36,7 +40,173 @@ import { unlock } from '../../lock-unlock';
 
 const { Badge } = unlock( componentsPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
-const { useStyle } = unlock( editorPrivateApis );
+const { useStyle, useGlobalStyles } = unlock( editorPrivateApis );
+
+/**
+ * Hook to get pattern settings with optional style variation override.
+ *
+ * When a template has an associated style variation, this hook merges the
+ * variation's styles with the base theme styles to generate the correct
+ * preview styles. If the variation has been edited (has a wp_global_styles post),
+ * it uses the post's styles; otherwise it uses the registered variation's styles.
+ *
+ * @param {string|null} styleVariationId The style variation ID, or null for default.
+ * @return {Object} Settings object for EditorProvider.
+ */
+function usePatternSettingsWithVariation( styleVariationId ) {
+	const basePatternSettings = usePatternSettings();
+	const { base: baseConfig } = useGlobalStyles();
+
+	// Get registered variation to find its post_id (if any).
+	const registeredVariation = useSelect(
+		( select ) => {
+			if ( ! styleVariationId ) {
+				return null;
+			}
+
+			const getRegisteredVariations =
+				select( coreStore ).__experimentalGetRegisteredStyleVariations;
+			if ( typeof getRegisteredVariations !== 'function' ) {
+				return null;
+			}
+
+			const variations = getRegisteredVariations() || [];
+			return (
+				variations.find( ( v ) => v.id === styleVariationId ) || null
+			);
+		},
+		[ styleVariationId ]
+	);
+
+	// If the variation has a post, fetch the post's styles (edited version).
+	const variationPostData = useSelect(
+		( select ) => {
+			const postId = registeredVariation?.post_id;
+			if ( ! postId ) {
+				return null;
+			}
+
+			const { getEntityRecord } = select( coreStore );
+			const record = getEntityRecord( 'root', 'globalStyles', postId );
+
+			if ( ! record ) {
+				return null;
+			}
+
+			return {
+				settings: record.settings || {},
+				styles: record.styles || {},
+			};
+		},
+		[ registeredVariation?.post_id ]
+	);
+
+	// Use post data if available, otherwise fall back to registered variation data.
+	const effectiveVariationData = useMemo( () => {
+		// Priority 1: Use edited post data if it exists.
+		if ( variationPostData ) {
+			return variationPostData;
+		}
+		// Priority 2: Use registered variation data.
+		if ( registeredVariation ) {
+			return {
+				settings: registeredVariation.settings || {},
+				styles: registeredVariation.styles || {},
+			};
+		}
+		return null;
+	}, [ variationPostData, registeredVariation ] );
+
+	// If we have variation data, merge it with base and generate new styles.
+	const settings = useMemo( () => {
+		if ( ! effectiveVariationData ) {
+			return basePatternSettings;
+		}
+
+		// Merge variation styles with base theme styles.
+		const mergedConfig = mergeGlobalStyles(
+			baseConfig || {},
+			effectiveVariationData
+		);
+
+		// Generate CSS from merged config.
+		const [ globalStyles, globalSettings ] = generateGlobalStyles(
+			mergedConfig,
+			[],
+			{ disableRootPadding: false }
+		);
+
+		return {
+			...basePatternSettings,
+			styles: globalStyles,
+			__experimentalFeatures: globalSettings,
+		};
+	}, [ basePatternSettings, effectiveVariationData, baseConfig ] );
+
+	return settings;
+}
+
+/**
+ * Hook to get the background color for a template preview.
+ *
+ * When a template has a style variation, returns the variation's background color.
+ * If the variation has been edited (has a post), uses the post's background color.
+ * Otherwise returns the default background color.
+ *
+ * @param {string|null} styleVariationId The style variation ID, or null for default.
+ * @return {string} The background color.
+ */
+function usePreviewBackgroundColor( styleVariationId ) {
+	const defaultBackgroundColor = useStyle( 'color.background' ) ?? 'white';
+
+	// Get the variation's background color, preferring post data over registered data.
+	const variationBackgroundColor = useSelect(
+		( select ) => {
+			if ( ! styleVariationId ) {
+				return null;
+			}
+
+			const getRegisteredVariations =
+				select( coreStore ).__experimentalGetRegisteredStyleVariations;
+
+			if ( typeof getRegisteredVariations !== 'function' ) {
+				return null;
+			}
+
+			const variations = getRegisteredVariations() || [];
+			const variation = variations.find(
+				( v ) => v.id === styleVariationId
+			);
+
+			if ( ! variation ) {
+				return null;
+			}
+
+			// If variation has a post, use the post's background color.
+			if ( variation.post_id ) {
+				const record = select( coreStore ).getEntityRecord(
+					'root',
+					'globalStyles',
+					variation.post_id
+				);
+				if ( record?.styles?.color?.background ) {
+					return record.styles.color.background;
+				}
+			}
+
+			// Fall back to registered variation's background color.
+			return variation?.styles?.color?.background || null;
+		},
+		[ styleVariationId ]
+	);
+
+	// If variation has a background color, use it. Otherwise use default.
+	if ( variationBackgroundColor ) {
+		return variationBackgroundColor;
+	}
+
+	return defaultBackgroundColor;
+}
 
 function useAllDefaultTemplateTypes() {
 	const defaultTemplateTypes = useDefaultTemplateTypes();
@@ -59,8 +229,13 @@ function useAllDefaultTemplateTypes() {
 }
 
 function PreviewField( { item } ) {
-	const settings = usePatternSettings();
-	const backgroundColor = useStyle( 'color.background' ) ?? 'white';
+	// Get the template's style variation ID (if any).
+	const styleVariationId = item.style_variation || null;
+
+	// Use variation-aware settings and background color.
+	const settings = usePatternSettingsWithVariation( styleVariationId );
+	const backgroundColor = usePreviewBackgroundColor( styleVariationId );
+
 	const blocks = useMemo( () => {
 		return parse( item.content.raw );
 	}, [ item.content.raw ] );

--- a/packages/edit-site/src/components/template-style-variation-panel/index.js
+++ b/packages/edit-site/src/components/template-style-variation-panel/index.js
@@ -1,0 +1,149 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	PanelBody,
+	Spinner,
+} from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { TemplateStyleVariationPicker } from '@wordpress/global-styles-ui';
+
+/**
+ * A panel component for selecting a style variation for the current template.
+ *
+ * This component is shown in the document settings sidebar when editing
+ * a template. It allows users to assign a registered style variation to
+ * the template, which will be used instead of the global styles when
+ * that template is rendered.
+ *
+ * @return {Element|null} The panel element, or null if not editing a template.
+ */
+export default function TemplateStyleVariationPanel() {
+	const {
+		isTemplate,
+		templateId,
+		currentStyleVariationId,
+		registeredVariations,
+		isLoading,
+		isExperimentEnabled,
+	} = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		const {
+			getEditedEntityRecord,
+			__experimentalGetRegisteredStyleVariations,
+			hasFinishedResolution,
+		} = select( coreStore );
+
+		const postType = getCurrentPostType();
+		const isTemplateType = postType === 'wp_template';
+
+		if ( ! isTemplateType ) {
+			return {
+				isTemplate: false,
+				templateId: null,
+				currentStyleVariationId: null,
+				registeredVariations: [],
+				isLoading: false,
+				isExperimentEnabled: false,
+			};
+		}
+
+		const postId = getCurrentPostId();
+		const template = getEditedEntityRecord(
+			'postType',
+			'wp_template',
+			postId
+		);
+
+		// Get registered style variations.
+		// If the selector doesn't exist, the experiment is not enabled.
+		let variations = [];
+		let experimentEnabled = false;
+		try {
+			if (
+				typeof __experimentalGetRegisteredStyleVariations === 'function'
+			) {
+				variations = __experimentalGetRegisteredStyleVariations() || [];
+				experimentEnabled = true;
+			}
+		} catch {
+			// Selector might not exist if experiment is not enabled.
+			variations = [];
+		}
+
+		const hasFinished = experimentEnabled
+			? hasFinishedResolution?.(
+					'__experimentalGetRegisteredStyleVariations',
+					[]
+			  ) ?? true
+			: true;
+
+		return {
+			isTemplate: true,
+			templateId: template?.id || postId,
+			currentStyleVariationId: template?.style_variation || null,
+			registeredVariations: variations,
+			isLoading: ! hasFinished,
+			isExperimentEnabled: experimentEnabled,
+		};
+	}, [] );
+
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const handleSelect = useCallback(
+		( variationId ) => {
+			// Update the template's style_variation meta.
+			editEntityRecord( 'postType', 'wp_template', templateId, {
+				style_variation: variationId,
+			} );
+		},
+		[ templateId, editEntityRecord ]
+	);
+
+	// Don't render if not editing a template.
+	if ( ! isTemplate ) {
+		return null;
+	}
+
+	// Don't render if experiment is not enabled.
+	if ( ! isExperimentEnabled ) {
+		return null;
+	}
+
+	// Don't render if no variations are registered.
+	if ( ! isLoading && registeredVariations.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<PanelBody
+			title={ __( 'Style Variation' ) }
+			className="edit-site-template-style-variation-panel"
+		>
+			<VStack spacing={ 4 }>
+				{ isLoading ? (
+					<Spinner />
+				) : (
+					<>
+						<Text>
+							{ __(
+								'Select a style variation to override global styles for this template.'
+							) }
+						</Text>
+						<TemplateStyleVariationPicker
+							currentStyleVariationId={ currentStyleVariationId }
+							onSelect={ handleSelect }
+							gap={ 3 }
+						/>
+					</>
+				) }
+			</VStack>
+		</PanelBody>
+	);
+}

--- a/packages/edit-site/src/components/template-style-variation-provider/index.js
+++ b/packages/edit-site/src/components/template-style-variation-provider/index.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { TemplateStyleVariationProvider } = unlock( editorPrivateApis );
+
+export default TemplateStyleVariationProvider;

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -1,207 +1,33 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo, useCallback } from '@wordpress/element';
-import { mergeGlobalStyles } from '@wordpress/global-styles-engine';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
+import { useGlobalStyles } from '../global-styles';
 
-const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
-
-function useGlobalStylesUserConfig() {
-	const { globalStylesId, isReady, settings, styles, _links } = useSelect(
-		( select ) => {
-			const {
-				getEntityRecord,
-				getEditedEntityRecord,
-				hasFinishedResolution,
-				canUser,
-			} = select( coreStore );
-			const _globalStylesId =
-				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
-
-			let record;
-
-			/*
-			 * Ensure that the global styles ID request is complete by testing `_globalStylesId`,
-			 * before firing off the `canUser` OPTIONS request for user capabilities, otherwise it will
-			 * fetch `/wp/v2/global-styles` instead of `/wp/v2/global-styles/{id}`.
-			 * NOTE: Please keep in sync any preload paths sent to `block_editor_rest_api_preload()`,
-			 * or set using the `block_editor_rest_api_preload_paths` filter, if this changes.
-			 */
-			const userCanEditGlobalStyles = _globalStylesId
-				? canUser( 'update', {
-						kind: 'root',
-						name: 'globalStyles',
-						id: _globalStylesId,
-				  } )
-				: null;
-
-			if (
-				_globalStylesId &&
-				/*
-				 * Test that the OPTIONS request for user capabilities is complete
-				 * before fetching the global styles entity record.
-				 * This is to avoid fetching the global styles entity unnecessarily.
-				 */
-				typeof userCanEditGlobalStyles === 'boolean'
-			) {
-				/*
-				 * Fetch the global styles entity record based on the user's capabilities.
-				 * The default context is `edit` for users who can edit global styles.
-				 * Otherwise, the context is `view`.
-				 * NOTE: There is an equivalent conditional check using `current_user_can()` in the backend
-				 * to preload the global styles entity. Please keep in sync any preload paths sent to `block_editor_rest_api_preload()`,
-				 * or set using `block_editor_rest_api_preload_paths` filter, if this changes.
-				 */
-				if ( userCanEditGlobalStyles ) {
-					record = getEditedEntityRecord(
-						'root',
-						'globalStyles',
-						_globalStylesId
-					);
-				} else {
-					record = getEntityRecord(
-						'root',
-						'globalStyles',
-						_globalStylesId,
-						{ context: 'view' }
-					);
-				}
-			}
-
-			let hasResolved = false;
-			if (
-				hasFinishedResolution(
-					'__experimentalGetCurrentGlobalStylesId'
-				)
-			) {
-				if ( _globalStylesId ) {
-					hasResolved = userCanEditGlobalStyles
-						? hasFinishedResolution( 'getEditedEntityRecord', [
-								'root',
-								'globalStyles',
-								_globalStylesId,
-						  ] )
-						: hasFinishedResolution( 'getEntityRecord', [
-								'root',
-								'globalStyles',
-								_globalStylesId,
-								{ context: 'view' },
-						  ] );
-				} else {
-					hasResolved = true;
-				}
-			}
-
-			return {
-				globalStylesId: _globalStylesId,
-				isReady: hasResolved,
-				settings: record?.settings,
-				styles: record?.styles,
-				_links: record?._links,
-			};
-		},
-		[]
-	);
-
-	const { getEditedEntityRecord } = useSelect( coreStore );
-	const { editEntityRecord } = useDispatch( coreStore );
-	const config = useMemo( () => {
-		return {
-			settings: settings ?? {},
-			styles: styles ?? {},
-			_links: _links ?? {},
-		};
-	}, [ settings, styles, _links ] );
-
-	const setConfig = useCallback(
-		/**
-		 * Set the global styles config.
-		 * @param {Function|Object} callbackOrObject If the callbackOrObject is a function, pass the current config to the callback so the consumer can merge values.
-		 *                                           Otherwise, overwrite the current config with the incoming object.
-		 * @param {Object}          options          Options for editEntityRecord Core selector.
-		 */
-		( callbackOrObject, options = {} ) => {
-			const record = getEditedEntityRecord(
-				'root',
-				'globalStyles',
-				globalStylesId
-			);
-
-			const currentConfig = {
-				styles: record?.styles ?? {},
-				settings: record?.settings ?? {},
-				_links: record?._links ?? {},
-			};
-
-			const updatedConfig =
-				typeof callbackOrObject === 'function'
-					? callbackOrObject( currentConfig )
-					: callbackOrObject;
-
-			editEntityRecord(
-				'root',
-				'globalStyles',
-				globalStylesId,
-				{
-					styles: cleanEmptyObject( updatedConfig.styles ) || {},
-					settings: cleanEmptyObject( updatedConfig.settings ) || {},
-					_links: cleanEmptyObject( updatedConfig._links ) || {},
-				},
-				options
-			);
-		},
-		[ globalStylesId, editEntityRecord, getEditedEntityRecord ]
-	);
-
-	return [ isReady, config, setConfig ];
-}
-
-function useGlobalStylesBaseConfig() {
-	const baseConfig = useSelect(
-		( select ) =>
-			select( coreStore ).__experimentalGetCurrentThemeBaseGlobalStyles(),
-		[]
-	);
-	return [ !! baseConfig, baseConfig ];
-}
-
+/**
+ * Hook to get global styles context.
+ *
+ * This hook is template-aware: when editing a template with an associated
+ * style variation, it returns that variation's styles instead of the default.
+ *
+ * @return {Object} Global styles context with merged, base, user, and setUserConfig.
+ */
 export function useGlobalStylesContext() {
-	const [ isUserConfigReady, userConfig, setUserConfig ] =
-		useGlobalStylesUserConfig();
-	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig();
-
-	const mergedConfig = useMemo( () => {
-		if ( ! baseConfig || ! userConfig ) {
-			return {};
-		}
-
-		return mergeGlobalStyles( baseConfig, userConfig );
-	}, [ userConfig, baseConfig ] );
+	const { merged, base, user, setUser, isReady } = useGlobalStyles();
 
 	const context = useMemo( () => {
 		return {
-			isReady: isUserConfigReady && isBaseConfigReady,
-			user: userConfig,
-			base: baseConfig,
-			merged: mergedConfig,
-			setUserConfig,
+			isReady,
+			user,
+			base,
+			merged,
+			setUserConfig: setUser,
 		};
-	}, [
-		mergedConfig,
-		userConfig,
-		baseConfig,
-		setUserConfig,
-		isUserConfigReady,
-		isBaseConfigReady,
-	] );
+	}, [ merged, user, base, setUser, isReady ] );
 
 	return context;
 }

--- a/packages/editor/src/components/global-styles-renderer/index.js
+++ b/packages/editor/src/components/global-styles-renderer/index.js
@@ -15,6 +15,14 @@ function useGlobalStylesRenderer( disableRootPadding ) {
 	const { getEditorSettings } = useSelect( editorStore );
 	const { updateEditorSettings } = useDispatch( editorStore );
 
+	// Get the current post ID to force re-run when navigating between posts.
+	// This ensures template-aware global styles are re-applied when the
+	// active post or template changes, since ExperimentalEditorProvider's
+	// updateEditorSettings call may overwrite styles before this effect runs.
+	const postId = useSelect( ( select ) =>
+		select( editorStore ).getCurrentPostId()
+	);
+
 	useEffect( () => {
 		if ( ! styles || ! settings ) {
 			return;
@@ -24,12 +32,13 @@ function useGlobalStylesRenderer( disableRootPadding ) {
 		const nonGlobalStyles = Object.values(
 			currentStoreSettings.styles ?? []
 		).filter( ( style ) => ! style.isGlobalStyles );
+
 		updateEditorSettings( {
 			...currentStoreSettings,
 			styles: [ ...nonGlobalStyles, ...styles ],
 			__experimentalFeatures: settings,
 		} );
-	}, [ styles, settings, updateEditorSettings, getEditorSettings ] );
+	}, [ styles, settings, updateEditorSettings, getEditorSettings, postId ] );
 }
 
 export function GlobalStylesRenderer( { disableRootPadding } ) {

--- a/packages/editor/src/components/global-styles/hooks.js
+++ b/packages/editor/src/components/global-styles/hooks.js
@@ -1,22 +1,69 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useContext } from '@wordpress/element';
 import {
 	mergeGlobalStyles,
 	getStyle,
 	getSetting,
 } from '@wordpress/global-styles-engine';
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { TemplateStyleVariationContext } from '../template-style-variation-context';
 
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
+
+/**
+ * Preset setting keys that use origin-based format in the merged config.
+ * E.g., settings.color.palette = { default: [], theme: [], custom: [] }
+ *
+ * Base theme data from the REST API uses flat arrays instead.
+ * This map defines: settingsPath -> presetKey for each preset type.
+ */
+const ORIGIN_BASED_PRESETS = [
+	[ 'color', 'palette' ],
+	[ 'color', 'gradients' ],
+	[ 'color', 'duotone' ],
+	[ 'typography', 'fontSizes' ],
+	[ 'typography', 'fontFamilies' ],
+	[ 'spacing', 'spacingSizes' ],
+	[ 'shadow', 'presets' ],
+];
+
+/**
+ * Converts flat-array presets in settings to origin-based format
+ * so they merge correctly with the editor's merged config.
+ *
+ * E.g., { color: { palette: [...] } }
+ * becomes { color: { palette: { theme: [...] } } }
+ *
+ * @param {Object|null} settings The settings object from a base theme.
+ * @return {Object} Settings with presets nested under the "theme" origin.
+ */
+function nestPresetsUnderThemeOrigin( settings ) {
+	if ( ! settings ) {
+		return {};
+	}
+	const result = { ...settings };
+	for ( const [ category, presetKey ] of ORIGIN_BASED_PRESETS ) {
+		if ( Array.isArray( result[ category ]?.[ presetKey ] ) ) {
+			result[ category ] = {
+				...result[ category ],
+				[ presetKey ]: {
+					theme: result[ category ][ presetKey ],
+				},
+			};
+		}
+	}
+	return result;
+}
 
 /**
  * Hook to fetch and manage user global styles config
@@ -161,27 +208,323 @@ function useGlobalStylesBaseConfig() {
 /**
  * Hook to get merged global styles configuration
  *
+ * This hook is template-aware: when editing a template with an associated
+ * style variation, it will use the variation's styles instead of the default
+ * global styles. If the variation has an associated wp_global_styles post,
+ * edits are saved to that post; otherwise, a post is created on first save.
+ *
  * @return {Object} Object containing merged, base, user configs and setUser function
  *                  { merged, base, user, setUser }
  */
 export function useGlobalStyles() {
-	const [ isUserConfigReady, userConfig, setUserConfig ] =
+	const {
+		templateId,
+		styleVariationId,
+		styleVariationPostId,
+		baseThemeId,
+		isTemplateStyleVariationsEnabled,
+	} = useContext( TemplateStyleVariationContext );
+
+	// Get variation post data if we have a post ID.
+	const variationPostData = useSelect(
+		( select ) => {
+			if (
+				! styleVariationPostId ||
+				! isTemplateStyleVariationsEnabled
+			) {
+				return null;
+			}
+
+			const {
+				getEntityRecord,
+				getEditedEntityRecord,
+				hasFinishedResolution,
+			} = select( coreStore );
+
+			// First, trigger the fetch by calling getEntityRecord.
+			// This ensures the entity is loaded from the server.
+			getEntityRecord( 'root', 'globalStyles', styleVariationPostId );
+
+			const hasResolved = hasFinishedResolution( 'getEntityRecord', [
+				'root',
+				'globalStyles',
+				styleVariationPostId,
+			] );
+
+			if ( ! hasResolved ) {
+				return null;
+			}
+
+			// Now get the edited record which includes any local edits.
+			const record = getEditedEntityRecord(
+				'root',
+				'globalStyles',
+				styleVariationPostId
+			);
+
+			if ( ! record ) {
+				return null;
+			}
+
+			return {
+				settings: record.settings ?? {},
+				styles: record.styles ?? {},
+				_links: record._links ?? {},
+			};
+		},
+		[ styleVariationPostId, isTemplateStyleVariationsEnabled ]
+	);
+
+	// Get registered variation data. We always fetch this when we have a variation ID,
+	// because we need it both for initial display (before post exists) and for reset functionality.
+	const registeredVariationData = useSelect(
+		( select ) => {
+			if ( ! styleVariationId || ! isTemplateStyleVariationsEnabled ) {
+				return null;
+			}
+
+			const getRegisteredVariations =
+				select( coreStore ).__experimentalGetRegisteredStyleVariations;
+			if ( typeof getRegisteredVariations !== 'function' ) {
+				return null;
+			}
+
+			const variations = getRegisteredVariations() || [];
+			return (
+				variations.find( ( v ) => v.id === styleVariationId ) || null
+			);
+		},
+		[ styleVariationId, isTemplateStyleVariationsEnabled ]
+	);
+
+	// Fetch base theme data if the variation specifies one.
+	const baseThemeData = useSelect(
+		( select ) => {
+			if ( ! baseThemeId || ! isTemplateStyleVariationsEnabled ) {
+				return null;
+			}
+
+			const getBaseThemes =
+				select( coreStore ).__experimentalGetBaseThemes;
+			if ( typeof getBaseThemes !== 'function' ) {
+				return null;
+			}
+
+			const baseThemes = getBaseThemes() || [];
+			return baseThemes.find( ( bt ) => bt.id === baseThemeId ) || null;
+		},
+		[ baseThemeId, isTemplateStyleVariationsEnabled ]
+	);
+
+	const [ isUserConfigReady, defaultUserConfig, setDefaultUserConfig ] =
 		useGlobalStylesUserConfig();
-	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig();
+	const [ isBaseConfigReady, defaultBaseConfig ] =
+		useGlobalStylesBaseConfig();
+
+	// When a base theme is specified, merge its settings/styles on top of
+	// the default base config. This replaces theme-level values (palette,
+	// font families, etc.) with the base theme's values while keeping core
+	// defaults intact.
+	//
+	// Base theme settings from the REST API use flat arrays for presets
+	// (e.g., settings.color.palette = []). The merged config uses origin-based
+	// format (e.g., settings.color.palette = { default: [], theme: [], custom: [] }).
+	// We must nest them under the "theme" origin so mergeGlobalStyles replaces
+	// the theme's presets without destroying the origin structure.
+	const baseConfig = useMemo( () => {
+		if ( baseThemeData && defaultBaseConfig ) {
+			const normalizedSettings = nestPresetsUnderThemeOrigin(
+				baseThemeData.settings
+			);
+			return mergeGlobalStyles( defaultBaseConfig, {
+				settings: normalizedSettings,
+				styles: baseThemeData.styles ?? {},
+			} );
+		}
+		return defaultBaseConfig;
+	}, [ baseThemeData, defaultBaseConfig ] );
+
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { getEditedEntityRecord } = useSelect( coreStore );
+	const registry = useRegistry();
+
+	// Determine the effective user config based on variation state.
+	const effectiveUserConfig = useMemo( () => {
+		// Priority 1: Use variation post data if it exists.
+		if ( variationPostData ) {
+			return variationPostData;
+		}
+		// Priority 2: Use registered variation data if no post yet.
+		if ( registeredVariationData ) {
+			return {
+				settings: registeredVariationData.settings ?? {},
+				styles: registeredVariationData.styles ?? {},
+				_links: {},
+			};
+		}
+		// Priority 3: Fall back to default global styles.
+		return defaultUserConfig;
+	}, [ variationPostData, registeredVariationData, defaultUserConfig ] );
+
+	const { invalidateResolution } = useDispatch( coreStore );
+
+	// Create a custom setConfig that handles variation posts.
+	const setUserConfig = useCallback(
+		async ( callbackOrObject, options = {} ) => {
+			// If we have a style variation, we should save to the variation post,
+			// NEVER to the default global styles.
+			if ( styleVariationId && isTemplateStyleVariationsEnabled ) {
+				let targetPostId = styleVariationPostId;
+
+				// If we don't have a post ID yet, create one.
+				if ( ! targetPostId ) {
+					try {
+						// Call the API to create the variation post.
+						// Pass the variation ID directly since the template may not be
+						// customized yet (no wp_id), so we can't look it up from meta.
+						const response = await apiFetch( {
+							path: `/wp/v2/templates-variation-post/${ encodeURIComponent(
+								templateId
+							) }`,
+							method: 'POST',
+							data: {
+								variation_id: styleVariationId,
+							},
+						} );
+
+						if ( response?.post_id ) {
+							targetPostId = response.post_id;
+
+							// Fetch the new entity into the store so
+							// editEntityRecord can find the raw record.
+							// Without this, getRawEntityRecord returns
+							// undefined and editEntityRecord throws.
+							await registry
+								.resolveSelect( coreStore )
+								.getEntityRecord(
+									'root',
+									'globalStyles',
+									targetPostId
+								);
+
+							// Invalidate the registered variations cache so it refetches
+							// with the new post_id. This updates the context for subsequent edits.
+							invalidateResolution(
+								'__experimentalGetRegisteredStyleVariations',
+								[]
+							);
+						}
+					} catch {
+						// If we can't create a post, don't save anything.
+						// This prevents accidentally editing the default global styles.
+						// eslint-disable-next-line no-console
+						console.error(
+							'Failed to create variation post for style variation:',
+							styleVariationId
+						);
+						return;
+					}
+				}
+
+				// If we have a target post ID, save to it.
+				if ( targetPostId ) {
+					const record = getEditedEntityRecord(
+						'root',
+						'globalStyles',
+						targetPostId
+					);
+
+					const currentConfig = {
+						styles: record?.styles ?? {},
+						settings: record?.settings ?? {},
+						_links: record?._links ?? {},
+					};
+
+					const updatedConfig =
+						typeof callbackOrObject === 'function'
+							? callbackOrObject( currentConfig )
+							: callbackOrObject;
+
+					editEntityRecord(
+						'root',
+						'globalStyles',
+						targetPostId,
+						{
+							styles:
+								cleanEmptyObject( updatedConfig.styles ) || {},
+							settings:
+								cleanEmptyObject( updatedConfig.settings ) ||
+								{},
+							_links:
+								cleanEmptyObject( updatedConfig._links ) || {},
+						},
+						options
+					);
+					return;
+				}
+
+				// If we still don't have a post ID, don't save anything.
+				// This should not happen, but prevents editing the default.
+				return;
+			}
+
+			// Default behavior: save to global styles (no variation selected).
+			setDefaultUserConfig( callbackOrObject, options );
+		},
+		[
+			templateId,
+			styleVariationId,
+			styleVariationPostId,
+			isTemplateStyleVariationsEnabled,
+			editEntityRecord,
+			invalidateResolution,
+			getEditedEntityRecord,
+			setDefaultUserConfig,
+			registry,
+		]
+	);
 
 	const merged = useMemo( () => {
 		if ( ! isUserConfigReady || ! isBaseConfigReady ) {
 			return {};
 		}
-		return mergeGlobalStyles( baseConfig || {}, userConfig );
-	}, [ isUserConfigReady, isBaseConfigReady, baseConfig, userConfig ] );
+		return mergeGlobalStyles( baseConfig || {}, effectiveUserConfig );
+	}, [
+		isUserConfigReady,
+		isBaseConfigReady,
+		baseConfig,
+		effectiveUserConfig,
+	] );
+
+	// Get the registered variation's original data for reset functionality.
+	// This is the data the variation was registered with, before any user edits.
+	const registeredVariationBaseData = useMemo( () => {
+		if ( ! styleVariationId || ! isTemplateStyleVariationsEnabled ) {
+			return null;
+		}
+		// Return the registered variation data (not the post data which may have edits).
+		if ( registeredVariationData ) {
+			return {
+				settings: registeredVariationData.settings ?? {},
+				styles: registeredVariationData.styles ?? {},
+			};
+		}
+		return null;
+	}, [
+		styleVariationId,
+		isTemplateStyleVariationsEnabled,
+		registeredVariationData,
+	] );
 
 	return {
 		merged,
 		base: baseConfig || {},
-		user: userConfig,
+		user: effectiveUserConfig,
 		setUser: setUserConfig,
 		isReady: isUserConfigReady && isBaseConfigReady,
+		// Expose variation-specific data for reset and other operations.
+		styleVariationId,
+		registeredVariationBaseData,
 	};
 }
 

--- a/packages/editor/src/components/global-styles/menu.js
+++ b/packages/editor/src/components/global-styles/menu.js
@@ -25,7 +25,8 @@ export function GlobalStylesActionMenu( {
 	hideWelcomeGuide = false,
 	onChangePath,
 } ) {
-	const { user, setUser } = useGlobalStyles();
+	const { user, setUser, styleVariationId, registeredVariationBaseData } =
+		useGlobalStyles();
 
 	// Check if there are user customizations that can be reset
 	const canReset =
@@ -33,9 +34,20 @@ export function GlobalStylesActionMenu( {
 		( Object.keys( user?.styles ?? {} ).length > 0 ||
 			Object.keys( user?.settings ?? {} ).length > 0 );
 
-	// Reset function to clear all user customizations
+	// Reset function to clear all user customizations.
+	// When editing a template with a style variation, reset to the registered
+	// variation's original data. Otherwise, reset to empty (default global styles).
 	const onReset = () => {
-		setUser( { styles: {}, settings: {} } );
+		if ( styleVariationId && registeredVariationBaseData ) {
+			// Reset to the registered variation's original data.
+			setUser( {
+				styles: registeredVariationBaseData.styles ?? {},
+				settings: registeredVariationBaseData.settings ?? {},
+			} );
+		} else {
+			// Reset to empty (default global styles behavior).
+			setUser( { styles: {}, settings: {} } );
+		}
 	};
 	const { toggle } = useDispatch( preferencesStore );
 	const { canEditCSS } = useSelect( ( select ) => {

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -103,6 +103,12 @@ export { default as CharacterCount } from './character-count';
 // State Related Components.
 export { default as EditorProvider } from './provider';
 
+// Template Style Variation (experimental).
+export {
+	TemplateStyleVariationContext as __experimentalTemplateStyleVariationContext,
+	TemplateStyleVariationProvider as __experimentalTemplateStyleVariationProvider,
+} from './template-style-variation-context';
+
 export * from './deprecated';
 
 /**

--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -3,18 +3,34 @@
  */
 import { useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
-import { MenuItem, Modal, SearchControl } from '@wordpress/components';
+import {
+	BlockPreview,
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import {
+	Composite,
+	MenuItem,
+	Modal,
+	SearchControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { parse } from '@wordpress/blocks';
+import {
+	mergeGlobalStyles,
+	generateGlobalStyles,
+} from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
  */
 import { useAvailableTemplates, useEditedPostContext } from './hooks';
 import { searchTemplates } from '../../utils/search-templates';
+import { unlock } from '../../lock-unlock';
+
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 
 export default function SwapTemplateButton( { onClick } ) {
 	const [ showModal, setShowModal ] = useState( false );
@@ -61,6 +77,213 @@ export default function SwapTemplateButton( { onClick } ) {
 	);
 }
 
+/**
+ * Hook to get block editor settings with optional style variation override.
+ *
+ * When a template has an associated style variation, this hook merges the
+ * variation's styles with the default base config to generate the correct
+ * preview styles. Uses the default theme base config (not the current
+ * template's base-theme-merged config) so each preview is independent.
+ *
+ * @param {string|null} styleVariationId The style variation ID, or null for default.
+ * @return {Object} Settings object for BlockEditorProvider.
+ */
+function useSettingsWithVariation( styleVariationId ) {
+	const parentSettings = useSelect(
+		( select ) => select( blockEditorStore ).getSettings(),
+		[]
+	);
+
+	// Get the default theme base config directly, independent of any
+	// current template's variation context.
+	const defaultBaseConfig = useSelect(
+		( select ) =>
+			select(
+				coreStore
+			).__experimentalGetCurrentThemeBaseGlobalStyles() || {},
+		[]
+	);
+
+	// Get the default user (global styles) config.
+	const defaultUserConfig = useSelect( ( select ) => {
+		const globalStylesId = select(
+			coreStore
+		).__experimentalGetCurrentGlobalStylesId();
+		if ( ! globalStylesId ) {
+			return {};
+		}
+		const record = select( coreStore ).getEditedEntityRecord(
+			'root',
+			'globalStyles',
+			globalStylesId
+		);
+		return {
+			settings: record?.settings ?? {},
+			styles: record?.styles ?? {},
+		};
+	}, [] );
+
+	// Get registered variation to find its post_id (if any).
+	const registeredVariation = useSelect(
+		( select ) => {
+			if ( ! styleVariationId ) {
+				return null;
+			}
+
+			const getRegisteredVariations =
+				select( coreStore ).__experimentalGetRegisteredStyleVariations;
+			if ( typeof getRegisteredVariations !== 'function' ) {
+				return null;
+			}
+
+			const variations = getRegisteredVariations() || [];
+			return (
+				variations.find( ( v ) => v.id === styleVariationId ) || null
+			);
+		},
+		[ styleVariationId ]
+	);
+
+	// If the variation has a post, fetch the post's styles (edited version).
+	const variationPostData = useSelect(
+		( select ) => {
+			const postId = registeredVariation?.post_id;
+			if ( ! postId ) {
+				return null;
+			}
+
+			const { getEntityRecord } = select( coreStore );
+			const record = getEntityRecord( 'root', 'globalStyles', postId );
+
+			if ( ! record ) {
+				return null;
+			}
+
+			return {
+				settings: record.settings || {},
+				styles: record.styles || {},
+			};
+		},
+		[ registeredVariation?.post_id ]
+	);
+
+	// Use post data if available, otherwise fall back to registered variation data.
+	const effectiveVariationData = useMemo( () => {
+		if ( variationPostData ) {
+			return variationPostData;
+		}
+		if ( registeredVariation ) {
+			return {
+				settings: registeredVariation.settings || {},
+				styles: registeredVariation.styles || {},
+			};
+		}
+		return null;
+	}, [ variationPostData, registeredVariation ] );
+
+	// Default merged config (base + user global styles, no variation).
+	const defaultMergedConfig = useMemo(
+		() => mergeGlobalStyles( defaultBaseConfig, defaultUserConfig ),
+		[ defaultBaseConfig, defaultUserConfig ]
+	);
+
+	// Generate base global styles (no variation) for the default case.
+	const [ baseGlobalStyles, baseGlobalSettings ] = useMemo( () => {
+		return generateGlobalStyles( defaultMergedConfig, [], {
+			disableRootPadding: false,
+		} );
+	}, [ defaultMergedConfig ] );
+
+	// Build settings, overriding styles when a variation is active.
+	const settings = useMemo( () => {
+		const base = {
+			...parentSettings,
+			styles: baseGlobalStyles,
+			__experimentalFeatures: baseGlobalSettings,
+			isPreviewMode: true,
+		};
+
+		if ( ! effectiveVariationData ) {
+			return base;
+		}
+
+		// Merge variation styles with the default base config.
+		const variationMergedConfig = mergeGlobalStyles(
+			defaultBaseConfig,
+			effectiveVariationData
+		);
+
+		// Generate CSS from merged config.
+		const [ globalStyles, globalSettings ] = generateGlobalStyles(
+			variationMergedConfig,
+			[],
+			{ disableRootPadding: false }
+		);
+
+		return {
+			...base,
+			styles: globalStyles,
+			__experimentalFeatures: globalSettings,
+		};
+	}, [
+		parentSettings,
+		baseGlobalStyles,
+		baseGlobalSettings,
+		effectiveVariationData,
+		defaultBaseConfig,
+	] );
+
+	return settings;
+}
+
+function TemplatePreviewItem( { template, onClick } ) {
+	const styleVariationId = template.style_variation || null;
+	const settings = useSettingsWithVariation( styleVariationId );
+
+	const blocks = useMemo( () => {
+		return parse( template.content.raw );
+	}, [ template.content.raw ] );
+
+	const isEmpty = ! blocks?.length;
+	const title = decodeEntities( template.title.rendered );
+
+	return (
+		<Composite.Item
+			render={
+				<div
+					role="option"
+					aria-label={ title }
+					className="block-editor-block-patterns-list__item"
+				/>
+			}
+			id={ template.slug }
+			onClick={ () =>
+				onClick( {
+					name: template.slug,
+					blocks,
+					title,
+					id: template.id,
+				} )
+			}
+		>
+			{ isEmpty && __( 'Empty template' ) }
+			{ ! isEmpty && (
+				<ExperimentalBlockEditorProvider
+					value={ blocks }
+					settings={ settings }
+				>
+					<BlockPreview.Async>
+						<BlockPreview blocks={ blocks } />
+					</BlockPreview.Async>
+				</ExperimentalBlockEditorProvider>
+			) }
+			<div className="block-editor-block-patterns-list__item-title">
+				{ title }
+			</div>
+		</Composite.Item>
+	);
+}
+
 function TemplatesList( { postType, onSelect } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
 	const availableTemplates = useAvailableTemplates( postType );
@@ -75,9 +298,14 @@ function TemplatesList( { postType, onSelect } ) {
 		[ availableTemplates ]
 	);
 
-	const filteredBlockTemplates = useMemo( () => {
-		return searchTemplates( templatesAsPatterns, searchValue );
-	}, [ templatesAsPatterns, searchValue ] );
+	const filteredTemplates = useMemo( () => {
+		const filtered = searchTemplates( templatesAsPatterns, searchValue );
+		// Map back to original template objects by slug.
+		const filteredSlugs = new Set( filtered.map( ( p ) => p.name ) );
+		return availableTemplates.filter( ( t ) =>
+			filteredSlugs.has( t.slug )
+		);
+	}, [ templatesAsPatterns, availableTemplates, searchValue ] );
 
 	return (
 		<>
@@ -88,11 +316,23 @@ function TemplatesList( { postType, onSelect } ) {
 				placeholder={ __( 'Search' ) }
 				className="editor-post-template__swap-template-search"
 			/>
-			<BlockPatternsList
-				label={ __( 'Templates' ) }
-				blockPatterns={ filteredBlockTemplates }
-				onClickPattern={ onSelect }
-			/>
+			<Composite
+				role="listbox"
+				className="block-editor-block-patterns-list"
+				aria-label={ __( 'Templates' ) }
+			>
+				{ filteredTemplates.map( ( template ) => (
+					<div
+						key={ template.slug }
+						className="block-editor-block-patterns-list__list-item"
+					>
+						<TemplatePreviewItem
+							template={ template }
+							onClick={ onSelect }
+						/>
+					</div>
+				) ) }
+			</Composite>
 		</>
 	);
 }

--- a/packages/editor/src/components/template-style-variation-context/index.js
+++ b/packages/editor/src/components/template-style-variation-context/index.js
@@ -1,0 +1,173 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+/**
+ * Context for template-specific style variations.
+ *
+ * This context provides information about whether the current template
+ * has an associated style variation, and if so, which one.
+ */
+export const TemplateStyleVariationContext = createContext( {
+	templateId: null,
+	styleVariationId: null,
+	styleVariationPostId: null,
+	baseThemeId: null,
+	isTemplateStyleVariationsEnabled: false,
+} );
+
+/**
+ * Provider component for template style variation context.
+ *
+ * This component fetches the current template's style variation (if any)
+ * and provides it to child components via context.
+ *
+ * It handles two cases:
+ * 1. Directly editing a template (postType === 'wp_template')
+ * 2. Editing a page/post with its template (postType !== 'wp_template' but templateId is set)
+ *
+ * @param {Object}  props                    Component props.
+ * @param {Element} props.children           Child components.
+ * @param {string}  props.resolvedTemplateId Optional template ID passed directly from parent.
+ *                                           Takes precedence over editor store value to avoid
+ *                                           timing issues during navigation.
+ * @return {Element} Provider component.
+ */
+export function TemplateStyleVariationProvider( {
+	children,
+	resolvedTemplateId,
+} ) {
+	// First, get the current post info to determine which template to use.
+	// This needs to be reactive to navigation changes.
+	const { postType, postId, currentTemplateId } = useSelect( ( select ) => {
+		const {
+			getCurrentPostType,
+			getCurrentPostId,
+			getCurrentTemplateId: getTemplateId,
+		} = select( editorStore );
+
+		return {
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+			currentTemplateId: getTemplateId(),
+		};
+	}, [] );
+
+	// Determine the effective template ID based on what we're editing.
+	// If resolvedTemplateId is provided (from parent during navigation),
+	// use it to avoid timing issues with the editor store update.
+	const effectiveTemplateId =
+		resolvedTemplateId ||
+		( postType === 'wp_template' ? postId : currentTemplateId );
+
+	// Now fetch the template data with the effective template ID as a dependency.
+	// This ensures we re-fetch when the template changes during navigation.
+	const {
+		templateId,
+		styleVariationId,
+		styleVariationPostId,
+		baseThemeId,
+		isEnabled,
+	} = useSelect(
+		( select ) => {
+			if ( ! effectiveTemplateId ) {
+				return {
+					templateId: null,
+					styleVariationId: null,
+					styleVariationPostId: null,
+					baseThemeId: null,
+					isEnabled: false,
+				};
+			}
+
+			const { getEditedEntityRecord, getEntityRecord } =
+				select( coreStore );
+
+			// Trigger the fetch for the template.
+			getEntityRecord( 'postType', 'wp_template', effectiveTemplateId );
+
+			// Get the template record (with any local edits).
+			const template = getEditedEntityRecord(
+				'postType',
+				'wp_template',
+				effectiveTemplateId
+			);
+
+			if ( ! template ) {
+				return {
+					templateId: effectiveTemplateId,
+					styleVariationId: null,
+					styleVariationPostId: null,
+					baseThemeId: null,
+					isEnabled: true,
+				};
+			}
+
+			// The style_variation field contains the registered variation string ID.
+			const variationId = template.style_variation || null;
+
+			// Look up the variation's post_id and base_theme from the registry.
+			let variationPostId = null;
+			let variationBaseThemeId = null;
+
+			if ( variationId ) {
+				const getRegisteredVariations =
+					select(
+						coreStore
+					).__experimentalGetRegisteredStyleVariations;
+				if ( typeof getRegisteredVariations === 'function' ) {
+					const variations = getRegisteredVariations() || [];
+					const variation = variations.find(
+						( v ) => v.id === variationId
+					);
+					if ( variation ) {
+						variationPostId = variation.post_id || null;
+						variationBaseThemeId = variation.base_theme || null;
+					}
+				}
+			}
+
+			return {
+				templateId: template.id || effectiveTemplateId,
+				styleVariationId: variationId,
+				styleVariationPostId: variationPostId,
+				baseThemeId: variationBaseThemeId,
+				isEnabled: true,
+			};
+		},
+		[ effectiveTemplateId ]
+	);
+
+	const contextValue = useMemo(
+		() => ( {
+			templateId,
+			styleVariationId,
+			styleVariationPostId,
+			baseThemeId,
+			isTemplateStyleVariationsEnabled: isEnabled,
+		} ),
+		[
+			templateId,
+			styleVariationId,
+			styleVariationPostId,
+			baseThemeId,
+			isEnabled,
+		]
+	);
+
+	return (
+		<TemplateStyleVariationContext.Provider value={ contextValue }>
+			{ children }
+		</TemplateStyleVariationContext.Provider>
+	);
+}
+
+export default TemplateStyleVariationContext;

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -33,6 +33,7 @@ import {
 	useGenerateBlockPath,
 	useRestoreBlockFromPath,
 } from './utils/block-selection-path';
+import { TemplateStyleVariationProvider } from './components/template-style-variation-context';
 
 const { store: interfaceStore, ...remainingInterfaceApis } = interfaceApis;
 
@@ -63,6 +64,8 @@ lock( privateApis, {
 	// Block selection
 	useGenerateBlockPath,
 	useRestoreBlockFromPath,
+	// Template style variations
+	TemplateStyleVariationProvider,
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	interfaceStore,
 	...remainingInterfaceApis,

--- a/packages/global-styles-ui/src/index.ts
+++ b/packages/global-styles-ui/src/index.ts
@@ -3,6 +3,9 @@ export { StyleVariations } from './style-variations';
 export { ColorVariations } from './color-variations';
 export { TypographyVariations } from './typography-variations';
 
+// Template Style Variations (experimental)
+export { TemplateStyleVariationPicker } from './template-style-variation-picker';
+
 // Ideally this should just be a core-data selector.
 export { default as useGlobalStylesRevisions } from './screen-revisions/use-global-styles-revisions';
 

--- a/packages/global-styles-ui/src/template-style-variation-picker.tsx
+++ b/packages/global-styles-ui/src/template-style-variation-picker.tsx
@@ -1,0 +1,345 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useState } from '@wordpress/element';
+import {
+	__experimentalGrid as Grid,
+	__experimentalVStack as VStack,
+	Spinner,
+	Tooltip,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ENTER } from '@wordpress/keycodes';
+import clsx from 'clsx';
+import { mergeGlobalStyles } from '@wordpress/global-styles-engine';
+
+/**
+ * Internal dependencies
+ */
+import PreviewStyles from './preview-styles';
+import { GlobalStylesContext } from './context';
+import { Subtitle } from './subtitle';
+
+interface RegisteredStyleVariation {
+	id: string;
+	title: string;
+	settings?: Record< string, unknown >;
+	styles?: Record< string, unknown >;
+	base_theme?: string | null;
+	source?: string;
+	post_id?: number | null;
+}
+
+interface TemplateStyleVariationPickerProps {
+	/**
+	 * The currently selected style variation ID (string like 'demo//dark-mode').
+	 */
+	currentStyleVariationId?: string | null;
+	/**
+	 * Callback when a style variation is selected.
+	 * Receives the variation string ID or null for default.
+	 */
+	onSelect?: ( variationId: string | null ) => void;
+	/**
+	 * Gap between variation previews.
+	 */
+	gap?: number;
+}
+
+interface VariationPreviewProps {
+	variation: RegisteredStyleVariation;
+	isSelected: boolean;
+	onSelect: () => void;
+	baseConfig: Record< string, unknown >;
+}
+
+/**
+ * A single variation preview that provides its own context for rendering.
+ *
+ * @param props            Component props.
+ * @param props.variation  The registered style variation to preview.
+ * @param props.isSelected Whether this variation is currently selected.
+ * @param props.onSelect   Callback invoked when the variation is selected.
+ * @param props.baseConfig The base global styles config for merging.
+ */
+function VariationPreview( {
+	variation,
+	isSelected,
+	onSelect,
+	baseConfig,
+}: VariationPreviewProps ) {
+	const [ isFocused, setIsFocused ] = useState( false );
+
+	// When the variation has a wp_global_styles post, fetch user-edited data.
+	const postData = useSelect(
+		( select ) => {
+			if ( ! variation.post_id ) {
+				return null;
+			}
+			const coreSelectors = select( coreStore ) as Record<
+				string,
+				unknown
+			>;
+			const getEditedEntityRecord =
+				coreSelectors.getEditedEntityRecord as (
+					kind: string,
+					name: string,
+					recordId: number
+				) => Record< string, unknown > | undefined;
+			return getEditedEntityRecord(
+				'root',
+				'globalStyles',
+				variation.post_id
+			);
+		},
+		[ variation.post_id ]
+	);
+
+	// Use post data when available (user edits), falling back to registered data.
+	const effectiveSettings = useMemo(
+		() => postData?.settings || variation.settings || {},
+		[ postData?.settings, variation.settings ]
+	);
+	const effectiveStyles = useMemo(
+		() => postData?.styles || variation.styles || {},
+		[ postData?.styles, variation.styles ]
+	);
+
+	// Create a context with the variation's styles merged with base
+	const context = useMemo( () => {
+		const variationConfig = {
+			settings: effectiveSettings,
+			styles: effectiveStyles,
+		};
+		const merged = mergeGlobalStyles( baseConfig, variationConfig );
+
+		return {
+			user: variationConfig,
+			base: baseConfig,
+			merged,
+			onChange: () => {},
+		};
+	}, [ effectiveSettings, effectiveStyles, baseConfig ] );
+
+	const handleKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.keyCode === ENTER ) {
+			event.preventDefault();
+			onSelect();
+		}
+	};
+
+	return (
+		<GlobalStylesContext.Provider value={ context }>
+			<Tooltip text={ variation.title }>
+				<div
+					className={ clsx(
+						'global-styles-ui-variations_item',
+						'global-styles-ui-template-variation-preview',
+						{
+							'is-active': isSelected,
+						}
+					) }
+					role="button"
+					onClick={ onSelect }
+					onKeyDown={ handleKeyDown }
+					tabIndex={ 0 }
+					aria-label={ variation.title }
+					aria-current={ isSelected }
+					onFocus={ () => setIsFocused( true ) }
+					onBlur={ () => setIsFocused( false ) }
+				>
+					<div className="global-styles-ui-variations_item-preview">
+						<PreviewStyles
+							label={ variation.title }
+							withHoverView
+							isFocused={ isFocused || isSelected }
+							variation={ {
+								title: variation.title,
+								settings: effectiveSettings,
+								styles: effectiveStyles,
+							} }
+						/>
+					</div>
+				</div>
+			</Tooltip>
+		</GlobalStylesContext.Provider>
+	);
+}
+
+/**
+ * A component for selecting a style variation to assign to a template.
+ *
+ * This component displays all registered style variations with visual previews
+ * and allows assigning one to a specific template. When a variation is assigned,
+ * that variation's global styles will be used when rendering the template.
+ *
+ * @param props                         Component props.
+ * @param props.currentStyleVariationId The currently selected style variation ID.
+ * @param props.onSelect                Callback invoked when a variation is selected.
+ * @param props.gap                     Gap between variation previews.
+ * @example
+ * ```tsx
+ * <TemplateStyleVariationPicker
+ *   currentStyleVariationId="demo//dark-mode"
+ *   onSelect={(id) => console.log('Selected variation:', id)}
+ * />
+ * ```
+ */
+export function TemplateStyleVariationPicker( {
+	currentStyleVariationId,
+	onSelect,
+	gap = 2,
+}: TemplateStyleVariationPickerProps ) {
+	const { registeredVariations, isLoading, baseConfig } = useSelect(
+		( select ) => {
+			// Cast to any to access experimental selectors that aren't in the public type definitions.
+			const coreSelectors = select( coreStore ) as Record<
+				string,
+				unknown
+			>;
+			const __experimentalGetRegisteredStyleVariations =
+				coreSelectors.__experimentalGetRegisteredStyleVariations as
+					| ( () => RegisteredStyleVariation[] )
+					| undefined;
+			const hasFinishedResolution =
+				coreSelectors.hasFinishedResolution as
+					| ( ( selector: string, args: unknown[] ) => boolean )
+					| undefined;
+			const __experimentalGetCurrentThemeBaseGlobalStyles =
+				coreSelectors.__experimentalGetCurrentThemeBaseGlobalStyles as
+					| ( () => Record< string, unknown > )
+					| undefined;
+
+			// Try to get registered style variations.
+			let variations: RegisteredStyleVariation[] = [];
+			try {
+				variations =
+					__experimentalGetRegisteredStyleVariations?.() || [];
+			} catch {
+				// Selector might not exist if experiment is not enabled.
+				variations = [];
+			}
+
+			// Get base global styles for proper preview rendering.
+			let base: Record< string, unknown > = {};
+			try {
+				base = __experimentalGetCurrentThemeBaseGlobalStyles?.() || {};
+			} catch {
+				// Selector might not exist.
+				base = {};
+			}
+
+			// Check if we're still loading.
+			const hasFinished =
+				hasFinishedResolution?.(
+					'__experimentalGetRegisteredStyleVariations',
+					[]
+				) ?? true;
+
+			return {
+				registeredVariations: variations,
+				isLoading: ! hasFinished,
+				baseConfig: base,
+			};
+		},
+		[]
+	);
+
+	// Build grouped variations: default, theme, and other (custom/plugin).
+	const { defaultVariation, themeVariations, otherVariations } =
+		useMemo( () => {
+			const def: RegisteredStyleVariation = {
+				id: '',
+				title: __( 'Default (Global Styles)' ),
+				settings: {},
+				styles: {},
+				source: 'default',
+			};
+
+			const theme: RegisteredStyleVariation[] = [];
+			const other: RegisteredStyleVariation[] = [];
+
+			for ( const variation of registeredVariations ) {
+				if ( variation.source === 'theme' ) {
+					theme.push( variation );
+				} else {
+					other.push( variation );
+				}
+			}
+
+			return {
+				defaultVariation: def,
+				themeVariations: theme,
+				otherVariations: other,
+			};
+		}, [ registeredVariations ] );
+
+	if ( isLoading ) {
+		return (
+			<VStack alignment="center" spacing={ 4 }>
+				<Spinner />
+			</VStack>
+		);
+	}
+
+	if ( registeredVariations.length === 0 ) {
+		return null;
+	}
+
+	const showSubtitles =
+		themeVariations.length > 0 && otherVariations.length > 0;
+
+	const renderVariation = ( variation: RegisteredStyleVariation ) => {
+		const isSelected =
+			variation.id === ''
+				? ! currentStyleVariationId
+				: variation.id === currentStyleVariationId;
+
+		return (
+			<VariationPreview
+				key={ variation.id || 'default' }
+				variation={ variation }
+				isSelected={ isSelected }
+				baseConfig={ baseConfig }
+				onSelect={ () => {
+					onSelect?.( variation.id === '' ? null : variation.id );
+				} }
+			/>
+		);
+	};
+
+	return (
+		<VStack
+			className="global-styles-ui-template-style-variation-picker"
+			spacing={ 4 }
+		>
+			<Grid columns={ 2 } gap={ gap }>
+				{ renderVariation( defaultVariation ) }
+			</Grid>
+			{ themeVariations.length > 0 && (
+				<VStack spacing={ 3 }>
+					{ showSubtitles && (
+						<Subtitle level={ 3 }>{ __( 'Theme' ) }</Subtitle>
+					) }
+					<Grid columns={ 2 } gap={ gap }>
+						{ themeVariations.map( renderVariation ) }
+					</Grid>
+				</VStack>
+			) }
+			{ otherVariations.length > 0 && (
+				<VStack spacing={ 3 }>
+					{ showSubtitles && (
+						<Subtitle level={ 3 }>{ __( 'Custom' ) }</Subtitle>
+					) }
+					<Grid columns={ 2 } gap={ gap }>
+						{ otherVariations.map( renderVariation ) }
+					</Grid>
+				</VStack>
+			) }
+		</VStack>
+	);
+}
+
+export default TemplateStyleVariationPicker;


### PR DESCRIPTION
## What?

Exploratory prototype for template-specific style variations — allowing individual templates to use distinct global style configurations instead of inheriting a single site-wide set of styles.

**This is a proof of concept and is not intended to be merged as-is.** It is meant to validate the architecture and inform a proposal (see https://github.com/WordPress/gutenberg/issues/75331).

Note: The style variation picker in the template sidebar is a placeholder UI for demonstration purposes. A more natural home for this would likely be the existing style browser in the Styles panel, where a user could choose whether to apply a style variation site-wide or scope it to the current template.

## Why?

The current global styles system operates site-wide: every template inherits the same `theme.json` settings and user customizations. This proposal makes it easier to support real-world scenarios like:

- **Seasonal or campaign pages** that need unique color schemes and typography without affecting the rest of the site.
- **Multi-brand sites** where different sections require distinct design systems.
- **Plugin-provided templates** (e-commerce, email, forums) that need tailored styles complementing — but not overriding — the site theme.

## How?

The feature is gated behind the **`gutenberg-template-style-variations`** experiment flag (Gutenberg > Experiments). Nothing is loaded or registered unless the experiment is enabled.

### Architecture

**Data model — three entities and their relationships:**

1. **Style Variations** — registered sets of `theme.json`-compatible styles/settings (similar to theme style variations, but scoped to templates). Stored in a `WP_Style_Variations_Registry` singleton; plugins and themes register them via `gutenberg_register_style_variation()`.

2. **Base Themes** — optional alternative `theme.json` configurations that replace the active theme's base layer. Registered via `gutenberg_register_base_theme()`. A style variation can reference a base theme to start from a completely different design foundation.

3. **Templates** — link to a style variation by ID via post meta (`_wp_style_variation_id` on `wp_template`). Multiple templates can share the same variation.

**How variations become editable:**

When a user edits a variation's styles in the Styles UI, a `wp_global_styles` post is created for that variation (linked via `_wp_source_variation_id` meta). This post stores user customizations scoped to the variation, parallel to how the default `wp_global_styles` post stores site-wide customizations. The relationship is one-to-one: one post per variation, shared by all templates using it.

**Style merge order (matching the existing global styles cascade):**

```
Core defaults → Block styles → Theme (or Base Theme) → Variation user customizations
```

**REST API for third-party integration:**

| Endpoint | Purpose |
|----------|---------|
| `GET /wp/v2/style-variations` | List registered variations |
| `GET /wp/v2/base-themes` | List registered base themes |
| `PATCH /wp/v2/templates/{id}` | Set/unset `style_variation` on a template |
| `POST /wp/v2/templates-variation-post/{id}` | Get or create the editable `wp_global_styles` post for a variation |

**PHP registration API for plugins/themes:**

```php
// Register a style variation
gutenberg_register_style_variation( 'my-plugin//dark-mode', array(
    'title'      => 'Dark Mode',
    'base_theme' => 'my-plugin//dark-base', // optional
    'data'       => array( /* theme.json-compatible styles/settings */ ),
) );

// Register a base theme
gutenberg_register_base_theme( 'my-plugin//dark-base', array(
    'title' => 'Dark Base',
    'data'  => array( /* full theme.json structure */ ),
) );
```

### Demo

The PR includes demo code (`lib/experimental/demo-template-style-variations.php`) that exercises the registration API — it registers two base themes and five style variations, and creates a "Campaign Landing Page" template with an assigned variation. This serves as a practical reference for how plugins and themes would use `gutenberg_register_style_variation()` and `gutenberg_register_base_theme()`.

## Testing Instructions

1. Enable the experiment: **Gutenberg > Experiments > Template Style Variations**.
2. Go to **Appearance > Editor > Templates**. You should see a "Campaign Landing Page" template with warm-toned styling in its preview.
3. Open any template for editing. In the sidebar, a "Style Variation" panel shows a picker with the registered variations.
4. Select a variation (e.g., "Dark Mode") and save. The editor canvas should update to use that variation's styles.
5. Visit the template on the frontend — the variation styles should be applied there as well.
6. Open the Styles sidebar while a variation is active — edits are scoped to the variation, not the global styles.

## Screenshots or screencast


https://github.com/user-attachments/assets/31f1f9b6-6179-46be-8d41-d6e83f6742e0



