### PR TITLE
[WIP] Unify device switcher and resizer in overlay editors

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -392,6 +392,22 @@ _Returns_
 
 Undocumented declaration.
 
+### DEVICE_PREVIEW_HEIGHTS
+
+Undocumented declaration.
+
+### DEVICE_PREVIEW_WIDTHS
+
+Device preview width constants.
+
+These values match the breakpoints in:
+
+-   packages/base-styles/\_breakpoints.scss ($break-medium: 782px, $break-mobile: 480px)
+-   packages/compose/src/hooks/use-viewport-match/index.js (medium: 782, mobile: 480)
+-   packages/components/src/utils/breakpoint-values.js
+
+The minus-1 arithmetic ensures the preview triggers the correct media query for useViewportMatch with '\<' operator.
+
 ### DimensionControl
 
 DimensionControl renders a linked unit control and range control for adjusting dimensions of a block.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -116,6 +116,10 @@ export { default as __unstableBlockToolbarLastItem } from './block-toolbar/block
 export { default as __unstableInserterMenuExtension } from './inserter-menu-extension';
 export { default as __experimentalPreviewOptions } from './preview-options';
 export { default as __experimentalUseResizeCanvas } from './use-resize-canvas';
+export {
+	DEVICE_PREVIEW_WIDTHS,
+	DEVICE_PREVIEW_HEIGHTS,
+} from './use-resize-canvas/constants';
 export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
 export { useBlockProps } from './block-list/use-block-props';

--- a/packages/block-editor/src/components/use-resize-canvas/constants.js
+++ b/packages/block-editor/src/components/use-resize-canvas/constants.js
@@ -14,10 +14,12 @@ export const DEVICE_PREVIEW_WIDTHS = {
 	Desktop: null, // full width, no constraint
 	Tablet: 781, // 782 - 1: triggers useViewportMatch( 'medium', '<' )
 	Mobile: 479, // 480 - 1: triggers useViewportMatch( 'mobile', '<' )
+	Custom: null, // manual resize, no constraint
 };
 
 export const DEVICE_PREVIEW_HEIGHTS = {
 	Desktop: null,
 	Tablet: 1024,
 	Mobile: 768,
+	Custom: null,
 };

