### PR TITLE
Real-time Collaboration: Regenerate the blocks correctly in RTC mode and allow use of the code editor

### DIFF
--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -60,7 +60,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return undefined;
 		}
 
-		if ( editedBlocks && editedBlocks.length > 0 ) {
+		if ( editedBlocks ) {
 			return editedBlocks;
 		}
 

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -60,7 +60,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return undefined;
 		}
 
-		if ( editedBlocks ) {
+		if ( editedBlocks && editedBlocks.length > 0 ) {
 			return editedBlocks;
 		}
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -53,7 +53,10 @@ export type PostChanges = Partial< Post > & {
 // A post record as represented in the CRDT document (Y.Map).
 export interface YPostRecord extends YMapRecord {
 	author: number;
-	blocks: YBlocks;
+	// Note: Blocks can be undefined when they need to be re-parsed.
+	// So this has been typed to communicate that the property can
+	// exist, but could be undefined.
+	blocks: YBlocks | undefined;
 	categories: number[];
 	comment_status: string;
 	date: string | null;
@@ -156,6 +159,12 @@ export function applyPostChangesToCRDTDoc(
 
 		switch ( key ) {
 			case 'blocks': {
+				// Blocks can be undefined when they need to be re-parsed.
+				if ( newValue === undefined ) {
+					ymap.set( key, undefined );
+					break;
+				}
+
 				let currentBlocks = ymap.get( key );
 
 				// Initialize.
@@ -314,7 +323,10 @@ export function getPostChangesFromCRDTDoc(
 					// We cannot directly compare the `blocks` from the CRDT document to
 					// the `blocks` derived from the `content` in the persisted record,
 					// because the latter will have different client IDs.
+					//
+					// Note: Blocks can be undefined when they need to be re-parsed.
 					if (
+						currentValue !== undefined &&
 						ydoc.meta?.get( CRDT_DOC_META_PERSISTENCE_KEY ) &&
 						editedRecord.content
 					) {

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -160,7 +160,7 @@ export function applyPostChangesToCRDTDoc(
 		switch ( key ) {
 			case 'blocks': {
 				// Blocks can be undefined when they need to be re-parsed.
-				if ( newValue === undefined ) {
+				if ( ! newValue ) {
 					ymap.set( key, undefined );
 					break;
 				}
@@ -331,11 +331,14 @@ export function getPostChangesFromCRDTDoc(
 						editedRecord.content
 					) {
 						const blocks = ymap.get( 'blocks' ) as YBlocks;
-						return (
-							__unstableSerializeAndClean(
-								blocks.toJSON()
-							).trim() !== editedRecord.content.raw.trim()
-						);
+
+						if ( blocks ) {
+							return (
+								__unstableSerializeAndClean(
+									blocks.toJSON()
+								).trim() !== editedRecord.content.raw.trim()
+							);
+						}
 					}
 
 					// The consumers of blocks have memoization that renders optimization

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -615,7 +615,7 @@ export const restoreRevision =
 
 		// Build the edits object with all restorable fields from the revision.
 		const edits = {
-			blocks: parse( revision.content.raw ),
+			blocks: undefined,
 			content: revision.content.raw,
 		};
 		if ( revision.title?.raw !== undefined ) {


### PR DESCRIPTION
## What?

Blocks are not being re-generated automatically within the editor, when RTC is enabled. It's increasingly getting necessary to send parsed blocks down to the `editEntityRecord` method rather than the default way it's done in Gutenberg which is to not worry as they'd be regenerated.

Interestingly, this also rears its head in the code editor where if any modification is made to the blocks (valid or not) they are cleared entirely. There's no follow up parsing that's done.

Partially fixes #74831.

## Why?

The hook `use-entity-block-editor` doesn't look to see if the `editedBlocks` within a record are empty. When RTC mode isn't enabled it's fine because the blocks will be regenerated before the editor renders them. Within RTC mode however, the YJS doc immediately transmits all the changes to all the collaborators as soon as it receives the empty blocks.

This also ensure any changes in the code editor correctly parse the blocks, and doesn't result in any data loss.

Note: you do have to hit save draft to see changes from the code editor

## How?

The hook is now tweaked to check if the `editedBlocks` are empty or not. If they are empty, it's regenerated rather than just being returned as is which results in data loss.

I've also reverted the change that was made in https://github.com/WordPress/gutenberg/pull/75233, because that wasn't the correct way to solve this problem. That hid the true underlying problem.

## Testing Instructions

1. Pull down this branch.
2. Enable RTC via `settings->writing`
3. Open up two browser sessions
4. Make changes in both of em.
5. Restore a previous revision and ensure no data loss occurs
6. Make changes in the code editor and ensure no data loss occurs.
7. Repeat the above with RTC off as well.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/32d7325f-0223-47be-969e-4c70252591d2

### After


https://github.com/user-attachments/assets/7c01638c-b448-4708-8191-e3202022e2b5


Thank you @youknowriad for pointing me in the right direction for this investigation.