### PR TITLE
Breadcrumbs: Improve loading state rendering

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -117,16 +117,16 @@ export default function BreadcrumbEdit( {
 	}, [ content, status ] );
 	const [ showLoader, setShowLoader ] = useState( false );
 	useEffect( () => {
-		if ( status === 'loading' ) {
-			const timeout = setTimeout( () => {
-				setShowLoader( true );
-			}, 400 );
-			return () => {
-				clearTimeout( timeout );
-				setShowLoader( false );
-			};
+		if ( status !== 'loading' ) {
+			return;
 		}
-		setShowLoader( false );
+		const timeout = setTimeout( () => {
+			setShowLoader( true );
+		}, 400 );
+		return () => {
+			clearTimeout( timeout );
+			setShowLoader( false );
+		};
 	}, [ status ] );
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( { ref: disabledRef } );

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { useDisabled } from '@wordpress/compose';
 
@@ -109,7 +109,25 @@ export default function BreadcrumbEdit( {
 		block: name,
 		urlQueryArgs: { post_id: postId, invalidationKey },
 	} );
-
+	const prevContentRef = useRef( '' );
+	useEffect( () => {
+		if ( status === 'success' ) {
+			prevContentRef.current = content;
+		}
+	}, [ content, status ] );
+	const [ showLoader, setShowLoader ] = useState( false );
+	useEffect( () => {
+		if ( status === 'loading' ) {
+			const timeout = setTimeout( () => {
+				setShowLoader( true );
+			}, 400 );
+			return () => {
+				clearTimeout( timeout );
+				setShowLoader( false );
+			};
+		}
+		setShowLoader( false );
+	}, [ status ] );
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( { ref: disabledRef } );
 
@@ -286,11 +304,24 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 			</InspectorControls>
-			{ status === 'loading' && ! showPlaceholder && (
-				<div { ...blockProps }>
-					<Spinner />
-				</div>
-			) }
+			{ status === 'loading' &&
+				! showPlaceholder &&
+				( prevContentRef.current ? (
+					<HtmlRenderer
+						wrapperProps={ {
+							...blockProps,
+							style: {
+								...blockProps.style,
+								opacity: showLoader ? 0.3 : 1,
+							},
+						} }
+						html={ prevContentRef.current }
+					/>
+				) : (
+					<div { ...blockProps }>
+						<Spinner />
+					</div>
+				) ) }
 			{ status === 'error' && (
 				<div { ...blockProps }>
 					<p>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/75375

This PR preserves the previous content of the Breadcrumbs block while the server side content is being loaded. If the loading takes more than 400ms, we reduce the opacity, similarly to the `ServerSideRender` component.

**Noting** that this is effective when we use the real preview and not the placeholder content. 

## Testing Instructions
1. Insert the `Breadcrumbs` block in a `post`, which guarantees we're not using the placeholder
2. Select the block and change settings
3. Observe that the spinner is not showing on every change
4. If you throttle your network, you can also observer the reduced opacity 


## After


https://github.com/user-attachments/assets/27235b02-508c-4262-939e-22eb57e60477

