### PR TITLE
Auto-switch viewport based on Overlay Visibility setting when entering overlay editor

### DIFF
--- a/packages/block-editor/src/components/block-visibility/constants.js
+++ b/packages/block-editor/src/components/block-visibility/constants.js
@@ -6,7 +6,10 @@ import { desktop, tablet, mobile } from '@wordpress/icons';
 
 /**
  * The choices for the block visibility.
- * Must match those in packages/editor/src/components/preview-dropdown/index.js.
+ *
+ * Duplicated in packages/editor/src/components/preview-dropdown/index.js (choices array)
+ * and packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+ * (VALID_DEVICE_TYPES). Update all three when adding new viewport types.
  *
  * @todo create a single source of truth for the viewport types.
  */

--- a/packages/block-editor/src/components/block-visibility/constants.js
+++ b/packages/block-editor/src/components/block-visibility/constants.js
@@ -8,7 +8,7 @@ import { desktop, tablet, mobile } from '@wordpress/icons';
  * The choices for the block visibility.
  *
  * Duplicated in packages/editor/src/components/preview-dropdown/index.js (choices array)
- * and packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+ * and packages/edit-site/src/components/block-editor/use-viewport-sync.js
  * (VALID_DEVICE_TYPES). Update all three when adding new viewport types.
  *
  * @todo create a single source of truth for the viewport types.

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -76,6 +76,7 @@ export default function OverlayPanel( {
 				{ overlayMenu !== 'never' && (
 					<OverlayTemplatePartSelector
 						overlay={ overlay }
+						overlayMenu={ overlayMenu }
 						setAttributes={ setAttributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
 						isCreatingOverlay={ isCreatingOverlay }

--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -31,6 +31,7 @@ import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
  *
  * @param {Object}   props                          Component props.
  * @param {string}   props.overlay                  Currently selected overlay template part ID.
+ * @param {string}   props.overlayMenu              Overlay visibility setting ('never', 'mobile', 'always').
  * @param {Function} props.setAttributes            Function to update block attributes.
  * @param {Function} props.onNavigateToEntityRecord Function to navigate to template part editor.
  * @param {boolean}  props.isCreatingOverlay        Whether an overlay is being created (lifted state).
@@ -39,6 +40,7 @@ import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
  */
 export default function OverlayTemplatePartSelector( {
 	overlay,
+	overlayMenu,
 	setAttributes,
 	onNavigateToEntityRecord,
 	isCreatingOverlay,
@@ -165,10 +167,14 @@ export default function OverlayTemplatePartSelector( {
 		const theme = selectedTemplatePart.theme || currentTheme;
 		const templatePartId = createTemplatePartId( theme, overlay );
 
-		onNavigateToEntityRecord( {
+		const params = {
 			postId: templatePartId,
 			postType: 'wp_template_part',
-		} );
+		};
+		if ( overlayMenu === 'mobile' ) {
+			params.viewport = 'mobile';
+		}
+		onNavigateToEntityRecord( params );
 	};
 
 	const handleCreateOverlay = useCallback( async () => {
@@ -189,10 +195,14 @@ export default function OverlayTemplatePartSelector( {
 					theme,
 					templatePart.slug
 				);
-				onNavigateToEntityRecord( {
+				const params = {
 					postId: templatePartId,
 					postType: 'wp_template_part',
-				} );
+				};
+				if ( overlayMenu === 'mobile' ) {
+					params.viewport = 'mobile';
+				}
+				onNavigateToEntityRecord( params );
 			} else {
 				setIsCreating( false );
 			}
@@ -219,6 +229,7 @@ export default function OverlayTemplatePartSelector( {
 		createErrorNotice,
 		currentTheme,
 		setIsCreating,
+		overlayMenu,
 	] );
 
 	const handleClearOverlay = useCallback( () => {

--- a/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+++ b/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
@@ -13,42 +13,23 @@ import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
-const VIEWPORT_TO_DEVICE_TYPE = {
-	desktop: 'Desktop',
-	tablet: 'Tablet',
-	mobile: 'Mobile',
-};
-const DEFAULT_DEVICE_TYPE = 'Desktop';
+export const DEFAULT_DEVICE_TYPE = 'Desktop';
 
-// Inverse mapping for URL serialization (device type → viewport param)
-export const DEVICE_TYPE_TO_VIEWPORT = Object.fromEntries(
-	Object.entries( VIEWPORT_TO_DEVICE_TYPE ).map( ( [ k, v ] ) => [ v, k ] )
-);
-export { VALID_VIEWPORTS, VIEWPORT_TO_DEVICE_TYPE, DEFAULT_DEVICE_TYPE };
+// URL viewport params are lowercase; the editor store uses PascalCase.
+const capitalize = ( str ) => str.charAt( 0 ).toUpperCase() + str.slice( 1 );
 
 /**
  * Syncs the editor's device type with the `viewport` URL query param.
- * - When viewport is in the URL and valid: use it (e.g. mobile when editing a specific entity).
- * - When no viewport or invalid: default to Desktop (full-size viewport), e.g. when
- *   returning from a focused entity editor without a saved viewport.
  */
 export default function useInitialViewportSync() {
 	const { query } = useLocation();
 	const { setDeviceType } = useDispatch( editorStore );
 
 	useEffect( () => {
-		const viewport = query?.viewport;
-		const isValidViewport =
-			viewport &&
-			typeof viewport === 'string' &&
-			VALID_VIEWPORTS.includes( viewport.toLowerCase() );
+		const viewport = query?.viewport?.toLowerCase();
+		const isValid = [ 'desktop', 'tablet', 'mobile' ].includes( viewport );
 
-		const deviceType = isValidViewport
-			? VIEWPORT_TO_DEVICE_TYPE[ viewport.toLowerCase() ]
-			: DEFAULT_DEVICE_TYPE;
-
-		setDeviceType( deviceType );
+		setDeviceType( isValid ? capitalize( viewport ) : DEFAULT_DEVICE_TYPE );
 	}, [ query?.viewport, setDeviceType ] );
 }
 

--- a/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+++ b/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
@@ -15,11 +15,19 @@ const { useLocation } = unlock( routerPrivateApis );
 
 export const DEFAULT_DEVICE_TYPE = 'Desktop';
 
+// Lowercase values for URL params. Duplicated from block-editor block-visibility constants
+// and editor preview-dropdown choices. See those files when adding new viewport types.
+const VALID_DEVICE_TYPES = [ 'desktop', 'tablet', 'mobile' ];
+
 // URL viewport params are lowercase; the editor store uses PascalCase.
 const capitalize = ( str ) => str.charAt( 0 ).toUpperCase() + str.slice( 1 );
 
 /**
  * Syncs the editor's device type with the `viewport` URL query param.
+ *
+ * Intentionally responds to ongoing URL changes (not just initial load) so that
+ * viewport is restored correctly when navigating back (e.g. from overlay template
+ * part editor to the previous entity).
  */
 export default function useInitialViewportSync() {
 	const { query } = useLocation();
@@ -27,7 +35,7 @@ export default function useInitialViewportSync() {
 
 	useEffect( () => {
 		const viewport = query?.viewport?.toLowerCase();
-		const isValid = [ 'desktop', 'tablet', 'mobile' ].includes( viewport );
+		const isValid = VALID_DEVICE_TYPES.includes( viewport );
 
 		setDeviceType( isValid ? capitalize( viewport ) : DEFAULT_DEVICE_TYPE );
 	}, [ query?.viewport, setDeviceType ] );

--- a/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+++ b/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
@@ -21,9 +21,10 @@ const VIEWPORT_TO_DEVICE_TYPE = {
 };
 
 /**
- * Syncs the editor's device type with the `viewport` URL query param when present.
- * Used to open the editor in a specific viewport (e.g. mobile for overlay template parts).
- * Runs once on mount when a valid viewport param is in the URL.
+ * Syncs the editor's device type with the `viewport` URL query param.
+ * - When viewport is in the URL and valid: use it (e.g. mobile when editing a specific entity).
+ * - When no viewport or invalid: default to Desktop (full-size viewport), e.g. when
+ *   returning from a focused entity editor without a saved viewport.
  */
 export default function useInitialViewportSync() {
 	const { query } = useLocation();
@@ -31,18 +32,16 @@ export default function useInitialViewportSync() {
 
 	useEffect( () => {
 		const viewport = query?.viewport;
-		if (
-			! viewport ||
-			typeof viewport !== 'string' ||
-			! VALID_VIEWPORTS.includes( viewport.toLowerCase() )
-		) {
-			return;
-		}
+		const isValidViewport =
+			viewport &&
+			typeof viewport === 'string' &&
+			VALID_VIEWPORTS.includes( viewport.toLowerCase() );
 
-		const deviceType = VIEWPORT_TO_DEVICE_TYPE[ viewport.toLowerCase() ];
-		if ( deviceType ) {
-			setDeviceType( deviceType );
-		}
+		const deviceType = isValidViewport
+			? VIEWPORT_TO_DEVICE_TYPE[ viewport.toLowerCase() ]
+			: 'Desktop';
+
+		setDeviceType( deviceType );
 	}, [ query?.viewport, setDeviceType ] );
 }
 

--- a/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+++ b/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
@@ -19,6 +19,13 @@ const VIEWPORT_TO_DEVICE_TYPE = {
 	tablet: 'Tablet',
 	mobile: 'Mobile',
 };
+const DEFAULT_DEVICE_TYPE = 'Desktop';
+
+// Inverse mapping for URL serialization (device type → viewport param)
+export const DEVICE_TYPE_TO_VIEWPORT = Object.fromEntries(
+	Object.entries( VIEWPORT_TO_DEVICE_TYPE ).map( ( [ k, v ] ) => [ v, k ] )
+);
+export { VALID_VIEWPORTS, VIEWPORT_TO_DEVICE_TYPE, DEFAULT_DEVICE_TYPE };
 
 /**
  * Syncs the editor's device type with the `viewport` URL query param.
@@ -39,7 +46,7 @@ export default function useInitialViewportSync() {
 
 		const deviceType = isValidViewport
 			? VIEWPORT_TO_DEVICE_TYPE[ viewport.toLowerCase() ]
-			: 'Desktop';
+			: DEFAULT_DEVICE_TYPE;
 
 		setDeviceType( deviceType );
 	}, [ query?.viewport, setDeviceType ] );

--- a/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
+++ b/packages/edit-site/src/components/block-editor/use-initial-viewport-sync.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
+const VIEWPORT_TO_DEVICE_TYPE = {
+	desktop: 'Desktop',
+	tablet: 'Tablet',
+	mobile: 'Mobile',
+};
+
+/**
+ * Syncs the editor's device type with the `viewport` URL query param when present.
+ * Used to open the editor in a specific viewport (e.g. mobile for overlay template parts).
+ * Runs once on mount when a valid viewport param is in the URL.
+ */
+export default function useInitialViewportSync() {
+	const { query } = useLocation();
+	const { setDeviceType } = useDispatch( editorStore );
+
+	useEffect( () => {
+		const viewport = query?.viewport;
+		if (
+			! viewport ||
+			typeof viewport !== 'string' ||
+			! VALID_VIEWPORTS.includes( viewport.toLowerCase() )
+		) {
+			return;
+		}
+
+		const deviceType = VIEWPORT_TO_DEVICE_TYPE[ viewport.toLowerCase() ];
+		if ( deviceType ) {
+			setDeviceType( deviceType );
+		}
+	}, [ query?.viewport, setDeviceType ] );
+}
+
+/**
+ * Component wrapper that runs the viewport sync hook.
+ * Renders nothing; used to run the hook inside the Editor tree (inside EditorProvider).
+ */
+export function InitialViewportSync() {
+	useInitialViewportSync();
+	return null;
+}

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -12,12 +12,12 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import {
+	DEFAULT_DEVICE_TYPE,
+	VALID_VIEWPORTS,
+} from './use-initial-viewport-sync';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
-
-const DEFAULT_DEVICE_TYPE = 'Desktop';
-const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
-
 /**
  * Hook to handle navigation to entity records.
  *

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { useSelect, useRegistry } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useCallback } from '@wordpress/element';
-import { useRegistry } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
@@ -15,6 +15,9 @@ import { unlock } from '../../lock-unlock';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
+const DEFAULT_DEVICE_TYPE = 'Desktop';
+const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
+
 /**
  * Hook to handle navigation to entity records.
  *
@@ -25,6 +28,10 @@ export default function useNavigateToEntityRecord() {
 	const location = useLocation();
 	const { query, path } = location;
 	const registry = useRegistry();
+	const currentDeviceType = useSelect(
+		( select ) => select( editorStore ).getDeviceType(),
+		[]
+	);
 
 	const onNavigateToEntityRecord = useCallback(
 		( params ) => {
@@ -45,27 +52,55 @@ export default function useNavigateToEntityRecord() {
 			const externalClientId =
 				entityEdits?.selection?.selectionStart?.clientId;
 
+			const urlUpdates = { ...query };
+
 			// Store the selected block in the URL for restoration when navigating back.
 			if ( externalClientId ) {
-				const currentUrl = addQueryArgs( path, {
-					...query,
-					selectedBlock: externalClientId,
+				urlUpdates.selectedBlock = externalClientId;
+			}
+
+			// Save the current viewport for when we navigate back (e.g. from overlay editor)
+			const requestedViewport =
+				typeof params.viewport === 'string'
+					? params.viewport.toLowerCase()
+					: undefined;
+			const isValidRequestedViewport =
+				VALID_VIEWPORTS.includes( requestedViewport );
+
+			if ( isValidRequestedViewport ) {
+				const currentViewportLower = (
+					currentDeviceType || DEFAULT_DEVICE_TYPE
+				).toLowerCase();
+				if ( currentViewportLower === DEFAULT_DEVICE_TYPE.toLowerCase() ) {
+					delete urlUpdates.viewport;
+				} else {
+					urlUpdates.viewport = currentViewportLower;
+				}
+			}
+
+			const hasUpdatesToSave = externalClientId || isValidRequestedViewport;
+			if ( hasUpdatesToSave ) {
+				history.navigate( addQueryArgs( path, urlUpdates ), {
+					replace: true,
 				} );
-				history.navigate( currentUrl, { replace: true } );
 			}
 
 			// Navigate to the new entity record
+			const queryArgs = {
+				canvas: 'edit',
+				focusMode: true,
+			};
+			if ( isValidRequestedViewport ) {
+				queryArgs.viewport = requestedViewport;
+			}
 			const url = addQueryArgs(
 				`/${ params.postType }/${ params.postId }`,
-				{
-					canvas: 'edit',
-					focusMode: true,
-				}
+				queryArgs
 			);
 
 			history.navigate( url );
 		},
-		[ history, path, query, registry ]
+		[ history, path, query, registry, currentDeviceType ]
 	);
 
 	return onNavigateToEntityRecord;

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -12,12 +12,11 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import {
-	DEFAULT_DEVICE_TYPE,
-	VALID_VIEWPORTS,
-} from './use-initial-viewport-sync';
+import { DEFAULT_DEVICE_TYPE } from './use-viewport-sync';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
+
+const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
 /**
  * Hook to handle navigation to entity records.
  *
@@ -72,14 +71,17 @@ export default function useNavigateToEntityRecord() {
 				const currentViewportLower = (
 					currentDeviceType || DEFAULT_DEVICE_TYPE
 				).toLowerCase();
-				if ( currentViewportLower === DEFAULT_DEVICE_TYPE.toLowerCase() ) {
+				if (
+					currentViewportLower === DEFAULT_DEVICE_TYPE.toLowerCase()
+				) {
 					delete urlUpdates.viewport;
 				} else {
 					urlUpdates.viewport = currentViewportLower;
 				}
 			}
 
-			const hasUpdatesToSave = externalClientId || isValidRequestedViewport;
+			const hasUpdatesToSave =
+				externalClientId || isValidRequestedViewport;
 			if ( hasUpdatesToSave ) {
 				history.navigate( addQueryArgs( path, urlUpdates ), {
 					replace: true,

--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -59,7 +59,8 @@ export default function useNavigateToEntityRecord() {
 				urlUpdates.selectedBlock = externalClientId;
 			}
 
-			// Save the current viewport for when we navigate back (e.g. from overlay editor)
+			// Save the current viewport for when we navigate back (e.g. from overlay editor).
+			// Omit viewport from URL when it's the default to keep URLs clean.
 			const requestedViewport =
 				typeof params.viewport === 'string'
 					? params.viewport.toLowerCase()

--- a/packages/edit-site/src/components/block-editor/use-viewport-sync.js
+++ b/packages/edit-site/src/components/block-editor/use-viewport-sync.js
@@ -29,7 +29,7 @@ const capitalize = ( str ) => str.charAt( 0 ).toUpperCase() + str.slice( 1 );
  * viewport is restored correctly when navigating back (e.g. from overlay template
  * part editor to the previous entity).
  */
-export default function useInitialViewportSync() {
+export default function useViewportSync() {
 	const { query } = useLocation();
 	const { setDeviceType } = useDispatch( editorStore );
 
@@ -45,7 +45,7 @@ export default function useInitialViewportSync() {
  * Component wrapper that runs the viewport sync hook.
  * Renders nothing; used to run the hook inside the Editor tree (inside EditorProvider).
  */
-export function InitialViewportSync() {
-	useInitialViewportSync();
+export function ViewportSync() {
+	useViewportSync();
 	return null;
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -39,7 +39,7 @@ import SavePanel from '../save-panel';
 import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
-import { InitialViewportSync } from '../block-editor/use-initial-viewport-sync';
+import { ViewportSync } from '../block-editor/use-viewport-sync';
 import useEditorTitle from './use-editor-title';
 import { useIsSiteEditorLoading } from '../layout/hooks';
 import { useAdaptEditorToCanvas } from './use-adapt-editor-to-canvas';
@@ -239,7 +239,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 						)
 					}
 				>
-					{ isEditMode && <InitialViewportSync /> }
+					{ isEditMode && <ViewportSync /> }
 					{ isEditMode && (
 						<BackButton>
 							{ ( { length } ) =>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -39,9 +39,7 @@ import SavePanel from '../save-panel';
 import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
-import {
-	InitialViewportSync,
-} from '../block-editor/use-initial-viewport-sync';
+import { InitialViewportSync } from '../block-editor/use-initial-viewport-sync';
 import useEditorTitle from './use-editor-title';
 import { useIsSiteEditorLoading } from '../layout/hooks';
 import { useAdaptEditorToCanvas } from './use-adapt-editor-to-canvas';

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -39,6 +39,9 @@ import SavePanel from '../save-panel';
 import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
+import {
+	InitialViewportSync,
+} from '../block-editor/use-initial-viewport-sync';
 import useEditorTitle from './use-editor-title';
 import { useIsSiteEditorLoading } from '../layout/hooks';
 import { useAdaptEditorToCanvas } from './use-adapt-editor-to-canvas';
@@ -238,6 +241,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 						)
 					}
 				>
+					{ isEditMode && <InitialViewportSync /> }
 					{ isEditMode && (
 						<BackButton>
 							{ ( { length } ) =>

--- a/packages/edit-site/src/components/editor/use-adapt-editor-to-canvas.js
+++ b/packages/edit-site/src/components/editor/use-adapt-editor-to-canvas.js
@@ -10,7 +10,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
-import { DEFAULT_DEVICE_TYPE } from '../block-editor/use-initial-viewport-sync';
+import { DEFAULT_DEVICE_TYPE } from '../block-editor/use-viewport-sync';
 
 export function useAdaptEditorToCanvas( canvas ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );

--- a/packages/edit-site/src/components/editor/use-adapt-editor-to-canvas.js
+++ b/packages/edit-site/src/components/editor/use-adapt-editor-to-canvas.js
@@ -7,6 +7,11 @@ import { store as editorStore } from '@wordpress/editor';
 import { useLayoutEffect } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_DEVICE_TYPE } from '../block-editor/use-initial-viewport-sync';
+
 export function useAdaptEditorToCanvas( canvas ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const {
@@ -27,7 +32,7 @@ export function useAdaptEditorToCanvas( canvas ) {
 			if ( getCurrentPost()?.type ) {
 				editPost( { selection: undefined }, { undoIgnore: true } );
 			}
-			setDeviceType( 'Desktop' );
+			setDeviceType( DEFAULT_DEVICE_TYPE );
 			closePublishSidebar();
 			setIsInserterOpened( false );
 

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -97,6 +97,8 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 
 	/**
 	 * The choices for the device type.
+	 * Duplicated in block-editor block-visibility constants and edit-site
+	 * use-initial-viewport-sync. Update all three when adding new viewport types.
 	 *
 	 * @type {Array}
 	 */

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -98,7 +98,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	/**
 	 * The choices for the device type.
 	 * Duplicated in block-editor block-visibility constants and edit-site
-	 * use-initial-viewport-sync. Update all three when adding new viewport types.
+	 * use-viewport-sync. Update all three when adding new viewport types.
 	 *
 	 * @type {Array}
 	 */


### PR DESCRIPTION
## What

Fixes #75222

When entering the overlay template part editor, the editor automatically switches to the viewport that matches the overlay's "Overlay Visibility" setting. When navigating back, the previous viewport is restored.

## Why

Overlays are commonly configured for mobile-only visibility, but the editor didn't open in a matching viewport by default. Switching to the correct viewport on entry makes overlay editing more contextual and reduces friction. Restoring the viewport on Back gives users a consistent navigation experience.

## How

- **Pass viewport when navigating**: The overlay template part selector reads `overlayMenu` from the Navigation block. When `overlayMenu === 'mobile'`, it passes `viewport: 'mobile'` when navigating to the template part editor (both edit and create flows).
- **Persist viewport in URL**: `useNavigateToEntityRecord` accepts optional `params.viewport` and adds it to the target URL query (e.g. `?viewport=mobile`). When navigating to a viewport-specific entity, it saves the current viewport to the current URL before navigating away so the Back button restores it.
- **Auto-set device type on load**: `useInitialViewportSync` reads `viewport` from the URL on editor load, validates it (desktop/tablet/mobile), and dispatches `setDeviceType`. If missing or invalid, defaults to Desktop. The hook runs inside the Editor when in edit mode.

The `viewport` URL param is generic and reusable for any focused entity editor (template parts, patterns, etc.). We do not re-enable the viewport switcher in the focused editor: the resizable canvas and device preview toggle cannot work together (see #65931 / PR #65970), so we only auto-set the viewport on entry.

## Testing Instructions

1. Add a Navigation block with "Overlay Visibility" set to "Mobile".
2. Add or select an overlay template part.
3. Click "Edit" to open the overlay editor. **Expected**: Editor opens in Mobile viewport.
4. Switch to Tablet viewport in the overlay editor.
5. Click the Back button. **Expected**: Returns to parent context with Tablet viewport restored.
6. Repeat with "Overlay Visibility" set to "Always". **Expected**: Editor opens in the current viewport (no auto-switch).
