### PR TITLE
Content Guidelines: Add UX for site, copy, image, and additional guidelines

### DIFF
--- a/lib/experimental/content-guidelines/load.php
+++ b/lib/experimental/content-guidelines/load.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Bootstraps the Content Guidelines page in wp-admin under Settings.
+ *
+ * @package gutenberg
+ */
+
+add_action( 'admin_menu', 'gutenberg_register_content_guidelines_settings_submenu', 10 );
+
+/**
+ * Registers the Content Guidelines submenu item under Settings.
+ * Uses the same layout/style as the Font Library admin page (wp-admin integrated).
+ */
+function gutenberg_register_content_guidelines_settings_submenu() {
+	add_submenu_page(
+		'options-general.php',
+		__( 'Content Guidelines', 'gutenberg' ),
+		__( 'Content Guidelines', 'gutenberg' ),
+		'manage_options',
+		'content-guidelines-wp-admin',
+		'gutenberg_content_guidelines_wp_admin_render_page'
+	);
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -206,5 +206,6 @@ require __DIR__ . '/overlay-patterns.php';
 
 // Content Guidelines (only load when experiment is enabled).
 if ( gutenberg_is_experiment_enabled( 'gutenberg-content-guidelines' ) ) {
+	require __DIR__ . '/experimental/content-guidelines/load.php';
 	require __DIR__ . '/experimental/content-guidelines/index.php';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62983,7 +62983,6 @@
 				"@wordpress/api-fetch": "file:../../packages/api-fetch",
 				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/components": "file:../../packages/components",
-				"@wordpress/compose": "file:../../packages/compose",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/dataviews": "file:../../packages/dataviews",
 				"@wordpress/element": "file:../../packages/element",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62988,7 +62988,8 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/notices": "file:../../packages/notices"
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/ui": "file:../../packages/ui"
 			}
 		},
 		"routes/font-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20775,6 +20775,10 @@
 			"resolved": "routes/connectors-home",
 			"link": true
 		},
+		"node_modules/@wordpress/content-guidelines-route": {
+			"resolved": "routes/content-guidelines",
+			"link": true
+		},
 		"node_modules/@wordpress/core-abilities": {
 			"resolved": "packages/core-abilities",
 			"link": true
@@ -62969,6 +62973,19 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/ui": "file:../../packages/ui"
+			}
+		},
+		"routes/content-guidelines": {
+			"name": "@wordpress/content-guidelines-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/base-styles": "file:../../packages/base-styles",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/icons": "file:../../packages/icons"
 			}
 		},
 		"routes/font-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62980,12 +62980,15 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/api-fetch": "file:../../packages/api-fetch",
 				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/icons": "file:../../packages/icons"
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/notices": "file:../../packages/notices"
 			}
 		},
 		"routes/font-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62985,6 +62985,7 @@
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/compose": "file:../../packages/compose",
 				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 				"experimental": true
 			},
 			"font-library",
-			"options-connectors"
+			"options-connectors",
+			"content-guidelines"
 		]
 	},
 	"config": {

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -22,30 +22,13 @@ export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse 
 		setFromResponse: ( response: RestGuidelinesResponse ) => void;
 	};
 
-	try {
-		const response = ( await apiFetch( {
-			path: '/wp/v2/content-guidelines?context=edit',
-		} ) ) as RestGuidelinesResponse;
+	const response = ( await apiFetch( {
+		path: '/wp/v2/content-guidelines?context=edit',
+	} ) ) as RestGuidelinesResponse;
 
-		setFromResponse( response );
+	setFromResponse( response );
 
-		return response;
-	} catch ( error: unknown ) {
-		const { createErrorNotice } = dispatch( noticesStore ) as {
-			createErrorNotice: (
-				message: string,
-				options?: { type?: 'snackbar' | 'default'; context?: string }
-			) => void;
-		};
-
-		createErrorNotice(
-			__(
-				'There was an error loading your content guidelines. Please try again.'
-			),
-			{ type: 'snackbar' }
-		);
-		throw error;
-	}
+	return response;
 }
 
 export async function saveContentGuidelines(): Promise< RestGuidelinesResponse > {
@@ -82,35 +65,25 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 		},
 	};
 
-	const { createSuccessNotice, createErrorNotice } = dispatch( noticesStore );
+	const { createSuccessNotice } = dispatch( noticesStore );
 
-	try {
-		const hasExistingId = !! ( id && id > 0 );
-		const path = hasExistingId
-			? `/wp/v2/content-guidelines/${ id }`
-			: '/wp/v2/content-guidelines';
-		const method = hasExistingId ? 'PUT' : 'POST';
+	const hasExistingId = !! ( id && id > 0 );
+	const path = hasExistingId
+		? `/wp/v2/content-guidelines/${ id }`
+		: '/wp/v2/content-guidelines';
+	const method = hasExistingId ? 'PUT' : 'POST';
 
-		const response = ( await apiFetch( {
-			path,
-			method,
-			data,
-		} ) ) as RestGuidelinesResponse;
+	const response = ( await apiFetch( {
+		path,
+		method,
+		data,
+	} ) ) as RestGuidelinesResponse;
 
-		setFromResponse( response );
+	setFromResponse( response );
 
-		createSuccessNotice( __( 'Content guidelines saved.' ), {
-			type: 'snackbar',
-		} );
+	createSuccessNotice( __( 'Content guidelines saved.' ), {
+		type: 'snackbar',
+	} );
 
-		return response;
-	} catch ( error: unknown ) {
-		createErrorNotice(
-			__(
-				'There was an error saving your content guidelines. Please try again.'
-			),
-			{ type: 'snackbar' }
-		);
-		throw error;
-	}
+	return response;
 }

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -10,12 +10,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { STORE_NAME } from './store';
-
-interface RestGuidelinesResponse {
-	id: number;
-	status: string;
-	guideline_categories?: Record< string, { guidelines?: string } >;
-}
+import type { RestGuidelinesResponse } from './types';
 
 export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse > {
 	const { setFromResponse } = dispatch( STORE_NAME ) as {

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -3,6 +3,8 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -29,6 +31,19 @@ export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse 
 
 		return response;
 	} catch ( error: unknown ) {
+		const { createErrorNotice } = dispatch( noticesStore ) as {
+			createErrorNotice: (
+				message: string,
+				options?: { type?: 'snackbar' | 'default'; context?: string }
+			) => void;
+		};
+
+		createErrorNotice(
+			__(
+				'There was an error loading your content guidelines. Please try again.'
+			),
+			{ type: 'snackbar' }
+		);
 		throw error;
 	}
 }
@@ -74,6 +89,8 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 		data.id = id;
 	}
 
