### PR TITLE
DataViews Filters: Fix styling of long values in filter dropdown

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- DataViews: Improve styling for filters when long values are in use. [#75369](https://github.com/WordPress/gutenberg/pull/75369)
 - DataForm: Fix label case for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -206,7 +206,9 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 							selected={ currentValue.includes( element.value ) }
 						/>
 					) }
-					<span>{ element.label }</span>
+					<span className="dataviews-filters__search-widget-listitem-value">
+						{ element.label }
+					</span>
 				</Composite.Hover>
 			) ) }
 		</Composite>
@@ -307,7 +309,7 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 									) }
 								/>
 							) }
-							<span>
+							<span className="dataviews-filters__search-widget-listitem-value">
 								<Ariakit.ComboboxItemValue
 									className="dataviews-filters__search-widget-filter-combobox-item-value"
 									value={ element.label }

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -206,7 +206,10 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 							selected={ currentValue.includes( element.value ) }
 						/>
 					) }
-					<span className="dataviews-filters__search-widget-listitem-value">
+					<span
+						className="dataviews-filters__search-widget-listitem-value"
+						title={ element.label }
+					>
 						{ element.label }
 					</span>
 				</Composite.Hover>
@@ -309,7 +312,10 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 									) }
 								/>
 							) }
-							<span className="dataviews-filters__search-widget-listitem-value">
+							<span
+								className="dataviews-filters__search-widget-listitem-value"
+								title={ element.label }
+							>
 								<Ariakit.ComboboxItemValue
 									className="dataviews-filters__search-widget-filter-combobox-item-value"
 									value={ element.label }

--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -231,6 +231,13 @@
 		}
 	}
 
