### PR TITLE
Fix: Changing URL in link after changing text outside the popover resets it

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -169,16 +169,21 @@ function InlineLinkUI( {
 
 			return;
 		} else if ( newText === richTextText ) {
-			// Use explicit format boundaries rather than relying on the
-			// current selection which may be collapsed or misaligned.
-			const boundary = getFormatBoundary( value, {
-				type: 'core/link',
-			} );
+			// Use explicit format boundaries rather than relying on
+			// the current selection which may be collapsed or
+			// misaligned after external value changes.
+			const boundary = isActive
+				? getFormatBoundary( value, {
+						type: 'core/link',
+				  } )
+				: undefined;
 			newValue = applyFormat(
 				value,
 				linkFormat,
-				boundary.start,
-				boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET
+				boundary?.start,
+				boundary?.end
+					? boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET
+					: undefined
 			);
 		} else {
 			// Scenario: Editing an existing link.

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -31,7 +31,9 @@ import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
 import CSSClassesSettingComponent from './css-classes-setting';
 
-// CSSClassesSettingComponent moved to its own file and imported above.
+// Text *selection* always extends +1 beyond the edge of the format.
+// This offset accounts for that when calculating the format boundaries for active formats.
+const FORMAT_BOUNDARY_EDGE_OFFSET = 1;
 
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
@@ -167,7 +169,17 @@ function InlineLinkUI( {
 
 			return;
 		} else if ( newText === richTextText ) {
-			newValue = applyFormat( value, linkFormat );
+			// Use explicit format boundaries rather than relying on the
+			// current selection which may be collapsed or misaligned.
+			const boundary = getFormatBoundary( value, {
+				type: 'core/link',
+			} );
+			newValue = applyFormat(
+				value,
+				linkFormat,
+				boundary.start,
+				boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET
+			);
 		} else {
 			// Scenario: Editing an existing link.
 
@@ -319,9 +331,7 @@ function getRichTextValueFromSelection( value, isActive ) {
 
 		textStart = boundary.start;
 
-		// Text *selection* always extends +1 beyond the edge of the format.
-		// We account for that here.
-		textEnd = boundary.end + 1;
+		textEnd = boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET;
 	}
 
 	// Get a RichTextValue containing the selected text content.

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -31,10 +31,7 @@ import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
 import CSSClassesSettingComponent from './css-classes-setting';
 
-// Text *selection* always extends +1 beyond the edge of the format.
-// This offset accounts for that when calculating the format boundaries for active formats.
 const FORMAT_BOUNDARY_EDGE_OFFSET = 1;
-
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
@@ -181,7 +178,8 @@ function InlineLinkUI( {
 				value,
 				linkFormat,
 				boundary?.start,
-				boundary?.end
+				// Text *selection* always extends +1 beyond the edge of the format. Account for it.
+				boundary?.end !== undefined
 					? boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET
 					: undefined
 			);
@@ -335,7 +333,7 @@ function getRichTextValueFromSelection( value, isActive ) {
 		} );
 
 		textStart = boundary.start;
-
+		// Text *selection* always extends +1 beyond the edge of the format. Account for it.
 		textEnd = boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET;
 	}
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -168,16 +168,14 @@ function InlineLinkUI( {
 			// Use explicit format boundaries rather than relying on
 			// the current selection which may be collapsed or
 			// misaligned after external value changes.
-			const boundary = isActive
-				? getFormatBoundary( value, {
-						type: 'core/link',
-				  } )
-				: undefined;
+			const boundary = getFormatBoundary( value, {
+				type: 'core/link',
+			} );
 			newValue = applyFormat(
 				value,
 				linkFormat,
-				boundary?.start,
-				boundary?.end
+				boundary.start,
+				boundary.end
 			);
 		} else {
 			// Scenario: Editing an existing link.

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -31,7 +31,6 @@ import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
 import CSSClassesSettingComponent from './css-classes-setting';
 
-const FORMAT_BOUNDARY_EDGE_OFFSET = 1;
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
@@ -178,10 +177,7 @@ function InlineLinkUI( {
 				value,
 				linkFormat,
 				boundary?.start,
-				// Text *selection* always extends +1 beyond the edge of the format. Account for it.
-				boundary?.end !== undefined
-					? boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET
-					: undefined
+				boundary?.end
 			);
 		} else {
 			// Scenario: Editing an existing link.
@@ -333,8 +329,7 @@ function getRichTextValueFromSelection( value, isActive ) {
 		} );
 
 		textStart = boundary.start;
-		// Text *selection* always extends +1 beyond the edge of the format. Account for it.
-		textEnd = boundary.end + FORMAT_BOUNDARY_EDGE_OFFSET;
+		textEnd = boundary.end;
 	}
 
 	// Get a RichTextValue containing the selected text content.

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -127,8 +127,8 @@ describe( 'getFormatBoundary', () => {
 			expect(
 				getFormatBoundary( record, { type: 'core/link' } )
 			).toEqual( {
-				start: null,
-				end: null,
+				start: undefined,
+				end: undefined,
 			} );
 		} );
 
@@ -168,8 +168,8 @@ describe( 'getFormatBoundary', () => {
 				expect(
 					getFormatBoundary( record, { type: 'core/link' } )
 				).toEqual( {
-					start: null,
-					end: null,
+					start: undefined,
+					end: undefined,
 				} );
 			}
 		);
@@ -213,8 +213,8 @@ describe( 'getFormatBoundary', () => {
 				expect(
 					getFormatBoundary( record, { type: 'core/link' } )
 				).toEqual( {
-					start: null,
-					end: null,
+					start: undefined,
+					end: undefined,
 				} );
 			}
 		);

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -254,7 +254,7 @@ describe( 'getFormatBoundary', () => {
 					getFormatBoundary( record, { type: 'core/link' } )
 				).toEqual( {
 					start: 6,
-					end: 10,
+					end: 11,
 				} );
 			}
 		);
@@ -289,7 +289,7 @@ describe( 'getFormatBoundary', () => {
 				getFormatBoundary( record, { type: 'core/link' } )
 			).toEqual( {
 				start: 6,
-				end: 10,
+				end: 11,
 			} );
 		} );
 	} );
