### PR TITLE
DataForm: Style SummaryButton in panel layout with `is-disabled` classname

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### Bug Fixes
 
-- DataForm: Fix summary button a11y issue in panel layout. [#75470](https://github.com/WordPress/gutenberg/pull/75470)
 - DataViews: Improve styling for filters when long values are in use. [#75369](https://github.com/WordPress/gutenberg/pull/75369)
 - DataForm: Fix label case for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)
@@ -24,6 +23,9 @@
 - DataViews: Add details form layout validation. [#74996](https://github.com/WordPress/gutenberg/pull/74996)
 - Add new `adaptiveSelect` DataForm control. [#74937](https://github.com/WordPress/gutenberg/pull/74937)
 - DataViews: Consistent rendering of selection checkbox and actions in grid layout. [#75056](https://github.com/WordPress/gutenberg/pull/75056)
+
+### Code Quality
+- DataForm: Style SummaryButton in panel layout with `is-disabled` classname. [#75470](https://github.com/WordPress/gutenberg/pull/75470)
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- DataForm: Fix summary button a11y issue in panel layout. [#75470](https://github.com/WordPress/gutenberg/pull/75470)
 - DataViews: Improve styling for filters when long values are in use. [#75369](https://github.com/WordPress/gutenberg/pull/75369)
 - DataForm: Fix label case for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)
 - DataViews: Add title attribute in grid item title field. [#75085](https://github.com/WordPress/gutenberg/pull/75085)

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -27,7 +27,7 @@
 		align-items: center;
 	}
 
-	&:not([aria-disabled="true"]):hover {
+	&:not(.is-disabled):hover {
 		color: var(--wp-admin-theme-color);
 
 		.dataforms-layouts-panel__field-trigger-icon {
@@ -39,7 +39,7 @@
 		}
 	}
 
-	&[aria-disabled="true"] {
+	&.is-disabled {
 		cursor: default;
 
 		.dataforms-layouts-panel__field-control {
@@ -50,15 +50,8 @@
 }
 
 .dataforms-layouts-panel__field-trigger-icon {
-	appearance: none;
-	background: none;
-	border: none;
 	padding: 0;
-	margin: 0;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	fill: var(--wp-admin-theme-color);
+	color: var(--wp-admin-theme-color);
 	flex: 0 0 auto;
 	opacity: 0;
 	border-radius: var(--wpds-border-radius-xs);
@@ -71,7 +64,6 @@
 
 	&:focus-visible {
 		opacity: 1;
-		outline: var(--wpds-border-width-focus) solid var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Icon, Tooltip } from '@wordpress/components';
+import { Button, Icon, Tooltip } from '@wordpress/components';
 import { sprintf, _x } from '@wordpress/i18n';
 import { error as errorIcon, pencil } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
@@ -53,7 +53,8 @@ export default function SummaryButton< Item >( {
 	const labelContent = getLabelContent( showError, errorMessage, fieldLabel );
 	const className = clsx(
 		'dataforms-layouts-panel__field-trigger',
-		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`
+		`dataforms-layouts-panel__field-trigger--label-${ labelPosition }`,
+		{ 'is-disabled': disabled }
 	);
 
 	const controlId = useInstanceId(
@@ -74,7 +75,7 @@ export default function SummaryButton< Item >( {
 		  );
 
 	return (
-		<div className={ className } aria-disabled={ disabled || undefined }>
+		<div className={ className }>
 			{ labelPosition !== 'none' && (
 				<span className={ labelClassName }>{ labelContent }</span>
 			) }
@@ -121,19 +122,20 @@ export default function SummaryButton< Item >( {
 					) )
 				) }
 			</span>
-			{ ! disabled && (
-				<button
-					type="button"
-					className="dataforms-layouts-panel__field-trigger-icon"
-					aria-label={ ariaLabel }
-					aria-expanded={ ariaExpanded }
-					aria-haspopup="dialog"
-					aria-describedby={ `${ controlId }` }
-					onClick={ onClick }
-				>
-					<Icon icon={ pencil } size={ 24 } />
-				</button>
-			) }
+			<Button
+				__next40pxDefaultSize
+				className="dataforms-layouts-panel__field-trigger-icon"
+				label={ ariaLabel }
+				showTooltip={ false }
+				icon={ pencil }
+				size="small"
+				aria-expanded={ ariaExpanded }
+				aria-haspopup="dialog"
+				aria-describedby={ `${ controlId }` }
+				disabled={ disabled }
+				accessibleWhenDisabled
+				onClick={ onClick }
+			/>
 		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -123,14 +123,13 @@ export default function SummaryButton< Item >( {
 				) }
 			</span>
 			<Button
-				__next40pxDefaultSize
 				className="dataforms-layouts-panel__field-trigger-icon"
 				label={ ariaLabel }
 				showTooltip={ false }
 				icon={ pencil }
 				size="small"
-				aria-expanded={ ariaExpanded }
-				aria-haspopup="dialog"
+				aria-expanded={ disabled ? undefined : ariaExpanded }
+				aria-haspopup={ disabled ? undefined : 'dialog' }
 				aria-describedby={ `${ controlId }` }
 				disabled={ disabled }
 				accessibleWhenDisabled

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -122,19 +122,19 @@ export default function SummaryButton< Item >( {
 					) )
 				) }
 			</span>
-			<Button
-				className="dataforms-layouts-panel__field-trigger-icon"
-				label={ ariaLabel }
-				showTooltip={ false }
-				icon={ pencil }
-				size="small"
-				aria-expanded={ disabled ? undefined : ariaExpanded }
-				aria-haspopup={ disabled ? undefined : 'dialog' }
-				aria-describedby={ `${ controlId }` }
-				disabled={ disabled }
-				accessibleWhenDisabled
-				onClick={ onClick }
-			/>
+			{ ! disabled && (
+				<Button
+					className="dataforms-layouts-panel__field-trigger-icon"
+					label={ ariaLabel }
+					showTooltip={ false }
+					icon={ pencil }
+					size="small"
+					aria-expanded={ ariaExpanded }
+					aria-haspopup="dialog"
+					aria-describedby={ `${ controlId }` }
+					onClick={ onClick }
+				/>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/75290

This PR addresses this a11y issue: https://github.com/WordPress/gutenberg/pull/75290#discussion_r2790062203

Having `aria-disabled` in a generic not focusable `div` is not useful for a11y, but we want some styles for 'disabled' fields. This PR does that and additionally  I updated to use `Button` from components package to get some styles for free and the `accessibleWhenDisabled` functionality.




## Testing Instructions
2. Visually everything should be the same as trunk (button, on hover, on focus styles etc..) 
