### PR TITLE
BorderBoxControl : Remove orphaned color values when border width is cleared

### DIFF
--- a/packages/block-editor/src/hooks/use-border-props.js
+++ b/packages/block-editor/src/hooks/use-border-props.js
@@ -20,9 +20,23 @@ export function getBorderClassesAndStyles( attributes ) {
 	const border = attributes.style?.border || {};
 	const className = getBorderClasses( attributes );
 
+	// Sanitize border sides: remove sides that have color but no width.
+	// A border with only color (no width) is invisible and generates
+	// orphaned CSS like `border-right-color` without `border-right-width`.
+	const sanitizedBorder = { ...border };
+	[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
+		if (
+			sanitizedBorder[ side ] &&
+			! sanitizedBorder[ side ]?.width &&
+			sanitizedBorder[ side ]?.color
+		) {
+			delete sanitizedBorder[ side ];
+		}
+	} );
+
 	return {
 		className: className || undefined,
-		style: getInlineStyles( { border } ),
+		style: getInlineStyles( { border: sanitizedBorder } ),
 	};
 }
 

--- a/packages/block-editor/src/hooks/use-border-props.js
+++ b/packages/block-editor/src/hooks/use-border-props.js
@@ -20,23 +20,9 @@ export function getBorderClassesAndStyles( attributes ) {
 	const border = attributes.style?.border || {};
 	const className = getBorderClasses( attributes );
 
-	// Sanitize border sides: remove sides that have color but no width.
-	// A border with only color (no width) is invisible and generates
-	// orphaned CSS like `border-right-color` without `border-right-width`.
-	const sanitizedBorder = { ...border };
-	[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
-		if (
-			sanitizedBorder[ side ] &&
-			! sanitizedBorder[ side ]?.width &&
-			sanitizedBorder[ side ]?.color
-		) {
-			delete sanitizedBorder[ side ];
-		}
-	} );
-
 	return {
 		className: className || undefined,
-		style: getInlineStyles( { border: sanitizedBorder } ),
+		style: getInlineStyles( { border } ),
 	};
 }
 

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -108,12 +108,20 @@ export function useBorderBoxControl(
 		newBorder: Border | undefined,
 		side: BorderSide
 	) => {
-		const updatedBorders = { ...splitValue, [ side ]: newBorder };
+		// Sanitize: if a border side has color but no width, treat it as
+		// empty. A color-only border generates orphaned CSS on the frontend
+		// (e.g. `border-right-color` without `border-right-width`).
+		const sanitizedBorder =
+			newBorder && ! newBorder.width && newBorder.color
+				? undefined
+				: newBorder;
+
+		const updatedBorders = { ...splitValue, [ side ]: sanitizedBorder };
 
 		if ( hasMixedBorders( updatedBorders ) ) {
 			onChange( updatedBorders );
 		} else {
-			onChange( newBorder );
+			onChange( sanitizedBorder );
 		}
 	};
 


### PR DESCRIPTION
## What?

Fixes a mismatch between the editor and frontend when individual border widths are cleared in split border mode. The editor correctly shows only the intended border, but the frontend renders all four borders due to orphaned color values generating unwanted inline CSS.

Fixes #75415

## Why?

When a block has a unified border (e.g., 2px solid black on all sides) and the user switches to split border mode and clears the width from individual sides, the color value persists even though the width has been removed.

This results in the saved block attributes containing color-only border sides:

```json
{
  "border": {
    "top": { "width": "2px", "color": "var:preset|color|contrast" },
    "right": { "color": "var:preset|color|contrast" },
    "bottom": { "color": "var:preset|color|contrast" },
    "left": { "color": "var:preset|color|contrast" }
  }
}
```

These orphaned color values are then serialized into inline CSS like `border-right-color`, `border-bottom-color`, and `border-left-color`, without corresponding `border-width` declarations. Browsers render these with their default width, causing all four borders to appear on the frontend even though only the top border was intended.

## How?

In `onSplitChange()` within `BorderBoxControl`'s `hook.ts`, border sides are now sanitized before being passed up to the parent. If a border side has a `color` but no `width`, it is treated as empty (`undefined`), preventing orphaned color values from being saved to block attributes.

A border with only color and no width is not useful and should not be persisted.

## Testing Instructions

1. Add a **Paragraph** block
2. Set a unified border (e.g., 2px width, black color)
3. Click the **unlink** button to switch to individual border controls
4. Clear the width from **Right**, **Bottom**, and **Left** borders
5. Save the post and view on the frontend

**Expected:** Only the **top** border is visible on the frontend.

**Before fix:** All four borders appear because orphaned `border-*-color` declarations are rendered with default browser widths.

## Screencast or Screenshot

### Before fix :

https://github.com/user-attachments/assets/79b0654a-91d5-4b8f-b3f1-0d3936db051a

### After fix :

https://github.com/user-attachments/assets/397570dc-b7a9-43d3-beff-5288d4b356ee



