### PR TITLE
Block Visibility: Simplify toolbar for hidden blocks

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -225,8 +225,7 @@ export function PrivateBlockToolbar( {
 										clientIds={ blockClientIds }
 									/>
 								) }
-							{ ! areSelectedBlocksHiddenOnViewport &&
-								! isMultiToolbar &&
+							{ ! isMultiToolbar &&
 								isDefaultEditingMode &&
 								showLockButtons && (
 									<BlockLockToolbar
@@ -280,9 +279,7 @@ export function PrivateBlockToolbar( {
 							<__unstableBlockToolbarLastItem.Slot />
 						</>
 					) }
-				{ ! areSelectedBlocksHiddenOnViewport && (
-					<BlockEditVisuallyButton clientIds={ blockClientIds } />
-				) }
+				<BlockEditVisuallyButton clientIds={ blockClientIds } />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
 			</div>
 		</NavigableToolbar>

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -209,10 +209,9 @@ export function PrivateBlockToolbar( {
 			key={ toolbarKey }
 		>
 			<div ref={ toolbarWrapperRef } className={ innerClasses }>
-				{ ! areSelectedBlocksHiddenOnViewport &&
-					showParentSelector &&
-					! isMultiToolbar &&
-					isLargeViewport && <BlockParentSelector /> }
+				{ showParentSelector && ! isMultiToolbar && isLargeViewport && (
+					<BlockParentSelector />
+				) }
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
 					<div ref={ nodeRef } { ...showHoveredOrFocusedGestures }>
 						<ToolbarGroup className="block-editor-block-toolbar__block-controls">

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -37,6 +37,7 @@ import { useHasBlockToolbar } from './use-has-block-toolbar';
 import ChangeDesign from './change-design';
 import SwitchSectionStyle from './switch-section-style';
 import { unlock } from '../../lock-unlock';
+import { deviceTypeKey } from '../../store/private-keys';
 import BlockToolbarIcon from './block-toolbar-icon';
 
 /**
@@ -75,6 +76,7 @@ export function PrivateBlockToolbar( {
 		showLockButtons,
 		showBlockVisibilityButton,
 		showSwitchSectionStyleButton,
+		areSelectedBlocksHiddenOnViewport,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -84,10 +86,12 @@ export function PrivateBlockToolbar( {
 			isBlockValid,
 			getBlockEditingMode,
 			getBlockAttributes,
+			getSettings,
 			getTemplateLock,
 			getParentSectionBlock,
 			isZoomOut,
 			isSectionBlock,
+			isBlockHiddenAtViewport,
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -119,6 +123,14 @@ export function PrivateBlockToolbar( {
 		const _isSectionBlock = isSectionBlock( selectedBlockClientId );
 		const _showSwitchSectionStyleButton = _isZoomOut || _isSectionBlock;
 
+		const _currentDeviceType =
+			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
+		const _areSelectedBlocksHiddenOnViewport =
+			selectedBlockClientIds.length > 0 &&
+			selectedBlockClientIds.every( ( id ) =>
+				isBlockHiddenAtViewport( id, _currentDeviceType )
+			);
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -146,6 +158,8 @@ export function PrivateBlockToolbar( {
 			showLockButtons: ! _isZoomOut,
 			showBlockVisibilityButton: ! _isZoomOut,
 			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
+			areSelectedBlocksHiddenOnViewport:
+				_areSelectedBlocksHiddenOnViewport,
 		};
 	}, [] );
 
@@ -195,9 +209,10 @@ export function PrivateBlockToolbar( {
 			key={ toolbarKey }
 		>
 			<div ref={ toolbarWrapperRef } className={ innerClasses }>
-				{ showParentSelector && ! isMultiToolbar && isLargeViewport && (
-					<BlockParentSelector />
-				) }
+				{ ! areSelectedBlocksHiddenOnViewport &&
+					showParentSelector &&
+					! isMultiToolbar &&
+					isLargeViewport && <BlockParentSelector /> }
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
 					<div ref={ nodeRef } { ...showHoveredOrFocusedGestures }>
 						<ToolbarGroup className="block-editor-block-toolbar__block-controls">
@@ -211,7 +226,8 @@ export function PrivateBlockToolbar( {
 										clientIds={ blockClientIds }
 									/>
 								) }
-							{ ! isMultiToolbar &&
+							{ ! areSelectedBlocksHiddenOnViewport &&
+								! isMultiToolbar &&
 								isDefaultEditingMode &&
 								showLockButtons && (
 									<BlockLockToolbar
@@ -225,43 +241,49 @@ export function PrivateBlockToolbar( {
 						</ToolbarGroup>
 					</div>
 				) }
-				{ ! hasContentOnlyLocking &&
+				{ ! areSelectedBlocksHiddenOnViewport &&
+					! hasContentOnlyLocking &&
 					shouldShowVisualToolbar &&
 					isMultiToolbar &&
 					showGroupButtons && <BlockGroupToolbar /> }
-				{ showShuffleButton && (
+				{ ! areSelectedBlocksHiddenOnViewport && showShuffleButton && (
 					<ChangeDesign clientId={ blockClientIds[ 0 ] } />
 				) }
-				{ showSwitchSectionStyleButton && (
-					<SwitchSectionStyle clientId={ blockClientIds[ 0 ] } />
+				{ ! areSelectedBlocksHiddenOnViewport &&
+					showSwitchSectionStyleButton && (
+						<SwitchSectionStyle clientId={ blockClientIds[ 0 ] } />
+					) }
+				{ ! areSelectedBlocksHiddenOnViewport &&
+					shouldShowVisualToolbar &&
+					showSlots && (
+						<>
+							{ ! isSectionContainer && (
+								<>
+									<BlockControls.Slot
+										group="parent"
+										className="block-editor-block-toolbar__slot"
+									/>
+									<BlockControls.Slot
+										group="block"
+										className="block-editor-block-toolbar__slot"
+									/>
+									<BlockControls.Slot className="block-editor-block-toolbar__slot" />
+									<BlockControls.Slot
+										group="inline"
+										className="block-editor-block-toolbar__slot"
+									/>
+								</>
+							) }
+							<BlockControls.Slot
+								group="other"
+								className="block-editor-block-toolbar__slot"
+							/>
+							<__unstableBlockToolbarLastItem.Slot />
+						</>
+					) }
+				{ ! areSelectedBlocksHiddenOnViewport && (
+					<BlockEditVisuallyButton clientIds={ blockClientIds } />
 				) }
-				{ shouldShowVisualToolbar && showSlots && (
-					<>
-						{ ! isSectionContainer && (
-							<>
-								<BlockControls.Slot
-									group="parent"
-									className="block-editor-block-toolbar__slot"
-								/>
-								<BlockControls.Slot
-									group="block"
-									className="block-editor-block-toolbar__slot"
-								/>
-								<BlockControls.Slot className="block-editor-block-toolbar__slot" />
-								<BlockControls.Slot
-									group="inline"
-									className="block-editor-block-toolbar__slot"
-								/>
-							</>
-						) }
-						<BlockControls.Slot
-							group="other"
-							className="block-editor-block-toolbar__slot"
-						/>
-						<__unstableBlockToolbarLastItem.Slot />
-					</>
-				) }
-				<BlockEditVisuallyButton clientIds={ blockClientIds } />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
 			</div>
 		</NavigableToolbar>


### PR DESCRIPTION
## What?

Removes formatting and other items from the block toolbar when a block is hidden on the currently previewed viewport. Only items related to visibility and movement are shown; everything else is stripped away.

Part of https://github.com/WordPress/gutenberg/issues/73776.

## Why?

When a block is hidden on the current viewport (e.g., hidden on mobile while previewing mobile), editing its alignment, formatting, or other visual properties isn't meaningful — the block won't be rendered for that viewport. 

A simplified toolbar reduces noise and makes the relevant actions (visibility toggle, mover, context menu) easier to find.

## How?

Uses the existing `isBlockHiddenAtViewport` selector combined with the current device type from editor settings to compute an `areSelectedBlocksHiddenOnViewport` flag. When `true`, the toolbar only renders:

- **Parent block icon** - for navigation/selection
- **Block icon** — for identification
- **Visibility button** — to change visibility settings
- **Block mover** — for reordering
- **Context menu** — for other block actions

Hidden toolbar items include: lock controls, group toolbar, change design, switch section style, all block control slots (alignment, formatting, inline, etc.), and the edit visually button.

The toolbar is only simplified when blocks are hidden on the **currently previewed viewport**. If a block is hidden on mobile but you're viewing desktop, the full toolbar remains available.

Part of #73776.

## Testing Instructions

1. Open the site editor or post editor
2. Add a few blocks (e.g., a Paragraph, a Heading, an Image)
3. Select a block and open the block visibility modal (right-click context menu > "Block visibility" or `Cmd/Ctrl+Shift+H`)
4. Hide the block on the current viewport (e.g., hide on Desktop if previewing Desktop)
5. Click the hidden block — verify the toolbar only shows: block icon, visibility (eye) button, mover arrows, and the three-dot context menu
6. Switch to a viewport where the block is visible (e.g., switch to Mobile preview if the block is only hidden on Desktop)
7. Click the block — verify the full toolbar is shown
8. Multi-select blocks that are all hidden on the current viewport — verify the simplified toolbar applies
9. Multi-select blocks where some are hidden and some are visible — verify the full toolbar is shown


https://github.com/user-attachments/assets/2e527e62-0ec8-4db5-9ad6-17202851034a

