### PR TITLE
Compose: Add `useDelayedLoading` hook

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -15,7 +15,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
-import { useDisabled } from '@wordpress/compose';
+import { useDelayedLoading, useDisabled } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -115,19 +115,7 @@ export default function BreadcrumbEdit( {
 			prevContentRef.current = content;
 		}
 	}, [ content, status ] );
-	const [ showLoader, setShowLoader ] = useState( false );
-	useEffect( () => {
-		if ( status !== 'loading' ) {
-			return;
-		}
-		const timeout = setTimeout( () => {
-			setShowLoader( true );
-		}, 400 );
-		return () => {
-			clearTimeout( timeout );
-			setShowLoader( false );
-		};
-	}, [ status ] );
+	const showLoading = useDelayedLoading( status === 'loading' );
 	const disabledRef = useDisabled();
 	const blockProps = useBlockProps( { ref: disabledRef } );
 
@@ -312,7 +300,7 @@ export default function BreadcrumbEdit( {
 							...blockProps,
 							style: {
 								...blockProps.style,
-								opacity: showLoader ? 0.3 : 1,
+								opacity: showLoading ? 0.3 : 1,
 							},
 						} }
 						html={ prevContentRef.current }

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -271,6 +271,22 @@ _Returns_
 
 -   `[ string, ( value: string ) => void, string ]`: The input value, the setter and the debounced input value.
 
+### useDelayedLoading
+
+Delay showing a loader to avoid visual flicker for fast loads.
+
+Returns `true` only after `isLoading` has been `true` for at least `options.delay` milliseconds. Resets to `false` when loading ends.
+
+_Parameters_
+
+-   _isLoading_ `boolean`: Whether a loading operation is in progress.
+-   _options_ `{ delay: number; }`: Options object.
+-   _options.delay_ `{ delay: number; }`: Time in milliseconds to wait before showing the loader. Default `400`.
+
+_Returns_
+
+-   `boolean`: Whether the loader should be shown.
+
 ### useDisabled
 
 In some circumstances, such as block previews, all focusable DOM elements (input fields, links, buttons, etc.) need to be disabled. This hook adds the behavior to disable nested DOM elements to the returned ref.

--- a/packages/compose/src/hooks/use-delayed-loading/index.ts
+++ b/packages/compose/src/hooks/use-delayed-loading/index.ts
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Delay showing a loader to avoid visual flicker for fast loads.
+ *
+ * Returns `true` only after `isLoading` has been `true` for at least
+ * `options.delay` milliseconds. Resets to `false` when loading ends.
+ *
+ * @param isLoading     Whether a loading operation is in progress.
+ * @param options       Options object.
+ * @param options.delay Time in milliseconds to wait before showing the loader. Default `400`.
+ *
+ * @return Whether the loader should be shown.
+ */
+export default function useDelayedLoading(
+	isLoading: boolean,
+	options: { delay: number } = { delay: 400 }
+): boolean {
+	const [ showLoader, setShowLoader ] = useState( false );
+	useEffect( () => {
+		if ( ! isLoading ) {
+			return;
+		}
+		const timeout = setTimeout( () => {
+			setShowLoader( true );
+		}, options.delay );
+		return () => {
+			clearTimeout( timeout );
+			setShowLoader( false );
+		};
+	}, [ isLoading, options.delay ] );
+	return showLoader;
+}

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -43,6 +43,7 @@ export { default as useAsyncList } from './hooks/use-async-list';
 export { default as useWarnOnChange } from './hooks/use-warn-on-change';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useDebouncedInput } from './hooks/use-debounced-input';
+export { default as useDelayedLoading } from './hooks/use-delayed-loading';
 export { default as useThrottle } from './hooks/use-throttle';
 export { default as useMergeRefs } from './hooks/use-merge-refs';
 export { default as useRefEffect } from './hooks/use-ref-effect';

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -1,16 +1,11 @@
 /**
  * WordPress dependencies
  */
-import {
-	RawHTML,
-	useEffect,
-	useState,
-	useRef,
-	useMemo,
-} from '@wordpress/element';
+import { RawHTML, useEffect, useRef, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useDelayedLoading } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -37,15 +32,7 @@ function DefaultErrorResponsePlaceholder( { message, className } ) {
 }
 
 function DefaultLoadingResponsePlaceholder( { children } ) {
-	const [ showLoader, setShowLoader ] = useState( false );
-
-	useEffect( () => {
-		// Schedule showing the Spinner after 1 second.
-		const timeout = setTimeout( () => {
-			setShowLoader( true );
-		}, 1000 );
-		return () => clearTimeout( timeout );
-	}, [] );
+	const showLoader = useDelayedLoading( true, { delay: 1000 } );
 
 	return (
 		<div style={ { position: 'relative' } }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds a new `useD` hook in compose package.

It seems we might want to show loaders/loading states a bit delayed because usually the resolution is fast. It has been mentioned [here](https://github.com/WordPress/gutenberg/pull/74572#issuecomment-3876916392) and [here](https://github.com/WordPress/gutenberg/pull/75383#pullrequestreview-3778853817) AFAIK.


### Notes

I'll keep this as a draft for now until we start using such functionality more in our codebase to justify this new API.


