### PR TITLE
Language Format: Add missing attribute definiton

### DIFF
--- a/packages/format-library/src/language/index.js
+++ b/packages/format-library/src/language/index.js
@@ -24,10 +24,14 @@ const title = __( 'Language' );
 
 export const language = {
 	name,
+	title,
 	tagName: 'bdo',
 	className: null,
+	attributes: {
+		lang: 'lang',
+		dir: 'dir',
+	},
 	edit: Edit,
-	title,
 };
 
 function Edit( { isActive, value, onChange, contentRef } ) {


### PR DESCRIPTION
## What?
PR adds missing format attribute definition for Language format. This also fixes a bug that occurred when modifying a freshly created format, which caused nested formats to be created.

## Testing Instructions
1. Open a post or page.
2. Add any text block.
3. Select partial text and set language format.
4. Select formatted text and change it.
5. The formatted text should have a single wrapper `bdo` tag.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/13724d7b-1c6b-4a5f-bed2-4c79e81aadff

**After**

https://github.com/user-attachments/assets/288270d2-aeb0-4bfb-849e-0f1148de1edb


