### PR TITLE
DataViews: Hide table headers when there is no data.

### DIFF
--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -353,6 +353,26 @@ function ViewTable< Item >( {
 
 	const hasData = !! data?.length;
 
+	if ( ! hasData ) {
+		return (
+			<div
+				className={ clsx( {
+					'dataviews-loading': isLoading,
+					'dataviews-no-results': ! isLoading,
+				} ) }
+				id={ tableNoticeId }
+			>
+				{ isLoading ? (
+					<p>
+						<Spinner />
+					</p>
+				) : (
+					empty
+				) }
+			</div>
+		);
+	}
+
 	const titleField = fields.find( ( field ) => field.id === view.titleField );
 	const mediaField = fields.find( ( field ) => field.id === view.mediaField );
 	const descriptionField = fields.find(
@@ -536,7 +556,7 @@ function ViewTable< Item >( {
 					</tr>
 				</thead>
 				{ /* Render grouped data if groupBy is specified */ }
-				{ hasData && groupField && dataByGroup ? (
+				{ groupField && dataByGroup ? (
 					Array.from( dataByGroup.entries() ).map(
 						( [ groupName, groupItems ] ) => (
 							<tbody key={ `group-${ groupName }` }>
@@ -597,58 +617,48 @@ function ViewTable< Item >( {
 					)
 				) : (
 					<tbody>
-						{ hasData &&
-							data.map( ( item, index ) => (
-								<TableRow
-									key={ getItemId( item ) }
-									item={ item }
-									level={
-										view.showLevels &&
-										typeof getItemLevel === 'function'
-											? getItemLevel( item )
-											: undefined
-									}
-									hasBulkActions={ hasBulkActions }
-									actions={ actions }
-									fields={ fields }
-									id={ getItemId( item ) || index.toString() }
-									view={ view }
-									titleField={ titleField }
-									mediaField={ mediaField }
-									descriptionField={ descriptionField }
-									selection={ selection }
-									getItemId={ getItemId }
-									onChangeSelection={ onChangeSelection }
-									onClickItem={ onClickItem }
-									renderItemLink={ renderItemLink }
-									isItemClickable={ isItemClickable }
-									isActionsColumnSticky={
-										! isHorizontalScrollEnd
-									}
-									posinset={
-										isInfiniteScroll ? index + 1 : undefined
-									}
-								/>
-							) ) }
+						{ data.map( ( item, index ) => (
+							<TableRow
+								key={ getItemId( item ) }
+								item={ item }
+								level={
+									view.showLevels &&
+									typeof getItemLevel === 'function'
+										? getItemLevel( item )
+										: undefined
+								}
+								hasBulkActions={ hasBulkActions }
+								actions={ actions }
+								fields={ fields }
+								id={ getItemId( item ) || index.toString() }
+								view={ view }
+								titleField={ titleField }
+								mediaField={ mediaField }
+								descriptionField={ descriptionField }
+								selection={ selection }
+								getItemId={ getItemId }
+								onChangeSelection={ onChangeSelection }
+								onClickItem={ onClickItem }
+								renderItemLink={ renderItemLink }
+								isItemClickable={ isItemClickable }
+								isActionsColumnSticky={
+									! isHorizontalScrollEnd
+								}
+								posinset={
+									isInfiniteScroll ? index + 1 : undefined
+								}
+							/>
+						) ) }
 					</tbody>
 				) }
 			</table>
 			<div
 				className={ clsx( {
 					'dataviews-loading': isLoading,
-					'dataviews-no-results': ! hasData && ! isLoading,
 				} ) }
 				id={ tableNoticeId }
 			>
-				{ ! hasData &&
-					( isLoading ? (
-						<p>
-							<Spinner />
-						</p>
-					) : (
-						empty
-					) ) }
-				{ hasData && isLoading && (
+				{ isLoading && (
 					<p className="dataviews-loading-more">
 						<Spinner />
 					</p>

--- a/packages/dataviews/src/components/dataviews-layouts/table/test/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/test/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ViewTable from '../index';
+import type {
+	ViewTable as ViewTableType,
+	NormalizedField,
+} from '../../../../types';
+
+type Item = { id: string; title: string };
+
+const fields = [
+	{
+		id: 'title',
+		label: 'Title',
+		type: 'text',
+		render: ( { item }: { item: Item } ) => <span>{ item.title }</span>,
+		getValue: ( { item }: { item: Item } ) => item.title,
+	},
+] as unknown as NormalizedField< Item >[];
+
+const view: ViewTableType = {
+	type: 'table',
+	fields: [],
+	titleField: 'title',
+};
+
+const defaultProps = {
+	actions: [],
+	fields,
+	getItemId: ( item: Item ) => item.id,
+	isItemClickable: () => false,
+	onChangeView: jest.fn(),
+	onChangeSelection: jest.fn(),
+	selection: [] as string[],
+	setOpenedFilter: jest.fn(),
+	view,
+	empty: <p>No results</p>,
+};
+
+describe( 'ViewTable', () => {
+	it( 'should not render table headers when data is empty', () => {
+		render( <ViewTable { ...defaultProps } data={ [] } /> );
+
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'columnheader' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'No results' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render a loading spinner without table headers when loading with no data', () => {
+		render( <ViewTable { ...defaultProps } data={ [] } isLoading /> );
+
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'columnheader' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render table headers when data is present', () => {
+		const data = [
+			{ id: '1', title: 'Item 1' },
+			{ id: '2', title: 'Item 2' },
+		];
+		render( <ViewTable { ...defaultProps } data={ data } /> );
+
+		expect( screen.getByRole( 'table' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Item 1' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Item 2' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Implements: #75272
                                                                                                                                                                                                                                                             
## What?

Hide the table layout content (including headers) when there is no data, matching the existing behavior of grid, list, and activity layouts.

## Why?

When DataViews table layout receives an empty data array, it renders an empty table with headers. This is confusing because headers imply there are results, column widths can collapse/jitter, and header interactions (sort/menus) appear usable but operate on nothing.

The grid, list, and activity layouts already hide their structure when empty — the table was the only outlier.

## How?

Added an early return in ViewTable when !hasData that renders only the empty state or loading spinner, skipping the entire <table> element (colgroup, thead, tbody). Also:

- Removed dead hasData guards that became unreachable after the early return.
- Kept the tableNoticeId div always rendered in the has-data path to avoid a dangling aria-describedby reference.
- Added unit tests for the empty, loading, and has-data states.

## Testing Instructions

1. Open the Site Editor and navigate to a view that uses the table layout (e.g., Pages).
2. Apply a filter or search term that returns zero results.
3. Verify the table headers are not visible — only the "No results" empty state should appear.
4. Clear the filter so results appear again — verify the table renders normally with headers and rows.
5. Apply a filter that returns results and observe the loading state — verify headers appear alongside data.

## Testing Instructions for Keyboard

1. Use keyboard to navigate to the search/filter controls in a table DataView.
2. Type a query that returns no results.
3. Verify focus is not lost and the empty state is announced by screen readers.
4. Clear the query and verify the table reappears with proper keyboard navigation.