### PR TITLE
Theme: Fix gap token migration guide in changelog

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -16,8 +16,7 @@
     -   `--wpds-dimension-gap-sm`: use `--wpds-dimension-gap-md` instead.
     -   `--wpds-dimension-gap-md`: use `--wpds-dimension-gap-lg` instead.
     -   `--wpds-dimension-gap-lg`: use `--wpds-dimension-gap-xl` instead.
-    -   `--wpds-dimension-gap-xl`: use `--wpds-dimension-gap-2xl` instead.
-    -   `--wpds-dimension-gap-2xl`: use `--wpds-dimension-gap-3xl` instead.
+    -   `--wpds-dimension-gap-xl`: use `--wpds-dimension-gap-3xl` instead.
 -   Renamed elevation tokens to use abbreviated size names for consistency with other tokens ([#75103](https://github.com/WordPress/gutenberg/pull/75103)):
     -   `--wpds-elevation-x-small`: use `--wpds-elevation-xs` instead.
     -   `--wpds-elevation-small`: use `--wpds-elevation-sm` instead.


### PR DESCRIPTION
## What?

Follow up to #75054

Fixes the gap token migration guide in the `@wordpress/theme` changelog.

## Why?

The migration guide had two errors:
- `--wpds-dimension-gap-xl` was listed as mapping to `--wpds-dimension-gap-2xl` (32px), but the old `xl` token was 40px, which corresponds to `--wpds-dimension-gap-3xl`.
- `--wpds-dimension-gap-2xl` was listed as an old token to migrate from, but it didn't exist in the old scale (which ended at `xl`).

Changes can be confirmed in the [design tokens stylesheet diff here](https://github.com/WordPress/gutenberg/pull/75054/changes#diff-3589c464d6b6f7ef8c8298ea2edb61e8b70bf8c1419fee14da4bab44e6cb7c0dL104-L108).

## Testing Instructions

Review the changelog at `packages/theme/CHANGELOG.md` and verify the gap migration entries match the actual token values.