### PR TITLE
Block Editor: Fix Columns block horizontal spacing when setting vertical gap

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -153,7 +153,7 @@ export default {
 				'0.5em'
 			);
 			// Use the column gap value (second value if two values exist)
-			const gapParts = processedGlobalGap?.split( ' ' ) || [];
+			const gapParts = processedGlobalGap.split( ' ' );
 			fallbackGapValue =
 				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
 		}

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -138,16 +138,32 @@ export default {
 		style,
 		blockName,
 		hasBlockGapSupport,
+		globalBlockGapValue,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
 		const { orientation = 'horizontal' } = layout;
+
+		// Determine the fallback gap value using global styles (theme.json),
+		// falling back to '0.5em' for backwards compatibility.
+		let fallbackGapValue = '0.5em';
+		if ( globalBlockGapValue ) {
+			// Process the global gap value to handle preset values
+			const processedGlobalGap = getGapCSSValue(
+				globalBlockGapValue,
+				'0.5em'
+			);
+			// Use the column gap value (second value if two values exist)
+			const gapParts = processedGlobalGap?.split( ' ' ) || [];
+			fallbackGapValue =
+				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
+		}
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
 		const blockGapValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
+				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
 				: undefined;
 		const justifyContent = justifyContentMap[ layout.justifyContent ];
 		const flexWrap = flexWrapOptions.includes( layout.flexWrap )

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -144,7 +144,7 @@ export default {
 		let fallbackGapValue = '1.2rem';
 		if ( globalBlockGapValue ) {
 			const processedGap = getGapCSSValue( globalBlockGapValue, '0.5em' );
-			const gapParts = processedGap?.split( ' ' ) || [];
+			const gapParts = processedGap.split( ' ' );
 			fallbackGapValue =
 				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
 		}

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -139,23 +139,23 @@ export default {
 			}
 		}
 
+		// Use the global blockGap value as fallback when available.
+		// If the gap value has both top and left (separated by space), use the left value for horizontal calculations.
+		let fallbackGapValue = '1.2rem';
+		if ( globalBlockGapValue ) {
+			const processedGap = getGapCSSValue( globalBlockGapValue, '0.5em' );
+			const gapParts = processedGap?.split( ' ' ) || [];
+			fallbackGapValue =
+				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
+		}
+
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
 		const blockGapValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
+				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
 				: undefined;
-
-		// Use the global blockGap value for grid column calculations when available
-		// If the gap value has both top and left (separated by space), use the left value for horizontal calculations
-		let fallbackGapValue = '1.2rem';
-		if ( globalBlockGapValue ) {
-			const processedGap = getGapCSSValue( globalBlockGapValue, '0.5em' );
-			const gapParts = processedGap.split( ' ' );
-			fallbackGapValue =
-				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
-		}
 
 		let output = '';
 		const rules = [];


### PR DESCRIPTION
## What?
Closes #45277

Fixes an issue where changing only the vertical block spacing in the Columns block incorrectly changes the horizontal spacing to hardcoded values instead of maintaining the theme.json default.

## Why?

The Columns block uses a flex layout, and when users set only vertical spacing, the horizontal spacing should maintain its default value from theme.json (e.g., 1.5rem in Twenty Twenty-Three). Instead, it was falling back to hardcoded values:
- `0.5em` in the editor
- `2em` on the frontend

## How?

Updated the `getLayoutStyle` function in both `flex.js` and `grid.js` to:
1. Accept the `globalBlockGapValue` parameter (already passed from the layout hook)
2. Calculate a proper `fallbackGapValue` from `globalBlockGapValue` before processing user-defined spacing
3. Use this theme-aware fallback instead of the hardcoded `0.5em` default

This ensures that when users set only one axis of spacing (vertical or horizontal), the other axis uses the theme's default blockGap value instead of an arbitrary hardcoded value.

## Testing Instructions

### Setup
1. Use the any theme with a custom blockGap in theme.json
2. Add a Columns block with two columns for ref use below code. 

```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"primary"} -->
<div class="wp-block-column has-primary-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut leo nibh, placerat eget nisi non, sagittis convallis purus.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"primary"} -->
<div class="wp-block-column has-primary-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
<p>Morbi in iaculis ligula. Mauris in libero suscipit, pulvinar erat a, rutrum purus.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
### Before the fix
1. In the block settings sidebar, change only the **vertical** block spacing
2. Inspect the generated CSS
3. The horizontal gap incorrectly changes to `0.5em` in editor, `2em` on frontend

### After the fix
1. In the block settings sidebar, change only the **vertical** block spacing 
2. Inspect the generated CSS
3. The horizontal gap maintains the theme default 

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/d8f056e0-0e96-4515-b00b-90a4501f49c9


After:


https://github.com/user-attachments/assets/d9d8da39-6bab-4d24-96e9-e81302cd2c3a

