### PR TITLE
Feature : Toggle to prevent inline JS

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -129,7 +129,7 @@ Display a list of all terms of a given taxonomy. ([Source](https://github.com/Wo
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-	**Attributes:** disableInlineScript, displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -39,6 +39,10 @@
 		"showLabel": {
 			"type": "boolean",
 			"default": true
+		},
+		"disableInlineScript": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "enhancedPagination" ],

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -42,6 +42,7 @@ export default function CategoriesEdit( {
 		showEmpty,
 		label,
 		showLabel,
+		disableInlineScript,
 		taxonomy: taxonomySlug,
 	},
 	setAttributes,
@@ -219,6 +220,7 @@ export default function CategoriesEdit( {
 							showOnlyTopLevel: false,
 							showEmpty: false,
 							showLabel: true,
+							disableInlineScript: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -278,6 +280,27 @@ export default function CategoriesEdit( {
 								label={ __( 'Show label' ) }
 								checked={ showLabel }
 								onChange={ toggleAttribute( 'showLabel' ) }
+							/>
+						</ToolsPanelItem>
+					) }
+					{ displayAsDropdown && (
+						<ToolsPanelItem
+							hasValue={ () => !! disableInlineScript }
+							label={ __( 'Disable inline script' ) }
+							isShownByDefault
+							onDeselect={ () =>
+								setAttributes( {
+									disableInlineScript: false,
+								} )
+							}
+						>
+							<ToggleControl
+								className="wp-block-categories__indentation"
+								label={ __( 'Disable inline script' ) }
+								checked={ disableInlineScript }
+								onChange={ toggleAttribute(
+									'disableInlineScript'
+								) }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -10,6 +10,7 @@
  *
  * @since 5.0.0
  * @since 6.7.0 Enable client-side rendering if enhancedPagination context is true.
+ * @since 6.9.0 Added support for the `disableInlineScript` attribute.
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    Block default content.
@@ -57,7 +58,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 		$items_markup   = wp_dropdown_categories( $args );
 		$type           = 'dropdown';
 
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && empty( $attributes['disableInlineScript'] ) ) {
 			// Inject the dropdown script immediately after the select dropdown.
 			$items_markup = preg_replace(
 				'#(?<=</select>)#',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

- Closes https://github.com/WordPress/gutenberg/issues/73899

<!-- In a few words, what is the PR actually doing? -->

- This PR introduces a new `disableInlineScript` attribute to the Categories block that allows developers to prevent the injection of inline JavaScript when using the block in dropdown mode. This provides better control over the block's output, especially when using block variations or custom navigation implementations.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the growing use of block variations and custom block implementations, developers often need to use the Categories block as a primitive building block. Currently, when displaying terms as a dropdown, the block automatically injects an inline script tag that handles client-side navigation. This can be problematic when:

-   Developers want to implement custom navigation behavior (e.g., AJAX loading, custom routing)
-   The inline script conflicts with existing JavaScript implementations
-   Developers need cleaner HTML output without inline scripts

The current workaround of manually removing the inline script is cumbersome and unreliable. This PR provides a clean, supported way to disable the inline script injection.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The implementation adds a new optional attribute `disableInlineScript` (boolean, defaults to `false`) to maintain backward compatibility:

1. **Block Definition (`block.json`)**: Added the new `disableInlineScript` attribute with default value `false`
2. **Editor UI (`edit.js`)**: Added a toggle control in the block inspector that appears when "Display as dropdown" is enabled, allowing users to disable inline scripts
3. **Server-side Rendering (`index.php`)**: Modified the render function to check the `disableInlineScript` attribute before injecting the inline JavaScript. When the attribute is `true`, the script tag is omitted from the output

The changes are backward compatible - existing blocks will continue to work as before since the default value is `false`.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Basic Testing

1. Create a new post or page
2. Insert a Categories block
3. In the block settings panel, enable "Display as dropdown"
4. Observe that a new toggle "Disable inline script" appears
5. Enable the "Disable inline script" toggle
6. Save the post and view it on the frontend
7. Check the page source (Ctrl+U / Cmd+Option+U)
8. Search for inline JavaScript after the dropdown select element
9. **Expected**: No `<script>` tag should be present after the `</select>` tag

### Control Test (Default Behavior)

1. Go back to the editor
2. Disable the "Disable inline script" toggle (or add a new Categories block without changing this setting)
3. Save and view the frontend source again
4. **Expected**: The inline JavaScript `<script>` tag should be present after the `<select>` element, enabling client-side navigation

### Block Variation Testing (Developer Scenario)

1. Create a custom block variation in your theme's JavaScript:
    ```javascript
    wp.blocks.registerBlockVariation( 'core/categories', {
    	name: 'custom-categories',
    	title: 'Custom Categories',
    	attributes: {
    		displayAsDropdown: true,
    		disableInlineScript: true,
    	},
    } );
    ```
2. Insert the custom variation in a post
3. Save and view frontend
4. **Expected**: The dropdown renders without inline JavaScript, allowing your custom navigation script to handle the interaction

## Additional Notes

-   **Backward Compatibility**: The default value `false` ensures existing blocks continue to work as before
-   **Use Case**: Particularly useful for developers creating block variations with custom navigation implementations
-   **Scope**: This setting only affects the frontend output when `displayAsDropdown` is enabled
-   **Accessibility**: The new toggle in the editor is properly labeled and keyboard accessible