### PR TITLE
Block Visibility: Show keyboard shortcut in context menu

### DIFF
--- a/packages/block-editor/src/components/block-visibility/viewport-menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-menu-item.js
@@ -3,9 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
-import { seen, unseen } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { unlock } from '../../lock-unlock';
 
 export default function BlockVisibilityViewportMenuItem( { clientIds } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const { areBlocksHiddenAnywhere } = useSelect(
+	const { areBlocksHiddenAnywhere, shortcut } = useSelect(
 		( select ) => {
 			const { isBlockHiddenAnywhere } = unlock(
 				select( blockEditorStore )
@@ -25,6 +25,11 @@ export default function BlockVisibilityViewportMenuItem( { clientIds } ) {
 				areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
 					isBlockHiddenAnywhere( clientId )
 				),
+				shortcut: select(
+					keyboardShortcutsStore
+				).getShortcutRepresentation(
+					'core/block-editor/toggle-block-visibility'
+				),
 			};
 		},
 		[ clientIds ]
@@ -32,8 +37,8 @@ export default function BlockVisibilityViewportMenuItem( { clientIds } ) {
 	return (
 		<>
 			<MenuItem
-				icon={ areBlocksHiddenAnywhere ? unseen : seen }
 				onClick={ () => setIsModalOpen( true ) }
+				shortcut={ shortcut }
 			>
 				{ areBlocksHiddenAnywhere ? __( 'Show' ) : __( 'Hide' ) }
 			</MenuItem>


### PR DESCRIPTION
## What?

Show the keyboard shortcut hint (Ctrl+Shift+H / Cmd+Shift+H) in the Hide/Show context menu item instead of the eye icon.

Part of #73776.

## Why?

The shortcut was already registered and functional but not discoverable in the context menu. Other menu items (Rename, Duplicate, Delete) display their shortcuts — this makes visibility consistent with them.

## Testing Instructions

1. Open the editor and select a block that supports visibility (e.g., a Paragraph or Group block).
2. Right-click to open the context menu (or use the block toolbar kebab menu).
3. Verify the "Hide" menu item displays the keyboard shortcut (`⇧⌘H` on Mac, `Ctrl+Shift+H` on Windows) instead of an eye icon.
4. Hide the block, reopen the menu, and verify the "Show" item also displays the shortcut.
5. Confirm the shortcut itself still works (`Cmd+Shift+H` / `Ctrl+Shift+H`).

<img width="329" height="593" alt="Screenshot 2026-02-09 at 12 39 32 pm" src="https://github.com/user-attachments/assets/dd1ef929-c508-4b9a-852e-e1e26c70e2de" />
