### PR TITLE
Block Visibility: Show viewport tooltip in list view for hidden blocks

### DIFF
--- a/packages/block-editor/src/components/block-visibility/index.js
+++ b/packages/block-editor/src/components/block-visibility/index.js
@@ -3,3 +3,4 @@ export { default as useBlockVisibility } from './use-block-visibility';
 export { default as ViewportVisibilityToolbar } from './viewport-toolbar';
 export { default as BlockVisibilityViewportMenuItem } from './viewport-menu-item';
 export { default as ViewportVisibilityInfo } from './viewport-visibility-info';
+export { getBlockVisibilityLabel } from './utils';

--- a/packages/block-editor/src/components/block-visibility/utils.js
+++ b/packages/block-editor/src/components/block-visibility/utils.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { BLOCK_VISIBILITY_VIEWPORT_ENTRIES } from './constants';
@@ -100,4 +105,39 @@ export function getHideEverywhereCheckboxState( blocks ) {
 	}
 
 	return null; // Indeterminate: some but not all
+}
+
+/**
+ * Get a human-readable label describing which viewports a block is hidden on.
+ *
+ * @param {boolean|Object} blockVisibility The block's visibility metadata.
+ * @return {string|null} A descriptive label, or null if the block is not hidden.
+ */
+export function getBlockVisibilityLabel( blockVisibility ) {
+	// Not hidden at all
+	if ( ! blockVisibility && blockVisibility !== false ) {
+		return null;
+	}
+
+	if ( blockVisibility === false ) {
+		// Hidden on all viewports
+		return __( 'Block is hidden' );
+	}
+
+	if ( blockVisibility?.viewport ) {
+		// Hidden on specific viewports - list them
+		const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
+			( [ key ] ) => blockVisibility.viewport?.[ key ] === false
+		).map( ( [ , viewport ] ) => viewport.label );
+
+		if ( hiddenViewports.length > 0 ) {
+			return sprintf(
+				/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+				__( 'Block is hidden on %s' ),
+				hiddenViewports.join( ', ' )
+			);
+		}
+	}
+
+	return null;
 }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -35,9 +35,7 @@ import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { BLOCK_VISIBILITY_VIEWPORTS } from '../block-visibility/constants';
-import useBlockVisibility from '../block-visibility/use-block-visibility';
-import { deviceTypeKey } from '../../store/private-keys';
+import { BLOCK_VISIBILITY_VIEWPORT_ENTRIES } from '../block-visibility/constants';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -65,26 +63,17 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const {
-		isBlockHidden,
-		hasPatternName,
-		blockVisibility,
-		selectedDeviceType,
-	} = useSelect(
+	const { isBlockHidden, hasPatternName, blockVisibility } = useSelect(
 		( select ) => {
 			const {
 				isBlockHiddenAnywhere: _isBlockHidden,
 				getBlockAttributes,
-				getSettings,
 			} = unlock( select( blockEditorStore ) );
 			const attributes = getBlockAttributes( clientId );
 			return {
 				isBlockHidden: _isBlockHidden( clientId ),
 				hasPatternName: !! attributes?.metadata?.patternName,
 				blockVisibility: attributes?.metadata?.blockVisibility,
-				selectedDeviceType:
-					getSettings()?.[ deviceTypeKey ]?.toLowerCase() ||
-					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
 			};
 		},
 		[ clientId ]
@@ -94,26 +83,25 @@ function ListViewBlockSelectButton(
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 
-	// Use hook to get current viewport and if block is currently hidden
-	const { isBlockCurrentlyHidden, currentViewport } = useBlockVisibility( {
-		blockVisibility,
-		deviceType: selectedDeviceType,
-	} );
-
-	// Determine visibility label and current viewport icon
+	// Determine visibility label from blockVisibility metadata
 	let visibilityLabel;
-	let currentViewportIcon;
 	if ( isBlockHidden ) {
 		if ( blockVisibility === false ) {
+			// Hidden on all viewports
 			visibilityLabel = __( 'Hidden on all viewports' );
-		} else if ( isBlockCurrentlyHidden && currentViewport ) {
-			const viewport = BLOCK_VISIBILITY_VIEWPORTS[ currentViewport ];
-			currentViewportIcon = viewport?.icon;
-			visibilityLabel = sprintf(
-				/* translators: %s: viewport name (Desktop, Tablet, Mobile) */
-				__( 'Hidden on %s' ),
-				viewport?.label || currentViewport
-			);
+		} else if ( blockVisibility?.viewport ) {
+			// Hidden on specific viewports - list them
+			const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
+				( [ key ] ) => blockVisibility.viewport[ key ] === false
+			).map( ( [ , viewport ] ) => viewport.label );
+
+			if ( hiddenViewports.length > 0 ) {
+				visibilityLabel = sprintf(
+					/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+					__( 'Hidden on %s' ),
+					hiddenViewports.join( ', ' )
+				);
+			}
 		}
 	}
 
@@ -199,16 +187,13 @@ function ListViewBlockSelectButton(
 						) ) }
 					</span>
 				) : null }
