### PR TITLE
Fix: ISO 8601 compliant year formatting in TimePicker

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#75343](https://github.com/WordPress/gutenberg/pull/75343)).
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).

--- a/packages/components/src/date-time/stories/time.story.tsx
+++ b/packages/components/src/date-time/stories/time.story.tsx
@@ -60,29 +60,6 @@ Default.args = {
 	currentTime: new Date(),
 };
 
-/**
- * Test story for ISO 8601 zero-padding with years below 1000.
- * Open browser console to see zero-padded output format.
- */
-export const YearBelow1000: StoryFn< typeof TimePicker > = () => {
-	const [ time, setTime ] = useState( '0999-10-18T11:00:00' );
-	return (
-		<div>
-			<p>
-				Current value: <code>{ time }</code>
-			</p>
-			<TimePicker
-				currentTime={ time }
-				onChange={ ( newTime ) => {
-					console.log( '🔍 onChange output:', newTime );
-					setTime( newTime );
-				} }
-				is12Hour
-			/>
-		</div>
-	);
-};
-
 const TimeInputTemplate: StoryFn< typeof TimePicker.TimeInput > = ( args ) => {
 	return <TimePicker.TimeInput { ...args } />;
 };

--- a/packages/components/src/date-time/stories/time.story.tsx
+++ b/packages/components/src/date-time/stories/time.story.tsx
@@ -60,6 +60,29 @@ Default.args = {
 	currentTime: new Date(),
 };
 
+/**
+ * Test story for ISO 8601 zero-padding with years below 1000.
+ * Open browser console to see zero-padded output format.
+ */
+export const YearBelow1000: StoryFn< typeof TimePicker > = () => {
+	const [ time, setTime ] = useState( '0999-10-18T11:00:00' );
+	return (
+		<div>
+			<p>
+				Current value: <code>{ time }</code>
+			</p>
+			<TimePicker
+				currentTime={ time }
+				onChange={ ( newTime ) => {
+					console.log( '🔍 onChange output:', newTime );
+					setTime( newTime );
+				} }
+				is12Hour
+			/>
+		</div>
+	);
+};
+
 const TimeInputTemplate: StoryFn< typeof TimePicker.TimeInput > = ( args ) => {
 	return <TimePicker.TimeInput { ...args } />;
 };

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -591,4 +591,35 @@ describe( 'TimePicker', () => {
 			} );
 		} );
 	} );
