### PR TITLE
Block Editor: Remove formatting controls restriction private API

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -137,7 +137,7 @@ export function RichTextWrapper(
 			return { isSelected: false };
 		}
 
-		const { getSelectionStart, getSelectionEnd, getBlockEditingMode } =
+		const { getSelectionStart, getSelectionEnd } =
 			select( blockEditorStore );
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
@@ -159,17 +159,15 @@ export function RichTextWrapper(
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
-			isContentOnly: getBlockEditingMode( clientId ) === 'contentOnly',
 		};
 	};
-	const { selectionStart, selectionEnd, isSelected, isContentOnly } =
-		useSelect( selector, [
-			clientId,
-			identifier,
-			instanceId,
-			originalIsSelected,
-			isBlockSelected,
-		] );
+	const { selectionStart, selectionEnd, isSelected } = useSelect( selector, [
+		clientId,
+		identifier,
+		instanceId,
+		originalIsSelected,
+		isBlockSelected,
+	] );
 
 	const { disableBoundBlock, bindingsPlaceholder, bindingsLabel } = useSelect(
 		( select ) => {
@@ -350,9 +348,8 @@ export function RichTextWrapper(
 	} = useFormatTypes( {
 		clientId,
 		identifier,
-		allowedFormats: adjustedAllowedFormats,
 		withoutInteractiveFormatting,
-		disableNoneEssentialFormatting: isContentOnly,
+		allowedFormats: adjustedAllowedFormats,
 	} );
 
 	function addEditorOnlyFormats( value ) {

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -5,11 +5,6 @@ import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as richTextStore } from '@wordpress/rich-text';
 
-/**
- * Internal dependencies
- */
-import { essentialFormatKey } from '../../store/private-keys';
-
 function formatTypesSelector( select ) {
 	return select( richTextStore ).getFormatTypes();
 }
@@ -61,53 +56,35 @@ function getPrefixedSelectKeys( selected, prefix ) {
  * This hook provides RichText with the `formatTypes` and its derived props from
  * experimental format type settings.
  *
- * @param {Object}  options                                Options
- * @param {string}  options.clientId                       Block client ID.
- * @param {string}  options.identifier                     Block attribute.
- * @param {Array}   options.allowedFormats                 Allowed formats
- * @param {boolean} options.withoutInteractiveFormatting   Whether to clean the interactive formatting or not.
- * @param {boolean} options.disableNoneEssentialFormatting Whether to disable none-essential formatting or not.
+ * @param {Object}  $0                              Options
+ * @param {string}  $0.clientId                     Block client ID.
+ * @param {string}  $0.identifier                   Block attribute.
+ * @param {boolean} $0.withoutInteractiveFormatting Whether to clean the interactive formatting or not.
+ * @param {Array}   $0.allowedFormats               Allowed formats
  */
 export function useFormatTypes( {
 	clientId,
 	identifier,
-	allowedFormats,
 	withoutInteractiveFormatting,
-	disableNoneEssentialFormatting = false,
+	allowedFormats,
 } ) {
 	const allFormatTypes = useSelect( formatTypesSelector, [] );
 	const formatTypes = useMemo( () => {
-		return allFormatTypes.filter(
-			( {
-				name,
-				interactive,
-				tagName,
-				[ essentialFormatKey ]: isEssential,
-			} ) => {
-				if ( allowedFormats && ! allowedFormats.includes( name ) ) {
-					return false;
-				}
-
-				if ( disableNoneEssentialFormatting && ! isEssential ) {
-					return false;
-				}
-
-				if (
-					withoutInteractiveFormatting &&
-					( interactive || interactiveContentTags.has( tagName ) )
-				) {
-					return false;
-				}
-
-				return true;
+		return allFormatTypes.filter( ( { name, interactive, tagName } ) => {
+			if ( allowedFormats && ! allowedFormats.includes( name ) ) {
+				return false;
 			}
-		);
-	}, [
-		allFormatTypes,
-		allowedFormats,
-		disableNoneEssentialFormatting,
-		withoutInteractiveFormatting,
-	] );
+
+			if (
+				withoutInteractiveFormatting &&
+				( interactive || interactiveContentTags.has( tagName ) )
+			) {
+				return false;
+			}
+
+			return true;
+		} );
+	}, [ allFormatTypes, allowedFormats, withoutInteractiveFormatting ] );
 	const keyedSelected = useSelect(
 		( select ) =>
 			formatTypes.reduce( ( accumulator, type ) => {

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -42,7 +42,6 @@ import {
 	sectionRootClientIdKey,
 	mediaEditKey,
 	getMediaSelectKey,
-	essentialFormatKey,
 	deviceTypeKey,
 	isIsolatedEditorKey,
 } from './store/private-keys';
@@ -122,7 +121,6 @@ lock( privateApis, {
 	CommentIconToolbarSlotFill,
 	mediaEditKey,
 	getMediaSelectKey,
-	essentialFormatKey,
 	deviceTypeKey,
 	isIsolatedEditorKey,
 	useBlockElement,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -5,6 +5,5 @@ export const reusableBlocksSelectKey = Symbol( 'reusableBlocksSelect' );
 export const sectionRootClientIdKey = Symbol( 'sectionRootClientIdKey' );
 export const mediaEditKey = Symbol( 'mediaEditKey' );
 export const getMediaSelectKey = Symbol( 'getMediaSelect' );
-export const essentialFormatKey = Symbol( 'essentialFormat' );
 export const isIsolatedEditorKey = Symbol( 'isIsolatedEditor' );
 export const deviceTypeKey = Symbol( 'deviceTypeKey' );

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -7,16 +7,8 @@ import {
 	RichTextToolbarButton,
 	RichTextShortcut,
 	__unstableRichTextInputEvent,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { formatBold } from '@wordpress/icons';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-const { essentialFormatKey } = unlock( blockEditorPrivateApis );
 
 const name = 'core/bold';
 const title = __( 'Bold' );
@@ -26,7 +18,6 @@ export const bold = {
 	title,
 	tagName: 'strong',
 	className: null,
-	[ essentialFormatKey ]: true,
 	edit( { isActive, value, onChange, onFocus, isVisible = true } ) {
 		function onToggle() {
 			onChange( toggleFormat( value, { type: name, title } ) );

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -7,16 +7,8 @@ import {
 	RichTextToolbarButton,
 	RichTextShortcut,
 	__unstableRichTextInputEvent,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { formatItalic } from '@wordpress/icons';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-const { essentialFormatKey } = unlock( blockEditorPrivateApis );
 
 const name = 'core/italic';
 const title = __( 'Italic' );
@@ -26,7 +18,6 @@ export const italic = {
 	title,
 	tagName: 'em',
 	className: null,
-	[ essentialFormatKey ]: true,
 	edit( { isActive, value, onChange, onFocus, isVisible = true } ) {
 		function onToggle() {
 			onChange( toggleFormat( value, { type: name, title } ) );

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -16,7 +16,6 @@ import { isURL, isEmail, isPhoneNumber } from '@wordpress/url';
 import {
 	RichTextToolbarButton,
 	RichTextShortcut,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon } from '@wordpress/icons';
@@ -27,9 +26,6 @@ import { speak } from '@wordpress/a11y';
  */
 import InlineLinkUI from './inline';
 import { isValidHref } from './utils';
-import { unlock } from '../lock-unlock';
-
-const { essentialFormatKey } = unlock( blockEditorPrivateApis );
 
 const name = 'core/link';
 const title = __( 'Link' );
@@ -236,7 +232,6 @@ export const link = {
 		rel: 'rel',
 		class: 'class',
 	},
-	[ essentialFormatKey ]: true,
 	__unstablePasteRule( value, { html, plainText } ) {
 		const pastedText = ( html || plainText )
 			.replace( /<[^>]+>/g, '' )


### PR DESCRIPTION
## What?
Closes #74765.

PR reverts private API introduced in https://github.com/WordPress/gutenberg/pull/71058.

## Why?
See https://github.com/WordPress/gutenberg/issues/74765.

## Testing Instructions

Same as #74799.

### Pattern Override

- Create a synced pattern containing a Paragraph block.
- In the block's Advanced settings, toggle "Enable Overrides".
- Insert this pattern into a new Page.
- Attempt to apply any of the inline formats.
  - When the "Restrict formatting controls in Content Only mode" setting is enabled: Only the bold, italic, and link formats are displayed.
  - When the "Restrict formatting controls in Content Only mode" setting is disabled: All available formats are displayed.

### templateLock: contentOnly

```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Hello World</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

- Attempt to apply any of the inline formats to the Paragraph block inside the Group block.
  - When the "Restrict formatting controls in Content Only mode" setting is enabled: Only the bold, italic, and link formats are displayed.
  - When the "Restrict formatting controls in Content Only mode" setting is disabled: All available formats are displayed.
