### PR TITLE
Gutenberg plugin: always enforce the iframe in the post editor

### DIFF
--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -15,18 +15,19 @@ const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
 
 export function useShouldIframe() {
 	return useSelect( ( select ) => {
-		const { getEditorSettings, getCurrentPostType, getDeviceType } =
-			select( editorStore );
+		const { getCurrentPostType, getDeviceType } = select( editorStore );
 		const { getClientIdsWithDescendants, getBlockName } =
 			select( blockEditorStore );
 		const { getBlockType } = select( blocksStore );
 
 		return (
-			// If the theme is block based and the Gutenberg plugin is active,
-			// we ALWAYS use the iframe for consistency across the post and site
-			// editor.
-			( isGutenbergPlugin &&
-				getEditorSettings().__unstableIsBlockBasedTheme ) ||
+			// If the Gutenberg plugin is active, we ALWAYS use the iframe for
+			// consistency across the post and site editor. We plan on enforcing
+			// the iframe in the future, so Gutenberg both serves as way for us
+			// to warn plugin developers and for plugin developers to test their
+			// blocks easily. Before GB v22.5, we only enforced it for
+			// block-based themes (classic themes used the same rules as core).
+			isGutenbergPlugin ||
 			// We also still want to iframe all the special
 			// editor features and modes such as device previews, zoom out, and
 			// template/pattern editing.

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -8,7 +8,7 @@ test.describe( 'Should iframe', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should switch to non-iframe when a v2 block is added', async ( {
+	test( 'should remain iframed when a v1 block is added', async ( {
 		page,
 		editor,
 	} ) => {
@@ -33,7 +33,7 @@ test.describe( 'Should iframe', () => {
 		// Insert the v1 block.
 		await editor.insertBlock( { name: 'test/v1' } );
 
-		// The editor should no longer be iframed.
-		await expect( iframe ).toBeHidden();
+		// The editor should remain iframed because Gutenberg is active.
+		await expect( iframe ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

#74042, but only for the Gutenberg plugin. See more information there but in short:

* This only affects the post editor. All other editors are already iframed, including all previews.
* This only affects classic themes. We already enforce the iframe for block-based themes.
* We already iframe the classic themes too, except if there are blocks inserted that are v2 or lower, so there's no compatibility concerns regarding themes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Quoting #74042:

> Themes and plugins are used to having content appear in an iframe and often don't consider both iframed and non-iframe editors, which causes a lot of frustration when an editor suddenly switches to a non-iframed if the user installs a plugin with a API v1 or v2 block. For example: https://x.com/thekevingeary/status/1803760573718397081.
>
> On the other hand we might cause some breakage for some blocks that don't render or function well in an iframe. Out of caution we disable the iframe when there any plugin adds any block that is less than version 3, even though they might function fine. (We check for installed blocks rather than inserted blocks because we don't want to flip this mid editing.)
>
> We're probably at a point where far more breakage is caused by the inconsistency than blocks not functioning well with iframe.
>
> Let's enforce the iframe early in Gutenberg so that we get early feedback about the non functioning blocks. That way we can work on one of the back-compat techniques described in https://github.com/WordPress/gutenberg/issues/73138#issuecomment-3542479748.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adjust the check. Note that we also need to remove the e2e test, we can no longer test the non-GB behavior. We should probably move this test to core.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try a classic theme with v2 blocks.

```js
window.wp.blocks.registerBlockType( 'test/v1', {
  apiVersion: 1,
  title: 'Test V1 Block',
  edit: () =>
	  window.wp.element.createElement( 'p', null, 'v1 block' ),
  save: () => null,
} );
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
