### PR TITLE
Navigation: Improved help on create page flow

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -5,7 +5,7 @@ import {
 	Button,
 	TextControl,
 	Notice,
-	CheckboxControl,
+	ToggleControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
@@ -37,7 +37,7 @@ export function LinkUIPageCreator( {
 	initialTitle = '',
 } ) {
 	const [ title, setTitle ] = useState( initialTitle );
-	const [ shouldPublish, setShouldPublish ] = useState( false );
+	const [ shouldPublish, setShouldPublish ] = useState( true );
 
 	// Check if the title is valid for submission
 	const isTitleValid = title.trim().length > 0;
@@ -135,10 +135,10 @@ export function LinkUIPageCreator( {
 							value={ title }
 						/>
 
-						<CheckboxControl
-							label={ __( 'Publish immediately' ) }
+						<ToggleControl
+							label={ __( 'Publish' ) }
 							help={ __(
-								'If unchecked, the page will be created as a draft.'
+								"Turn off to save as a draft. Drafts won't appear on your site until published."
 							) }
 							checked={ shouldPublish }
 							onChange={ setShouldPublish }

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -5,7 +5,7 @@ import {
 	Button,
 	TextControl,
 	Notice,
-	ToggleControl,
+	CheckboxControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
@@ -135,7 +135,7 @@ export function LinkUIPageCreator( {
 							value={ title }
 						/>
 
-						<ToggleControl
+						<CheckboxControl
 							label={ __( 'Publish' ) }
 							help={ __(
 								"Turn off to save as a draft. Drafts won't appear on your site until published."

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -955,16 +955,15 @@ test.describe( 'Navigation block', () => {
 				const createPageButton = page.getByRole( 'button', {
 					name: 'Create page',
 				} );
-				// Publish the page immediately
+				// Verify the Publish toggle (on by default)
 				await page.keyboard.press( 'Tab' );
-				const publishCheckbox = page.getByRole( 'checkbox', {
-					name: 'Publish immediately',
+				const publishToggle = page.getByRole( 'checkbox', {
+					name: 'Publish',
 				} );
-				// expect to be on the checkbox
-				await expect( publishCheckbox ).toBeFocused();
-				await page.keyboard.press( 'Space' );
-				// expect the checkbox to be checked
-				await expect( publishCheckbox ).toBeChecked();
+				// expect to be on the toggle
+				await expect( publishToggle ).toBeFocused();
+				// expect the toggle to be checked (publish is the default)
+				await expect( publishToggle ).toBeChecked();
 				// Tab to the Create page button
 				await pageUtils.pressKeys( 'Tab', { times: 2 } );
 				await expect( createPageButton ).toBeFocused();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -955,15 +955,15 @@ test.describe( 'Navigation block', () => {
 				const createPageButton = page.getByRole( 'button', {
 					name: 'Create page',
 				} );
-				// Verify the Publish toggle (on by default)
+				// Verify the Publish checkbox (on by default)
 				await page.keyboard.press( 'Tab' );
-				const publishToggle = page.getByRole( 'checkbox', {
+				const publishCheckbox = page.getByRole( 'checkbox', {
 					name: 'Publish',
 				} );
-				// expect to be on the toggle
-				await expect( publishToggle ).toBeFocused();
-				// expect the toggle to be checked (publish is the default)
-				await expect( publishToggle ).toBeChecked();
+				// expect to be on the checkbox
+				await expect( publishCheckbox ).toBeFocused();
+				// expect the checkbox to be checked (publish is the default)
+				await expect( publishCheckbox ).toBeChecked();
 				// Tab to the Create page button
 				await pageUtils.pressKeys( 'Tab', { times: 2 } );
 				await expect( createPageButton ).toBeFocused();


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71758

<!-- In a few words, what is the PR actually doing? -->
Clarify and simplify publish vs draft meaning and avoid invalid states by default.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Make it clearer and easier to understand (or ignore) Publish vs draft

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? --> 
- **Use toggle component instead of checkbox**: We use toggles over checkboxes in most places, so this seemed like a more integrated UX.
* **Default to true (publish) instead of false (draft)**: When we default to "draft" we're defaulting them to an error state. They'll immediately see "(draft)" in their navigation link and have to fix it.
* **Change Publish immediately to Publish**: I think "immediately" gives it more scariness than warranted.
* **Change help text from "'If unchecked, the page will be created as a draft.'" to "Turn off to save as a draft. Drafts won't appear on your site until published"**. I think the big improvement is "Drafts won't appear on your site until published" so it's clearer what the implication is.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Click the block appender for a navigation block
- Click "Create Page
- Interact with the create page modal

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="353" height="245" alt="Publish immediately with checkbox" src="https://github.com/user-attachments/assets/ab9f6390-a355-4898-8c0d-2958fdd6ca55" />|<img width="352" height="263" alt="Publish as toggle" src="https://github.com/user-attachments/assets/bdecde3b-bb71-42c2-b04a-d859a9bdfb69" />|


