### PR TITLE
Tabs: Improve Tab Panel accessibility

### DIFF
--- a/packages/block-library/src/tab/index.php
+++ b/packages/block-library/src/tab/index.php
@@ -49,7 +49,7 @@ function block_core_tab_render( array $attributes, string $content ): string {
 	$tag_processor->set_attribute( 'role', 'tabpanel' );
 	$tag_processor->set_attribute( 'aria-labelledby', 'tab__' . $tab_id );
 	$tag_processor->set_attribute( 'data-wp-bind--hidden', '!state.isActiveTab' );
-	$tag_processor->set_attribute( 'data-wp-bind--tabindex', 'state.tabIndexAttribute' );
+	$tag_processor->set_attribute( 'data-wp-bind--tabindex', 'state.tabPanelTabIndexAttribute' );
 
 	return (string) $tag_processor->get_updated_html();
 }

--- a/packages/block-library/src/tab/index.php
+++ b/packages/block-library/src/tab/index.php
@@ -49,7 +49,7 @@ function block_core_tab_render( array $attributes, string $content ): string {
 	$tag_processor->set_attribute( 'role', 'tabpanel' );
 	$tag_processor->set_attribute( 'aria-labelledby', 'tab__' . $tab_id );
 	$tag_processor->set_attribute( 'data-wp-bind--hidden', '!state.isActiveTab' );
-	$tag_processor->set_attribute( 'data-wp-bind--tabindex', 'state.tabPanelTabIndexAttribute' );
+	$tag_processor->set_attribute( 'tabindex', 0 );
 
 	return (string) $tag_processor->get_updated_html();
 }

--- a/packages/block-library/src/tab/style.scss
+++ b/packages/block-library/src/tab/style.scss
@@ -15,9 +15,6 @@
 	&:empty {
 		display: none !important;
 	}
