### PR TITLE
Button: prevent outline flicker when focused and active at the same time

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).
 -   `ToggleControl`: Prevent `__nextHasNoMarginBottom` from logging a console warning ([#75296](https://github.com/WordPress/gutenberg/pull/75296)).
 -   `createSlotFill`: fix ref forwarding ([#75274](https://github.com/WordPress/gutenberg/pull/75274)).
+-   `Button`: Fix native outline showing when focused and active ([#75346](https://github.com/WordPress/gutenberg/pull/75346)).
 
 ### Enhancements
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -46,8 +46,10 @@
 	// See https://github.com/WordPress/gutenberg/issues/13267 for more context on these selectors.
 	&:focus:not(:active) {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+	}
 
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	&:focus {
 		outline: 3px solid transparent;
 	}
 
@@ -378,8 +380,10 @@
 
 		&:focus:not(:active) {
 			box-shadow: inset 0 0 0 1px $components-color-background, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		}
 
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		&:focus {
 			outline: 2px solid transparent;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

As flagged in https://github.com/WordPress/gutenberg/pull/74106#issuecomment-3862632992, the `Button` component from `@wordpress/component` shows the native browser outline while `:focus`ed and `:active`. This PR fixes this regression.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a visual regression

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By moving the `outline` override to its separate CSS rule that is not dependent on the `:active` state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Tab onto the button to focus it
- Press the space key to click the button
- While the space key is down, make sure no outline is shown

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/81ff8887-91b5-4804-8cd4-44a186a12f6b

### After

https://github.com/user-attachments/assets/46b2bc68-d64e-4daa-bed6-6b590fa9e419


