### PR TITLE
Bugfix: Set the removed users to empty for awareness

### DIFF
--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -52,7 +52,8 @@ class HttpPollingProvider extends ObservableV2< BaseEventTypes > {
 			this.options.room,
 			this.options.ydoc,
 			this.awareness,
-			this.onSync
+			this.onSync,
+			this.log
 		);
 		this.emitStatus( 'connected' );
 	}
@@ -90,7 +91,7 @@ class HttpPollingProvider extends ObservableV2< BaseEventTypes > {
 	 * @param message The debug message
 	 * @param debug   Additional debug information
 	 */
-	protected log( message: string, debug: object = {} ): void {
+	protected log = ( message: string, debug: object = {} ): void => {
 		if ( this.options.debug ) {
 			// eslint-disable-next-line no-console
 			console.log( `[${ this.constructor.name }]: ${ message }`, {
@@ -98,8 +99,11 @@ class HttpPollingProvider extends ObservableV2< BaseEventTypes > {
 				...debug,
 			} );
 		}
-	}
+	};
 
+	/**
+	 * Handle synchronization events from the polling manager.
+	 */
 	protected onSync = (): void => {
 		if ( ! this.synced ) {
 			this.synced = true;

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -31,12 +31,15 @@ const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = 250; // 250 milliseconds
 const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
 const POLLING_MANAGER_ORIGIN = 'polling-manager';
 
+type LogFunction = ( message: string, debug?: object ) => void;
+
 interface PollingManager {
 	registerRoom: (
 		room: string,
 		doc: Y.Doc,
 		awareness: Awareness,
-		onSync: () => void
+		onSync: () => void,
+		log: LogFunction
 	) => void;
 	unregisterRoom: ( room: string ) => void;
 }
@@ -45,6 +48,7 @@ interface RoomState {
 	clientId: number;
 	endCursor: number;
 	localAwarenessState: LocalAwarenessState;
+	log: LogFunction;
 	processAwarenessUpdate: ( state: AwarenessState ) => void;
 	processDocUpdate: ( update: SyncUpdate ) => SyncUpdate | void;
 	unregister: () => void;
@@ -296,8 +300,11 @@ function poll(): void {
 				}
 			} );
 		} catch ( error ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Error posting sync update:', error );
+			// Exponential backoff on error: double the backoff time, up to max
+			pollInterval = Math.min(
+				pollInterval * 2,
+				MAX_ERROR_BACKOFF_IN_MS
+			);
 
 			// Restore updates to queues on failure so they can be retried.
 			for ( const room of payload.rooms ) {
@@ -307,13 +314,14 @@ function poll(): void {
 
 				const state = roomStates.get( room.room )!;
 				state.updateQueue.restore( room.updates );
+				state.log(
+					'Error posting sync update, will retry with backoff',
+					{
+						error,
+						nextPoll: pollInterval,
+					}
+				);
 			}
-
-			// Exponential backoff on error: double the backoff time, up to max
-			pollInterval = Math.min(
-				pollInterval * 2,
-				MAX_ERROR_BACKOFF_IN_MS
-			);
 		}
 
 		setTimeout( poll, pollInterval );
@@ -327,7 +335,8 @@ function registerRoom(
 	room: string,
 	doc: Y.Doc,
 	awareness: Awareness,
-	onSync: () => void
+	onSync: () => void,
+	log: LogFunction
 ): void {
 	if ( roomStates.has( room ) ) {
 		return;
@@ -360,6 +369,7 @@ function registerRoom(
 		clientId: doc.clientID,
 		endCursor: 0,
 		localAwarenessState: awareness.getLocalState() ?? {},
+		log,
 		processAwarenessUpdate: ( state: AwarenessState ) =>
 			processAwarenessUpdate( state, awareness ),
 		processDocUpdate: ( update: SyncUpdate ) =>

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -168,6 +168,8 @@ function processAwarenessUpdate(
 			{
 				added: Array.from( added ),
 				updated: Array.from( updated ),
+				// Left blank on purpose, as the removal of clients is handled in the if condition below.
+				removed: [],
 			},
 		] );
 	}
@@ -294,6 +296,9 @@ function poll(): void {
 				}
 			} );
 		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Error posting sync update:', error );
+
 			// Restore updates to queues on failure so they can be retried.
 			for ( const room of payload.rooms ) {
 				if ( ! roomStates.has( room.room ) ) {


### PR DESCRIPTION
## What?

The polling provider is not syncing any changes after the first change when RTC is enabled.

## Why?

The `removed` property for awareness is not set when awareness changes are being transmitted. Also, there is not console logging in the default provider when an error is encountered during polling.

## How?

The `added`, `updated` and `removed` properties have to always exist when an awareness change is transmitted. We expect them to always be present, which they are via the default awareness methods within Yjs. In our custom provider, we had removed `removed` in https://github.com/WordPress/gutenberg/commit/f0290c638523474238c70632b7a741ab744db044 in favour of the y-protocols method that'd properly remove the client. While that was correct, we should have left the `removed` property as empty and that caused an error to occur.

I have also logged any errors encountered during polling to the console to ensure that, this is caught in the future. This was missed as no logging was present, so the errors were being silently eaten.

## Testing Instructions

1. Pull down this branch
2. Enable RTC via `settings->writing`
3. Open up two browser sessions
4. Make changes in one session and ensure it shows up in the other

### Testing Instructions for Keyboard

N/A
