### PR TITLE
POC Footnotes: Migrate storage from post meta to block attributes (Phase 1)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -330,6 +330,7 @@ Display footnotes added to the page. ([Source](https://github.com/WordPress/gute
 -	**Name:** core/footnotes
 -	**Category:** text
 -	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
+-	**Attributes:** footnotes
 
 ## Form
 

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -8,6 +8,12 @@
 	"keywords": [ "references" ],
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"footnotes": {
+			"type": "array",
+			"default": []
+		}
+	},
 	"supports": {
 		"anchor": true,
 		"__experimentalBorder": {

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -7,7 +7,16 @@ import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
 import { formatListNumbered as icon } from '@wordpress/icons';
 
-export default function FootnotesEdit( { context: { postType, postId } } ) {
+/**
+ * Internal dependencies
+ */
+import { useMigrateFootnotes } from './use-migrate-footnotes';
+
+export default function FootnotesEdit( {
+	attributes,
+	setAttributes,
+	context: { postType, postId },
+} ) {
 	const [ meta, updateMeta ] = useEntityProp(
 		'postType',
 		postType,
@@ -15,7 +24,9 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 		postId
 	);
 	const footnotesSupported = 'string' === typeof meta?.footnotes;
-	const footnotes = meta?.footnotes ? JSON.parse( meta.footnotes ) : [];
+
+	// Migrate footnotes from meta to block attributes on first load.
+	const footnotes = useMigrateFootnotes( attributes, setAttributes, meta );
 	const blockProps = useBlockProps();
 
 	if ( ! footnotesSupported ) {
@@ -75,19 +86,32 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 							}
 						} }
 						onChange={ ( nextFootnote ) => {
-							updateMeta( {
-								...meta,
-								footnotes: JSON.stringify(
-									footnotes.map( ( footnote ) => {
-										return footnote.id === id
-											? {
-													content: nextFootnote,
-													id,
-											  }
-											: footnote;
-									} )
-								),
+							const updatedFootnotes = footnotes.map(
+								( footnote ) => {
+									return footnote.id === id
+										? {
+												content: nextFootnote,
+												id,
+										  }
+										: footnote;
+								}
+							);
+
+							// Primary: update block attributes.
+							setAttributes( {
+								footnotes: updatedFootnotes,
 							} );
+
+							// Phase 1: dual-write to meta for backward compatibility.
+							// This ensures older editor versions can still read footnotes.
+							// Remove in Phase 2 when meta writes are dropped.
+							if ( footnotesSupported ) {
+								updateMeta( {
+									...meta,
+									footnotes:
+										JSON.stringify( updatedFootnotes ),
+								} );
+							}
 						} }
 					/>{ ' ' }
 					<a href={ `#${ id }-link` }>↩︎</a>

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -26,13 +26,17 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$footnotes = get_post_meta( $block->context['postId'], 'footnotes', true );
-
-	if ( ! $footnotes ) {
-		return '';
+	// Read from block attributes first (new approach), fall back to post meta
+	// for backward compatibility with posts not yet migrated.
+	$footnotes = null;
+	if ( ! empty( $attributes['footnotes'] ) && is_array( $attributes['footnotes'] ) ) {
+		$footnotes = $attributes['footnotes'];
+	} else {
+		$footnotes_meta = get_post_meta( $block->context['postId'], 'footnotes', true );
+		if ( $footnotes_meta ) {
+			$footnotes = json_decode( $footnotes_meta, true );
+		}
 	}
-
-	$footnotes = json_decode( $footnotes, true );
 
 	if ( ! is_array( $footnotes ) || count( $footnotes ) === 0 ) {
 		return '';

--- a/packages/block-library/src/footnotes/test/use-migrate-footnotes.js
+++ b/packages/block-library/src/footnotes/test/use-migrate-footnotes.js
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useMigrateFootnotes } from '../use-migrate-footnotes';
+
+describe( 'useMigrateFootnotes', () => {
+	let mockSetAttributes;
+
+	beforeEach( () => {
+		mockSetAttributes = jest.fn();
+		jest.clearAllMocks();
+	} );
+
+	describe( 'when footnotes are already in block attributes', () => {
+		it( 'should return footnotes from attributes', () => {
+			const attributes = {
+				footnotes: [
+					{ id: '1', content: 'First footnote' },
+					{ id: '2', content: 'Second footnote' },
+				],
+			};
+			const meta = {};
+
+			const { result } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( result.current ).toEqual( attributes.footnotes );
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not migrate when attributes already have footnotes', () => {
+			const attributes = {
+				footnotes: [ { id: '1', content: 'Existing' } ],
+			};
+			const meta = {
+				footnotes: JSON.stringify( [
+					{ id: '1', content: 'From meta' },
+				] ),
+			};
+
+			renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when footnotes need migration from meta', () => {
+		it( 'should return footnotes from meta before migration completes', () => {
+			const attributes = {};
+			const footnotesFromMeta = [
+				{ id: '1', content: 'First footnote' },
+				{ id: '2', content: 'Second footnote' },
+			];
+			const meta = {
+				footnotes: JSON.stringify( footnotesFromMeta ),
+			};
+
+			const { result } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( result.current ).toEqual( footnotesFromMeta );
+		} );
+
+		it( 'should migrate footnotes from meta to attributes', () => {
+			const attributes = {};
+			const footnotesFromMeta = [
+				{ id: '1', content: 'First footnote' },
+				{ id: '2', content: 'Second footnote' },
+			];
+			const meta = {
+				footnotes: JSON.stringify( footnotesFromMeta ),
+			};
+
+			renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( mockSetAttributes ).toHaveBeenCalledTimes( 1 );
+			expect( mockSetAttributes ).toHaveBeenCalledWith( {
+				footnotes: footnotesFromMeta,
+			} );
+		} );
+
+		it( 'should only migrate once even if hook re-renders', () => {
+			const attributes = {};
+			const footnotesFromMeta = [
+				{ id: '1', content: 'First footnote' },
+			];
+			const meta = {
+				footnotes: JSON.stringify( footnotesFromMeta ),
+			};
+
+			const { rerender } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( mockSetAttributes ).toHaveBeenCalledTimes( 1 );
+
+			rerender();
+
+			expect( mockSetAttributes ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'when footnotes are not supported', () => {
+		it( 'should return empty array when meta.footnotes is not a string', () => {
+			const attributes = {};
+			const meta = {
+				footnotes: [ { id: '1', content: 'Not a string' } ],
+			};
+
+			const { result } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( result.current ).toEqual( [] );
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should return empty array when meta.footnotes is undefined', () => {
+			const attributes = {};
+			const meta = {};
+
+			const { result } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( result.current ).toEqual( [] );
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when meta contains invalid JSON', () => {
+		it( 'should return empty array', () => {
+			const attributes = {};
+			const meta = { footnotes: 'invalid json {' };
+
+			const { result } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( result.current ).toEqual( [] );
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when meta contains empty array', () => {
+		it( 'should return empty array and not migrate', () => {
+			const attributes = {};
+			const meta = { footnotes: JSON.stringify( [] ) };
+
+			const { result } = renderHook( () =>
+				useMigrateFootnotes( attributes, mockSetAttributes, meta )
+			);
+
+			expect( result.current ).toEqual( [] );
+			expect( mockSetAttributes ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'migration flow', () => {
+		it( 'should return meta footnotes initially, then attributes after migration', () => {
+			const footnotesFromMeta = [
+				{ id: '1', content: 'First footnote' },
+			];
+			const meta = {
+				footnotes: JSON.stringify( footnotesFromMeta ),
+			};
+
+			const { result, rerender } = renderHook(
+				( props ) =>
+					useMigrateFootnotes(
+						props.attributes,
+						mockSetAttributes,
+						props.meta
+					),
+				{
+					initialProps: {
+						attributes: {},
+						meta,
+					},
+				}
+			);
+
+			// Should return from meta initially.
+			expect( result.current ).toEqual( footnotesFromMeta );
+			expect( mockSetAttributes ).toHaveBeenCalledWith( {
+				footnotes: footnotesFromMeta,
+			} );
+
+			// Simulate attributes being updated after migration.
+			rerender( {
+				attributes: { footnotes: footnotesFromMeta },
+				meta,
+			} );
+
+			// Should now return from attributes.
+			expect( result.current ).toEqual( footnotesFromMeta );
+		} );
+	} );
+} );

--- a/packages/block-library/src/footnotes/use-migrate-footnotes.js
+++ b/packages/block-library/src/footnotes/use-migrate-footnotes.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useMemo, useRef } from '@wordpress/element';
+
+/**
+ * Migrates footnotes from post meta to block attributes when the block loads.
+ *
+ * On first render, if the block has no footnotes in attributes but meta
+ * contains footnotes, it copies them to attributes (one-time migration).
+ * Returns the current footnotes array from whichever source has data,
+ * so the UI always renders correctly even before migration completes.
+ *
+ * @param {Object}   attributes    Block attributes.
+ * @param {Function} setAttributes Function to update block attributes.
+ * @param {Object}   meta          Post meta object.
+ * @return {Array} The current footnotes array.
+ */
+export function useMigrateFootnotes( attributes, setAttributes, meta ) {
+	const migrationAttemptedRef = useRef( false );
+	const footnotesSupported = 'string' === typeof meta?.footnotes;
+
+	// Parse meta.footnotes once per value change.
+	const footnotesFromMeta = useMemo( () => {
+		if ( footnotesSupported && meta?.footnotes ) {
+			try {
+				return JSON.parse( meta.footnotes );
+			} catch ( e ) {
+				return null;
+			}
+		}
+		return null;
+	}, [ meta?.footnotes, footnotesSupported ] );
+
+	// Return footnotes from attributes if available, otherwise from meta.
+	const footnotes = useMemo( () => {
+		if (
+			attributes?.footnotes &&
+			Array.isArray( attributes.footnotes ) &&
+			attributes.footnotes.length > 0
+		) {
+			return attributes.footnotes;
+		}
+		return Array.isArray( footnotesFromMeta ) ? footnotesFromMeta : [];
+	}, [ attributes?.footnotes, footnotesFromMeta ] );
+
+	// One-time migration: copy meta footnotes to block attributes.
+	useEffect( () => {
+		if ( ! footnotesSupported || migrationAttemptedRef.current ) {
+			return;
+		}
+
+		// Already has data in attributes — no migration needed.
+		if (
+			attributes?.footnotes &&
+			Array.isArray( attributes.footnotes ) &&
+			attributes.footnotes.length > 0
+		) {
+			return;
+		}
+
+		// Has data in meta — migrate it.
+		if (
+			footnotesFromMeta &&
+			Array.isArray( footnotesFromMeta ) &&
+			footnotesFromMeta.length > 0
+		) {
+			migrationAttemptedRef.current = true;
+			setAttributes( { footnotes: [ ...footnotesFromMeta ] } );
+		}
+	}, [ attributes, setAttributes, footnotesFromMeta, footnotesSupported ] );
+
+	return footnotes;
+}

--- a/packages/core-data/src/footnotes/find-footnotes-block.js
+++ b/packages/core-data/src/footnotes/find-footnotes-block.js
@@ -1,0 +1,20 @@
+/**
+ * Finds the first footnotes block in a block tree (depth-first search).
+ *
+ * @param {Array} blocks The blocks array to search.
+ * @return {Object|null} The footnotes block, or null if not found.
+ */
+export default function findFootnotesBlock( blocks ) {
+	for ( const block of blocks ) {
+		if ( block.name === 'core/footnotes' ) {
+			return block;
+		}
+		if ( block.innerBlocks ) {
+			const found = findFootnotesBlock( block.innerBlocks );
+			if ( found ) {
+				return found;
+			}
+		}
+	}
+	return null;
+}

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -6,21 +6,58 @@ import { RichTextData, create, toHTMLString } from '@wordpress/rich-text';
 /**
  * Internal dependencies
  */
+import findFootnotesBlock from './find-footnotes-block';
 import getFootnotesOrder from './get-footnotes-order';
+import updateFootnotesFromBlockAttributes from './update-footnotes-from-block-attributes';
 
 let oldFootnotes = {};
 
 export function updateFootnotesFromMeta( blocks, meta ) {
 	const output = { blocks };
+
 	if ( ! meta ) {
 		return output;
 	}
 
-	// If meta.footnotes is empty, it means the meta is not registered.
+	// If meta.footnotes is undefined, the meta is not registered.
 	if ( meta.footnotes === undefined ) {
 		return output;
 	}
 
+	// Check if the footnotes block has data in block attributes (new approach).
+	// If so, use the block-attributes path and keep meta in sync for backward
+	// compatibility (Phase 1: dual-write).
+	const footnotesBlock = findFootnotesBlock( blocks );
+	const hasBlockAttributes =
+		footnotesBlock?.attributes?.footnotes &&
+		Array.isArray( footnotesBlock.attributes.footnotes ) &&
+		footnotesBlock.attributes.footnotes.length > 0;
+
+	if ( hasBlockAttributes ) {
+		const result = updateFootnotesFromBlockAttributes( blocks );
+
+		// No changes needed — return input blocks unchanged.
+		if ( result.blocks === blocks ) {
+			return output;
+		}
+
+		// Footnote order changed. Keep meta in sync (Phase 1: dual-write).
+		const updatedFootnotesBlock = findFootnotesBlock( result.blocks );
+		const updatedFootnotes =
+			updatedFootnotesBlock?.attributes?.footnotes || [];
+
+		return {
+			blocks: result.blocks,
+			meta: {
+				...meta,
+				footnotes: JSON.stringify( updatedFootnotes ),
+			},
+		};
+	}
+
+	// Legacy path: footnotes stored in post meta.
+	// This handles posts that haven't been migrated yet.
+	// Can be removed once Phase 3 migration is complete.
 	const newOrder = getFootnotesOrder( blocks );
 
 	const footnotes = meta.footnotes ? JSON.parse( meta.footnotes ) : [];

--- a/packages/core-data/src/footnotes/test/find-footnotes-block.js
+++ b/packages/core-data/src/footnotes/test/find-footnotes-block.js
@@ -1,0 +1,102 @@
+/**
+ * Internal dependencies
+ */
+import findFootnotesBlock from '../find-footnotes-block';
+
+describe( 'findFootnotesBlock', () => {
+	it( 'should return null when no footnotes block exists', () => {
+		const blocks = [
+			{ name: 'core/paragraph', attributes: {} },
+			{ name: 'core/heading', attributes: {} },
+		];
+
+		expect( findFootnotesBlock( blocks ) ).toBeNull();
+	} );
+
+	it( 'should return null for empty blocks array', () => {
+		expect( findFootnotesBlock( [] ) ).toBeNull();
+	} );
+
+	it( 'should find footnotes block at root level', () => {
+		const footnotesBlock = {
+			name: 'core/footnotes',
+			attributes: { footnotes: [] },
+		};
+		const blocks = [
+			{ name: 'core/paragraph', attributes: {} },
+			footnotesBlock,
+		];
+
+		expect( findFootnotesBlock( blocks ) ).toBe( footnotesBlock );
+	} );
+
+	it( 'should find footnotes block in inner blocks', () => {
+		const footnotesBlock = {
+			name: 'core/footnotes',
+			attributes: { footnotes: [] },
+		};
+		const blocks = [
+			{
+				name: 'core/group',
+				attributes: {},
+				innerBlocks: [
+					{ name: 'core/paragraph', attributes: {} },
+					footnotesBlock,
+				],
+			},
+		];
+
+		expect( findFootnotesBlock( blocks ) ).toBe( footnotesBlock );
+	} );
+
+	it( 'should find deeply nested footnotes block', () => {
+		const footnotesBlock = {
+			name: 'core/footnotes',
+			attributes: { footnotes: [] },
+		};
+		const blocks = [
+			{
+				name: 'core/group',
+				attributes: {},
+				innerBlocks: [
+					{
+						name: 'core/columns',
+						attributes: {},
+						innerBlocks: [
+							{
+								name: 'core/column',
+								attributes: {},
+								innerBlocks: [ footnotesBlock ],
+							},
+						],
+					},
+				],
+			},
+		];
+
+		expect( findFootnotesBlock( blocks ) ).toBe( footnotesBlock );
+	} );
+
+	it( 'should return first footnotes block when multiple exist', () => {
+		const firstFootnotesBlock = {
+			name: 'core/footnotes',
+			attributes: { footnotes: [] },
+		};
+		const secondFootnotesBlock = {
+			name: 'core/footnotes',
+			attributes: { footnotes: [] },
+		};
+		const blocks = [ firstFootnotesBlock, secondFootnotesBlock ];
+
+		expect( findFootnotesBlock( blocks ) ).toBe( firstFootnotesBlock );
+	} );
+
+	it( 'should handle blocks without innerBlocks property', () => {
+		const blocks = [
+			{ name: 'core/paragraph', attributes: {} },
+			{ name: 'core/image', attributes: {} },
+		];
+
+		expect( findFootnotesBlock( blocks ) ).toBeNull();
+	} );
+} );

--- a/packages/core-data/src/footnotes/test/update-blocks-attributes-for-numbering.js
+++ b/packages/core-data/src/footnotes/test/update-blocks-attributes-for-numbering.js
@@ -1,0 +1,159 @@
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+
+/**
+ * Internal dependencies
+ */
+import updateBlocksAttributesForNumbering from '../update-blocks-attributes-for-numbering';
+
+function makeFootnoteHTML( id, number ) {
+	return `Text with <sup class="fn" data-fn="${ id }"><a href="#${ id }" id="${ id }-link">${ number }</a></sup>`;
+}
+
+describe( 'updateBlocksAttributesForNumbering', () => {
+	it( 'should return blocks with same structure when no footnotes exist', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'No footnotes here' },
+			},
+		];
+		const newOrder = [];
+
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].name ).toBe( 'core/paragraph' );
+		expect( result[ 0 ].attributes.content ).toBe( 'No footnotes here' );
+	} );
+
+	it( 'should update numbering when order changes', () => {
+		const fn1 = 'fn-1';
+		const fn2 = 'fn-2';
+		const richTextValue = RichTextData.fromHTMLString(
+			`Text ${ makeFootnoteHTML( fn1, '1' ) } and ${ makeFootnoteHTML(
+				fn2,
+				'2'
+			) }`
+		);
+
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: richTextValue },
+			},
+		];
+
+		// Reverse order: fn-2 should become 1, fn-1 should become 2.
+		const newOrder = [ fn2, fn1 ];
+
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].attributes.content ).toBeInstanceOf( RichTextData );
+		// Should create new reference.
+		expect( result[ 0 ] ).not.toBe( blocks[ 0 ] );
+	} );
+
+	it( 'should handle string-type rich text attributes', () => {
+		const fn1 = 'fn-str';
+		const htmlContent = makeFootnoteHTML( fn1, '1' );
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: htmlContent },
+			},
+		];
+
+		const newOrder = [ fn1 ];
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect( typeof result[ 0 ].attributes.content ).toBe( 'string' );
+		expect( result[ 0 ].attributes.content ).toContain( fn1 );
+	} );
+
+	it( 'should handle blocks with inner blocks', () => {
+		const fn1 = 'fn-inner';
+		const richTextValue = RichTextData.fromHTMLString(
+			makeFootnoteHTML( fn1, '1' )
+		);
+
+		const blocks = [
+			{
+				name: 'core/group',
+				attributes: {},
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: richTextValue },
+					},
+				],
+			},
+		];
+
+		const newOrder = [ fn1 ];
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect(
+			result[ 0 ].innerBlocks[ 0 ].attributes.content
+		).toBeInstanceOf( RichTextData );
+	} );
+
+	it( 'should skip footnotes not in new order (deleted)', () => {
+		const fn1 = 'fn-deleted';
+		const richTextValue = RichTextData.fromHTMLString(
+			makeFootnoteHTML( fn1, '1' )
+		);
+
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: richTextValue },
+			},
+		];
+
+		// Empty order — footnote was deleted.
+		const newOrder = [];
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect( result ).toHaveLength( 1 );
+	} );
+
+	it( 'should preserve non-rich-text attributes', () => {
+		const blocks = [
+			{
+				name: 'core/image',
+				attributes: {
+					url: 'https://example.com/image.jpg',
+					alt: 'An image',
+					width: 300,
+				},
+			},
+		];
+
+		const newOrder = [];
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect( result[ 0 ].attributes.url ).toBe(
+			'https://example.com/image.jpg'
+		);
+		expect( result[ 0 ].attributes.alt ).toBe( 'An image' );
+		expect( result[ 0 ].attributes.width ).toBe( 300 );
+	} );
+
+	it( 'should handle null/undefined attributes gracefully', () => {
+		const blocks = [
+			{ name: 'core/spacer', attributes: null },
+			{ name: 'core/spacer', attributes: undefined },
+		];
+
+		const newOrder = [];
+		const result = updateBlocksAttributesForNumbering( blocks, newOrder );
+
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 0 ].attributes ).toBeNull();
+		expect( result[ 1 ].attributes ).toBeUndefined();
+	} );
+} );

