### PR TITLE
Sync: Add cron cleanup for stale CRDT document post meta

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -16,6 +16,13 @@ defined( 'GUTENBERG_MINIMUM_WP_VERSION' ) or define( 'GUTENBERG_MINIMUM_WP_VERSI
 
 gutenberg_pre_init();
 
+register_deactivation_hook(
+	__FILE__,
+	function () {
+		wp_clear_scheduled_hook( 'wp_sync_cleanup' );
+	}
+);
+
 /**
  * Display a version notice and deactivate the Gutenberg plugin.
  *

--- a/lib/compat/wordpress-7.0/class-gutenberg-sync-cleanup.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-sync-cleanup.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Gutenberg_Sync_Cleanup class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Handles scheduled cleanup of stale real-time collaboration post meta.
+ *
+ * Registers a daily WP-Cron event that removes stale `sync_update_*` and
+ * `sync_awareness_*` meta from the sync storage post when all updates in
+ * a room are older than the expiration period.
+ *
+ * @access private
+ * @internal
+ */
+class Gutenberg_Sync_Cleanup {
+	/**
+	 * WP-Cron hook name.
+	 */
+	const CRON_HOOK = 'wp_sync_cleanup';
+
+	/**
+	 * Default expiration period for stale sync updates.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_EXPIRATION = 7 * DAY_IN_SECONDS;
+
+	/**
+	 * Register the cron callback.
+	 */
+	public function init(): void {
+		add_action( self::CRON_HOOK, array( $this, 'run_cleanup' ) );
+	}
+
+	/**
+	 * Schedule the daily cleanup event if not already scheduled.
+	 */
+	public static function schedule(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Clear the scheduled cleanup event.
+	 */
+	public static function unschedule(): void {
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	/**
+	 * Run the cleanup routine.
+	 */
+	public function run_cleanup(): void {
+		$this->cleanup_sync_storage_meta();
+	}
+
+	/**
+	 * Get the expiration period in seconds.
+	 *
+	 * @return int Expiration period in seconds.
+	 */
+	private function get_expiration_seconds(): int {
+		/**
+		 * Filters the expiration period for stale sync update cleanup.
+		 *
+		 * @param int $expiration Expiration period in seconds. Default 7 days.
+		 */
+		return (int) apply_filters( 'wp_sync_cleanup_expiration', self::DEFAULT_EXPIRATION );
+	}
+
+	/**
+	 * Remove stale sync update and awareness meta from the sync storage post.
+	 *
+	 * Each sync update is an associative array envelope with a `timestamp`
+	 * property (milliseconds since epoch). If the most recent update in a
+	 * room is older than the expiration period, all meta for that room is
+	 * deleted. Awareness meta for matching rooms is also removed.
+	 */
+	private function cleanup_sync_storage_meta(): void {
+		global $wpdb;
+
+		$storage_post_id = $this->get_sync_storage_post_id();
+		if ( null === $storage_post_id ) {
+			return;
+		}
+
+		$expiration = $this->get_expiration_seconds();
+		$cutoff_ms  = ( time() - $expiration ) * 1000;
+
+		// Find all sync_update_* meta keys on the storage post.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$update_keys = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT meta_key FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key LIKE %s",
+				$storage_post_id,
+				'sync\_update\_%'
+			)
+		);
+
+		foreach ( $update_keys as $meta_key ) {
+			$updates       = get_post_meta( $storage_post_id, $meta_key, false );
+			$max_timestamp = 0;
+
+			foreach ( $updates as $update ) {
+				if ( is_array( $update ) && isset( $update['timestamp'] ) ) {
+					$max_timestamp = max( $max_timestamp, (int) $update['timestamp'] );
+				}
+			}
+
+			// If the newest update is older than the cutoff, delete all meta for this room.
+			if ( $max_timestamp < $cutoff_ms ) {
+				delete_post_meta( $storage_post_id, $meta_key );
+
+				// Also remove the corresponding awareness meta.
+				$awareness_key = str_replace( 'sync_update_', 'sync_awareness_', $meta_key );
+				delete_post_meta( $storage_post_id, $awareness_key );
+			}
+		}
+	}
+
+	/**
+	 * Get the sync storage post ID without creating it.
+	 *
+	 * @return int|null Post ID, or null if no storage post exists.
+	 */
+	private function get_sync_storage_post_id(): ?int {
+		$posts = get_posts(
+			array(
+				'post_type'      => 'wp_sync_storage',
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return null;
+		}
+
+		return $posts[0]->ID;
+	}
+}

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -11,6 +11,10 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 	require_once __DIR__ . '/class-wp-http-polling-sync-server.php';
 }
 
+if ( ! class_exists( 'Gutenberg_Sync_Cleanup' ) ) {
+	require_once __DIR__ . '/class-gutenberg-sync-cleanup.php';
+}
+
 if ( ! function_exists( 'gutenberg_register_sync_storage_post_type' ) ) {
 	/**
 	 * Registers the custom post type for sync storage.
@@ -163,3 +167,15 @@ function gutenberg_inject_real_time_collaboration_setting() {
 }
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' );
+
+if ( ! function_exists( 'wp_sync_cleanup_init' ) ) {
+	/**
+	 * Initializes the sync cleanup cron event.
+	 */
+	function wp_sync_cleanup_init(): void {
+		$cleanup = new Gutenberg_Sync_Cleanup();
+		$cleanup->init();
+		Gutenberg_Sync_Cleanup::schedule();
+	}
+}
+add_action( 'init', 'wp_sync_cleanup_init' );

--- a/phpunit/experimental/class-gutenberg-sync-cleanup-test.php
+++ b/phpunit/experimental/class-gutenberg-sync-cleanup-test.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Unit tests covering Gutenberg_Sync_Cleanup functionality.
+ *
+ * @package Gutenberg
+ */
+class Gutenberg_Sync_Cleanup_Test extends WP_UnitTestCase {
+
+	/**
+	 * Sync storage post ID used across tests.
+	 *
+	 * @var int
+	 */
+	private static $storage_post_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		register_post_type( 'wp_sync_storage', array( 'public' => false ) );
+		self::$storage_post_id = $factory->post->create(
+			array(
+				'post_type'   => 'wp_sync_storage',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$storage_post_id, true );
+	}
+
+	public function tear_down() {
+		$this->cleanup_sync_storage_meta();
+		remove_all_filters( 'wp_sync_cleanup_expiration' );
+		parent::tear_down();
+	}
+
+	private function cleanup_sync_storage_meta() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->postmeta} WHERE post_id = %d AND (meta_key LIKE %s OR meta_key LIKE %s)",
+				self::$storage_post_id,
+				'sync\_update\_%',
+				'sync\_awareness\_%'
+			)
+		);
+	}
+
+	public function test_cleanup_removes_stale_sync_updates() {
+		$stale_timestamp = ( time() - ( 8 * DAY_IN_SECONDS ) ) * 1000;
+		$meta_key        = 'sync_update_' . md5( 'postType/post:1' );
+
+		add_post_meta(
+			self::$storage_post_id,
+			$meta_key,
+			array(
+				'client_id' => 1,
+				'type'      => 'update',
+				'data'      => 'test',
+				'timestamp' => $stale_timestamp,
+			)
+		);
+		add_post_meta(
+			self::$storage_post_id,
+			str_replace( 'sync_update_', 'sync_awareness_', $meta_key ),
+			array(
+				array(
+					'client_id'  => 1,
+					'state'      => array(),
+					'updated_at' => time() - ( 8 * DAY_IN_SECONDS ),
+				),
+			)
+		);
+
+		$cleanup = new Gutenberg_Sync_Cleanup();
+		$cleanup->run_cleanup();
+
+		$this->assertEmpty( get_post_meta( self::$storage_post_id, $meta_key, false ) );
+		$this->assertEmpty(
+			get_post_meta(
+				self::$storage_post_id,
+				str_replace( 'sync_update_', 'sync_awareness_', $meta_key ),
+				true
+			)
+		);
+	}
+
+	public function test_cleanup_preserves_recent_sync_updates() {
+		$recent_timestamp = ( time() - HOUR_IN_SECONDS ) * 1000;
+		$meta_key         = 'sync_update_' . md5( 'postType/post:2' );
+
+		add_post_meta(
+			self::$storage_post_id,
+			$meta_key,
+			array(
+				'client_id' => 1,
+				'type'      => 'update',
+				'data'      => 'test',
+				'timestamp' => $recent_timestamp,
+			)
+		);
+
+		$cleanup = new Gutenberg_Sync_Cleanup();
+		$cleanup->run_cleanup();
+
+		$this->assertNotEmpty( get_post_meta( self::$storage_post_id, $meta_key, false ) );
+	}
+
+	public function test_expiration_filter() {
+		// Set a sync update from 2 hours ago.
+		$two_hours_ago_ms = ( time() - ( 2 * HOUR_IN_SECONDS ) ) * 1000;
+		$meta_key         = 'sync_update_' . md5( 'postType/post:3' );
+
+		add_post_meta(
+			self::$storage_post_id,
+			$meta_key,
+			array(
+				'client_id' => 1,
+				'type'      => 'update',
+				'data'      => 'test',
+				'timestamp' => $two_hours_ago_ms,
+			)
+		);
+
+		// Default expiration (7 days) would keep this, but set it to 1 hour.
+		add_filter(
+			'wp_sync_cleanup_expiration',
+			function () {
+				return HOUR_IN_SECONDS;
+			}
+		);
+
+		$cleanup = new Gutenberg_Sync_Cleanup();
+		$cleanup->run_cleanup();
+
+		$this->assertEmpty( get_post_meta( self::$storage_post_id, $meta_key, false ) );
+	}
+
+	public function test_schedule_registers_cron() {
+		// Ensure clean state.
+		wp_clear_scheduled_hook( Gutenberg_Sync_Cleanup::CRON_HOOK );
+
+		Gutenberg_Sync_Cleanup::schedule();
+
+		$this->assertNotFalse( wp_next_scheduled( Gutenberg_Sync_Cleanup::CRON_HOOK ) );
+
+		// Clean up.
+		wp_clear_scheduled_hook( Gutenberg_Sync_Cleanup::CRON_HOOK );
+	}
+
+	public function test_unschedule_clears_cron() {
+		Gutenberg_Sync_Cleanup::schedule();
+		Gutenberg_Sync_Cleanup::unschedule();
+
+		$this->assertFalse( wp_next_scheduled( Gutenberg_Sync_Cleanup::CRON_HOOK ) );
+	}
+}


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/75311

