### PR TITLE
Fix: Make all Navigation Overlay Close buttons work

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1094,8 +1094,8 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
  * @return string Overlay close markup with the directives injected.
  */
 function block_core_navigation_add_directives_to_overlay_close( $tags ) {
-	// Find the navigation-overlay-close button.
-	if ( $tags->next_tag(
+	// Find all navigation-overlay-close buttons.
+	while ( $tags->next_tag(
 		array(
 			'tag_name'   => 'BUTTON',
 			'class_name' => 'wp-block-navigation-overlay-close',


### PR DESCRIPTION
## What

Fixes #74940. Makes every Navigation Overlay Close button in an overlay close the menu when clicked, not only the first one.

## Why

Users can add multiple "Navigation Overlay Close" block instances in overlay template parts (e.g. in header and footer). Only the first button received the close handler; the rest did nothing. All close buttons should work.

## How

The navigation block injects Interactivity API directives into overlay close buttons on the server. That logic used a single `if` with `next_tag()`, so only the first matching button got the click directive. It now uses a `while` loop over all matching buttons, so each one receives the same `closeMenuOnClick` directive. The pattern matches the existing submenu directive injection in the same file.

## Testing instructions

1. In the Site Editor, open a template part used as a navigation overlay (or create a Navigation block with overlay enabled and edit its overlay template part).
2. Insert two or more **Navigation Overlay Close** blocks in different places (e.g. top and bottom of the overlay).
3. Save and view the site at a mobile breakpoint (or with overlay always on).
4. Open the overlay menu, then click the second (or any non-first) close button.
5. Confirm the overlay closes. Repeat with the first close button and any others; all should close the overlay.
6. Also confirm that using only a SINGLE close button still works!

## Screenshots

https://github.com/user-attachments/assets/8fac4643-7229-4f57-bac4-e6ceccc1b183