--- a/packages/core-data/src/footnotes/test/update-blocks-with-footnotes.js
+++ b/packages/core-data/src/footnotes/test/update-blocks-with-footnotes.js
@@ -1,0 +1,134 @@
+/**
+ * Internal dependencies
+ */
+import updateBlocksWithFootnotes from '../update-blocks-with-footnotes';
+
+describe( 'updateBlocksWithFootnotes', () => {
+	it( 'should update footnotes block with new footnotes array', () => {
+		const blocks = [
+			{
+				name: 'core/footnotes',
+				attributes: {
+					footnotes: [ { id: 'fn-1', content: 'Old' } ],
+				},
+			},
+		];
+
+		const newFootnotes = [
+			{ id: 'fn-1', content: 'Updated' },
+			{ id: 'fn-2', content: 'New' },
+		];
+		const newOrder = [ 'fn-1', 'fn-2' ];
+
+		const result = updateBlocksWithFootnotes(
+			blocks,
+			newFootnotes,
+			newOrder
+		);
+
+		expect( result[ 0 ].attributes.footnotes ).toEqual( newFootnotes );
+	} );
+
+	it( 'should not add __footnotesVersion', () => {
+		const blocks = [
+			{
+				name: 'core/footnotes',
+				attributes: {
+					footnotes: [ { id: 'fn-1', content: 'Test' } ],
+				},
+			},
+		];
+
+		const newFootnotes = [ { id: 'fn-1', content: 'Updated' } ];
+		const newOrder = [ 'fn-1' ];
+
+		const result = updateBlocksWithFootnotes(
+			blocks,
+			newFootnotes,
+			newOrder
+		);
+
+		expect( result[ 0 ].attributes.__footnotesVersion ).toBeUndefined();
+	} );
+
+	it( 'should handle blocks without footnotes block', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'No footnotes' },
+			},
+		];
+
+		const newFootnotes = [];
+		const newOrder = [];
+
+		const result = updateBlocksWithFootnotes(
+			blocks,
+			newFootnotes,
+			newOrder
+		);
+
+		expect( result ).not.toBe( blocks );
+		expect( result ).toHaveLength( 1 );
+	} );
+
+	it( 'should update footnotes block in inner blocks', () => {
+		const blocks = [
+			{
+				name: 'core/group',
+				attributes: {},
+				innerBlocks: [
+					{
+						name: 'core/footnotes',
+						attributes: {
+							footnotes: [ { id: 'fn-1', content: 'Old' } ],
+						},
+					},
+				],
+			},
+		];
+
+		const newFootnotes = [ { id: 'fn-1', content: 'Updated' } ];
+		const newOrder = [ 'fn-1' ];
+
+		const result = updateBlocksWithFootnotes(
+			blocks,
+			newFootnotes,
+			newOrder
+		);
+
+		expect( result[ 0 ].innerBlocks[ 0 ].attributes.footnotes ).toEqual(
+			newFootnotes
+		);
+	} );
+
+	it( 'should update numbering in other blocks', () => {
+		const footnoteId = 'fn-1';
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: `Text with footnote <sup class="fn" data-fn="${ footnoteId }"><a href="#${ footnoteId }" id="${ footnoteId }-link">1</a></sup>`,
+				},
+			},
+			{
+				name: 'core/footnotes',
+				attributes: {
+					footnotes: [ { id: footnoteId, content: 'Test' } ],
+				},
+			},
+		];
+
+		const newFootnotes = [ { id: footnoteId, content: 'Updated' } ];
+		const newOrder = [ footnoteId ];
+
+		const result = updateBlocksWithFootnotes(
+			blocks,
+			newFootnotes,
+			newOrder
+		);
+
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 1 ].attributes.footnotes ).toEqual( newFootnotes );
+	} );
+} );

