### PR TITLE
Real-time Collaboration: Sync content and don't sync undefined blocks

### DIFF
--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -60,7 +60,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return undefined;
 		}
 
-		if ( editedBlocks && editedBlocks.length > 0 ) {
+		if ( editedBlocks ) {
 			return editedBlocks;
 		}
 

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -60,7 +60,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return undefined;
 		}
 
-		if ( editedBlocks ) {
+		if ( editedBlocks && editedBlocks.length > 0 ) {
 			return editedBlocks;
 		}
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -53,7 +53,10 @@ export type PostChanges = Partial< Post > & {
 // A post record as represented in the CRDT document (Y.Map).
 export interface YPostRecord extends YMapRecord {
 	author: number;
-	blocks: YBlocks;
+	// Note: Blocks can be undefined when they need to be re-parsed.
+	// So this has been typed to communicate that the property can
+	// exist, but could be undefined.
+	blocks: YBlocks | undefined;
 	categories: number[];
 	comment_status: string;
 	date: string | null;
@@ -156,6 +159,12 @@ export function applyPostChangesToCRDTDoc(
 
 		switch ( key ) {
 			case 'blocks': {
+				// Blocks can be undefined when they need to be re-parsed.
+				if ( newValue === undefined ) {
+					ymap.set( key, undefined );
+					break;
+				}
+
 				let currentBlocks = ymap.get( key );
 
 				// Initialize.
@@ -314,7 +323,10 @@ export function getPostChangesFromCRDTDoc(
 					// We cannot directly compare the `blocks` from the CRDT document to
 					// the `blocks` derived from the `content` in the persisted record,
 					// because the latter will have different client IDs.
+					//
+					// Note: Blocks can be undefined when they need to be re-parsed.
 					if (
+						currentValue !== undefined &&
 						ydoc.meta?.get( CRDT_DOC_META_PERSISTENCE_KEY ) &&
 						editedRecord.content
 					) {

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -160,7 +160,7 @@ export function applyPostChangesToCRDTDoc(
 		switch ( key ) {
 			case 'blocks': {
 				// Blocks can be undefined when they need to be re-parsed.
-				if ( newValue === undefined ) {
+				if ( ! newValue ) {
 					ymap.set( key, undefined );
 					break;
 				}
@@ -331,11 +331,14 @@ export function getPostChangesFromCRDTDoc(
 						editedRecord.content
 					) {
 						const blocks = ymap.get( 'blocks' ) as YBlocks;
-						return (
-							__unstableSerializeAndClean(
-								blocks.toJSON()
-							).trim() !== editedRecord.content.raw.trim()
-						);
+
+						if ( blocks ) {
+							return (
+								__unstableSerializeAndClean(
+									blocks.toJSON()
+								).trim() !== editedRecord.content.raw.trim()
+							);
+						}
 					}
 
 					// The consumers of blocks have memoization that renders optimization

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -45,6 +45,7 @@ import {
 // Changes that can be applied to a post entity record.
 export type PostChanges = Partial< Post > & {
 	blocks?: Block[];
+	content?: Post[ 'content' ] | string;
 	excerpt?: Post[ 'excerpt' ] | string;
 	selection?: WPSelection;
 	title?: Post[ 'title' ] | string;
@@ -57,6 +58,7 @@ export interface YPostRecord extends YMapRecord {
 	// So this has been typed to communicate that the property can
 	// exist, but could be undefined.
 	blocks: YBlocks | undefined;
+	content: string;
 	categories: number[];
 	comment_status: string;
 	date: string | null;
@@ -77,6 +79,7 @@ export interface YPostRecord extends YMapRecord {
 const allowedPostProperties = new Set< string >( [
 	'author',
 	'blocks',
+	'content',
 	'categories',
 	'comment_status',
 	'date',
@@ -159,8 +162,10 @@ export function applyPostChangesToCRDTDoc(
 
 		switch ( key ) {
 			case 'blocks': {
-				// Blocks can be undefined when they need to be re-parsed.
+				// Blocks are undefined when they need to be re-parsed from content.
 				if ( ! newValue ) {
+					// Set to undefined instead of deleting the key. This is important
+					// since we iterate over the Y.Map keys in getPostChangesFromCRDTDoc.
 					ymap.set( key, undefined );
 					break;
 				}
@@ -173,9 +178,6 @@ export function applyPostChangesToCRDTDoc(
 					ymap.set( key, currentBlocks );
 				}
 
-				// Block[] from local changes.
-				const newBlocks = ( newValue as PostChanges[ 'blocks' ] ) ?? [];
-
 				// Block changes from typing are bundled with a 'selection' update.
 				// Pass the resulting cursor position to the mergeCrdtBlocks function.
 				const cursorPosition =
@@ -183,7 +185,15 @@ export function applyPostChangesToCRDTDoc(
 
 				// Merge blocks does not need `setValue` because it is operating on a
 				// Yjs type that is already in the Y.Doc.
-				mergeCrdtBlocks( currentBlocks, newBlocks, cursorPosition );
+				mergeCrdtBlocks( currentBlocks, newValue, cursorPosition );
+				break;
+			}
+
+			case 'content': {
+				const currentValue = ymap.get( 'content' );
+				const rawNewValue = getRawValue( newValue );
+
+				updateMapValue( ymap, key, currentValue, rawNewValue );
 				break;
 			}
 
@@ -306,6 +316,8 @@ export function getPostChangesFromCRDTDoc(
 
 			switch ( key ) {
 				case 'blocks': {
+					const blocks = ymap.get( 'blocks' );
+
 					// When we are passed a persisted CRDT document, make a special
 					// comparison of the content and blocks.
 					//
@@ -326,19 +338,15 @@ export function getPostChangesFromCRDTDoc(
 					//
 					// Note: Blocks can be undefined when they need to be re-parsed.
 					if (
-						currentValue !== undefined &&
+						blocks &&
 						ydoc.meta?.get( CRDT_DOC_META_PERSISTENCE_KEY ) &&
 						editedRecord.content
 					) {
-						const blocks = ymap.get( 'blocks' ) as YBlocks;
-
-						if ( blocks ) {
-							return (
-								__unstableSerializeAndClean(
-									blocks.toJSON()
-								).trim() !== editedRecord.content.raw.trim()
-							);
-						}
+						return (
+							__unstableSerializeAndClean(
+								blocks.toJSON()
+							).trim() !== getRawValue( editedRecord.content )
+						);
 					}
 
 					// The consumers of blocks have memoization that renders optimization
@@ -390,6 +398,7 @@ export function getPostChangesFromCRDTDoc(
 					return haveValuesChanged( currentValue, newValue );
 				}
 
+				case 'content':
 				case 'excerpt':
 				case 'title': {
 					return haveValuesChanged(

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -615,7 +615,7 @@ export const restoreRevision =
 
 		// Build the edits object with all restorable fields from the revision.
 		const edits = {
-			blocks: parse( revision.content.raw ),
+			blocks: undefined,
 			content: revision.content.raw,
 		};
 		if ( revision.title?.raw !== undefined ) {


### PR DESCRIPTION
## Summary

Ensures blocks are regenerated from content when needed in RTC mode, and prevents syncing `undefined` blocks which would clear all blocks on remote peers.

## Changes

- **Don't sync undefined blocks**: When `blocks: undefined` is set (e.g., on revision restore), set the Y.Map blocks key to `undefined` instead of coalescing to empty array, signaling remote peers to regenerate from content.
- **Sync content properly**: Added support for syncing `content` field through the CRDT layer using `getRawValue` to extract raw content from `RenderedText` format.
- **Revision restore**: Changed to set `blocks: undefined` instead of pre-parsing blocks, allowing the hook to regenerate blocks from the synced content.

## Testing

1. Enable RTC via settings → writing
2. Open post, restore a previous revision
3. Verify no data loss and blocks regenerate correctly
4. Test with code editor — changes should parse and sync without clearing blocks