### PR TITLE
Core Data: Improve blocks cache in useEntityBlockEditor

### DIFF
--- a/packages/core-data/src/test/entity-provider.js
+++ b/packages/core-data/src/test/entity-provider.js
@@ -276,4 +276,78 @@ describe( 'useEntityBlockEditor', () => {
 			'A paragraph<sup data-fn="abcd" class="fn"><a href="#abcd" id="abcd-link">2</a></sup>'
 		);
 	} );
+
+	it( 'preserves block clientIds across unmount and remount when content is unchanged', () => {
+		let blocks;
+		const TestComponent = () => {
+			[ blocks ] = useEntityBlockEditor( 'postType', 'post', {
+				id: 1,
+			} );
+			return <div />;
+		};
+
+		const { unmount } = render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		const firstClientIds = blocks.map( ( b ) => b.clientId );
+		expect( firstClientIds ).toHaveLength( 2 );
+
+		// Simulate navigating away.
+		unmount();
+
+		// Simulate navigating back — same entity, same content.
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		// The cache should return the same block objects with the same clientIds.
+		expect( blocks.map( ( b ) => b.clientId ) ).toEqual( firstClientIds );
+	} );
+
+	it( 'returns new blocks when content changes', () => {
+		let blocks;
+		const TestComponent = () => {
+			[ blocks ] = useEntityBlockEditor( 'postType', 'post', {
+				id: 1,
+			} );
+			return <div />;
+		};
+
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		const firstClientIds = blocks.map( ( b ) => b.clientId );
+
+		// Receive a new entity record with different content.
+		act( () => {
+			registry
+				.dispatch( coreDataStore )
+				.receiveEntityRecords( 'postType', 'post', [
+					{
+						id: 1,
+						type: 'post',
+						content: {
+							raw: '<!-- wp:test-block --><p>Different content</p><!-- /wp:test-block -->',
+							rendered: '<p>Different content</p>',
+						},
+						meta: { footnotes: '[]' },
+					},
+				] );
+		} );
+
+		// Blocks should be new objects with new clientIds.
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].attributes.content ).toEqual( 'Different content' );
+		expect( blocks.map( ( b ) => b.clientId ) ).not.toEqual(
+			firstClientIds
+		);
+	} );
 } );


### PR DESCRIPTION
Extracted from #75371 

## What?

Replace WeakMap-based parsed blocks cache with a Map keyed by stable entity identity (kind:name:id). This improves cache behavior when navigating between entities. There's no big visible impact, maybe it's a small performance improvement but it's mandatory to be able to restore selection properly after entity navigation (see linked PR)

## Why?

The previous WeakMap approach relied on object identity for cache keys. When navigating away from an entity and back, the entity record object reference could differ, causing a cache miss and unnecessary re-parsing of identical content. This prevented proper selection restoration after navigation.

## How?

- Changed cache from `WeakMap` to `Map` with string key `kind:name:id`
- Cache now stores both content and blocks, validating content hasn't changed before returning cached blocks
- Simplified useMemo dependencies by removing unused selector functions
- Added tests validating cache behavior across unmount/remount and on content changes

## Testing Instructions

Run the test suite: `npx wp-scripts test-unit-js --config test/unit/jest.config.js --testPathPattern="packages/core-data/src/test/entity-provider"`

All 4 tests in useEntityBlockEditor should pass:
- does not mutate block attributes that include an array of strings or null values
- updates the order of footnotes when a new footnote is inserted
- preserves block clientIds across unmount and remount when content is unchanged
- returns new blocks when content changes