--- a/packages/core-data/src/footnotes/test/update-footnotes-from-block-attributes.js
+++ b/packages/core-data/src/footnotes/test/update-footnotes-from-block-attributes.js
@@ -1,0 +1,246 @@
+/**
+ * Internal dependencies
+ */
+import updateFootnotesFromBlockAttributes from '../update-footnotes-from-block-attributes';
+
+// Mock getFootnotesOrder to avoid the deep dependency chain through
+// getRichTextValuesCached → block-editor private APIs. We use a simple
+// `_footnoteIds` test property on blocks instead.
+jest.mock( '../get-footnotes-order', () => ( {
+	__esModule: true,
+	default: ( blocks ) => {
+		const order = [];
+		( function extract( blockList ) {
+			for ( const block of blockList ) {
+				if ( block._footnoteIds ) {
+					order.push( ...block._footnoteIds );
+				}
+				if ( block.innerBlocks ) {
+					extract( block.innerBlocks );
+				}
+			}
+		} )( blocks );
+		return order;
+	},
+} ) );
+
+// Mock updateBlocksWithFootnotes to avoid deep rich text processing.
+// It returns blocks with the footnotes block updated to the new array.
+jest.mock( '../update-blocks-with-footnotes', () => ( {
+	__esModule: true,
+	default: ( blocks, newFootnotes ) => {
+		return blocks.map( ( block ) => {
+			if ( block.name === 'core/footnotes' ) {
+				return {
+					...block,
+					attributes: {
+						...block.attributes,
+						footnotes: newFootnotes,
+					},
+				};
+			}
+			return block;
+		} );
+	},
+} ) );
+
+function makeBlocks( footnoteIds ) {
+	const paragraphs = footnoteIds.map( ( id ) => ( {
+		name: 'core/paragraph',
+		attributes: { content: `Text with ${ id }` },
+		_footnoteIds: [ id ],
+		innerBlocks: [],
+	} ) );
+
+	const footnotesBlock = {
+		name: 'core/footnotes',
+		attributes: {
+			footnotes: footnoteIds.map( ( id ) => ( {
+				id,
+				content: `Footnote for ${ id }`,
+			} ) ),
+		},
+		innerBlocks: [],
+	};
+
+	return [ ...paragraphs, footnotesBlock ];
+}
+
+describe( 'updateFootnotesFromBlockAttributes', () => {
+	describe( 'short-circuit behavior', () => {
+		it( 'should return same reference when no footnotes block exists', () => {
+			const blocks = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello' },
+					innerBlocks: [],
+				},
+			];
+
+			const result = updateFootnotesFromBlockAttributes( blocks );
+
+			expect( result.blocks ).toBe( blocks );
+		} );
+
+		it( 'should return same reference when footnotes block has no footnotes attribute', () => {
+			const blocks = [
+				{
+					name: 'core/footnotes',
+					attributes: {},
+					innerBlocks: [],
+				},
+			];
+
+			const result = updateFootnotesFromBlockAttributes( blocks );
+
+			expect( result.blocks ).toBe( blocks );
+		} );
+
+		it( 'should return same reference when order has not changed', () => {
+			const blocks = makeBlocks( [ 'fn-1', 'fn-2' ] );
+
+			const result = updateFootnotesFromBlockAttributes( blocks );
+
+			expect( result.blocks ).toBe( blocks );
+		} );
+	} );
+
+	describe( 'reordering', () => {
+		it( 'should reorder footnotes when block order changes', () => {
+			const blocks = makeBlocks( [ 'fn-1', 'fn-2' ] );
+
+			// Swap paragraphs: fn-2's paragraph first, then fn-1's.
+			const reorderedBlocks = [
+				blocks[ 1 ], // paragraph with fn-2
+				blocks[ 0 ], // paragraph with fn-1
+				blocks[ 2 ], // footnotes block (order still [fn-1, fn-2])
+			];
+
+			const result =
+				updateFootnotesFromBlockAttributes( reorderedBlocks );
+
+			expect( result.blocks ).not.toBe( reorderedBlocks );
+
+			const footnotesBlock = result.blocks.find(
+				( b ) => b.name === 'core/footnotes'
+			);
+			expect( footnotesBlock.attributes.footnotes[ 0 ].id ).toBe(
+				'fn-2'
+			);
+			expect( footnotesBlock.attributes.footnotes[ 1 ].id ).toBe(
+				'fn-1'
+			);
+		} );
+
+		it( 'should create empty footnote for new IDs not in attributes', () => {
+			// Blocks reference fn-1 and fn-new, but footnotes block only knows fn-1.
+			const blocks = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'First' },
+					_footnoteIds: [ 'fn-1' ],
+					innerBlocks: [],
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Second' },
+					_footnoteIds: [ 'fn-new' ],
+					innerBlocks: [],
+				},
+				{
+					name: 'core/footnotes',
+					attributes: {
+						footnotes: [
+							{ id: 'fn-1', content: 'First footnote' },
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			const result = updateFootnotesFromBlockAttributes( blocks );
+
+			const footnotesBlock = result.blocks.find(
+				( b ) => b.name === 'core/footnotes'
+			);
+			expect( footnotesBlock.attributes.footnotes ).toHaveLength( 2 );
+			expect( footnotesBlock.attributes.footnotes[ 1 ].id ).toBe(
+				'fn-new'
+			);
+			expect( footnotesBlock.attributes.footnotes[ 1 ].content ).toBe(
+				''
+			);
+		} );
+	} );
+
+	describe( 'footnote deletion', () => {
+		it( 'should remove footnotes whose references were deleted', () => {
+			const blocks = makeBlocks( [ 'fn-1', 'fn-2' ] );
+
+			// Remove first paragraph (fn-1 gone).
+			const afterDeletion = [
+				blocks[ 1 ], // paragraph with fn-2
+				blocks[ 2 ], // footnotes block (still has [fn-1, fn-2])
+			];
+
+			const result = updateFootnotesFromBlockAttributes( afterDeletion );
+
+			const footnotesBlock = result.blocks.find(
+				( b ) => b.name === 'core/footnotes'
+			);
+			expect( footnotesBlock.attributes.footnotes ).toHaveLength( 1 );
+			expect( footnotesBlock.attributes.footnotes[ 0 ].id ).toBe(
+				'fn-2'
+			);
+		} );
+
+		it( 'should produce empty footnotes when all references deleted', () => {
+			const blocks = makeBlocks( [ 'fn-1' ] );
+
+			// Remove paragraph, keep only footnotes block.
+			const afterDeletion = [
+				blocks[ 1 ], // footnotes block
+			];
+
+			const result = updateFootnotesFromBlockAttributes( afterDeletion );
+
+			const footnotesBlock = result.blocks.find(
+				( b ) => b.name === 'core/footnotes'
+			);
+			expect( footnotesBlock.attributes.footnotes ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'nested footnotes block', () => {
+		it( 'should find footnotes block in inner blocks', () => {
+			const blocks = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Text' },
+					_footnoteIds: [ 'fn-1' ],
+					innerBlocks: [],
+				},
+				{
+					name: 'core/group',
+					attributes: {},
+					innerBlocks: [
+						{
+							name: 'core/footnotes',
+							attributes: {
+								footnotes: [
+									{ id: 'fn-1', content: 'Nested' },
+								],
+							},
+							innerBlocks: [],
+						},
+					],
+				},
+			];
+
+			const result = updateFootnotesFromBlockAttributes( blocks );
+
+			// Order matches ([fn-1] === [fn-1]), so same reference.
+			expect( result.blocks ).toBe( blocks );
+		} );
+	} );
+} );

--- a/packages/core-data/src/footnotes/update-blocks-attributes-for-numbering.js
+++ b/packages/core-data/src/footnotes/update-blocks-attributes-for-numbering.js
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+
+/**
+ * Updates footnote numbering in rich text attributes across all blocks.
+ * Only called when footnote order has changed, so always creates new
+ * block references for the updated tree.
+ *
+ * @param {Array} blocks   The blocks array.
+ * @param {Array} newOrder The new footnote order (array of IDs).
+ * @return {Array} Updated blocks array with new references.
+ */
+export default function updateBlocksAttributesForNumbering( blocks, newOrder ) {
+	function updateAttributes( attributes ) {
+		if (
+			! attributes ||
+			Array.isArray( attributes ) ||
+			typeof attributes !== 'object'
+		) {
+			return attributes;
+		}
+
+		let hasChanges = false;
+		attributes = { ...attributes };
+
+		for ( const key in attributes ) {
+			const value = attributes[ key ];
+
+			if ( Array.isArray( value ) ) {
+				const updatedArray = value.map( updateAttributes );
+				// Check if any array item changed (by reference).
+				if ( updatedArray.some( ( item, i ) => item !== value[ i ] ) ) {
+					attributes[ key ] = updatedArray;
+					hasChanges = true;
+				}
+				continue;
+			}
+
+			if (
+				typeof value !== 'string' &&
+				! ( value instanceof RichTextData )
+			) {
+				continue;
+			}
+
+			const richTextValue =
+				typeof value === 'string'
+					? RichTextData.fromHTMLString( value )
+					: new RichTextData( value );
+
+			let hasFootnotes = false;
+
+			richTextValue.replacements.forEach( ( replacement ) => {
+				if ( replacement.type === 'core/footnote' ) {
+					const id = replacement.attributes[ 'data-fn' ];
+					const index = newOrder.indexOf( id );
+					// If footnote ID not found in order, skip it (it was deleted).
+					if ( index === -1 ) {
+						return;
+					}
+					const expectedNumber = String( index + 1 );
+					// Reconstruct innerHTML with the current data-fn ID and number.
+					replacement.innerHTML = `<a href="#${ id }" id="${ id }-link">${ expectedNumber }</a>`;
+					hasFootnotes = true;
+				}
+			} );
+
+			if ( hasFootnotes ) {
+				hasChanges = true;
+				// Round-trip through HTML to ensure updated innerHTML is serialized.
+				attributes[ key ] =
+					typeof value === 'string'
+						? RichTextData.fromHTMLString(
+								richTextValue.toHTMLString()
+						  ).toHTMLString()
+						: new RichTextData( richTextValue );
+			}
+		}
+
+		return hasChanges ? attributes : attributes;
+	}
+
+	return blocks.map( ( block ) => ( {
+		...block,
+		attributes: updateAttributes( block.attributes ),
+		innerBlocks: block.innerBlocks
+			? updateBlocksAttributesForNumbering( block.innerBlocks, newOrder )
+			: [],
+	} ) );
+}

--- a/packages/core-data/src/footnotes/update-blocks-with-footnotes.js
+++ b/packages/core-data/src/footnotes/update-blocks-with-footnotes.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import updateBlocksAttributesForNumbering from './update-blocks-attributes-for-numbering';
+
+/**
+ * Updates blocks with a new footnotes array and corrected numbering.
+ * Sets the new footnotes on the footnotes block and updates all
+ * footnote numbers in rich text across the block tree.
+ *
+ * @param {Array} blocks       The blocks array.
+ * @param {Array} newFootnotes The reordered footnotes array.
+ * @param {Array} newOrder     The new footnote ID order.
+ * @return {Array} Updated blocks array.
+ */
+export default function updateBlocksWithFootnotes(
+	blocks,
+	newFootnotes,
+	newOrder
+) {
+	// First, update numbering in all rich text attributes.
+	const updatedBlocks = updateBlocksAttributesForNumbering(
+		blocks,
+		newOrder
+	);
+
+	// Then, update the footnotes block with the reordered footnotes array.
+	function setFootnotesOnBlock( __blocks ) {
+		return __blocks.map( ( block ) => {
+			if ( block.name === 'core/footnotes' ) {
+				return {
+					...block,
+					attributes: {
+						...block.attributes,
+						footnotes: newFootnotes,
+					},
+				};
+			}
+			return {
+				...block,
+				innerBlocks: block.innerBlocks
+					? setFootnotesOnBlock( block.innerBlocks )
+					: block.innerBlocks,
+			};
+		} );
+	}
+
+	return setFootnotesOnBlock( updatedBlocks );
+}

--- a/packages/core-data/src/footnotes/update-footnotes-from-block-attributes.js
+++ b/packages/core-data/src/footnotes/update-footnotes-from-block-attributes.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import findFootnotesBlock from './find-footnotes-block';
+import getFootnotesOrder from './get-footnotes-order';
+import updateBlocksWithFootnotes from './update-blocks-with-footnotes';
+
+/**
+ * Updates footnotes from block attributes (new storage approach).
+ * Compares the footnote order in the block tree with the order stored
+ * in the footnotes block's attributes. When order differs, reorders
+ * the footnotes array and updates numbering in all rich text.
+ *
+ * Short-circuits when order hasn't changed to avoid unnecessary work.
+ *
+ * @param {Array} blocks The blocks array.
+ * @return {Object} Object with `blocks` (updated or original reference).
+ */
+export default function updateFootnotesFromBlockAttributes( blocks ) {
+	const footnotesBlock = findFootnotesBlock( blocks );
+
+	if ( ! footnotesBlock?.attributes?.footnotes ) {
+		return { blocks };
+	}
+
+	const footnotes = footnotesBlock.attributes.footnotes;
+	const currentOrder = footnotes.map( ( fn ) => fn.id );
+	const newOrder = getFootnotesOrder( blocks );
+
+	// Short-circuit: if order hasn't changed, return input blocks unchanged.
+	// This avoids a full tree traversal on every keystroke.
+	if ( currentOrder.join( '' ) === newOrder.join( '' ) ) {
+		return { blocks };
+	}
+
+	// Order changed: reorder the footnotes array to match document order.
+	const newFootnotes = newOrder.map( ( fnId ) => {
+		const existing = footnotes.find( ( fn ) => fn.id === fnId );
+		return existing || { id: fnId, content: '' };
+	} );
+
+	// Update numbering in all blocks and set the new footnotes array.
+	const updatedBlocks = updateBlocksWithFootnotes(
+		blocks,
+		newFootnotes,
+		newOrder
+	);
+
+	return { blocks: updatedBlocks };
+}

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -60,33 +60,41 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return undefined;
 		}
 
