### PR TITLE
Editor: Add user preference toggle for content-only pattern sections

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -521,8 +521,12 @@ export function isSectionBlock( state, clientId ) {
 	// don't treat nested unsynced patterns as section blocks.
 	const isIsolatedEditor = state.settings?.[ isIsolatedEditorKey ];
 
+	const contentOnlyPatternSections =
+		state.settings?.contentOnlyPatternSections !== false;
+
 	if (
-		( attributes?.metadata?.patternName || isTemplatePart ) &&
+		( ( contentOnlyPatternSections && attributes?.metadata?.patternName ) ||
+			isTemplatePart ) &&
 		! isIsolatedEditor
 	) {
 		return true;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2398,15 +2398,19 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	// don't apply contentOnly mode to nested unsynced patterns or template parts.
 	const isIsolatedEditor = state.settings?.[ isIsolatedEditorKey ];
 
+	const contentOnlyPatternSections =
+		state.settings?.contentOnlyPatternSections !== false;
+
 	// Use array.from for better back compat. Older versions of the iterator returned
 	// from `keys()` didn't have the `filter` method.
-	const unsyncedPatternClientIds = isIsolatedEditor
-		? []
-		: Array.from( state.blocks.attributes.keys() ).filter(
-				( clientId ) =>
-					state.blocks.attributes.get( clientId )?.metadata
-						?.patternName
-		  );
+	const unsyncedPatternClientIds =
+		isIsolatedEditor || ! contentOnlyPatternSections
+			? []
+			: Array.from( state.blocks.attributes.keys() ).filter(
+					( clientId ) =>
+						state.blocks.attributes.get( clientId )?.metadata
+							?.patternName
+			  );
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,
@@ -2702,6 +2706,13 @@ export function withDerivedBlockEditingModes( reducer ) {
 				// Handle unsynced patterns which indicate their contentOnly-ness via
 				// the `attributes.metadata.patternName` property.
 				// Check when this is added or removed and update blockEditingModes.
+				const contentOnlyPatternSections =
+					nextState.settings?.contentOnlyPatternSections !== false;
+
+				if ( ! contentOnlyPatternSections ) {
+					break;
+				}
+
 				const addedBlocks = [];
 				const removedClientIds = [];
 
@@ -2914,10 +2925,13 @@ export function withDerivedBlockEditingModes( reducer ) {
 				break;
 			}
 			case 'UPDATE_SETTINGS': {
-				// Recompute the entire tree if the section root changes.
+				// Recompute the entire tree if the section root or
+				// contentOnlyPatternSections setting changes.
 				if (
 					state?.settings?.[ sectionRootClientIdKey ] !==
-					nextState?.settings?.[ sectionRootClientIdKey ]
+						nextState?.settings?.[ sectionRootClientIdKey ] ||
+					state?.settings?.contentOnlyPatternSections !==
+						nextState?.settings?.contentOnlyPatternSections
 				) {
 					return {
 						...nextState,

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -22,6 +22,7 @@ import {
 	isBlockHiddenAnywhere,
 	isBlockHiddenAtViewport,
 	getViewportModalClientIds,
+	isSectionBlock,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -1337,6 +1338,80 @@ describe( 'private selectors', () => {
 				viewportModalClientIds: clientIds,
 			};
 			expect( getViewportModalClientIds( state ) ).toEqual( clientIds );
+		} );
+	} );
+
+	describe( 'isSectionBlock', () => {
+		const createState = ( {
+			blockName = 'core/group',
+			patternName,
+			contentOnlyPatternSections,
+			templateLock,
+			rootTemplateLock,
+		} = {} ) => {
+			const clientId = 'block-1';
+			const rootClientId = '';
+			const attributes = patternName ? { metadata: { patternName } } : {};
+
+			return {
+				blocks: {
+					byClientId: new Map( [
+						[ clientId, { name: blockName } ],
+					] ),
+					attributes: new Map( [ [ clientId, attributes ] ] ),
+					parents: new Map( [ [ clientId, rootClientId ] ] ),
+				},
+				blockListSettings: {
+					[ clientId ]: templateLock ? { templateLock } : {},
+					'': rootTemplateLock
+						? { templateLock: rootTemplateLock }
+						: {},
+				},
+				settings:
+					contentOnlyPatternSections !== undefined
+						? { contentOnlyPatternSections }
+						: {},
+				editedContentOnlySection: undefined,
+			};
+		};
+
+		it( 'should return true for blocks with patternName by default', () => {
+			const state = createState( {
+				patternName: 'my-pattern',
+			} );
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return false for blocks with patternName when contentOnlyPatternSections is false', () => {
+			const state = createState( {
+				patternName: 'my-pattern',
+				contentOnlyPatternSections: false,
+			} );
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'should still return true for template parts when contentOnlyPatternSections is false', () => {
+			const state = createState( {
+				blockName: 'core/template-part',
+				contentOnlyPatternSections: false,
+			} );
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should still return true for synced patterns (core/block) when contentOnlyPatternSections is false', () => {
+			const state = createState( {
+				blockName: 'core/block',
+				contentOnlyPatternSections: false,
+			} );
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'should return true for blocks with patternName when contentOnlyPatternSections is true', () => {
+			const state = createState( {
+				patternName: 'my-pattern',
+				contentOnlyPatternSections: true,
+			} );
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4457,6 +4457,114 @@ describe( 'state', () => {
 			} );
 		} );
 
+		describe( 'unsynced patterns with contentOnlyPatternSections disabled', () => {
+			let initialState;
+			beforeAll( () => {
+				initialState = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								contentOnlyPatternSections: false,
+							},
+						},
+						{
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-1',
+									attributes: {
+										metadata: {
+											patternName: 'test-pattern',
+										},
+									},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-1',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-2',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													clientId: 'paragraph-2',
+													attributes: {},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer
+				);
+			} );
+
+			it( 'returns no derived editing modes for unsynced patterns when contentOnlyPatternSections is false', () => {
+				expect( initialState.derivedBlockEditingModes ).toEqual(
+					new Map()
+				);
+			} );
+
+			it( 'does not add editing modes when a patternName attribute is set via UPDATE_BLOCK_ATTRIBUTES', () => {
+				const stateWithoutPatternName = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								contentOnlyPatternSections: false,
+							},
+						},
+						{
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-1',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-1',
+											attributes: {},
+											innerBlocks: [],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer
+				);
+
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'UPDATE_BLOCK_ATTRIBUTES',
+							clientIds: [ 'group-1' ],
+							attributes: {
+								metadata: {
+									patternName: 'test-pattern',
+								},
+							},
+						},
+					],
+					testReducer,
+					stateWithoutPatternName
+				);
+
+				expect( derivedBlockEditingModes ).toEqual( new Map() );
+			} );
+		} );
+
 		describe( 'template parts', () => {
 			let initialState;
 			beforeAll( () => {

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -71,6 +71,7 @@ export function initializeEditor(
 		showIconLabels: false,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		contentOnlyPatternSections: true,
 		isPublishSidebarEnabled: true,
 	} );
 

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -73,6 +73,7 @@ export function initializeEditor( id, settings ) {
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		contentOnlyPatternSections: true,
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -55,20 +55,29 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 
 function PreferencesModalContents( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const showBlockBreadcrumbsOption = useSelect(
-		( select ) => {
-			const { getEditorSettings } = select( editorStore );
-			const { get } = select( preferencesStore );
-			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
-			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );
-			return (
-				! isDistractionFreeEnabled &&
-				isLargeViewport &&
-				isRichEditingEnabled
-			);
-		},
-		[ isLargeViewport ]
-	);
+	const { showBlockBreadcrumbsOption, showContentOnlyPatternSectionsOption } =
+		useSelect(
+			( select ) => {
+				const { getEditorSettings } = select( editorStore );
+				const { get } = select( preferencesStore );
+				const isRichEditingEnabled =
+					getEditorSettings().richEditingEnabled;
+				const isDistractionFreeEnabled = get(
+					'core',
+					'distractionFree'
+				);
+				return {
+					showBlockBreadcrumbsOption:
+						! isDistractionFreeEnabled &&
+						isLargeViewport &&
+						isRichEditingEnabled,
+					showContentOnlyPatternSectionsOption:
+						getEditorSettings().contentOnlyPatternSections !==
+						false,
+				};
+			},
+			[ isLargeViewport ]
+		);
 	const { setIsListViewOpened, setIsInserterOpened } =
 		useDispatch( editorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
@@ -120,6 +129,18 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									) }
 									label={ __( 'Show starter patterns' ) }
 								/>
+								{ showContentOnlyPatternSectionsOption && (
+									<PreferenceToggleControl
+										scope="core"
+										featureName="contentOnlyPatternSections"
+										help={ __(
+											'Restrict editing in pattern sections to content blocks only.'
+										) }
+										label={ __(
+											'Content-only pattern editing'
+										) }
+									/>
+								) }
 							</PreferencesModalSection>
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }
@@ -332,6 +353,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 			].filter( Boolean ),
 		[
 			showBlockBreadcrumbsOption,
+			showContentOnlyPatternSectionsOption,
 			extraSections,
 			setIsInserterOpened,
 			setIsListViewOpened,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -130,6 +130,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		pageForPosts,
 		userPatternCategories,
 		restBlockPatternCategories,
+		contentOnlyPatternSections,
 		sectionRootClientId,
 		deviceType,
 	} = useSelect(
@@ -170,6 +171,10 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				allowRightClickOverrides: get(
 					'core',
 					'allowRightClickOverrides'
+				),
+				contentOnlyPatternSections: get(
+					'core',
+					'contentOnlyPatternSections'
 				),
 				blockTypes: getBlockTypes(),
 				canUseUnfilteredHTML: getRawEntityRecord(
@@ -306,6 +311,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	}, [ settings.allowedBlockTypes, hiddenBlockTypes, blockTypes ] );
 
 	const forceDisableFocusMode = settings.focusMode === false;
+	const forceDisableContentOnlyPatternSections =
+		settings.contentOnlyPatternSections === false;
 
 	return useMemo( () => {
 		const blockEditorSettings = {
@@ -321,6 +328,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			[ globalStylesLinksDataKey ]: globalStylesLinksData,
 			allowedBlockTypes,
 			allowRightClickOverrides,
+			contentOnlyPatternSections:
+				contentOnlyPatternSections &&
+				! forceDisableContentOnlyPatternSections,
 			focusMode: focusMode && ! forceDisableFocusMode,
 			hasFixedToolbar,
 			isDistractionFree,
@@ -396,6 +406,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	}, [
 		allowedBlockTypes,
 		allowRightClickOverrides,
+		contentOnlyPatternSections,
+		forceDisableContentOnlyPatternSections,
 		focusMode,
 		forceDisableFocusMode,
 		hasFixedToolbar,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -57,6 +57,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'clearBlockSelection',
 	'codeEditingEnabled',
 	'colors',
+	'contentOnlyPatternSections',
 	'disableCustomColors',
 	'disableCustomFontSizes',
 	'disableCustomSpacingSizes',


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of #75457

## What?

Part of #71573
Follow up to #75457

Adds a user preference toggle in the editor Preferences modal for the `contentOnlyPatternSections` setting introduced in the parent PR.

## Why?

The parent PR added the `contentOnlyPatternSections` block editor setting, controllable only via PHP filter. This PR gives users a UI toggle to control the behavior themselves, following the same pattern used by `focusMode` / Spotlight mode — where a PHP filter can force-disable the feature, but otherwise the user preference controls it.

## How?

- Registers `contentOnlyPatternSections: true` as a default user preference in both `edit-site` and `edit-post` via `preferencesStore.setDefaults`.
- In `use-block-editor-settings.js`, reads the user preference and combines it with the PHP-level setting. If the PHP filter sets `contentOnlyPatternSections` to `false`, it force-disables the feature regardless of the user preference.
- Adds a "Content-only pattern editing" toggle in Preferences > General > Interface. The toggle is conditionally rendered — hidden when PHP has force-disabled the setting.

## Testing Instructions

1. Open the site editor or post editor.
2. Open Preferences (three-dot menu > Preferences) > General tab > Interface section.
3. Verify the "Content-only pattern editing" toggle is visible and enabled by default.
4. Toggle it off, then insert or select an unsynced pattern — confirm all inner blocks are fully editable (not restricted to content-only mode).
5. Toggle it back on and confirm content-only editing is restored.
6. To test PHP force-disable: add a filter that sets `contentOnlyPatternSections` to `false` in the editor settings, reload, and verify the toggle is hidden and patterns are fully editable regardless of the stored preference.

### Testing Instructions for Keyboard

1. Open the Preferences modal using the keyboard (three-dot menu > Preferences).
2. Navigate to the General tab.
3. Tab to the "Content-only pattern editing" toggle and use Space/Enter to toggle it.
4. Verify the toggle responds correctly and focus is maintained.




https://github.com/user-attachments/assets/119c43ad-f3d7-4517-805a-f0ea6ac9ddf7


