### PR TITLE
Snackbar: `CSS` fix for positioning in large screens

### DIFF
--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -2,6 +2,8 @@
 @use "@wordpress/admin-ui/build-style/style.css" as *;
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/breakpoints" as *;
+
 
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke
@@ -32,8 +34,11 @@
 
 .boot-layout .components-editor-notices__snackbar {
 	position: fixed;
-	right: 0;
 	bottom: 16px;
 	padding-left: 16px;
 	padding-right: 16px;
+
+	@media (max-width: $break-small) {
+		right: 0;
+	}
 }


### PR DESCRIPTION


## What?
Closes https://github.com/WordPress/gutenberg/issues/75350

Fixes the success snackbar positioning on the Fonts screen so it appears above the sidebar instead of behind it when saving via keyboard shortcut.

## Why?
When saving font changes using ⌘S / Ctrl+S, the success snackbar is rendered behind the sidebar, making it partially or fully hidden.

## How?
Adjusts the snackbar positioning so it is correctly visible on bigger viewports, ensuring it is not overlapped by the sidebar.

##  Testing Instructions for Keyboard

1. Go to Appearance → Fonts
2. Change any font setting
3. Press ⌘S (macOS) or Ctrl+S (Windows)
4. Confirm the modal
5. Verify the success snackbar is fully visible and not hidden behind the sidebar


## Screenshots or screencast <!-- if applicable -->

### Screencast

https://github.com/user-attachments/assets/996f0f61-f8c7-41b9-9aea-769bbfe7f303




### Screenshots
|Before|After|
|-|-|
|<img width="2926" height="1582" alt="Screenshot 2026-02-10 at 11 41 02 AM" src="https://github.com/user-attachments/assets/70130eca-9efe-4b5f-b61d-2fd91e39cd54" />|<img width="2926" height="1582" alt="image" src="https://github.com/user-attachments/assets/b80b88b3-a31d-4eb8-b688-5111b3f61a28" />|



