### PR TITLE
Dependency extraction: bundle theme, route and boot by default

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Add `@wordpress/boot`,  `@wordpress/theme`, and `@wordpress/route` to list of bundled packages. These won't be externalized to WP/Gutenberg by the plugin and are instead included in the build output.
+-   Add `@wordpress/boot`, `@wordpress/theme`, and `@wordpress/route` to list of bundled packages. These won't be externalized to WP/Gutenberg by the plugin and are instead included in the build output.
 
 ## 6.39.0 (2026-01-29)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add `@wordpress/boot`,  `@wordpress/theme`, and `@wordpress/route` to list of bundled packages. These won't be externalized to WP/Gutenberg by the plugin and are instead included in the build output.
+
 ## 6.39.0 (2026-01-29)
 
 ## 6.38.0 (2026-01-16)

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -1,14 +1,17 @@
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [
 	'@wordpress/admin-ui',
+	'@wordpress/boot',
 	'@wordpress/dataviews',
 	'@wordpress/dataviews/wp',
+	'@wordpress/fields',
 	'@wordpress/icons',
 	'@wordpress/interface',
-	'@wordpress/undo-manager',
-	'@wordpress/fields',
-	'@wordpress/views',
+	'@wordpress/route',
+	'@wordpress/theme',
 	'@wordpress/ui',
+	'@wordpress/undo-manager',
+	'@wordpress/views',
 ];
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

- Add `@wordpress/boot`, `@wordpress/theme`, and `@wordpress/route` to list of bundled packages; these are heavily used with [`WP Build`](https://github.com/WordPress/gutenberg/tree/trunk/packages/wp-build) package.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- These packages aren't super stable yet visually or functionally, and they've changed a lot recently (especially [theme](https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+is%3Aclosed+label%3A%22%5BPackage%5D+Theme%22)).
   - If a plugin wants to support older WP versions or just wants to ensure stability even with the latest WP without Gutenberg, it's not really possible to use these packages without bundling them for now.
   - We should bundle the theme since we also bundle packages using it (UI, DataViews…); otherwise, there can be version conflicts when using both packages together ([example](https://github.com/Automattic/jetpack/pull/46973)).
- I suggest we could unbundle them again once they're in WP 7.1 and stabilised.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
