### PR TITLE
Preserve existing URLInput defaults by only using validation component when validity settings are used

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -147,7 +147,6 @@ const LinkControlSearchInput = forwardRef(
 					__experimentalShowInitialSuggestions={
 						showInitialSuggestions
 					}
-					useCustomValidation
 					customValidity={ customValidityProp }
 					// Validation is handled manually via onSubmit and handleSubmit. We may be able to rely
 					// on browser validation when enhancements land to base level components:

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -147,6 +147,7 @@ const LinkControlSearchInput = forwardRef(
 					__experimentalShowInitialSuggestions={
 						showInitialSuggestions
 					}
+					useCustomValidation
 					customValidity={ customValidityProp }
 					// Validation is handled manually via onSubmit and handleSubmit. We may be able to rely
 					// on browser validation when enhancements land to base level components:

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -494,17 +494,17 @@ class URLInput extends Component {
 			return renderControl( controlProps, inputProps, loading );
 		}
 
+		const MaybeValidatedInputControl = useCustomValidation
+			? ValidatedInputControl
+			: InputControl;
+
 		return (
 			<BaseControl { ...controlProps }>
-				{ useCustomValidation ? (
-					<ValidatedInputControl
-						{ ...inputProps }
-						{ ...validationProps }
-						__next40pxDefaultSize
-					/>
-				) : (
-					<InputControl { ...inputProps } __next40pxDefaultSize />
-				) }
+				<MaybeValidatedInputControl
+					{ ...inputProps }
+					{ ...( useCustomValidation ? validationProps : {} ) }
+					__next40pxDefaultSize
+				/>
 				{ loading && <Spinner /> }
 			</BaseControl>
 		);

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -57,6 +57,7 @@ class URLInput extends Component {
 		this.bindSuggestionNode = this.bindSuggestionNode.bind( this );
 		this.autocompleteRef = props.autocompleteRef || createRef();
 		this.inputRef = props.inputRef || createRef();
+		this.hasRenderedValidation = { current: false };
 		this.updateSuggestions = debounce(
 			this.updateSuggestions.bind( this ),
 			200
@@ -432,7 +433,6 @@ class URLInput extends Component {
 			disabled = false,
 			customValidity,
 			markWhenOptional,
-			useCustomValidation = false,
 		} = this.props;
 
 		const {
@@ -494,7 +494,12 @@ class URLInput extends Component {
 			return renderControl( controlProps, inputProps, loading );
 		}
 
-		const MaybeValidatedInputControl = useCustomValidation
+		// Use ValidatedInputControl if customValidity has ever had a non-undefined value.
+		if ( customValidity !== undefined ) {
+			this.hasRenderedValidation.current = true;
+		}
+
+		const MaybeValidatedInputControl = this.hasRenderedValidation.current
 			? ValidatedInputControl
 			: InputControl;
 
@@ -502,7 +507,9 @@ class URLInput extends Component {
 			<BaseControl { ...controlProps }>
 				<MaybeValidatedInputControl
 					{ ...inputProps }
-					{ ...( useCustomValidation ? validationProps : {} ) }
+					{ ...( this.hasRenderedValidation.current
+						? validationProps
+						: {} ) }
 					__next40pxDefaultSize
 				/>
 				{ loading && <Spinner /> }

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -12,6 +12,7 @@ import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import {
 	BaseControl,
 	Button,
+	__experimentalInputControl as InputControl,
 	Spinner,
 	withSpokenMessages,
 	Popover,
@@ -431,6 +432,7 @@ class URLInput extends Component {
 			disabled = false,
 			customValidity,
 			markWhenOptional,
+			useCustomValidation = false,
 		} = this.props;
 
 		const {
@@ -494,11 +496,15 @@ class URLInput extends Component {
 
 		return (
 			<BaseControl { ...controlProps }>
-				<ValidatedInputControl
-					{ ...inputProps }
-					{ ...validationProps }
-					__next40pxDefaultSize
-				/>
+				{ useCustomValidation ? (
+					<ValidatedInputControl
+						{ ...inputProps }
+						{ ...validationProps }
+						__next40pxDefaultSize
+					/>
+				) : (
+					<InputControl { ...inputProps } __next40pxDefaultSize />
+				) }
 				{ loading && <Spinner /> }
 			</BaseControl>
 		);

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1377,6 +1377,32 @@ test.describe( 'Navigation block', () => {
 				).toBeVisible();
 			} );
 
+			await test.step( 'Verify focus remains on link input after validation error', async () => {
+				// Verify the input is focused and has the correct value
+				await expect( linkInput ).toBeFocused();
+				await expect( linkInput ).toHaveValue( 'invalid url string' );
+			} );
+
+			// If we type in the link input after a validation error, the validation error should be removed and the input should remain focused
+			// This checks to make sure the input switching from a base input to validated input does not cause focus loss
+			await test.step( 'Verify typing in link input after validation error works', async () => {
+				await page.keyboard.press( 'ArrowRight' );
+				await page.keyboard.type( ' after validation error' );
+
+				// Verify the input is still focused
+				await expect( linkInput ).toBeFocused();
+
+				// Verify validation error is gone now
+				await expect(
+					page.getByText( 'Please enter a valid URL.' )
+				).toBeHidden();
+
+				await expect( linkInput ).toHaveValue(
+					'invalid url string after validation error'
+				);
+				await expect( linkInput ).toBeFocused();
+			} );
+
 			// Cancel to preserve bound state for sidebar tests
 			await linkPopover.getByRole( 'button', { name: 'Cancel' } ).click();
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1356,53 +1356,6 @@ test.describe( 'Navigation block', () => {
 				await expect( linkInput ).toHaveValue( '' );
 			} );
 
-			await test.step( 'Verify link field validates on submit in Link UI popover', async () => {
-				await page.keyboard.type( 'invalid url string' );
-
-				await page.keyboard.press( 'Tab' );
-
-				// Verify validation error is not shown on blur
-				await expect(
-					page.getByText( 'Please fill out this field' )
-				).toBeHidden();
-
-				// Go back to the link input and press enter to submit
-				await pageUtils.pressKeys( 'Shift+Tab' );
-				await expect( linkInput ).toBeFocused();
-				await page.keyboard.press( 'Enter' );
-
-				// Verify validation error is shown
-				await expect(
-					page.getByText( 'Please enter a valid URL.' )
-				).toBeVisible();
-			} );
-
-			await test.step( 'Verify focus remains on link input after validation error', async () => {
-				// Verify the input is focused and has the correct value
-				await expect( linkInput ).toBeFocused();
-				await expect( linkInput ).toHaveValue( 'invalid url string' );
-			} );
-
-			// If we type in the link input after a validation error, the validation error should be removed and the input should remain focused
-			// This checks to make sure the input switching from a base input to validated input does not cause focus loss
-			await test.step( 'Verify typing in link input after validation error works', async () => {
-				await page.keyboard.press( 'ArrowRight' );
-				await page.keyboard.type( ' after validation error' );
-
-				// Verify the input is still focused
-				await expect( linkInput ).toBeFocused();
-
-				// Verify validation error is gone now
-				await expect(
-					page.getByText( 'Please enter a valid URL.' )
-				).toBeHidden();
-
-				await expect( linkInput ).toHaveValue(
-					'invalid url string after validation error'
-				);
-				await expect( linkInput ).toBeFocused();
-			} );
-
 			// Cancel to preserve bound state for sidebar tests
 			await linkPopover.getByRole( 'button', { name: 'Cancel' } ).click();
 
@@ -1732,6 +1685,128 @@ test.describe( 'Navigation block', () => {
 				await expect( updatedLinkButton ).toContainText(
 					'example.com'
 				);
+			} );
+		} );
+	} );
+
+	test.describe( 'URL Validation', () => {
+		let testPage1;
+
+		test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+			// Create test pages
+			testPage1 = await requestUtils.createPage( {
+				title: 'Test Page 1',
+				status: 'publish',
+			} );
+
+			// Create post and navigation block with pre-populated links
+			await admin.createNewPost();
+
+			const menu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content:
+					`<!-- wp:navigation-link {"label":"Test Page 1","type":"page","id":${ testPage1.id },"url":"${ testPage1.link }","kind":"post-type"} /-->` +
+					'<!-- wp:navigation-link {"label":"wordpress.org","type":"custom","url":"https://wordpress.org","kind":"custom"} /-->' +
+					'<!-- wp:navigation-link {"label":"Empty Link"} /-->',
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: menu.id,
+				},
+			} );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllPages();
+		} );
+
+		test( 'link field validates on submit in Link UI popover', async ( {
+			editor,
+			page,
+			admin,
+			navigation,
+			requestUtils,
+			pageUtils,
+		} ) => {
+			await test.step( 'Setup - Create menu and navigation block', async () => {
+				await admin.createNewPost();
+
+				// create an empty menu for use - avoids Page List block
+				const menu = await requestUtils.createNavigationMenu( {
+					title: 'Test Menu',
+					content: '',
+				} );
+
+				await editor.insertBlock( {
+					name: 'core/navigation',
+					attributes: {
+						ref: menu.id,
+					},
+				} );
+			} );
+
+			const linkPopover = navigation.getLinkPopover();
+			const linkInput = linkPopover.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+
+			await test.step( 'Open Link inspector', async () => {
+				await expect( navigation.getNavBlockInserter() ).toBeVisible();
+				await pageUtils.pressKeys( 'ArrowDown' );
+				await navigation.useBlockInserter();
+
+				await expect( linkPopover ).toBeVisible();
+				await expect( linkInput ).toBeFocused();
+				await expect( linkInput ).toHaveValue( '' );
+			} );
+
+			await test.step( 'Verify link field validates on submit in Link UI popover', async () => {
+				await page.keyboard.type( 'invalid url string' );
+
+				await page.keyboard.press( 'Tab' );
+
+				// Verify validation error is not shown on blur
+				await expect(
+					page.getByText( 'Please fill out this field' )
+				).toBeHidden();
+
+				// Go back to the link input and press enter to submit
+				await pageUtils.pressKeys( 'Shift+Tab' );
+				await expect( linkInput ).toBeFocused();
+				await page.keyboard.press( 'Enter' );
+
+				// Verify validation error is shown
+				await expect(
+					page.getByText( 'Please enter a valid URL.' )
+				).toBeVisible();
+			} );
+
+			await test.step( 'Verify focus remains on link input after validation error', async () => {
+				// Verify the input is focused and has the correct value
+				await expect( linkInput ).toBeFocused();
+				await expect( linkInput ).toHaveValue( 'invalid url string' );
+			} );
+
+			// If we type in the link input after a validation error, the validation error should be removed and the input should remain focused
+			// This checks to make sure the input switching from a base input to validated input does not cause focus loss
+			await test.step( 'Verify typing in link input after validation error works', async () => {
+				await page.keyboard.press( 'ArrowRight' );
+				await page.keyboard.type( ' after validation error' );
+
+				// Verify the input is still focused
+				await expect( linkInput ).toBeFocused();
+
+				// Verify validation error is gone now
+				await expect(
+					page.getByText( 'Please enter a valid URL.' )
+				).toBeHidden();
+
+				await expect( linkInput ).toHaveValue(
+					'invalid url string after validation error'
+				);
+				await expect( linkInput ).toBeFocused();
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes bug raised by @t-hamano in https://github.com/WordPress/gutenberg/pull/73486#issuecomment-3876518970.

<!-- In a few words, what is the PR actually doing? -->
Using only the Validation Input for URLInput breaks the contract with existing implementations of URLInput. Fixes the "(Required)" text appearing in the URL input field when adding a link to an Image block via the toolbar.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Using the Custom Validation needs to be opt-in to avoid breaking existing usage. Otherwise, they see a "(REQUIRED)" above their input. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the new custom validity component **opt-in** rather than default:

1. **Added `useCustomValidation` prop to URLInput:**
   - Defaults to `false` (preserves backward compatibility)
   - When `true`, uses `ValidatedInputControl` (new validation system)
   - When `false`, uses original `InputControl` (no validation UI changes)

2. **Updated LinkControl to opt in:**
   - Added `useCustomValidation` prop to explicitly enable the validation system

3. **No component swapping issues:**
   - `useCustomValidation` is a stable prop that won't change during the component lifecycle
      - I considered relying on the value of `customValidity`, but swapping the underlying component based on a dynamic value causes focus loss issues. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
## Test 1: Image block link should NOT show "(Required)"
1. Add an image block
3. Click the "Link" button in the block toolbar
4. Verify the URL input field label shows "URL" without "(Required)" text
5. Verify you can create a link

### Test 2: LinkControl should still work for inline text
3. Add a link to inline text (like a paragraph block)
4. Verify the link control appears and functions normally
6. Verify validation still works as expected
7. Verify you can create the link

### Test 3: Navigation block links (uses LinkControl)
2. Add a new link to a navigation block 
4. Verify the link control appears and functions normally
6. Verify validation still works as expected
4. Verify you can create the link

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="524" height="317" alt="Image block link showing Required input text" src="https://github.com/user-attachments/assets/2ce065ee-3d4c-494e-86c4-6760f7fee535" />|<img width="660" height="339" alt="Image block url input without required text" src="https://github.com/user-attachments/assets/2ec738c2-3764-42da-9a0e-345567806a1f" />
|

