### PR TITLE
Remove backport changelog committed by mistake

### DIFF
--- a/backport-changelog/7.0/10665.md
+++ b/backport-changelog/7.0/10665.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/10665
-
-* https://github.com/WordPress/gutenberg/pull/74234


### PR DESCRIPTION
Removes `backport-changelog/7.0/10665.md` which was committed by mistake.

## Test plan

- Verify the file is deleted