-				{ isBlockHidden && (
+				{ isBlockHidden && visibilityLabel && (
 					<Tooltip text={ visibilityLabel }>
 						<span
 							className="block-editor-list-view-block-select-button__block-visibility"
 							aria-hidden="true"
 						>
 							<Icon icon={ unseen } />
-							{ currentViewportIcon && (
-								<Icon icon={ currentViewportIcon } />
-							) }
 						</span>
 					</Tooltip>
 				) }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -163,7 +163,7 @@ function ListViewBlockSelectButton(
 						) ) }
 					</span>
 				) : null }
-				{ visibilityLabel && (
+				{ !! visibilityLabel && (
 					<Tooltip text={ visibilityLabel }>
 						<span
 							className="block-editor-list-view-block-select-button__block-visibility"

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -88,7 +88,7 @@ function ListViewBlockSelectButton(
 	if ( isBlockHidden ) {
 		if ( blockVisibility === false ) {
 			// Hidden on all viewports
-			visibilityLabel = __( 'Hidden on all viewports' );
+			visibilityLabel = __( 'Block is hidden' );
 		} else if ( blockVisibility?.viewport ) {
 			// Hidden on specific viewports - list them
 			const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -35,10 +35,9 @@ import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import {
-	BLOCK_VISIBILITY_VIEWPORTS,
-	BLOCK_VISIBILITY_VIEWPORT_ENTRIES,
-} from '../block-visibility/constants';
+import { BLOCK_VISIBILITY_VIEWPORTS } from '../block-visibility/constants';
+import useBlockVisibility from '../block-visibility/use-block-visibility';
+import { deviceTypeKey } from '../../store/private-keys';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -66,17 +65,26 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { isBlockHidden, hasPatternName, blockVisibility } = useSelect(
+	const {
+		isBlockHidden,
+		hasPatternName,
+		blockVisibility,
+		selectedDeviceType,
+	} = useSelect(
 		( select ) => {
 			const {
 				isBlockHiddenAnywhere: _isBlockHidden,
 				getBlockAttributes,
+				getSettings,
 			} = unlock( select( blockEditorStore ) );
 			const attributes = getBlockAttributes( clientId );
 			return {
 				isBlockHidden: _isBlockHidden( clientId ),
 				hasPatternName: !! attributes?.metadata?.patternName,
 				blockVisibility: attributes?.metadata?.blockVisibility,
+				selectedDeviceType:
+					getSettings()?.[ deviceTypeKey ]?.toLowerCase() ||
+					BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
 			};
 		},
 		[ clientId ]
@@ -86,27 +94,25 @@ function ListViewBlockSelectButton(
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 
-	// Determine which viewports the block is hidden on.
-	let hiddenViewports = [];
-	if ( isBlockHidden ) {
-		if ( blockVisibility === false ) {
-			hiddenViewports = Object.values( BLOCK_VISIBILITY_VIEWPORTS );
-		} else if ( blockVisibility?.viewport ) {
-			hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
-				( [ key ] ) => blockVisibility.viewport[ key ] === false
-			).map( ( [ , viewport ] ) => viewport );
-		}
-	}
+	// Use hook to get current viewport and if block is currently hidden
+	const { isBlockCurrentlyHidden, currentViewport } = useBlockVisibility( {
+		blockVisibility,
+		deviceType: selectedDeviceType,
+	} );
 
+	// Determine visibility label and current viewport icon
 	let visibilityLabel;
+	let currentViewportIcon;
 	if ( isBlockHidden ) {
 		if ( blockVisibility === false ) {
 			visibilityLabel = __( 'Hidden on all viewports' );
-		} else if ( hiddenViewports.length > 0 ) {
+		} else if ( isBlockCurrentlyHidden && currentViewport ) {
+			const viewport = BLOCK_VISIBILITY_VIEWPORTS[ currentViewport ];
+			currentViewportIcon = viewport?.icon;
 			visibilityLabel = sprintf(
-				/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+				/* translators: %s: viewport name (Desktop, Tablet, Mobile) */
 				__( 'Hidden on %s' ),
-				hiddenViewports.map( ( v ) => v.label ).join( ', ' )
+				viewport?.label || currentViewport
 			);
 		}
 	}
@@ -195,16 +201,14 @@ function ListViewBlockSelectButton(
 				) : null }
 				{ isBlockHidden && (
 					<Tooltip text={ visibilityLabel }>
-						<span className="block-editor-list-view-block-select-button__block-visibility">
+						<span
+							className="block-editor-list-view-block-select-button__block-visibility"
+							aria-hidden="true"
+						>
 							<Icon icon={ unseen } />
-							{ blockVisibility !== false &&
-								hiddenViewports.map( ( viewport ) => (
-									<Icon
-										key={ viewport.key }
-										icon={ viewport.icon }
-										size={ 20 }
-									/>
-								) ) }
+							{ currentViewportIcon && (
+								<Icon icon={ currentViewportIcon } />
+							) }
 						</span>
 					</Tooltip>
 				) }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -13,7 +13,6 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
 import {
 	Icon,
 	lockSmall as lock,
@@ -35,7 +34,7 @@ import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { BLOCK_VISIBILITY_VIEWPORT_ENTRIES } from '../block-visibility/constants';
+import { getBlockVisibilityLabel } from '../block-visibility';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -80,24 +79,7 @@ function ListViewBlockSelectButton(
 	const images = useListViewImages( { clientId, isExpanded } );
 
 	// Determine visibility label from blockVisibility metadata
-	let visibilityLabel;
-	if ( blockVisibility === false ) {
-		// Hidden on all viewports
-		visibilityLabel = __( 'Block is hidden' );
-	} else if ( blockVisibility?.viewport ) {
-		// Hidden on specific viewports - list them
-		const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
-			( [ key ] ) => blockVisibility.viewport?.[ key ] === false
-		).map( ( [ , viewport ] ) => viewport.label );
-
-		if ( hiddenViewports.length > 0 ) {
-			visibilityLabel = sprintf(
-				/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
-				__( 'Hidden on %s' ),
-				hiddenViewports.join( ', ' )
-			);
-		}
-	}
+	const visibilityLabel = getBlockVisibilityLabel( blockVisibility );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -9,9 +9,11 @@ import clsx from 'clsx';
 import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
+	Tooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Icon,
 	lockSmall as lock,
@@ -33,6 +35,10 @@ import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import {
+	BLOCK_VISIBILITY_VIEWPORTS,
+	BLOCK_VISIBILITY_VIEWPORT_ENTRIES,
+} from '../block-visibility/constants';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -60,16 +66,17 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { isBlockHidden, hasPatternName } = useSelect(
+	const { isBlockHidden, hasPatternName, blockVisibility } = useSelect(
 		( select ) => {
 			const {
 				isBlockHiddenAnywhere: _isBlockHidden,
 				getBlockAttributes,
 			} = unlock( select( blockEditorStore ) );
+			const attributes = getBlockAttributes( clientId );
 			return {
 				isBlockHidden: _isBlockHidden( clientId ),
-				hasPatternName:
-					!! getBlockAttributes( clientId )?.metadata?.patternName,
+				hasPatternName: !! attributes?.metadata?.patternName,
+				blockVisibility: attributes?.metadata?.blockVisibility,
 			};
 		},
 		[ clientId ]
@@ -78,6 +85,31 @@ function ListViewBlockSelectButton(
 	const shouldShowLockIcon = isLocked;
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
+
+	// Determine which viewports the block is hidden on.
+	let hiddenViewports = [];
+	if ( isBlockHidden ) {
+		if ( blockVisibility === false ) {
+			hiddenViewports = Object.values( BLOCK_VISIBILITY_VIEWPORTS );
+		} else if ( blockVisibility?.viewport ) {
+			hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
+				( [ key ] ) => blockVisibility.viewport[ key ] === false
+			).map( ( [ , viewport ] ) => viewport );
+		}
+	}
+
+	let visibilityLabel;
+	if ( isBlockHidden ) {
+		if ( blockVisibility === false ) {
+			visibilityLabel = __( 'Hidden on all viewports' );
+		} else if ( hiddenViewports.length > 0 ) {
+			visibilityLabel = sprintf(
+				/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+				__( 'Hidden on %s' ),
+				hiddenViewports.map( ( v ) => v.label ).join( ', ' )
+			);
+		}
+	}
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -162,9 +194,19 @@ function ListViewBlockSelectButton(
 					</span>
 				) : null }
 				{ isBlockHidden && (
-					<span className="block-editor-list-view-block-select-button__block-visibility">
-						<Icon icon={ unseen } />
-					</span>
+					<Tooltip text={ visibilityLabel }>
+						<span className="block-editor-list-view-block-select-button__block-visibility">
+							<Icon icon={ unseen } />
+							{ blockVisibility !== false &&
+								hiddenViewports.map( ( viewport ) => (
+									<Icon
+										key={ viewport.key }
+										icon={ viewport.icon }
+										size={ 20 }
+									/>
+								) ) }
+						</span>
+					</Tooltip>
 				) }
 				{ shouldShowLockIcon && (
 					<span className="block-editor-list-view-block-select-button__lock">

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -63,15 +63,11 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { isBlockHidden, hasPatternName, blockVisibility } = useSelect(
+	const { hasPatternName, blockVisibility } = useSelect(
 		( select ) => {
-			const {
-				isBlockHiddenAnywhere: _isBlockHidden,
-				getBlockAttributes,
-			} = unlock( select( blockEditorStore ) );
+			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
 			const attributes = getBlockAttributes( clientId );
 			return {
-				isBlockHidden: _isBlockHidden( clientId ),
 				hasPatternName: !! attributes?.metadata?.patternName,
 				blockVisibility: attributes?.metadata?.blockVisibility,
 			};
@@ -85,23 +81,21 @@ function ListViewBlockSelectButton(
 
 	// Determine visibility label from blockVisibility metadata
 	let visibilityLabel;
-	if ( isBlockHidden ) {
-		if ( blockVisibility === false ) {
-			// Hidden on all viewports
-			visibilityLabel = __( 'Block is hidden' );
-		} else if ( blockVisibility?.viewport ) {
-			// Hidden on specific viewports - list them
-			const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
-				( [ key ] ) => blockVisibility.viewport[ key ] === false
-			).map( ( [ , viewport ] ) => viewport.label );
+	if ( blockVisibility === false ) {
+		// Hidden on all viewports
+		visibilityLabel = __( 'Block is hidden' );
+	} else if ( blockVisibility?.viewport ) {
+		// Hidden on specific viewports - list them
+		const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
+			( [ key ] ) => blockVisibility.viewport?.[ key ] === false
+		).map( ( [ , viewport ] ) => viewport.label );
 
-			if ( hiddenViewports.length > 0 ) {
-				visibilityLabel = sprintf(
-					/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
-					__( 'Hidden on %s' ),
-					hiddenViewports.join( ', ' )
-				);
-			}
+		if ( hiddenViewports.length > 0 ) {
+			visibilityLabel = sprintf(
+				/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+				__( 'Hidden on %s' ),
+				hiddenViewports.join( ', ' )
+			);
 		}
 	}
 
@@ -187,7 +181,7 @@ function ListViewBlockSelectButton(
 						) ) }
 					</span>
 				) : null }
-				{ isBlockHidden && visibilityLabel && (
+				{ visibilityLabel && (
 					<Tooltip text={ visibilityLabel }>
 						<span
 							className="block-editor-list-view-block-select-button__block-visibility"

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -25,7 +25,7 @@ import {
 	memo,
 } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { isShallowEqual } from '@wordpress/is-shallow-equal';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
@@ -54,7 +54,7 @@ import { useBlockRename, BlockRenameModal } from '../block-rename';
 import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
 import usePasteStyles from '../use-paste-styles';
-import { BLOCK_VISIBILITY_VIEWPORT_ENTRIES } from '../block-visibility/constants';
+import { getBlockVisibilityLabel } from '../block-visibility';
 
 function ListViewBlock( {
 	block: { clientId },
@@ -141,38 +141,6 @@ function ListViewBlock( {
 		[ clientId ]
 	);
 	const { canRename } = useBlockRename( blockName );
-
-	// Determine label based on where block is hidden (not when/current viewport)
-	const blockVisibilityDescription = useMemo( () => {
-		const blockVisibility = block?.attributes?.metadata?.blockVisibility;
-
-		// Not hidden at all
-		if ( ! blockVisibility && blockVisibility !== false ) {
-			return null;
-		}
-
-		if ( blockVisibility === false ) {
-			// Hidden on all viewports
-			return __( 'Block is hidden' );
-		}
-
-		if ( blockVisibility?.viewport ) {
-			// Hidden on specific viewports - list them
-			const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
-				( [ key ] ) => blockVisibility.viewport?.[ key ] === false
-			).map( ( [ , viewport ] ) => viewport.label );
-
-			if ( hiddenViewports.length > 0 ) {
-				return sprintf(
-					/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
-					__( 'Block is hidden on %s' ),
-					hiddenViewports.join( ', ' )
-				);
-			}
-		}
-
-		return null;
-	}, [ block?.attributes?.metadata?.blockVisibility ] );
 
 	const showBlockActions =
 		// When a block hides its toolbar it also hides the block settings menu,
@@ -558,6 +526,11 @@ function ListViewBlock( {
 	const blockPropertiesDescription = getBlockPropertiesDescription(
 		blockInformation,
 		isLocked
+	);
+
+	// Determine label based on where block is hidden (not when/current viewport)
+	const blockVisibilityDescription = getBlockVisibilityLabel(
+		block?.attributes?.metadata?.blockVisibility
 	);
 
 	const hasSiblings = siblingBlockCount > 0;

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -142,24 +142,14 @@ function ListViewBlock( {
 	);
 	const { canRename } = useBlockRename( blockName );
 
-	const { isBlockHiddenAnywhere } = useSelect(
-		( select ) => {
-			return {
-				isBlockHiddenAnywhere: unlock(
-					select( blockEditorStore )
-				).isBlockHiddenAnywhere( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
 	// Determine label based on where block is hidden (not when/current viewport)
 	const blockVisibilityDescription = useMemo( () => {
-		if ( ! isBlockHiddenAnywhere ) {
+		const blockVisibility = block?.attributes?.metadata?.blockVisibility;
+
+		// Not hidden at all
+		if ( ! blockVisibility && blockVisibility !== false ) {
 			return null;
 		}
-
-		const blockVisibility = block?.attributes?.metadata?.blockVisibility;
 
 		if ( blockVisibility === false ) {
 			// Hidden on all viewports
@@ -169,7 +159,7 @@ function ListViewBlock( {
 		if ( blockVisibility?.viewport ) {
 			// Hidden on specific viewports - list them
 			const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
-				( [ key ] ) => blockVisibility.viewport[ key ] === false
+				( [ key ] ) => blockVisibility.viewport?.[ key ] === false
 			).map( ( [ , viewport ] ) => viewport.label );
 
 			if ( hiddenViewports.length > 0 ) {
@@ -182,10 +172,7 @@ function ListViewBlock( {
 		}
 
 		return null;
-	}, [
-		isBlockHiddenAnywhere,
-		block?.attributes?.metadata?.blockVisibility,
-	] );
+	}, [ block?.attributes?.metadata?.blockVisibility ] );
 
 	const showBlockActions =
 		// When a block hides its toolbar it also hides the block settings menu,

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -54,9 +54,7 @@ import { useBlockRename, BlockRenameModal } from '../block-rename';
 import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
 import usePasteStyles from '../use-paste-styles';
-import { useBlockVisibility } from '../block-visibility';
-import { deviceTypeKey } from '../../store/private-keys';
-import { BLOCK_VISIBILITY_VIEWPORTS } from '../block-visibility/constants';
+import { BLOCK_VISIBILITY_VIEWPORT_ENTRIES } from '../block-visibility/constants';
 
 function ListViewBlock( {
 	block: { clientId },
@@ -127,50 +125,66 @@ function ListViewBlock( {
 
 	const pasteStyles = usePasteStyles();
 
-	const { block, blockName, allowRightClickOverrides, selectedDeviceType } =
-		useSelect(
-			( select ) => {
-				const { getBlock, getBlockName, getSettings } = unlock(
-					select( blockEditorStore )
-				);
-
-				return {
-					block: getBlock( clientId ),
-					blockName: getBlockName( clientId ),
-					allowRightClickOverrides:
-						getSettings().allowRightClickOverrides,
-					selectedDeviceType:
-						getSettings()?.[ deviceTypeKey ]?.toLowerCase() ||
-						BLOCK_VISIBILITY_VIEWPORTS.desktop.value,
-				};
-			},
-			[ clientId ]
-		);
-	const { canRename } = useBlockRename( blockName );
-	// Use hook to get current viewport and if block is currently hidden (accurate viewport detection)
-	const { isBlockCurrentlyHidden, currentViewport } = useBlockVisibility( {
-		blockVisibility: block?.attributes?.metadata?.blockVisibility,
-		deviceType: selectedDeviceType,
-	} );
-
-	// Determine label based on whether block or parent is hidden
-	const blockVisibilityDescription = useMemo( () => {
-		if ( isBlockCurrentlyHidden ) {
-			if ( block?.attributes?.metadata?.blockVisibility === false ) {
-				return __( 'Block is hidden' );
-			}
-			return sprintf(
-				/* translators: %s: viewport name (Desktop, Tablet, Mobile) */
-				__( 'Block is hidden on %s' ),
-				BLOCK_VISIBILITY_VIEWPORTS[ currentViewport ]?.label ||
-					currentViewport
+	const { block, blockName, allowRightClickOverrides } = useSelect(
+		( select ) => {
+			const { getBlock, getBlockName, getSettings } = unlock(
+				select( blockEditorStore )
 			);
+
+			return {
+				block: getBlock( clientId ),
+				blockName: getBlockName( clientId ),
+				allowRightClickOverrides:
+					getSettings().allowRightClickOverrides,
+			};
+		},
+		[ clientId ]
+	);
+	const { canRename } = useBlockRename( blockName );
+
+	const { isBlockHiddenAnywhere } = useSelect(
+		( select ) => {
+			return {
+				isBlockHiddenAnywhere: unlock(
+					select( blockEditorStore )
+				).isBlockHiddenAnywhere( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	// Determine label based on where block is hidden (not when/current viewport)
+	const blockVisibilityDescription = useMemo( () => {
+		if ( ! isBlockHiddenAnywhere ) {
+			return null;
 		}
+
+		const blockVisibility = block?.attributes?.metadata?.blockVisibility;
+
+		if ( blockVisibility === false ) {
+			// Hidden on all viewports
+			return __( 'Block is hidden' );
+		}
+
+		if ( blockVisibility?.viewport ) {
+			// Hidden on specific viewports - list them
+			const hiddenViewports = BLOCK_VISIBILITY_VIEWPORT_ENTRIES.filter(
+				( [ key ] ) => blockVisibility.viewport[ key ] === false
+			).map( ( [ , viewport ] ) => viewport.label );
+
+			if ( hiddenViewports.length > 0 ) {
+				return sprintf(
+					/* translators: %s: comma-separated list of viewport names (Desktop, Tablet, Mobile) */
+					__( 'Block is hidden on %s' ),
+					hiddenViewports.join( ', ' )
+				);
+			}
+		}
+
 		return null;
 	}, [
-		isBlockCurrentlyHidden,
+		isBlockHiddenAnywhere,
 		block?.attributes?.metadata?.blockVisibility,
-		currentViewport,
 	] );
 
 	const showBlockActions =


### PR DESCRIPTION
## What?

This PR adds a tooltip to the hidden block indicator in the list view. It also harmonizes the tooltip and the block accessibility description to declare where a block is hidden, not when. 

Relates to https://github.com/WordPress/gutenberg/issues/73776

## Why?

When a block is hidden on specific viewports, the list view currently just shows the eye icon with no indication of *which* viewports are affected.

Now a tooltip will do that!

Also, to make the tooltip and the aria description match. 

## How?

- Tooltip on hover says "Hidden on Desktop" (or Tablet/Mobile) or "Hidden on all viewports"

## Testing

1. Add a block and hide it on a specific viewport (e.g., Desktop) via the block visibility controls
2. Open the list view. You should see the eye icon next to the block name
3. Hover over the icon . The tooltip should say "Hidden on Desktop" and should remain regardless of the viewport width.
4. Switch to a different viewport (e.g., Tablet) using the device preview controls. 
5. Hide on multiple viewports (e.g., Desktop + Tablet). Ensure the tooltip updates
6. Hide everywhere . The tooltip says "Block is hidden"

Thank you for testing!


<img width="426" height="109" alt="Screenshot 2026-02-17 at 12 09 20 pm" src="https://github.com/user-attachments/assets/8b0430d7-58e6-4097-859c-c303bb195c61" />

<img width="387" height="194" alt="Screenshot 2026-02-17 at 12 20 42 pm" src="https://github.com/user-attachments/assets/790bb584-d97c-45cd-93f5-e7049d5643e3" />
