### PR TITLE
Tabs: Stabilize Tabs blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -985,7 +985,6 @@ Add white space between blocks and customize its height. ([Source](https://githu
 Content for a tab in a tabbed interface. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tab))
 
 -	**Name:** core/tab
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/tab-panel
 -	**Supports:** anchor, color (background, text), layout, renaming, spacing (blockGap, padding, ~~margin~~), typography (fontSize), ~~html~~, ~~reusable~~
@@ -996,7 +995,6 @@ Content for a tab in a tabbed interface. ([Source](https://github.com/WordPress/
 Container for tab panel content in a tabbed interface. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tab-panel))
 
 -	**Name:** core/tab-panel
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/tabs
 -	**Allowed Blocks:** core/tab
@@ -1026,7 +1024,6 @@ Summarize your post with a list of headings. Add HTML anchors to Heading blocks 
 Display content in a tabbed interface to help users navigate detailed content with ease. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tabs))
 
 -	**Name:** core/tabs
--	**Experimental:** true
 -	**Category:** design
 -	**Allowed Blocks:** core/tabs-menu, core/tab-panel
 -	**Supports:** align, anchor, color (~~background~~, ~~text~~), interactivity, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowVerticalAlignment, default, ~~allowSwitching~~), renaming, spacing (blockGap, margin, padding), typography (fontSize), ~~html~~
@@ -1037,7 +1034,6 @@ Display content in a tabbed interface to help users navigate detailed content wi
 Display the tab buttons for a tabbed interface. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tabs-menu))
 
 -	**Name:** core/tabs-menu
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/tabs
 -	**Allowed Blocks:** core/tabs-menu-item
@@ -1048,7 +1044,6 @@ Display the tab buttons for a tabbed interface. ([Source](https://github.com/Wor
 A single tab button in the tabs menu. Used as a template for styling all tab buttons. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/tabs-menu-item))
 
 -	**Name:** core/tabs-menu-item
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/tabs-menu
 -	**Supports:** color (background, text), layout (~~allowEditing~~), shadow, spacing (padding), typography (fontSize, textAlign), ~~html~~, ~~lock~~, ~~reusable~~

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -275,15 +275,12 @@ const getAllBlocks = () => {
 		queryTitle,
 		postAuthorBiography,
 		breadcrumbs,
+		tab,
+		tabs,
+		tabsMenu,
+		tabsMenuItem,
+		tabPanel,
 	];
