### PR TITLE
Link Control: Use featured image in preview popover

### DIFF
--- a/packages/block-editor/src/components/hooks/index.js
+++ b/packages/block-editor/src/components/hooks/index.js
@@ -1,0 +1,1 @@
+export { useFeaturedImage } from './use-featured-image';

--- a/packages/block-editor/src/components/hooks/use-featured-image.js
+++ b/packages/block-editor/src/components/hooks/use-featured-image.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Hook to fetch the featured image for an entity record.
+ *
+ * @param {Object} entityRecord - The entity record containing featured_media reference
+ * @return {string|null} The featured image URL or null
+ */
+export function useFeaturedImage( entityRecord ) {
+	return useSelect(
+		( select ) => {
+			// Only post-type entities have featured_media
+			// Taxonomies and other entities won't have this property
+			if ( ! entityRecord?.featured_media ) {
+				return null;
+			}
+
+			// Use string literal to avoid circular dependency with @wordpress/core-data
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
+			const { getEntityRecord } = select( 'core' );
+
+			// Get the media entity to fetch the image URL
+			const media = getEntityRecord(
+				'postType',
+				'attachment',
+				entityRecord.featured_media
+			);
+
+			// Return the thumbnail or medium size URL, fallback to source_url
+			return (
+				media?.media_details?.sizes?.thumbnail?.source_url ||
+				media?.media_details?.sizes?.medium?.source_url ||
+				media?.source_url ||
+				null
+			);
+		},
+		[ entityRecord?.featured_media ]
+	);
+}

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -34,6 +34,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { ViewerSlot } from './viewer-slot';
 
 import useRichUrlData from './use-rich-url-data';
