### PR TITLE
Fix: Font Library reports missing font files via REST API

### DIFF
--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-font-faces-controller-7-0.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-font-faces-controller-7-0.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Font_Faces_Controller_7_0 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Controller which overrides the core WP_REST_Font_Faces_Controller
+ * to add a file_status field indicating whether font files exist on disk.
+ *
+ * @since 20.4.0
+ *
+ * @see WP_REST_Font_Faces_Controller
+ */
+class Gutenberg_REST_Font_Faces_Controller_7_0 extends WP_REST_Font_Faces_Controller {
+
+	/**
+	 * Prepares a single font face output for response.
+	 *
+	 * Adds a 'file_status' field indicating whether local font files exist on disk.
+	 *
+	 * @since 20.4.0
+	 *
+	 * @param WP_Post         $item    Font face post object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		$fields = $this->get_fields_for_response( $request );
+
+		if ( rest_is_field_included( 'file_status', $fields ) ) {
+			$data                = $response->get_data();
+			$data['file_status'] = $this->get_file_status( $item );
+			$response->set_data( $data );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Determines the file status for a font face post.
+	 *
+	 * Checks the `_wp_font_face_file` post meta entries against the filesystem.
+	 * If the meta is empty (external URL or system font), returns 'none'.
+	 * If all referenced files exist on disk, returns 'existing'.
+	 * If any are missing, returns 'missing'.
+	 *
+	 * @since 20.4.0
+	 *
+	 * @param WP_Post $post Font face post object.
+	 * @return string One of 'existing', 'missing', or 'none'.
+	 */
+	private function get_file_status( $post ) {
+		$font_files = get_post_meta( $post->ID, '_wp_font_face_file', false );
+
+		// No local files tracked: external URL or system font.
+		if ( empty( $font_files ) ) {
+			return 'none';
+		}
+
+		$font_dir = wp_get_font_dir();
+
+		// Also check the legacy Gutenberg fonts directory (wp-content/fonts).
+		$site_path = '';
+		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
+			$site_path = '/sites/' . get_current_blog_id();
+		}
+		$legacy_font_dir = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
+
+		foreach ( $font_files as $font_file ) {
+			$standard_path = path_join( $font_dir['basedir'], $font_file );
+			$legacy_path   = $legacy_font_dir . '/' . $font_file;
+
+			if ( ! file_exists( $standard_path ) && ! file_exists( $legacy_path ) ) {
+				return 'missing';
+			}
+		}
+
+		return 'existing';
+	}
+
+	/**
+	 * Retrieves the font face's schema, conforming to JSON Schema.
+	 *
+	 * Adds the 'file_status' property to the schema.
+	 *
+	 * @since 20.4.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['file_status'] = array(
+			'description' => __( 'Status of the font file(s) on disk.', 'gutenberg' ),
+			'type'        => 'string',
+			'enum'        => array( 'existing', 'missing', 'none' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'readonly'    => true,
+		);
+
+		return $schema;
+	}
+}

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -108,3 +108,22 @@ function gutenberg_rest_theme_global_styles_link_rel_7_0( $response, $theme ) {
 	return $response;
 }
 add_filter( 'rest_prepare_theme', 'gutenberg_rest_theme_global_styles_link_rel_7_0', 10, 2 );
+
+/**
+ * Overrides the REST controller for the wp_font_face post type to add
+ * a file_status field indicating whether font files exist on disk.
+ *
+ * @since 20.4.0
+ *
+ * @param array  $args      Array of arguments for registering a post type.
+ * @param string $post_type Post type key.
+ * @return array Modified array of arguments.
+ */
+function gutenberg_override_font_faces_rest_controller_7_0( $args, $post_type ) {
+	if ( 'wp_font_face' === $post_type ) {
+		$args['rest_controller_class']   = 'Gutenberg_REST_Font_Faces_Controller_7_0';
+		$args['late_route_registration'] = true;
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_override_font_faces_rest_controller_7_0', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -68,6 +68,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 7.0 compat.
 	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-block-patterns-controller-7-0.php';
 	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-templates-controller-7-0.php';
+	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-font-faces-controller-7-0.php';
 	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-static-templates-controller.php';
 	require __DIR__ . '/compat/wordpress-7.0/template-activate.php';
 	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';

--- a/lib/remove-core-enqueue-scripts.php
+++ b/lib/remove-core-enqueue-scripts.php
@@ -10,3 +10,12 @@
 
 remove_action( 'admin_enqueue_scripts', 'wp_font_library_wp_admin_enqueue_scripts' );
 remove_action( 'admin_enqueue_scripts', 'wp_site_editor_v2_wp_admin_enqueue_scripts' );
+
+// Also remove Core's route registration callbacks from page init actions.
+// Even though we remove Core's enqueue_scripts above, the plugin's enqueue
+// functions fire the same init actions, which would trigger Core's route
+// registration (registering modules with Core URLs instead of plugin URLs).
+remove_action( 'font-library-wp-admin_init', 'wp_register_font_library_wp_admin_page_routes' );
+remove_action( 'font-library_init', 'wp_register_font_library_page_routes' );
+remove_action( 'site-editor_init', 'wp_register_site_editor_page_routes' );
+remove_action( 'site-editor-wp-admin_init', 'wp_register_site_editor_wp_admin_page_routes' );

--- a/packages/core-data/src/entity-types/font-collection.ts
+++ b/packages/core-data/src/entity-types/font-collection.ts
@@ -54,6 +54,7 @@ export interface CollectionFontFamily {
 export interface CollectionFontFace {
 	id: string;
 	font_face_settings: FontFace;
+	file_status?: 'existing' | 'missing' | 'none';
 }
 
 export type FontCollection< C extends Context = 'edit' > =

--- a/packages/core-data/src/entity-types/font-family.ts
+++ b/packages/core-data/src/entity-types/font-family.ts
@@ -39,6 +39,7 @@ declare module './base-entity-records' {
 					font_faces?: Array< {
 						id: string;
 						font_face_settings: FontFace;
+						file_status?: 'existing' | 'missing' | 'none';
 					} >;
 				},
 				'view' | 'edit',
@@ -85,6 +86,7 @@ export interface FontFace {
 	fontFeatureSettings?: string;
 	fontVariationSettings?: string;
 	unicodeRange?: string;
+	fileStatus?: 'existing' | 'missing' | 'none';
 }
 
 export type WpFontFamily< C extends Context = 'edit' > = OmitNevers<

--- a/packages/global-styles-ui/src/font-library/context.tsx
+++ b/packages/global-styles-ui/src/font-library/context.tsx
@@ -82,9 +82,10 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 				id: fontFamilyPost.id,
 				...( fontFamilyPost.font_family_settings || {} ),
 				fontFace:
-					fontFamilyPost?._embedded?.font_faces?.map(
-						( face ) => face.font_face_settings
-					) || [],
+					fontFamilyPost?._embedded?.font_faces?.map( ( face ) => ( {
+						...face.font_face_settings,
+						fileStatus: face.file_status,
+					} ) ) || [],
 			};
 		} ) || [];
 
