### PR TITLE
In-editor Revisions: Update success notice message

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -10,6 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -638,12 +639,17 @@ export const restoreRevision =
 		await dispatch.savePost();
 
 		// Show success notice.
-		registry
-			.dispatch( noticesStore )
-			.createSuccessNotice( __( 'Revision restored.' ), {
+		registry.dispatch( noticesStore ).createSuccessNotice(
+			sprintf(
+				/* translators: %s: Date and time of the revision. */
+				__( 'Restored to revision from %s.' ),
+				dateI18n( getDateSettings().formats.datetime, revision.date )
+			),
+			{
 				type: 'snackbar',
 				id: 'editor-revision-restored',
-			} );
+			}
+		);
 	};
 
 /**

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Revisions', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Revision restored' } )
+				.filter( { hasText: 'Restored to revision' } )
 		).toBeVisible();
 
 		// Verify the original content is restored.


### PR DESCRIPTION
## What?
Closes #19226.
Closes #20349.
This is a follow-up to #74771.

PR updates the revision restoration success message to match the [text used in classic views](https://github.com/WordPress/wordpress-develop/blob/81885a9ff64f3902d4f3162c011745a35b46e6ba/src/wp-admin/edit-form-advanced.php#L180).

* I've omitted the post type prefix to keep the message more general.
* The date formatting matches one used in [slider tooltips](https://github.com/WordPress/gutenberg/blob/362af57e564e88499d2d50c40a492dce21bc168a/packages/editor/src/components/post-revisions-preview/revisions-slider.js#L82).

## Testing Instructions
1. Open a post or page with revisions.
2. Open the in-editor revisions view.
3. Restore to the previous revision.
4. Confirm the new success notice message.

### Testing Instructions for Keyboard

<img width="1245" height="704" alt="CleanShot 2026-02-11 at 14 56 42" src="https://github.com/user-attachments/assets/315dc8b0-2074-44f9-9ffb-a187acf3da11" />
