### PR TITLE
Use null coalescing operator for common isset patterns

### DIFF
--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -91,7 +91,7 @@ add_action( 'wp_update_nav_menu_item', 'gutenberg_update_nav_menu_item_content',
 function gutenberg_setup_block_nav_menu_item( $menu_item ) {
 	if ( 'block' === $menu_item->type ) {
 		$menu_item->type_label = __( 'Block', 'gutenberg' );
-		$menu_item->content    = ! isset( $menu_item->content ) ? get_post_meta( $menu_item->db_id, '_menu_item_content', true ) : $menu_item->content;
+		$menu_item->content    = $menu_item->content ?? get_post_meta( $menu_item->db_id, '_menu_item_content', true );
 
 		// Set to make the menu item display nicely in nav-menus.php.
 		$menu_item->object = 'block';
@@ -305,10 +305,7 @@ function gutenberg_output_block_nav_menu( $output, $args ) {
 		$menu_items_by_parent_id[ $menu_item->menu_item_parent ][] = $menu_item;
 	}
 
-	$block_attributes = array();
-	if ( isset( $args->block_attributes ) ) {
-		$block_attributes = $args->block_attributes;
-	}
+	$block_attributes = $args->block_attributes ?? array();
 
 	$navigation_block = array(
 		'blockName'   => 'core/navigation',

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -29,8 +29,8 @@ function render_block_core_media_text( $attributes, $content ) {
 		return $content;
 	}
 
-	$has_media_on_right = isset( $attributes['mediaPosition'] ) && 'right' === $attributes['mediaPosition'];
-	$image_fill         = isset( $attributes['imageFill'] ) && $attributes['imageFill'];
+	$has_media_on_right = 'right' === ( $attributes['mediaPosition'] ?? null );
+	$image_fill         = $attributes['imageFill'] ?? false;
 	$focal_point        = isset( $attributes['focalPoint'] ) ? round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%' : '50% 50%';
 	$unique_id          = 'wp-block-media-text__media-' . wp_unique_id();
 

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -30,7 +30,7 @@ function render_block_core_media_text( $attributes, $content ) {
 	}
 
 	$has_media_on_right = 'right' === ( $attributes['mediaPosition'] ?? null );
-	$image_fill         = $attributes['imageFill'] ?? false;
+	$image_fill         = (bool) ( $attributes['imageFill'] ?? false );
 	$focal_point        = isset( $attributes['focalPoint'] ) ? round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%' : '50% 50%';
 	$unique_id          = 'wp-block-media-text__media-' . wp_unique_id();
 

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -48,11 +48,11 @@ function block_core_post_template_uses_featured_image( $inner_blocks ) {
  */
 function render_block_core_post_template( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
+	$enhanced_pagination = (bool) ( $block->context['enhancedPagination'] ?? false );
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 	// Use global query if needed.
-	$use_global_query = $block->context['query']['inherit'] ?? false;
+	$use_global_query = (bool) ( $block->context['query']['inherit'] ?? false );
 	if ( $use_global_query ) {
 		global $wp_query;
 

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -48,11 +48,11 @@ function block_core_post_template_uses_featured_image( $inner_blocks ) {
  */
 function render_block_core_post_template( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = isset( $block->context['enhancedPagination'] ) && $block->context['enhancedPagination'];
+	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 	// Use global query if needed.
-	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
+	$use_global_query = $block->context['query']['inherit'] ?? false;
 	if ( $use_global_query ) {
 		global $wp_query;
 

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -20,7 +20,7 @@
  */
 function render_block_core_query_pagination_next( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
+	$enhanced_pagination = (bool) ( $block->context['enhancedPagination'] ?? false );
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -20,12 +20,12 @@
  */
 function render_block_core_query_pagination_next( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = isset( $block->context['enhancedPagination'] ) && $block->context['enhancedPagination'];
+	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$max_page            = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
+	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-	$show_label         = isset( $block->context['showLabel'] ) ? (bool) $block->context['showLabel'] : true;
+	$show_label         = (bool) ( $block->context['showLabel'] ?? true );
 	$default_label      = __( 'Next Page' );
 	$label_text         = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
 	$label              = $show_label ? $label_text : '';

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -20,9 +20,9 @@
  */
 function render_block_core_query_pagination_numbers( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = isset( $block->context['enhancedPagination'] ) && $block->context['enhancedPagination'];
+	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$max_page            = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
+	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	$content            = '';

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -20,7 +20,7 @@
  */
 function render_block_core_query_pagination_numbers( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
+	$enhanced_pagination = (bool) ( $block->context['enhancedPagination'] ?? false );
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -18,7 +18,7 @@
  */
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
+	$enhanced_pagination = (bool) ( $block->context['enhancedPagination'] ?? false );
 	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$wrapper_attributes  = get_block_wrapper_attributes();

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -18,11 +18,11 @@
  */
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$enhanced_pagination = isset( $block->context['enhancedPagination'] ) && $block->context['enhancedPagination'];
-	$max_page            = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
+	$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
+	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$wrapper_attributes  = get_block_wrapper_attributes();
-	$show_label          = isset( $block->context['showLabel'] ) ? (bool) $block->context['showLabel'] : true;
+	$show_label          = (bool) ( $block->context['showLabel'] ?? true );
 	$default_label       = __( 'Previous Page' );
 	$label_text          = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
 	$label               = $show_label ? $label_text : '';

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -74,8 +74,8 @@ function render_block_core_query_title( $attributes, $content, $block ) {
 		}
 	}
 
-	$level    = isset( $attributes['level'] ) ? (int) $attributes['level'] : 1;
-	$tag_name = 0 === $level ? 'p' : 'h' . (int) $attributes['level'];
+	$level    = (int) ( $attributes['level'] ?? 1 );
+	$tag_name = 0 === $level ? 'p' : 'h' . $level;
 
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -21,12 +21,12 @@
 function render_block_core_query_total( $attributes, $content, $block ) {
 	global $wp_query;
 	$wrapper_attributes = get_block_wrapper_attributes();
-	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+	if ( $block->context['query']['inherit'] ?? false ) {
 		$query_to_use = $wp_query;
 		$current_page = max( 1, (int) get_query_var( 'paged', 1 ) );
 	} else {
 		$page_key     = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-		$current_page = isset( $_GET[ $page_key ] ) ? (int) $_GET[ $page_key ] : 1;
+		$current_page = (int) ( $_GET[ $page_key ] ?? 1 );
 		$query_to_use = new WP_Query( build_query_vars_from_query_block( $block, $current_page ) );
 	}
 


### PR DESCRIPTION
This is a follow-up to Core-63430, to leverage the null coalescing operator. I used Gemini CLI to scour the codebase to find additional opportunities.

Previously:

- https://github.com/WordPress/gutenberg/pull/75425
- https://github.com/WordPress/gutenberg/pull/75419
- https://github.com/WordPress/gutenberg/pull/74335

Per commit message:

> Refactor several PHP blocks and support files to use the null coalescing operator (??), which is supported since PHP 7.0 (and the project requirement is 7.4). This simplifies code patterns involving property or array element access with defaults.
