### PR TITLE
Note: Remove block highlight when deleting parent note

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -158,6 +158,7 @@ export function Comments( {
 			focusCommentThread( prevThread.id, commentSidebarRef.current );
 		} else {
 			selectNote( undefined );
+			toggleBlockSpotlight( comment.blockClientId, false );
 			// Move focus to the related block.
 			relatedBlockElement?.focus();
 		}


### PR DESCRIPTION
## What?
Closes #75452.

Clean up the spotlight when deleting the main (parent: 0) note for a block.

## Why?
When the block has no notes, focus returns to the block, and it should also toggle to spotlight mode.

## Testing Instructions
1. Add a note to a block
2. Delete the note
3. Observe that the spotlight mode for the block is removed.

### Testing Instructions for Keyboard
Same