+		let _blocks;
+
 		if ( editedBlocks ) {
-			return editedBlocks;
-		}
-
-		if ( ! content || typeof content !== 'string' ) {
+			_blocks = editedBlocks;
+		} else if ( ! content || typeof content !== 'string' ) {
 			return EMPTY_ARRAY;
+		} else {
+			// If there's an edit, cache the parsed blocks by the edit.
+			// If not, cache by the original entity record.
+			const edits = getEntityRecordEdits( kind, name, id );
+			const isUnedited = ! edits || ! Object.keys( edits ).length;
+			const cackeKey = isUnedited
+				? getEntityRecord( kind, name, id )
+				: edits;
+			_blocks = parsedBlocksCache.get( cackeKey );
+
+			if ( ! _blocks ) {
+				_blocks = parse( content );
+				parsedBlocksCache.set( cackeKey, _blocks );
+			}
 		}
 
-		// If there's an edit, cache the parsed blocks by the edit.
-		// If not, cache by the original entity record.
-		const edits = getEntityRecordEdits( kind, name, id );
-		const isUnedited = ! edits || ! Object.keys( edits ).length;
-		const cackeKey = isUnedited ? getEntityRecord( kind, name, id ) : edits;
-		let _blocks = parsedBlocksCache.get( cackeKey );
-
-		if ( ! _blocks ) {
-			_blocks = parse( content );
-			parsedBlocksCache.set( cackeKey, _blocks );
-		}
-
-		return _blocks;
+		// Process footnote numbering. This ensures correct numbering on
+		// initial load (from parsed content) and after undo/redo (when
+		// editedBlocks may have stale numbering). The function short-circuits
+		// when order hasn't changed, so the cost is a cheap comparison.
+		const footnotesResult = updateFootnotesFromMeta( _blocks, meta );
+		return footnotesResult.blocks || _blocks;
 	}, [
 		kind,
 		name,
 		id,
 		editedBlocks,
 		content,
+		meta,
 		getEntityRecord,
 		getEntityRecordEdits,
 	] );


