### PR TITLE
Pattern Editing: Move List View selectors to private-selectors

### DIFF
--- a/packages/block-editor/src/components/use-list-view-panel-state/index.js
+++ b/packages/block-editor/src/components/use-list-view-panel-state/index.js
@@ -7,6 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Custom hook for managing List View panel state.
@@ -17,13 +18,12 @@ import { store as blockEditorStore } from '../../store';
 export default function useListViewPanelState( clientId ) {
 	const { isOpened, expandRevision } = useSelect(
 		( select ) => {
-			const {
-				__unstableIsListViewPanelOpened,
-				__unstableGetListViewExpandRevision,
-			} = select( blockEditorStore );
+			const { isListViewPanelOpened, getListViewExpandRevision } = unlock(
+				select( blockEditorStore )
+			);
 			return {
-				isOpened: __unstableIsListViewPanelOpened( clientId ),
-				expandRevision: __unstableGetListViewExpandRevision(),
+				isOpened: isListViewPanelOpened( clientId ),
+				expandRevision: getListViewExpandRevision(),
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -961,3 +961,30 @@ export function isLockedBlock( state, clientId ) {
 export function isListViewContentPanelOpen( state ) {
 	return state.listViewContentPanelOpen;
 }
+
+/**
+ * Returns whether a List View panel is opened.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client ID of the block.
+ *
+ * @return {boolean} Whether the panel is opened.
+ */
+export function isListViewPanelOpened( state, clientId ) {
+	// If allOpen flag is set, all panels are open
+	if ( state.openedListViewPanels?.allOpen ) {
+		return true;
+	}
+	return state.openedListViewPanels?.panels?.[ clientId ] === true;
+}
+
+/**
+ * Returns the List View expand revision number.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number} The expand revision number.
+ */
+export function getListViewExpandRevision( state ) {
+	return state.listViewExpandRevision || 0;
+}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3286,30 +3286,3 @@ export function __unstableGetTemporarilyEditingAsBlocks( state ) {
 	);
 	return getEditedContentOnlySection( state );
 }
-
-/**
- * Returns whether a List View panel is opened.
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId Client ID of the block.
- *
- * @return {boolean} Whether the panel is opened.
- */
-export function __unstableIsListViewPanelOpened( state, clientId ) {
-	// If allOpen flag is set, all panels are open
-	if ( state.openedListViewPanels?.allOpen ) {
-		return true;
-	}
-	return state.openedListViewPanels?.panels?.[ clientId ] === true;
-}
-
-/**
- * Returns the List View expand revision number.
- *
- * @param {Object} state Global application state.
- *
- * @return {number} The expand revision number.
- */
-export function __unstableGetListViewExpandRevision( state ) {
-	return state.listViewExpandRevision || 0;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses https://github.com/WordPress/gutenberg/pull/75246#discussion_r2791745800

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

From the above comment:

> The __unstable prefix is no longer a practice that's followed.
> The preferred option now is to make it a private selector (using the private-selectors.js file)
> ([trunk/docs/contributors/code/coding-guidelines.md#legacy-experimental-apis](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/coding-guidelines.md#legacy-experimental-apis))

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Moved the List View selectors from selectors.js to private-selectors.js (without __unstable prefix)
  - isListViewPanelOpened(state, clientId)
  - getListViewExpandRevision(state)

Updated use-list-view-panel-state/index.js to use private API:
  - Added unlock import
  - Changed to use unlock(select(blockEditorStore)) pattern
  - Updated selector calls to use the new names without __unstable prefix

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Ensure the testing instructions from https://github.com/WordPress/gutenberg/pull/75246 still work, i.e. that the List View still opens when selecting a Navigation block in the Content tab, when editing a template (contentOnly mode):

  1. Insert a Navigation block in a header template part
  2. Add some navigation links with sub-menus
  3. Select the Navigation block from the template view
  4. In the Content tab, click on a navigation link that has sub-items
  5. Verify the List View opens with the selected block's panel expanded
  6. Verify that the navigation blocks use the custom menu title if one is available
