### PR TITLE
Block Visibility: Disable visibility toggle for children of sections

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -255,6 +255,16 @@ export default function BlockTools( {
 					return;
 				}
 
+				// Don't allow visibility toggle for blocks that
+				// are not in the default editing mode.
+				if (
+					clientIds.some(
+						( id ) => getBlockEditingMode( id ) !== 'default'
+					)
+				) {
+					return;
+				}
+
 				// Open the visibility breakpoints modal.
 				showViewportModal( clientIds );
 			}

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -412,6 +412,16 @@ function ListViewBlock( {
 				return;
 			}
 
+			// Don't allow visibility toggle for blocks that
+			// are not in the default editing mode.
+			if (
+				blocksToUpdate.some(
+					( id ) => getBlockEditingMode( id ) !== 'default'
+				)
+			) {
+				return;
+			}
+
 			// Open the visibility breakpoints modal.
 			showViewportModal( blocksToUpdate );
 		} else if ( isMatch( 'core/block-editor/rename', event ) ) {

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -162,6 +162,7 @@ const getQuickActionsCommands = () =>
 			canRemoveBlocks,
 			isBlockHiddenAnywhere,
 		} = unlock( useSelect( blockEditorStore ) );
+		const { getBlockEditingMode } = useSelect( blockEditorStore );
 		const { getDefaultBlockName, getGroupingBlockName } =
 			useSelect( blocksStore );
 
@@ -293,8 +294,11 @@ const getQuickActionsCommands = () =>
 			( block ) =>
 				!! block && hasBlockSupport( block.name, 'visibility', true )
 		);
+		const allBlocksDefaultMode = clientIds.every(
+			( id ) => getBlockEditingMode( id ) === 'default'
+		);
 
-		if ( supportsVisibility ) {
+		if ( supportsVisibility && allBlocksDefaultMode ) {
 			const hasHiddenBlock = clientIds.some( ( id ) =>
 				isBlockHiddenAnywhere( id )
 			);

--- a/test/e2e/specs/editor/various/block-hiding.spec.js
+++ b/test/e2e/specs/editor/various/block-hiding.spec.js
@@ -70,6 +70,126 @@ test.describe( 'Block Hiding', () => {
 		).toBeVisible();
 	} );
 
+	test( 'should not allow block visibility shortcut on children of a content-only locked section, but should after editing section', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Add content only locked block in the code editor.
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group"><!-- wp:paragraph -->
+			<p>Locked block a</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>Locked block b</p>
+			<!-- /wp:paragraph --></div>
+			<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+		await editor.openDocumentSettingsSidebar();
+
+		// Select the content locked group block.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.click();
+
+		// Select a nested paragraph.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Paragraph"i]' )
+			.first()
+			.click();
+
+		// Press the visibility shortcut (Shift+Cmd+H / Shift+Ctrl+H).
+		await pageUtils.pressKeys( 'primaryShift+h' );
+
+		// The visibility modal should NOT appear.
+		await expect(
+			page.getByRole( 'dialog', { name: 'Hide block' } )
+		).toBeHidden();
+
+		// Now enter edit mode via "Edit section".
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Edit section' } )
+			.click();
+
+		// Select a nested paragraph again.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Paragraph"i]' )
+			.first()
+			.click();
+
+		// Press the visibility shortcut again.
+		await pageUtils.pressKeys( 'primaryShift+h' );
+
+		// The visibility modal SHOULD appear now.
+		await expect(
+			page.getByRole( 'dialog', { name: 'Hide block' } )
+		).toBeVisible();
+	} );
+
+	test( 'should not allow block visibility shortcut on children of an unsynced pattern, but should after editing section', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Insert an unsynced pattern with patternName metadata.
+		await editor.setContent( `<!-- wp:group {"metadata":{"patternName":"core/block/123","name":"My pattern"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Pattern paragraph</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await editor.openDocumentSettingsSidebar();
+
+		// Select the pattern block.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.click();
+
+		// Select the nested paragraph.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+
+		// Press the visibility shortcut.
+		await pageUtils.pressKeys( 'primaryShift+h' );
+
+		// The visibility modal should NOT appear.
+		await expect(
+			page.getByRole( 'dialog', { name: 'Hide block' } )
+		).toBeHidden();
+
+		// Select the pattern block and enter edit mode via "Edit section".
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Edit section' } )
+			.click();
+
+		// Select the nested paragraph again.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+
+		// Press the visibility shortcut again.
+		await pageUtils.pressKeys( 'primaryShift+h' );
+
+		// The visibility modal SHOULD appear now.
+		await expect(
+			page.getByRole( 'dialog', { name: 'Hide block' } )
+		).toBeVisible();
+	} );
+
 	test( 'should hide a block only on Mobile viewport', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?

Prevents the block visibility toggle from being triggered on child blocks within a pattern or template part that is not being edited.

Related to #73776 

When a pattern or template part is not in edit mode, its children should not be individually hidden/shown. The visibility toggle should only be available for blocks in the default editing mode.

See https://github.com/WordPress/gutenberg/pull/75367#pullrequestreview-3784275629.

## How?

Checks `getBlockEditingMode(clientId) !== 'default'` before allowing the visibility toggle. Blocks inside unedited sections have a `contentOnly` editing mode, and switch to `default` when the section is being edited via "Edit Section". This matches the logic that hides other UI controls.

The check is added in three places:
- Keyboard shortcut handler (`Shift+Cmd+H`) in `block-tools`
- Keyboard shortcut handler in `list-view`
- Command center "Hide"/"Show" command in `use-block-commands`

## Testing

1. Open the Site Editor and edit a template that contains an unsynced pattern (or add one).
2. Select a child block inside the pattern (e.g., via List View).
3. Press `Shift+Cmd+H` — the visibility modal should **not** open.
4. Open the command center (`Cmd+K`) — the "Hide"/"Show" command should **not** appear.
5. Now click "Edit Section" on the pattern to enter edit mode.
6. Select a child block inside the pattern.
7. Press `Shift+Cmd+H` — the visibility modal **should** open.
8. Open the command center — the "Hide"/"Show" command **should** appear.
9. Select the root pattern block itself (not a child) — the visibility modal should work regardless of edit mode.