### PR TITLE
Navigation Submenu: Restore `openSubmenusOnClick` to `usesContext` for backward compatibility.

### DIFF
--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -55,6 +55,7 @@
 		"customFontSize",
 		"showSubmenuIcon",
 		"maxNestingLevel",
+		"openSubmenusOnClick",
 		"submenuVisibility",
 		"style"
 	],


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/75433.

Adds `openSubmenusOnClick` back to the `usesContext` array in `packages/block-library/src/navigation-submenu/block.json`.

## Why?

PR #74653 migrated `openSubmenusOnClick` (`boolean`) to `submenuVisibility` (`enum`) with backward compatibility in `block_core_navigation_submenu_get_submenu_visibility()`.

However, the PR removed `openSubmenusOnClick` from `usesContext`, which breaks context propagation for plugins that create navigation submenu blocks programmatically.

## How?

Restore `openSubmenusOnClick` to `usesContext` for backward compatibility.