### PR TITLE
Tabs: Improve tab keyboard nav

### DIFF
--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -34,8 +34,8 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 		$tag_processor->remove_attribute( 'hidden' );
 
 		// Set tab-specific attributes
+		$tag_processor->set_attribute( 'type', 'button' );
 		$tag_processor->set_attribute( 'id', 'tab__' . $tab_id );
-		$tag_processor->set_attribute( 'href', '#' . $tab_id );
 		$tag_processor->set_attribute( 'role', 'tab' );
 		$tag_processor->set_attribute( 'aria-controls', $tab_id );
 
@@ -56,10 +56,10 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 	// Get updated HTML and inject the label
 	$output = $tag_processor->get_updated_html();
 
-	// The save.js outputs <a><span class="screen-reader-text">...</span></a>
-	// Replace the anchor content with the actual tab label
+	// The save.js outputs <button><span class="screen-reader-text">...</span></button>
+	// Replace the button content with the actual tab label
 	$output = preg_replace(
-		'/(<a[^>]*>).*?(<\/a>)/s',
+		'/(<button[^>]*>).*?(<\/button>)/s',
 		'$1' . '<span>' . esc_html( html_entity_decode( $tab_label ) ) . '</span>' . '$2',
 		$output
 	);

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -40,7 +40,6 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 		// Add IAPI directives
 		$tag_processor->set_attribute( 'data-wp-on--click', 'actions.handleTabClick' );
 		$tag_processor->set_attribute( 'data-wp-on--keydown', 'actions.handleTabKeyDown' );
-		$tag_processor->set_attribute( 'data-wp-on--keyup', 'actions.handleTabKeyUp' );
 		$tag_processor->set_attribute( 'data-wp-bind--aria-selected', 'state.isActiveTab' );
 		$tag_processor->set_attribute( 'data-wp-bind--tabindex', 'state.tabIndexAttribute' );
 

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -42,6 +42,7 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 		// Add IAPI directives
 		$tag_processor->set_attribute( 'data-wp-on--click', 'actions.handleTabClick' );
 		$tag_processor->set_attribute( 'data-wp-on--keydown', 'actions.handleTabKeyDown' );
+		$tag_processor->set_attribute( 'data-wp-on--keyup', 'actions.handleTabKeyUp' );
 		$tag_processor->set_attribute( 'data-wp-bind--aria-selected', 'state.isActiveTab' );
 		$tag_processor->set_attribute( 'data-wp-bind--tabindex', 'state.tabIndexAttribute' );
 

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -34,9 +34,7 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 		$tag_processor->remove_attribute( 'hidden' );
 
 		// Set tab-specific attributes
-		$tag_processor->set_attribute( 'type', 'button' );
 		$tag_processor->set_attribute( 'id', 'tab__' . $tab_id );
-		$tag_processor->set_attribute( 'role', 'tab' );
 		$tag_processor->set_attribute( 'aria-controls', $tab_id );
 
 		// Add IAPI directives

--- a/packages/block-library/src/tabs-menu-item/save.js
+++ b/packages/block-library/src/tabs-menu-item/save.js
@@ -35,10 +35,10 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<a { ...blockProps }>
+		<button type="button" { ...blockProps }>
 			<span className="screen-reader-text">
 				{ __( 'Tab menu item' ) }
 			</span>
-		</a>
+		</button>
 	);
 }

