### PR TITLE
Block context menu: context menu not closing for disconnecting unsynced pattern menu items

### DIFF
--- a/packages/patterns/src/components/index.js
+++ b/packages/patterns/src/components/index.js
@@ -22,6 +22,7 @@ export default function PatternsMenuItems( { rootClientId } ) {
 					{ selectedClientIds.length === 1 && (
 						<PatternsManageButton
 							clientId={ selectedClientIds[ 0 ] }
+							onClose={ onClose }
 						/>
 					) }
 				</>

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -143,7 +143,6 @@ export default function PatternConvertButton( {
 
 			replaceBlocks( clientIds, newBlock );
 			setEditingPattern( newBlock.clientId, true );
-			closeBlockSettingsMenu();
 		}
 
 		createSuccessNotice(
@@ -164,6 +163,7 @@ export default function PatternConvertButton( {
 			}
 		);
 		setIsModalOpen( false );
+		closeBlockSettingsMenu();
 	};
 	return (
 		<>
@@ -186,6 +186,7 @@ export default function PatternConvertButton( {
 					} }
 					onClose={ () => {
 						setIsModalOpen( false );
+						closeBlockSettingsMenu();
 					} }
 				/>
 			) }

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -15,7 +15,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as patternsStore } from '../store';
 import { unlock } from '../lock-unlock';
 
-function PatternsManageButton( { clientId } ) {
+function PatternsManageButton( { clientId, onClose } ) {
 	const {
 		attributes,
 		canDetach,
@@ -103,6 +103,7 @@ function PatternsManageButton( { clientId } ) {
 								metadata: attributesWithoutPatternName,
 							} );
 						}
+						onClose?.();
 					} }
 				>
 					{ isSyncedPattern


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix the block options (context) menu so it closes when the user clicks "Disconnect pattern" on an unsynced pattern.

## Why?

Clicking "Disconnect pattern" in the block options menu (three-dot menu) did not close the dropdown for unsynced patterns. The menu stayed open, which was inconsistent with other menu items (e.g. "Edit section"), which do close the menu after the action.

## How?

Pass `onClose` from `BlockSettingsMenuControls` into `PatternsManageButton`.

## Testing Instructions

1. Open the Site Editor or the Post/Page editor.
2. Insert an **unsynced pattern** block.
3. Open the block options menu (three-dot menu on the block toolbar or from the list view).
4. Click **"Disconnect pattern"**.
   - **Expected:** The menu closes and the block is disconnected (synced → static / pattern name removed).

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/2810c37b-a5ff-4633-aa6d-11271846a2bd



### After



https://github.com/user-attachments/assets/ca3f660a-3dbe-4af0-8ab5-eb01ecac6494