--- a/packages/block-editor/src/components/use-resize-canvas/constants.js
+++ b/packages/block-editor/src/components/use-resize-canvas/constants.js
@@ -1,0 +1,23 @@
+/**
+ * Device preview width constants.
+ *
+ * These values match the breakpoints in:
+ * - packages/base-styles/_breakpoints.scss ($break-medium: 782px, $break-mobile: 480px)
+ * - packages/compose/src/hooks/use-viewport-match/index.js (medium: 782, mobile: 480)
+ * - packages/components/src/utils/breakpoint-values.js
+ *
+ * The minus-1 arithmetic ensures the preview triggers the correct media query
+ * for useViewportMatch with '<' operator.
+ */
+
+export const DEVICE_PREVIEW_WIDTHS = {
+	Desktop: null, // full width, no constraint
+	Tablet: 781, // 782 - 1: triggers useViewportMatch( 'medium', '<' )
+	Mobile: 479, // 480 - 1: triggers useViewportMatch( 'mobile', '<' )
+};
+
+export const DEVICE_PREVIEW_HEIGHTS = {
+	Desktop: null,
+	Tablet: 1024,
+	Mobile: 768,
+};

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -4,6 +4,11 @@
 import { useEffect, useState } from '@wordpress/element';
 
 /**
+ * Internal dependencies
+ */
+import { DEVICE_PREVIEW_WIDTHS, DEVICE_PREVIEW_HEIGHTS } from './constants';
+
+/**
  * Function to resize the editor window.
  *
  * @param {string} deviceType Used for determining the size of the container (e.g. Desktop, Tablet, Mobile)
@@ -27,29 +32,17 @@ export default function useResizeCanvas( deviceType ) {
 	}, [ deviceType ] );
 
 	const getCanvasWidth = ( device ) => {
-		let deviceWidth;
+		const deviceWidth = DEVICE_PREVIEW_WIDTHS[ device ];
 
-		/*
-		 * Matches the breakpoints in packages/base-styles/_breakpoints.scss,
-		 * and breakpoints in packages/compose/src/hooks/use-viewport-match/index.js.
-		 * minus 1 to trigger the media query for device preview.
-		 */
-		switch ( device ) {
-			case 'Tablet':
-				deviceWidth = 782 - 1; // preview for useViewportMatch( 'medium', '<' )
-				break;
-			case 'Mobile':
-				deviceWidth = 480 - 1; // preview for useViewportMatch( 'mobile', '<' )
-				break;
-			default:
-				return null;
+		if ( deviceWidth === null || deviceWidth === undefined ) {
+			return null;
 		}
 
 		return deviceWidth < actualWidth ? deviceWidth : actualWidth;
 	};
 
 	const contentInlineStyles = ( device ) => {
-		const height = device === 'Mobile' ? '768px' : '1024px';
+		const height = DEVICE_PREVIEW_HEIGHTS[ device ];
 		const marginVertical = '40px';
 		const marginHorizontal = 'auto';
 
@@ -64,7 +57,7 @@ export default function useResizeCanvas( deviceType ) {
 					marginBottom: marginVertical,
 					marginLeft: marginHorizontal,
 					marginRight: marginHorizontal,
-					height,
+					height: height ? `${ height }px` : undefined,
 					overflowY: 'auto',
 				};
 			default:

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -23,12 +23,7 @@ import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
 import ZoomOutToggle from '../zoom-out-toggle';
 import { store as editorStore } from '../../store';
-import {
-	ATTACHMENT_POST_TYPE,
-	TEMPLATE_PART_POST_TYPE,
-	PATTERN_POST_TYPE,
-	NAVIGATION_POST_TYPE,
-} from '../../store/constants';
+import { ATTACHMENT_POST_TYPE } from '../../store/constants';
 import { CollaboratorsPresence } from '../collaborators-presence/index';
 import { unlock } from '../../lock-unlock';
 
@@ -89,12 +84,7 @@ function Header( {
 		hasSectionRootClientId;
 
 	const disablePreviewOption =
-		[
-			ATTACHMENT_POST_TYPE,
-			NAVIGATION_POST_TYPE,
-			TEMPLATE_PART_POST_TYPE,
-			PATTERN_POST_TYPE,
-		].includes( postType ) || isStylesCanvasActive;
+		[ ATTACHMENT_POST_TYPE ].includes( postType ) || isStylesCanvasActive;
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -23,7 +23,12 @@ import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
 import ZoomOutToggle from '../zoom-out-toggle';
 import { store as editorStore } from '../../store';
-import { ATTACHMENT_POST_TYPE } from '../../store/constants';
+import {
+	ATTACHMENT_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+} from '../../store/constants';
 import { CollaboratorsPresence } from '../collaborators-presence/index';
 import { unlock } from '../../lock-unlock';
 
@@ -35,6 +40,7 @@ function Header( {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const {
 		postId,
 		postType,
@@ -46,6 +52,8 @@ function Header( {
 		hasSectionRootClientId,
 		isStylesCanvasActive,
 		isAttachment,
+		isPreview,
+		isZoomedOut,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -53,13 +61,16 @@ function Header( {
 			getCurrentPostType,
 			getCurrentPostId,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
+			getEditorSettings,
 		} = select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
 			select( editorStore )
 		);
-		const { getBlockSelectionStart, getSectionRootClientId } = unlock(
-			select( blockEditorStore )
-		);
+		const {
+			getBlockSelectionStart,
+			getSectionRootClientId,
+			isZoomOut: _isZoomOut,
+		} = unlock( select( blockEditorStore ) );
 
 		return {
 			postId: getCurrentPostId(),
@@ -76,6 +87,8 @@ function Header( {
 			isAttachment:
 				getCurrentPostType() === ATTACHMENT_POST_TYPE &&
 				window?.__experimentalMediaEditor,
+			isPreview: getEditorSettings().isPreviewMode,
+			isZoomedOut: _isZoomOut(),
 		};
 	}, [] );
 
@@ -85,6 +98,16 @@ function Header( {
 
 	const disablePreviewOption =
 		[ ATTACHMENT_POST_TYPE ].includes( postType ) || isStylesCanvasActive;
+
+	const enableResizing =
+		[
+			NAVIGATION_POST_TYPE,
+			TEMPLATE_PART_POST_TYPE,
+			PATTERN_POST_TYPE,
+		].includes( postType ) &&
+		! isPreview &&
+		! isMobileViewport &&
+		! isZoomedOut;
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
@@ -143,6 +166,7 @@ function Header( {
 					<PreviewDropdown
 						forceIsAutosaveable={ forceIsDirty }
 						disabled={ disablePreviewOption }
+						enableResizing={ enableResizing }
 					/>
 
 					<PostPreviewButton

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -16,7 +16,14 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
+import {
+	desktop,
+	mobile,
+	tablet,
+	external,
+	check,
+	dragHandle,
+} from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -93,6 +100,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		desktop,
 		mobile,
 		tablet,
+		custom: dragHandle,
 	};
 
 	/**
@@ -115,6 +123,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			value: 'Mobile',
 			label: __( 'Mobile' ),
 			icon: mobile,
+		},
+		{
+			value: 'Custom',
+			label: __( 'Custom' ),
+			icon: dragHandle,
 		},
 	];
 

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -37,7 +37,11 @@ import { store as editorStore } from '../../store';
 import PostPreviewButton from '../post-preview-button';
 import { unlock } from '../../lock-unlock';
 
-export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
+export default function PreviewDropdown( {
+	forceIsAutosaveable,
+	disabled,
+	enableResizing = false,
+} ) {
 	const {
 		deviceType,
 		homeUrl,
@@ -108,7 +112,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	 *
 	 * @type {Array}
 	 */
-	const choices = [
+	const allChoices = [
 		{
 			value: 'Desktop',
 			label: __( 'Desktop' ),
@@ -130,6 +134,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			icon: dragHandle,
 		},
 	];
+
+	// Only include Custom option when resizing is enabled
+	const choices = enableResizing
+		? allChoices
+		: allChoices.filter( ( choice ) => choice.value !== 'Custom' );
 
 	return (
 		<DropdownMenu

--- a/packages/editor/src/components/resizable-editor/index.js
+++ b/packages/editor/src/components/resizable-editor/index.js
@@ -34,9 +34,12 @@ function ResizableEditor( {
 	height,
 	children,
 	deviceType,
+	onDeviceTypeChange,
 } ) {
 	const [ width, setWidth ] = useState( '100%' );
 	const resizableRef = useRef();
+	const isResizingRef = useRef( false );
+
 	const resizeWidthBy = useCallback( ( deltaPixels ) => {
 		if ( resizableRef.current ) {
 			setWidth( resizableRef.current.offsetWidth + deltaPixels );
@@ -45,7 +48,7 @@ function ResizableEditor( {
 
 	// When deviceType changes, snap the width to the device preset
 	useEffect( () => {
-		if ( enableResizing && deviceType ) {
+		if ( enableResizing && deviceType && deviceType !== 'Custom' ) {
 			const deviceWidth = DEVICE_PREVIEW_WIDTHS[ deviceType ];
 			setWidth( deviceWidth ?? '100%' );
 		}
@@ -63,8 +66,33 @@ function ResizableEditor( {
 				width: enableResizing ? width : '100%',
 				height: enableResizing && height ? height : '100%',
 			} }
+			onResizeStart={ () => {
+				isResizingRef.current = true;
+			} }
 			onResizeStop={ ( event, direction, element ) => {
+				const newWidth = parseInt( element.style.width );
 				setWidth( element.style.width );
+				isResizingRef.current = false;
+
+				// Check if the new width matches any device preset
+				const matchesPreset = Object.entries(
+					DEVICE_PREVIEW_WIDTHS
+				).some(
+					( [ type, presetWidth ] ) =>
+						type !== 'Custom' &&
+						presetWidth !== null &&
+						Math.abs( newWidth - presetWidth ) < 5 // Allow 5px tolerance
+				);
+
+				// If manually resized to a width that doesn't match a preset, switch to Custom
+				if (
+					enableResizing &&
+					onDeviceTypeChange &&
+					! matchesPreset &&
+					deviceType !== 'Custom'
+				) {
+					onDeviceTypeChange( 'Custom' );
+				}
 			} }
 			minWidth={ 300 }
 			maxWidth="100%"

--- a/packages/editor/src/components/resizable-editor/index.js
+++ b/packages/editor/src/components/resizable-editor/index.js
@@ -37,8 +37,10 @@ function ResizableEditor( {
 	onDeviceTypeChange,
 } ) {
 	const [ width, setWidth ] = useState( '100%' );
+	const [ isAnimating, setIsAnimating ] = useState( false );
 	const resizableRef = useRef();
 	const isResizingRef = useRef( false );
+	const previousDeviceTypeRef = useRef( deviceType );
 
 	const resizeWidthBy = useCallback( ( deltaPixels ) => {
 		if ( resizableRef.current ) {
@@ -50,7 +52,24 @@ function ResizableEditor( {
 	useEffect( () => {
 		if ( enableResizing && deviceType && deviceType !== 'Custom' ) {
 			const deviceWidth = DEVICE_PREVIEW_WIDTHS[ deviceType ];
+
+			// Animate only when switching between known presets (not from Custom)
+			const shouldAnimate =
+				previousDeviceTypeRef.current &&
+				previousDeviceTypeRef.current !== 'Custom' &&
+				previousDeviceTypeRef.current !== deviceType;
+
+			if ( shouldAnimate ) {
+				setIsAnimating( true );
+				const timeoutId = setTimeout(
+					() => setIsAnimating( false ),
+					300
+				); // Match CSS transition duration
+				return () => clearTimeout( timeoutId );
+			}
+
 			setWidth( deviceWidth ?? '100%' );
+			previousDeviceTypeRef.current = deviceType;
 		}
 	}, [ deviceType, enableResizing ] );
 
@@ -58,6 +77,7 @@ function ResizableEditor( {
 		<ResizableBox
 			className={ clsx( 'editor-resizable-editor', className, {
 				'is-resizable': enableResizing,
+				'is-animating': isAnimating && enableResizing,
 			} ) }
 			ref={ ( api ) => {
 				resizableRef.current = api?.resizable;
@@ -68,6 +88,7 @@ function ResizableEditor( {
 			} }
 			onResizeStart={ () => {
 				isResizingRef.current = true;
+				setIsAnimating( false ); // Disable animation during manual resize
 			} }
 			onResizeStop={ ( event, direction, element ) => {
 				const newWidth = parseInt( element.style.width );

--- a/packages/editor/src/components/resizable-editor/index.js
+++ b/packages/editor/src/components/resizable-editor/index.js
@@ -6,8 +6,9 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useCallback } from '@wordpress/element';
+import { useState, useRef, useCallback, useEffect } from '@wordpress/element';
 import { ResizableBox } from '@wordpress/components';
+import { DEVICE_PREVIEW_WIDTHS } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -27,7 +28,13 @@ const HANDLE_STYLES_OVERRIDE = {
 	left: undefined,
 };
 
-function ResizableEditor( { className, enableResizing, height, children } ) {
+function ResizableEditor( {
+	className,
+	enableResizing,
+	height,
+	children,
+	deviceType,
+} ) {
 	const [ width, setWidth ] = useState( '100%' );
 	const resizableRef = useRef();
 	const resizeWidthBy = useCallback( ( deltaPixels ) => {
@@ -35,6 +42,15 @@ function ResizableEditor( { className, enableResizing, height, children } ) {
 			setWidth( resizableRef.current.offsetWidth + deltaPixels );
 		}
 	}, [] );
+
+	// When deviceType changes, snap the width to the device preset
+	useEffect( () => {
+		if ( enableResizing && deviceType ) {
+			const deviceWidth = DEVICE_PREVIEW_WIDTHS[ deviceType ];
+			setWidth( deviceWidth ?? '100%' );
+		}
+	}, [ deviceType, enableResizing ] );
+
 	return (
 		<ResizableBox
 			className={ clsx( 'editor-resizable-editor', className, {

--- a/packages/editor/src/components/resizable-editor/style.scss
+++ b/packages/editor/src/components/resizable-editor/style.scss
@@ -7,6 +7,11 @@
 .editor-resizable-editor.is-resizable {
 	overflow: visible;
 	margin: 0 auto;
+
+	// Animate width changes when switching between device presets
+	&.is-animating {
+		transition: width 0.3s ease-in-out;
+	}
 }
 
 .editor-resizable-editor__resize-handle {

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -186,8 +186,25 @@ function VisualEditor( {
 		};
 	}, [] );
 
+	const enableResizing =
+		[
+			NAVIGATION_POST_TYPE,
+			TEMPLATE_PART_POST_TYPE,
+			PATTERN_POST_TYPE,
+		].includes( postType ) &&
+		// Disable in previews / view mode.
+		! isPreview &&
+		// Disable resizing in mobile viewport.
+		! isMobileViewport &&
+		// Disable resizing in zoomed-out mode.
+		! isZoomedOut;
+
 	const localRef = useRef();
-	const deviceStyles = useResizeCanvas( deviceType );
+	// When resizing is enabled, skip useResizeCanvas by passing 'Desktop' (no width constraint).
+	// The ResizableEditor handles width instead, responding to deviceType changes.
+	const deviceStyles = useResizeCanvas(
+		enableResizing ? 'Desktop' : deviceType
+	);
 	const [ globalLayoutSettings ] = useSettings( 'layout' );
 
 	// fallbackLayout is used if there is no Post Content,
@@ -320,19 +337,6 @@ function VisualEditor( {
 		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
 		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
-	const enableResizing =
-		[
-			NAVIGATION_POST_TYPE,
-			TEMPLATE_PART_POST_TYPE,
-			PATTERN_POST_TYPE,
-		].includes( postType ) &&
-		// Disable in previews / view mode.
-		! isPreview &&
-		// Disable resizing in mobile viewport.
-		! isMobileViewport &&
-		// Disable resizing in zoomed-out mode.
-		! isZoomedOut;
-
 	// Calculate the minimum height including scroll offset to fit all notes.
 	const calculatedMinHeight = useMemo( () => {
 		if ( ! localRef.current ) {
@@ -409,7 +413,11 @@ function VisualEditor( {
 				}
 			) }
 		>
-			<ResizableEditor enableResizing={ enableResizing } height="100%">
+			<ResizableEditor
+				enableResizing={ enableResizing }
+				height="100%"
+				deviceType={ deviceType }
+			>
 				<BlockCanvas
 					shouldIframe={ ! disableIframe }
 					contentRef={ contentRef }

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -17,7 +17,7 @@ import {
 	__experimentalUseResizeCanvas as useResizeCanvas,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
@@ -185,6 +185,8 @@ function VisualEditor( {
 			isZoomedOut: _isZoomOut(),
 		};
 	}, [] );
+
+	const { setDeviceType } = unlock( useDispatch( editorStore ) );
 
 	const enableResizing =
 		[
@@ -417,6 +419,7 @@ function VisualEditor( {
 				enableResizing={ enableResizing }
 				height="100%"
 				deviceType={ deviceType }
+				onDeviceTypeChange={ setDeviceType }
 			>
 				<BlockCanvas
 					shouldIframe={ ! disableIframe }


### PR DESCRIPTION
## What?
Enables the device preview dropdown (Desktop/Tablet/Mobile) to work alongside resize handles in navigation, template-part, and pattern editors - similar to Chrome DevTools' unified approach.

**⚠️ Work In Progress** - Testing and feedback needed on UX intuitiveness.

## Why?
The device switcher and resize handles were previously mutually exclusive. PR #65970 disabled the device dropdown in these editors to avoid conflicts, but users need both:
- Device presets for quick viewport testing
- Resize handles for fine-tuned width adjustments

Related to #75222, this provides the foundation for viewport-aware overlay editing by making device switching available in template part contexts.

## How?
**Unified dimension control:** Device presets and drag handles now control the same `ResizableEditor` width:
1. Centralized device preview constants (`DEVICE_PREVIEW_WIDTHS`)
2. `ResizableEditor` responds to `deviceType` changes, snapping to preset widths
3. When resizing is enabled, `useResizeCanvas` is bypassed (Desktop mode), letting `ResizableEditor` handle width
4. Device dropdown re-enabled for navigation/template-part/pattern post types

**Custom mode:** Manual resizing switches to "Custom" in the dropdown (like Chrome DevTools' "Responsive" mode), clearly indicating free-resize state. Switching back to a preset snaps to that width with smooth animation.

## Testing Instructions
1. Open a **Template Part** or **Navigation** block in the Site Editor
2. Use the device preview dropdown to switch between Desktop/Tablet/Mobile
   - Verify smooth animation between presets
3. Use the drag handles to manually resize
   - Verify it switches to "Custom" in the dropdown
4. Switch back to a preset (e.g., Mobile)
   - Verify it snaps to that width with animation
5. **Does this feel intuitive?** The device dropdown and resize handles should feel like complementary tools, not competing ones

## Screenshots or screencast



https://github.com/user-attachments/assets/79157f2f-36ac-445e-b217-b6a4d661ae18