Adds a daily WP-Cron event that cleans up stale `sync` post meta left behind by real-time collaboration sessions.

## Why?

When real-time collaboration sessions end (e.g. browser closed, network lost), `sync_awareness_` and `sync_update_` post meta can be left behind indefinitely. Over time this can accumulate unnecessary data in the database.

## How?

A new `Gutenberg_Sync_Cleanup` class registers a daily cron event (`wp_sync_cleanup`) that:

1. Queries all post meta with `sync_` meta
2. Checks the timestamp stored within the meta_value
3. If the timestamp is greater than the `wp_sync_cleanup_expiration`, deletes the relevant meta values.

The expiration period is configurable via the `wp_sync_cleanup_expiration` filter. The cron event is properly unscheduled on plugin deactivation.

## Testing Instructions

1. Create a post enable RTC and edit collaboratively.
2. Verify the cron event is scheduled: `wp_next_scheduled( 'wp_sync_cleanup' )` returns a timestamp
3. Trigger the cleanup manually: `do_action( 'wp_sync_cleanup' )`
4. Posts which have not been recently edited should have their older `sync_` meta removed
5. Posts which have been recently edited should retain their `sync_` meta
6. In order to check 4 & 5, you may need to query the DB to confirm.
7. Run PHPUnit tests: `phpunit phpunit/experimental/class-gutenberg-sync-cleanup-test.php`