-	&:not(.wp-block):focus {
-		outline: none;
-	}
 }
 
 .wp-block-tab.wp-block.has-background,

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -86,13 +86,51 @@ const { actions: privateActions, state: privateState } = store(
 				return activeTabIndex === tabIndex;
 			},
 			/**
-			 * The value of the tabindex attribute.
+			 * The value of the tabindex attribute for tab buttons.
 			 * Only the active tab should be in the tab sequence.
 			 *
 			 * @type {number}
 			 */
 			get tabIndexAttribute() {
 				return privateState.isActiveTab ? 0 : -1;
+			},
+			/**
+			 * The value of the tabindex attribute for tab panels.
+			 * Returns 0 if the panel contains no focusable elements,
+			 * -1 if it does (to allow direct tabbing to content).
+			 *
+			 * Guidelines: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+			 *
+			 * @type {number}
+			 */
+			get tabPanelTabIndexAttribute() {
+				const { ref } = getElement();
+
+				if ( ! ref ) {
+					return -1;
+				}
+
+				// Check if panel contains any focusable elements
+				const focusableSelector = [
+					'a[href]',
+					'button:not([disabled])',
+					'input:not([disabled])',
+					'select:not([disabled])',
+					'textarea:not([disabled])',
+					'[tabindex]:not([tabindex="-1"])',
+					'audio[controls]',
+					'video[controls]',
+					'[contenteditable]:not([contenteditable="false"])',
+					'details > summary:first-of-type',
+					'details',
+				].join( ', ' );
+
+				const hasFocusableContent =
+					ref.querySelector( focusableSelector ) !== null;
+
+				// If panel has focusable content, use -1
+				// If panel has no focusable content, use 0
+				return hasFocusableContent ? -1 : 0;
 			},
 		},
 		actions: {

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -94,16 +94,6 @@ const { actions: privateActions, state: privateState } = store(
 			get tabIndexAttribute() {
 				return privateState.isActiveTab ? 0 : -1;
 			},
-			/**
-			 * The value of the tabindex attribute for tab panels.
-			 *
-			 * Guidelines: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
-			 *
-			 * @type {number}
-			 */
-			get tabPanelTabIndexAttribute() {
-				return 0;
-			},
 		},
 		actions: {
 			/**

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -96,48 +96,13 @@ const { actions: privateActions, state: privateState } = store(
 			},
 			/**
 			 * The value of the tabindex attribute for tab panels.
-			 * Returns 0 if the panel contains no focusable elements,
-			 * -1 if it does (to allow direct tabbing to content).
 			 *
 			 * Guidelines: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
 			 *
 			 * @type {number}
 			 */
 			get tabPanelTabIndexAttribute() {
-				const { attributes } = getElement();
-				const panelId = attributes?.id;
-
-				if ( ! panelId ) {
-					return -1;
-				}
-
-				// Get the DOM element
-				const panelElement = document.getElementById( panelId );
-				if ( ! panelElement ) {
-					return -1;
-				}
-
-				// Check if panel contains any focusable elements
-				const focusableSelector = [
-					'a[href]',
-					'button:not([disabled])',
-					'input:not([disabled])',
-					'select:not([disabled])',
-					'textarea:not([disabled])',
-					'audio[controls]',
-					'video[controls]',
-					'[contenteditable]:not([contenteditable="false"])',
-					'details > summary:first-of-type',
-					'details',
-					'iframe',
-				].join( ', ' );
-
-				const hasFocusableContent =
-					panelElement.querySelector( focusableSelector ) !== null;
-
-				// If panel has focusable content, use -1
-				// If panel has no focusable content, use 0
-				return hasFocusableContent ? -1 : 0;
+				return 0;
 			},
 		},
 		actions: {

--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -104,9 +104,16 @@ const { actions: privateActions, state: privateState } = store(
 			 * @type {number}
 			 */
 			get tabPanelTabIndexAttribute() {
-				const { ref } = getElement();
+				const { attributes } = getElement();
+				const panelId = attributes?.id;
 
-				if ( ! ref ) {
+				if ( ! panelId ) {
+					return -1;
+				}
+
+				// Get the DOM element
+				const panelElement = document.getElementById( panelId );
+				if ( ! panelElement ) {
 					return -1;
 				}
 
@@ -117,16 +124,16 @@ const { actions: privateActions, state: privateState } = store(
 					'input:not([disabled])',
 					'select:not([disabled])',
 					'textarea:not([disabled])',
-					'[tabindex]:not([tabindex="-1"])',
 					'audio[controls]',
 					'video[controls]',
 					'[contenteditable]:not([contenteditable="false"])',
 					'details > summary:first-of-type',
 					'details',
+					'iframe',
 				].join( ', ' );
 
 				const hasFocusableContent =
-					ref.querySelector( focusableSelector ) !== null;
+					panelElement.querySelector( focusableSelector ) !== null;
 
 				// If panel has focusable content, use -1
 				// If panel has no focusable content, use 0


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/75402
Follow-up to https://github.com/WordPress/gutenberg/pull/75471

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- The tab panel is focusable, but the outline was not visible. 
- Following [these guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#:~:text=When%20the%20tabpanel%20does%20not%20contain%20any%20focusable%20elements%20or%20the%20first%20element%20with%20content%20is%20not%20focusable%2C%20the%20tabpanel%20should%20set%20tabindex%3D%220%22%20to%20include%20it%20in%20the%20tab%20sequence%20of%20the%20page.), tab panels should only apply `tabindex=0` if their content does not contain any focusable elements.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removes some CSS that was overriding the focus outline on the tab panel.
- Adds `tabPanelTabIndexAttribute` state so we can detect whether a tab panel includes any focusable content, and set its `tabindex` accordingly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new post or page
  2. Insert a Tabs block with at least 3 tabs
  3. Add different content in each tab panel:
     - Tab 1: Just text (no focusable elements)
     - Tab 2: Text with a button
     - Tab 3: Text with multiple links
  4. Save and view on the front end

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Use the tab key to navigate to Tab 1, with no focusable content. The tab panel should have a visible outline.
2. Use the tab key to navigate to the button or the links in Tab 2 and 3. The tab panel should not receive focus, but the elements within the content should.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


