### PR TITLE
Real-time Collaboration: Add warning for non-syncing meta box fields

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Fragment } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -8,6 +9,7 @@ import { useSelect } from '@wordpress/data';
  */
 import MetaBoxesArea from './meta-boxes-area';
 import MetaBoxVisibility from './meta-box-visibility';
+import MetaBoxCollaborationWarning from './meta-box-collaboration-warning';
 import { store as editPostStore } from '../../store';
 
 export default function MetaBoxes( { location } ) {
@@ -19,7 +21,10 @@ export default function MetaBoxes( { location } ) {
 	return (
 		<>
 			{ ( metaBoxes ?? [] ).map( ( { id } ) => (
-				<MetaBoxVisibility key={ id } id={ id } />
+				<Fragment key={ id }>
+					<MetaBoxVisibility id={ id } />
+					<MetaBoxCollaborationWarning id={ id } />
+				</Fragment>
 			) ) }
 			<MetaBoxesArea location={ location } />
 		</>

--- a/packages/edit-post/src/components/meta-boxes/meta-box-collaboration-warning.js
+++ b/packages/edit-post/src/components/meta-boxes/meta-box-collaboration-warning.js
@@ -1,0 +1,227 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Known WordPress core form field names that are not post meta keys.
+ * These should be excluded when inspecting meta box form fields.
+ */
+const KNOWN_CORE_FIELDS = new Set( [
+	'post_ID',
+	'post_type',
+	'_wpnonce',
+	'originalaction',
+	'action',
+	'referredby',
+	'_wp_http_referer',
+	'original_post_status',
+	'save',
+	'publish',
+	'post_status',
+	'hidden_post_status',
+	'post_author',
+	'comment_status',
+	'ping_status',
+	'sticky',
+	'post_format',
+	'tax_input',
+	'newtag',
+	'post_category',
+	'newcategory',
+	'newcategory_parent',
+] );
+
+/**
+ * Extracts likely meta key names from a form field's `name` attribute.
+ * Handles array notation like `meta[key_name]`.
+ *
+ * @param {string} fieldName The form field name attribute value.
+ * @return {string} The extracted meta key name.
+ */
+function extractMetaKey( fieldName ) {
+	// Handle array notation: "meta[key_name]" → "key_name"
+	const match = fieldName.match( /^meta\[([^\]]+)\]/ );
+	if ( match ) {
+		return match[ 1 ];
+	}
+	// Handle array fields like "tax_input[post_tag][]" → "tax_input"
+	const bracketIndex = fieldName.indexOf( '[' );
+	if ( bracketIndex !== -1 ) {
+		return fieldName.substring( 0, bracketIndex );
+	}
+	return fieldName;
+}
+
+/**
+ * Checks whether a meta box contains form fields that reference
+ * post meta keys not registered with the REST API.
+ *
+ * @param {HTMLElement} metaBoxElement The meta box DOM element.
+ * @param {Object}      registeredMeta Object whose keys are REST-registered meta key names.
+ * @return {boolean} True if the meta box has non-REST-registered fields.
+ */
+function hasNonRestFields( metaBoxElement, registeredMeta ) {
+	const formFields = metaBoxElement.querySelectorAll(
+		'input[name], select[name], textarea[name]'
+	);
+
+	const registeredKeys = new Set( Object.keys( registeredMeta ) );
+
+	for ( const field of formFields ) {
+		const name = field.getAttribute( 'name' );
+		if ( ! name ) {
+			continue;
+		}
+
+		// Skip submit buttons and button-type inputs.
+		const type = ( field.getAttribute( 'type' ) || '' ).toLowerCase();
+		if ( type === 'submit' || type === 'button' ) {
+			continue;
+		}
+
+		// Skip hidden nonce fields (names starting with _).
+		if ( name.startsWith( '_' ) ) {
+			continue;
+		}
+
+		const metaKey = extractMetaKey( name );
+
+		// Skip known WordPress core fields.
+		if ( KNOWN_CORE_FIELDS.has( metaKey ) ) {
+			continue;
+		}
+
+		// If the field's meta key is not REST-registered, flag it.
+		if ( ! registeredKeys.has( metaKey ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Injects or removes a collaboration warning element in a meta box's DOM.
+ *
+ * @param {HTMLElement} metaBoxElement The meta box DOM element.
+ * @param {string}      id             The meta box ID.
+ * @param {boolean}     shouldShow     Whether the warning should be visible.
+ */
+function updateWarningElement( metaBoxElement, id, shouldShow ) {
+	const warningId = `meta-box-collab-warning-${ id }`;
+	const existing = document.getElementById( warningId );
+
+	if ( ! shouldShow ) {
+		if ( existing ) {
+			existing.remove();
+		}
+		return;
+	}
+
+	if ( existing ) {
+		return;
+	}
+
+	const warning = document.createElement( 'div' );
+	warning.id = warningId;
+	warning.className = 'meta-box-collaboration-warning';
+	warning.setAttribute( 'role', 'status' );
+	warning.setAttribute( 'aria-live', 'polite' );
+
+	const icon = document.createElement( 'span' );
+	icon.className =
+		'dashicons dashicons-warning meta-box-collaboration-warning__icon';
+	icon.setAttribute( 'aria-hidden', 'true' );
+
+	const text = document.createElement( 'span' );
+	text.className = 'meta-box-collaboration-warning__text';
+
+	const srText = document.createElement( 'span' );
+	srText.className = 'screen-reader-text';
+	srText.textContent = __( 'Warning:' ) + ' ';
+
+	text.appendChild( srText );
+	text.appendChild(
+		document.createTextNode(
+			__( 'Changes here may not sync with collaborators.' )
+		)
+	);
+
+	warning.appendChild( icon );
+	warning.appendChild( text );
+
+	const postboxHeader = metaBoxElement.querySelector( '.postbox-header' );
+	if ( postboxHeader ) {
+		postboxHeader.insertAdjacentElement( 'afterend', warning );
+	} else {
+		metaBoxElement.insertAdjacentElement( 'afterbegin', warning );
+	}
+}
+
+export default function MetaBoxCollaborationWarning( { id } ) {
+	const { isCollaborationEnabled, registeredMeta } = useSelect(
+		( select ) => {
+			const { isCollaborationEnabledForCurrentPost, getCurrentPostType } =
+				select( editorStore );
+			const isEnabled = isCollaborationEnabledForCurrentPost();
+			let meta = {};
+			if ( isEnabled ) {
+				const postType = getCurrentPostType();
+				meta =
+					unlock( select( coreStore ) ).getRegisteredPostMeta(
+						postType
+					) ?? {};
+			}
+			return {
+				isCollaborationEnabled: isEnabled,
+				registeredMeta: meta,
+			};
+		},
+		[]
+	);
+
+	useEffect( () => {
+		const metaBoxElement = document.getElementById( id );
+		if ( ! metaBoxElement ) {
+			updateWarningElement( metaBoxElement, id, false );
+			return;
+		}
+
+		if ( ! isCollaborationEnabled ) {
+			updateWarningElement( metaBoxElement, id, false );
+			return;
+		}
+
+		// Custom Fields meta box can edit arbitrary meta — always flag.
+		if ( id === 'postcustom' ) {
+			updateWarningElement( metaBoxElement, id, true );
+		} else {
+			const shouldWarn = hasNonRestFields(
+				metaBoxElement,
+				registeredMeta
+			);
+			updateWarningElement( metaBoxElement, id, shouldWarn );
+		}
+
+		return () => {
+			const warningEl = document.getElementById(
+				`meta-box-collab-warning-${ id }`
+			);
+			if ( warningEl ) {
+				warningEl.remove();
+			}
+		};
+	}, [ id, isCollaborationEnabled, registeredMeta ] );
+
+	return null;
+}

--- a/packages/edit-post/src/components/meta-boxes/meta-box-collaboration-warning.js
+++ b/packages/edit-post/src/components/meta-boxes/meta-box-collaboration-warning.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -68,12 +69,24 @@ function extractMetaKey( fieldName ) {
  *
  * @param {HTMLElement} metaBoxElement The meta box DOM element.
  * @param {Object}      registeredMeta Object whose keys are REST-registered meta key names.
+ * @param {string}      id             The meta box ID.
  * @return {boolean} True if the meta box has non-REST-registered fields.
  */
-function hasNonRestFields( metaBoxElement, registeredMeta ) {
+function hasNonRestFields( metaBoxElement, registeredMeta, id ) {
 	const formFields = metaBoxElement.querySelectorAll(
 		'input[name], select[name], textarea[name]'
 	);
+
+	const extraIgnoredFields = applyFilters(
+		'editPost.metaBoxCollaborationWarning.ignoredFields',
+		[],
+		id
+	);
+
+	const ignoredFields = new Set( [
+		...KNOWN_CORE_FIELDS,
+		...extraIgnoredFields,
+	] );
 
 	const registeredKeys = new Set( Object.keys( registeredMeta ) );
 
@@ -96,8 +109,8 @@ function hasNonRestFields( metaBoxElement, registeredMeta ) {
 
 		const metaKey = extractMetaKey( name );
 
-		// Skip known WordPress core fields.
-		if ( KNOWN_CORE_FIELDS.has( metaKey ) ) {
+		// Skip known WordPress core fields and extra ignored fields.
+		if ( ignoredFields.has( metaKey ) ) {
 			continue;
 		}
 
@@ -203,15 +216,20 @@ export default function MetaBoxCollaborationWarning( { id } ) {
 		}
 
 		// Custom Fields meta box can edit arbitrary meta — always flag.
+		let shouldWarn;
 		if ( id === 'postcustom' ) {
-			updateWarningElement( metaBoxElement, id, true );
+			shouldWarn = true;
 		} else {
-			const shouldWarn = hasNonRestFields(
-				metaBoxElement,
-				registeredMeta
-			);
-			updateWarningElement( metaBoxElement, id, shouldWarn );
+			shouldWarn = hasNonRestFields( metaBoxElement, registeredMeta, id );
 		}
+
+		shouldWarn = applyFilters(
+			'editPost.metaBoxCollaborationWarning.shouldShow',
+			shouldWarn,
+			id
+		);
+
+		updateWarningElement( metaBoxElement, id, shouldWarn );
 
 		return () => {
 			const warningEl = document.getElementById(

--- a/packages/edit-post/src/components/meta-boxes/meta-box-collaboration-warning.js
+++ b/packages/edit-post/src/components/meta-boxes/meta-box-collaboration-warning.js
@@ -14,33 +14,38 @@ import { applyFilters } from '@wordpress/hooks';
 import { unlock } from '../../lock-unlock';
 
 /**
- * Known WordPress core form field names that are not post meta keys.
- * These should be excluded when inspecting meta box form fields.
+ * Classic editor form field names that are not post meta.
+ * These are form/UI-specific fields (nonces, actions, submit buttons,
+ * taxonomy creation inputs) that have no REST API equivalent.
  */
-const KNOWN_CORE_FIELDS = new Set( [
-	'post_ID',
-	'post_type',
+const FORM_ONLY_FIELDS = new Set( [
 	'_wpnonce',
+	'_wp_http_referer',
 	'originalaction',
 	'action',
 	'referredby',
-	'_wp_http_referer',
 	'original_post_status',
+	'hidden_post_status',
 	'save',
 	'publish',
-	'post_status',
-	'hidden_post_status',
-	'post_author',
-	'comment_status',
-	'ping_status',
-	'sticky',
-	'post_format',
-	'tax_input',
 	'newtag',
-	'post_category',
 	'newcategory',
 	'newcategory_parent',
 ] );
+
+/**
+ * Maps classic editor form field names to their REST API property equivalents.
+ * Fields not in this map are assumed to use the same name in both contexts.
+ */
+const FORM_FIELD_TO_REST_PROPERTY = {
+	post_ID: 'id',
+	post_type: 'type',
+	post_status: 'status',
+	post_author: 'author',
+	post_format: 'format',
+	post_category: 'categories',
+	tax_input: 'categories',
+};
 
 /**
  * Extracts likely meta key names from a form field's `name` attribute.
@@ -70,9 +75,10 @@ function extractMetaKey( fieldName ) {
  * @param {HTMLElement} metaBoxElement The meta box DOM element.
  * @param {Object}      registeredMeta Object whose keys are REST-registered meta key names.
  * @param {string}      id             The meta box ID.
+ * @param {string[]}    postFields     REST API property names from the post entity record.
  * @return {boolean} True if the meta box has non-REST-registered fields.
  */
-function hasNonRestFields( metaBoxElement, registeredMeta, id ) {
+function hasNonRestFields( metaBoxElement, registeredMeta, id, postFields ) {
 	const formFields = metaBoxElement.querySelectorAll(
 		'input[name], select[name], textarea[name]'
 	);
@@ -83,8 +89,13 @@ function hasNonRestFields( metaBoxElement, registeredMeta, id ) {
 		id
 	);
 
+	// Build the set of fields to ignore: form-only fields, REST property
+	// names from the entity record, form-field aliases that map to REST
+	// properties, and any extra fields added via filter.
 	const ignoredFields = new Set( [
-		...KNOWN_CORE_FIELDS,
+		...FORM_ONLY_FIELDS,
+		...postFields,
+		...Object.keys( FORM_FIELD_TO_REST_PROPERTY ),
 		...extraIgnoredFields,
 	] );
 
@@ -109,7 +120,7 @@ function hasNonRestFields( metaBoxElement, registeredMeta, id ) {
 
 		const metaKey = extractMetaKey( name );
 
-		// Skip known WordPress core fields and extra ignored fields.
+		// Skip known core fields, REST properties, and extra ignored fields.
 		if ( ignoredFields.has( metaKey ) ) {
 			continue;
 		}
@@ -182,22 +193,34 @@ function updateWarningElement( metaBoxElement, id, shouldShow ) {
 }
 
 export default function MetaBoxCollaborationWarning( { id } ) {
-	const { isCollaborationEnabled, registeredMeta } = useSelect(
+	const { isCollaborationEnabled, registeredMeta, postFields } = useSelect(
 		( select ) => {
-			const { isCollaborationEnabledForCurrentPost, getCurrentPostType } =
-				select( editorStore );
+			const {
+				isCollaborationEnabledForCurrentPost,
+				getCurrentPostType,
+				getCurrentPostId,
+			} = select( editorStore );
 			const isEnabled = isCollaborationEnabledForCurrentPost();
 			let meta = {};
+			let fields = [];
 			if ( isEnabled ) {
 				const postType = getCurrentPostType();
+				const postId = getCurrentPostId();
 				meta =
 					unlock( select( coreStore ) ).getRegisteredPostMeta(
 						postType
 					) ?? {};
+				const record = select( coreStore ).getEditedEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				fields = record ? Object.keys( record ) : [];
 			}
 			return {
 				isCollaborationEnabled: isEnabled,
 				registeredMeta: meta,
+				postFields: fields,
 			};
 		},
 		[]
@@ -220,7 +243,12 @@ export default function MetaBoxCollaborationWarning( { id } ) {
 		if ( id === 'postcustom' ) {
 			shouldWarn = true;
 		} else {
-			shouldWarn = hasNonRestFields( metaBoxElement, registeredMeta, id );
+			shouldWarn = hasNonRestFields(
+				metaBoxElement,
+				registeredMeta,
+				id,
+				postFields
+			);
 		}
 
 		shouldWarn = applyFilters(
@@ -239,7 +267,7 @@ export default function MetaBoxCollaborationWarning( { id } ) {
 				warningEl.remove();
 			}
 		};
-	}, [ id, isCollaborationEnabled, registeredMeta ] );
+	}, [ id, isCollaborationEnabled, registeredMeta, postFields ] );
 
 	return null;
 }

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -107,6 +107,30 @@
 	}
 }
 
+.meta-box-collaboration-warning {
+	background-color: #fcf0cd;
+	border-left: 4px solid #dba617;
+	padding: $grid-unit-10 $grid-unit-30;
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	font-size: 13px;
+	line-height: 1.5;
+	color: $gray-900;
+}
+
+.meta-box-collaboration-warning__icon {
+	flex-shrink: 0;
+	color: #dba617;
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+}
+
+.meta-box-collaboration-warning__text {
+	flex: 1;
+}
+
 .edit-post-meta-boxes-area__clear {
 	clear: both;
 }


### PR DESCRIPTION
## What?

Adds a collaboration warning indicator for meta box fields that may not sync with other collaborators during real-time editing.

Fixes #75308

## Why?

When real-time collaboration is enabled, meta box fields that are not registered with the REST API will not sync to other users. Without a visible indicator, users may not realize their changes are invisible to collaborators, leading to confusion and potential data conflicts.

## How?

Introduces a `MetaBoxCollaborationWarning` component that:
- Checks if collaboration is enabled for the current post
- Inspects meta box DOM elements to find form fields referencing post meta keys not registered with the REST API
- Injects a warning banner ("Changes here may not sync with collaborators") into meta boxes containing non-REST fields
- Always flags the "Custom Fields" meta box (`postcustom`) since it can edit arbitrary meta
- Includes proper accessibility attributes (`role="status"`, `aria-live="polite"`, screen reader text)

## Testing Instructions

1. Enable real-time collaboration on a post.
2. Open a post that has meta boxes with custom fields not registered via the REST API.
3. Verify that a yellow warning banner appears below the meta box header reading "Changes here may not sync with collaborators."
4. Verify the Custom Fields meta box always shows the warning when collaboration is enabled.
5. Verify meta boxes with only REST-registered fields do not show the warning.
6. Verify the warning is removed when collaboration is disabled or the component unmounts.

### Testing Instructions for Keyboard

1. Navigate to a meta box using Tab.
2. Verify the warning banner is announced by screen readers via the `role="status"` and `aria-live="polite"` attributes.
3. Verify the "Warning:" prefix is available as screen reader text.