### PR TITLE
Updated Typo in template-activate file

### DIFF
--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -83,7 +83,7 @@ function gutenberg_maintain_templates_routes() {
 	global $wp_post_types;
 	// Register the old templates endpoints. The WP_REST_Templates_Controller
 	// and sub-controllers used to be linked to the wp_template post type, but
-	// are no longer. They still require a post type object when contructing the
+	// are no longer. They still require a post type object when constructing the
 	// class. To maintain backward and changes to these controller classes, we
 	// make use that the wp_template post type has the right information it
 	// needs.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- There is a Typo in `template-activate.php`  `contructing` should be `constructing`

## How?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Updated Typo in `template-activate.php`  in Line no 86. Used `constructing` instead of `contructing`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1.  open `template-activate.php` file
2. Go to Line no 86
3. See Typo

