### PR TITLE
Use null coalescing operator `??` instead of `isset()` ternaries

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -18,8 +18,8 @@
  * @return string The visibility mode: 'hover', 'click', or 'always'.
  */
 function block_core_navigation_submenu_get_submenu_visibility( $attributes ) {
-	$submenu_visibility     = isset( $attributes['submenuVisibility'] ) ? $attributes['submenuVisibility'] : null;
-	$open_submenus_on_click = isset( $attributes['openSubmenusOnClick'] ) ? $attributes['openSubmenusOnClick'] : null;
+	$submenu_visibility     = $attributes['submenuVisibility'] ?? null;
+	$open_submenus_on_click = $attributes['openSubmenusOnClick'] ?? null;
 
 	// If new attribute is set, use it.
 	if ( null !== $submenu_visibility ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -21,8 +21,8 @@
  * @return string The visibility mode: 'hover', 'click', or 'always'.
  */
 function block_core_navigation_get_submenu_visibility( $attributes ) {
-	$submenu_visibility     = isset( $attributes['submenuVisibility'] ) ? $attributes['submenuVisibility'] : null;
-	$open_submenus_on_click = isset( $attributes['openSubmenusOnClick'] ) ? $attributes['openSubmenusOnClick'] : null;
+	$submenu_visibility     = $attributes['submenuVisibility'] ?? null;
+	$open_submenus_on_click = $attributes['openSubmenusOnClick'] ?? null;
 
 	// If new attribute is set, use it.
 	if ( null !== $submenu_visibility ) {

--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -21,9 +21,9 @@ function render_block_core_playlist_track( $attributes ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 
-	$unique_id = isset( $attributes['uniqueId'] ) ? $attributes['uniqueId'] : wp_unique_id( 'playlist-track-' );
-	$artist    = isset( $attributes['artist'] ) ? $attributes['artist'] : '';
-	$length    = isset( $attributes['length'] ) ? $attributes['length'] : '';
+	$unique_id = $attributes['uniqueId'] ?? wp_unique_id( 'playlist-track-' );
+	$artist    = $attributes['artist'] ?? '';
+	$length    = $attributes['length'] ?? '';
 	$title     = isset( $attributes['title'] ) && ! empty( $attributes['title'] ) ? $attributes['title'] : __( 'Unknown title' );
 
 	$context = wp_interactivity_data_wp_context(

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -35,17 +35,17 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 				$inner_block->context['playlistId'] = $playlist_id;
 
 				$track_attributes  = $inner_block->attributes;
-				$unique_id         = isset( $track_attributes['uniqueId'] ) ? $track_attributes['uniqueId'] : wp_unique_id( 'playlist-track-' );
+				$unique_id         = $track_attributes['uniqueId'] ?? wp_unique_id( 'playlist-track-' );
 				$playlist_tracks[] = $unique_id;
 
 				$inner_block->attributes['uniqueId'] = $unique_id;
 
 				// Extract track metadata from block attributes.
 				$title      = isset( $track_attributes['title'] ) && ! empty( $track_attributes['title'] ) ? $track_attributes['title'] : __( 'Unknown title' );
-				$artist     = isset( $track_attributes['artist'] ) ? $track_attributes['artist'] : '';
-				$album      = isset( $track_attributes['album'] ) ? $track_attributes['album'] : '';
-				$image      = isset( $track_attributes['image'] ) ? $track_attributes['image'] : '';
-				$url        = isset( $track_attributes['src'] ) ? $track_attributes['src'] : '';
+				$artist     = $track_attributes['artist'] ?? '';
+				$album      = $track_attributes['album'] ?? '';
+				$image      = $track_attributes['image'] ?? '';
+				$url        = $track_attributes['src'] ?? '';
 				$aria_label = $title;
 
 				if ( $title && $artist && $album ) {
@@ -100,7 +100,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	$html = '<div class="wp-block-playlist__current-item">';
 
 	// The alt attribute is intentionally left empty, as the image is decorative.
-	if ( isset( $attributes['showImages'] ) ? $attributes['showImages'] : false ) {
+	if ( $attributes['showImages'] ?? false ) {
 		$html .=
 		'<img
 			class="wp-block-playlist__item-image"


### PR DESCRIPTION
This pull request refactors several PHP files in the block library to use the null coalescing operator (`??`) instead of the `isset()` ternary pattern for attribute handling. This change improves readability and consistency across the codebase.

This feature is avaiable since PHP 7.0

We did the same in core: https://core.trac.wordpress.org/ticket/63430