### PR TITLE
Allow grid to use style variation blockGap values for columns calculation

### DIFF
--- a/backport-changelog/7.0/10906.md
+++ b/backport-changelog/7.0/10906.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10906
+
+* https://github.com/WordPress/gutenberg/pull/75360

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -8,7 +8,7 @@
 /**
  * Get the first style variation name from a className string that matches a registered style.
  *
- * @param string $class_name       CSS class string for a block.
+ * @param string $class_name        CSS class string for a block.
  * @param array  $registered_styles Currently registered block styles.
  *
  * @return string|null The name of the first registered variation, or null if none found.

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -18,21 +18,15 @@ function gutenberg_get_variation_name_from_class( $class_name, $registered_style
 		return null;
 	}
 
-	$matches = array();
-	$classes = explode( ' ', $class_name );
+	$registered_names = array_filter( array_column( $registered_styles, 'name' ) );
 
-	foreach ( $classes as $name ) {
-		if ( str_starts_with( $name, 'is-style-' ) ) {
-			$match = substr( $name, strlen( 'is-style-' ) );
-			if ( 'default' !== $match ) {
-				$matches[] = $match;
-			}
-		}
-	}
+	$prefix = 'is-style-';
+	$len    = strlen( $prefix );
 
-	foreach ( $matches as $variation ) {
-		foreach ( $registered_styles as $style ) {
-			if ( isset( $style['name'] ) && $style['name'] === $variation ) {
+	foreach ( explode( ' ', $class_name ) as $class ) {
+		if ( str_starts_with( $class, $prefix ) ) {
+			$variation = substr( $class, $len );
+			if ( 'default' !== $variation && in_array( $variation, $registered_names, true ) ) {
 				return $variation;
 			}
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -6,6 +6,42 @@
  */
 
 /**
+ * Get the first style variation name from a className string that matches a registered style.
+ *
+ * @param string $class_name       CSS class string for a block.
+ * @param array  $registered_styles Currently registered block styles.
+ *
+ * @return string|null The name of the first registered variation, or null if none found.
+ */
+function gutenberg_get_variation_name_from_class( $class_name, $registered_styles = array() ) {
+	if ( empty( $class_name ) ) {
+		return null;
+	}
+
+	$matches = array();
+	$classes = explode( ' ', $class_name );
+
+	foreach ( $classes as $name ) {
+		if ( str_starts_with( $name, 'is-style-' ) ) {
+			$match = substr( $name, strlen( 'is-style-' ) );
+			if ( 'default' !== $match ) {
+				$matches[] = $match;
+			}
+		}
+	}
+
+	foreach ( $matches as $variation ) {
+		foreach ( $registered_styles as $style ) {
+			if ( isset( $style['name'] ) && $style['name'] === $variation ) {
+				return $variation;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
  * Returns layout definitions, keyed by layout type.
  *
  * Provides a common definition of slugs, classnames, base styles, and spacing styles for each layout type.
@@ -898,12 +934,26 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$has_block_gap_support = isset( $block_gap );
 
 		// Get default blockGap value from global styles for use in layouts like grid.
-		// Check block-specific styles first, then fall back to root styles.
+		// Check style variation first, then block-specific styles, then fall back to root styles.
 		$block_name = $block['blockName'] ?? '';
 		if ( null === $global_styles ) {
 			$global_styles = gutenberg_get_global_styles();
 		}
-		$global_block_gap_value = $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? ( $global_styles['spacing']['blockGap'] ?? null );
+
+		// Check if the block has an active style variation with a blockGap value.
+		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.
+		$variation_block_gap_value = null;
+		$block_class_name          = $block['attrs']['className'] ?? '';
+		if ( ! empty( $block_class_name ) && str_contains( $block_class_name, 'is-style-' ) && ! empty( $block_name ) ) {
+			$styles_registry   = WP_Block_Styles_Registry::get_instance();
+			$registered_styles = $styles_registry->get_registered_styles_for_block( $block_name );
+			$variation_name    = gutenberg_get_variation_name_from_class( $block_class_name, $registered_styles );
+			if ( $variation_name ) {
+				$variation_block_gap_value = $global_styles['blocks'][ $block_name ]['variations'][ $variation_name ]['spacing']['blockGap'] ?? null;
+			}
+		}
+
+		$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? ( $global_styles['spacing']['blockGap'] ?? null );
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;

--- a/packages/block-editor/src/hooks/block-style-variation.js
+++ b/packages/block-editor/src/hooks/block-style-variation.js
@@ -40,7 +40,7 @@ function getVariationMatches( className ) {
  *
  * @return {string|null} The name of the first registered variation.
  */
-function getVariationNameFromClass( className, registeredStyles = [] ) {
+export function getVariationNameFromClass( className, registeredStyles = [] ) {
 	// The global flag affects how capturing groups work in JS. So the regex
 	// below will only return full CSS classes not just the variation name.
 	const matches = getVariationMatches( className );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -35,39 +35,9 @@ import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
 import { useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 import { globalStylesDataKey } from '../store/private-keys';
+import { getVariationNameFromClass } from './block-style-variation';
 
 const VARIATION_PREFIX = 'is-style-';
-
-/**
- * Get the first style variation name from a className string that matches a registered style.
- *
- * @param {string} className        CSS class string for a block.
- * @param {Array}  registeredStyles Currently registered block styles.
- *
- * @return {string|null} The name of the first registered variation, or null if none found.
- */
-function getVariationNameFromClass( className, registeredStyles = [] ) {
-	if ( ! className ) {
-		return null;
-	}
-
-	const matches = className.split( /\s+/ ).reduce( ( acc, name ) => {
-		if ( name.startsWith( VARIATION_PREFIX ) ) {
-			const match = name.slice( VARIATION_PREFIX.length );
-			if ( match !== 'default' ) {
-				acc.push( match );
-			}
-		}
-		return acc;
-	}, [] );
-
-	for ( const variation of matches ) {
-		if ( registeredStyles.some( ( style ) => style.name === variation ) ) {
-			return variation;
-		}
-	}
-	return null;
-}
 
 const layoutBlockSupportKey = 'layout';
 const { kebabCase } = unlock( componentsPrivateApis );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -8,7 +8,11 @@ import clsx from 'clsx';
  */
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import {
+	getBlockSupport,
+	hasBlockSupport,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
@@ -31,6 +35,39 @@ import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
 import { useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 import { globalStylesDataKey } from '../store/private-keys';
+
+const VARIATION_PREFIX = 'is-style-';
+
+/**
+ * Get the first style variation name from a className string that matches a registered style.
+ *
+ * @param {string} className        CSS class string for a block.
+ * @param {Array}  registeredStyles Currently registered block styles.
+ *
+ * @return {string|null} The name of the first registered variation, or null if none found.
+ */
+function getVariationNameFromClass( className, registeredStyles = [] ) {
+	if ( ! className ) {
+		return null;
+	}
+
+	const matches = className.split( /\s+/ ).reduce( ( acc, name ) => {
+		if ( name.startsWith( VARIATION_PREFIX ) ) {
+			const match = name.slice( VARIATION_PREFIX.length );
+			if ( match !== 'default' ) {
+				acc.push( match );
+			}
+		}
+		return acc;
+	}, [] );
+
+	for ( const variation of matches ) {
+		if ( registeredStyles.some( ( style ) => style.name === variation ) ) {
+			return variation;
+		}
+	}
+	return null;
+}
 
 const layoutBlockSupportKey = 'layout';
 const { kebabCase } = unlock( componentsPrivateApis );
@@ -452,15 +489,35 @@ export const withLayoutStyles = createHigherOrderComponent(
 					);
 
 					// Get default blockGap value from global styles for use in layouts like grid.
-					// Check block-specific styles first, then fall back to root styles.
+					// Check style variation first, then block-specific styles, then fall back to root styles.
 					const globalStyles = settings[ globalStylesDataKey ];
+
+					// Check if the block has an active style variation with a blockGap value.
+					// Only check the registry if the className contains a variation class to avoid unnecessary lookups.
+					let variationBlockGapValue;
+					const className = attributes?.className;
+					if ( className?.includes( VARIATION_PREFIX ) ) {
+						const { getBlockStyles } = select( blocksStore );
+						const registeredStyles = getBlockStyles( name );
+						const variationName = getVariationNameFromClass(
+							className,
+							registeredStyles
+						);
+						variationBlockGapValue = variationName
+							? globalStyles?.blocks?.[ name ]?.variations?.[
+									variationName
+							  ]?.spacing?.blockGap
+							: undefined;
+					}
+
 					const globalBlockGapValue =
+						variationBlockGapValue ??
 						globalStyles?.blocks?.[ name ]?.spacing?.blockGap ??
 						globalStyles?.spacing?.blockGap;
 
 					return { blockGapSupport, globalBlockGapValue };
 				},
-				[ blockSupportsLayout, clientId ]
+				[ blockSupportsLayout, clientId, attributes?.className, name ]
 			);
 
 			if ( ! extraProps ) {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow-up to #74725 made possible by #74529.

Now that we output blockGap values for block style variations, we should ensure the grid block columns computation takes any active variation value into account.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In your block theme folder, under styles > blocks, add a file with something like:
```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Large gap",
	"slug": "largegap",
	"blockTypes": ["core/group"],
	"styles": {
		"spacing": {
			"blockGap": "99px"
		}
	}
}
```
2. Add a Grid block to a page and set both an explicit column count and min column width for it.
3. The correct number of columns should display provided the screen is wide enough.

<img width="1259" height="329" alt="Screenshot 2026-02-10 at 11 43 33 am" src="https://github.com/user-attachments/assets/00a05227-7fb0-4b81-9e46-b4e9cbf5dee6" />
