### PR TITLE
Remove border-bottom from admin-ui page header

### DIFF
--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -16,7 +16,6 @@
 
 .admin-ui-page__header {
 	padding: $grid-unit-20 $grid-unit-30;
-	border-bottom: 1px solid $gray-100;
 	background: $white;
 	position: sticky;
 	top: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Resolves https://github.com/WordPress/gutenberg/issues/75428

Experiment with how it would look if the header didn't have the bottom border.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the border

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Visit:
- Appearance -> Fonts
- Appearance -> Pages (try different views for DataViews)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|
<img width="1414" height="1031" alt="Screenshot 2026-02-11 at 17 24 03" src="https://github.com/user-attachments/assets/8225fdeb-5e35-4d5c-8d97-764e1e9a0434" />
|
<img width="1421" height="1043" alt="Screenshot 2026-02-11 at 17 40 01" src="https://github.com/user-attachments/assets/46cf2b0d-1088-4214-b2c5-780d64c8453d" />
|
