### PR TITLE
Real-Time Collaboration: Import Yjs correctly in core-data

### DIFF
--- a/packages/core-data/src/awareness/test/awareness-state.ts
+++ b/packages/core-data/src/awareness/test/awareness-state.ts
@@ -9,7 +9,11 @@ import {
 	beforeEach,
 	afterEach,
 } from '@jest/globals';
-import * as Y from 'yjs';
+
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies

--- a/packages/core-data/src/awareness/test/typed-awareness.ts
+++ b/packages/core-data/src/awareness/test/typed-awareness.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
-import * as Y from 'yjs';
+
+/**
+ * WordPress dependencies
+ */
+import { Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?

Yjs should be imported from the sync package only.

## Why?

Libraries that aren't imported in the dependencies of a package should not be referenced.

## How?

We export Yjs from the sync package, so it should be used via that only.

## Testing Instructions

Run the tests

### Testing Instructions for Keyboard

N/A