+	const { createSuccessNotice, createErrorNotice } = dispatch( noticesStore );
+
 	try {
 		const hasExistingId = !! ( id && id > 0 );
 		const path = hasExistingId
@@ -89,8 +106,18 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 
 		setFromResponse( response );
 
+		createSuccessNotice( __( 'Content guidelines saved.' ), {
+			type: 'snackbar',
+		} );
+
 		return response;
 	} catch ( error: unknown ) {
+		createErrorNotice(
+			__(
+				'There was an error saving your content guidelines. Please try again.'
+			),
+			{ type: 'snackbar' }
+		);
 		throw error;
 	}
 }

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from './store';
+
+interface RestGuidelinesResponse {
+	id: number;
+	status: string;
+	guideline_categories?: Record< string, { guidelines?: string } >;
+}
+
+export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse > {
+	const { setFromResponse } = dispatch( STORE_NAME ) as {
+		setFromResponse: ( response: RestGuidelinesResponse ) => void;
+	};
+
+	try {
+		const response = ( await apiFetch( {
+			path: '/wp/v2/content-guidelines?context=edit',
+		} ) ) as RestGuidelinesResponse;
+
+		setFromResponse( response );
+
+		return response;
+	} catch ( error: unknown ) {
+		throw error;
+	}
+}
+
+export async function saveContentGuidelines(): Promise< RestGuidelinesResponse > {
+	const { setFromResponse } = dispatch( STORE_NAME ) as {
+		setFromResponse: ( response: RestGuidelinesResponse ) => void;
+	};
+
+	const guidelinesStore = select( STORE_NAME ) as {
+		getId: () => number | null;
+		getStatus: () => string | null;
+		getAllGuidelines: () => Partial< Record< string, string > >;
+	};
+
+	const id = guidelinesStore.getId();
+	const status = guidelinesStore.getStatus() || 'draft';
+	const categories = guidelinesStore.getAllGuidelines();
+
+	const data: {
+		id?: number;
+		status: string;
+		guideline_categories: RestGuidelinesResponse[ 'guideline_categories' ];
+	} = {
+		status,
+		guideline_categories: {
+			site: {
+				guidelines: categories.site,
+			},
+			copy: {
+				guidelines: categories.copy,
+			},
+			images: {
+				guidelines: categories.images,
+			},
+			additional: {
+				guidelines: categories.additional,
+			},
+		},
+	};
+
+	if ( id && id > 0 ) {
+		data.id = id;
+	}
+
+	try {
+		const hasExistingId = !! ( id && id > 0 );
+		const path = hasExistingId
+			? `/wp/v2/content-guidelines/${ id }`
+			: '/wp/v2/content-guidelines';
+		const method = hasExistingId ? 'PUT' : 'POST';
+
+		const response = ( await apiFetch( {
+			path,
+			method,
+			data,
+		} ) ) as RestGuidelinesResponse;
+
+		setFromResponse( response );
+
+		return response;
+	} catch ( error: unknown ) {
+		throw error;
+	}
+}

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -49,25 +49,22 @@ export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse 
 }
 
 export async function saveContentGuidelines(): Promise< RestGuidelinesResponse > {
-	const { setFromResponse } = dispatch( STORE_NAME ) as {
-		setFromResponse: ( response: RestGuidelinesResponse ) => void;
-	};
+	// @ts-ignore
+	const { setFromResponse } = dispatch( STORE_NAME );
 
 	const guidelinesStore = select( STORE_NAME ) as {
 		getId: () => number | null;
 		getStatus: () => string | null;
 		getAllGuidelines: () => Partial< Record< string, string > >;
+		getGuideline: ( category: string ) => string;
 	};
 
 	const id = guidelinesStore.getId();
 	const status = guidelinesStore.getStatus() || 'draft';
 	const categories = guidelinesStore.getAllGuidelines();
 
-	const data: {
-		id?: number;
-		status: string;
-		guideline_categories: RestGuidelinesResponse[ 'guideline_categories' ];
-	} = {
+	const data = {
+		id: id && id > 0 ? id : undefined,
 		status,
 		guideline_categories: {
 			site: {
@@ -84,10 +81,6 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 			},
 		},
 	};
-
-	if ( id && id > 0 ) {
-		data.id = id;
-	}
 
 	const { createSuccessNotice, createErrorNotice } = dispatch( noticesStore );
 

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -42,7 +42,7 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 	const categories = guidelinesStore.getAllGuidelines();
 
 	const data = {
-		id: id && id > 0 ? id : undefined,
+		id,
 		status,
 		guideline_categories: {
 			site: {
@@ -62,11 +62,10 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 
 	const { createSuccessNotice } = dispatch( noticesStore );
 
-	const hasExistingId = !! ( id && id > 0 );
-	const path = hasExistingId
+	const path = id
 		? `/wp/v2/content-guidelines/${ id }`
 		: '/wp/v2/content-guidelines';
-	const method = hasExistingId ? 'PUT' : 'POST';
+	const method = id ? 'PUT' : 'POST';
 
 	const response = ( await apiFetch( {
 		path,

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -106,7 +106,7 @@ export default function GuidelineAccordionForm( {
 					variant="primary"
 					type="submit"
 					className="save-button"
-					disabled={ loading || ! draft }
+					disabled={ loading }
 				>
 					{ __( 'Save guidelines' ) }
 				</Button>

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -1,15 +1,12 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	__experimentalVStack as VStack,
-	TextareaControl,
-} from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import type { Field, Form } from '@wordpress/dataviews';
 import { Notice } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import type { FormEvent } from 'react';
+import { useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -40,7 +37,33 @@ export default function GuidelineAccordionForm( {
 
 	const [ draft, setDraft ] = useState( value );
 
-	const handleSave = ( event: FormEvent< HTMLFormElement > ) => {
+	const data = useMemo( () => ( { guidelines: draft } ), [ draft ] );
+
+	const fields: Field< { guidelines: string } >[] = useMemo(
+		() => [
+			{
+				id: 'guidelines',
+				label: sprintf(
+					/* translators: %s: Guideline category. */
+					__( '%s guidelines' ),
+					slug
+				),
+				type: 'text',
+				Edit: 'textarea',
+			},
+		],
+		[ slug ]
+	);
+
+	const form: Form = useMemo(
+		() => ( {
+			layout: { type: 'regular', labelPosition: 'none' },
+			fields: [ 'guidelines' ],
+		} ),
+		[]
+	);
+
+	const handleSave = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 		setGuideline( slug, draft );
 		setLoading( true );
@@ -58,11 +81,13 @@ export default function GuidelineAccordionForm( {
 			className="content-guidelines__accordion-form"
 		>
 			<VStack spacing={ 4 }>
-				<TextareaControl
-					label={ __( 'Copy guidelines' ) }
-					hideLabelFromVision
-					value={ draft }
-					onChange={ setDraft }
+				<DataForm
+					data={ data }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits ) =>
+						setDraft( edits.guidelines ?? draft )
+					}
 				/>
 				{ error && (
 					<Notice.Root intent="error">

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -17,13 +17,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { STORE_NAME } from '../store';
 import { saveContentGuidelines } from '../api';
-
-interface GuidelineAccordionFormProps {
-	slug: string;
-	contentId?: string; // Used for a11y.
-	headingId?: string; // Used for a11y.
-	descriptionId?: string;
-}
+import type { GuidelineAccordionFormProps } from '../types';
 
 export default function GuidelineAccordionForm( {
 	slug,

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalVStack as VStack,
+	TextareaControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import type { FormEvent } from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../store';
+import { saveContentGuidelines } from '../api';
+
+interface GuidelineAccordionFormProps {
+	slug: string;
+	contentId?: string; // Used for a11y.
+	headingId?: string; // Used for a11y.
+	descriptionId?: string;
+}
+
+export default function GuidelineAccordionForm( {
+	slug,
+	contentId,
+	headingId,
+	descriptionId,
+}: GuidelineAccordionFormProps ) {
+	// @ts-ignore
+	const { setGuideline } = useDispatch( STORE_NAME );
+
+	const { value } = useSelect(
+		( select ) => ( {
+			// @ts-ignore
+			value: select( STORE_NAME ).getGuideline( slug ) as string,
+		} ),
+		[ slug ]
+	);
+
+	const [ draft, setDraft ] = useState( value );
+
+	const handleSave = ( event: FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		setGuideline( slug, draft );
+		saveContentGuidelines();
+	};
+
+	return (
+		<form
+			id={ contentId }
+			aria-labelledby={ headingId }
+			aria-describedby={ descriptionId }
+			onSubmit={ handleSave }
+			className="content-guidelines__accordion-form"
+		>
+			<VStack spacing={ 4 }>
+				<TextareaControl
+					label={ __( 'Copy guidelines' ) }
+					hideLabelFromVision
+					value={ draft }
+					onChange={ setDraft }
+				/>
+				<Button variant="primary" type="submit" className="save-button">
+					{ __( 'Save guidelines' ) }
+				</Button>
+			</VStack>
+		</form>
+	);
+}

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -69,6 +69,7 @@ export default function GuidelineAccordionForm( {
 		setGuideline( slug, draft );
 		setLoading( true );
 		saveContentGuidelines()
+			.then( () => setError( null ) )
 			.catch( ( e: Error ) => setError( e.message ) )
 			.finally( () => setLoading( false ) );
 	};
@@ -105,7 +106,7 @@ export default function GuidelineAccordionForm( {
 					variant="primary"
 					type="submit"
 					className="save-button"
-					disabled={ loading }
+					disabled={ loading || ! draft }
 				>
 					{ __( 'Save guidelines' ) }
 				</Button>

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -6,7 +6,8 @@ import {
 	__experimentalVStack as VStack,
 	TextareaControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import type { FormEvent } from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -32,6 +33,8 @@ export default function GuidelineAccordionForm( {
 }: GuidelineAccordionFormProps ) {
 	// @ts-ignore
 	const { setGuideline } = useDispatch( STORE_NAME );
+	const [ loading, setLoading ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
 
 	const { value } = useSelect(
 		( select ) => ( {
@@ -46,7 +49,10 @@ export default function GuidelineAccordionForm( {
 	const handleSave = ( event: FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 		setGuideline( slug, draft );
-		saveContentGuidelines();
+		setLoading( true );
+		saveContentGuidelines()
+			.catch( ( e: Error ) => setError( e.message ) )
+			.finally( () => setLoading( false ) );
 	};
 
 	return (
@@ -64,7 +70,23 @@ export default function GuidelineAccordionForm( {
 					value={ draft }
 					onChange={ setDraft }
 				/>
-				<Button variant="primary" type="submit" className="save-button">
+				{ error && (
+					<Notice.Root intent="error">
+						<Notice.Title>
+							{ sprintf(
+								/* translators: %s: Error message. */
+								__( 'Error saving guidelines: %s' ),
+								error
+							) }
+						</Notice.Title>
+					</Notice.Root>
+				) }
+				<Button
+					variant="primary"
+					type="submit"
+					className="save-button"
+					disabled={ loading }
+				>
 					{ __( 'Save guidelines' ) }
 				</Button>
 			</VStack>

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -6,7 +6,7 @@ import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
 import { Notice } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -36,6 +36,7 @@ export default function GuidelineAccordionForm( {
 	);
 
 	const [ draft, setDraft ] = useState( value );
+	useEffect( () => setDraft( value ), [ value ] );
 
 	const data = useMemo( () => ( { guidelines: draft } ), [ draft ] );
 

--- a/routes/content-guidelines/components/guideline-accordion.scss
+++ b/routes/content-guidelines/components/guideline-accordion.scss
@@ -4,12 +4,12 @@
 .content-guidelines__accordion {
 	padding: $grid-unit-20 $grid-unit-30;
 
-	.rotate-180 {
+	&-chevron-up {
 		transition: transform 0.3s ease-in-out;
 		transform: rotate(180deg);
 	}
 
-	.rotate-0 {
+	&-chevron-down {
 		transition: transform 0.3s ease-in-out;
 		transform: rotate(0deg);
 	}

--- a/routes/content-guidelines/components/guideline-accordion.scss
+++ b/routes/content-guidelines/components/guideline-accordion.scss
@@ -1,0 +1,32 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.content-guidelines__accordion {
+	padding: $grid-unit-30;
+
+	.rotate-180 {
+		transition: transform 0.3s ease-in-out;
+		transform: rotate(180deg);
+	}
+
+	.rotate-0 {
+		transition: transform 0.3s ease-in-out;
+		transform: rotate(0deg);
+	}
+}
+
+.content-guidelines__accordion-header {
+	color: $gray-900;
+}
+
+.content-guidelines__accordion-description {
+	color: $gray-700;
+}
+
+.content-guidelines__accordion-form {
+	margin-top: $grid-unit-30;
+
+	.save-button {
+		width: 122px;
+	}
+}

--- a/routes/content-guidelines/components/guideline-accordion.scss
+++ b/routes/content-guidelines/components/guideline-accordion.scss
@@ -2,7 +2,7 @@
 @use "@wordpress/base-styles/variables" as *;
 
 .content-guidelines__accordion {
-	padding: $grid-unit-30;
+	padding: $grid-unit-20 $grid-unit-30;
 
 	.rotate-180 {
 		transition: transform 0.3s ease-in-out;
@@ -15,12 +15,18 @@
 	}
 }
 
+.content-guidelines__accordion-header-container {
+	cursor: pointer;
+}
+
 .content-guidelines__accordion-header {
 	color: $gray-900;
+	padding-top: $grid-unit-05;
 }
 
 .content-guidelines__accordion-description {
 	color: $gray-700;
+	padding-bottom: $grid-unit-05;
 }
 
 .content-guidelines__accordion-form {

--- a/routes/content-guidelines/components/guideline-accordion.scss
+++ b/routes/content-guidelines/components/guideline-accordion.scss
@@ -33,6 +33,6 @@
 	margin-top: $grid-unit-30;
 
 	.save-button {
-		width: 122px;
+		width: max-content;
 	}
 }

--- a/routes/content-guidelines/components/guideline-accordion.scss
+++ b/routes/content-guidelines/components/guideline-accordion.scss
@@ -4,6 +4,26 @@
 .content-guidelines__accordion {
 	padding: $grid-unit-20 $grid-unit-30;
 
+	&-trigger {
+		display: block;
+		width: 100%;
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		cursor: pointer;
+		text-align: left;
+		height: auto;
+
+		&:focus {
+			box-shadow: none !important;
+		}
+
+		&:focus-visible {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color, #3858e9) !important;
+		}
+	}
+
 	&-chevron-up {
 		transition: transform 0.3s ease-in-out;
 		transform: rotate(180deg);
@@ -15,9 +35,6 @@
 	}
 }
 
-.content-guidelines__accordion-header-container {
-	cursor: pointer;
-}
 
 .content-guidelines__accordion-header {
 	color: $gray-900;

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -2,13 +2,13 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	Icon,
 	__experimentalText as Text,
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	Card,
+	Button,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
@@ -32,10 +32,25 @@ export default function GuidelineAccordion( {
 
 	return (
 		<Card className="content-guidelines__accordion">
-			<VStack
-				spacing={ 4 }
+			<Button
+				className="content-guidelines__accordion-trigger"
 				onClick={ () => setIsOpen( ! isOpen ) }
-				className="content-guidelines__accordion-header-container"
+				aria-expanded={ isOpen }
+				aria-controls={ contentId }
+				aria-describedby={ descriptionId }
+				aria-label={
+					isOpen
+						? sprintf(
+								/* translators: %s: Guideline title */
+								__( 'Collapse %s guidelines' ),
+								title
+						  )
+						: sprintf(
+								/* translators: %s: Guideline title */
+								__( 'Expand %s guidelines' ),
+								title
+						  )
+				}
 			>
 				<HStack spacing={ 4 }>
 					<VStack spacing={ 1 }>
@@ -58,42 +73,17 @@ export default function GuidelineAccordion( {
 							{ description }
 						</Text>
 					</VStack>
-					<Button
-						icon={
-							<Icon
-								icon={ chevronDown }
-								className={
-									isOpen
-										? 'content-guidelines__accordion-chevron-up'
-										: 'content-guidelines__accordion-chevron-down'
-								}
-							/>
-						}
-						onClick={ (
-							event: React.MouseEvent< HTMLButtonElement >
-						) => {
-							event.stopPropagation();
-							setIsOpen( ! isOpen );
-						} }
-						aria-expanded={ isOpen }
-						aria-controls={ contentId }
-						aria-label={
+					<Icon
+						icon={ chevronDown }
+						className={
 							isOpen
-								? sprintf(
-										/* translators: %s: Guideline title */
-										__( 'Collapse %s guidelines' ),
-										title
-								  )
-								: sprintf(
-										/* translators: %s: Guideline title */
-										__( 'Expand %s guidelines' ),
-										title
-								  )
+								? 'content-guidelines__accordion-chevron-up'
+								: 'content-guidelines__accordion-chevron-down'
 						}
 					/>
 				</HStack>
-			</VStack>
-			{ isOpen && children }
+			</Button>
+			<div hidden={ ! isOpen }>{ children }</div>
 		</Card>
 	);
 }

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -62,7 +62,11 @@ export default function GuidelineAccordion( {
 						icon={
 							<Icon
 								icon={ chevronDown }
-								className={ isOpen ? 'rotate-180' : 'rotate-0' }
+								className={
+									isOpen
+										? 'content-guidelines__accordion-chevron-up'
+										: 'content-guidelines__accordion-chevron-down'
+								}
 							/>
 						}
 						onClick={ (

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -65,7 +65,12 @@ export default function GuidelineAccordion( {
 								className={ isOpen ? 'rotate-180' : 'rotate-0' }
 							/>
 						}
-						onClick={ () => setIsOpen( ! isOpen ) }
+						onClick={ (
+							event: React.MouseEvent< HTMLButtonElement >
+						) => {
+							event.stopPropagation();
+							setIsOpen( ! isOpen );
+						} }
 						aria-expanded={ isOpen }
 						aria-controls={ contentId }
 						aria-label={

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -8,55 +8,33 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	TextareaControl,
 	Card,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
-import { useState, useId } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useState, useId, Children, cloneElement } from '@wordpress/element';
+import type { ReactNode, ReactElement } from 'react';
 
 /**
  * Internal dependencies
  */
 import './guideline-accordion.scss';
-import { STORE_NAME } from '../store';
-import { saveContentGuidelines } from '../api';
 
 interface GuidelineAccordionProps {
 	title: string;
 	description: string;
-	slug: string;
+	children: ReactNode;
 }
 
 export default function GuidelineAccordion( {
 	title,
 	description,
-	slug,
+	children,
 }: GuidelineAccordionProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const contentId = useId();
 	const headingId = useId();
 	const descriptionId = useId();
-
-	// @ts-ignore
-	const { setGuideline } = useDispatch( STORE_NAME );
-
-	const { value } = useSelect(
-		( select ) => ( {
-			// @ts-ignore
-			value: select( STORE_NAME ).getGuideline( slug ) as string,
-		} ),
-		[ slug ]
-	);
-
-	const [ draft, setDraft ] = useState( value );
-
-	const handleSave = ( event: SubmitEvent ) => {
-		event.preventDefault();
-		setGuideline( slug, draft );
-		saveContentGuidelines();
-	};
 
 	return (
 		<Card className="content-guidelines__accordion">
@@ -108,31 +86,12 @@ export default function GuidelineAccordion( {
 					/>
 				</HStack>
 			</VStack>
-			{ isOpen && (
-				<form
-					id={ contentId }
-					aria-labelledby={ headingId }
-					aria-describedby={ descriptionId }
-					onSubmit={ handleSave }
-					className="content-guidelines__accordion-form"
-				>
-					<VStack spacing={ 4 }>
-						<TextareaControl
-							label={ __( 'Copy guidelines' ) }
-							hideLabelFromVision
-							value={ draft }
-							onChange={ setDraft }
-						/>
-						<Button
-							variant="primary"
-							type="submit"
-							className="save-button"
-						>
-							{ __( 'Save guidelines' ) }
-						</Button>
-					</VStack>
-				</form>
-			) }
+			{ isOpen &&
+				cloneElement( Children.only( children ) as ReactElement, {
+					contentId,
+					headingId,
+					descriptionId,
+				} ) }
 		</Card>
 	);
 }

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -12,8 +12,8 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
-import { useState, useId, Children, cloneElement } from '@wordpress/element';
-import type { ReactNode, ReactElement } from 'react';
+import { useState } from '@wordpress/element';
+import type { ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -24,17 +24,20 @@ interface GuidelineAccordionProps {
 	title: string;
 	description: string;
 	children: ReactNode;
+	contentId?: string;
+	headingId?: string;
+	descriptionId?: string;
 }
 
 export default function GuidelineAccordion( {
 	title,
 	description,
 	children,
+	contentId,
+	headingId,
+	descriptionId,
 }: GuidelineAccordionProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const contentId = useId();
-	const headingId = useId();
-	const descriptionId = useId();
 
 	return (
 		<Card className="content-guidelines__accordion">
@@ -86,12 +89,7 @@ export default function GuidelineAccordion( {
 					/>
 				</HStack>
 			</VStack>
-			{ isOpen &&
-				cloneElement( Children.only( children ) as ReactElement, {
-					contentId,
-					headingId,
-					descriptionId,
-				} ) }
+			{ isOpen && children }
 		</Card>
 	);
 }

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -53,7 +53,7 @@ export default function GuidelineAccordion( {
 							className="content-guidelines__accordion-description"
 							size={ 13 }
 							weight={ 400 }
-							color="#757575"
+							variant="muted"
 						>
 							{ description }
 						</Text>

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -39,6 +39,7 @@ export default function GuidelineAccordion( {
 	const headingId = useId();
 	const descriptionId = useId();
 
+	// @ts-ignore
 	const { setGuideline } = useDispatch( STORE_NAME );
 
 	const { value } = useSelect(
@@ -49,9 +50,12 @@ export default function GuidelineAccordion( {
 		[ slug ]
 	);
 
-	const handleSave = ( event: React.FormEvent< HTMLFormElement > ) => {
+	const [ draft, setDraft ] = useState( value );
+
+	const handleSave = ( event: SubmitEvent ) => {
 		event.preventDefault();
-		void saveContentGuidelines();
+		setGuideline( slug, draft );
+		saveContentGuidelines();
 	};
 
 	return (
@@ -116,10 +120,8 @@ export default function GuidelineAccordion( {
 						<TextareaControl
 							label={ __( 'Copy guidelines' ) }
 							hideLabelFromVision
-							value={ value }
-							onChange={ ( newValue: string ) => {
-								setGuideline( slug, newValue );
-							} }
+							value={ draft }
+							onChange={ setDraft }
 						/>
 						<Button
 							variant="primary"

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -41,15 +41,19 @@ export default function GuidelineAccordion( {
 
 	return (
 		<Card className="content-guidelines__accordion">
-			<VStack spacing={ 4 }>
+			<VStack
+				spacing={ 4 }
+				onClick={ () => setIsOpen( ! isOpen ) }
+				className="content-guidelines__accordion-header-container"
+			>
 				<HStack spacing={ 4 }>
-					<VStack spacing={ 4 }>
+					<VStack spacing={ 1 }>
 						<Heading
 							id={ headingId }
 							className="content-guidelines__accordion-header"
 							level={ 2 }
 							size={ 15 }
-							weight={ 500 }
+							weight={ 400 }
 						>
 							{ title }
 						</Heading>

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -14,25 +14,45 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
 import { useState, useId } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './guideline-accordion.scss';
+import { STORE_NAME } from '../store';
+import { saveContentGuidelines } from '../api';
 
 interface GuidelineAccordionProps {
 	title: string;
 	description: string;
+	slug: string;
 }
 
 export default function GuidelineAccordion( {
 	title,
 	description,
+	slug,
 }: GuidelineAccordionProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const contentId = useId();
 	const headingId = useId();
 	const descriptionId = useId();
+
+	const { setGuideline } = useDispatch( STORE_NAME );
+
+	const { value } = useSelect(
+		( select ) => ( {
+			// @ts-ignore
+			value: select( STORE_NAME ).getGuideline( slug ) as string,
+		} ),
+		[ slug ]
+	);
+
+	const handleSave = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		void saveContentGuidelines();
+	};
 
 	return (
 		<Card className="content-guidelines__accordion">
@@ -89,13 +109,17 @@ export default function GuidelineAccordion( {
 					id={ contentId }
 					aria-labelledby={ headingId }
 					aria-describedby={ descriptionId }
-					onSubmit={ ( event ) => event.preventDefault() }
+					onSubmit={ handleSave }
 					className="content-guidelines__accordion-form"
 				>
 					<VStack spacing={ 4 }>
 						<TextareaControl
 							label={ __( 'Copy guidelines' ) }
 							hideLabelFromVision
+							value={ value }
+							onChange={ ( newValue: string ) => {
+								setGuideline( slug, newValue );
+							} }
 						/>
 						<Button
 							variant="primary"

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -13,21 +13,12 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
-import type { ReactNode } from 'react';
 
 /**
  * Internal dependencies
  */
 import './guideline-accordion.scss';
-
-interface GuidelineAccordionProps {
-	title: string;
-	description: string;
-	children: ReactNode;
-	contentId?: string;
-	headingId?: string;
-	descriptionId?: string;
-}
+import type { GuidelineAccordionProps } from '../types';
 
 export default function GuidelineAccordion( {
 	title,

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -1,0 +1,112 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Icon,
+	__experimentalText as Text,
+	__experimentalHeading as Heading,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	TextareaControl,
+	Card,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+import { useState, useId } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './guideline-accordion.scss';
+
+interface GuidelineAccordionProps {
+	title: string;
+	description: string;
+}
+
+export default function GuidelineAccordion( {
+	title,
+	description,
+}: GuidelineAccordionProps ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const contentId = useId();
+	const headingId = useId();
+	const descriptionId = useId();
+
+	return (
+		<Card className="content-guidelines__accordion">
+			<VStack spacing={ 4 }>
+				<HStack spacing={ 4 }>
+					<VStack spacing={ 4 }>
+						<Heading
+							id={ headingId }
+							className="content-guidelines__accordion-header"
+							level={ 2 }
+							size={ 15 }
+							weight={ 500 }
+						>
+							{ title }
+						</Heading>
+						<Text
+							id={ descriptionId }
+							className="content-guidelines__accordion-description"
+							size={ 13 }
+							weight={ 400 }
+							color="#757575"
+						>
+							{ description }
+						</Text>
+					</VStack>
+					<Button
+						icon={
+							<Icon
+								icon={ chevronDown }
+								className={ isOpen ? 'rotate-180' : 'rotate-0' }
+							/>
+						}
+						onClick={ () => setIsOpen( ! isOpen ) }
+						aria-expanded={ isOpen }
+						aria-controls={ contentId }
+						aria-label={
+							isOpen
+								? sprintf(
+										/* translators: %s: Guideline title */
+										__( 'Collapse %s guidelines' ),
+										title
+								  )
+								: sprintf(
+										/* translators: %s: Guideline title */
+										__( 'Expand %s guidelines' ),
+										title
+								  )
+						}
+					/>
+				</HStack>
+			</VStack>
+			{ isOpen && (
+				<form
+					id={ contentId }
+					aria-labelledby={ headingId }
+					aria-describedby={ descriptionId }
+					onSubmit={ ( event ) => event.preventDefault() }
+					className="content-guidelines__accordion-form"
+				>
+					<VStack spacing={ 4 }>
+						<TextareaControl
+							label={ __( 'Copy guidelines' ) }
+							hideLabelFromVision
+						/>
+						<Button
+							variant="primary"
+							type="submit"
+							className="save-button"
+						>
+							{ __( 'Save guidelines' ) }
+						</Button>
+					</VStack>
+				</form>
+			) }
+		</Card>
+	);
+}

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -17,7 +17,6 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/compose": "file:../../packages/compose",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/ui": "file:../../packages/ui"

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@wordpress/content-guidelines-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/",
+		"page": [
+			"content-guidelines"
+		]
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/base-styles": "file:../../packages/base-styles",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/compose": "file:../../packages/compose"
+	}
+}

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -18,6 +18,7 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/ui": "file:../../packages/ui"
 	}

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -18,6 +18,7 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/compose": "file:../../packages/compose",
-		"@wordpress/notices": "file:../../packages/notices"
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/ui": "file:../../packages/ui"
 	}
 }

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -10,8 +10,10 @@
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/api-fetch": "file:../../packages/api-fetch",
 		"@wordpress/base-styles": "file:../../packages/base-styles",
 		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -17,6 +17,7 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/compose": "file:../../packages/compose"
+		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/notices": "file:../../packages/notices"
 	}
 }

--- a/routes/content-guidelines/route.ts
+++ b/routes/content-guidelines/route.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const route = {
+	title: () => __( 'Content Guidelines' ),
+};

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -11,6 +11,7 @@ import { Spinner } from '@wordpress/components';
  */
 import './style.scss';
 import GuidelineAccordion from './components/guideline-accordion';
+import GuidelineAccordionForm from './components/guideline-accordion-form';
 import { fetchContentGuidelines } from './api';
 
 const GUIDELINE_ITEMS = [
@@ -82,8 +83,11 @@ function ContentGuidelinesPage() {
 									<GuidelineAccordion
 										title={ item.title }
 										description={ item.description }
-										slug={ item.slug }
-									/>
+									>
+										<GuidelineAccordionForm
+											slug={ item.slug }
+										/>
+									</GuidelineAccordion>
 								</div>
 							</li>
 						) ) }

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
+import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -49,10 +50,13 @@ const GUIDELINE_ITEMS = [
 
 function ContentGuidelinesPage() {
 	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState< string | null >( null );
 
 	useEffect( () => {
 		// Populate the store with the content guidelines.
-		fetchContentGuidelines().then( () => setLoading( false ) );
+		fetchContentGuidelines()
+			.catch( ( e: Error ) => setError( e.message ) )
+			.finally( () => setLoading( false ) );
 	}, [] );
 
 	return (
@@ -62,50 +66,72 @@ function ContentGuidelinesPage() {
 				"Set content standards that guide your team, inform plugins, and help AI tools generate content that matches your site's voice and requirements."
 			) }
 		>
+			{ error && (
+				<div className="content-guidelines__content">
+					<Notice.Root intent="error">
+						<Notice.Title>
+							{ sprintf(
+								/* translators: %s: Error message. */
+								__( 'Error loading content guidelines: %s' ),
+								error
+							) }
+						</Notice.Title>
+						<Notice.Description>
+							{ __(
+								'Please try again. If the problem persists, contact support.'
+							) }
+						</Notice.Description>
+					</Notice.Root>
+				</div>
+			) }
 			{ loading ? (
 				<div className="content-guidelines__loading">
 					<Spinner />
 				</div>
 			) : (
-				<div className="content-guidelines__content">
-					{ /*
-					 * Disable reason: The `list` ARIA role is redundant but
-					 * Safari+VoiceOver won't announce the list otherwise.
-					 */
-					/* eslint-disable jsx-a11y/no-redundant-roles */ }
-					<ul role="list" className="content-guidelines__list">
-						{ GUIDELINE_ITEMS.map( ( item ) => {
-							const contentId = `content-guidelines-${ item.slug }`;
-							const headingId = `content-guidelines-${ item.slug }-heading`;
-							const descriptionId = `content-guidelines-${ item.slug }-description`;
+				! error && (
+					<div className="content-guidelines__content">
+						{ /*
+						 * Disable reason: The `list` ARIA role is redundant but
+						 * Safari+VoiceOver won't announce the list otherwise.
+						 */
+						/* eslint-disable jsx-a11y/no-redundant-roles */ }
+						<ul role="list" className="content-guidelines__list">
+							{ GUIDELINE_ITEMS.map( ( item ) => {
+								const contentId = `content-guidelines-${ item.slug }`;
+								const headingId = `content-guidelines-${ item.slug }-heading`;
+								const descriptionId = `content-guidelines-${ item.slug }-description`;
 
-							return (
-								<li
-									key={ item.slug }
-									className="content-guidelines__list-item"
-								>
-									<div className="content-guidelines__accordion-item">
-										<GuidelineAccordion
-											title={ item.title }
-											description={ item.description }
-											contentId={ contentId }
-											headingId={ headingId }
-											descriptionId={ descriptionId }
-										>
-											<GuidelineAccordionForm
-												slug={ item.slug }
+								return (
+									<li
+										key={ item.slug }
+										className="content-guidelines__list-item"
+									>
+										<div className="content-guidelines__accordion-item">
+											<GuidelineAccordion
+												title={ item.title }
+												description={ item.description }
 												contentId={ contentId }
 												headingId={ headingId }
 												descriptionId={ descriptionId }
-											/>
-										</GuidelineAccordion>
-									</div>
-								</li>
-							);
-						} ) }
-					</ul>
-					{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
-				</div>
+											>
+												<GuidelineAccordionForm
+													slug={ item.slug }
+													contentId={ contentId }
+													headingId={ headingId }
+													descriptionId={
+														descriptionId
+													}
+												/>
+											</GuidelineAccordion>
+										</div>
+									</li>
+								);
+							} ) }
+						</ul>
+						{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+					</div>
+				)
 			) }
 		</Page>
 	);

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -39,10 +39,8 @@ const GUIDELINE_ITEMS = [
 		slug: 'images',
 	},
 	{
-		title: __( 'Additional guidelines' ),
-		description: __(
-			'Include any additional standards such as SEO preferences, legal requirements, citation styles, or other content considerations.'
-		),
+		title: __( 'Internal' ),
+		description: __( 'Add private notes and standards for your team.' ),
 
 		slug: 'additional',
 	},

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -41,8 +41,8 @@ const GUIDELINE_ITEMS = [
 		slug: 'images',
 	},
 	{
-		title: __( 'Internal' ),
-		description: __( 'Add private notes and standards for your team.' ),
+		title: __( 'Additional' ),
+		description: __( 'Add additional guidelines for your team.' ),
 
 		slug: 'additional',
 	},

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import GuidelineAccordion from './components/guideline-accordion';
+
+const GUIDELINE_ITEMS = [
+	{
+		title: __( 'Site' ),
+		description: __(
+			"Describe your site's purpose, goals, and primary audience."
+		),
+
+		slug: 'site',
+	},
+	{
+		title: __( 'Copy' ),
+		description: __(
+			'Set your writing standards for tone, voice, style, and formatting.'
+		),
+
+		slug: 'copy',
+	},
+	{
+		title: __( 'Images' ),
+		description: __(
+			'Outline your style, dimensions, formats, mood and aesthetic preferences.'
+		),
+
+		slug: 'images',
+	},
+	{
+		title: __( 'Additional guidelines' ),
+		description: __(
+			'Include any additional standards such as SEO preferences, legal requirements, citation styles, or other content considerations.'
+		),
+
+		slug: 'additional-guidelines',
+	},
+];
+
+function ContentGuidelinesPage() {
+	return (
+		<Page
+			title={ __( 'Content guidelines' ) }
+			subTitle={ __(
+				"Set content standards that guide your team, inform plugins, and help AI tools generate content that matches your site's voice and requirements."
+			) }
+		>
+			<div className="content-guidelines__content">
+				{ /*
+				 * Disable reason: The `list` ARIA role is redundant but
+				 * Safari+VoiceOver won't announce the list otherwise.
+				 */
+				/* eslint-disable jsx-a11y/no-redundant-roles */ }
+				<ul role="list" className="content-guidelines__list">
+					{ GUIDELINE_ITEMS.map( ( item ) => (
+						<li
+							key={ item.slug }
+							className="content-guidelines__list-item"
+						>
+							<div className="content-guidelines__accordion-item">
+								<GuidelineAccordion
+									title={ item.title }
+									description={ item.description }
+								/>
+							</div>
+						</li>
+					) ) }
+				</ul>
+				{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+			</div>
+		</Page>
+	);
+}
+
+export const stage = ContentGuidelinesPage;

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -3,12 +3,15 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import GuidelineAccordion from './components/guideline-accordion';
+import { fetchContentGuidelines } from './api';
 
 const GUIDELINE_ITEMS = [
 	{
@@ -41,11 +44,18 @@ const GUIDELINE_ITEMS = [
 			'Include any additional standards such as SEO preferences, legal requirements, citation styles, or other content considerations.'
 		),
 
-		slug: 'additional-guidelines',
+		slug: 'additional',
 	},
 ];
 
 function ContentGuidelinesPage() {
+	const [ loading, setLoading ] = useState( true );
+
+	useEffect( () => {
+		// Populate the store with the content guidelines.
+		fetchContentGuidelines().then( () => setLoading( false ) );
+	}, [] );
+
 	return (
 		<Page
 			title={ __( 'Content guidelines' ) }
@@ -53,29 +63,36 @@ function ContentGuidelinesPage() {
 				"Set content standards that guide your team, inform plugins, and help AI tools generate content that matches your site's voice and requirements."
 			) }
 		>
-			<div className="content-guidelines__content">
-				{ /*
-				 * Disable reason: The `list` ARIA role is redundant but
-				 * Safari+VoiceOver won't announce the list otherwise.
-				 */
-				/* eslint-disable jsx-a11y/no-redundant-roles */ }
-				<ul role="list" className="content-guidelines__list">
-					{ GUIDELINE_ITEMS.map( ( item ) => (
-						<li
-							key={ item.slug }
-							className="content-guidelines__list-item"
-						>
-							<div className="content-guidelines__accordion-item">
-								<GuidelineAccordion
-									title={ item.title }
-									description={ item.description }
-								/>
-							</div>
-						</li>
-					) ) }
-				</ul>
-				{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
-			</div>
+			{ loading ? (
+				<div className="content-guidelines__loading">
+					<Spinner />
+				</div>
+			) : (
+				<div className="content-guidelines__content">
+					{ /*
+					 * Disable reason: The `list` ARIA role is redundant but
+					 * Safari+VoiceOver won't announce the list otherwise.
+					 */
+					/* eslint-disable jsx-a11y/no-redundant-roles */ }
+					<ul role="list" className="content-guidelines__list">
+						{ GUIDELINE_ITEMS.map( ( item ) => (
+							<li
+								key={ item.slug }
+								className="content-guidelines__list-item"
+							>
+								<div className="content-guidelines__accordion-item">
+									<GuidelineAccordion
+										title={ item.title }
+										description={ item.description }
+										slug={ item.slug }
+									/>
+								</div>
+							</li>
+						) ) }
+					</ul>
+					{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+				</div>
+			) }
 		</Page>
 	);
 }

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -55,6 +55,7 @@ function ContentGuidelinesPage() {
 	useEffect( () => {
 		// Populate the store with the content guidelines.
 		fetchContentGuidelines()
+			.then( () => setError( null ) )
 			.catch( ( e: Error ) => setError( e.message ) )
 			.finally( () => setLoading( false ) );
 	}, [] );

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -74,23 +74,35 @@ function ContentGuidelinesPage() {
 					 */
 					/* eslint-disable jsx-a11y/no-redundant-roles */ }
 					<ul role="list" className="content-guidelines__list">
-						{ GUIDELINE_ITEMS.map( ( item ) => (
-							<li
-								key={ item.slug }
-								className="content-guidelines__list-item"
-							>
-								<div className="content-guidelines__accordion-item">
-									<GuidelineAccordion
-										title={ item.title }
-										description={ item.description }
-									>
-										<GuidelineAccordionForm
-											slug={ item.slug }
-										/>
-									</GuidelineAccordion>
-								</div>
-							</li>
-						) ) }
+						{ GUIDELINE_ITEMS.map( ( item ) => {
+							const contentId = `content-guidelines-${ item.slug }`;
+							const headingId = `content-guidelines-${ item.slug }-heading`;
+							const descriptionId = `content-guidelines-${ item.slug }-description`;
+
+							return (
+								<li
+									key={ item.slug }
+									className="content-guidelines__list-item"
+								>
+									<div className="content-guidelines__accordion-item">
+										<GuidelineAccordion
+											title={ item.title }
+											description={ item.description }
+											contentId={ contentId }
+											headingId={ headingId }
+											descriptionId={ descriptionId }
+										>
+											<GuidelineAccordionForm
+												slug={ item.slug }
+												contentId={ contentId }
+												headingId={ headingId }
+												descriptionId={ descriptionId }
+											/>
+										</GuidelineAccordion>
+									</div>
+								</li>
+							);
+						} ) }
 					</ul>
 					{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
 				</div>

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -3,13 +3,12 @@
  */
 import { createReduxStore, register } from '@wordpress/data';
 
-export const STORE_NAME = 'core/content-guidelines';
+/**
+ * Internal dependencies
+ */
+import type { ContentGuidelinesState, RestGuidelinesResponse } from './types';
 
-export interface ContentGuidelinesState {
-	id: number | null;
-	status: string | null;
-	categories: Record< string, string >;
-}
+export const STORE_NAME = 'core/content-guidelines';
 
 const DEFAULT_STATE: ContentGuidelinesState = {
 	id: null,
@@ -20,7 +19,7 @@ const DEFAULT_STATE: ContentGuidelinesState = {
 const CATEGORIES = [ 'site', 'copy', 'images', 'additional' ];
 
 const actions = {
-	setFromResponse( response: unknown ) {
+	setFromResponse( response: RestGuidelinesResponse ) {
 		return {
 			type: 'SET_FROM_RESPONSE' as const,
 			response,
@@ -37,22 +36,18 @@ const actions = {
 
 type Action = ReturnType< ( typeof actions )[ keyof typeof actions ] >;
 
-function parseResponse( response: unknown ): Partial< ContentGuidelinesState > {
+function parseResponse(
+	response: RestGuidelinesResponse | null | undefined
+): Partial< ContentGuidelinesState > {
 	if ( ! response || typeof response !== 'object' ) {
 		return {};
 	}
 
-	const data = response as {
-		id?: unknown;
-		status?: unknown;
-		guideline_categories?: Record< string, { guidelines?: unknown } >;
-	};
-
-	const categoriesFromResponse = data.guideline_categories ?? {};
+	const categoriesFromResponse = response.guideline_categories ?? {};
 
 	const result = {
-		id: data.id as number | null,
-		status: data.status as string | null,
+		id: response.id ?? null,
+		status: response.status ?? null,
 		categories: {},
 	};
 

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -8,7 +8,7 @@ export const STORE_NAME = 'core/content-guidelines';
 export interface ContentGuidelinesState {
 	id: number | null;
 	status: string | null;
-	categories: Partial< Record< string, string > >;
+	categories: Record< string, string >;
 }
 
 const DEFAULT_STATE: ContentGuidelinesState = {
@@ -16,6 +16,8 @@ const DEFAULT_STATE: ContentGuidelinesState = {
 	status: null,
 	categories: {},
 };
+
+const CATEGORIES = [ 'site', 'copy', 'images', 'additional' ];
 
 const actions = {
 	setFromResponse( response: unknown ) {
@@ -48,17 +50,16 @@ function parseResponse( response: unknown ): Partial< ContentGuidelinesState > {
 
 	const categoriesFromResponse = data.guideline_categories ?? {};
 
-	const result: Partial< ContentGuidelinesState > = {
-		id: typeof data.id === 'number' ? data.id : null,
-		status: typeof data.status === 'string' ? data.status : null,
+	const result = {
+		id: data.id as number | null,
+		status: data.status as string | null,
 		categories: {},
 	};
 
-	[ 'site', 'copy', 'images', 'additional' ].forEach( ( slug ) => {
-		const guidelines = categoriesFromResponse?.[ slug ]?.guidelines;
+	CATEGORIES.forEach( ( category ) => {
+		const guidelines = categoriesFromResponse?.[ category ]?.guidelines;
 		if ( typeof guidelines === 'string' ) {
-			( result.categories as Record< string, string > )[ slug ] =
-				guidelines;
+			result.categories[ category ] = guidelines;
 		}
 	} );
 
@@ -89,8 +90,8 @@ function reducer(
 }
 
 const selectors = {
-	getGuideline( state: ContentGuidelinesState, slug: string ): string {
-		return state.categories[ slug ] ?? '';
+	getGuideline( state: ContentGuidelinesState, category: string ): string {
+		return state.categories[ category ] ?? '';
 	},
 	getAllGuidelines(
 		state: ContentGuidelinesState

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+export const STORE_NAME = 'core/content-guidelines';
+
+export interface ContentGuidelinesState {
+	id: number | null;
+	status: string | null;
+	categories: Partial< Record< string, string > >;
+}
+
+const DEFAULT_STATE: ContentGuidelinesState = {
+	id: null,
+	status: null,
+	categories: {},
+};
+
+const actions = {
+	setFromResponse( response: unknown ) {
+		return {
+			type: 'SET_FROM_RESPONSE' as const,
+			response,
+		};
+	},
+	setGuideline( category: string, value: string ) {
+		return {
+			type: 'SET_GUIDELINE' as const,
+			category,
+			value,
+		};
+	},
+};
+
+type Action = ReturnType< ( typeof actions )[ keyof typeof actions ] >;
+
+function parseResponse( response: unknown ): Partial< ContentGuidelinesState > {
+	if ( ! response || typeof response !== 'object' ) {
+		return {};
+	}
+
+	const data = response as {
+		id?: unknown;
+		status?: unknown;
+		guideline_categories?: Record< string, { guidelines?: unknown } >;
+	};
+
+	const categoriesFromResponse = data.guideline_categories ?? {};
+
+	const result: Partial< ContentGuidelinesState > = {
+		id: typeof data.id === 'number' ? data.id : null,
+		status: typeof data.status === 'string' ? data.status : null,
+		categories: {},
+	};
+
+	[ 'site', 'copy', 'images', 'additional' ].forEach( ( slug ) => {
+		const guidelines = categoriesFromResponse?.[ slug ]?.guidelines;
+		if ( typeof guidelines === 'string' ) {
+			( result.categories as Record< string, string > )[ slug ] =
+				guidelines;
+		}
+	} );
+
+	return result;
+}
+
+function reducer(
+	state: ContentGuidelinesState = DEFAULT_STATE,
+	action: Action
+): ContentGuidelinesState {
+	switch ( action.type ) {
+		case 'SET_FROM_RESPONSE':
+			return {
+				...state,
+				...parseResponse( action.response ),
+			};
+		case 'SET_GUIDELINE':
+			return {
+				...state,
+				categories: {
+					...state.categories,
+					[ action.category ]: action.value,
+				},
+			};
+		default:
+			return state;
+	}
+}
+
+const selectors = {
+	getGuideline( state: ContentGuidelinesState, slug: string ): string {
+		return state.categories[ slug ] ?? '';
+	},
+	getAllGuidelines(
+		state: ContentGuidelinesState
+	): Partial< Record< string, string > > {
+		return state.categories;
+	},
+	getId( state: ContentGuidelinesState ): number | null {
+		return state.id;
+	},
+	getStatus( state: ContentGuidelinesState ): string | null {
+		return state.status;
+	},
+};
+
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+register( store );

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -20,3 +20,10 @@
 	width: min(680px, 100%);
 	margin: 0 auto;
 }
+
+.content-guidelines__loading {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin-top: $grid-unit-20;
+}

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -1,0 +1,22 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.content-guidelines__content {
+	margin-top: 0;
+	padding: $grid-unit-30;
+	border-radius: $radius-large;
+}
+
+.content-guidelines__list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+}
+
+.content-guidelines__list-item {
+	width: min(680px, 100%);
+	margin: 0 auto;
+}

--- a/routes/content-guidelines/types.ts
+++ b/routes/content-guidelines/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Types for the Content Guidelines feature.
+ */
+
+import type { ReactNode } from 'react';
+
+export interface ContentGuidelinesState {
+	id: number | null;
+	status: string | null;
+	categories: Record< string, string >;
+}
+
+export interface RestGuidelinesResponse {
+	id: number;
+	status: string;
+	guideline_categories?: Record< string, { guidelines?: string } >;
+}
+
+export interface GuidelineAccordionProps {
+	title: string;
+	description: string;
+	children: ReactNode;
+	contentId?: string;
+	headingId?: string;
+	descriptionId?: string;
+}
+
+export interface GuidelineAccordionFormProps {
+	slug: string;
+	contentId?: string; // Used for a11y.
+	headingId?: string; // Used for a11y.
+	descriptionId?: string;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Related issue: https://github.com/WordPress/gutenberg/issues/75260

This PR introduces a new Content Guidelines admin page that allows site administrators to define content standards for their site. The page is accessible via **Settings > Content Guidelines** in wp-admin and provides a structured interface for setting guidelines across four categories: Site, Copy, Images, and Additional guidelines.

## Why?

This feature enables site administrators to establish and maintain content standards that can guide content creators, inform plugins, and help AI tools generate content that matches the site's voice and requirements. By providing a centralized location for content guidelines, teams can ensure consistency across all content creation workflows.

## How?

This PR adds:

- **New Admin Page Route**: Created `routes/content-guidelines/` with a React-based admin page route that integrates with wp-admin
- **PHP Integration**: Added `lib/experimental/content-guidelines/load.php` to register the admin submenu page under Settings
- **UI Components**:
  - `GuidelineItemCard`: Displays guideline categories as clickable cards in the list view
  - `GuidelineItemEdit`: Form component for editing individual guideline categories with TextareaControl
- **Navigation**: Uses WordPress Navigator component for seamless navigation between list and edit views
- **Four Guideline Categories**:
  - **Site**: Purpose, goals, and primary audience
  - **Copy**: Writing standards for tone, voice, style, and formatting
  - **Images**: Style, dimensions, formats, mood and aesthetic preferences
  - **Additional guidelines**: SEO preferences, legal requirements, citation styles, etc.
- **Accessibility**: Proper ARIA labels, semantic HTML, keyboard navigation support, and screen reader friendly attributes
- **Styling**: Custom SCSS following Figma design tokens for consistent UI

The page follows the same wp-admin integrated pattern as other admin pages like Font Library, maintaining the WordPress admin sidebar.

**Note**: This is an experimental feature (located in `lib/experimental/`). The save functionality for guidelines is not yet implemented - this PR focuses on establishing the UI structure and navigation flow.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Navigate to **Settings > Content Guidelines** in wp-admin
2. Verify the list view displays all four guideline categories (Site, Copy, Images, Additional guidelines)
3. Verify each card displays an icon, title, and description
4. Click on any category card (e.g., "Site") to navigate to the edit view
5. Verify the edit view displays:
   - A back button in the header
   - The category title
   - A description explaining what the category is for
   - A textarea control for entering guidelines
   - A "Save guidelines" button
6. Click the back button to return to the list view
7. Repeat steps 4-6 for all four categories
8. Verify the page maintains the WordPress admin sidebar and styling

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Navigate to **Settings > Content Guidelines** using keyboard navigation (Tab key)
2. Use Tab to navigate through the guideline category cards
3. Press Enter or Space on a category card to navigate to its edit view
4. Verify focus is visible on all interactive elements (cards, back button, textarea, save button)
5. Use Tab to navigate through the edit form elements:
   - Back button
   - Textarea control
   - Save button
6. Press Enter on the back button to return to the list view
7. Verify screen reader announcements are clear and descriptive (test with NVDA/JAWS/VoiceOver)
8. Verify all interactive elements are reachable via keyboard only

## Screenshots
<img width="1021" height="915" alt="Screenshot 2026-02-27 at 3 55 32 PM" src="https://github.com/user-attachments/assets/631fdfd0-d427-4329-8056-5073db1a8ec2" />