+	.dataviews-filters__search-widget-listitem-value {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		min-width: 0;
+	}
+
 	.dataviews-filters__search-widget-listitem-description {
 		display: block;
 		overflow: hidden;

--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -275,6 +275,7 @@
 
 	.dataviews-filters__search-widget-listitem-multi-selection {
 		--checkbox-size: 24px; // Width & height for small viewports.
+		flex-shrink: 0;
 
 		@include checkbox-control;
 		position: relative;

--- a/packages/dataviews/src/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/dataviews/stories/fixtures.tsx
@@ -24,6 +24,7 @@ export type SpaceObject = {
 	date: string;
 	datetime: string;
 	email: string;
+	author: string;
 };
 
 export const data: SpaceObject[] = [
@@ -42,6 +43,7 @@ export const data: SpaceObject[] = [
 		date: '2021-01-01',
 		datetime: '2021-01-01T14:30:00Z',
 		email: 'moon@example.com',
+		author: 'lunarian_observer',
 	},
 	{
 		id: 2,
@@ -57,6 +59,7 @@ export const data: SpaceObject[] = [
 		date: '2019-01-02',
 		datetime: '2019-01-02T09:15:00Z',
 		email: 'io@example.com',
+		author: 'galilean_moon_enthusiast_supreme',
 	},
 	{
 		id: 3,
@@ -72,6 +75,7 @@ export const data: SpaceObject[] = [
 		date: '2025-01-03',
 		datetime: '2025-01-03T16:45:30Z',
 		email: 'europa@example.com',
+		author: 'icy_ocean_explorer',
 	},
 	{
 		id: 4,
@@ -87,6 +91,7 @@ export const data: SpaceObject[] = [
 		date: '2022-01-04',
 		datetime: '2022-01-04T12:30:00Z',
 		email: 'ganymede@example.com',
+		author: 'jovian_satellite_researcher',
 	},
 	{
 		id: 5,
@@ -102,6 +107,7 @@ export const data: SpaceObject[] = [
 		date: '2021-01-05',
 		datetime: '2021-01-05T14:15:30Z',
 		email: 'callisto@example.com',
+		author: 'crater_cartography_specialist',
 	},
 	{
 		id: 6,
@@ -117,6 +123,7 @@ export const data: SpaceObject[] = [
 		date: '2020-01-06',
 		datetime: '2020-01-06T10:45:15Z',
 		email: 'amalthea@example.com',
+		author: 'astro_photographer',
 	},
 	{
 		id: 7,
@@ -132,6 +139,7 @@ export const data: SpaceObject[] = [
 		date: '2019-01-07',
 		datetime: '2019-01-07T16:20:45Z',
 		email: 'himalia@example.com',
+		author: 'irregular_orbit_analyst',
 	},
 	{
 		id: 8,
@@ -147,6 +155,7 @@ export const data: SpaceObject[] = [
 		date: '2020-01-01',
 		datetime: '2020-01-01T11:22:15Z',
 		email: 'neptune@example.com',
+		author: 'neptunian_dynamics_professor',
 	},
 	{
 		id: 9,
@@ -162,6 +171,7 @@ export const data: SpaceObject[] = [
 		date: '2021-02-01',
 		datetime: '2021-02-01T11:30:00Z',
 		email: 'triton@example.com',
+		author: 'retrograde_orbit_specialist',
 	},
 	{
 		id: 10,
@@ -177,6 +187,7 @@ export const data: SpaceObject[] = [
 		date: '2020-02-02',
 		datetime: '2020-02-02T15:45:30Z',
 		email: 'nereid@example.com',
+		author: 'outer_solar_system_voyager_mission_director',
 	},
 	{
 		id: 11,
@@ -192,6 +203,7 @@ export const data: SpaceObject[] = [
 		date: '2019-02-03',
 		datetime: '2019-02-03T09:20:15Z',
 		email: 'proteus@example.com',
+		author: 'space_observer',
 	},
 	{
 		id: 12,
@@ -207,6 +219,7 @@ export const data: SpaceObject[] = [
 		date: '2020-01-02',
 		datetime: '2020-01-02T13:05:45Z',
 		email: 'mercury@example.com',
+		author: 'solar_wind_scientist',
 	},
 	{
 		id: 13,
@@ -222,6 +235,7 @@ export const data: SpaceObject[] = [
 		date: '2020-01-02',
 		datetime: '2020-01-02T08:30:12Z',
 		email: 'venus@example.com',
+		author: 'atmospheric_chemistry_expert',
 	},
 	{
 		id: 14,
@@ -237,6 +251,7 @@ export const data: SpaceObject[] = [
 		date: '2023-01-03',
 		datetime: '2023-01-03T18:15:30Z',
 		email: 'earth@example.com',
+		author: 'planetary_geologist',
 	},
 	{
 		id: 15,
@@ -252,6 +267,7 @@ export const data: SpaceObject[] = [
 		date: '2020-01-01',
 		datetime: '2020-01-01T20:45:00Z',
 		email: 'mars@example.com',
+		author: 'red_planet_explorer',
 	},
 	{
 		id: 16,
@@ -267,6 +283,7 @@ export const data: SpaceObject[] = [
 		date: '2017-01-01',
 		datetime: '2017-01-01T00:01:00Z',
 		email: 'jupiter@example.com',
+		author: 'gas_giant_meteorologist',
 	},
 	{
 		id: 17,
@@ -282,6 +299,7 @@ export const data: SpaceObject[] = [
 		date: '2020-02-01',
 		datetime: '2020-02-01T00:02:00Z',
 		email: 'saturn@example.com',
+		author: 'ring_system_analyst',
 	},
 	{
 		id: 18,
@@ -297,6 +315,7 @@ export const data: SpaceObject[] = [
 		date: '2020-03-01',
 		datetime: '2020-03-01T10:15:20Z',
 		email: 'uranus@example.com',
+		author: 'axial_tilt_researcher',
 	},
 	{
 		id: 19,
@@ -312,6 +331,7 @@ export const data: SpaceObject[] = [
 		date: '2020-03-01',
 		datetime: '2020-03-01T10:15:20Z',
 		email: 'thessalonikopolymnianebuchodonossarinacharybdis@example.com',
+		author: 'interstellar_nomadic_planetary_body_tracking_specialist',
 	},
 ];
 
@@ -429,6 +449,10 @@ export const fields: Field< SpaceObject >[] = [
 				value: 'Trans-Neptunian object',
 				label: 'Trans-Neptunian object',
 			},
+			{
+				value: 'Extreme Trans-Neptunian Scattered Disc Object',
+				label: 'Extreme Trans-Neptunian Scattered Disc Object',
+			},
 		],
 		filterBy: {
 			operators: [ 'is', 'isNot' ],
@@ -492,8 +516,73 @@ export const fields: Field< SpaceObject >[] = [
 			{ value: 'Ice giant', label: 'Ice giant' },
 			{ value: 'Terrestrial', label: 'Terrestrial' },
 			{ value: 'Gas giant', label: 'Gas giant' },
+			{
+				value: 'Extreme Outer Solar System Trans-Neptunian Region',
+				label: 'Extreme Outer Solar System Trans-Neptunian Region',
+			},
 		],
 		type: 'array',
 		enableGlobalSearch: true,
+	},
+	{
+		label: 'Author',
+		id: 'author',
+		type: 'text',
+		enableHiding: false,
+		enableGlobalSearch: true,
+		elements: [
+			{ value: 'lunarian_observer', label: 'lunarian_observer' },
+			{
+				value: 'galilean_moon_enthusiast_supreme',
+				label: 'galilean_moon_enthusiast_supreme',
+			},
+			{ value: 'icy_ocean_explorer', label: 'icy_ocean_explorer' },
+			{
+				value: 'jovian_satellite_researcher',
+				label: 'jovian_satellite_researcher',
+			},
+			{
+				value: 'crater_cartography_specialist',
+				label: 'crater_cartography_specialist',
+			},
+			{ value: 'astro_photographer', label: 'astro_photographer' },
+			{
+				value: 'irregular_orbit_analyst',
+				label: 'irregular_orbit_analyst',
+			},
+			{
+				value: 'neptunian_dynamics_professor',
+				label: 'neptunian_dynamics_professor',
+			},
+			{
+				value: 'retrograde_orbit_specialist',
+				label: 'retrograde_orbit_specialist',
+			},
+			{
+				value: 'outer_solar_system_voyager_mission_director',
+				label: 'outer_solar_system_voyager_mission_director',
+			},
+			{ value: 'space_observer', label: 'space_observer' },
+			{ value: 'solar_wind_scientist', label: 'solar_wind_scientist' },
+			{
+				value: 'atmospheric_chemistry_expert',
+				label: 'atmospheric_chemistry_expert',
+			},
+			{ value: 'planetary_geologist', label: 'planetary_geologist' },
+			{ value: 'red_planet_explorer', label: 'red_planet_explorer' },
+			{
+				value: 'gas_giant_meteorologist',
+				label: 'gas_giant_meteorologist',
+			},
+			{ value: 'ring_system_analyst', label: 'ring_system_analyst' },
+			{ value: 'axial_tilt_researcher', label: 'axial_tilt_researcher' },
+			{
+				value: 'interstellar_nomadic_planetary_body_tracking_specialist',
+				label: 'interstellar_nomadic_planetary_body_tracking_specialist',
+			},
+		],
+		filterBy: {
+			operators: [ 'isAny', 'isNone' ],
+		},
 	},
 ];


### PR DESCRIPTION
## What?

In DataViews filters, add some rules to ensure that _really_ long values get truncated rather than creating a horizontal scrollbar, and that the checkbox doesn't shrink.

## Why?

While testing the experimental media modal (and media fields), I created a _very_ long username and noticed that the filters dropdown/popover doesn't work very nicely with very long values.

So, this PR proposes truncating (to prevent a horizontal scrollbar) and updates the Storybook data for DataViews to include some cases to better cover this.

## How?

* Ensure the checkbox doesn't shrink
* Ensure the filter values are wrapped in a span with a classname that sets the truncation

## Testing Instructions

To test in Storybook, run `npm run storybook:dev` and then navigate to the DataViews story. I was testing with the Table layout. Then try the different filters, e.g. Type, Category, Author and check that the long values look okay now.

Does truncating feel like the right approach here?

You can also test this PR with the experimental media modal by enabling the experiment in Gutenberg settings, add a user with a _really_ long username, and then go to add a featured image to a post or page, and user the Author filter.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="614" height="784" alt="image" src="https://github.com/user-attachments/assets/0f01dd04-49da-4de9-a8c1-787ac8e9d86b" /> | <img width="728" height="862" alt="image" src="https://github.com/user-attachments/assets/1c66a34b-e097-4c77-a61d-98170c5296ad" /> |

Screenshots from Storybook to show the new examples:

| Category example (checkbox) | Type example (radio button | Checkbox with Search example |
| --- | --- | --- |
| <img width="630" height="1020" alt="image" src="https://github.com/user-attachments/assets/698375a4-2ebe-462d-b5f4-87102a774b84" /> | <img width="612" height="844" alt="image" src="https://github.com/user-attachments/assets/37d86d84-5fa6-4304-9f6c-7a317218c35d" /> | <img alt="image" src="https://github.com/user-attachments/assets/50322b63-c639-42c0-bae6-38a8fb272ae5" /> |
