### PR TITLE
Improve command search experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58036,6 +58036,7 @@
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
+				"@wordpress/compose": "file:../compose",
 				"@wordpress/data": "file:../data",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -46,6 +46,7 @@
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -17,11 +17,13 @@ import {
 	isValidElement,
 	Component,
 } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
 	Modal,
 	TextHighlight,
 	__experimentalHStack as HStack,
+	Spinner,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
@@ -60,13 +62,34 @@ export function isValidIcon( icon ) {
 	);
 }
 
-function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
-	const { isLoading, commands = [] } = hook( { search } ) ?? {};
-	useEffect( () => {
-		setLoader( name, isLoading );
-	}, [ setLoader, name, isLoading ] );
+function useDebouncedValue( value ) {
+	const [ debouncedValue, setDebouncedValue ] = useState( '' );
+	const debounced = useDebounce( setDebouncedValue, 250 );
 
-	if ( ! commands.length ) {
+	useEffect( () => {
+		debounced( value );
+		return () => debounced.cancel();
+	}, [ debounced, value ] );
+
+	return debouncedValue;
+}
+
+function CommandMenuLoader( {
+	isLoading,
+	name,
+	search,
+	hook,
+	setLoader,
+	close,
+} ) {
+	const { isLoading: isLoadingCommands, commands = [] } =
+		hook( { search } ) ?? {};
+
+	useEffect( () => {
+		setLoader( name, isLoadingCommands );
+	}, [ setLoader, name, isLoadingCommands ] );
+
+	if ( ! commands.length || isLoadingCommands || isLoading ) {
 		return null;
 	}
 
@@ -102,7 +125,14 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 	);
 }
 
