### PR TITLE
Block Visibility: Centralize modal state in block-editor store

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -45,7 +45,7 @@ function selector( select ) {
 		isTyping,
 		isDragging,
 		isZoomOut,
-		getBlockVisibilityModalClientIds,
+		getViewportModalClientIds,
 	} = unlock( select( blockEditorStore ) );
 
 	const clientId =
@@ -57,7 +57,7 @@ function selector( select ) {
 		isTyping: isTyping(),
 		isZoomOutMode: isZoomOut(),
 		isDragging: isDragging(),
-		visibilityModalClientIds: getBlockVisibilityModalClientIds(),
+		viewportModalClientIds: getViewportModalClientIds(),
 	};
 }
 
@@ -81,7 +81,7 @@ export default function BlockTools( {
 		isTyping,
 		isZoomOutMode,
 		isDragging,
-		visibilityModalClientIds,
+		viewportModalClientIds,
 	} = useSelect( selector, [] );
 	const isMatch = useShortcutEventMatch();
 	const {
@@ -114,8 +114,8 @@ export default function BlockTools( {
 		moveBlocksDown,
 		expandBlock,
 		stopEditingContentOnlySection,
-		showBlockVisibilityModal,
-		hideBlockVisibilityModal,
+		showViewportModal,
+		hideViewportModal,
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	function onKeyDown( event ) {
@@ -256,7 +256,7 @@ export default function BlockTools( {
 				}
 
 				// Open the visibility breakpoints modal.
-				showBlockVisibilityModal( clientIds );
+				showViewportModal( clientIds );
 			}
 		}
 
@@ -329,10 +329,10 @@ export default function BlockTools( {
 					onClose={ () => setRenamingBlockClientId( null ) }
 				/>
 			) }
-			{ visibilityModalClientIds && (
+			{ viewportModalClientIds && (
 				<BlockVisibilityModal
-					clientIds={ visibilityModalClientIds }
-					onClose={ hideBlockVisibilityModal }
+					clientIds={ viewportModalClientIds }
+					onClose={ hideViewportModal }
 				/>
 			) }
 		</div>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -75,8 +75,6 @@ export default function BlockTools( {
 } ) {
 	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode, isDragging } =
 		useSelect( selector, [] );
-	const [ visibilityModalClientIds, setVisibilityModalClientIds ] =
-		useState( null );
 	const isMatch = useShortcutEventMatch();
 	const {
 		getBlocksByClientId,
@@ -86,7 +84,9 @@ export default function BlockTools( {
 		getBlockName,
 		isGroupable,
 		getEditedContentOnlySection,
+		getBlockVisibilityModalClientIds,
 	} = unlock( useSelect( blockEditorStore ) );
+	const visibilityModalClientIds = getBlockVisibilityModalClientIds();
 	const { getGroupingBlockName } = useSelect( blocksStore );
 	const { showEmptyBlockSideInserter, showBlockToolbarPopover } =
 		useShowBlockTools();
@@ -108,6 +108,8 @@ export default function BlockTools( {
 		moveBlocksDown,
 		expandBlock,
 		stopEditingContentOnlySection,
+		showBlockVisibilityModal,
+		hideBlockVisibilityModal,
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	function onKeyDown( event ) {
@@ -248,7 +250,7 @@ export default function BlockTools( {
 				}
 
 				// Open the visibility breakpoints modal.
-				setVisibilityModalClientIds( clientIds );
+				showBlockVisibilityModal( clientIds );
 			}
 		}
 
@@ -324,7 +326,7 @@ export default function BlockTools( {
 			{ visibilityModalClientIds && (
 				<BlockVisibilityModal
 					clientIds={ visibilityModalClientIds }
-					onClose={ () => setVisibilityModalClientIds( null ) }
+					onClose={ hideBlockVisibilityModal }
 				/>
 			) }
 		</div>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -45,6 +45,7 @@ function selector( select ) {
 		isTyping,
 		isDragging,
 		isZoomOut,
+		getBlockVisibilityModalClientIds,
 	} = unlock( select( blockEditorStore ) );
 
 	const clientId =
@@ -56,6 +57,7 @@ function selector( select ) {
 		isTyping: isTyping(),
 		isZoomOutMode: isZoomOut(),
 		isDragging: isDragging(),
+		visibilityModalClientIds: getBlockVisibilityModalClientIds(),
 	};
 }
 
@@ -73,8 +75,14 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode, isDragging } =
-		useSelect( selector, [] );
+	const {
+		clientId,
+		hasFixedToolbar,
+		isTyping,
+		isZoomOutMode,
+		isDragging,
+		visibilityModalClientIds,
+	} = useSelect( selector, [] );
 	const isMatch = useShortcutEventMatch();
 	const {
 		getBlocksByClientId,
@@ -84,9 +92,7 @@ export default function BlockTools( {
 		getBlockName,
 		isGroupable,
 		getEditedContentOnlySection,
-		getBlockVisibilityModalClientIds,
 	} = unlock( useSelect( blockEditorStore ) );
-	const visibilityModalClientIds = getBlockVisibilityModalClientIds();
 	const { getGroupingBlockName } = useSelect( blocksStore );
 	const { showEmptyBlockSideInserter, showBlockToolbarPopover } =
 		useShowBlockTools();

--- a/packages/block-editor/src/components/block-visibility/viewport-menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-menu-item.js
@@ -3,19 +3,16 @@
  */
 import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
-import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
  */
-import { BlockVisibilityModal } from './';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export default function BlockVisibilityViewportMenuItem( { clientIds } ) {
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const { areBlocksHiddenAnywhere, shortcut } = useSelect(
 		( select ) => {
 			const { isBlockHiddenAnywhere } = unlock(
@@ -34,20 +31,15 @@ export default function BlockVisibilityViewportMenuItem( { clientIds } ) {
 		},
 		[ clientIds ]
 	);
+	const { showBlockVisibilityModal } = unlock(
+		useDispatch( blockEditorStore )
+	);
 	return (
-		<>
-			<MenuItem
-				onClick={ () => setIsModalOpen( true ) }
-				shortcut={ shortcut }
-			>
-				{ areBlocksHiddenAnywhere ? __( 'Show' ) : __( 'Hide' ) }
-			</MenuItem>
-			{ isModalOpen && (
-				<BlockVisibilityModal
-					clientIds={ clientIds }
-					onClose={ () => setIsModalOpen( false ) }
-				/>
-			) }
-		</>
+		<MenuItem
+			onClick={ () => showBlockVisibilityModal( clientIds ) }
+			shortcut={ shortcut }
+		>
+			{ areBlocksHiddenAnywhere ? __( 'Show' ) : __( 'Hide' ) }
+		</MenuItem>
 	);
 }

--- a/packages/block-editor/src/components/block-visibility/viewport-menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-menu-item.js
@@ -31,12 +31,10 @@ export default function BlockVisibilityViewportMenuItem( { clientIds } ) {
 		},
 		[ clientIds ]
 	);
-	const { showBlockVisibilityModal } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { showViewportModal } = unlock( useDispatch( blockEditorStore ) );
 	return (
 		<MenuItem
-			onClick={ () => showBlockVisibilityModal( clientIds ) }
+			onClick={ () => showViewportModal( clientIds ) }
 			shortcut={ shortcut }
 		>
 			{ areBlocksHiddenAnywhere ? __( 'Show' ) : __( 'Hide' ) }

--- a/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
@@ -3,21 +3,19 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { seen, unseen } from '@wordpress/icons';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { BlockVisibilityModal } from './';
 import { unlock } from '../../lock-unlock';
 
 export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 	const hasBlockVisibilityButtonShownRef = useRef( false );
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const { canToggleBlockVisibility, areBlocksHiddenAnywhere } = useSelect(
 		( select ) => {
 			const { getBlocksByClientId, getBlockName, isBlockHiddenAnywhere } =
@@ -39,6 +37,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 
 		[ clientIds ]
 	);
+	const blockEditorDispatch = useDispatch( blockEditorStore );
 
 	/*
 	 * If the block visibility button has been shown, we don't want to
@@ -60,28 +59,19 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 		return null;
 	}
 
+	const { showBlockVisibilityModal } = unlock( blockEditorDispatch );
+
 	return (
-		<>
-			<ToolbarGroup className="block-editor-block-visibility-toolbar">
-				<ToolbarButton
-					disabled={ ! canToggleBlockVisibility }
-					icon={ areBlocksHiddenAnywhere ? unseen : seen }
-					label={
-						areBlocksHiddenAnywhere
-							? __( 'Hidden' )
-							: __( 'Visible' )
-					}
-					onClick={ () => setIsModalOpen( true ) }
-					aria-expanded={ isModalOpen }
-					aria-haspopup={ ! isModalOpen ? 'dialog' : undefined }
-				/>
-			</ToolbarGroup>
-			{ isModalOpen && (
-				<BlockVisibilityModal
-					clientIds={ clientIds }
-					onClose={ () => setIsModalOpen( false ) }
-				/>
-			) }
-		</>
+		<ToolbarGroup className="block-editor-block-visibility-toolbar">
+			<ToolbarButton
+				disabled={ ! canToggleBlockVisibility }
+				icon={ areBlocksHiddenAnywhere ? unseen : seen }
+				label={
+					areBlocksHiddenAnywhere ? __( 'Hidden' ) : __( 'Visible' )
+				}
+				onClick={ () => showBlockVisibilityModal( clientIds ) }
+				aria-haspopup="dialog"
+			/>
+		</ToolbarGroup>
 	);
 }

--- a/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
@@ -23,7 +23,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 					getBlocksByClientId,
 					getBlockName,
 					isBlockHiddenAnywhere,
-					getBlockVisibilityModalClientIds,
+					getViewportModalClientIds,
 				} = unlock( select( blockEditorStore ) );
 				const _blocks = getBlocksByClientId( clientIds );
 				return {
@@ -37,7 +37,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 					areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
 						isBlockHiddenAnywhere( clientId )
 					),
-					isModalOpen: getBlockVisibilityModalClientIds() !== null,
+					isModalOpen: getViewportModalClientIds() !== null,
 				};
 			},
 
@@ -65,7 +65,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 		return null;
 	}
 
-	const { showBlockVisibilityModal } = unlock( blockEditorDispatch );
+	const { showViewportModal } = unlock( blockEditorDispatch );
 
 	return (
 		<ToolbarGroup className="block-editor-block-visibility-toolbar">
@@ -75,7 +75,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 				label={
 					areBlocksHiddenAnywhere ? __( 'Hidden' ) : __( 'Visible' )
 				}
-				onClick={ () => showBlockVisibilityModal( clientIds ) }
+				onClick={ () => showViewportModal( clientIds ) }
 				aria-expanded={ isModalOpen }
 				aria-haspopup="dialog"
 			/>

--- a/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
@@ -16,27 +16,33 @@ import { unlock } from '../../lock-unlock';
 
 export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 	const hasBlockVisibilityButtonShownRef = useRef( false );
-	const { canToggleBlockVisibility, areBlocksHiddenAnywhere } = useSelect(
-		( select ) => {
-			const { getBlocksByClientId, getBlockName, isBlockHiddenAnywhere } =
-				unlock( select( blockEditorStore ) );
-			const _blocks = getBlocksByClientId( clientIds );
-			return {
-				canToggleBlockVisibility: _blocks.every( ( { clientId } ) =>
-					hasBlockSupport(
-						getBlockName( clientId ),
-						'visibility',
-						true
-					)
-				),
-				areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
-					isBlockHiddenAnywhere( clientId )
-				),
-			};
-		},
+	const { canToggleBlockVisibility, areBlocksHiddenAnywhere, isModalOpen } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlocksByClientId,
+					getBlockName,
+					isBlockHiddenAnywhere,
+					getBlockVisibilityModalClientIds,
+				} = unlock( select( blockEditorStore ) );
+				const _blocks = getBlocksByClientId( clientIds );
+				return {
+					canToggleBlockVisibility: _blocks.every( ( { clientId } ) =>
+						hasBlockSupport(
+							getBlockName( clientId ),
+							'visibility',
+							true
+						)
+					),
+					areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
+						isBlockHiddenAnywhere( clientId )
+					),
+					isModalOpen: getBlockVisibilityModalClientIds() !== null,
+				};
+			},
 
-		[ clientIds ]
-	);
+			[ clientIds ]
+		);
 	const blockEditorDispatch = useDispatch( blockEditorStore );
 
 	/*
@@ -70,6 +76,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 					areBlocksHiddenAnywhere ? __( 'Hidden' ) : __( 'Visible' )
 				}
 				onClick={ () => showBlockVisibilityModal( clientIds ) }
+				aria-expanded={ isModalOpen }
 				aria-haspopup="dialog"
 			/>
 		</ToolbarGroup>

--- a/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
@@ -16,33 +16,27 @@ import { unlock } from '../../lock-unlock';
 
 export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 	const hasBlockVisibilityButtonShownRef = useRef( false );
-	const { canToggleBlockVisibility, areBlocksHiddenAnywhere, isModalOpen } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlocksByClientId,
-					getBlockName,
-					isBlockHiddenAnywhere,
-					getViewportModalClientIds,
-				} = unlock( select( blockEditorStore ) );
-				const _blocks = getBlocksByClientId( clientIds );
-				return {
-					canToggleBlockVisibility: _blocks.every( ( { clientId } ) =>
-						hasBlockSupport(
-							getBlockName( clientId ),
-							'visibility',
-							true
-						)
-					),
-					areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
-						isBlockHiddenAnywhere( clientId )
-					),
-					isModalOpen: getViewportModalClientIds() !== null,
-				};
-			},
+	const { canToggleBlockVisibility, areBlocksHiddenAnywhere } = useSelect(
+		( select ) => {
+			const { getBlocksByClientId, getBlockName, isBlockHiddenAnywhere } =
+				unlock( select( blockEditorStore ) );
+			const _blocks = getBlocksByClientId( clientIds );
+			return {
+				canToggleBlockVisibility: _blocks.every( ( { clientId } ) =>
+					hasBlockSupport(
+						getBlockName( clientId ),
+						'visibility',
+						true
+					)
+				),
+				areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
+					isBlockHiddenAnywhere( clientId )
+				),
+			};
+		},
 
-			[ clientIds ]
-		);
+		[ clientIds ]
+	);
 	const blockEditorDispatch = useDispatch( blockEditorStore );
 
 	/*
@@ -76,7 +70,6 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 					areBlocksHiddenAnywhere ? __( 'Hidden' ) : __( 'Visible' )
 				}
 				onClick={ () => showViewportModal( clientIds ) }
-				aria-expanded={ isModalOpen }
 				aria-haspopup="dialog"
 			/>
 		</ToolbarGroup>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -99,7 +99,7 @@ function ListViewBlock( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
-		showBlockVisibilityModal,
+		showViewportModal,
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	const debouncedToggleBlockHighlight = useDebounce(
@@ -413,7 +413,7 @@ function ListViewBlock( {
 			}
 
 			// Open the visibility breakpoints modal.
-			showBlockVisibilityModal( blocksToUpdate );
+			showViewportModal( blocksToUpdate );
 		} else if ( isMatch( 'core/block-editor/rename', event ) ) {
 			const { blocksToUpdate } = getBlocksToUpdate();
 			const isContentOnly =

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -54,7 +54,7 @@ import { useBlockRename, BlockRenameModal } from '../block-rename';
 import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
 import usePasteStyles from '../use-paste-styles';
-import { useBlockVisibility, BlockVisibilityModal } from '../block-visibility';
+import { useBlockVisibility } from '../block-visibility';
 import { deviceTypeKey } from '../../store/private-keys';
 import { BLOCK_VISIBILITY_VIEWPORTS } from '../block-visibility/constants';
 
@@ -83,8 +83,6 @@ function ListViewBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ settingsAnchorRect, setSettingsAnchorRect ] = useState();
 	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
-	const [ visibilityModalClientIds, setVisibilityModalClientIds ] =
-		useState( null );
 	const { isLocked } = useBlockLock( clientId );
 
 	const isFirstSelectedBlock =
@@ -101,6 +99,7 @@ function ListViewBlock( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
+		showBlockVisibilityModal,
 	} = unlock( useDispatch( blockEditorStore ) );
 
 	const debouncedToggleBlockHighlight = useDebounce(
@@ -414,7 +413,7 @@ function ListViewBlock( {
 			}
 
 			// Open the visibility breakpoints modal.
-			setVisibilityModalClientIds( blocksToUpdate );
+			showBlockVisibilityModal( blocksToUpdate );
 		} else if ( isMatch( 'core/block-editor/rename', event ) ) {
 			const { blocksToUpdate } = getBlocksToUpdate();
 			const isContentOnly =
@@ -720,12 +719,6 @@ function ListViewBlock( {
 						/>
 					) }
 				</TreeGridCell>
-			) }
-			{ visibilityModalClientIds && (
-				<BlockVisibilityModal
-					clientIds={ visibilityModalClientIds }
-					onClose={ () => setVisibilityModalClientIds( null ) }
-				/>
 			) }
 			{ isRenameModalOpen && (
 				<BlockRenameModal

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -16,6 +16,7 @@ import {
 	plus as add,
 	group,
 	ungroup,
+	unseen,
 } from '@wordpress/icons';
 
 /**
@@ -23,6 +24,7 @@ import {
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const getTransformCommands = () =>
 	function useTransformCommands() {
@@ -163,13 +165,14 @@ const getQuickActionsCommands = () =>
 
 		const blocks = getBlocksByClientId( clientIds );
 
+		const blockEditorDispatch = useDispatch( blockEditorStore );
 		const {
 			removeBlocks,
 			replaceBlocks,
 			duplicateBlocks,
 			insertAfterBlock,
 			insertBeforeBlock,
-		} = useDispatch( blockEditorStore );
+		} = blockEditorDispatch;
 
 		const onGroup = () => {
 			if ( ! blocks.length ) {
@@ -204,6 +207,7 @@ const getQuickActionsCommands = () =>
 			return { isLoading: false, commands: [] };
 		}
 
+		const { showBlockVisibilityModal } = unlock( blockEditorDispatch );
 		const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 		const canInsertDefaultBlock = canInsertBlockType(
 			getDefaultBlockName(),
@@ -280,6 +284,20 @@ const getQuickActionsCommands = () =>
 				label: __( 'Delete' ),
 				callback: () => removeBlocks( clientIds, true ),
 				icon: remove,
+			} );
+		}
+
+		const supportsVisibility = blocks.every(
+			( block ) =>
+				!! block && hasBlockSupport( block.name, 'visibility', true )
+		);
+
+		if ( supportsVisibility ) {
+			commands.push( {
+				name: 'toggle-visibility',
+				label: __( 'Hide' ),
+				callback: () => showBlockVisibilityModal( clientIds ),
+				icon: unseen,
 			} );
 		}
 

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -209,7 +209,7 @@ const getQuickActionsCommands = () =>
 			return { isLoading: false, commands: [] };
 		}
 
-		const { showBlockVisibilityModal } = unlock( blockEditorDispatch );
+		const { showViewportModal } = unlock( blockEditorDispatch );
 		const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 		const canInsertDefaultBlock = canInsertBlockType(
 			getDefaultBlockName(),
@@ -301,7 +301,7 @@ const getQuickActionsCommands = () =>
 			commands.push( {
 				name: 'toggle-visibility',
 				label: hasHiddenBlock ? __( 'Show' ) : __( 'Hide' ),
-				callback: () => showBlockVisibilityModal( clientIds ),
+				callback: () => showViewportModal( clientIds ),
 				icon: hasHiddenBlock ? seen : unseen,
 			} );
 		}

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -16,6 +16,7 @@ import {
 	plus as add,
 	group,
 	ungroup,
+	seen,
 	unseen,
 } from '@wordpress/icons';
 
@@ -159,7 +160,8 @@ const getQuickActionsCommands = () =>
 			getBlockRootClientId,
 			getBlocksByClientId,
 			canRemoveBlocks,
-		} = useSelect( blockEditorStore );
+			isBlockHiddenAnywhere,
+		} = unlock( useSelect( blockEditorStore ) );
 		const { getDefaultBlockName, getGroupingBlockName } =
 			useSelect( blocksStore );
 
@@ -293,11 +295,14 @@ const getQuickActionsCommands = () =>
 		);
 
 		if ( supportsVisibility ) {
+			const hasHiddenBlock = clientIds.some( ( id ) =>
+				isBlockHiddenAnywhere( id )
+			);
 			commands.push( {
 				name: 'toggle-visibility',
-				label: __( 'Hide' ),
+				label: hasHiddenBlock ? __( 'Show' ) : __( 'Hide' ),
 				callback: () => showBlockVisibilityModal( clientIds ),
-				icon: unseen,
+				icon: hasHiddenBlock ? seen : unseen,
 			} );
 		}
 

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -475,3 +475,28 @@ export function closeListViewContentPanel() {
 		type: 'CLOSE_LIST_VIEW_CONTENT_PANEL',
 	};
 }
+
+/**
+ * Returns an action object used to open the block visibility modal
+ * for the given client IDs.
+ *
+ * @param {string[]} clientIds Client IDs of blocks to configure visibility for.
+ * @return {Object} Action object.
+ */
+export function showBlockVisibilityModal( clientIds ) {
+	return {
+		type: 'SHOW_BLOCK_VISIBILITY_MODAL',
+		clientIds,
+	};
+}
+
+/**
+ * Returns an action object used to close the block visibility modal.
+ *
+ * @return {Object} Action object.
+ */
+export function hideBlockVisibilityModal() {
+	return {
+		type: 'HIDE_BLOCK_VISIBILITY_MODAL',
+	};
+}

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -477,26 +477,26 @@ export function closeListViewContentPanel() {
 }
 
 /**
- * Returns an action object used to open the block visibility modal
+ * Returns an action object used to open the viewport modal
  * for the given client IDs.
  *
- * @param {string[]} clientIds Client IDs of blocks to configure visibility for.
+ * @param {string[]} clientIds Client IDs of blocks to configure viewport settings for.
  * @return {Object} Action object.
  */
-export function showBlockVisibilityModal( clientIds ) {
+export function showViewportModal( clientIds ) {
 	return {
-		type: 'SHOW_BLOCK_VISIBILITY_MODAL',
+		type: 'SHOW_VIEWPORT_MODAL',
 		clientIds,
 	};
 }
 
 /**
- * Returns an action object used to close the block visibility modal.
+ * Returns an action object used to close the viewport modal.
  *
  * @return {Object} Action object.
  */
-export function hideBlockVisibilityModal() {
+export function hideViewportModal() {
 	return {
-		type: 'HIDE_BLOCK_VISIBILITY_MODAL',
+		type: 'HIDE_VIEWPORT_MODAL',
 	};
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -990,33 +990,6 @@ export function getListViewExpandRevision( state ) {
 }
 
 /**
- * Returns whether a List View panel is opened.
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId Client ID of the block.
- *
- * @return {boolean} Whether the panel is opened.
- */
-export function isListViewPanelOpened( state, clientId ) {
-	// If allOpen flag is set, all panels are open
-	if ( state.openedListViewPanels?.allOpen ) {
-		return true;
-	}
-	return state.openedListViewPanels?.panels?.[ clientId ] === true;
-}
-
-/**
- * Returns the List View expand revision number.
- *
- * @param {Object} state Global application state.
- *
- * @return {number} The expand revision number.
- */
-export function getListViewExpandRevision( state ) {
-	return state.listViewExpandRevision || 0;
-}
-
-/**
  * Returns the client IDs for the viewport modal, or null if
  * the modal is not open.
  *

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -988,3 +988,15 @@ export function isListViewPanelOpened( state, clientId ) {
 export function getListViewExpandRevision( state ) {
 	return state.listViewExpandRevision || 0;
 }
+
+/**
+ * Returns the client IDs for the block visibility modal, or null if
+ * the modal is not open.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array|null} Client IDs for the visibility modal, or null.
+ */
+export function getBlockVisibilityModalClientIds( state ) {
+	return state.blockVisibilityModalClientIds;
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -995,7 +995,7 @@ export function getListViewExpandRevision( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {Array|null} Client IDs for the visibility modal, or null.
+ * @return {string[]|null} Client IDs for the visibility modal, or null.
  */
 export function getBlockVisibilityModalClientIds( state ) {
 	return state.blockVisibilityModalClientIds;

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -990,13 +990,40 @@ export function getListViewExpandRevision( state ) {
 }
 
 /**
- * Returns the client IDs for the block visibility modal, or null if
+ * Returns whether a List View panel is opened.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client ID of the block.
+ *
+ * @return {boolean} Whether the panel is opened.
+ */
+export function isListViewPanelOpened( state, clientId ) {
+	// If allOpen flag is set, all panels are open
+	if ( state.openedListViewPanels?.allOpen ) {
+		return true;
+	}
+	return state.openedListViewPanels?.panels?.[ clientId ] === true;
+}
+
+/**
+ * Returns the List View expand revision number.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number} The expand revision number.
+ */
+export function getListViewExpandRevision( state ) {
+	return state.listViewExpandRevision || 0;
+}
+
+/**
+ * Returns the client IDs for the viewport modal, or null if
  * the modal is not open.
  *
  * @param {Object} state Global application state.
  *
  * @return {string[]|null} Client IDs for the visibility modal, or null.
  */
-export function getBlockVisibilityModalClientIds( state ) {
-	return state.blockVisibilityModalClientIds;
+export function getViewportModalClientIds( state ) {
+	return state.viewportModalClientIds;
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1503,22 +1503,13 @@ export function isSelectionEnabled( state = true, action ) {
 }
 
 /**
- * Reducer returning the data needed to display a prompt when certain blocks
- * are removed, or `false` if no such prompt is requested.
- *
- * @param {boolean} state  Current state.
- * @param {Object}  action Dispatched action.
- *
- * @return {Object|false} Data for removal prompt display, if any.
- */
-/**
  * Reducer returning the client IDs for the block visibility modal,
  * or null if the modal is not open.
  *
- * @param {Array|null} state  Current state.
- * @param {Object}     action Dispatched action.
+ * @param {string[]|null} state  Current state.
+ * @param {Object}        action Dispatched action.
  *
- * @return {Array|null} Client IDs for the visibility modal.
+ * @return {string[]|null} Client IDs for the visibility modal.
  */
 export function blockVisibilityModalClientIds( state = null, action ) {
 	switch ( action.type ) {
@@ -1530,6 +1521,15 @@ export function blockVisibilityModalClientIds( state = null, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the data needed to display a prompt when certain blocks
+ * are removed, or `false` if no such prompt is requested.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {Object|false} Data for removal prompt display, if any.
+ */
 function removalPromptData( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISPLAY_BLOCK_REMOVAL_PROMPT':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1503,19 +1503,19 @@ export function isSelectionEnabled( state = true, action ) {
 }
 
 /**
- * Reducer returning the client IDs for the block visibility modal,
+ * Reducer returning the client IDs for the viewport modal,
  * or null if the modal is not open.
  *
  * @param {string[]|null} state  Current state.
  * @param {Object}        action Dispatched action.
  *
- * @return {string[]|null} Client IDs for the visibility modal.
+ * @return {string[]|null} Client IDs for the viewport modal.
  */
-export function blockVisibilityModalClientIds( state = null, action ) {
+export function viewportModalClientIds( state = null, action ) {
 	switch ( action.type ) {
-		case 'SHOW_BLOCK_VISIBILITY_MODAL':
+		case 'SHOW_VIEWPORT_MODAL':
 			return action.clientIds;
-		case 'HIDE_BLOCK_VISIBILITY_MODAL':
+		case 'HIDE_VIEWPORT_MODAL':
 			return null;
 	}
 	return state;
@@ -2239,7 +2239,7 @@ const combinedReducers = combineReducers( {
 	lastBlockInserted,
 	editedContentOnlySection,
 	blockVisibility,
-	blockVisibilityModalClientIds,
+	viewportModalClientIds,
 	blockEditingModes,
 	styleOverrides,
 	removalPromptData,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1511,6 +1511,25 @@ export function isSelectionEnabled( state = true, action ) {
  *
  * @return {Object|false} Data for removal prompt display, if any.
  */
+/**
+ * Reducer returning the client IDs for the block visibility modal,
+ * or null if the modal is not open.
+ *
+ * @param {Array|null} state  Current state.
+ * @param {Object}     action Dispatched action.
+ *
+ * @return {Array|null} Client IDs for the visibility modal.
+ */
+export function blockVisibilityModalClientIds( state = null, action ) {
+	switch ( action.type ) {
+		case 'SHOW_BLOCK_VISIBILITY_MODAL':
+			return action.clientIds;
+		case 'HIDE_BLOCK_VISIBILITY_MODAL':
+			return null;
+	}
+	return state;
+}
+
 function removalPromptData( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISPLAY_BLOCK_REMOVAL_PROMPT':
@@ -2220,6 +2239,7 @@ const combinedReducers = combineReducers( {
 	lastBlockInserted,
 	editedContentOnlySection,
 	blockVisibility,
+	blockVisibilityModalClientIds,
 	blockEditingModes,
 	styleOverrides,
 	removalPromptData,

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -9,6 +9,8 @@ import {
 	setInsertionPoint,
 	startDragging,
 	stopDragging,
+	showBlockVisibilityModal,
+	hideBlockVisibilityModal,
 } from '../private-actions';
 
 describe( 'private actions', () => {
@@ -118,6 +120,24 @@ describe( 'private actions', () => {
 			).toEqual( {
 				type: 'SET_INSERTION_POINT',
 				value: { rootClientId: '', index: '123' },
+			} );
+		} );
+	} );
+
+	describe( 'showBlockVisibilityModal', () => {
+		it( 'should return the SHOW_BLOCK_VISIBILITY_MODAL action with clientIds', () => {
+			const clientIds = [ 'client-1', 'client-2' ];
+			expect( showBlockVisibilityModal( clientIds ) ).toEqual( {
+				type: 'SHOW_BLOCK_VISIBILITY_MODAL',
+				clientIds,
+			} );
+		} );
+	} );
+
+	describe( 'hideBlockVisibilityModal', () => {
+		it( 'should return the HIDE_BLOCK_VISIBILITY_MODAL action', () => {
+			expect( hideBlockVisibilityModal() ).toEqual( {
+				type: 'HIDE_BLOCK_VISIBILITY_MODAL',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -9,8 +9,8 @@ import {
 	setInsertionPoint,
 	startDragging,
 	stopDragging,
-	showBlockVisibilityModal,
-	hideBlockVisibilityModal,
+	showViewportModal,
+	hideViewportModal,
 } from '../private-actions';
 
 describe( 'private actions', () => {
@@ -124,20 +124,20 @@ describe( 'private actions', () => {
 		} );
 	} );
 
-	describe( 'showBlockVisibilityModal', () => {
-		it( 'should return the SHOW_BLOCK_VISIBILITY_MODAL action with clientIds', () => {
+	describe( 'showViewportModal', () => {
+		it( 'should return the SHOW_VIEWPORT_MODAL action with clientIds', () => {
 			const clientIds = [ 'client-1', 'client-2' ];
-			expect( showBlockVisibilityModal( clientIds ) ).toEqual( {
-				type: 'SHOW_BLOCK_VISIBILITY_MODAL',
+			expect( showViewportModal( clientIds ) ).toEqual( {
+				type: 'SHOW_VIEWPORT_MODAL',
 				clientIds,
 			} );
 		} );
 	} );
 
-	describe( 'hideBlockVisibilityModal', () => {
-		it( 'should return the HIDE_BLOCK_VISIBILITY_MODAL action', () => {
-			expect( hideBlockVisibilityModal() ).toEqual( {
-				type: 'HIDE_BLOCK_VISIBILITY_MODAL',
+	describe( 'hideViewportModal', () => {
+		it( 'should return the HIDE_VIEWPORT_MODAL action', () => {
+			expect( hideViewportModal() ).toEqual( {
+				type: 'HIDE_VIEWPORT_MODAL',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -21,7 +21,7 @@ import {
 	isLockedBlock,
 	isBlockHiddenAnywhere,
 	isBlockHiddenAtViewport,
-	getBlockVisibilityModalClientIds,
+	getViewportModalClientIds,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -1323,22 +1323,20 @@ describe( 'private selectors', () => {
 		} );
 	} );
 
-	describe( 'getBlockVisibilityModalClientIds', () => {
+	describe( 'getViewportModalClientIds', () => {
 		it( 'should return null when modal is not open', () => {
 			const state = {
-				blockVisibilityModalClientIds: null,
+				viewportModalClientIds: null,
 			};
-			expect( getBlockVisibilityModalClientIds( state ) ).toBeNull();
+			expect( getViewportModalClientIds( state ) ).toBeNull();
 		} );
 
 		it( 'should return client IDs when modal is open', () => {
 			const clientIds = [ 'client-1', 'client-2' ];
 			const state = {
-				blockVisibilityModalClientIds: clientIds,
+				viewportModalClientIds: clientIds,
 			};
-			expect( getBlockVisibilityModalClientIds( state ) ).toEqual(
-				clientIds
-			);
+			expect( getViewportModalClientIds( state ) ).toEqual( clientIds );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -21,6 +21,7 @@ import {
 	isLockedBlock,
 	isBlockHiddenAnywhere,
 	isBlockHiddenAtViewport,
+	getBlockVisibilityModalClientIds,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -1319,6 +1320,25 @@ describe( 'private selectors', () => {
 			);
 			const result = isBlockHiddenAnywhere( state, 'test-block' );
 			expect( result ).toBe( false );
+		} );
+	} );
+
+	describe( 'getBlockVisibilityModalClientIds', () => {
+		it( 'should return null when modal is not open', () => {
+			const state = {
+				blockVisibilityModalClientIds: null,
+			};
+			expect( getBlockVisibilityModalClientIds( state ) ).toBeNull();
+		} );
+
+		it( 'should return client IDs when modal is open', () => {
+			const clientIds = [ 'client-1', 'client-2' ];
+			const state = {
+				blockVisibilityModalClientIds: clientIds,
+			};
+			expect( getBlockVisibilityModalClientIds( state ) ).toEqual(
+				clientIds
+			);
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -42,7 +42,7 @@ import {
 	zoomLevel,
 	editedContentOnlySection,
 	withDerivedBlockEditingModes,
-	blockVisibilityModalClientIds,
+	viewportModalClientIds,
 } from '../reducer';
 
 import { unlock } from '../../lock-unlock';
@@ -4572,31 +4572,31 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'blockVisibilityModalClientIds', () => {
+	describe( 'viewportModalClientIds', () => {
 		it( 'should default to null', () => {
-			const state = blockVisibilityModalClientIds( undefined, {} );
+			const state = viewportModalClientIds( undefined, {} );
 			expect( state ).toBeNull();
 		} );
 
-		it( 'should return clientIds on SHOW_BLOCK_VISIBILITY_MODAL', () => {
+		it( 'should return clientIds on SHOW_VIEWPORT_MODAL', () => {
 			const clientIds = [ 'client-1', 'client-2' ];
-			const state = blockVisibilityModalClientIds( null, {
-				type: 'SHOW_BLOCK_VISIBILITY_MODAL',
+			const state = viewportModalClientIds( null, {
+				type: 'SHOW_VIEWPORT_MODAL',
 				clientIds,
 			} );
 			expect( state ).toEqual( clientIds );
 		} );
 
-		it( 'should return null on HIDE_BLOCK_VISIBILITY_MODAL', () => {
-			const state = blockVisibilityModalClientIds( [ 'client-1' ], {
-				type: 'HIDE_BLOCK_VISIBILITY_MODAL',
+		it( 'should return null on HIDE_VIEWPORT_MODAL', () => {
+			const state = viewportModalClientIds( [ 'client-1' ], {
+				type: 'HIDE_VIEWPORT_MODAL',
 			} );
 			expect( state ).toBeNull();
 		} );
 
 		it( 'should return current state for unknown actions', () => {
 			const currentState = [ 'client-1' ];
-			const state = blockVisibilityModalClientIds( currentState, {
+			const state = viewportModalClientIds( currentState, {
 				type: 'UNKNOWN_ACTION',
 			} );
 			expect( state ).toBe( currentState );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -42,6 +42,7 @@ import {
 	zoomLevel,
 	editedContentOnlySection,
 	withDerivedBlockEditingModes,
+	blockVisibilityModalClientIds,
 } from '../reducer';
 
 import { unlock } from '../../lock-unlock';
@@ -4568,6 +4569,37 @@ describe( 'state', () => {
 					)
 				);
 			} );
+		} );
+	} );
+
+	describe( 'blockVisibilityModalClientIds', () => {
+		it( 'should default to null', () => {
+			const state = blockVisibilityModalClientIds( undefined, {} );
+			expect( state ).toBeNull();
+		} );
+
+		it( 'should return clientIds on SHOW_BLOCK_VISIBILITY_MODAL', () => {
+			const clientIds = [ 'client-1', 'client-2' ];
+			const state = blockVisibilityModalClientIds( null, {
+				type: 'SHOW_BLOCK_VISIBILITY_MODAL',
+				clientIds,
+			} );
+			expect( state ).toEqual( clientIds );
+		} );
+
+		it( 'should return null on HIDE_BLOCK_VISIBILITY_MODAL', () => {
+			const state = blockVisibilityModalClientIds( [ 'client-1' ], {
+				type: 'HIDE_BLOCK_VISIBILITY_MODAL',
+			} );
+			expect( state ).toBeNull();
+		} );
+
+		it( 'should return current state for unknown actions', () => {
+			const currentState = [ 'client-1' ];
+			const state = blockVisibilityModalClientIds( currentState, {
+				type: 'UNKNOWN_ACTION',
+			} );
+			expect( state ).toBe( currentState );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

This PR decouples “request to open the visibility modal” from “rendering the visibility modal” within the block editor package.

Part of the block visibility feature for: 

- https://github.com/WordPress/gutenberg/issues/72502 and 
- https://github.com/WordPress/gutenberg/issues/73776


## Why?

There was no way to trigger the block visibility modal from outside the components that render it. E.g., the command palette hooks (use-block-commands) lived inside the block editor package but couldn’t open the modal because they don't render UI.

This was identified in [this discussion](https://github.com/WordPress/gutenberg/pull/74249#discussion_r2666995692) as a broader architectural gap: the block-editor package has no mechanism for arbitrary code to request that a modal be shown.

By moving the modal state into the block-editor store as private actions/selectors, **any code with access to the store can open the modal** — regardless of whether it renders UI. A command palette callback, a keyboard shortcut handler, a context menu item, or even code in a consuming package like `editor` can all dispatch `showViewportModal( clientIds )` and the modal will appear.

This PR demonstrates the pattern by re-adding the "Hide" command to the command palette, which was previously impossible.

## How?

Follows the existing `removalPromptData` pattern in the block-editor store:

- **New reducer**: `viewportModalClientIds` — holds `string[] | null`
- **New private actions**: `showViewportModal(clientIds)` / `hideViewportModal()`
- **New private selector**: `getViewportModalClientIds()`
- **Single render point**: The modal is rendered only from `BlockTools`, driven by the store selector
- **All entry points** now dispatch to the store instead of managing local state
- **New command**: "Hide" command added to the command palette via `use-block-commands`

## Testing Instructions

1. Enable the experimental block visibility flag in `/wp-admin/admin.php?page=gutenberg-experiments`
2. Test all entry points open the modal:
   - Toolbar visibility button (when block is hidden)
   - Block settings menu "Show/Hide"
   - Keyboard shortcut `Cmd/Ctrl+Shift+H`
   - List view keyboard shortcut
   - **Command palette** (`Cmd/Ctrl+K` → type "Hide") — **this is new!**
3. Test the modal closes correctly from all entry points
4. Test multi-block selection still works
5. Applying block visibility rules should work as expected (no regressions)



https://github.com/user-attachments/assets/0c446903-18cf-447e-be1e-4bcb9e521936