### PR TITLE
Block Visibility: Disable Apply button on non-dirty state

### DIFF
--- a/packages/block-editor/src/components/block-visibility/modal.js
+++ b/packages/block-editor/src/components/block-visibility/modal.js
@@ -146,6 +146,17 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 		[ viewportChecked ]
 	);
 
+	const isDirty = useMemo( () => {
+		if ( hideEverywhere !== initialViewportValues.hideEverywhere ) {
+			return true;
+		}
+		return BLOCK_VISIBILITY_VIEWPORT_ENTRIES.some(
+			( [ , { key } ] ) =>
+				viewportChecked[ key ] !==
+				initialViewportValues.viewportChecked[ key ]
+		);
+	}, [ hideEverywhere, viewportChecked, initialViewportValues ] );
+
 	const hasIndeterminateValues = useMemo( () => {
 		if ( hideEverywhere === null ) {
 			return true;
@@ -348,6 +359,8 @@ export default function BlockVisibilityModal( { clientIds, onClose } ) {
 						<Button
 							variant="primary"
 							type="submit"
+							disabled={ ! isDirty }
+							accessibleWhenDisabled
 							__next40pxDefaultSize
 						>
 							{ __( 'Apply' ) }


### PR DESCRIPTION
## What?

Related to #73776

Disables the Apply button in the block visibility modal when no changes have been made.

## Why?

The Apply button was always enabled, even when the modal was opened without making any changes.

## How?

Adds an `isDirty` memo that compares current checkbox state against the initial values derived from block attributes. The Apply button is disabled when `!isDirty`.

## Testing Instructions

1. Add a block and open the block visibility modal.
2. Verify the Apply button is disabled.
3. Toggle a checkbox — Apply should become enabled.
4. Toggle it back — Apply should become disabled again.
5. Repeat with a block that already has visibility settings.


https://github.com/user-attachments/assets/7e469f3b-5456-4b57-b718-c874b357b2cc