--- a/packages/block-library/src/tabs-menu-item/save.js
+++ b/packages/block-library/src/tabs-menu-item/save.js
@@ -32,10 +32,12 @@ export default function save( { attributes } ) {
 		className: 'wp-block-tabs-menu-item__template',
 		style: customColorStyles,
 		hidden: true,
+		type: 'button',
+		role: 'tab',
 	} );
 
 	return (
-		<button type="button" { ...blockProps }>
+		<button { ...blockProps }>
 			<span className="screen-reader-text">
 				{ __( 'Tab menu item' ) }
 			</span>

--- a/packages/block-library/src/tabs-menu-item/style.scss
+++ b/packages/block-library/src/tabs-menu-item/style.scss
@@ -7,6 +7,12 @@
 	flex-basis: inherit !important;
 	flex-grow: inherit !important;
 
+	// Button reset
+	border: none;
+	background: none;
+	appearance: none;
+	-webkit-appearance: none;
+
 	margin: 0;
 	padding-block: var(--tab-padding-block, var(--wp--preset--spacing--20, 0.5em));
 	padding-inline: var(--tab-padding-inline, var(--wp--preset--spacing--30, 1em));

--- a/packages/block-library/src/tabs-menu/index.php
+++ b/packages/block-library/src/tabs-menu/index.php
@@ -50,7 +50,7 @@ function block_core_tabs_menu_render_callback( array $attributes, string $conten
 
 	// Find the template block and replace it in $content with $tabs_markup
 	$content = preg_replace(
-		'/<a\b[^>]*\bwp-block-tabs-menu-item__template\b[^>]*>.*?<\/a>/si',
+		'/<button\b[^>]*\bwp-block-tabs-menu-item__template\b[^>]*>.*?<\/button>/si',
 		$tabs_markup,
 		$content
 	);

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -118,9 +118,9 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 		'data-wp-context',
 		wp_json_encode(
 			array(
-				'tabsId'          => $tabs_id,
-				'activeTabIndex'  => $active_tab_index,
-				'isVertical'      => $is_vertical,
+				'tabsId'         => $tabs_id,
+				'activeTabIndex' => $active_tab_index,
+				'isVertical'     => $is_vertical,
 			)
 		)
 	);

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -118,9 +118,10 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 		'data-wp-context',
 		wp_json_encode(
 			array(
-				'tabsId'         => $tabs_id,
-				'activeTabIndex' => $active_tab_index,
-				'isVertical'     => $is_vertical,
+				'tabsId'          => $tabs_id,
+				'activeTabIndex'  => $active_tab_index,
+				'focusedTabIndex' => $active_tab_index,
+				'isVertical'      => $is_vertical,
 			)
 		)
 	);

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -120,7 +120,6 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 			array(
 				'tabsId'          => $tabs_id,
 				'activeTabIndex'  => $active_tab_index,
-				'focusedTabIndex' => $active_tab_index,
 				'isVertical'      => $is_vertical,
 			)
 		)

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -86,12 +86,23 @@ const { actions: privateActions, state: privateState } = store(
 				return activeTabIndex === tabIndex;
 			},
 			/**
-			 * The value of the tabindex attribute.
+			 * Whether the tab has keyboard focus.
 			 *
-			 * @type {false|string}
+			 * @type {boolean}
+			 */
+			get isFocusedTab() {
+				const { focusedTabIndex } = getContext();
+				const { tabIndex } = privateState;
+				return focusedTabIndex === tabIndex;
+			},
+			/**
+			 * The value of the tabindex attribute.
+			 * Only the focused tab should be keyboard-focusable.
+			 *
+			 * @type {number}
 			 */
 			get tabIndexAttribute() {
-				return privateState.isActiveTab ? -1 : 0;
+				return privateState.isFocusedTab ? 0 : -1;
 			},
 		},
 		actions: {
@@ -101,33 +112,48 @@ const { actions: privateActions, state: privateState } = store(
 			 * @param {KeyboardEvent} event The keydown event.
 			 */
 			handleTabKeyDown: withSyncEvent( ( event ) => {
-				// If this is the enter key then lets get the tab index from context and set the active tab to that index.
-				const { isVertical } = getContext();
+				const context = getContext();
+				const { isVertical } = context;
+				const { tabIndex } = privateState;
+
+				if ( tabIndex === null ) {
+					return;
+				}
+
 				if ( event.key === 'Enter' ) {
-					const { tabIndex } = privateState;
-					if ( tabIndex !== null ) {
-						privateActions.setActiveTab( tabIndex );
-					}
+					event.preventDefault();
+					privateActions.setActiveTab( tabIndex );
+				} else if ( event.key === ' ' ) {
+					event.preventDefault();
 				} else if ( event.key === 'ArrowRight' && ! isVertical ) {
-					const { tabIndex } = privateState;
-					if ( tabIndex !== null ) {
-						privateActions.setActiveTab( tabIndex + 1 );
-					}
+					event.preventDefault();
+					privateActions.moveFocus( tabIndex + 1 );
 				} else if ( event.key === 'ArrowLeft' && ! isVertical ) {
-					const { tabIndex } = privateState;
-					if ( tabIndex !== null ) {
-						privateActions.setActiveTab( tabIndex - 1 );
-					}
+					event.preventDefault();
+					privateActions.moveFocus( tabIndex - 1 );
 				} else if ( event.key === 'ArrowDown' && isVertical ) {
-					const { tabIndex } = privateState;
-					if ( tabIndex !== null ) {
-						privateActions.setActiveTab( tabIndex + 1 );
-					}
+					event.preventDefault();
+					privateActions.moveFocus( tabIndex + 1 );
 				} else if ( event.key === 'ArrowUp' && isVertical ) {
-					const { tabIndex } = privateState;
-					if ( tabIndex !== null ) {
-						privateActions.setActiveTab( tabIndex - 1 );
-					}
+					event.preventDefault();
+					privateActions.moveFocus( tabIndex - 1 );
+				}
+			} ),
+			/**
+			 * Handles the keyup event for the tab label.
+			 *
+			 * @param {KeyboardEvent} event The keyup event.
+			 */
+			handleTabKeyUp: withSyncEvent( ( event ) => {
+				const { tabIndex } = privateState;
+
+				if ( tabIndex === null ) {
+					return;
+				}
+
+				if ( event.key === ' ' ) {
+					event.preventDefault();
+					privateActions.setActiveTab( tabIndex );
 				}
 			} ),
 			/**
@@ -144,16 +170,59 @@ const { actions: privateActions, state: privateState } = store(
 				}
 			} ),
 			/**
+			 * Moves focus to a specific tab without activating it.
+			 *
+			 * @param {number} tabIndex The index to move focus to.
+			 */
+			moveFocus: ( tabIndex ) => {
+				const { tabsList } = privateState;
+
+				if ( ! tabsList || tabsList.length === 0 ) {
+					return;
+				}
+
+				let newIndex = tabIndex;
+				if ( newIndex < 0 ) {
+					newIndex = tabsList.length - 1;
+				} else if ( newIndex >= tabsList.length ) {
+					newIndex = 0;
+				}
+
+				const context = getContext();
+				context.focusedTabIndex = newIndex;
+
+				const tabId = tabsList[ newIndex ].id;
+				const tabElement = document.getElementById( 'tab__' + tabId );
+				if ( tabElement ) {
+					tabElement.focus();
+				}
+			},
+			/**
 			 * Sets the active tab index (internal implementation).
 			 *
 			 * @param {number}  tabIndex    The index of the active tab.
 			 * @param {boolean} scrollToTab Whether to scroll to the tab element.
 			 */
 			setActiveTab: ( tabIndex, scrollToTab = false ) => {
+				const { tabsList } = privateState;
+
+				if ( ! tabsList || tabsList.length === 0 ) {
+					return;
+				}
+
+				let newIndex = tabIndex;
+				if ( newIndex < 0 ) {
+					newIndex = 0;
+				} else if ( newIndex >= tabsList.length ) {
+					newIndex = tabsList.length - 1;
+				}
+
 				const context = getContext();
-				context.activeTabIndex = tabIndex;
+				context.activeTabIndex = newIndex;
+				context.focusedTabIndex = newIndex;
+
 				if ( scrollToTab ) {
-					const tabId = privateState.tabsList[ tabIndex ].id;
+					const tabId = tabsList[ newIndex ].id;
 					const tabElement = document.getElementById( tabId );
 					if ( tabElement ) {
 						setTimeout( () => {
@@ -173,6 +242,12 @@ const { actions: privateActions, state: privateState } = store(
 				if ( tabsList.length === 0 ) {
 					return;
 				}
+
+				const context = getContext();
+				if ( context.focusedTabIndex === undefined ) {
+					context.focusedTabIndex = context.activeTabIndex ?? 0;
+				}
+
 				const { hash } = window.location;
 				const tabId = hash.replace( '#', '' );
 				const tabIndex = tabsList.findIndex( ( t ) => t.id === tabId );

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -110,12 +110,7 @@ const { actions: privateActions, state: privateState } = store(
 					return;
 				}
 
-				if ( event.key === 'Enter' ) {
-					event.preventDefault();
-					privateActions.setActiveTab( tabIndex );
-				} else if ( event.key === ' ' ) {
-					event.preventDefault();
-				} else if ( event.key === 'ArrowRight' && ! isVertical ) {
+				if ( event.key === 'ArrowRight' && ! isVertical ) {
 					event.preventDefault();
 					privateActions.moveFocus( tabIndex + 1 );
 				} else if ( event.key === 'ArrowLeft' && ! isVertical ) {
@@ -127,23 +122,6 @@ const { actions: privateActions, state: privateState } = store(
 				} else if ( event.key === 'ArrowUp' && isVertical ) {
 					event.preventDefault();
 					privateActions.moveFocus( tabIndex - 1 );
-				}
-			} ),
-			/**
-			 * Handles the keyup event for the tab label.
-			 *
-			 * @param {KeyboardEvent} event The keyup event.
-			 */
-			handleTabKeyUp: withSyncEvent( ( event ) => {
-				const { tabIndex } = privateState;
-
-				if ( tabIndex === null ) {
-					return;
-				}
-
-				if ( event.key === ' ' ) {
-					event.preventDefault();
-					privateActions.setActiveTab( tabIndex );
 				}
 			} ),
 			/**

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -86,23 +86,13 @@ const { actions: privateActions, state: privateState } = store(
 				return activeTabIndex === tabIndex;
 			},
 			/**
-			 * Whether the tab has keyboard focus.
-			 *
-			 * @type {boolean}
-			 */
-			get isFocusedTab() {
-				const { focusedTabIndex } = getContext();
-				const { tabIndex } = privateState;
-				return focusedTabIndex === tabIndex;
-			},
-			/**
 			 * The value of the tabindex attribute.
-			 * Only the focused tab should be keyboard-focusable.
+			 * Only the active tab should be in the tab sequence.
 			 *
 			 * @type {number}
 			 */
 			get tabIndexAttribute() {
-				return privateState.isFocusedTab ? 0 : -1;
+				return privateState.isActiveTab ? 0 : -1;
 			},
 		},
 		actions: {

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -156,9 +156,6 @@ const { actions: privateActions, state: privateState } = store(
 					newIndex = 0;
 				}
 
-				const context = getContext();
-				context.focusedTabIndex = newIndex;
-
 				const tabId = tabsList[ newIndex ].id;
 				const tabElement = document.getElementById( 'tab__' + tabId );
 				if ( tabElement ) {
@@ -187,7 +184,6 @@ const { actions: privateActions, state: privateState } = store(
 
 				const context = getContext();
 				context.activeTabIndex = newIndex;
-				context.focusedTabIndex = newIndex;
 
 				if ( scrollToTab ) {
 					const tabId = tabsList[ newIndex ].id;
@@ -209,11 +205,6 @@ const { actions: privateActions, state: privateState } = store(
 				const { tabsList } = privateState;
 				if ( tabsList.length === 0 ) {
 					return;
-				}
-
-				const context = getContext();
-				if ( context.focusedTabIndex === undefined ) {
-					context.focusedTabIndex = context.activeTabIndex ?? 0;
 				}
 
 				const { hash } = window.location;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/75402

<!-- In a few words, what is the PR actually doing? -->

Fixes some keyboard accessibility issues in the Tabs block by implementing proper ARIA tabs pattern navigation, including manual activation mode, roving tabindex management, and button semantics.

cc @sethrubenstein 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Tabs block had several keyboard accessibility issues that prevented it from following the [W3C ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/):

  1. Active tab was not focusable: The active tab had `tabindex="-1"`, making it impossible to reach via keyboard
  2. Arrow keys auto-activated tabs: Tabs changed immediately on arrow navigation, which is not recommended and caused focus management issues
  3. Arrow navigation broke completely: Tabindex was mismanaged during navigation, causing tabs to become unreachable
  4. Space key didn't work: Tabs only responded to Enter, not Space
  5. Wrong element type: Used `<a>` elements instead of semantic `<button>` elements

These issues made the Tabs block difficult to use with keyboard navigation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changed tabs to `<button>` elements:
  - Updated `tabs-menu-item/save.js` to use `<button type="button">` instead of `<a>`
  - Updated PHP render callbacks to remove `href` attribute and add `type="button"`
  - Added button reset styles to remove default button appearance
  - Updated regex patterns in both `tabs-menu-item/index.php` and `tabs-menu/index.php` to match `<button>` tags

 Implemented roving tabindex management:
  - Added `focusedTabIndex` state separate from `activeTabIndex`
  - Added `isFocusedTab` computed state to track keyboard focus
  - Fixed `tabIndexAttribute` logic: focused tab gets `tabindex="0"`, all others get `tabindex="-1"`

 Implemented manual activation mode:
  - Added `moveFocus()` action that updates focus without activating tabs
  - Arrow keys now only move focus between tabs (with wrapping at boundaries)
  - Enter and Space keys activate the focused tab

 Added Space key support:
  - Space key activates on `keyup` 
  - Added `handleTabKeyUp` action

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

  1. Create a new post or page
  2. Insert a Tabs block
  3. Add at least 3 tabs with different content in each tab panel
  4. Save and view the page on the front end

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

  1. **Test Tab key reaches first tab:**
     - Place focus before the tabs block (e.g., in browser address bar)
     - Press `Tab` key
     - Verify: Focus moves to the currently active tab (not skipping it)

  2. **Test arrow key navigation:**
     - With a tab focused, press `Right Arrow` (or `Down Arrow` if vertical)
     - Verify: Focus moves to the next tab but the tab panel content does NOT change
     - Press `Right Arrow` again
     - Verify: Focus continues moving through tabs without activating them
     - Press `Left Arrow`
     - Verify: Focus moves backward through tabs
     - From the last tab, press `Right Arrow`
     - Verify: Focus wraps to the first tab

  3. **Test tab activation:**
     - Use arrow keys to move focus to a different tab
     - Press `Enter` key
     - Verify: The focused tab activates and its panel content is displayed
     - Use arrow keys to move focus to another tab
     - Press `Space` key
     - Verify: The focused tab activates and its panel content is displayed

  4. **Test focus indicators:**
     - Navigate through tabs with arrow keys
     - Verify: The focus indicator is always visible on exactly one tab
     - Verify: No focus jumps or lost focus during navigation

  5. **Test with vertical tabs:**
     - Set the tabs to vertical orientation in the block settings
     - Repeat tests 1-4 using `Up Arrow` and `Down Arrow` instead
     - Verify: All navigation works correctly

  6. **Test mouse interaction:**
     - Click on a tab
     - Verify: The tab activates and becomes focusable
     - Use arrow keys from there
     - Verify: Keyboard navigation still works correctly

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



https://github.com/user-attachments/assets/035323ec-3de0-40cd-a158-05cd9fcdba4c