+
+	describe( 'ISO 8601 compliance', () => {
+		it( 'should handle years below 1000 with zero-padded output', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+
+			render(
+				<TimePicker
+					currentTime="0999-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					minYear={ 1 }
+					is12Hour
+				/>
+			);
+
+			const yearInput = screen.getByLabelText( 'Year' );
+			expect( yearInput ).toHaveValue( 999 );
+
+			// Verify onChange emits zero-padded ISO 8601 format
+			await user.clear( yearInput );
+			await user.type( yearInput, '500' );
+			await user.keyboard( '{Tab}' );
+
+			// With zero-padding, this should work without errors
+			if ( onChangeSpy.mock.calls.length > 0 ) {
+				const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+				expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
+				expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
+			}
+		} );
+	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -615,15 +615,21 @@ describe( 'TimePicker', () => {
 		await user.type( yearInput, '500' );
 		await user.keyboard( '{Tab}' );
 
-		// Verify input field value after change
+		// Verify input field value after change (human-readable, not zero-padded)
 		expect( yearInput ).toHaveValue( 500 );
 
 		// Verify onChange emits zero-padded ISO 8601 format
-		if ( onChangeSpy.mock.calls.length > 0 ) {
-			const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-			expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
-			expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
-		}
+		expect( onChangeSpy ).toHaveBeenCalled();
+		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+		const outputDate = lastCall[ 0 ];
+
+		// Extract year from output and verify it's zero-padded to 4 digits
+		const yearMatch = outputDate.match( /^(\d{4})-/ );
+		expect( yearMatch ).not.toBeNull();
+		expect( yearMatch[ 1 ] ).toBe( '0500' ); // Explicitly verify zero-padded year
+
+		expect( outputDate ).not.toContain( 'NaN' );
+		expect( outputDate ).not.toContain( 'Invalid' );
 		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -605,20 +605,25 @@ describe( 'TimePicker', () => {
 			/>
 		);
 
-			const yearInput = screen.getByLabelText( 'Year' );
-			expect( yearInput ).toHaveValue( 999 );
+		const yearInput = screen.getByLabelText( 'Year' );
+		
+		// Verify initial input displays correctly
+		expect( yearInput ).toHaveValue( 999 );
 
-			// Verify onChange emits zero-padded ISO 8601 format
-			await user.clear( yearInput );
-			await user.type( yearInput, '500' );
-			await user.keyboard( '{Tab}' );
+		// Change to year 500
+		await user.clear( yearInput );
+		await user.type( yearInput, '500' );
+		await user.keyboard( '{Tab}' );
 
-			// With zero-padding, this should work without errors
-			if ( onChangeSpy.mock.calls.length > 0 ) {
-				const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-				expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
-				expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
-			}
+		// Verify input field value after change
+		expect( yearInput ).toHaveValue( 500 );
+
+		// Verify onChange emits zero-padded ISO 8601 format
+		if ( onChangeSpy.mock.calls.length > 0 ) {
+			const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+			expect( lastCall[ 0 ] ).toMatch( /^0500-/ );
+			expect( lastCall[ 0 ] ).not.toContain( 'NaN' );
+		}
 		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -597,39 +597,40 @@ describe( 'TimePicker', () => {
 			const user = userEvent.setup();
 			const onChangeSpy = jest.fn();
 
-		render(
-			<TimePicker
-				currentTime="0999-10-18T11:00:00"
-				onChange={ onChangeSpy }
-				is12Hour
-			/>
-		);
+			render(
+				<TimePicker
+					currentTime="0999-10-18T11:00:00"
+					onChange={ onChangeSpy }
+					is12Hour
+				/>
+			);
 
-		const yearInput = screen.getByLabelText( 'Year' );
+			const yearInput = screen.getByLabelText( 'Year' );
 
-		// Verify initial input displays correctly
-		expect( yearInput ).toHaveValue( 999 );
+			// Verify initial input displays correctly
+			expect( yearInput ).toHaveValue( 999 );
 
-		// Change to year 500
-		await user.clear( yearInput );
-		await user.type( yearInput, '500' );
-		await user.keyboard( '{Tab}' );
+			// Change to year 500
+			await user.clear( yearInput );
+			await user.type( yearInput, '500' );
+			await user.keyboard( '{Tab}' );
 
-		// Verify input field value after change (human-readable, not zero-padded)
-		expect( yearInput ).toHaveValue( 500 );
+			// Verify input field value after change (human-readable, not zero-padded)
+			expect( yearInput ).toHaveValue( 500 );
 
-		// Verify onChange emits zero-padded ISO 8601 format
-		expect( onChangeSpy ).toHaveBeenCalled();
-		const lastCall = onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
-		const outputDate = lastCall[ 0 ];
+			// Verify onChange emits zero-padded ISO 8601 format
+			expect( onChangeSpy ).toHaveBeenCalled();
+			const lastCall =
+				onChangeSpy.mock.calls[ onChangeSpy.mock.calls.length - 1 ];
+			const outputDate = lastCall[ 0 ];
 
-		// Extract year from output and verify it's zero-padded to 4 digits
-		const yearMatch = outputDate.match( /^(\d{4})-/ );
-		expect( yearMatch ).not.toBeNull();
-		expect( yearMatch[ 1 ] ).toBe( '0500' ); // Explicitly verify zero-padded year
+			// Extract year from output and verify it's zero-padded to 4 digits
+			const yearMatch = outputDate.match( /^(\d{4})-/ );
+			expect( yearMatch ).not.toBeNull();
+			expect( yearMatch[ 1 ] ).toBe( '0500' ); // Explicitly verify zero-padded year
 
-		expect( outputDate ).not.toContain( 'NaN' );
-		expect( outputDate ).not.toContain( 'Invalid' );
+			expect( outputDate ).not.toContain( 'NaN' );
+			expect( outputDate ).not.toContain( 'Invalid' );
 		} );
 	} );
 } );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -597,14 +597,13 @@ describe( 'TimePicker', () => {
 			const user = userEvent.setup();
 			const onChangeSpy = jest.fn();
 
-			render(
-				<TimePicker
-					currentTime="0999-10-18T11:00:00"
-					onChange={ onChangeSpy }
-					minYear={ 1 }
-					is12Hour
-				/>
-			);
+		render(
+			<TimePicker
+				currentTime="0999-10-18T11:00:00"
+				onChange={ onChangeSpy }
+				is12Hour
+			/>
+		);
 
 			const yearInput = screen.getByLabelText( 'Year' );
 			expect( yearInput ).toHaveValue( 999 );

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -606,7 +606,7 @@ describe( 'TimePicker', () => {
 		);
 
 		const yearInput = screen.getByLabelText( 'Year' );
-		
+
 		// Verify initial input displays correctly
 		expect( yearInput ).toHaveValue( 999 );
 

--- a/packages/components/src/date-time/utils.ts
+++ b/packages/components/src/date-time/utils.ts
@@ -139,7 +139,7 @@ export function setInConfiguredTimezone(
 		...updates,
 	};
 
-	const year = String( values.year );
+	const year = String( values.year ).padStart( 4, '0' );
 	const month = String( values.month + 1 ).padStart( 2, '0' );
 	const day = String( values.date ).padStart( 2, '0' );
 	const hours = String( values.hours ).padStart( 2, '0' );


### PR DESCRIPTION
## What?

Fixes date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding.

**This is a sub-PR extracted from #75285** to allow the core fix to be merged independently before the broader enhancements.

## Why?

Fixes #75254

`setInConfiguredTimezone()` was creating non-ISO-8601-compliant date strings for years below 1000:
- Year 999 → `"999-10-18T11:00:00"` (only 3 digits)
- Year 1 → `"1-10-18T11:00:00"` (only 1 digit)

ISO 8601 requires a minimum of 4 digits for the year. When `getDate()` calls `momentLib.tz()` without an explicit format, it fails to parse these strings, resulting in `Invalid Date` errors.

## How?

**Single line fix in `packages/components/src/date-time/utils.ts`:**

```typescript
const year = String(values.year).padStart(4, '0');
```

This ensures all date strings are ISO 8601 compliant:
- `"0999-10-18T11:00:00"` → Valid, year 999
- `"0001-10-18T11:00:00"` → Valid, year 1

## Testing Instructions

```bash
# Run all date-time tests
npm run test:unit -- packages/components/src/date-time/

# Should pass 114 tests
```

All tests pass including the new test for zero-padded output.

## Notes

- This is a minimal, focused fix - only changes internal date string formatting
- No API changes
- No changes to UI behavior or validation
- Once merged, PR #75285 will rebase on this and add:
  - Removal of MIN_SUPPORTED_YEAR guards
  - Change minYear defaults from 1000 to 1
  - Comprehensive test suite
  - Documentation updates
