### PR TITLE
Rich Text: Remove min-width inline style causing flex layout issues

### DIFF
--- a/packages/rich-text/src/component/use-default-style.js
+++ b/packages/rich-text/src/component/use-default-style.js
@@ -25,18 +25,11 @@ import { useCallback } from '@wordpress/element';
  */
 const whiteSpace = 'pre-wrap';
 
-/**
- * A minimum width of 1px will prevent the rich text container from collapsing
- * to 0 width and hiding the caret. This is useful for inline containers.
- */
-const minWidth = '1px';
-
 export function useDefaultStyle() {
 	return useCallback( ( element ) => {
 		if ( ! element ) {
 			return;
 		}
 		element.style.whiteSpace = whiteSpace;
-		element.style.minWidth = minWidth;
 	}, [] );
 }


### PR DESCRIPTION
## What?
Closes #45141 
Removes the `min-width: 1px` inline style that was being applied to all rich text elements via the `useDefaultStyle` hook.

## Why?

The inline `min-width: 1px` style was causing layout issues in flex containers (group blocks) when using elements with large font sizes. When grouping paragraphs with padding:
- The paragraph with a large letter (e.g., `font-size: 5em`) wouldn't take up its proper space
- The layout would stretch awkwardly in the editor
- The frontend and editor displayed differently

**Root Cause Analysis:**
- The `minWidth: 1px` was added in March 2021 to prevent rich text containers from collapsing to 0 width and hiding the caret
- However, the codebase already uses **ZWNBSP (zero-width non-breaking space)** as the primary mechanism for caret visibility in empty elements
- The minWidth specifically interferes with flex layout behavior by preventing natural flex shrinking

## How?

- Removed the `minWidth` constant from `packages/rich-text/src/component/use-default-style.js`
- Removed the `element.style.minWidth = minWidth` application
- Retained the `white-space: pre-wrap` style, which is essential for proper WYSIWYG editing

## Testing Instructions

1. Add spacing presets to your theme (if not already present)
2. Create 2 paragraphs:
   - First paragraph: Add one large letter with `font-size: 5em`
   - Second paragraph: Use default font size with regular text
3. Add padding from the presets to both paragraphs
4. Group the paragraphs (don't allow wrapping on mobile)
5. **Problem:** Notice the paragraph with the large letter doesn't take up its proper space and the layout looks different between editor and frontend

Reference code:
```
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"fontSize":"5em"}}} -->
<p style="font-size:5em">A</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut leo nibh, placerat eget nisi non, sagittis convallis purus. Morbi in iaculis ligula. Mauris in libero suscipit, pulvinar erat a, rutrum purus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut leo nibh, placerat eget nisi non, sagittis convallis purus.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/54c328fa-ab6d-4658-8a91-94e2a01047be



After:

https://github.com/user-attachments/assets/9ed3b86a-a44d-4f48-a781-40c085978f49



## References 

Related PR's:
https://github.com/WordPress/gutenberg/pull/30190
https://github.com/WordPress/gutenberg/pull/30224


Related Commits:
https://github.com/WordPress/gutenberg/commit/b690b8fb27f3147c1f7a3c98e7b50f1780780961
https://github.com/WordPress/gutenberg/commit/f7f66431792978516575eaa439f57ad61f18616f