### PR TITLE
Select: Remove unnecessary `jest.setTimeout` from test

### DIFF
--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
 import * as Select from '../index';
 
-jest.setTimeout( 10000 );
-
 describe( 'Select', () => {
 	it( 'forwards ref', async () => {
 		const user = userEvent.setup();


### PR DESCRIPTION
## What?

Removes the `jest.setTimeout( 10000 )` override from the `Select` primitive test.

## Why?

These overrides were added as a workaround for slow `ThemeProvider` rendering, which has since been resolved. The default timeout is sufficient for this test.

## Testing Instructions

`npm run test:unit packages/ui/src/form/primitives/select`