+import { useFeaturedImage } from '../hooks/use-featured-image';
 
 /**
  * Filters the title for display. Removes the protocol and www prefix.
@@ -62,6 +63,33 @@ export default function LinkPreview( {
 		[]
 	);
 
+	// Fetch entity record for internal entity links (post-type only)
+	// We can tell it's an entity by checking if value has an id
+	const entityRecord = useSelect(
+		( select ) => {
+			// Only fetch for post-type entities with id, kind, and type
+			if (
+				! value?.id ||
+				! value?.kind ||
+				! value?.type ||
+				value.kind !== 'post-type'
+			) {
+				return null;
+			}
+
+			// Use string literal to avoid circular dependency with @wordpress/core-data
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
+			const { getEntityRecord } = select( 'core' );
+
+			// getEntityRecord expects 'postType' (camelCase) not 'post-type' (kebab-case)
+			return getEntityRecord( 'postType', value.type, value.id );
+		},
+		[ value?.id, value?.kind, value?.type ]
+	);
+
+	// Fetch featured image from the entity record
+	const featuredImage = useFeaturedImage( entityRecord );
+
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
 
@@ -86,7 +114,12 @@ export default function LinkPreview( {
 
 	let icon;
 
-	if ( richData?.icon ) {
+	const hasFeaturedImage = featuredImage && typeof featuredImage === 'string';
+
+	// Only use featuredImage if it's a valid string URL
+	if ( hasFeaturedImage ) {
+		icon = <img src={ featuredImage } alt="" />;
+	} else if ( richData?.icon ) {
 		icon = <img src={ richData?.icon } alt="" />;
 	} else if ( isEmptyURL ) {
 		icon = <Icon icon={ info } size={ 32 } />;
@@ -125,17 +158,26 @@ export default function LinkPreview( {
 					}
 					justify="start"
 				>
-					<Flex
-						className={ clsx(
-							'block-editor-link-control__preview-icon',
-							{
-								'is-image': richData?.icon,
-							}
-						) }
-						justify="center"
-					>
-						{ icon }
-					</Flex>
+					{ hasFeaturedImage ? (
+						<Flex
+							className="block-editor-link-control__preview-image"
+							justify="center"
+						>
+							{ icon }
+						</Flex>
+					) : (
+						<Flex
+							className={ clsx(
+								'block-editor-link-control__preview-icon',
+								{
+									'is-image': richData?.icon,
+								}
+							) }
+							justify="center"
+						>
+							{ icon }
+						</Flex>
+					) }
 					<Flex
 						className="block-editor-link-control__preview-details"
 						direction="column"

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -192,6 +192,7 @@ $block-editor-link-control-number-of-actions: 1;
 		word-break: break-all;
 	}
 
+	.block-editor-link-control__preview-image,
 	.block-editor-link-control__preview-icon {
 		position: relative;
 		flex-shrink: 0;
@@ -199,7 +200,9 @@ $block-editor-link-control-number-of-actions: 1;
 		width: $grid-unit-40;
 		height: $grid-unit-40;
 		border-radius: $radius-small;
+	}
 
+	.block-editor-link-control__preview-icon.is-favicon {
 		img {
 			width: $grid-unit-20; // favicons often have a source of 32px
 		}

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -63,6 +63,7 @@ import {
 } from './components/block-list/use-block-props/use-block-refs';
 import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
+import { useFeaturedImage } from './components/hooks/use-featured-image';
 import { PrivateBlockContext } from './components/block-list/private-block-context';
 import useListViewPanelState from './components/use-list-view-panel-state';
 import {
@@ -128,6 +129,7 @@ lock( privateApis, {
 	useBlockElementRef,
 	LinkPicker,
 	useRemoteUrlData,
+	useFeaturedImage,
 	PrivateBlockContext,
 	useListViewPanelState,
 	isHashLink,

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -115,38 +115,6 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		setAttributes,
 	} );
 
-	const linkTitle =
-		entityRecord?.title?.rendered ||
-		entityRecord?.title ||
-		entityRecord?.name;
-
-	const linkImage = useSelect(
-		( select ) => {
-			// Only fetch for post-type entities with featured media
-			if ( ! entityRecord?.featured_media ) {
-				return null;
-			}
-
-			const { getEntityRecord } = select( coreStore );
-
-			// Get the media entity to fetch the image URL
-			const media = getEntityRecord(
-				'postType',
-				'attachment',
-				entityRecord.featured_media
-			);
-
-			// Return the thumbnail or medium size URL, fallback to source_url
-			return (
-				media?.media_details?.sizes?.thumbnail?.source_url ||
-				media?.media_details?.sizes?.medium?.source_url ||
-				media?.source_url ||
-				null
-			);
-		},
-		[ entityRecord?.featured_media ]
-	);
-
 	const onNavigateToEntityRecord = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
@@ -159,11 +127,9 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	}, [] );
 
 	const preview = useLinkPreview( {
+		entityRecord,
 		url,
-		title: linkTitle,
-		image: linkImage,
 		type: attributes.type,
-		entityStatus: entityRecord?.status,
 		hasBinding: hasUrlBinding,
 		isEntityAvailable: isBoundEntityAvailable,
 	} );

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -10,7 +10,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const { useRemoteUrlData } = unlock( blockEditorPrivateApis );
+const { useRemoteUrlData, useFeaturedImage } = unlock( blockEditorPrivateApis );
 
 /**
  * Capitalize the first letter of a string.
@@ -125,28 +125,37 @@ function computeBadges( {
 /**
  * Hook to compute link preview data for display.
  *
- * This hook takes raw link data and entity information and computes
- * presentation-ready preview data including formatted title, URL, and badges.
+ * This hook takes an entity record and computes presentation-ready preview data
+ * including formatted title, URL, featured image, and badges.
  *
  * @param {Object}  options                   - Options object
+ * @param {Object}  options.entityRecord      - The entity record containing link data
  * @param {string}  options.url               - Link URL
- * @param {string}  options.title             - Link title (from entity or rich data)
- * @param {string}  options.image             - Link image URL
  * @param {string}  options.type              - Entity type (page, post, etc.)
- * @param {string}  options.entityStatus      - Entity status (publish, draft, etc.)
  * @param {boolean} options.hasBinding        - Whether link has entity binding
  * @param {boolean} options.isEntityAvailable - Whether bound entity exists
  * @return {Object} Preview data object with title, url, image, and badges
  */
 export function useLinkPreview( {
+	entityRecord: providedEntityRecord,
 	url,
-	title,
-	image,
 	type,
-	entityStatus,
 	hasBinding,
 	isEntityAvailable,
 } ) {
+	// Use provided entity record directly (navigation controls provide this)
+	const entityRecord = providedEntityRecord;
+
+	// Fetch the featured image using the shared hook
+	const image = useFeaturedImage( entityRecord );
+
+	// Extract entity data
+	const title =
+		entityRecord?.title?.rendered ||
+		entityRecord?.title ||
+		entityRecord?.name;
+	const entityStatus = entityRecord?.status;
+
 	// Fetch rich URL data if we don't have a title. Internal links should have passed a title.
 	const { richData } = useRemoteUrlData( title ? null : url );
 


### PR DESCRIPTION
## What?
Adds featured image support to LinkControl's link preview popover.

## Why?
Featured images were already displayed in LinkPicker's preview (navigation link sidebar controls), but were missing from LinkControl's link preview popover. This creates an inconsistent experience when working with entity links.

When users select an internal link to a page or post that has a featured image, showing that image in the preview helps them:
- Quickly identify the linked content
- Distinguish between similar link titles
- Maintain visual consistency across different link editing interfaces

## How?
- Created a reusable `useFeaturedImage` hook in `@wordpress/block-editor/src/components/hooks/use-featured-image.js`
- Exported the hook via private APIs (`privateApis`)
- Updated `LinkPreview` component to fetch entity records and featured images for entity links
- Navigation link's `useLinkPreview` hook now uses the shared `useFeaturedImage` hook
- Featured images are only fetched for post-type entities (pages, posts) - taxonomies don't have featured images
- Uses string literal `select('core')` to avoid circular dependency between `@wordpress/block-editor` and `@wordpress/core-data`

## Testing Instructions
1. Create a page or post with a featured image set
2. Create another page/post and insert a Paragraph block
3. Select some text and create a link to the page from step 1
4. Click the existing link to open the preview popover
5. Verify the featured image appears in the preview (thumbnail-sized image on the left)
6. Test with navigation links:
   - Insert a Navigation block
   - Add a navigation link to a page with a featured image
   - Open the link settings in the sidebar
   - Verify the featured image appears in the preview button
7. Test with links that don't have featured images:
   - Link to a category/tag (taxonomy) - should show globe icon, no featured image
   - Link to an external URL - should show globe or site icon, no featured image
   - Link to a page without a featured image - should show globe icon

## Screenshots or screencast



<img width="393" height="122" alt="Screenshot 2026-02-09 at 3 35 18 PM" src="https://github.com/user-attachments/assets/3eb60212-300b-453a-8ded-4bffdb4d5f58" />
