### PR TITLE
DataForm: add edit variant

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Enhancements
 
+- DataForm: add edit variant. [#75462](https://github.com/WordPress/gutenberg/pull/75462)
 - DataForm: Update trigger mechanism for panel layout. [#75290](https://github.com/WordPress/gutenberg/pull/75290)
 - DataViews: Add `onReset` prop to control view reset functionality from the view config dropdown. [#75093](https://github.com/WordPress/gutenberg/pull/75093)
 - DataForm: Add automatic field labeling - forms now automatically mark the minority of fields (required or optional) to reduce visual noise. [#74430](https://github.com/WordPress/gutenberg/pull/74430)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -2057,7 +2057,9 @@ For example:
 #### Panel
 
 -   `type`: `panel`. Required.
--   `labelPosition`: one of `side`, `top`, or `none`. Optional. `top` by default.
+-   `labelPosition`: one of `side`, `top`, or `none`. Optional. `side` by default.
+-   `editVisibility`: one of `always`, or `on-hover`. Optional. `on-hover` by default.
+-   `openAs`: one of `dropdown`, `modal`. Optional. `dropdown` by default.
 -   `summary`: Summary field configuration. Optional. Specifies which field(s) to display in the panel header. Can be:
     -   A string (single field ID)
     -   An array of strings (multiple field IDs)

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -60,6 +60,7 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			labelPosition: layout?.labelPosition ?? 'side',
 			openAs: layout?.openAs ?? 'dropdown',
 			summary: normalizedSummary,
+			editVisibility: layout?.editVisibility ?? 'on-hover',
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -49,6 +49,10 @@
 	}
 }
 
+.dataforms-layouts-panel__field-trigger--edit-always .dataforms-layouts-panel__field-trigger-icon {
+	opacity: 1;
+}
+
 .dataforms-layouts-panel__field-trigger-icon {
 	padding: 0;
 	color: var(--wp-admin-theme-color);

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -49,8 +49,15 @@
 	}
 }
 
-.dataforms-layouts-panel__field-trigger--edit-always .dataforms-layouts-panel__field-trigger-icon {
+.dataforms-layouts-panel__field-trigger--edit-always
+.dataforms-layouts-panel__field-trigger-icon {
 	opacity: 1;
+	fill: currentColor;
+
+	&:hover,
+	&:focus-visible {
+		fill: var(--wp-admin-theme-color);
+	}
 }
 
 .dataforms-layouts-panel__field-trigger-icon {
@@ -68,6 +75,9 @@
 
 	&:focus-visible {
 		opacity: 1;
+		outline:
+			var(--wpds-border-width-focus) solid
+			var(--wp-admin-theme-color);
 	}
 }
 
@@ -129,15 +139,18 @@
 	}
 }
 
