### PR TITLE
Real-time collaboration: Sync post content and undefined `blocks` value

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -615,7 +615,7 @@ export const restoreRevision =
 
 		// Build the edits object with all restorable fields from the revision.
 		const edits = {
-			blocks: parse( revision.content.raw ),
+			blocks: undefined,
 			content: revision.content.raw,
 		};
 		if ( revision.title?.raw !== undefined ) {


### PR DESCRIPTION
## What?

Sync post content and an undefined `blocks` value during collaborative editing. This improves the experience of restoring revisions and code editing during collaborative sessions.

## Why?

Under some editing conditions, `blocks` can be deleted or set to `undefined`, then re-parsed from `content`. Restoring revisions and code editing are two examples.

Sync changes are captured by hooking into `editEntityRecord`, but re-parsing blocks (a transient property) is not always an explicit edit in these scenarios. Subsequent actions can accidentally "restore" collaborative editing by triggering an explicit edit, but the time gap can introduce conflicts or result in data loss.

Instead, as suggested by @youknowriad, we should sync the underlying values (`content` and `blocks`) and let each peer's editor behave normally—i.e., as if the edits were local.

Note: Since we are additionally syncing `content`, this does increase the size of the CRDT document both in-memory and in persisted post meta. Additionally, because `content` is stored as a primitive string (and not a `Y.Text`), changes result in transmission of the full string on each change. However, `content` is edited or serialized only in specific situations and not on every keystroke.

Additionally: Solving this problem raises a previously unseen issue. Re-parsing blocks results in new client IDs, which breaks presence indicators (awareness cursors) that reference them. Separately, we should probably transition to using `Y.RelativePosition`s pointing to an `Y.Array` index or range. cc: @alecgeatches 

## How?

1. Revert [this change](https://github.com/WordPress/gutenberg/pull/75233).
1. Add `content` to the list of synced post properties.
1. Allow an undefined `blocks` value to be synced.

## Testing Instructions

1. Check out this PR.
2. Settings > Writing > Enable real-time collaboration.
3. Open a post for editing in two browsers / browser tabs.
4. Restore a revision or use the code editor. See screencasts below for testing ideas.

### Testing Instructions for Keyboard

n/a

## Screenshots or screencast <!-- if applicable -->

### Using the code editor

Note that code editing can result in brief (or permanent) invalid markup, which syncs in various different ways. Using the code editor, even by oneself, is inherently dangerous, so this is not especially surprising. But it may signal the need for presence indicators when a collaborator is using the code editor or warnings when one enters it.

https://github.com/user-attachments/assets/24ca6d43-5dfb-4b4c-b089-17d574ada50c



### Restoring a revision

https://github.com/user-attachments/assets/9ef7cbc3-b0c4-4011-8ff5-e88a0d170d44

