### PR TITLE
BorderBoxControl: Fix split border control layout in RTL mode

### DIFF
--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
@@ -72,6 +72,34 @@ const BorderBoxControlSplitControls = (
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
 
+	// In RTL mode, the layout is mirrored, so we need to swap the left and right controls.
+	const leftBorderControl = (
+		/* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component */
+		/* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */
+		<BorderControl
+			hideLabelFromVision
+			label={ __( 'Left border' ) }
+			onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
+			__unstablePopoverProps={ popoverProps }
+			value={ value?.left }
+			{ ...sharedBorderControlProps }
+		/>
+	);
+
+	const rightBorderControl = (
+		/* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */
+		/* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */
+		<BorderControl
+			className={ rightAlignedClassName }
+			hideLabelFromVision
+			label={ __( 'Right border' ) }
+			onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
+			__unstablePopoverProps={ popoverProps }
+			value={ value?.right }
+			{ ...sharedBorderControlProps }
+		/>
+	);
+
 	return (
 		<Grid { ...otherProps } ref={ mergedRef } gap={ 3 }>
 			<BorderBoxControlVisualizer value={ value } size={ size } />
@@ -87,27 +115,9 @@ const BorderBoxControlSplitControls = (
 				value={ value?.top }
 				{ ...sharedBorderControlProps }
 			/>
-			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
-			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
-			<BorderControl
-				hideLabelFromVision
-				label={ __( 'Left border' ) }
-				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
-				__unstablePopoverProps={ popoverProps }
-				value={ value?.left }
-				{ ...sharedBorderControlProps }
-			/>
-			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
-			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
-			<BorderControl
-				className={ rightAlignedClassName }
-				hideLabelFromVision
-				label={ __( 'Right border' ) }
-				onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
-				__unstablePopoverProps={ popoverProps }
-				value={ value?.right }
-				{ ...sharedBorderControlProps }
-			/>
+			{ /* In RTL mode, the layout is mirrored, so we swap the left and right controls */ }
+			{ isRTL() ? rightBorderControl : leftBorderControl }
+			{ isRTL() ? leftBorderControl : rightBorderControl }
 			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
 			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
 			<BorderControl


### PR DESCRIPTION
## What?
Closes #44171

Fixes the border control UI being backwards on RTL (Right-to-Left) sites.

## Why?

In RTL mode, when the border controls are split (unlinked), the left border control was appearing on the physical left side and the right border control on the physical right side. However, in RTL layouts, these should be swapped, the left border control should appear on the physical right side and vice versa, to match the mirrored layout.

## How?

- Import `isRTL` from `@wordpress/i18n`
- Extract left and right border controls into separate variables
- Conditionally render them in swapped order when `isRTL()` returns true

This ensures that:
- In LTR mode: Left control → left side, Right control → right side (existing behavior)
- In RTL mode: Left control → right side, Right control → left side (fixed behavior)

## Testing Instructions

1. Switch your WordPress site to an RTL language (e.g., Arabic)
2. Add any block with border support (e.g., Paragraph block)
3. In the block settings sidebar, find the Border controls
4. Click the unlink icon to split the borders
5. Verify that the left border control now appears on the right side
6. Verify that the right border control now appears on the left side
7. Add a left border - confirm it appears on the left side of the block
8. Add a right border - confirm it appears on the right side of the block

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Where|Before|After|
|-|-|-|
|LTR|<img width="2555" height="1241" alt="image" src="https://github.com/user-attachments/assets/cfe2549b-4b1a-4934-8f8c-a59f497449db" />|<img width="2539" height="1244" alt="image" src="https://github.com/user-attachments/assets/61c94679-e936-4b72-81dd-5852ecb1f774" />|
|RTL|<img width="2545" height="1233" alt="image" src="https://github.com/user-attachments/assets/9e6439b6-3003-448e-a9be-ec5b57093dcd" />|<img width="2542" height="1235" alt="image" src="https://github.com/user-attachments/assets/82b7d691-569b-4cb8-ab77-c5aab6f9e3ce" />|