### PR DESCRIPTION
🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧
POC only - don't merge. I'm just experimenting.
Sorry for the AI-generated piffle.
🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧


## What?

Migrates footnotes data from `post_meta` to the `core/footnotes` block's `footnotes` attribute. This is **Phase 1** of a multi-phase migration — it implements dual-write (attributes primary, meta for backward compatibility) and auto-migration on block load.

This PR is the foundation. It does **not** include copy/paste support or other new features — those build on this storage change in follow-up PRs.

> **Prior art:** This builds on the proof-of-concept in #74275, which explored the full scope (migration + copy/paste + keyboard shortcut) in a single branch. This PR extracts and cleans up the storage migration as a standalone, reviewable unit.

## Why?

Today, footnote **references** (`<sup data-fn="uuid">`) live in `post_content`, while footnote **definitions** (id + content) live in `post_meta`. This split causes two problems:

1. **Revisions don't track footnotes reliably.** Post meta revisions are a secondary system bolted onto WordPress core. Moving footnotes into `post_content` (as block attributes) gives them first-class revision support for free.

2. **Copy/paste doesn't carry footnotes.** Blocks are designed to be self-contained and portable. Data in meta breaks that contract. Once footnotes are in block attributes, cross-post copy/paste becomes possible (Phase 2).

