### PR TITLE
Theme: Render default density selector last in design tokens CSS

### DIFF
--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -144,24 +144,6 @@
 	--wpds-font-weight-regular: 400; /* Regular font weight for body text */
 }
 
-[data-wpds-theme-provider-id][data-wpds-density='default'] {
-	--wpds-dimension-base: 4px; /* Base dimension unit */
-	--wpds-dimension-gap-2xl: 32px; /* 2x extra large gap */
-	--wpds-dimension-gap-3xl: 40px; /* 3x extra large gap */
-	--wpds-dimension-gap-lg: 16px; /* Large gap */
-	--wpds-dimension-gap-md: 12px; /* Medium gap */
-	--wpds-dimension-gap-sm: 8px; /* Small gap */
-	--wpds-dimension-gap-xl: 24px; /* Extra large gap */
-	--wpds-dimension-gap-xs: 4px; /* Extra small gap */
-	--wpds-dimension-padding-2xl: 24px; /* 2x extra large padding */
-	--wpds-dimension-padding-3xl: 32px; /* 3x extra large padding */
-	--wpds-dimension-padding-lg: 16px; /* Large padding */
-	--wpds-dimension-padding-md: 12px; /* Medium padding */
-	--wpds-dimension-padding-sm: 8px; /* Small padding */
-	--wpds-dimension-padding-xl: 20px; /* Extra large padding */
-	--wpds-dimension-padding-xs: 4px; /* Extra small padding */
-}
-
 [data-wpds-theme-provider-id][data-wpds-density='compact'] {
 	--wpds-dimension-gap-2xl: 24px; /* 2x extra large gap */
 	--wpds-dimension-gap-3xl: 32px; /* 3x extra large gap */
@@ -194,6 +176,24 @@
 	--wpds-dimension-padding-sm: 12px; /* Small padding */
 	--wpds-dimension-padding-xl: 24px; /* Extra large padding */
 	--wpds-dimension-padding-xs: 8px; /* Extra small padding */
+}
+
+[data-wpds-theme-provider-id][data-wpds-density='default'] {
+	--wpds-dimension-base: 4px; /* Base dimension unit */
+	--wpds-dimension-gap-2xl: 32px; /* 2x extra large gap */
+	--wpds-dimension-gap-3xl: 40px; /* 3x extra large gap */
+	--wpds-dimension-gap-lg: 16px; /* Large gap */
+	--wpds-dimension-gap-md: 12px; /* Medium gap */
+	--wpds-dimension-gap-sm: 8px; /* Small gap */
+	--wpds-dimension-gap-xl: 24px; /* Extra large gap */
+	--wpds-dimension-gap-xs: 4px; /* Extra small gap */
+	--wpds-dimension-padding-2xl: 24px; /* 2x extra large padding */
+	--wpds-dimension-padding-3xl: 32px; /* 3x extra large padding */
+	--wpds-dimension-padding-lg: 16px; /* Large padding */
+	--wpds-dimension-padding-md: 12px; /* Medium padding */
+	--wpds-dimension-padding-sm: 8px; /* Small padding */
+	--wpds-dimension-padding-xl: 20px; /* Extra large padding */
+	--wpds-dimension-padding-xs: 4px; /* Extra small padding */
 }
 
 @media ( -webkit-min-device-pixel-ratio: 2 ), ( min-resolution: 192dpi ) {

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -64,13 +64,6 @@ export default defineConfig( {
 			modeSelectors: [
 				{
 					tokens: [ 'wpds-dimension.*' ],
-					mode: '.',
-					selectors: [
-						"[data-wpds-theme-provider-id][data-wpds-density='default']",
-					],
-				},
-				{
-					tokens: [ 'wpds-dimension.*' ],
 					mode: 'compact',
 					selectors: [
 						"[data-wpds-theme-provider-id][data-wpds-density='compact']",
@@ -81,6 +74,13 @@ export default defineConfig( {
 					mode: 'comfortable',
 					selectors: [
 						"[data-wpds-theme-provider-id][data-wpds-density='comfortable']",
+					],
+				},
+				{
+					tokens: [ 'wpds-dimension.*' ],
+					mode: '.',
+					selectors: [
+						"[data-wpds-theme-provider-id][data-wpds-density='default']",
 					],
 				},
 				{


### PR DESCRIPTION
## What?

Reorders the density mode selectors in the Terrazzo config so that the `default` density block is rendered last in the generated CSS.

## Why?

When hovering over a CSS variable (e.g. `var(--wpds-dimension-gap-sm)`) in the IDE, IntelliSense shows the resolved value from the last definition in the file (at least in my Cursor environment). Previously, `comfortable` was rendered last, so the IDE would show comfortable density values (e.g. 12px for `gap-sm`) instead of the default values (8px). Rendering the `default` density block last makes the IDE show the most commonly applicable values.

## How?

Reorder the `modeSelectors` array in `terrazzo.config.ts` from `default → compact → comfortable` to `compact → comfortable → default`, and regenerate the prebuilt files.

## Testing Instructions

1. Inspect the generated `packages/theme/src/prebuilt/css/design-tokens.css`.
2. The `[data-wpds-density='default']` block should appear after `compact` and `comfortable`.
3. Hover over a dimension CSS token in your IDE and see what pixel value it shows. Click through (go to definition) and see that it goes to the definition in the default density block.