### PR TITLE
Notes: Conditionally restore default sidebar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -31,6 +31,7 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { sidebars as DEFAULT_SIDEBARS } from '../sidebar/constants';
 import { FLOATING_NOTES_SIDEBAR } from './constants';
 import { unlock } from '../../lock-unlock';
 import { noop } from './utils';
@@ -348,19 +349,28 @@ export function useEnableFloatingSidebar( enabled = false ) {
 		const { disableComplementaryArea, enableComplementaryArea } =
 			registry.dispatch( interfaceStore );
 
+		let wasHiddenByUser = false;
 		const unsubscribe = registry.subscribe( () => {
 			// Return `null` to indicate the user hid the complementary area.
 			if ( getActiveComplementaryArea( 'core' ) === null ) {
+				wasHiddenByUser = true;
 				enableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
 			}
 		} );
 
 		return () => {
 			unsubscribe();
-			if (
-				getActiveComplementaryArea( 'core' ) === FLOATING_NOTES_SIDEBAR
-			) {
-				disableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
+			const activeArea = getActiveComplementaryArea( 'core' );
+			if ( activeArea === FLOATING_NOTES_SIDEBAR ) {
+				if ( wasHiddenByUser ) {
+					disableComplementaryArea( 'core' );
+				} else {
+					// Restore the default sidebar if user didn't explicitly hide it.
+					enableComplementaryArea(
+						'core',
+						DEFAULT_SIDEBARS.document
+					);
+				}
 			}
 		};
 	}, [ enabled, registry ] );


### PR DESCRIPTION
## What?
Closes #75450.

PR updates logic in `useEnableFloatingSidebar` to reopen the default document sidebar when the floating notes sidebar is no longer enabled.

## Why?
A small QoL improvement.

## Testing Instructions
1. Create a post or a page.
2. Add some blocks.
3. Try adding a note.
4. Cancel the form.
5. Confirm that the default document sidebar was restored.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/41ed1049-3a23-464e-af49-1acebfef2b41

