### PR TITLE
Notes: Fix sidebar display logic for small screens

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -117,13 +117,18 @@ function NotesSidebar( { postId } ) {
 		[]
 	);
 
-	const showFloatingSidebar = isLargeViewport;
 	const {
 		resultComments,
 		unresolvedSortedThreads,
 		reflowComments,
 		commentLastUpdated,
 	} = useBlockComments( postId );
+
+	// Only enable the floating sidebar for large viewports.
+	const showFloatingSidebar = isLargeViewport;
+	// Fallback to "All notes" sidebar on smaller viewports.
+	const showAllNotesSidebar =
+		resultComments.length > 0 || ! showFloatingSidebar;
 	useEnableFloatingSidebar(
 		showFloatingSidebar &&
 			( unresolvedSortedThreads.length > 0 || selectedNote !== undefined )
@@ -154,7 +159,6 @@ function NotesSidebar( { postId } ) {
 	const currentThread = blockCommentId
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
-	const showAllNotesSidebar = resultComments.length > 0;
 
 	async function openTheSidebar() {
 		const prevArea = await getActiveComplementaryArea( 'core' );


### PR DESCRIPTION
## What?
Regression after #74577.

PR fixes bug where user couldn't add the first note to a post. On small screens, the floating sidebar isn't enabled, and Notes should always use the "All notes" sidebar.

Discovered while testing - #75450.

## Testing Instructions
1. Resize the browser window so that the default sidebar is hidden.
2. Try adding the note to a block.
3. The "All notes" sidebar should open with the new note form.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5a7cfe2b-4693-40a5-b112-c9bbdaa77f62

