### PR TITLE
Fix LinkControl URL Normalization

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -24,7 +24,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { keyboardReturn, linkOff } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
-import { isURL } from '@wordpress/url';
+import { isURL, prependHTTPS } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -312,8 +312,10 @@ function LinkControl( {
 			type: 'valid',
 		};
 
+		const trimmedValue = urlToValidate?.trim();
+
 		// If empty or not URL-like, return invalid
-		if ( ! urlToValidate?.length || ! isURLLike( urlToValidate ) ) {
+		if ( ! trimmedValue?.length || ! isURLLike( trimmedValue ) ) {
 			return invalidResult;
 		}
 
@@ -321,13 +323,14 @@ function LinkControl( {
 		// valid href values but cannot be validated by the native URL constructor
 		// (which requires absolute URLs). These are already validated by isURLLike.
 		// Skip URL constructor validation for these cases.
-		if ( isHashLink( urlToValidate ) || isRelativePath( urlToValidate ) ) {
+		if ( isHashLink( trimmedValue ) || isRelativePath( trimmedValue ) ) {
 			return validResult;
 		}
 
 		// Perform URL validation using the native URL constructor as the authoritative source.
 		// The native URL constructor is the standard for URL validity - if it accepts a URL,
-		// we should allow it.
+		// we should allow it. For URLs without a protocol (e.g., "www.wordpress.org"),
+		// prepend "http://" before validating, as the URL constructor requires a protocol.
 		//
 		// Note: Protocol URLs (mailto:, tel:, etc.) are also validated by the native
 		// URL constructor, so we don't need special handling for them.
@@ -335,7 +338,8 @@ function LinkControl( {
 		// Note: We rely on the native URL constructor rather than implementing custom TLD
 		// validation to avoid blocking valid URLs. If a URL passes the native constructor,
 		// it's technically valid according to web standards.
-		return isURL( urlToValidate ) ? validResult : invalidResult;
+		const urlToCheck = prependHTTPS( trimmedValue );
+		return isURL( urlToCheck ) ? validResult : invalidResult;
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
@@ -360,6 +364,13 @@ function LinkControl( {
 				setCustomValidity( validation );
 				return;
 			}
+
+			// Validation passed - normalize the URL
+			const { url: normalizedUrl } = normalizeUrl( urlToValidate );
+			updatedValue = {
+				...updatedValue,
+				url: normalizedUrl,
+			};
 		}
 
 		// Preserve the URL for taxonomy entities before binding overrides it
@@ -396,10 +407,12 @@ function LinkControl( {
 	};
 
 	// Centralized validation function
-	const validateAndSetValidity = ( urlToValidate = currentUrlInputValue ) => {
+	const validateAndSetValidity = () => {
 		if ( currentInputIsEmpty ) {
 			return false;
 		}
+
+		const trimmedValue = currentUrlInputValue.trim();
 
 		// If the current value is an entity link (has id and type not in LINK_ENTRY_TYPES)
 		// and the URL hasn't changed from the original value, skip validation.
@@ -410,7 +423,7 @@ function LinkControl( {
 			internalControlValue.id &&
 			internalControlValue.type &&
 			! LINK_ENTRY_TYPES.includes( internalControlValue.type );
-		const urlUnchanged = value?.url === urlToValidate;
+		const urlUnchanged = value?.url === trimmedValue;
 
 		if ( isEntityLink && urlUnchanged ) {
 			// Entity link with unchanged URL - skip validation
@@ -419,7 +432,7 @@ function LinkControl( {
 		}
 
 		// Validate the URL using the shared validation helper
-		const validation = validateUrl( urlToValidate );
+		const validation = validateUrl( currentUrlInputValue );
 
 		if ( validation.type === 'invalid' ) {
 			setCustomValidity( validation );
@@ -432,14 +445,14 @@ function LinkControl( {
 	};
 
 	// Centralized submission function
-	const submitUrlValue = ( urlToSubmit ) => {
+	const submitUrlValue = () => {
 		if ( valueHasChanges ) {
 			// Submit the original value with new stored values applied
 			// on top. URL is a special case as it may also be a prop.
 			onChange( {
 				...value,
 				...internalControlValue,
-				url: urlToSubmit,
+				url: normalizeUrl( currentUrlInputValue ).url,
 			} );
 		}
 		stopEditing();
@@ -447,19 +460,18 @@ function LinkControl( {
 	};
 
 	const handleSubmit = () => {
-		// Normalize the URL
-		const { url: normalizedUrl } = normalizeUrl( currentUrlInputValue );
-		// Validate the normalized URL
-		if ( ! validateAndSetValidity( normalizedUrl ) ) {
+		// Validate URL before submitting
+		if ( ! validateAndSetValidity() ) {
 			return;
 		}
 
 		// Validation passed - proceed with submission
-		submitUrlValue( normalizedUrl );
+		submitUrlValue();
 	};
 
 	const handleSubmitWithEnter = ( event ) => {
 		const { keyCode } = event;
+
 		if (
 			keyCode === ENTER &&
 			! currentInputIsEmpty // Disallow submitting empty values.

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -24,7 +24,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { keyboardReturn, linkOff } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
-import { isURL, prependHTTPS } from '@wordpress/url';
+import { isURL } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -312,10 +312,8 @@ function LinkControl( {
 			type: 'valid',
 		};
 
-		const trimmedValue = urlToValidate?.trim();
-
 		// If empty or not URL-like, return invalid
-		if ( ! trimmedValue?.length || ! isURLLike( trimmedValue ) ) {
+		if ( ! urlToValidate?.length || ! isURLLike( urlToValidate ) ) {
 			return invalidResult;
 		}
 
@@ -323,14 +321,13 @@ function LinkControl( {
 		// valid href values but cannot be validated by the native URL constructor
 		// (which requires absolute URLs). These are already validated by isURLLike.
 		// Skip URL constructor validation for these cases.
-		if ( isHashLink( trimmedValue ) || isRelativePath( trimmedValue ) ) {
+		if ( isHashLink( urlToValidate ) || isRelativePath( urlToValidate ) ) {
 			return validResult;
 		}
 
 		// Perform URL validation using the native URL constructor as the authoritative source.
 		// The native URL constructor is the standard for URL validity - if it accepts a URL,
-		// we should allow it. For URLs without a protocol (e.g., "www.wordpress.org"),
-		// prepend "http://" before validating, as the URL constructor requires a protocol.
+		// we should allow it.
 		//
 		// Note: Protocol URLs (mailto:, tel:, etc.) are also validated by the native
 		// URL constructor, so we don't need special handling for them.
@@ -338,8 +335,7 @@ function LinkControl( {
 		// Note: We rely on the native URL constructor rather than implementing custom TLD
 		// validation to avoid blocking valid URLs. If a URL passes the native constructor,
 		// it's technically valid according to web standards.
-		const urlToCheck = prependHTTPS( trimmedValue );
-		return isURL( urlToCheck ) ? validResult : invalidResult;
+		return isURL( urlToValidate ) ? validResult : invalidResult;
 	};
 
 	const handleSelectSuggestion = ( updatedValue ) => {
@@ -405,8 +401,6 @@ function LinkControl( {
 			return false;
 		}
 
-		const trimmedValue = urlToValidate.trim();
-
 		// If the current value is an entity link (has id and type not in LINK_ENTRY_TYPES)
 		// and the URL hasn't changed from the original value, skip validation.
 		// This allows entity links with permalink formats like "?p=2" to work without
@@ -416,7 +410,7 @@ function LinkControl( {
 			internalControlValue.id &&
 			internalControlValue.type &&
 			! LINK_ENTRY_TYPES.includes( internalControlValue.type );
-		const urlUnchanged = value?.url === trimmedValue;
+		const urlUnchanged = value?.url === urlToValidate;
 
 		if ( isEntityLink && urlUnchanged ) {
 			// Entity link with unchanged URL - skip validation
@@ -454,10 +448,7 @@ function LinkControl( {
 
 	const handleSubmit = () => {
 		// Normalize the URL
-		const { url: normalizedUrl } = normalizeUrl(
-			currentUrlInputValue.trim()
-		);
-
+		const { url: normalizedUrl } = normalizeUrl( currentUrlInputValue );
 		// Validate the normalized URL
 		if ( ! validateAndSetValidity( normalizedUrl ) ) {
 			return;
@@ -469,7 +460,6 @@ function LinkControl( {
 
 	const handleSubmitWithEnter = ( event ) => {
 		const { keyCode } = event;
-
 		if (
 			keyCode === ENTER &&
 			! currentInputIsEmpty // Disallow submitting empty values.

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -38,6 +38,7 @@ import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS, LINK_ENTRY_TYPES } from './constants';
 import isURLLike, { isHashLink, isRelativePath } from './is-url-like';
+import normalizeUrl from './normalize-url';
 
 /**
  * Default properties associated with a link control value.
@@ -399,12 +400,12 @@ function LinkControl( {
 	};
 
 	// Centralized validation function
-	const validateAndSetValidity = () => {
+	const validateAndSetValidity = ( urlToValidate = currentUrlInputValue ) => {
 		if ( currentInputIsEmpty ) {
 			return false;
 		}
 
-		const trimmedValue = currentUrlInputValue.trim();
+		const trimmedValue = urlToValidate.trim();
 
 		// If the current value is an entity link (has id and type not in LINK_ENTRY_TYPES)
 		// and the URL hasn't changed from the original value, skip validation.
@@ -424,7 +425,7 @@ function LinkControl( {
 		}
 
 		// Validate the URL using the shared validation helper
-		const validation = validateUrl( currentUrlInputValue );
+		const validation = validateUrl( urlToValidate );
 
 		if ( validation.type === 'invalid' ) {
 			setCustomValidity( validation );
@@ -437,14 +438,14 @@ function LinkControl( {
 	};
 
 	// Centralized submission function
-	const submitUrlValue = () => {
+	const submitUrlValue = ( urlToSubmit ) => {
 		if ( valueHasChanges ) {
 			// Submit the original value with new stored values applied
 			// on top. URL is a special case as it may also be a prop.
 			onChange( {
 				...value,
 				...internalControlValue,
-				url: currentUrlInputValue,
+				url: urlToSubmit,
 			} );
 		}
 		stopEditing();
@@ -452,13 +453,18 @@ function LinkControl( {
 	};
 
 	const handleSubmit = () => {
-		// Validate URL before submitting
-		if ( ! validateAndSetValidity() ) {
+		// Normalize the URL
+		const { url: normalizedUrl } = normalizeUrl(
+			currentUrlInputValue.trim()
+		);
+
+		// Validate the normalized URL
+		if ( ! validateAndSetValidity( normalizedUrl ) ) {
 			return;
 		}
 
 		// Validation passed - proceed with submission
-		submitUrlValue();
+		submitUrlValue( normalizedUrl );
 	};
 
 	const handleSubmitWithEnter = ( event ) => {

--- a/packages/block-editor/src/components/link-control/normalize-url.js
+++ b/packages/block-editor/src/components/link-control/normalize-url.js
@@ -23,27 +23,34 @@ import { TEL_TYPE, MAILTO_TYPE, INTERNAL_TYPE, URL_TYPE } from './constants';
  * @return {Object} An object containing the normalized URL and its type
  */
 export default function normalizeUrl( url ) {
-	if ( ! url ) {
-		return { url, type: URL_TYPE };
+	const trimmedUrl = url?.trim();
+
+	if ( ! trimmedUrl ) {
+		return { url: trimmedUrl, type: URL_TYPE };
 	}
 
 	let type = URL_TYPE;
-	const protocol = getProtocol( url ) || '';
+	const protocol = getProtocol( trimmedUrl ) || '';
 
 	// Determine the type based on the URL format
 	if ( protocol.includes( 'mailto' ) ) {
 		type = MAILTO_TYPE;
 	} else if ( protocol.includes( 'tel' ) ) {
 		type = TEL_TYPE;
-	} else if ( url?.startsWith( '#' ) ) {
+	} else if ( trimmedUrl?.startsWith( '#' ) ) {
 		type = INTERNAL_TYPE;
 	}
 
-	// Hash links, relative paths, and URLs with protocols should not be modified
-	if ( isHashLink( url ) || isRelativePath( url ) || protocol ) {
-		return { url, type };
+	// Hash links, relative paths, query parameters, and URLs with protocols should not be modified
+	if (
+		isHashLink( trimmedUrl ) ||
+		isRelativePath( trimmedUrl ) ||
+		trimmedUrl.startsWith( '?' ) ||
+		protocol
+	) {
+		return { url: trimmedUrl, type };
 	}
 
 	// Bare domains need https:// prepended
-	return { url: prependHTTPS( url ), type };
+	return { url: prependHTTPS( trimmedUrl ), type };
 }

--- a/packages/block-editor/src/components/link-control/normalize-url.js
+++ b/packages/block-editor/src/components/link-control/normalize-url.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { getProtocol, prependHTTPS } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { isHashLink, isRelativePath } from './is-url-like';
+import { TEL_TYPE, MAILTO_TYPE, INTERNAL_TYPE, URL_TYPE } from './constants';
+
+/**
+ * Normalizes a URL string by adding https:// protocol if needed.
+ * This function determines the final URL that will be saved.
+ *
+ * Normalization rules:
+ * - Bare domains (wordpress.org, www.wordpress.org) → prepend https://
+ * - URLs with explicit protocols (http://, https://, mailto:, tel:, etc.) → keep as-is
+ * - Relative paths (/, ./, ../) → keep as-is
+ * - Hash links (#section) → keep as-is
+ *
+ * @param {string} url - The URL to normalize
+ * @return {Object} An object containing the normalized URL and its type
+ */
+export default function normalizeUrl( url ) {
+	if ( ! url ) {
+		return { url, type: URL_TYPE };
+	}
+
+	let type = URL_TYPE;
+	const protocol = getProtocol( url ) || '';
+
+	// Determine the type based on the URL format
+	if ( protocol.includes( 'mailto' ) ) {
+		type = MAILTO_TYPE;
+	} else if ( protocol.includes( 'tel' ) ) {
+		type = TEL_TYPE;
+	} else if ( url?.startsWith( '#' ) ) {
+		type = INTERNAL_TYPE;
+	}
+
+	// Hash links, relative paths, and URLs with protocols should not be modified
+	if ( isHashLink( url ) || isRelativePath( url ) || protocol ) {
+		return { url, type };
+	}
+
+	// Bare domains need https:// prepended
+	return { url: prependHTTPS( url ), type };
+}

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -12,7 +12,6 @@ import { URLInput } from '../';
 import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
-import normalizeUrl from './normalize-url';
 
 // Must be a function as otherwise URLInput will default
 // to the fetchLinkSuggestions passed in block editor settings
@@ -155,17 +154,14 @@ const LinkControlSearchInput = forwardRef(
 					required={ false }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
-						const directEntryUrl = {
-							url: normalizeUrl( value ).url,
-						};
 
 						// If there is no suggestion and the value (ie: any manually entered URL) is empty
 						// then don't allow submission otherwise we get empty links.
-						if ( ! hasSuggestion && ! directEntryUrl.url ) {
+						if ( ! hasSuggestion && ! value?.trim()?.length ) {
 							event.preventDefault();
 						} else {
 							onSuggestionSelected(
-								hasSuggestion || directEntryUrl
+								hasSuggestion || { url: value }
 							);
 						}
 					} }

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -12,6 +12,7 @@ import { URLInput } from '../';
 import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
+import normalizeUrl from './normalize-url';
 
 // Must be a function as otherwise URLInput will default
 // to the fetchLinkSuggestions passed in block editor settings
@@ -154,14 +155,17 @@ const LinkControlSearchInput = forwardRef(
 					required={ false }
 					onSubmit={ ( suggestion, event ) => {
 						const hasSuggestion = suggestion || focusedSuggestion;
+						const directEntryUrl = {
+							url: normalizeUrl( value ).url,
+						};
 
 						// If there is no suggestion and the value (ie: any manually entered URL) is empty
 						// then don't allow submission otherwise we get empty links.
-						if ( ! hasSuggestion && ! value?.trim()?.length ) {
+						if ( ! hasSuggestion && ! directEntryUrl.url ) {
 							event.preventDefault();
 						} else {
 							onSuggestionSelected(
-								hasSuggestion || { url: value }
+								hasSuggestion || directEntryUrl
 							);
 						}
 					} }

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -3267,28 +3267,43 @@ describe( 'URL validation', () => {
 		mockOnChange.mockClear();
 	} );
 
-	it( 'should prevent submission for invalid URLs', async () => {
-		render(
-			<LinkControl
-				value={ { url: '' } }
-				forceIsEditingLink
-				onChange={ mockOnChange }
-			/>
-		);
+	it.each( [
+		{
+			description: 'URLs with spaces',
+			inputUrl: 'not a url',
+		},
+		{
+			description: 'single words without TLD or protocol',
+			inputUrl: 'wordpress',
+		},
+	] )(
+		'should prevent submission for $description',
+		async ( { inputUrl } ) => {
+			render(
+				<LinkControl
+					value={ { url: '' } }
+					forceIsEditingLink
+					onChange={ mockOnChange }
+				/>
+			);
 
-		const searchInput = screen.getByRole( 'combobox' );
-		// Use a string that is not a valid URL
-		await user.type( searchInput, 'not a url' );
+			const searchInput = screen.getByRole( 'combobox' );
+			await user.type( searchInput, inputUrl );
 
-		// Press Enter - this should trigger validation
-		// Since the value doesn't pass isURLLike, it won't create a suggestion,
-		// but if it did, validation would prevent submission
-		triggerEnter( searchInput );
+			// Press Enter - this should trigger validation
+			triggerEnter( searchInput );
 
-		// For URLs that don't pass isURLLike, no suggestion is created,
-		// so onChange won't be called (which is the expected behavior)
-		expect( mockOnChange ).not.toHaveBeenCalled();
-	} );
+			// Wait for validation error to appear
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Please enter a valid URL.' )
+				).toBeInTheDocument();
+			} );
+
+			// onChange should NOT have been called (submission prevented)
+			expect( mockOnChange ).not.toHaveBeenCalled();
+		}
+	);
 
 	it.each( [
 		{

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -3293,54 +3293,61 @@ describe( 'URL validation', () => {
 	it.each( [
 		{
 			description: 'valid URLs with protocol',
-			url: 'https://wordpress.org',
+			inputUrl: 'https://wordpress.org',
+			expectedUrl: 'https://wordpress.org',
 			searchPattern: /https:\/\/wordpress\.org/,
 		},
 		{
 			description: 'valid URLs without protocol (without http://)',
-			url: 'www.wordpress.org',
+			inputUrl: 'www.wordpress.org',
+			expectedUrl: 'https://www.wordpress.org',
 			searchPattern: /www\.wordpress\.org/,
 		},
 		{
 			description: 'hash links (internal anchor links)',
-			url: '#section',
+			inputUrl: '#section',
+			expectedUrl: '#section',
 			searchPattern: /#section/,
 		},
 		{
 			description: 'relative paths (URLs starting with /)',
-			url: '/handbook',
+			inputUrl: '/handbook',
+			expectedUrl: '/handbook',
 			searchPattern: /\/handbook/,
 		},
-	] )( 'should accept $description', async ( { url, searchPattern } ) => {
-		render(
-			<LinkControl
-				value={ { url: '' } }
-				forceIsEditingLink
-				onChange={ mockOnChange }
-			/>
-		);
+	] )(
+		'should accept $description',
+		async ( { inputUrl, expectedUrl, searchPattern } ) => {
+			render(
+				<LinkControl
+					value={ { url: '' } }
+					forceIsEditingLink
+					onChange={ mockOnChange }
+				/>
+			);
 
-		const searchInput = screen.getByRole( 'combobox' );
-		await user.type( searchInput, url );
+			const searchInput = screen.getByRole( 'combobox' );
+			await user.type( searchInput, inputUrl );
 
-		// Wait for suggestion to appear and become stable
-		await screen.findByRole( 'option', {
-			name: searchPattern,
-		} );
+			// Wait for suggestion to appear and become stable
+			await screen.findByRole( 'option', {
+				name: searchPattern,
+			} );
 
-		triggerEnter( searchInput );
+			triggerEnter( searchInput );
 
-		// No validation error - should succeed
-		await waitFor( () => {
-			expect( mockOnChange ).toHaveBeenCalled();
-		} );
+			// No validation error - should succeed
+			await waitFor( () => {
+				expect( mockOnChange ).toHaveBeenCalled();
+			} );
 
-		expect( mockOnChange ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				url,
-			} )
-		);
-	} );
+			expect( mockOnChange ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					url: expectedUrl,
+				} )
+			);
+		}
+	);
 
 	it( 'should skip validation for entity suggestions (posts, pages, categories)', async () => {
 		const entityLink = {
@@ -3480,9 +3487,10 @@ describe( 'URL validation', () => {
 		// a useful URL in practice. However, our validation philosophy is to
 		// trust the native URL constructor as the authoritative source - if the
 		// browser accepts it, we accept it.
+		// Note: The URL gets normalized with https:// prepended since it's a bare domain.
 		expect( mockOnChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				url: 'www.wordpress',
+				url: 'https://www.wordpress',
 			} )
 		);
 	} );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2832,14 +2832,10 @@ describe( 'Entity handling', () => {
 
 		// Verify that onChange was called with entity metadata cleared.
 		// Kind should be undefined (no longer an entity).
-		// Note: Currently when clicking Apply (vs selecting a suggestion),
-		// type and id are also undefined - that's a separate issue with the
-		// TODO: Apply button handler not processing URLs through handleDirectEntry,
-		// so the shape of the data for a custom link can be different depending on
-		// how it was submitted.
+		// The URL should be normalized (https:// prepended to bare domain).
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				url: 'www.wordpress.org',
+				url: 'https://www.wordpress.org',
 				kind: undefined,
 			} )
 		);

--- a/packages/block-editor/src/components/link-control/test/url-normalization.test.js
+++ b/packages/block-editor/src/components/link-control/test/url-normalization.test.js
@@ -1,0 +1,264 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import LinkControl from '../';
+import { fetchFauxEntitySuggestions } from './fixtures';
+
+const mockFetchSearchSuggestions = jest.fn();
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	const mock = jest.fn();
+	return mock;
+} );
+
+useSelect.mockImplementation( () => ( {
+	fetchSearchSuggestions: mockFetchSearchSuggestions,
+} ) );
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useReducedMotion: jest.fn( () => true ),
+} ) );
+
+beforeEach( () => {
+	mockFetchSearchSuggestions.mockImplementation( fetchFauxEntitySuggestions );
+} );
+
+afterEach( () => {
+	mockFetchSearchSuggestions.mockReset();
+} );
+
+function renderWithProvider( ui ) {
+	return render( ui, { wrapper: SlotFillProvider } );
+}
+
+describe( 'URL normalization consistency', () => {
+	it( 'should normalize bare domain (wordpress.org) to https:// when clicking Apply', async () => {
+		const user = userEvent.setup();
+		const mockOnChange = jest.fn();
+
+		// Start with existing link to show Apply button
+		renderWithProvider(
+			<LinkControl
+				value={ { url: 'https://example.com' } }
+				forceIsEditingLink
+				onChange={ mockOnChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox' );
+		await user.clear( searchInput );
+		await user.type( searchInput, 'wordpress.org' );
+
+		// Wait for suggestion to appear
+		await screen.findByRole( 'option' );
+
+		// Click Apply button (not Enter key, not selecting suggestion)
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		await waitFor( () => {
+			expect( mockOnChange ).toHaveBeenCalled();
+		} );
+
+		// Should normalize to https://wordpress.org
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://wordpress.org',
+			} )
+		);
+	} );
+
+	it( 'should normalize www domain (www.wordpress.org) to https:// when clicking Apply', async () => {
+		const user = userEvent.setup();
+		const mockOnChange = jest.fn();
+
+		// Start with existing link to show Apply button
+		renderWithProvider(
+			<LinkControl
+				value={ { url: 'https://example.com' } }
+				forceIsEditingLink
+				onChange={ mockOnChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox' );
+		await user.clear( searchInput );
+		await user.type( searchInput, 'www.wordpress.org' );
+
+		// Wait for suggestion to appear
+		await screen.findByRole( 'option' );
+
+		// Click Apply button
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		await waitFor( () => {
+			expect( mockOnChange ).toHaveBeenCalled();
+		} );
+
+		// Should normalize to https://www.wordpress.org
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://www.wordpress.org',
+			} )
+		);
+	} );
+
+	it( 'should preserve explicit http:// protocol', async () => {
+		const user = userEvent.setup();
+		const mockOnChange = jest.fn();
+
+		renderWithProvider(
+			<LinkControl
+				value={ { url: 'https://example.com' } }
+				forceIsEditingLink
+				onChange={ mockOnChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox' );
+		await user.clear( searchInput );
+		await user.type( searchInput, 'http://example.com' );
+
+		await screen.findByRole( 'option' );
+
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		await waitFor( () => {
+			expect( mockOnChange ).toHaveBeenCalled();
+		} );
+
+		// Should keep http://, not change to https://
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'http://example.com',
+			} )
+		);
+	} );
+
+	it( 'should preserve mailto: links without normalization', async () => {
+		const user = userEvent.setup();
+		const mockOnChange = jest.fn();
+
+		renderWithProvider(
+			<LinkControl
+				value={ { url: 'https://example.com' } }
+				forceIsEditingLink
+				onChange={ mockOnChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox' );
+		await user.clear( searchInput );
+		await user.type( searchInput, 'mailto:test@example.com' );
+
+		await screen.findByRole( 'option' );
+
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		await waitFor( () => {
+			expect( mockOnChange ).toHaveBeenCalled();
+		} );
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'mailto:test@example.com',
+			} )
+		);
+	} );
+
+	it( 'should preserve relative paths without normalization', async () => {
+		const user = userEvent.setup();
+		const mockOnChange = jest.fn();
+
+		renderWithProvider(
+			<LinkControl
+				value={ { url: 'https://example.com' } }
+				forceIsEditingLink
+				onChange={ mockOnChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox' );
+		await user.clear( searchInput );
+		await user.type( searchInput, '/about' );
+
+		await screen.findByRole( 'option' );
+
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		await waitFor( () => {
+			expect( mockOnChange ).toHaveBeenCalled();
+		} );
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: '/about',
+			} )
+		);
+	} );
+
+	it( 'should preserve hash links without normalization', async () => {
+		const user = userEvent.setup();
+		const mockOnChange = jest.fn();
+
+		renderWithProvider(
+			<LinkControl
+				value={ { url: 'https://example.com' } }
+				forceIsEditingLink
+				onChange={ mockOnChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox' );
+		await user.clear( searchInput );
+		await user.type( searchInput, '#section' );
+
+		await screen.findByRole( 'option' );
+
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		await waitFor( () => {
+			expect( mockOnChange ).toHaveBeenCalled();
+		} );
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: '#section',
+			} )
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getProtocol, prependHTTPS } from '@wordpress/url';
 import { useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -9,39 +8,20 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import isURLLike from './is-url-like';
-import {
-	CREATE_TYPE,
-	TEL_TYPE,
-	MAILTO_TYPE,
-	INTERNAL_TYPE,
-	URL_TYPE,
-} from './constants';
+import normalizeUrl from './normalize-url';
+import { CREATE_TYPE } from './constants';
 import { store as blockEditorStore } from '../../store';
 
 export const handleNoop = () => Promise.resolve( [] );
 
 export const handleDirectEntry = ( val ) => {
-	let type = URL_TYPE;
-
-	const protocol = getProtocol( val ) || '';
-
-	if ( protocol.includes( 'mailto' ) ) {
-		type = MAILTO_TYPE;
-	}
-
-	if ( protocol.includes( 'tel' ) ) {
-		type = TEL_TYPE;
-	}
-
-	if ( val?.startsWith( '#' ) ) {
-		type = INTERNAL_TYPE;
-	}
+	const { url, type } = normalizeUrl( val );
 
 	return Promise.resolve( [
 		{
 			id: val,
 			title: val,
-			url: type === 'URL' ? prependHTTPS( val ) : val,
+			url,
 			type,
 		},
 	] );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -5,7 +5,7 @@ import { useMemo, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
-import { prependHTTP } from '@wordpress/url';
+import { prependHTTPS } from '@wordpress/url';
 import {
 	create,
 	insert,
@@ -122,7 +122,7 @@ function InlineLinkUI( {
 			...nextValue,
 		};
 
-		const newUrl = prependHTTP( nextValue.url );
+		const newUrl = prependHTTPS( nextValue.url );
 		const linkFormat = createLinkFormat( {
 			url: newUrl,
 			type: nextValue.type,

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -641,11 +641,12 @@ test.describe( 'Links', () => {
 
 		await expect( linkPopover ).toBeHidden();
 
+		// LinkControl normalizes bare domains to https://
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: 'This is <a href="http://w.org">WordPress</a>',
+					content: 'This is <a href="https://w.org">WordPress</a>',
 				},
 			},
 		] );
@@ -672,12 +673,13 @@ test.describe( 'Links', () => {
 		await expect( linkPopover ).toBeHidden();
 
 		// The link should have been updated.
+		// LinkControl normalizes bare domains to https://
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {
 					content:
-						'This is <a href="http://wordpress.org">WordPress</a>',
+						'This is <a href="https://wordpress.org">WordPress</a>',
 				},
 			},
 		] );
@@ -1225,12 +1227,13 @@ test.describe( 'Links', () => {
 			await pageUtils.pressKeys( 'Enter' );
 
 			// Check that the correct (i.e. last) instance of "a" was replaced with "z".
+			// LinkControl normalizes bare domains to https://
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'a b c <a href="http://www.wordpress.org">z</a>',
+							'a b c <a href="https://www.wordpress.org">z</a>',
 					},
 				},
 			] );


### PR DESCRIPTION
## What?

Refactors the LinkControl component to normalize URLs consistently and default to HTTPS for bare domains.

## Why?

Previously, URL validation and normalization happened at different times, causing inconsistencies:

1. **Validation issue**: When validating a URL, we temporarily prepended `http://` to check validity (a "fake" URL), but didn't use that normalized URL when saving
2. **Inconsistent normalization**:
   - Selecting a suggestion → URL normalized via `handleDirectEntry`
   - Clicking Apply button → URL submitted as-is without normalization
3. **Insecure default**: Bare domains defaulted to `http://` instead of `https://`

**Example of the bug:**
```js
// User types "wordpress.org" and clicks Apply
// Expected: "https://wordpress.org"
// Actual: "wordpress.org" (no protocol added)
```

## How?

### 1. Created centralized normalization

- New `normalize-url.js` extracts URL normalization logic from `handleDirectEntry`
- Returns `{ url, type }` for reuse across multiple contexts
- Handles bare domains, protocols, relative paths, and hash links

### 3. Defaulted to HTTPS

- `normalize-url.js` uses `prependHTTPS` instead of `prependHTTP`
- `format-library/link/inline.js` updated to use `prependHTTPS` for consistency
- Bare domains now default to `https://` (secure by default)

## URL Normalization Rules

| Input | Output |
|-------|--------|
| `wordpress.org` | `https://wordpress.org` |
| `www.wordpress.org` | `https://www.wordpress.org` |
| `http://example.com` | `http://example.com` (preserved) |
| `https://example.com` | `https://example.com` (preserved) |
| `mailto:hi@wp.org` | `mailto:hi@wp.org` (preserved) |
| `tel:123456` | `tel:123456` (preserved) |
| `/about` | `/about` (preserved) |
| `#section` | `#section` (preserved) |


## Note
I would have liked to do: normalization -> validation -> save, but I ran into an issue with `isURLLike`:

The main issue I ran into was that we use an initial `isURLLike` which has custom validation rules. Mainly, that a single string with no spaces, ie `WordPress` would be disallowed because of `isURLLike` which has an early return in the validation. If we normalize BEFORE validation, the string would become `https://WordPress`, which _does_ pass `isURLLike`. 

So, if we normalize and then validate, all single strings pass when they would have previously failed. So, I chose to validate using the same flow, but always normalize after validation so I didn't introduce a new standard of what was accepted.

I'm closing this PR to help with triage, but feel free to open it back up if I'm wrong!
## Testing Instructions

1. **Test bare domain normalization:**
   - Insert a paragraph block
   - Select text and press Cmd/Ctrl+K
   - Type `wordpress.org`
   - Click "Apply" button
   - ✅ Should save as `https://wordpress.org`

2. **Test protocol preservation:**
   - Same steps but type `http://example.com`
   - ✅ Should preserve `http://` (not change to `https://`)

3. **Test special protocols:**
   - Same steps but type `mailto:test@example.com`
   - ✅ Should preserve `mailto:` protocol

4. **Test relative paths:**
   - Same steps but type `/about`
   - ✅ Should preserve as `/about` (no protocol added)

5. **Test via Enter key:**
   - Repeat step 1 but press Enter instead of clicking Apply
   - ✅ Should produce same result

6. **Test via suggestion selection:**
   - Type `wordpress.org` and click the suggestion dropdown item
   - ✅ Should produce same result

7. **Single string should not be valid URL**
   - Type 'word`
   - Press Enter
   - Should see invalid URL message

## Technical Details

### Files Changed

- `packages/block-editor/src/components/link-control/normalize-url.js` (new)
- `packages/block-editor/src/components/link-control/index.js`
- `packages/block-editor/src/components/link-control/use-search-handler.js`
- `packages/format-library/src/link/inline.js`
- Tests: `url-normalization.test.js` (new), `index.js`, `links.spec.js`

### Architecture

The new flow ensures all three submission paths normalize identically:

1. **Selecting a suggestion**: `handleDirectEntry` → `normalizeUrl()` → onChange
2. **Clicking Apply**: `handleSubmit` → `normalizeUrl()` → validate → submit → onChange
3. **Pressing Enter**: Same as Apply

All paths use the same `normalizeUrl()` function, ensuring consistency.

## Screenshots

N/A - no visual changes, behavior only

