### PR TITLE
Gallery: Add list view block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -389,7 +389,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 -	**Name:** core/gallery
 -	**Category:** media
 -	**Allowed Blocks:** core/image
--	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -142,6 +142,10 @@ $z-layers: (
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
 	// because it uses emotion and not sass. We need it to render on top its parent popover.
 
+	// Show media replace flow and similar popovers beneath the media modal when its open.
+	".components-popover.block-editor-media-replace-flow__options": 99999,
+	".components-popover.block-editor-inspector-list-view-content-popover": 99999,
+
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
 	".components-popover.block-editor-inserter__popover": 99999,
 	".components-popover.table-of-contents__popover": 99998,

--- a/packages/block-editor/src/components/inspector-controls/list-view-content-popover.js
+++ b/packages/block-editor/src/components/inspector-controls/list-view-content-popover.js
@@ -102,6 +102,7 @@ export function ListViewContentPopover( { listViewRef } ) {
 	return (
 		<Popover
 			{ ...( popoverProps ?? {} ) }
+			className="block-editor-inspector-list-view-content-popover"
 			anchor={ anchorElement }
 			onClose={ closeListViewContentPanel }
 		>

--- a/packages/block-editor/src/components/inspector-controls/styles.scss
+++ b/packages/block-editor/src/components/inspector-controls/styles.scss
@@ -1,0 +1,7 @@
+
+@use "@wordpress/base-styles/z-index" as *;
+
+// Use a lower z-index for the popover when a modal is open to prevent it appearing atop the modal.
+.modal-open .block-editor-inspector-list-view-content-popover {
+	z-index: z-index(".components-popover.block-editor-media-replace-flow__options");
+}

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -1,11 +1,12 @@
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/z-index" as *;
 
 // Hack to hide when the media modal is open
 // Otherwise in Firefox the popover remains visible on top of the modal
-// Changing the z-index of Popovers have wider implications.
+// Changing the z-index of Popovers permanently have wider implications so only temporarily lower it.
 .modal-open .block-editor-media-replace-flow__options {
-	display: none;
+	z-index: z-index(".components-popover.block-editor-media-replace-flow__options");
 }
 
 .block-editor-media-replace-flow__indicator {

--- a/packages/block-editor/src/hooks/list-view.js
+++ b/packages/block-editor/src/hooks/list-view.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
 import { useContext } from '@wordpress/element';
 
@@ -15,6 +15,8 @@ import { PrivateListView } from '../components/list-view';
 import InspectorControls from '../components/inspector-controls/fill';
 import { PrivateBlockContext } from '../components/block-list/private-block-context';
 import useListViewPanelState from '../components/use-list-view-panel-state';
+
+import { unlock } from '../lock-unlock';
 
 export const LIST_VIEW_SUPPORT_KEY = 'listView';
 
@@ -42,6 +44,11 @@ export function ListViewPanel( { clientId, name } ) {
 
 	const { isOpened, expandRevision, handleToggle } =
 		useListViewPanelState( clientId );
+
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { openListViewContentPanel } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const isEnabled = hasListViewSupport( name );
 	const { hasChildren, isNestedListView } = useSelect(
@@ -97,6 +104,7 @@ export function ListViewPanel( { clientId, name } ) {
 					isExpanded
 					description={ title }
 					showAppender
+					onSelect={ openListViewContentPanel }
 				/>
 			</PanelBody>
 		</InspectorControls>

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -38,6 +38,7 @@
 @use "./components/height-control/style.scss" as *;
 @use "./components/iframe/style.scss" as *;
 @use "./components/inserter-list-item/style.scss" as *;
+@use "./components/inspector-controls/styles.scss" as *;
 @use "./components/inspector-controls-tabs/style.scss" as *;
 @use "./components/inspector-popover-header/style.scss" as *;
 @use "./components/justify-content-control/style.scss" as *;

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -162,7 +162,8 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"listView": true
 	},
 	"editorStyle": "wp-block-gallery-editor",
 	"style": "wp-block-gallery"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds List View block support for gallery blocks

## Why?
It's one of the blocks that's definitely list like, but is missing support currently.

I personally think it makes sense to add support. Especially after some recent changes for the navigation block (#75246, #75194) which can also be used for the gallery.

## How?
- Adds the block support flag
- Ensures the main List View hook can open the ListViewContent popover so that individual images can be edited from the list view
- Fixes a focus return issue for MediaReplaceFlow
- Fixes a z-index issue with the ListViewContent popover when the media modal is open.

## Testing Instructions
Outside of a pattern
1. Create a gallery block
2. Add some images to the gallery
3. Select the gallery if not already and open the block inspector sidebar
4. Note that the block now shows a List View tab
5. Click on an image
6. You should be take to the image block's content controls
7. Try changing an image using the controls

Inside of a pattern
1. Select the previously created gallery and potentially some other blocks and create a pattern
2. Note that you can click the navigation block from the Content panel in the sidebar and it shows the block's List View
3. Clicking an image in the List View should show the image block's controls in a popover
4. It should be possible to change the uploaded image and alt text using the popover

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/af35649b-8ed8-4620-9bc9-d47580addf57

