### PR TITLE
DataViews: Adjust column spacing in `table` layout when no titleField is provided

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -7,6 +7,10 @@
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
 
+### Enhancements
+
+- DataViews: Adjust column spacing in table layout when no titleField is provided. [#75410](https://github.com/WordPress/gutenberg/pull/75410)
+
 ## 12.0.0 (2026-02-18)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -403,7 +403,7 @@ function ViewTable< Item >( {
 						<col className="dataviews-view-table__col-checkbox" />
 					) }
 					{ hasPrimaryColumn && (
-						<col className="dataviews-view-table__col-expand" />
+						<col className="dataviews-view-table__col-first-data" />
 					) }
 					{ columns.map( ( column, index ) => (
 						<col

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -403,7 +403,7 @@ function ViewTable< Item >( {
 						<col className="dataviews-view-table__col-checkbox" />
 					) }
 					{ hasPrimaryColumn && (
-						<col className="dataviews-view-table__col-first-data" />
+						<col className="dataviews-view-table__col-expand" />
 					) }
 					{ columns.map( ( column, index ) => (
 						<col
@@ -411,8 +411,9 @@ function ViewTable< Item >( {
 							className={ clsx(
 								`dataviews-view-table__col-${ column }`,
 								{
-									'dataviews-view-table__col-first-data':
-										! hasPrimaryColumn && index === 0,
+									'dataviews-view-table__col-expand':
+										! hasPrimaryColumn &&
+										index === columns.length - 1,
 								}
 							) }
 						/>

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -306,6 +306,6 @@
 }
 
 /* Column width intents via colgroup: make non-primary columns shrink-to-fit */
-.dataviews-view-table col[class^="dataviews-view-table__col-"]:not(.dataviews-view-table__col-expand) {
+.dataviews-view-table col[class^="dataviews-view-table__col-"]:not(.dataviews-view-table__col-first-data):not(.dataviews-view-table__col-expand) {
 	width: 1%;
 }

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -306,6 +306,6 @@
 }
 
 /* Column width intents via colgroup: make non-primary columns shrink-to-fit */
-.dataviews-view-table col[class^="dataviews-view-table__col-"]:not(.dataviews-view-table__col-first-data) {
+.dataviews-view-table col[class^="dataviews-view-table__col-"]:not(.dataviews-view-table__col-expand) {
 	width: 1%;
 }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR updates a bit the logic added here: https://github.com/WordPress/gutenberg/pull/73729.

The main issue that PR wanted to solve is to have an expanding field in case a `titleField` is not provided. This PR updates the logic to expand the last column and not the first because when we don't have a `titleField` it doesn't mean the first column should be more prominent than the others.

## Testing Instructions
1. Table layout in DataViews should remain identical to what is right now in trunk
2. Check in storybook (`?path=/story/dataviews-dataviews--layout-table`) that when a `titleField` is not provided the last column is expanded. `npm run storybook:dev`



|Before|After|
|-|-|
|<img width="1212" height="444" alt="before" src="https://github.com/user-attachments/assets/64669a75-3c4e-4ec5-8e41-bda09abb554e" />|<img width="1212" height="444" alt="after" src="https://github.com/user-attachments/assets/129cbc82-f30d-460b-927f-ccb89d34a024" />|

