### PR TITLE
Real-time Collaboration: Fix error when collaboratorInfo is null

### DIFF
--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -219,8 +219,8 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 				( [ clientId, collaboratorState ] ) => [
 					String( clientId ),
 					{
-						name: collaboratorState.collaboratorInfo.name,
-						wpUserId: collaboratorState.collaboratorInfo.id,
+						name: collaboratorState?.collaboratorInfo?.name,
+						wpUserId: collaboratorState?.collaboratorInfo?.id,
 					},
 				]
 			)

--- a/packages/editor/src/components/collaborators-presence/avatar.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar.tsx
@@ -5,7 +5,7 @@ import './styles/avatar.scss';
 type AvatarSize = 'small' | 'medium';
 
 interface AvatarProps {
-	collaboratorInfo: PostEditorAwarenessState[ 'collaboratorInfo' ];
+	collaboratorInfo?: PostEditorAwarenessState[ 'collaboratorInfo' ] | null;
 	showCollaboratorColorBorder?: boolean;
 	size?: AvatarSize;
 }
@@ -23,6 +23,13 @@ export function Avatar( {
 	showCollaboratorColorBorder,
 	size = 'small',
 }: AvatarProps ) {
+	// collaboratorInfo can be undefined while awareness state is syncing (e.g. before
+	// getCurrentUser() resolves for the local user, or for remote users before their
+	// state is fully propagated).
+	if ( ! collaboratorInfo ) {
+		return null;
+	}
+
 	const className = clsx(
 		'editor-collaborators-presence__avatar',
 		`editor-collaborators-presence__avatar--${ size }`,
@@ -36,7 +43,7 @@ export function Avatar( {
 		collaboratorInfo.avatar_urls?.[ 24 ];
 
 	const avatarStyles = {
-		'--avatar-url': `url(${ avatarUrl })`,
+		'--avatar-url': avatarUrl ? `url(${ avatarUrl })` : undefined,
 		'--collaborator-color': collaboratorInfo.color,
 	} as React.CSSProperties;
 

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -36,9 +36,11 @@ export function CollaboratorsPresence( {
 		postType
 	) as PostEditorAwarenessState[];
 
-	// Filter out current user - we never show ourselves in the list
+	// Filter out current user - we never show ourselves in the list.
+	// Also filter out collaborators whose info is not yet available (can happen
+	// while awareness state is syncing, e.g. before getCurrentUser() resolves).
 	const otherActiveCollaborators = activeCollaborators.filter(
-		( collaborator ) => ! collaborator.isMe
+		( collaborator ) => ! collaborator.isMe && collaborator.collaboratorInfo
 	);
 
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
@@ -56,6 +58,7 @@ export function CollaboratorsPresence( {
 	const visibleCollaborators = otherActiveCollaborators.slice( 0, 3 );
 	const remainingCollaborators = otherActiveCollaborators.slice( 3 );
 	const remainingCollaboratorsText = remainingCollaborators
+		.filter( ( { collaboratorInfo } ) => collaboratorInfo )
 		.map( ( { collaboratorInfo } ) => collaboratorInfo.name )
 		.join( ', ' );
 

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -13,6 +13,34 @@ interface CollaboratorsListProps {
 	setIsPopoverVisible: ( isVisible: boolean ) => void;
 }
 
+function CollaboratorsListItem( {
+	collaboratorState,
+}: {
+	collaboratorState: PostEditorAwarenessState;
+} ) {
+	return (
+		<button
+			key={ collaboratorState.clientId }
+			className="editor-collaborators-presence__list-item"
+			disabled
+			style={ {
+				opacity: collaboratorState.isConnected ? 1 : 0.5,
+			} }
+		>
+			<Avatar
+				collaboratorInfo={ collaboratorState.collaboratorInfo }
+				showCollaboratorColorBorder
+				size="medium"
+			/>
+			<div className="editor-collaborators-presence__list-item-info">
+				<div className="editor-collaborators-presence__list-item-name">
+					{ collaboratorState.collaboratorInfo.name }
+				</div>
+			</div>
+		</button>
+	);
+}
+
 /**
  * Renders a list showing all active collaborators with their details.
  * Note: activeUsers should already exclude the current user (filtered by parent component).
@@ -51,31 +79,15 @@ export function CollaboratorsList( {
 					</div>
 				</div>
 				<div className="editor-collaborators-presence__list-items">
-					{ activeCollaborators.map( ( collaboratorState ) => (
-						<button
-							key={ collaboratorState.clientId }
-							className="editor-collaborators-presence__list-item"
-							disabled
-							style={ {
-								opacity: collaboratorState.isConnected
-									? 1
-									: 0.5,
-							} }
-						>
-							<Avatar
-								collaboratorInfo={
-									collaboratorState.collaboratorInfo
-								}
-								showCollaboratorColorBorder
-								size="medium"
-							/>
-							<div className="editor-collaborators-presence__list-item-info">
-								<div className="editor-collaborators-presence__list-item-name">
-									{ collaboratorState.collaboratorInfo.name }
-								</div>
-							</div>
-						</button>
-					) ) }
+					{ activeCollaborators.map(
+						( collaboratorState ) =>
+							collaboratorState.collaboratorInfo && (
+								<CollaboratorsListItem
+									key={ collaboratorState.clientId }
+									collaboratorState={ collaboratorState }
+								/>
+							)
+					) }
 				</div>
 			</div>
 		</Popover>


### PR DESCRIPTION
## What?
When retrieving collaborator info takes too long, the `collaboratorInfo` property can be null and cause exceptions. This change fixes that issue.

## Why?
User reported errors in real-world environments.

## Testing Instructions

1. Add a delay in `setCurrentCollaboratorInfo` (in `packages/core-data/src/awareness/base-awareness.ts`) with `await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );`
2. Open a post in two windows
3. Put your cursor in a paragraph
4. Prior to this fix, you'll see an error and content disappear