### PR TITLE
Block Lock: Disable Apply button on non-dirty state

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import {
 	Button,
 	CheckboxControl,
@@ -41,7 +41,6 @@ function getTemplateLockValue( lock ) {
 }
 
 export default function BlockLockModal( { clientId, onClose } ) {
-	const [ lock, setLock ] = useState( { move: false, remove: false } );
 	const { isEditLocked, isMoveLocked, isRemoveLocked } =
 		useBlockLock( clientId );
 	const { allowsEditLocking, templateLock, hasTemplateLock } = useSelect(
@@ -59,6 +58,11 @@ export default function BlockLockModal( { clientId, onClose } ) {
 		},
 		[ clientId ]
 	);
+	const [ lock, setLock ] = useState( {
+		move: isMoveLocked,
+		remove: isRemoveLocked,
+		...( allowsEditLocking ? { edit: isEditLocked } : {} ),
+	} );
 	const [ applyTemplateLock, setApplyTemplateLock ] = useState(
 		!! templateLock
 	);
@@ -75,6 +79,28 @@ export default function BlockLockModal( { clientId, onClose } ) {
 
 	const isAllChecked = Object.values( lock ).every( Boolean );
 	const isMixed = Object.values( lock ).some( Boolean ) && ! isAllChecked;
+
+	const isDirty = useMemo( () => {
+		if ( lock.move !== isMoveLocked || lock.remove !== isRemoveLocked ) {
+			return true;
+		}
+		if ( allowsEditLocking && lock.edit !== isEditLocked ) {
+			return true;
+		}
+		if ( hasTemplateLock && applyTemplateLock !== !! templateLock ) {
+			return true;
+		}
+		return false;
+	}, [
+		lock,
+		isMoveLocked,
+		isRemoveLocked,
+		isEditLocked,
+		allowsEditLocking,
+		applyTemplateLock,
+		templateLock,
+		hasTemplateLock,
+	] );
 
 	return (
 		<Modal
@@ -224,6 +250,8 @@ export default function BlockLockModal( { clientId, onClose } ) {
 						<Button
 							variant="primary"
 							type="submit"
+							disabled={ ! isDirty }
+							accessibleWhenDisabled
 							__next40pxDefaultSize
 						>
 							{ __( 'Apply' ) }

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -41,6 +41,7 @@ function getTemplateLockValue( lock ) {
 }
 
 export default function BlockLockModal( { clientId, onClose } ) {
+	const [ lock, setLock ] = useState( { move: false, remove: false } );
 	const { isEditLocked, isMoveLocked, isRemoveLocked } =
 		useBlockLock( clientId );
 	const { allowsEditLocking, templateLock, hasTemplateLock } = useSelect(
@@ -58,11 +59,6 @@ export default function BlockLockModal( { clientId, onClose } ) {
 		},
 		[ clientId ]
 	);
-	const [ lock, setLock ] = useState( {
-		move: isMoveLocked,
-		remove: isRemoveLocked,
-		...( allowsEditLocking ? { edit: isEditLocked } : {} ),
-	} );
 	const [ applyTemplateLock, setApplyTemplateLock ] = useState(
 		!! templateLock
 	);

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -96,6 +96,9 @@ export default function BlockLockModal( { clientId, onClose } ) {
 			<form
 				onSubmit={ ( event ) => {
 					event.preventDefault();
+					if ( ! isDirty ) {
+						return;
+					}
 					updateBlockAttributes( [ clientId ], {
 						lock,
 						templateLock: applyTemplateLock

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	Button,
 	CheckboxControl,
@@ -76,27 +76,11 @@ export default function BlockLockModal( { clientId, onClose } ) {
 	const isAllChecked = Object.values( lock ).every( Boolean );
 	const isMixed = Object.values( lock ).some( Boolean ) && ! isAllChecked;
 
-	const isDirty = useMemo( () => {
-		if ( lock.move !== isMoveLocked || lock.remove !== isRemoveLocked ) {
-			return true;
-		}
-		if ( allowsEditLocking && lock.edit !== isEditLocked ) {
-			return true;
-		}
-		if ( hasTemplateLock && applyTemplateLock !== !! templateLock ) {
-			return true;
-		}
-		return false;
-	}, [
-		lock,
-		isMoveLocked,
-		isRemoveLocked,
-		isEditLocked,
-		allowsEditLocking,
-		applyTemplateLock,
-		templateLock,
-		hasTemplateLock,
-	] );
+	const isDirty =
+		lock.move !== isMoveLocked ||
+		lock.remove !== isRemoveLocked ||
+		( allowsEditLocking && lock.edit !== isEditLocked ) ||
+		( hasTemplateLock && applyTemplateLock !== !! templateLock );
 
 	return (
 		<Modal


### PR DESCRIPTION
## What?

Similar to https://github.com/WordPress/gutenberg/pull/75494, disables the "Apply" button in the block lock modal when no changes have been made.

## Why?

As @talldan suggests in https://github.com/WordPress/gutenberg/pull/75494#pullrequestreview-3794705362, for consistency across these types of modals.

## How?

Adds an `isDirty` memo comparing `lock` state (`move`, `remove`, `edit`) and `applyTemplateLock` against their initial values. The Apply button is disabled when `!isDirty`.

## Testing Instructions

1. Add a block and open the block lock modal (More options > Lock).
2. Verify the Apply button is disabled.
3. Toggle a lock checkbox — Apply should become enabled.
4. Toggle it back — Apply should become disabled again.
5. Repeat with a block that already has lock settings.


https://github.com/user-attachments/assets/b76c0ff9-bef6-4e68-972b-00a4c095800e