@@ -332,7 +332,7 @@ describe( 'getFormatBoundary', () => {
 					getFormatBoundary( record, { type: 'core/link' } )
 				).toEqual( {
 					start: 6,
-					end: 10,
+					end: 11,
 				} );
 			}
 		);
@@ -381,7 +381,7 @@ describe( 'getFormatBoundary', () => {
 
 		expect( getFormatBoundary( record, { type: 'core/link' } ) ).toEqual( {
 			start: 0,
-			end: 5,
+			end: 6,
 		} );
 	} );
 
@@ -417,7 +417,7 @@ describe( 'getFormatBoundary', () => {
 				getFormatBoundary( record, { type: 'core/bold' } )
 			).toEqual( {
 				start: 4,
-				end: 6,
+				end: 7,
 			} );
 		} );
 	} );
@@ -453,7 +453,7 @@ describe( 'getFormatBoundary', () => {
 			)
 		).toEqual( {
 			start: 0,
-			end: 4,
+			end: 5,
 		} );
 	} );
 } );

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -210,10 +210,14 @@ export function getFormatBoundary(
 	// Safe guard: start index cannot be less than 0.
 	startIndex = startIndex < 0 ? 0 : startIndex;
 
-	// // Return the indices of the "edges" as the boundaries.
+	// Return the indices of the "edges" as the boundaries.
+	// walkToEnd returns the last index that has the format (e.g. 10),
+	// but rich-text APIs like applyFormat and slice expect the end to be
+	// one position past the last character (e.g. 11), just like
+	// String.prototype.slice. Adding 1 here so consumers don't have to.
 	return {
 		start: startIndex,
-		end: endIndex,
+		end: endIndex + 1,
 	};
 }
 

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -152,8 +152,8 @@ export function getFormatBoundary(
 	endIndex = value.end
 ) {
 	const EMPTY_BOUNDARIES = {
-		start: null,
-		end: null,
+		start: undefined,
+		end: undefined,
 	};
 
 	const { formats } = value;

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -683,6 +683,47 @@ test.describe( 'Links', () => {
 		] );
 	} );
 