## How?

### Architecture

```
                    ┌─────────────────────────────────────┐
                    │        updateFootnotesFromMeta()     │
                    │         (routing function)           │
                    └──────────┬──────────────┬───────────┘
                               │              │
                    Has block   │              │  No block
                    attributes  │              │  attributes
                               ▼              ▼
               ┌──────────────────┐  ┌──────────────────┐
               │  New path:       │  │  Legacy path:     │
               │  Block attributes│  │  Post meta        │
               │  (short-circuits │  │  (existing code,  │
               │   when order     │  │   unchanged)      │
               │   unchanged)     │  │                   │
               └────────┬─────────┘  └─────────┬────────┘
                        │                       │
                        ▼                       ▼
                 Returns { blocks }      Returns { blocks, meta }
                 + meta dual-write       (updates meta as before)
```

### Key design decisions

- **Dual-write in Phase 1**: Every footnote change writes to both block attributes and meta. This means older editor versions can still read footnotes from meta. The dual-write happens in two places: `edit.js` (content edits) and `updateFootnotesFromMeta` in `index.js` (structural changes like reordering).

- **Short-circuit optimization**: `updateFootnotesFromBlockAttributes` compares footnote order and returns the **same block reference** when nothing changed. This avoids a full tree traversal on every keystroke — the cost is a cheap array comparison.