-export function CommandMenuLoaderWrapper( { hook, search, setLoader, close } ) {
+export function CommandMenuLoaderWrapper( {
+	isLoading,
+	name,
+	hook,
+	search,
+	setLoader,
+	close,
+} ) {
 	// The "hook" prop is actually a custom React hook
 	// so to avoid breaking the rules of hooks
 	// the CommandMenuLoaderWrapper component need to be
@@ -121,14 +151,22 @@ export function CommandMenuLoaderWrapper( { hook, search, setLoader, close } ) {
 		<CommandMenuLoader
 			key={ key }
 			hook={ currentLoaderRef.current }
+			name={ name }
 			search={ search }
 			setLoader={ setLoader }
 			close={ close }
+			isLoading={ isLoading }
 		/>
 	);
 }
 
-export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
+export function CommandMenuGroup( {
+	isLoading,
+	isContextual,
+	search,
+	setLoader,
+	close,
+} ) {
 	const { commands, loaders } = useSelect(
 		( select ) => {
 			const { getCommands, getCommandLoaders } = select( commandsStore );
@@ -146,37 +184,40 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 
 	return (
 		<Command.Group>
-			{ commands.map( ( command ) => (
-				<Command.Item
-					key={ command.name }
-					value={ command.searchLabel ?? command.label }
-					keywords={ command.keywords }
-					onSelect={ () => command.callback( { close } ) }
-					id={ command.name }
-				>
-					<HStack
-						alignment="left"
-						className={ clsx( 'commands-command-menu__item', {
-							'has-icon': command.icon,
-						} ) }
+			{ ! isLoading &&
+				commands.map( ( command ) => (
+					<Command.Item
+						key={ command.name }
+						value={ command.searchLabel ?? command.label }
+						keywords={ command.keywords }
+						onSelect={ () => command.callback( { close } ) }
+						id={ command.name }
 					>
-						{ command.icon && <Icon icon={ command.icon } /> }
-						<span>
-							<TextHighlight
-								text={ command.label }
-								highlight={ search }
-							/>
-						</span>
-					</HStack>
-				</Command.Item>
-			) ) }
+						<HStack
+							alignment="left"
+							className={ clsx( 'commands-command-menu__item', {
+								'has-icon': command.icon,
+							} ) }
+						>
+							{ command.icon && <Icon icon={ command.icon } /> }
+							<span>
+								<TextHighlight
+									text={ command.label }
+									highlight={ search }
+								/>
+							</span>
+						</HStack>
+					</Command.Item>
+				) ) }
 			{ loaders.map( ( loader ) => (
 				<CommandMenuLoaderWrapper
 					key={ loader.name }
+					name={ loader.name }
 					hook={ loader.hook }
 					search={ search }
 					setLoader={ setLoader }
 					close={ close }
+					isLoading={ isLoading }
 				/>
 			) ) }
 		</Command.Group>
@@ -215,6 +256,9 @@ function CommandInput( { isOpen, search, setSearch } ) {
 export function CommandMenu() {
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 	const [ search, setSearch ] = useState( '' );
+
+	const debouncedSearch = useDebouncedValue( search );
+
 	const isOpen = useSelect(
 		( select ) => select( commandsStore ).isOpen(),
 		[]
@@ -296,22 +340,39 @@ export function CommandMenu() {
 						/>
 					</div>
 					<Command.List label={ __( 'Command suggestions' ) }>
-						{ search && ! isLoading && (
+						{ debouncedSearch && ! isLoading && (
 							<Command.Empty>
 								{ __( 'No results found.' ) }
 							</Command.Empty>
 						) }
+						{ isLoading && (
+							<Command.Loading>
+								<div
+									style={ {
+										display: 'flex',
+										justifyContent: 'center',
+										alignItems: 'center',
+										paddingBottom: '16px',
+									} }
+								>
+									<Spinner />
+									{ __( 'Loading commands…' ) }
+								</div>
+							</Command.Loading>
+						) }
 						<CommandMenuGroup
-							search={ search }
+							search={ debouncedSearch }
 							setLoader={ setLoader }
 							close={ closeAndReset }
+							isLoading={ isLoading }
 							isContextual
 						/>
-						{ search && (
+						{ debouncedSearch && (
 							<CommandMenuGroup
-								search={ search }
+								search={ debouncedSearch }
 								setLoader={ setLoader }
 								close={ closeAndReset }
+								isLoading={ isLoading }
 							/>
 						) }
 					</Command.List>

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -3,7 +3,7 @@
  */
 import { useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useEffect, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
@@ -18,7 +18,6 @@ import {
 } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs, getPath } from '@wordpress/url';
-import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -35,18 +34,6 @@ const icons = {
 	wp_template: layout,
 	wp_template_part: symbolFilled,
 };
-
-function useDebouncedValue( value ) {
-	const [ debouncedValue, setDebouncedValue ] = useState( '' );
-	const debounced = useDebounce( setDebouncedValue, 250 );
-
-	useEffect( () => {
-		debounced( value );
-		return () => debounced.cancel();
-	}, [ debounced, value ] );
-
-	return debouncedValue;
-}
 
 // Route mapping for experimental site editor
 const ROUTE_MAPPING = {
@@ -107,17 +94,17 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 			},
 			[]
 		);
-		const delayedSearch = useDebouncedValue( search );
+
 		const { records, isLoading } = useSelect(
 			( select ) => {
-				if ( ! delayedSearch ) {
+				if ( ! search ) {
 					return {
 						isLoading: false,
 					};
 				}
 
 				const query = {
-					search: delayedSearch,
+					search,
 					per_page: 10,
 					orderby: 'relevance',
 					status: [
@@ -140,7 +127,7 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 					),
 				};
 			},
-			[ delayedSearch ]
+			[ search ]
 		);
 
 		const commands = useMemo( () => {

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -411,11 +411,14 @@ const getManipulateDocumentCommands = () =>
 		const { revertTemplate } = unlock( useDispatch( editorStore ) );
 
 		if (
-			! hasResolved ||
 			! [ TEMPLATE_PART_POST_TYPE, TEMPLATE_POST_TYPE ].includes(
 				postType
 			)
 		) {
+			return { isLoading: false, commands: [] };
+		}
+
+		if ( ! hasResolved ) {
 			return { isLoading: true, commands: [] };
 		}
 


### PR DESCRIPTION
## What?
Closes #69184

Improving command search experience by debouncing the user input and showing loading state.

## Why?
It improves command search user experience by fixing following bugs:
* Slow rendering of `No Results` in modal.
* Showing nothing for the same search query on the second time.

## How?
* Debounced user input to fix slow use response and loading state as well.
* Fixed loading state of a specific command.

## Testing Instructions
1. Open the command palette.
2. Search something quickly, no slowness should be noticed in the UI rendering.
3. Loading state should be visible.
4. Erase and type same query again, same results must be visible.

### Testing Instructions for Keyboard
Same as above

## Screenshots or screencast

https://github.com/user-attachments/assets/d9041989-7ff8-40ad-aad8-d83e212e307a