### PR TITLE
Video: Add raw transform for direct video URLs

### DIFF
--- a/packages/block-library/src/video/transforms.js
+++ b/packages/block-library/src/video/transforms.js
@@ -6,9 +6,11 @@ import { createBlock } from '@wordpress/blocks';
 
 /**
  * Video file extensions that indicate a URL points directly to a video.
+ *
+ * 'mp4', 'm4v', 'webm', 'ogv', 'avi', 'mov', 'wmv', 'mpg', 'mpeg', 'ogg'
  */
 const VIDEO_EXTENSIONS =
-	/\.(?:mp4|m4v|webm|ogv|flv|avi|mov|wmv|mkv)(?:\?.*)?$/i;
+	/\.(?:mp4|m4v|webm|ogv|avi|mov|wmv|mpg|mpeg|ogg)(?:\?.*)?$/i;
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/video/transforms.js
+++ b/packages/block-library/src/video/transforms.js
@@ -4,8 +4,28 @@
 import { createBlobURL, isBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 
+/**
+ * Video file extensions that indicate a URL points directly to a video.
+ */
+const VIDEO_EXTENSIONS =
+	/\.(?:mp4|m4v|webm|ogv|flv|avi|mov|wmv|mkv)(?:\?.*)?$/i;
+
 const transforms = {
 	from: [
+		{
+			type: 'raw',
+			priority: 9,
+			isMatch: ( node ) =>
+				node.nodeName === 'P' &&
+				/^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ) &&
+				node.textContent?.match( /https/gi )?.length === 1 &&
+				VIDEO_EXTENSIONS.test( node.textContent.trim() ),
+			transform: ( node ) => {
+				return createBlock( 'core/video', {
+					src: node.textContent.trim(),
+				} );
+			},
+		},
 		{
 			type: 'files',
 			isMatch( files ) {

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -7,6 +7,7 @@ import { pasteHandler } from '@wordpress/blocks';
  */
 import { init as initAndRegisterTableBlock } from '../../../../../block-library/src/table';
 import { init as initAndRegisterVideoBlock } from '../../../../../block-library/src/video';
+import { init as initAndRegisterEmbedBlock } from '../../../../../block-library/src/embed';
 
 const tableWithHeaderFooterAndBodyUsingColspan = `
 <table>
@@ -85,6 +86,7 @@ describe( 'pasteHandler', () => {
 	beforeAll( () => {
 		initAndRegisterTableBlock();
 		initAndRegisterVideoBlock();
+		initAndRegisterEmbedBlock();
 	} );
 
 	it( 'can handle a table with thead, tbody and tfoot using colspan', () => {
@@ -286,5 +288,61 @@ describe( 'pasteHandler', () => {
 		} );
 		expect( result.name ).toEqual( 'core/video' );
 		expect( result.isValid ).toBeTruthy();
+	} );
+
+	it( 'creates a video block when pasting a direct video URL', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<p>https://example.com/video.mp4</p>',
+			plainText: 'https://example.com/video.mp4',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+		expect( result.name ).toEqual( 'core/video' );
+		expect( result.attributes.src ).toEqual(
+			'https://example.com/video.mp4'
+		);
+	} );
+
+	it( 'creates a video block for various video extensions', () => {
+		const extensions = [ 'mp4', 'webm', 'ogv', 'mov', 'avi' ];
+
+		for ( const ext of extensions ) {
+			const url = `https://example.com/video.${ ext }`;
+			const [ result ] = pasteHandler( {
+				HTML: `<p>${ url }</p>`,
+				plainText: url,
+				mode: 'BLOCKS',
+			} );
+
+			expect( result.name ).toEqual( 'core/video' );
+			expect( result.attributes.src ).toEqual( url );
+		}
+
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'creates a video block for video URLs with query parameters', () => {
+		const url = 'https://example.com/video.mp4?quality=hd&token=abc';
+		const [ result ] = pasteHandler( {
+			HTML: `<p>${ url }</p>`,
+			plainText: url,
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+		expect( result.name ).toEqual( 'core/video' );
+		expect( result.attributes.src ).toEqual( url );
+	} );
+
+	it( 'creates an embed block for non-video URLs', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<p>https://www.youtube.com/watch?v=dQw4w9WgXcQ</p>',
+			plainText: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+			mode: 'BLOCKS',
+		} );
+
+		expect( console ).toHaveLogged();
+		expect( result.name ).toEqual( 'core/embed' );
 	} );
 } );


### PR DESCRIPTION
Related to: https://github.com/WordPress/gutenberg/issues/74734

## What?

Adds video URL detection to prevent direct video URLs from being converted to Embed blocks, and creates video blocks instead when pasting video URLs.

## Why?

When pasting a direct video URL (e.g., ending in 'mp4', 'm4v', 'webm', 'ogv', 'avi', 'mov', 'wmv', 'mpg', 'mpeg', 'ogg') into the editor, the embed block's raw transform matches it and creates an Embed block. This results in a failed embed preview instead of displaying the video inline.

This issue was reported in #18696 and #19225. The embed block's raw transform never excluded image URLs, causing this behavior.

## How?

- Modified Priority to be 9 in video block transformation.
- Added a new raw transform to [packages/block-library/src/image/transforms.js] that matches pasted video URLs and creates video blocks
- Added unit tests to [packages/blocks/src/api/raw-handling/test/paste-handler.js]to prevent future regressions

## Testing Instructions

1. Open a new post or page in the editor
2. Paste a direct video URL into an empty paragraph block (e.g., `https://videos.files.wordpress.com/rWDRTDWK/wp-solution-optimized.mp4`)
3. Verify that an video block is created with the video displayed
4. Paste a non-video URL (e.g., `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
5. Verify that an Embed block is created as expected

https://github.com/user-attachments/assets/a12aedee-ffc2-4689-a553-21e74d867dad

