### PR TITLE
Change accordion title `text-decoration` to `text-decoration-line`

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -24,7 +24,7 @@
 	}
 
 	&:hover .wp-block-accordion-heading__toggle-title {
-		text-decoration: underline;
+		text-decoration-line: underline;
 	}
 }
 


### PR DESCRIPTION
The `text-decoration` shorthand overrides other properties (ex: `text-decoration-thickness`) that may be set by themes. Using the explicit `-line` property increases compatibility with themes, and doesn't require themes to re-apply styles on hover.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the use of `text-decoration` to `text-decoration-line`.

## Why?
Using the shorthand `text-decoration` overrides properties (ex: `text-decoration-thickness`) that themes may apply, forcing the themes to reapply other properties on hover. A simple use of `-line` increases compatibility and reduces file size for themes.

## How?
Being more specific.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a theme that styles the accordion title with the `text-decoration-thickness` property.
2. Create a Post/Page with the Accordion block.
3. Hover the accordion title, and observe that the `text-decoration-thickness` property is overwritten on hover.

```css
.wp-block-accordion-heading__toggle-title {
  text-decoration-thickness: 5px;
}
```