- **No `__footnotesVersion` counter**: The POC used an undeclared, ever-incrementing attribute to force React re-renders. This PR removes it. The `useMemo` in `useEntityBlockEditor` recomputes when `editedBlocks` or `meta` change, which handles undo/redo naturally.

- **Clean path separation**: The legacy meta path (existing code) is untouched. The new attributes path is in separate modules. The routing decision happens once at the top of `updateFootnotesFromMeta`.

### Files changed

**New modules:**
| File | Purpose |
|------|---------|
| `use-migrate-footnotes.js` | One-time migration hook (meta → attributes on block load) |
| `find-footnotes-block.js` | DFS utility to find footnotes block in tree |
| `update-blocks-attributes-for-numbering.js` | Updates footnote numbers in rich text |
| `update-blocks-with-footnotes.js` | Combines numbering + footnotes array update |
| `update-footnotes-from-block-attributes.js` | Main attributes path with short-circuit |

**Modified:**
| File | Change |
|------|--------|
| `block.json` | Added `footnotes` array attribute |
| `edit.js` | Uses migration hook, dual-writes to meta |
| `index.php` | Reads attributes first, falls back to meta |
| `footnotes/index.js` | Routes between attributes and meta paths |
| `use-entity-block-editor.js` | Processes numbering in `useMemo` |

