### PR TITLE
Fields: Update `author` field's query

### DIFF
--- a/packages/fields/src/fields/author/index.tsx
+++ b/packages/fields/src/fields/author/index.tsx
@@ -22,18 +22,29 @@ const authorField: Field< BasePostWithEmbeddedAuthor > = {
 	id: 'author',
 	type: 'integer',
 	getElements: async () => {
-		const authors: Author[] =
-			( await resolveSelect( coreDataStore ).getEntityRecords(
-				'root',
-				'user',
-				{
-					per_page: -1,
-					who: 'authors',
-					_fields: 'id,name',
-					context: 'view',
-				}
-			) ) ?? [];
-		return authors.map( ( { id, name } ) => ( {
+		const query = {
+			per_page: -1,
+			_fields: 'id,name',
+			context: 'view',
+		};
+		const [ capableAuthors, publishedAuthors ] = await Promise.all( [
+			resolveSelect( coreDataStore ).getEntityRecords( 'root', 'user', {
+				...query,
+				who: 'authors',
+			} ),
+			resolveSelect( coreDataStore ).getEntityRecords( 'root', 'user', {
+				...query,
+				has_published_posts: true,
+			} ),
+		] );
+		const authorsMap = new Map< number, Author >();
+		for ( const author of [
+			...( ( capableAuthors ?? [] ) as Author[] ),
+			...( ( publishedAuthors ?? [] ) as Author[] ),
+		] ) {
+			authorsMap.set( author.id, author );
+		}
+		return Array.from( authorsMap.values() ).map( ( { id, name } ) => ( {
 			value: id,
 			label: name,
 		} ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/75298

@t-hamano mentioned a [scenario](https://github.com/WordPress/gutenberg/pull/75298#issuecomment-3871554136), where a user had published some posts, but then their role gets updated to a role that can't publish posts. 

Besides that, there is another issue which involves the differentiation of the field's elements based on context (filter/edit). 
1. For `filters` it seems the query in this PR is correct.
2. For `edit` we would need to have a query with `who: authors`, and include only the current author - even if it falls into the above Aki's scenario. In this PR we still show all previous authors, so we can end up updating a page with an author, that cannot be an author anymore.


## Testing Instructions
1. Create an `author` user and create a page
2. Update the role of that user to `subscriber`
3. Go to site editor in pages and observe that the user is still an option for filtering and editing.
