### PR TITLE
DataForm: Fix color picker styles

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,6 +13,7 @@
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 - DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
+- DataForm: Fix color picker styles. [#75427](https://github.com/WordPress/gutenberg/pull/75427)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataform-controls/color.tsx
+++ b/packages/dataviews/src/components/dataform-controls/color.tsx
@@ -7,12 +7,16 @@ import { colord } from 'colord';
  * WordPress dependencies
  */
 import {
+	Button,
+	ColorIndicator,
 	ColorPicker,
 	Dropdown,
 	privateApis,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,38 +38,24 @@ const ColorPickerDropdown = ( {
 
 	return (
 		<Dropdown
-			renderToggle={ ( { onToggle, isOpen } ) => (
-				<InputControlPrefixWrapper variant="icon">
-					<button
-						type="button"
-						onClick={ onToggle }
-						style={ {
-							width: '24px',
-							height: '24px',
-							borderRadius: '50%',
-							backgroundColor: validColor,
-							border: '1px solid #ddd',
-							cursor: 'pointer',
-							outline: isOpen ? '2px solid #007cba' : 'none',
-							outlineOffset: '2px',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							padding: 0,
-							margin: 0,
-						} }
-						aria-label="Open color picker"
-					/>
-				</InputControlPrefixWrapper>
+			className="dataviews-controls__color-picker-dropdown"
+			popoverProps={ { resize: false } }
+			renderToggle={ ( { onToggle } ) => (
+				<Button
+					onClick={ onToggle }
+					aria-label={ __( 'Open color picker' ) }
+					size="small"
+					icon={ () => <ColorIndicator colorValue={ validColor } /> }
+				/>
 			) }
 			renderContent={ () => (
-				<div style={ { padding: '16px' } }>
+				<DropdownContentWrapper paddingSize="none">
 					<ColorPicker
 						color={ validColor }
 						onChange={ onColorChange }
 						enableAlpha
 					/>
-				</div>
+				</DropdownContentWrapper>
 			) }
 		/>
 	);
@@ -109,10 +99,12 @@ export default function Color< Item >( {
 			hideLabelFromVision={ hideLabelFromVision }
 			type="text"
 			prefix={
-				<ColorPickerDropdown
-					color={ value }
-					onColorChange={ handleColorChange }
-				/>
+				<InputControlPrefixWrapper variant="control">
+					<ColorPickerDropdown
+						color={ value }
+						onColorChange={ handleColorChange }
+					/>
+				</InputControlPrefixWrapper>
 			}
 		/>
 	);

--- a/packages/dataviews/src/components/dataform-controls/style.scss
+++ b/packages/dataviews/src/components/dataform-controls/style.scss
@@ -23,6 +23,10 @@
 	min-width: 0;
 }
 
+.dataviews-controls__color-picker-dropdown {
+	line-height: 1;
+}
+
 .dataviews-controls__date-preset {
 	border: 1px solid #ddd;
 

--- a/packages/dataviews/src/components/dataform-controls/style.scss
+++ b/packages/dataviews/src/components/dataform-controls/style.scss
@@ -24,7 +24,7 @@
 }
 
 .dataviews-controls__color-picker-dropdown {
-	line-height: 1;
+	display: flex;
 }
 
 .dataviews-controls__date-preset {


### PR DESCRIPTION
## What?

Follow up to #75394

Fixes the styling of the DataForm color picker dropdown toggle.

## Why?

The styles were ad hoc and did not match patterns elsewhere in the app.

## How?

- Replace the inline-styled `<button>` toggle with a `Button` component using `ColorIndicator` as the icon. This fixes the swatch size and the focus ring color.
- Use `DropdownContentWrapper` with no padding, instead of a raw `<div>` with inline padding.
- Wrap the prefix in `InputControlPrefixWrapper` with `variant="control"` for proper alignment. Moves the wrapper to the proper position for correct alignment.
- Translate the aria-label.

## Testing Instructions

1. Open Storybook and navigate to DataForm ▸ Validation, and see the color field.
2. The color indicator in the text input prefix should look visually correct and open a color picker popover on click.

### Testing Instructions for Keyboard

1. Tab to the color indicator button.
2. Press Enter or Space to open the color picker popover.
3. The popover should open and be usable.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="1060" height="1036" alt="DataForm color field, before" src="https://github.com/user-attachments/assets/d3ec5953-0bf5-4274-8472-0ea0cad3381e" />|<img width="1060" height="1036" alt="DataForm color field, after" src="https://github.com/user-attachments/assets/2fe4db6c-1a5c-4486-a9a3-936c75fdec90" />|