-
-	if ( window?.__experimentalEnableBlockExperiments ) {
-		blocks.push( tab );
-		blocks.push( tabs );
-		blocks.push( tabsMenu );
-		blocks.push( tabsMenuItem );
-		blocks.push( tabPanel );
-	}
 
 	if ( window?.__experimentalEnableFormBlocks ) {
 		blocks.push( form );

--- a/packages/block-library/src/tab-panel/block.json
+++ b/packages/block-library/src/tab-panel/block.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"__experimental": true,
 	"apiVersion": 3,
 	"name": "core/tab-panel",
 	"title": "Tab Panel",

--- a/packages/block-library/src/tab/block.json
+++ b/packages/block-library/src/tab/block.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"__experimental": true,
 	"apiVersion": 3,
 	"name": "core/tab",
 	"title": "Tab",

--- a/packages/block-library/src/tabs-menu-item/block.json
+++ b/packages/block-library/src/tabs-menu-item/block.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"__experimental": true,
 	"apiVersion": 3,
 	"name": "core/tabs-menu-item",
 	"title": "Tab Menu Item",

--- a/packages/block-library/src/tabs-menu/block.json
+++ b/packages/block-library/src/tabs-menu/block.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"__experimental": true,
 	"apiVersion": 3,
 	"name": "core/tabs-menu",
 	"title": "Tabs Menu",

--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"__experimental": true,
 	"apiVersion": 3,
 	"name": "core/tabs",
 	"title": "Tabs",

--- a/test/integration/fixtures/blocks/core__tab-panel.html
+++ b/test/integration/fixtures/blocks/core__tab-panel.html
@@ -1,0 +1,11 @@
+<!-- wp:tab-panel -->
+<div class="wp-block-tab-panel">
+	<!-- wp:tab {"label":"Tab 1"} -->
+	<section class="wp-block-tab">
+		<!-- wp:paragraph -->
+		<p>Content inside the tab panel.</p>
+		<!-- /wp:paragraph -->
+	</section>
+	<!-- /wp:tab -->
+</div>
+<!-- /wp:tab-panel -->

--- a/test/integration/fixtures/blocks/core__tab-panel.json
+++ b/test/integration/fixtures/blocks/core__tab-panel.json
@@ -1,0 +1,27 @@
+[
+	{
+		"name": "core/tab-panel",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": [
+			{
+				"name": "core/tab",
+				"isValid": true,
+				"attributes": {
+					"label": "Tab 1"
+				},
+				"innerBlocks": [
+					{
+						"name": "core/paragraph",
+						"isValid": true,
+						"attributes": {
+							"content": "Content inside the tab panel.",
+							"dropCap": false
+						},
+						"innerBlocks": []
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tab-panel.parsed.json
+++ b/test/integration/fixtures/blocks/core__tab-panel.parsed.json
@@ -1,0 +1,37 @@
+[
+	{
+		"blockName": "core/tab-panel",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/tab",
+				"attrs": {
+					"label": "Tab 1"
+				},
+				"innerBlocks": [
+					{
+						"blockName": "core/paragraph",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<p>Content inside the tab panel.</p>\n\t\t",
+						"innerContent": [
+							"\n\t\t<p>Content inside the tab panel.</p>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<section class=\"wp-block-tab\">\n\t\t\n\t</section>\n\t",
+				"innerContent": [
+					"\n\t<section class=\"wp-block-tab\">\n\t\t",
+					null,
+					"\n\t</section>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-tab-panel\">\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-tab-panel\">\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tab-panel.serialized.html
+++ b/test/integration/fixtures/blocks/core__tab-panel.serialized.html
@@ -1,0 +1,7 @@
+<!-- wp:tab-panel -->
+<div class="wp-block-tab-panel"><!-- wp:tab {"label":"Tab 1"} -->
+<section class="wp-block-tab"><!-- wp:paragraph -->
+<p>Content inside the tab panel.</p>
+<!-- /wp:paragraph --></section>
+<!-- /wp:tab --></div>
+<!-- /wp:tab-panel -->

--- a/test/integration/fixtures/blocks/core__tab.html
+++ b/test/integration/fixtures/blocks/core__tab.html
@@ -1,0 +1,7 @@
+<!-- wp:tab {"label":"Tab Label"} -->
+<section class="wp-block-tab">
+	<!-- wp:paragraph -->
+	<p>Tab content goes here.</p>
+	<!-- /wp:paragraph -->
+</section>
+<!-- /wp:tab -->

--- a/test/integration/fixtures/blocks/core__tab.json
+++ b/test/integration/fixtures/blocks/core__tab.json
@@ -1,0 +1,20 @@
+[
+	{
+		"name": "core/tab",
+		"isValid": true,
+		"attributes": {
+			"label": "Tab Label"
+		},
+		"innerBlocks": [
+			{
+				"name": "core/paragraph",
+				"isValid": true,
+				"attributes": {
+					"content": "Tab content goes here.",
+					"dropCap": false
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tab.parsed.json
+++ b/test/integration/fixtures/blocks/core__tab.parsed.json
@@ -1,0 +1,23 @@
+[
+	{
+		"blockName": "core/tab",
+		"attrs": {
+			"label": "Tab Label"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/paragraph",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<p>Tab content goes here.</p>\n\t",
+				"innerContent": [ "\n\t<p>Tab content goes here.</p>\n\t" ]
+			}
+		],
+		"innerHTML": "\n<section class=\"wp-block-tab\">\n\t\n</section>\n",
+		"innerContent": [
+			"\n<section class=\"wp-block-tab\">\n\t",
+			null,
+			"\n</section>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tab.serialized.html
+++ b/test/integration/fixtures/blocks/core__tab.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:tab {"label":"Tab Label"} -->
+<section class="wp-block-tab"><!-- wp:paragraph -->
+<p>Tab content goes here.</p>
+<!-- /wp:paragraph --></section>
+<!-- /wp:tab -->

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.html
@@ -1,0 +1,3 @@
+<!-- wp:tabs-menu-item -->
+<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<!-- /wp:tabs-menu-item -->

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.json
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.json
@@ -1,0 +1,8 @@
+[
+	{
+		"name": "core/tabs-menu-item",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.parsed.json
@@ -1,0 +1,11 @@
+[
+	{
+		"blockName": "core/tabs-menu-item",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n",
+		"innerContent": [
+			"\n<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:tabs-menu-item -->
+<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<!-- /wp:tabs-menu-item -->

--- a/test/integration/fixtures/blocks/core__tabs-menu.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu.html
@@ -1,0 +1,11 @@
+<!-- wp:tabs-menu -->
+<div class="wp-block-tabs-menu" role="tablist">
+	<!-- wp:tabs-menu-item -->
+	<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+	<!-- /wp:tabs-menu-item -->
+
+	<!-- wp:tabs-menu-item -->
+	<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+	<!-- /wp:tabs-menu-item -->
+</div>
+<!-- /wp:tabs-menu -->

--- a/test/integration/fixtures/blocks/core__tabs-menu.json
+++ b/test/integration/fixtures/blocks/core__tabs-menu.json
@@ -1,0 +1,21 @@
+[
+	{
+		"name": "core/tabs-menu",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": [
+			{
+				"name": "core/tabs-menu-item",
+				"isValid": true,
+				"attributes": {},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/tabs-menu-item",
+				"isValid": true,
+				"attributes": {},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tabs-menu.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs-menu.parsed.json
@@ -1,0 +1,34 @@
+[
+	{
+		"blockName": "core/tabs-menu",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/tabs-menu-item",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t",
+				"innerContent": [
+					"\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t"
+				]
+			},
+			{
+				"blockName": "core/tabs-menu-item",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t",
+				"innerContent": [
+					"\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-tabs-menu\" role=\"tablist\">\n\t\n\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-tabs-menu\" role=\"tablist\">\n\t",
+			null,
+			"\n\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tabs-menu.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu.serialized.html
@@ -1,0 +1,9 @@
+<!-- wp:tabs-menu -->
+<div role="tablist" class="wp-block-tabs-menu"><!-- wp:tabs-menu-item -->
+<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<!-- /wp:tabs-menu-item -->
+
+<!-- wp:tabs-menu-item -->
+<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<!-- /wp:tabs-menu-item --></div>
+<!-- /wp:tabs-menu -->

--- a/test/integration/fixtures/blocks/core__tabs.html
+++ b/test/integration/fixtures/blocks/core__tabs.html
@@ -1,0 +1,31 @@
+<!-- wp:tabs {"className":"is-example"} -->
+<div class="wp-block-tabs is-example">
+	<!-- wp:tabs-menu -->
+	<div class="wp-block-tabs-menu" role="tablist">
+		<!-- wp:tabs-menu-item -->
+		<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+		<!-- /wp:tabs-menu-item -->
+	</div>
+	<!-- /wp:tabs-menu -->
+
+	<!-- wp:tab-panel -->
+	<div class="wp-block-tab-panel">
+		<!-- wp:tab {"label":"Tab 1"} -->
+		<section class="wp-block-tab">
+			<!-- wp:paragraph -->
+			<p>Pariatur commodo sint mollit. Veniam Lorem labore voluptate fugiat. Ad nulla est labore cillum cillum qui nostrud do incididunt eiusmod.</p>
+			<!-- /wp:paragraph -->
+		</section>
+		<!-- /wp:tab -->
+
+		<!-- wp:tab {"label":"Tab 2"} -->
+		<section class="wp-block-tab"></section>
+		<!-- /wp:tab -->
+
+		<!-- wp:tab {"label":"Tab 3"} -->
+		<section class="wp-block-tab"></section>
+		<!-- /wp:tab -->
+	</div>
+	<!-- /wp:tab-panel -->
+</div>
+<!-- /wp:tabs -->

--- a/test/integration/fixtures/blocks/core__tabs.json
+++ b/test/integration/fixtures/blocks/core__tabs.json
@@ -1,0 +1,66 @@
+[
+	{
+		"name": "core/tabs",
+		"isValid": true,
+		"attributes": {
+			"activeTabIndex": 0,
+			"className": "is-example"
+		},
+		"innerBlocks": [
+			{
+				"name": "core/tabs-menu",
+				"isValid": true,
+				"attributes": {},
+				"innerBlocks": [
+					{
+						"name": "core/tabs-menu-item",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": []
+					}
+				]
+			},
+			{
+				"name": "core/tab-panel",
+				"isValid": true,
+				"attributes": {},
+				"innerBlocks": [
+					{
+						"name": "core/tab",
+						"isValid": true,
+						"attributes": {
+							"label": "Tab 1"
+						},
+						"innerBlocks": [
+							{
+								"name": "core/paragraph",
+								"isValid": true,
+								"attributes": {
+									"content": "Pariatur commodo sint mollit. Veniam Lorem labore voluptate fugiat. Ad nulla est labore cillum cillum qui nostrud do incididunt eiusmod.",
+									"dropCap": false
+								},
+								"innerBlocks": []
+							}
+						]
+					},
+					{
+						"name": "core/tab",
+						"isValid": true,
+						"attributes": {
+							"label": "Tab 2"
+						},
+						"innerBlocks": []
+					},
+					{
+						"name": "core/tab",
+						"isValid": true,
+						"attributes": {
+							"label": "Tab 3"
+						},
+						"innerBlocks": []
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tabs.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs.parsed.json
@@ -1,0 +1,100 @@
+[
+	{
+		"blockName": "core/tabs",
+		"attrs": {
+			"className": "is-example"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/tabs-menu",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/tabs-menu-item",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t\t",
+						"innerContent": [
+							"\n\t\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<div class=\"wp-block-tabs-menu\" role=\"tablist\">\n\t\t\n\t</div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-tabs-menu\" role=\"tablist\">\n\t\t",
+					null,
+					"\n\t</div>\n\t"
+				]
+			},
+			{
+				"blockName": "core/tab-panel",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/tab",
+						"attrs": {
+							"label": "Tab 1"
+						},
+						"innerBlocks": [
+							{
+								"blockName": "core/paragraph",
+								"attrs": {},
+								"innerBlocks": [],
+								"innerHTML": "\n\t\t\t<p>Pariatur commodo sint mollit. Veniam Lorem labore voluptate fugiat. Ad nulla est labore cillum cillum qui nostrud do incididunt eiusmod.</p>\n\t\t\t",
+								"innerContent": [
+									"\n\t\t\t<p>Pariatur commodo sint mollit. Veniam Lorem labore voluptate fugiat. Ad nulla est labore cillum cillum qui nostrud do incididunt eiusmod.</p>\n\t\t\t"
+								]
+							}
+						],
+						"innerHTML": "\n\t\t<section class=\"wp-block-tab\">\n\t\t\t\n\t\t</section>\n\t\t",
+						"innerContent": [
+							"\n\t\t<section class=\"wp-block-tab\">\n\t\t\t",
+							null,
+							"\n\t\t</section>\n\t\t"
+						]
+					},
+					{
+						"blockName": "core/tab",
+						"attrs": {
+							"label": "Tab 2"
+						},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<section class=\"wp-block-tab\"></section>\n\t\t",
+						"innerContent": [
+							"\n\t\t<section class=\"wp-block-tab\"></section>\n\t\t"
+						]
+					},
+					{
+						"blockName": "core/tab",
+						"attrs": {
+							"label": "Tab 3"
+						},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<section class=\"wp-block-tab\"></section>\n\t\t",
+						"innerContent": [
+							"\n\t\t<section class=\"wp-block-tab\"></section>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<div class=\"wp-block-tab-panel\">\n\t\t\n\n\t\t\n\n\t\t\n\t</div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-tab-panel\">\n\t\t",
+					null,
+					"\n\n\t\t",
+					null,
+					"\n\n\t\t",
+					null,
+					"\n\t</div>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-tabs is-example\">\n\t\n\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-tabs is-example\">\n\t",
+			null,
+			"\n\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__tabs.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs.serialized.html
@@ -1,0 +1,23 @@
+<!-- wp:tabs {"className":"is-example"} -->
+<div class="wp-block-tabs is-example"><!-- wp:tabs-menu -->
+<div role="tablist" class="wp-block-tabs-menu"><!-- wp:tabs-menu-item -->
+<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<!-- /wp:tabs-menu-item --></div>
+<!-- /wp:tabs-menu -->
+
+<!-- wp:tab-panel -->
+<div class="wp-block-tab-panel"><!-- wp:tab {"label":"Tab 1"} -->
+<section class="wp-block-tab"><!-- wp:paragraph -->
+<p>Pariatur commodo sint mollit. Veniam Lorem labore voluptate fugiat. Ad nulla est labore cillum cillum qui nostrud do incididunt eiusmod.</p>
+<!-- /wp:paragraph --></section>
+<!-- /wp:tab -->
+
+<!-- wp:tab {"label":"Tab 2"} -->
+<section class="wp-block-tab"></section>
+<!-- /wp:tab -->
+
+<!-- wp:tab {"label":"Tab 3"} -->
+<section class="wp-block-tab"></section>
+<!-- /wp:tab --></div>
+<!-- /wp:tab-panel --></div>
+<!-- /wp:tabs -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/73230

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Stabilizes the Tabs block and its inner blocks so this block can be used by a wider audience and released in the next major WordPress version.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes `__experimental: true` flag from related blocks and moves them out of the GB experimental blocks flag. Also adds test fixtures for all the new blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Tabs block and its inner blocks should work the same as before, without the need to have the GB experimental blocks experiment enabled.