### PR TITLE
wp-build: try without including private APIs

### DIFF
--- a/packages/wp-build/templates/script-registration.php.template
+++ b/packages/wp-build/templates/script-registration.php.template
@@ -85,5 +85,7 @@ if ( ! function_exists( '{{PREFIX}}_register_package_scripts' ) ) {
 		}
 	}
 
-	add_action( 'wp_default_scripts', '{{PREFIX}}_register_package_scripts' );
+	// Priority 9 so that the Gutenberg plugin (priority 10) can override
+	// these scripts with newer versions when it is active.
+	add_action( 'wp_default_scripts', '{{PREFIX}}_register_package_scripts', 9 );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make sure wp-build's private-apis script doesn't override Gutenberg's
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #75440.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move to priority 9, before GB scripts are added.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I'm testing by rebuilding https://github.com/dhasilva/minimal-wp-build-test/tree/trunk and trying http://localhost:8888/wp-admin/tools.php?page=minimal-wp-build-test-wp-admin without GB and with GB. There seems to be an unrelated error when GB is not active.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
