### PR TITLE
Tabs: Add text and background color support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1039,7 +1039,7 @@ Display content in a tabbed interface to help users navigate detailed content wi
 -	**Experimental:** true
 -	**Category:** design
 -	**Allowed Blocks:** core/tabs-menu, core/tab-panel
--	**Supports:** align, anchor, color (~~background~~, ~~text~~), interactivity, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowVerticalAlignment, default, ~~allowSwitching~~), renaming, spacing (blockGap, margin, padding), typography (fontSize), ~~html~~
+-	**Supports:** align, anchor, color (background, text), interactivity, layout (allowJustification, allowOrientation, allowSizingOnChildren, allowVerticalAlignment, default, ~~allowSwitching~~), renaming, spacing (blockGap, margin, padding), typography (fontSize), ~~html~~
 -	**Attributes:** activeTabIndex, editorActiveTabIndex
 
 ## Tabs Menu

--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -23,8 +23,12 @@
 		"align": true,
 		"anchor": true,
 		"color": {
-			"text": false,
-			"background": false
+			"text": true,
+			"background": true,
+			"__experimentalDefaultControls": {
+				"text": true,
+				"background": true
+			}
 		},
 		"layout": {
 			"default": {


### PR DESCRIPTION
## Summary

Enable text and background color support for the Tabs block, with default controls visible in the editor sidebar.

## Details

- Changed `color.text` from `false` to `true`
- Changed `color.background` from `false` to `true`
- Added `__experimentalDefaultControls` to show color controls by default

This aligns the parent Tabs block with its child blocks (tabs-menu, tabs-menu-item, tab-panel, tab) which already have color support enabled.

## Test plan

1. Insert a Tabs block
2. Open the block settings sidebar
3. Verify that text and background color controls are visible under "Color"
4. Change the colors and verify they apply to the block

🤖 Generated with [Claude Code](https://claude.ai/code)