### PR TITLE
Code Modernization: Replace isset() checks with null coalescing operator

### DIFF
--- a/backport-changelog/7.0/10911.md
+++ b/backport-changelog/7.0/10911.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10911
+
+* https://github.com/WordPress/gutenberg/pull/75425

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -144,7 +144,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	protected static function translate( $theme_json, $domain = 'default' ) {
 		if ( null === static::$i18n_schema ) {
 			$i18n_schema         = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
-			static::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
+			static::$i18n_schema = $i18n_schema ?? array();
 		}
 
 		return translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -151,10 +151,7 @@ function gutenberg_register_view_module_ids_rest_field() {
 		array(
 			'get_callback' => function ( $item ) {
 				$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
-				if ( isset( $block_type->view_script_module_ids ) ) {
-					return $block_type->view_script_module_ids;
-				}
-				return array();
+				return $block_type->view_script_module_ids ?? array();
 			},
 		)
 	);


### PR DESCRIPTION
## What?
This pull request makes minor improvements to the codebase by simplifying null checks using the null coalescing operator (`??`) in two places. These changes help make the code more concise and readable without altering functionality. 

In #75419 we did it already for the `block-library`. 