### PR TITLE
Block Editor: Optimize controlled inner blocks state churn

### DIFF
--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2404,6 +2404,71 @@ describe( 'state', () => {
 						)
 					);
 				} );
+
+				it( 'should preserve controlledInnerBlocks flags across RESET_BLOCKS', () => {
+					const original = blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					} );
+					const withControlled = blocks( original, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'chicken',
+						hasControlledInnerBlocks: true,
+					} );
+					expect( withControlled.controlledInnerBlocks.chicken ).toBe(
+						true
+					);
+
+					const state = blocks( withControlled, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					} );
+
+					expect( state.controlledInnerBlocks.chicken ).toBe( true );
+				} );
+
+				it( 'should not create new state references when setting controlled inner blocks on a block with no inner blocks', () => {
+					const original = blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					} );
+
+					const state = blocks( original, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'chicken',
+						hasControlledInnerBlocks: true,
+					} );
+
+					expect( state.controlledInnerBlocks.chicken ).toBe( true );
+					// The order and byClientId Maps should be the same
+					// reference because the block has no inner blocks to
+					// remove, so REPLACE_INNER_BLOCKS should be skipped.
+					expect( state.order ).toBe( original.order );
+					expect( state.byClientId ).toBe( original.byClientId );
+					expect( state.attributes ).toBe( original.attributes );
+					expect( state.parents ).toBe( original.parents );
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
## What?

Optimize the block-editor reducer to reduce unnecessary state churn and re-cloning when working with nested controlled blocks (patterns with posts, template parts, etc.).

## Why?

When using nested controlled blocks, the reducer was creating superfluous state objects and forcing unnecessary re-cloning of blocks. This PR extracts two focused optimizations from a larger PR to address this:

1. **Preserve `controlledInnerBlocks` flags on `RESET_BLOCKS`** — Previously cleared to `{}`, causing nested controllers to lose their controlled status and re-clone unnecessarily. Stale flags are naturally cleaned up by `useBlockSync` unmount.

2. **Skip no-op `REPLACE_INNER_BLOCKS` dispatch** — When a block has no inner blocks to remove, skip the dispatch entirely to avoid creating new Map references that trigger false-positive change detection in parent subscriptions.

## How?

- Modified `withBlockReset` to preserve `state?.controlledInnerBlocks` instead of resetting to `{}`
- Modified `withResetControlledBlocks` to check `state.order.get(clientId)?.length` before dispatching `REPLACE_INNER_BLOCKS`
- Added tests verifying flag preservation and referential equality of state references

## Testing Instructions

Run the reducer tests: `npm run test:unit -- --testPathPattern='packages/block-editor/src/store/test/reducer'`

All 160 tests pass, including two new tests that verify the optimizations work correctly.