## Migration Roadmap

This is Phase 1 of a 4-phase migration:

### Phase 1: Dual-read, dual-write (this PR)
- Read: block attributes first, fall back to meta
- Write: both attributes (primary) and meta (backward compat)
- Auto-migrate on editor load
- **Duration**: 1 release cycle

### Phase 2: Copy/paste support (follow-up PR)
- Extract footnotes on copy via custom clipboard MIME type
- Merge footnotes on paste with new UUIDs
- Keyboard shortcut (Cmd/Ctrl+Shift+F)
- Builds on the attributes storage from Phase 1

### Phase 3: Attributes-only write (future)
- Stop writing to meta
- Clear meta on save for migrated posts
- Still read from meta for unmigrated posts

### Phase 4: Remove meta (future, possibly Core)
- Batch migration CLI for remaining posts
- Remove meta fallback code
- Remove `register_post_meta` for footnotes
- Remove `_wp_post_revision_fields` filter

## Testing Instructions

1. **Existing post with footnotes**: Open a post that has footnotes — verify they appear correctly (migration from meta to attributes happens automatically).
2. **Add/remove/reorder footnotes**: Verify numbering updates correctly after each operation.
3. **Undo/redo**: After reordering footnotes, undo — verify numbering reverts correctly.
4. **New post**: Add footnotes to a new post — verify they work without any prior meta.
5. **Prevent nesting**: Try adding a footnote inside the footnotes block — should not be possible (toolbar button hidden).
6. **Run unit tests**:
   ```bash
   npx wp-scripts test-unit-js --testPathPattern="footnotes" --no-coverage
   ```
   Expected: 37 tests, 5 suites, all passing.

## Test Coverage

| Module | Tests |
|--------|-------|
| `find-footnotes-block` | 6 |
| `update-blocks-attributes-for-numbering` | 7 |
| `update-blocks-with-footnotes` | 5 |
| `update-footnotes-from-block-attributes` | 11 |
| `use-migrate-footnotes` | 8 |
| **Total** | **37** |