### PR TITLE
Hide navigation-overlay template parts from inserter

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -195,7 +195,7 @@ function build_template_part_block_area_variations( $instance_variations ) {
 	$defined_areas = get_allowed_block_template_part_areas();
 
 	foreach ( $defined_areas as $area ) {
-		if ( 'uncategorized' !== $area['area'] ) {
+		if ( 'uncategorized' !== $area['area'] && 'navigation-overlay' !== $area['area'] ) {
 			$has_instance_for_area = false;
 			foreach ( $instance_variations as $variation ) {
 				if ( $variation['attributes']['area'] === $area['area'] ) {
@@ -250,6 +250,13 @@ function build_template_part_block_instance_variations() {
 	$icon_by_area  = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
 
 	foreach ( $template_parts as $template_part ) {
+		// Navigation overlay template parts should not appear in the
+		// general inserter. They are managed through the Navigation
+		// block's overlay template part selector.
+		$scope = ( 'navigation-overlay' === $template_part->area )
+			? array()
+			: array( 'inserter' );
+
 		$variations[] = array(
 			'name'        => 'instance_' . sanitize_title( $template_part->slug ),
 			'title'       => $template_part->title,
@@ -263,7 +270,7 @@ function build_template_part_block_instance_variations() {
 				'theme' => $template_part->theme,
 				'area'  => $template_part->area,
 			),
-			'scope'       => array( 'inserter' ),
+			'scope'       => $scope,
 			'icon'        => $icon_by_area[ $template_part->area ] ?? null,
 			'example'     => array(
 				'attributes' => array(


### PR DESCRIPTION
## What?

Excludes navigation-overlay template parts from the general block inserter.

Closes to #75241 (this PR addresses the final template part variations aspect).

## Why?

Navigation overlay template parts are designed specifically for use within the Navigation block's overlay configuration. When they appear in the general block inserter (when searching "overlay", etc.), users can insert them at the template root level where they don't function correctly and cause confusion.

Currently, each user-created overlay template part (e.g., "Overlay", "Overlay 2") appears as a separate variation in the block inserter. The generic "Navigation Overlay" area variation also appears when no overlay template parts exist. These should not be available in the general inserter since overlays are managed through the Navigation block's overlay selector.

## How?

This PR excludes navigation-overlay template parts from the block inserter by:

1. **Instance variations** (user-created overlays): Sets empty scope (`scope: []`) instead of `scope: ['inserter']` in `build_template_part_block_instance_variations()`. The variations still exist (for block inspector, `isActive` matching) but are excluded from the inserter.

2. **Area variation** (generic "Navigation Overlay"): Skips creating the navigation-overlay area variation entirely in `build_template_part_block_area_variations()` (similar to the existing `uncategorized` skip). This prevents the generic "Navigation Overlay" block from being created when no overlay template parts exist.

The Navigation block's overlay selector queries template parts directly via the entity store (`useEntityRecords`) and is unaffected by inserter scope changes.

## Testing Instructions

### Test instance variations (user-created overlays)

1. Create overlay template parts (Navigation → Overlay → Create overlay, or use existing overlays)
2. Open the site editor and search "overlay" in the block inserter
3. **Expected**: User-created overlay template parts (e.g., "Overlay", "Overlay 2") should NOT appear
4. Verify header/footer template parts still appear normally when searching

### Test area variation (generic "Navigation Overlay")

**Note**: The area variation only appears when NO overlay template parts exist. You must delete all overlay template parts to test this.

1. Delete all navigation-overlay template parts from your site
2. Search "overlay" in the block inserter
3. **Expected**: The generic "Navigation Overlay" block should NOT appear

### Verify Navigation block overlay selector

1. Insert a Navigation block
2. Open block settings → Overlay configuration
3. **Expected**: Overlay template part selector still works - you can select existing overlays and create new ones
4. Create a new overlay from the Navigation block settings
5. **Expected**: The new overlay template part is created and selectable

## Future considerations

A better long-term solution would be to enhance the template part areas API (via the `default_wp_template_part_areas` filter) to include a `show_in_inserter` flag or similar option. This would allow any area to declaratively opt out of the inserter without requiring hardcoded checks for specific area names.

However, given the proximity to WordPress 7.0, this PR takes the pragmatic approach of hardcoding the `navigation-overlay` exclusion. The API enhancement can be addressed in a future release.

### Screenshots or screencast

<!-- Provide screenshots or a short video demonstrating the change -->

https://github.com/user-attachments/assets/e6ac6c57-a900-439c-bcf8-aa6b4808b94b