-.dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-label {
+.dataforms-layouts-panel__field-trigger--label-top
+.dataforms-layouts-panel__field-label {
 	width: 100%;
 }
 
-.dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-control {
+.dataforms-layouts-panel__field-trigger--label-top
+.dataforms-layouts-panel__field-control {
 	grid-column: 1 / -1;
 }
 
-.dataforms-layouts-panel__field-trigger--label-top .dataforms-layouts-panel__field-trigger-icon {
+.dataforms-layouts-panel__field-trigger--label-top
+.dataforms-layouts-panel__field-trigger-icon {
 	grid-row: 1;
 	grid-column: 2;
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -45,8 +45,8 @@ export default function SummaryButton< Item >( {
 	onClick: () => void;
 	'aria-expanded'?: boolean;
 } ) {
-	const labelPosition = ( field.layout as NormalizedPanelLayout )
-		.labelPosition;
+	const { labelPosition, editVisibility } =
+		field.layout as NormalizedPanelLayout;
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
 	const labelClassName = getLabelClassName( labelPosition, showError );
@@ -54,7 +54,11 @@ export default function SummaryButton< Item >( {
 	const className = clsx(
 		'dataforms-layouts-panel__field-trigger',
 		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`,
-		{ 'is-disabled': disabled }
+		{
+			'is-disabled': disabled,
+			'dataforms-layouts-panel__field-trigger--edit-always':
+				editVisibility === 'always',
+		}
 	);
 
 	const controlId = useInstanceId(

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -139,6 +139,7 @@ describe( 'normalizeFormFields', () => {
 					type: 'panel',
 					openAs: 'dropdown',
 					summary: [],
+					editVisibility: 'on-hover',
 				},
 				fields: [
 					{
@@ -148,6 +149,7 @@ describe( 'normalizeFormFields', () => {
 							labelPosition: 'side',
 							openAs: 'dropdown',
 							summary: [],
+							editVisibility: 'on-hover',
 						},
 					},
 				],
@@ -166,6 +168,7 @@ describe( 'normalizeFormFields', () => {
 					type: 'panel',
 					openAs: 'dropdown',
 					summary: [],
+					editVisibility: 'on-hover',
 				},
 				fields: [
 					{
@@ -175,6 +178,7 @@ describe( 'normalizeFormFields', () => {
 							labelPosition: 'top',
 							openAs: 'dropdown',
 							summary: [],
+							editVisibility: 'on-hover',
 						},
 					},
 				],
@@ -358,6 +362,7 @@ describe( 'normalizeFormFields', () => {
 							labelPosition: 'side',
 							openAs: 'dropdown',
 							summary: [],
+							editVisibility: 'on-hover',
 						},
 					},
 				],

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -62,6 +62,11 @@ export const LayoutPanel = {
 			description: 'Chooses how to open the panel.',
 			options: [ 'default', 'dropdown', 'modal' ],
 		},
+		editVisibility: {
+			control: { type: 'select' },
+			description: 'Chooses when the edit icon is visible.',
+			options: [ 'default', 'always', 'on-hover' ],
+		},
 	},
 };
 

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -7,7 +7,13 @@ import { useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import DataForm from '../index';
-import type { Field, Form, Layout, PanelLayout } from '../../types';
+import type {
+	Field,
+	Form,
+	Layout,
+	PanelLayout,
+	EditVisibility,
+} from '../../types';
 
 type SamplePost = {
 	title: string;
@@ -261,10 +267,12 @@ const getPanelLayoutFromStoryArgs = ( {
 	summary,
 	labelPosition,
 	openAs,
+	editVisibility,
 }: {
 	summary?: string[];
 	labelPosition?: 'default' | 'top' | 'side' | 'none';
 	openAs?: 'default' | 'dropdown' | 'modal';
+	editVisibility?: 'default' | EditVisibility;
 } ): Layout | undefined => {
 	const panelLayout: PanelLayout = {
 		type: 'panel',
@@ -282,16 +290,22 @@ const getPanelLayoutFromStoryArgs = ( {
 		panelLayout.summary = summary;
 	}
 
+	if ( editVisibility !== 'default' ) {
+		panelLayout.editVisibility = editVisibility;
+	}
+
 	return panelLayout;
 };
 
 const LayoutPanelComponent = ( {
 	labelPosition,
 	openAs,
+	editVisibility,
 }: {
 	type: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 	openAs: 'default' | 'dropdown' | 'modal';
+	editVisibility: 'default' | EditVisibility;
 } ) => {
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
@@ -321,6 +335,7 @@ const LayoutPanelComponent = ( {
 			layout: getPanelLayoutFromStoryArgs( {
 				labelPosition,
 				openAs,
+				editVisibility,
 			} ),
 			fields: [
 				'title',
@@ -357,6 +372,7 @@ const LayoutPanelComponent = ( {
 						summary: [ 'origin', 'destination', 'flight_status' ],
 						labelPosition,
 						openAs,
+						editVisibility,
 					} ),
 				},
 				{
@@ -367,11 +383,12 @@ const LayoutPanelComponent = ( {
 						summary: [ 'author', 'seat' ],
 						labelPosition,
 						openAs,
+						editVisibility,
 					} ),
 				},
 			],
 		};
-	}, [ labelPosition, openAs ] );
+	}, [ labelPosition, openAs, editVisibility ] );
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -21,17 +21,21 @@ export type NormalizedRegularLayout = {
 	labelPosition: LabelPosition;
 };
 
+export type EditVisibility = 'always' | 'on-hover';
+
 export type PanelLayout = {
 	type: 'panel';
 	labelPosition?: LabelPosition;
 	openAs?: 'dropdown' | 'modal';
 	summary?: PanelSummaryField;
+	editVisibility?: EditVisibility;
 };
 export type NormalizedPanelLayout = {
 	type: 'panel';
 	labelPosition: LabelPosition;
 	openAs: 'dropdown' | 'modal';
 	summary: NormalizedPanelSummaryField;
+	editVisibility: EditVisibility;
 };
 
 export type CardSummaryField =


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/75290

## What?
                                                                                                                                                                                   
Adds an `editVisibility` option to the DataForm panel layout, allowing the edit icon to be configured as always visible or onnly visible on hover. On hover is the default.

| | Hover | Always |
| --- | --- | --- |
| Rest | <img width="713" height="545" alt="Screenshot 2026-02-12 at 11 23 46" src="https://github.com/user-attachments/assets/8d2738fc-85b6-479b-a50a-9b796b466e72" /> | <img width="713" height="545" alt="Screenshot 2026-02-12 at 11 23 52" src="https://github.com/user-attachments/assets/4290ed5b-f4a9-4f80-8d00-89d902a6f4b4" /> |
| Hover | <img width="713" height="545" alt="Screenshot 2026-02-12 at 11 24 09" src="https://github.com/user-attachments/assets/1e394da1-d761-412e-9c14-67dd0ddec9cf" /> | <img width="713" height="545" alt="Screenshot 2026-02-12 at 11 24 02" src="https://github.com/user-attachments/assets/8642cda1-9ad4-4706-8208-507ff993e4d3" /> |
| Focus | <img width="713" height="545" alt="Screenshot 2026-02-12 at 11 24 26" src="https://github.com/user-attachments/assets/5a46e1cd-8b5a-49d3-a68c-da247fa5a013" /> | <img width="713" height="545" alt="Screenshot 2026-02-12 at 11 24 33" src="https://github.com/user-attachments/assets/4f2fe624-e20d-43d1-b6a6-3fb4a7c8b87b" /> |


## Why?

Currently, the panel layout's edit icon only appears on hover/focus. There are situations (where most fields are read-only) when consumers want to highlight the editable fields instead.

## How?

  - Adds `editVisibility: 'always' | 'on-hover'` as an optional property on PanelLayout, defaulting to 'on-hover' during normalization.
  - In SummaryButton, when editVisibility is `always`, applies a `--edit-always` modifier class that sets the edit icon to `opacity: 1` and applies theme color on hover/focus.
  - Adds a Storybook control to preview the behavior.

## Testing Instructions

`npm install && npm run storybook:dev` to open the local storybook.

  1. Open the DataForm storybook story for the Panel layout.
  2. Verify the edit icon appears only on hover/focus by default (on-hover).
  3. Change the editVisibility control to always.
  4. Verify the edit icon is now persistently visible on all panel fields.
  5. Verify the icon changes to the theme color on hover and focus.

  Testing Instructions for Keyboard

  1. Open the Panel layout story with editVisibility set to always.
  2. Tab through the panel fields — the edit icon should be visible at all times.
  3. Verify the icon gets the theme color on focus-visible.
  4. Switch back to on-hover and verify the icon only appears when the field trigger receives focus.
