### PR TITLE
Blocks: Allow the `Loginout` block as an inner block in the `Navigation Submenu` block

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -54,6 +54,7 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-link',
 	'core/navigation-submenu',
 	'core/page-list',
+	'core/loginout',
 ];
 
 /**


### PR DESCRIPTION


## What?
Closes #75408

Allow the Login/out block to be inserted and moved inside a Navigation Submenu block.

## Why?
Currently, the Login/out block cannot be added as a sub-menu item inside the Navigation block. This prevents a common pattern such as having a “My Account” parent item with “Logout” as a child item.

This PR enables that expected behavior.

## How?
Updates the allowed inner blocks configuration for wp:navigation-submenu to include wp:loginout.

## Testing Instructions

1. Add a Navigation block to a post or template and start editing it.
2. Add a few menu items (e.g., pages).
3. Convert one of the items into a Submenu and add at least one child item.
4. Insert the Login/out block.
5. Move the Login/out block inside the Submenu.
6. Verify it can be inserted and nested without errors.

## Screenshots or screencast <!-- if applicable -->


<img width="1299" height="726" alt="Image" src="https://github.com/user-attachments/assets/2d7b1fee-2df6-43f9-8f5a-6fea4bf55b15" />

https://github.com/user-attachments/assets/a5a6485c-f01a-47ce-91ba-b33197536381
