### PR TITLE
ui `Dialog`:  tweaks

### DIFF
--- a/packages/ui/src/dialog/close-icon-button.tsx
+++ b/packages/ui/src/dialog/close-icon-button.tsx
@@ -9,7 +9,7 @@ import type { CloseIconProps } from './types';
  * Renders an icon button that closes the dialog when clicked.
  * Provides a default close icon and accessible label.
  */
-const CloseIcon = forwardRef< HTMLButtonElement, CloseIconProps >(
+const CloseIconButton = forwardRef< HTMLButtonElement, CloseIconProps >(
 	function DialogCloseIcon( { icon, label, ...props }, ref ) {
 		return (
 			<_Dialog.Close
@@ -29,4 +29,4 @@ const CloseIcon = forwardRef< HTMLButtonElement, CloseIconProps >(
 	}
 );
 
-export { CloseIcon };
+export { CloseIconButton };

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -1,5 +1,5 @@
 import { Action } from './action';
-import { CloseIcon } from './close-icon';
+import { CloseIconButton } from './close-icon-button';
 import { Footer } from './footer';
 import { Header } from './header';
 import { Popup } from './popup';
@@ -7,4 +7,4 @@ import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export { Action, CloseIcon, Footer, Header, Popup, Root, Title, Trigger };
+export { Action, CloseIconButton, Footer, Header, Popup, Root, Title, Trigger };

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -11,7 +11,7 @@ const meta: Meta< typeof Dialog.Root > = {
 		'Dialog.Popup': Dialog.Popup,
 		'Dialog.Header': Dialog.Header,
 		'Dialog.Title': Dialog.Title,
-		'Dialog.CloseIcon': Dialog.CloseIcon,
+		'Dialog.CloseIconButton': Dialog.CloseIconButton,
 		'Dialog.Action': Dialog.Action,
 		'Dialog.Footer': Dialog.Footer,
 	},
@@ -33,9 +33,9 @@ const meta: Meta< typeof Dialog.Root > = {
 				component: `
 Dialog is a popup that opens on top of the entire page. Every dialog must include a \`Dialog.Title\` component for accessibility — it serves as both the visible heading and the accessible label for the dialog.
 
-When using the Dialog component, make sure to always include a visible close button, either \`Dialog.CloseIcon\` or a clear dismissing action button. If your dialog has a "Cancel" button in the footer, the close icon may be redundant and create confusion about what clicking "X" means.
+When using the Dialog component, make sure to always include a visible close button, either \`Dialog.CloseIconButton\` or a clear dismissing action button. If your dialog has a "Cancel" button in the footer, the close icon may be redundant and create confusion about what clicking "X" means.
 
-Use \`Dialog.CloseIcon\` for informational dialogs where dismissing is safe and expected. For dialogs requiring explicit user choice (especially destructive actions), omit the close icon and rely on footer action buttons like "Cancel" and "Confirm" instead.
+Use \`Dialog.CloseIconButton\` for informational dialogs where dismissing is safe and expected. For dialogs requiring explicit user choice (especially destructive actions), omit the close icon and rely on footer action buttons like "Cancel" and "Confirm" instead.
 				`,
 			},
 		},
@@ -57,7 +57,7 @@ export const _Default: Story = {
 				<Dialog.Popup>
 					<Dialog.Header>
 						<Dialog.Title>Welcome</Dialog.Title>
-						<Dialog.CloseIcon />
+						<Dialog.CloseIconButton />
 					</Dialog.Header>
 					<p>
 						This dialog demonstrates best practices for
@@ -155,7 +155,7 @@ function SizePlaygroundContent() {
 			<Dialog.Popup size={ size }>
 				<Dialog.Header>
 					<Dialog.Title>Size Playground</Dialog.Title>
-					<Dialog.CloseIcon />
+					<Dialog.CloseIconButton />
 				</Dialog.Header>
 				<SizeSelector value={ size } onChange={ setSize } />
 				<p>

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -90,13 +90,14 @@
 
 	.header {
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
+		gap: var(--wpds-dimension-gap-sm);
 		margin-bottom: var(--wpds-dimension-gap-lg);
 	}
 
 	.title {
 		margin: 0;
+		margin-inline-end: auto;
 		font-size: var(--wpds-font-size-xl);
 		font-weight: var(--wpds-font-weight-medium);
 		line-height: var(--wpds-font-line-height-xl);

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -52,7 +52,7 @@ describe( 'Dialog', () => {
 						<Dialog.Title ref={ titleRef }>
 							Test Dialog
 						</Dialog.Title>
-						<Dialog.CloseIcon ref={ closeIconRef } />
+						<Dialog.CloseIconButton ref={ closeIconRef } />
 					</Dialog.Header>
 					<Dialog.Footer ref={ footerRef }>
 						<Dialog.Action ref={ actionRef }>Close</Dialog.Action>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

- rename `CloseIcon` to `CloseIconButton`
- tweak `Header` layout to support multple actions

To consider:
- align close icon button optically (negative margin)
- remove header in favour of title + description + close icon + actions? similar to notice, and leveraging CSS grid
- move close icon after the content
- expose portal props

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