+	test( 'correctly updates the link when caret at outer edge of format boundary', async ( {
+		page,
+		editor,
+		LinkUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'<a href="https://wordpress.org/gutenberg">Gutenberg</a> is awesome',
+			},
+		} );
+
+		// Change the link text by typing to trigger a RichText value change.
+		await editor.canvas
+			.getByRole( 'link', { name: 'Gutenberg' } )
+			.dblclick();
+		await page.keyboard.type( 'Block Editor' );
+
+		const linkPopover = LinkUtils.getLinkPopover();
+		await expect( linkPopover ).toBeVisible();
+
+		// Edit only the URL.
+		await linkPopover.getByRole( 'button', { name: 'Edit' } ).click();
+		await linkPopover
+			.getByPlaceholder( 'Search or type URL' )
+			.fill( 'https://wordpress.org' );
+		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
+
+		// The link should have the updated URL.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content:
+						'<a href="https://wordpress.org">Block Editor</a> is awesome',
+				},
+			},
+		] );
+	} );
+
 	test( 'toggle state of advanced link settings is preserved across editing links', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -683,51 +683,6 @@ test.describe( 'Links', () => {
 		] );
 	} );
 
-	test( 'should preserve URL when only the URL is updated after the rich text value changes', async ( {
-		page,
-		editor,
-		LinkUtils,
-	} ) => {
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: {
-				content:
-					'<a href="https://wordpress.org/gutenberg">Gutenberg</a> is awesome',
-			},
-		} );
-
-		// Change the link text by typing to trigger a RichText value change.
-		await editor.canvas
-			.getByRole( 'link', { name: 'Gutenberg' } )
-			.dblclick();
-		await page.keyboard.type( 'Block Editor' );
-
-		// Click on the link to open the Link UI with a collapsed cursor.
-		await editor.canvas
-			.getByRole( 'link', { name: 'Block Editor' } )
-			.click();
-
-		const linkPopover = LinkUtils.getLinkPopover();
-		await expect( linkPopover ).toBeVisible();
-
-		// Edit only the URL.
-		await linkPopover.getByRole( 'button', { name: 'Edit' } ).click();
-		await linkPopover.getByPlaceholder( 'Search or type URL' ).fill( '' );
-		await page.keyboard.type( 'https://wordpress.org' );
-		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
-
-		// The link should have the updated URL.
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/paragraph',
-				attributes: {
-					content:
-						'<a href="https://wordpress.org">Block Editor</a> is awesome',
-				},
-			},
-		] );
-	} );
-
 	test( 'toggle state of advanced link settings is preserved across editing links', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -683,6 +683,51 @@ test.describe( 'Links', () => {
 		] );
 	} );
 
+	test( 'should preserve URL when only the URL is updated after the rich text value changes', async ( {
+		page,
+		editor,
+		LinkUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'<a href="https://wordpress.org/gutenberg">Gutenberg</a> is awesome',
+			},
+		} );
+
+		// Change the link text by typing to trigger a RichText value change.
+		await editor.canvas
+			.getByRole( 'link', { name: 'Gutenberg' } )
+			.dblclick();
+		await page.keyboard.type( 'Block Editor' );
+
+		// Click on the link to open the Link UI with a collapsed cursor.
+		await editor.canvas
+			.getByRole( 'link', { name: 'Block Editor' } )
+			.click();
+
+		const linkPopover = LinkUtils.getLinkPopover();
+		await expect( linkPopover ).toBeVisible();
+
+		// Edit only the URL.
+		await linkPopover.getByRole( 'button', { name: 'Edit' } ).click();
+		await linkPopover.getByPlaceholder( 'Search or type URL' ).fill( '' );
+		await page.keyboard.type( 'https://wordpress.org' );
+		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
+
+		// The link should have the updated URL.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content:
+						'<a href="https://wordpress.org">Block Editor</a> is awesome',
+				},
+			},
+		] );
+	} );
+
 	test( 'toggle state of advanced link settings is preserved across editing links', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?
Closes #52659.
Closes #53533.

PR fixes a bug where URL changes weren't persistent after changing the link text in canvas. The bug has diverged slightly from the original report, but it still exists on trunk.

P.S. I wanted to include e2e test coverage, but for some reason, tests were always passing on trunk. It was a similar case for #53533.

## How?
Use explicit format boundaries rather than relying on the current selection, which may be collapsed or misaligned.

## Testing Instructions
1. Open a post or page. 
2. Add a paragraph with a link.
3. Change the link text.
4. Open the link popover and change the URL.
5. Apply changes and confirm they're persisted.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/4cb0a3c5-928f-4261-9a2a-fb5a272493de

**After**

https://github.com/user-attachments/assets/f2458c16-640c-491d-9b36-4fab990a88c3

