### PR TITLE
iAPI Docs: Introduce reactive vs non-reactive distinction early in the state/context guide

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -522,9 +522,9 @@
 		"parent": "core-concepts"
 	},
 	{
-		"title": "Understanding global state, local context and derived state",
-		"slug": "undestanding-global-state-local-context-and-derived-state",
-		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md",
+		"title": "Understanding global state, local context, derived state and config",
+		"slug": "understanding-global-state-local-context-derived-state-and-config",
+		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md",
 		"parent": "core-concepts"
 	},
 	{

--- a/docs/reference-guides/interactivity-api/core-concepts/README.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/README.md
@@ -4,7 +4,7 @@ This section provides some guides on important concepts and mental models relate
 
 1. **[The Reactive and Declarative mindset](/docs/reference-guides/interactivity-api/core-concepts/the-reactive-and-declarative-mindset.md):** This guide covers core concepts of reactivity and declarativeness, providing a foundation for effective use of the Interactivity API.
 
-2. **[Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md):** The guide explains how to effectively use global state, local context, and derived state within the Interactivity API emphasizing the importance of choosing the appropriate state management technique based on the scope and requirements of your data.
+2. **[Understanding global state, local context, derived state and config](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md):** The guide explains how to effectively use global state, local context, and derived state within the Interactivity API emphasizing the importance of choosing the appropriate state management technique based on the scope and requirements of your data.
 
 3. **[Server-side rendering: Processing directives on the server](/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md):** The Interactivity API allows WordPress to use server-side rendering to create interactive and state-aware HTML, smoothly connected with client-side features while maintaining performance and SEO benefits.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md
@@ -175,7 +175,7 @@ store( 'myFruitPlugin', {
 
 The derived state, regardless of whether it derives from the global state, local context, or both, can also be processed on the server by the Server Directive Processing.
 
-_Please, visit the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md) guide to learn more about how derived state works in the Interactivity API._
+_Please, visit the [Understanding global state, local context, derived state and config](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md) guide to learn more about how derived state works in the Interactivity API._
 
 ### Derived state that can be defined statically
 

--- a/docs/reference-guides/interactivity-api/core-concepts/the-reactive-and-declarative-mindset.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/the-reactive-and-declarative-mindset.md
@@ -183,7 +183,7 @@ The Interactivity API uses a fine-grained reactivity system. Here's how it works
     - **Local context**: This is local data that is specific to a particular element and its children.
     - **Derived State**: In addition to basic state properties, you can define computed properties that automatically update when their dependencies change.
 
-    _Please, visit the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md) guide to learn more about how to work with the different types of reactive state in the Interactivity API._
+    _Please, visit the [Understanding global state, local context, derived state and config](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md) guide to learn more about how to work with the different types of reactive state in the Interactivity API._
 
 2. **Actions**: These are functions, usually triggered by event handlers, that mutate the global state or local context.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md
@@ -1,4 +1,4 @@
-# Understanding global state, local context and derived state
+# Understanding global state, local context, derived state and config
 
 The Interactivity API offers a powerful framework for creating interactive blocks. To make the most of its capabilities, it's crucial to understand when to use global state, local context, derived state, or config. This guide will clarify these concepts and provide practical examples to help you decide when to use each one.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -1,12 +1,18 @@
 # Understanding global state, local context and derived state
 
-The Interactivity API offers a powerful framework for creating interactive blocks. To make the most of its capabilities, it's crucial to understand when to use global state, local context, or derived state. This guide will clarify these concepts and provide practical examples to help you decide when to use each one.
+The Interactivity API offers a powerful framework for creating interactive blocks. To make the most of its capabilities, it's crucial to understand when to use global state, local context, derived state, or config. This guide will clarify these concepts and provide practical examples to help you decide when to use each one.
 
-Let's start with a brief definition of global state, local context and derived state.
+The Interactivity API distinguishes between **reactive** data, which triggers UI updates when it changes, and **non-reactive** data, which remains static throughout the client-side lifecycle. Let's start with a brief definition of each concept.
+
+**Reactive (state and context):**
 
 -   **Global state:** Global data that can be accessed and modified by any interactive block on the page, allowing different parts of your interactive blocks to stay in sync.
 -   **Local context:** Local data defined within a specific element in the HTML structure, accessible only to that element and its children, providing independent state for individual blocks.
 -   **Derived state:** Computed values based on global state or local context, dynamically calculated on-demand to ensure consistent data representation without storing redundant data.
+
+**Non-reactive:**
+
+-   **Config:** Static configuration data serialized from the server to the client, such as API endpoints, nonces, or feature flags. Config values don't trigger UI updates and remain constant during user interaction.
 
 Let's now dive into each of these concepts to study them in more detail and provide some examples.
 
@@ -805,7 +811,12 @@ Consider a quiz that has multiple questions. Each question is a separate page. W
 ```
 
 ```javascript
-import { store, getContext, getServerContext, withSyncEvent } from '@wordpress/interactivity';
+import {
+	store,
+	getContext,
+	getServerContext,
+	withSyncEvent,
+} from '@wordpress/interactivity';
 
 store( 'myPlugin', {
 	actions: {

--- a/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
@@ -269,7 +269,7 @@ That's it! Now you can access the context properties with the correct types.
 
 The derived state is data that is calculated based on the global state or local context. In the client store definition, it is defined using a getter in the `state` object.
 
-_Please, visit the [Understanding global state, local context and derived state](/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md) guide to learn more about how derived state works in the Interactivity API._
+_Please, visit the [Understanding global state, local context, derived state and config](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md) guide to learn more about how derived state works in the Interactivity API._
 
 Following our previous example, let's create a derived state that is the double of our counter.
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -217,7 +217,7 @@
 								"docs/reference-guides/interactivity-api/core-concepts/the-reactive-and-declarative-mindset.md": []
 							},
 							{
-								"docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md": []
+								"docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md": []
 							},
 							{
 								"docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md": []


### PR DESCRIPTION
## What?                                                                                                             
                                                                                                                                                                                                                                       
  Follow up to #71355                                                                                                                                                                                                                  
                                                                                                                                                                                                                                       
  Introduce the distinction between reactive and non-reactive data at the beginning of the Interactivity API state/context guide.                                                                                                      
                                                                                                                                                                                                                                       
  ## Why?
                                                                                                                                                                                                                                       
  As @DAreRodz [pointed out](https://github.com/WordPress/gutenberg/pull/71355#pullrequestreview-3710029131) in the review of #71355, the term "config" is not introduced until the very end of the document. Adding a reactive vs non-reactive distinction at the beginning helps readers understand the full picture before diving into details.                                                                                                                      
                                                                                                                                                                                                                                       
  ## How?                                                                                                                                                                                                                              
                                                                                                                                                                                                                                       
  - Updated the introductory paragraph to mention config alongside global state, local context, and derived state.                                                                                                                     
  - Grouped the definitions into **Reactive (state and context)** and **Non-reactive** categories.                                                                                                                                     
  - Added a brief definition of config in the introduction.                                                                                                                                                                            
                                                                                                                                                                                                                                      