### PR TITLE
[DO NOT MERGE] Stable reference branch with navigation overlays enabled by default

### DIFF
--- a/.playground-stable
+++ b/.playground-stable
@@ -1,0 +1,3 @@
+# Stable reference for WordPress Playground (gutenberg-branch parameter).
+# Includes navigation overlays enabled by default.
+# See: https://playground.wordpress.net/?gutenberg-branch=playground%2Fnav-overlays-stable-ref


### PR DESCRIPTION
This PR provides a stable reference branch for WP Playground's `gutenberg-branch` config.

**Purpose:**
This branch captures trunk at a point where navigation overlays are enabled by default (the experiment has been removed and overlays are now the default behavior). The current Gutenberg plugin release does not yet include these commits, so this branch allows users to test navigation overlays in Playground without waiting for the next release.

**Branch:** `playground/nav-overlays-stable-ref`
**Base:** `trunk`

**Usage:**
Use this branch name in WP Playground URL:
```
https://playground.wordpress.net/?gutenberg-branch=playground%2Fnav-overlays-stable-ref&url=...
```

**Note:** This PR is for reference only and should not be merged. It exists primarily to provide a stable branch reference for WordPress Playground.