### PR TITLE
Fix missed dimension token migration in UI package

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   Add `Tabs` primitive ([#74652](https://github.com/WordPress/gutenberg/pull/74652)).
 -   Add `Textarea` primitive ([#74707](https://github.com/WordPress/gutenberg/pull/74707)).
 
+### Bug Fixes
+
+-   `Field`: Fix default gap spacing ([#75446](https://github.com/WordPress/gutenberg/pull/75446)).
+
 ### Enhancements
 
 -   `Button`: Add minimum content width (`6ch` + padding) to prevent overly narrow buttons with short labels ([#75133](https://github.com/WordPress/gutenberg/pull/75133)).

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -7,7 +7,7 @@ const meta: Meta< typeof Badge > = {
 	component: Badge,
 	decorators: [
 		( Story ) => (
-			<Stack direction="row" gap="xs" wrap="wrap">
+			<Stack direction="row" gap="sm" wrap="wrap">
 				<Story />
 			</Stack>
 		),

--- a/packages/ui/src/form/primitives/field/root.tsx
+++ b/packages/ui/src/form/primitives/field/root.tsx
@@ -6,7 +6,7 @@ import type { FieldRootProps } from './types';
 import { Stack } from '../../../stack';
 
 const DEFAULT_RENDER = ( props: React.ComponentProps< typeof Stack > ) => (
-	<Stack { ...props } direction="column" gap="xs" />
+	<Stack { ...props } direction="column" gap="sm" />
 );
 
 /**

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj< typeof Stack >;
 
 export const Default: Story = {
 	args: {
-		gap: 'sm',
+		gap: 'md',
 		children: (
 			<>
 				<DemoBox />
@@ -90,7 +90,7 @@ export const Nested: Story = {
 		children: (
 			<>
 				<DemoBox variant="lg" />
-				<Stack gap="md">
+				<Stack gap="lg">
 					<DemoBox />
 					<DemoBox />
 				</Stack>


### PR DESCRIPTION
## What?

Follow up to #75054

Fixes a few `@wordpress/ui` components and stories that were missed during the dimension token scale migration.

## Why?

#75054 shifted the gap token scale (e.g. old `xs` → `sm`, old `sm` → `md`). Existing usages were updated to preserve their resolved values, but a few in `@wordpress/ui` were missed:

| File | Before | After (intended) |
|---|---|---|
| `Field.Root` default render | `gap="xs"` (8px) → now resolves to 4px | `gap="sm"` (8px) |
| Badge `choosing-intent` story decorator | `gap="xs"` (8px) → now resolves to 4px | `gap="sm"` (8px) |
| Stack story `Default` args | `gap: 'sm'` (12px) → now resolves to 8px | `gap: 'md'` (12px) |
| Stack story `Nested` | `gap="md"` (16px) → now resolves to 12px | `gap="lg"` (16px) |

## Testing Instructions

1. `npm run storybook:dev`
2. Compare Field, Badge "Choosing intent", and Stack stories against trunk — spacing should look the same as before #75054.