### PR TITLE
Writing Flow: Fix block selection from partially selected RichText

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -191,6 +191,26 @@ export default function useSelectionObserver() {
 					return;
 				}
 
+				// On mouseup, if the native selection is within one block
+				// but the click target is a different block, bail out
+				// and let the clicked block's focus handler manage
+				// selection.
+				if (
+					event.type === 'mouseup' &&
+					! event.shiftKey &&
+					! isMultiSelecting() &&
+					startClientId === endClientId
+				) {
+					const clickedClientId = getBlockClientId( event.target );
+					if (
+						clickedClientId &&
+						clickedClientId !== startClientId
+					) {
+						selection.removeAllRanges();
+						return;
+					}
+				}
+
 				const isSingularSelection = startClientId === endClientId;
 				if ( isSingularSelection ) {
 					if ( ! isMultiSelecting() ) {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1143,7 +1143,6 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await editor.canvas
 			.getByRole( 'document', { name: 'Empty block' } )
 			.fill( 'A partial selection' );
-		// Testing: Comment out this like for test to pass.
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
 
 		const spacer = editor.canvas.getByRole( 'document', {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1133,6 +1133,29 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 			editor.canvas.locator( '[data-type="core/block"]' )
 		).toBeFocused();
 	} );
+
+	test( 'should select non-contenteditable block via click after partial selection', async ( {
+		editor,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await editor.insertBlock( { name: 'core/spacer' } );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.fill( 'A partial selection' );
+		// Testing: Comment out this like for test to pass.
+		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
+
+		const spacer = editor.canvas.getByRole( 'document', {
+			name: 'Block: Spacer',
+		} );
+		await spacer.click();
+
+		await expect( spacer ).toBeFocused();
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).not.toBeFocused();
+	} );
 } );
 
 class WritingFlowUtils {


### PR DESCRIPTION
## What?
Closes #58788.

PR fixes a bug that caused focus to return to a previous block with a partial text selection after attempting to select a block with no text fields.

## Why?
The `useSelectionObserver` hook incorrectly calculated traget block from selection node, instead of actual event traget.


## Testing Instructions
1. Open a post or page.
2. Insert a text block and Spacer/Image.
3. Partially select text from the first block.
4. Try clicking on a second block without a content-editable element.
5. The block selection should move correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/d6808500-c0fd-47d6-838c-cfd70713faf1

**After**

https://github.com/user-attachments/assets/4e926f48-76a6-4ec9-b6f5-42780d90afa2

