### PR TITLE
Boot: Fix mobile admin bar covering single-page headers

### DIFF
--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -47,6 +47,10 @@
 	top: 0;
 	left: 0;
 	right: 0;
+
+	.boot-layout--single-page & {
+		top: variables.$admin-bar-height-big;
+	}
 	z-index: 3;
 	background: var(--wpds-color-bg-surface-neutral, #fff);
 	padding: variables.$grid-unit-20;
@@ -96,6 +100,11 @@
 	border-radius: 0;
 	margin: 0;
 
+	.boot-layout--single-page & {
+		top: variables.$admin-bar-height-big;
+		height: calc(100vh - variables.$admin-bar-height-big);
+	}
+
 	// Desktop: restore original styles
 	@include mixins.break-medium {
 		position: static;
@@ -142,6 +151,11 @@
 	z-index: 1; // Lowest surface priority
 	border-radius: 0;
 	margin: 0;
+
+	.boot-layout--single-page & {
+		top: variables.$admin-bar-height-big;
+		height: calc(100vh - variables.$admin-bar-height-big);
+	}
 
 	// Desktop: restore original styles
 	@include mixins.break-medium {
@@ -190,4 +204,12 @@
 	border: none;
 	box-shadow: none;
 	overflow: hidden;
+
+	.boot-layout--single-page & {
+		top: variables.$admin-bar-height-big;
+
+		@include mixins.break-medium {
+			top: variables.$admin-bar-height;
+		}
+	}
 }


### PR DESCRIPTION
## What?

Closes https://github.com/megane9988/gutenberg/issues/11
Closes https://github.com/WordPress/gutenberg/issues/75231 

Fixes the issue where the mobile WordPress admin bar (masterbar) covers page headers when using the Boot package in single-page mode within wp-admin.

## Why?

The Boot package's fixed-positioned canvas and surface elements on mobile viewports were not accounting for the admin bar height (46px), causing them to extend behind the admin bar and obscure page content.

## How?

Scoped the admin bar offset to `.boot-layout--single-page` class (used when Boot is embedded in wp-admin). On mobile, fixed elements now:
- Start at `top: $admin-bar-height-big` (46px) instead of `top: 0`
- Have heights reduced by the admin bar offset
- On desktop/full-screen, use `$admin-bar-height` (32px) where applicable

Full-page Boot usage (e.g., site editor) is unaffected since it doesn't use the single-page class.

## Testing Instructions

1. Create a block theme or use Assembler theme
2. Go to Appearance → Fonts page in wp-admin
3. Open DevTools and set mobile viewport (< 782px wide)
4. Verify the "Fonts" page header is now visible below the admin bar
5. Verify desktop viewport (> 782px) still displays correctly
6. Test full-screen editor mode on both mobile and desktop viewports

### Testing Instructions for Keyboard

Navigate to Appearance → Fonts using keyboard (Tab key), verify the page header is visible below the admin bar when viewport is resized to mobile width.