@@ -267,10 +268,10 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 							fontFace:
 								(
 									fontFamilyPost?._embedded?.font_faces ?? []
-								).map(
-									( face: CollectionFontFace ) =>
-										face.font_face_settings
-								) || [],
+								).map( ( face: CollectionFontFace ) => ( {
+									...face.font_face_settings,
+									fileStatus: face.file_status,
+								} ) ) || [],
 					  }
 					: null;
 
@@ -340,7 +341,10 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 					// Use font data from REST API not from client to ensure
 					// correct font information is used.
 					installedFontFamily.fontFace = [
-						...successfullyInstalledFontFaces,
+						...successfullyInstalledFontFaces.map( ( face ) => ( {
+							...face,
+							fileStatus: face.fileStatus ?? 'existing',
+						} ) ),
 					];
 
 					fontFamiliesToActivate.push( installedFontFamily );
@@ -492,6 +496,10 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		fonts.forEach( ( font ) => {
 			if ( font.fontFace ) {
 				font.fontFace.forEach( ( face ) => {
+					// Skip loading font faces with missing files.
+					if ( face.fileStatus === 'missing' ) {
+						return;
+					}
 					const displaySrc = getDisplaySrcFromFontFace(
 						face?.src ?? ''
 					);
@@ -528,7 +536,7 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		} else {
 			const displaySrc = getDisplaySrcFromFontFace( face?.src ?? '' );
 			// If the font doesn't have a src, don't load it.
-			if ( face && displaySrc ) {
+			if ( face && displaySrc && face.fileStatus !== 'missing' ) {
 				loadFontFaceInBrowser( face, displaySrc, 'all' );
 			}
 		}
@@ -537,6 +545,10 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 	const loadFontFaceAsset = async ( fontFace: FontFace ) => {
 		// If the font doesn't have a src, don't load it.
 		if ( ! fontFace.src ) {
+			return;
+		}
+		// Skip loading font faces with missing files.
+		if ( fontFace.fileStatus === 'missing' ) {
 			return;
 		}
 		// Get the src of the font.

--- a/packages/global-styles-ui/src/font-library/font-demo.tsx
+++ b/packages/global-styles-ui/src/font-library/font-demo.tsx
@@ -90,7 +90,11 @@ function FontDemo( { font, text }: FontDemoProps ) {
 	useEffect( () => {
 		const loadAsset = async () => {
 			if ( isIntersecting ) {
-				if ( ! isPreviewImage && fontFace.src ) {
+				// Skip loading font faces with missing files.
+				const isMissing =
+					'fileStatus' in fontFace &&
+					fontFace.fileStatus === 'missing';
+				if ( ! isPreviewImage && fontFace.src && ! isMissing ) {
 					await loadFontFaceAsset( fontFace );
 				}
 				setIsAssetLoaded( true );

--- a/packages/global-styles-ui/src/font-library/installed-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/installed-fonts.tsx
@@ -165,12 +165,27 @@ function InstalledFonts() {
 			font.slug,
 			font.source
 		).length;
-		return sprintf(
+		const variantsMissing =
+			font?.fontFace?.filter( ( face ) => face.fileStatus === 'missing' )
+				.length ?? 0;
+		const activeText = sprintf(
 			/* translators: 1: Active font variants, 2: Total font variants. */
 			__( '%1$d/%2$d variants active' ),
 			variantsActive,
 			variantsInstalled
 		);
+		if ( variantsMissing > 0 ) {
+			return (
+				activeText +
+				', ' +
+				sprintf(
+					/* translators: %d: Number of font variants with missing files. */
+					__( '%d missing' ),
+					variantsMissing
+				)
+			);
+		}
+		return activeText;
 	};
 
 	useEffect( () => {
@@ -218,7 +233,7 @@ function InstalledFonts() {
 			libraryFontSelected.fontFace.forEach( ( face ) => {
 				if ( isSelectAllChecked ) {
 					unloadFontFaceInBrowser( face, 'all' );
-				} else {
+				} else if ( face.fileStatus !== 'missing' ) {
 					const displaySrc = getDisplaySrcFromFontFace(
 						face?.src ?? ''
 					);

--- a/packages/global-styles-ui/src/font-library/library-font-variant.tsx
+++ b/packages/global-styles-ui/src/font-library/library-font-variant.tsx
@@ -2,7 +2,9 @@
  * WordPress dependencies
  */
 import { useContext, useId } from '@wordpress/element';
-import { CheckboxControl, Flex } from '@wordpress/components';
+import { CheckboxControl, Flex, Icon, Tooltip } from '@wordpress/components';
+import { cautionFilled } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 import type { FontFace, FontFamily } from '@wordpress/core-data';
 
 /**
@@ -32,6 +34,8 @@ function LibraryFontVariant( {
 			  )
 			: isFontActivated( font.slug, undefined, undefined, font.source );
 
+	const isMissingFile = face.fileStatus === 'missing';
+
 	const handleToggleActivation = () => {
 		if ( ( font?.fontFace?.length ?? 0 ) > 0 ) {
 			toggleActivateFont( font, face );
@@ -44,7 +48,11 @@ function LibraryFontVariant( {
 	const checkboxId = useId();
 
 	return (
-		<div className="font-library__font-card">
+		<div
+			className={ `font-library__font-card${
+				isMissingFile ? ' has-missing-file' : ''
+			}` }
+		>
 			<Flex justify="flex-start" align="center" gap="1rem">
 				<CheckboxControl
 					checked={ isInstalled }
@@ -58,6 +66,17 @@ function LibraryFontVariant( {
 						onClick={ handleToggleActivation }
 					/>
 				</label>
+				{ isMissingFile && (
+					<Tooltip
+						text={ __(
+							'Font file not found on the server. The file may have been deleted.'
+						) }
+					>
+						<span className="font-library__missing-file-icon">
+							<Icon icon={ cautionFilled } size={ 20 } />
+						</span>
+					</Tooltip>
+				) }
 			</Flex>
 		</div>
 	);

--- a/packages/global-styles-ui/src/font-library/style.scss
+++ b/packages/global-styles-ui/src/font-library/style.scss
@@ -214,6 +214,20 @@ button.font-library__upload-area {
 	}
 }
 
+.font-library__font-card.has-missing-file {
+	.font-library__font-variant_demo-text {
+		opacity: 0.5;
+		text-decoration: line-through;
+	}
+}
+
+.font-library__missing-file-icon {
+	color: colors.$alert-red;
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+}
+
 .font-library__select-all {
 	padding:
 		variables.$grid-unit-20 variables.$grid-unit-20

--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -123,7 +123,18 @@ export async function loadFontFaceInBrowser(
 		}
 	);
 
-	const loadedFace = await newFont.load();
+	let loadedFace;
+	try {
+		loadedFace = await newFont.load();
+	} catch ( error ) {
+		// Font file may be missing or corrupt. Log and bail gracefully.
+		// eslint-disable-next-line no-console
+		console.warn(
+			`Failed to load font face "${ fontFace.fontFamily }" (${ fontFace.fontStyle } ${ fontFace.fontWeight }):`,
+			error
+		);
+		return;
+	}
 
 	if ( addTo === 'document' || addTo === 'all' ) {
 		document.fonts.add( loadedFace );

--- a/phpunit/tests/fonts/font-library/fontFaceFileStatus.php
+++ b/phpunit/tests/fonts/font-library/fontFaceFileStatus.php
@@ -46,13 +46,13 @@ class Tests_Font_Face_File_Status extends WP_UnitTestCase {
 	 */
 	public function test_file_status_existing_when_file_exists() {
 		wp_set_current_user( self::$super_admin_id );
-		$font_family_id = $this->create_font_family();
+		$font_family_id  = $this->create_font_family();
 		$create_response = $this->create_font_face_with_upload( $font_family_id );
 
 		$this->assertSame( 201, $create_response->get_status(), 'The font face should be created successfully.' );
 
-		$create_data   = $create_response->get_data();
-		$font_face_id  = $create_data['id'];
+		$create_data  = $create_response->get_data();
+		$font_face_id = $create_data['id'];
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families/' . $font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );

--- a/phpunit/tests/fonts/font-library/fontFaceFileStatus.php
+++ b/phpunit/tests/fonts/font-library/fontFaceFileStatus.php
@@ -1,0 +1,291 @@
+<?php
+// @core-merge: Do not include these tests, they are for Gutenberg only.
+
+/**
+ * Tests the file_status field added by Gutenberg_REST_Font_Faces_Controller_7_0.
+ *
+ * @package WordPress
+ * @subpackage Font Library
+ *
+ * @group fonts
+ * @group font-library
+ *
+ * @covers Gutenberg_REST_Font_Faces_Controller_7_0
+ */
+class Tests_Font_Face_File_Status extends WP_UnitTestCase {
+	/**
+	 * ID of a super admin user.
+	 *
+	 * @var int
+	 */
+	protected static $super_admin_id;
+
+	/**
+	 * Sets up test class.
+	 *
+	 * @param WP_UnitTest_Factory $factory Unit test factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$super_admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		grant_super_admin( self::$super_admin_id );
+	}
+
+	/**
+	 * Tears down test class.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$super_admin_id );
+	}
+
+	/**
+	 * Tests that file_status is 'existing' when font files exist on disk.
+	 */
+	public function test_file_status_existing_when_file_exists() {
+		wp_set_current_user( self::$super_admin_id );
+		$font_family_id = $this->create_font_family();
+		$create_response = $this->create_font_face_with_upload( $font_family_id );
+
+		$this->assertSame( 201, $create_response->get_status(), 'The font face should be created successfully.' );
+
+		$create_data   = $create_response->get_data();
+		$font_face_id  = $create_data['id'];
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families/' . $font_family_id . '/font-faces/' . $font_face_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'file_status', $data, 'Response should include file_status field.' );
+		$this->assertSame( 'existing', $data['file_status'], 'file_status should be "existing" when font file is on disk.' );
+
+		// Clean up.
+		wp_delete_post( $font_family_id, true );
+	}
+
+	/**
+	 * Tests that file_status is 'missing' when font files have been deleted from disk.
+	 */
+	public function test_file_status_missing_when_file_deleted() {
+		wp_set_current_user( self::$super_admin_id );
+		$font_family_id  = $this->create_font_family();
+		$create_response = $this->create_font_face_with_upload( $font_family_id );
+
+		$this->assertSame( 201, $create_response->get_status(), 'The font face should be created successfully.' );
+
+		$create_data  = $create_response->get_data();
+		$font_face_id = $create_data['id'];
+
+		// Delete the font file from disk.
+		$font_path = str_replace( content_url(), WP_CONTENT_DIR, $create_data['font_face_settings']['src'] );
+		$this->assertTrue( file_exists( $font_path ), 'Font file should exist before deletion.' );
+		unlink( $font_path );
+		$this->assertFalse( file_exists( $font_path ), 'Font file should be deleted.' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families/' . $font_family_id . '/font-faces/' . $font_face_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'missing', $data['file_status'], 'file_status should be "missing" when font file is deleted from disk.' );
+
+		// Clean up.
+		wp_delete_post( $font_family_id, true );
+	}
+
+	/**
+	 * Tests that file_status is 'none' when font face has no local file (external URL or system font).
+	 */
+	public function test_file_status_none_when_no_local_file() {
+		wp_set_current_user( self::$super_admin_id );
+		$font_family_id = $this->create_font_family();
+
+		// Create a font face post directly with an external URL (no _wp_font_face_file meta).
+		$font_face_id = self::factory()->post->create(
+			wp_slash(
+				array(
+					'post_type'    => 'wp_font_face',
+					'post_parent'  => $font_family_id,
+					'post_status'  => 'publish',
+					'post_title'   => '',
+					'post_name'    => 'open-sans-normal-400',
+					'post_content' => wp_json_encode(
+						array(
+							'fontFamily' => '"Open Sans"',
+							'fontWeight' => '400',
+							'fontStyle'  => 'normal',
+							'src'        => 'https://fonts.example.com/open-sans-regular.woff2',
+						)
+					),
+				)
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families/' . $font_family_id . '/font-faces/' . $font_face_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'none', $data['file_status'], 'file_status should be "none" when font face has no local file.' );
+
+		// Clean up.
+		wp_delete_post( $font_family_id, true );
+	}
+
+	/**
+	 * Tests that file_status is 'existing' when font file exists in the legacy wp-content/fonts directory.
+	 */
+	public function test_file_status_existing_in_legacy_directory() {
+		wp_set_current_user( self::$super_admin_id );
+		$font_family_id = $this->create_font_family();
+
+		// Upload font to the legacy directory.
+		add_filter( 'font_dir', array( $this, 'filter_font_dir' ) );
+		$create_response = $this->create_font_face_with_upload( $font_family_id );
+		remove_filter( 'font_dir', array( $this, 'filter_font_dir' ) );
+
+		$this->assertSame( 201, $create_response->get_status(), 'The font face should be created successfully.' );
+
+		$create_data  = $create_response->get_data();
+		$font_face_id = $create_data['id'];
+		$font_path    = str_replace( content_url(), WP_CONTENT_DIR, $create_data['font_face_settings']['src'] );
+
+		$this->assertFalse( str_contains( $font_path, 'uploads' ), 'Font file should be in wp-content/fonts, not uploads.' );
+		$this->assertTrue( file_exists( $font_path ), 'Font file should exist in legacy directory.' );
+
+		// Query WITHOUT the legacy dir filter — the controller should still find it.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families/' . $font_family_id . '/font-faces/' . $font_face_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'existing', $data['file_status'], 'file_status should be "existing" when font file is in the legacy directory.' );
+
+		// Clean up.
+		wp_delete_post( $font_family_id, true );
+	}
+
+	/**
+	 * Tests that file_status is included in the schema.
+	 */
+	public function test_file_status_in_schema() {
+		$controller = new Gutenberg_REST_Font_Faces_Controller_7_0( 'wp_font_face' );
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'file_status', $schema['properties'], 'Schema should include file_status property.' );
+		$this->assertSame( 'string', $schema['properties']['file_status']['type'] );
+		$this->assertSame(
+			array( 'existing', 'missing', 'none' ),
+			$schema['properties']['file_status']['enum'],
+			'file_status enum should include existing, missing, and none.'
+		);
+		$this->assertTrue( $schema['properties']['file_status']['readonly'], 'file_status should be readonly.' );
+	}
+
+	/**
+	 * Tests that file_status is included when listing font faces.
+	 */
+	public function test_file_status_in_list_response() {
+		wp_set_current_user( self::$super_admin_id );
+		$font_family_id  = $this->create_font_family();
+		$create_response = $this->create_font_face_with_upload( $font_family_id );
+
+		$this->assertSame( 201, $create_response->get_status() );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families/' . $font_family_id . '/font-faces' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotEmpty( $data, 'Font faces list should not be empty.' );
+		$this->assertArrayHasKey( 'file_status', $data[0], 'List response should include file_status.' );
+		$this->assertSame( 'existing', $data[0]['file_status'] );
+
+		// Clean up.
+		wp_delete_post( $font_family_id, true );
+	}
+
+	/**
+	 * Sets the font upload directory to wp-content/fonts, the default previously used in Gutenberg.
+	 *
+	 * @param array $font_dir Font directory settings.
+	 * @return array Filtered font directory settings.
+	 */
+	public function filter_font_dir( $font_dir ) {
+		$site_path = '';
+		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
+			$site_path = '/sites/' . get_current_blog_id();
+		}
+
+		$font_dir['path']    = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
+		$font_dir['url']     = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
+		$font_dir['basedir'] = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
+		$font_dir['baseurl'] = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
+
+		return $font_dir;
+	}
+
+	/**
+	 * Creates a font family post for testing.
+	 *
+	 * @return int Font family post ID.
+	 */
+	protected function create_font_family() {
+		return self::factory()->post->create(
+			wp_slash(
+				array(
+					'post_type'    => 'wp_font_family',
+					'post_status'  => 'publish',
+					'post_title'   => 'Open Sans',
+					'post_name'    => 'open-sans',
+					'post_content' => wp_json_encode(
+						array(
+							'fontFamily' => '"Open Sans"',
+						)
+					),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Creates a font face post with a file upload under the specified font family.
+	 *
+	 * @param int $font_family_id Font family post ID.
+	 * @return WP_REST_Response REST response object.
+	 */
+	protected function create_font_face_with_upload( $font_family_id ) {
+		$font_file = GUTENBERG_DIR_TESTDATA . 'fonts/OpenSans-Regular.woff2';
+		$font_path = wp_tempnam( 'OpenSans-Regular.woff2' );
+		copy( $font_file, $font_path );
+
+		$files = array(
+			'file-0' => array(
+				'name'      => 'OpenSans-Regular.woff2',
+				'full_path' => 'OpenSans-Regular.woff2',
+				'type'      => 'font/woff2',
+				'tmp_name'  => $font_path,
+				'error'     => 0,
+				'size'      => filesize( $font_path ),
+			),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . $font_family_id . '/font-faces' );
+		$request->set_param(
+			'font_face_settings',
+			wp_json_encode(
+				array(
+					'fontFamily' => '"Open Sans"',
+					'fontWeight' => '400',
+					'fontStyle'  => 'normal',
+					'src'        => 'file-0',
+				)
+			)
+		);
+		$request->set_file_params( $files );
+		return rest_get_server()->dispatch( $request );
+	}
+}


### PR DESCRIPTION
## What?

Closes #58375

When font files are manually deleted via FTP, the Font Library now detects this and shows visual warnings instead of throwing unhandled DOMException.

## Why?

Users could delete font files via FTP while the Font Library still showed them as "installed" (database records remained). The browser would fail to load the missing fonts with an unhandled DOMException, providing no feedback to the user.

## How?

- **Backend**: Override Core's `WP_REST_Font_Faces_Controller` to add a `file_status` field that checks if font files exist on disk
- **Frontend**: Consume the `file_status` field to show warnings (strikethrough + caution icon), skip loading missing fonts, and report missing counts in the UI
- **Routes**: Fix Core's route module registrations to use the plugin's versions on the standalone Fonts page

## Testing Instructions

1. Install a Google font via Font Library (Settings > Typography > Manage Fonts or separate Fonts page)
2. Manually delete some font files from `wp-content/uploads/fonts/` or legacy `wp-content/fonts/`
3. Reload the Font Library — verify missing fonts show:
   - Strikethrough text and opacity reduction
   - Caution icon with tooltip "Font file not found on the server"
   - Missing count in the variant text (e.g., "2/4 active, 1 missing")
4. Open browser console — verify no DOMException or 404 errors (only `console.warn`)
5. Uninstall and reinstall the font — verify it works normally again

### Testing Instructions for Keyboard

1. Navigate to Settings > Typography > Manage Fonts using Tab
2. Use Tab to focus the caution icon for a missing font variant
3. Press Enter to reveal the tooltip describing the missing file status