### PR TITLE
Notes: Update shortcut category

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -111,7 +111,7 @@ function EditorKeyboardShortcutsRegister() {
 
 		registerShortcut( {
 			name: 'core/editor/new-note',
-			category: 'global',
+			category: 'block',
 			description: __( 'Add a new note.' ),
 			keyCombination: {
 				modifier: 'primaryAlt',


### PR DESCRIPTION
## What?
A follow-up to #75287.

PR changes Notes shortcut category from `global` to `block`.

Although it's registered in the editor's global registry, it is still a block-specific shortcut and should be listed in the correct category.

## Testing Instructions
The feature has e2e test coverage.

### Testing Instructions for Keyboard
Same.

## Screenshot

<img width="632" height="800" alt="CleanShot 2026-02-12 at 13 48 41" src="https://github.com/user-attachments/assets/2b60dddc-99df-49f6-96bf-f0f4765ccdc5" />
