### PR TITLE
AGENTS.md: Add CLAUDE.md symlinks, architecture decisions, and common pitfalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,23 @@ vendor/bin/phpcs         # Check PHP standards
 vendor/bin/phpcbf <path_to_php_file.php>
 ```
 
+## Architectural decisions
+
+-   **Package layering**: Three editor layers — `block-editor` (generic, WP-agnostic) → `editor` (WordPress post-aware) → `edit-post`/`edit-site` (full screens). Lower layers MUST NOT depend on higher ones.
+-   **Block data model**: Blocks are in-memory tree structures during editing, serialized as HTML with comment delimiters (`<!-- wp:name -->`). Work with the block tree via APIs, not the serialized HTML.
+-   **Data layer**: Uses `@wordpress/data` (Redux-like stores). Edit entities through `core-data` actions (`editEntityRecord` / `saveEditedEntityRecord`), not direct state manipulation.
+-   **Styles system**: Three-layer merge — WordPress defaults < `theme.json` < user preferences. Use Block Supports API and CSS custom properties (`--wp--preset--*`), not hardcoded values.
+-   **Modularity**: Packages are available both as npm packages and WordPress scripts (`wp-*` handles). Production packages must work in both contexts.
+
+For full architecture details, see `docs/explanations/architecture/`.
+
+## Common pitfalls
+
+-   PHP features in `lib/compat/` MUST target a specific `wordpress-X.Y/` subdirectory.
+-   Avoid using private APIs in bundled packages (packages without `wpScript` or `wpModuleExports`). Private APIs are intended for Core usage; bundled packages may also be imported via npm into plugin scripts, causing incompatibilities.
+-   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
+-   `@wordpress/scripts` (the `build` package) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
+
 ## PR instructions
 
 -   Ensure build passes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ vendor/bin/phpcbf <path_to_php_file.php>
 
 ## Architectural decisions
 
--   **Package layering**: Three editor layers — `block-editor` (generic, WP-agnostic) → `editor` (WordPress post-aware) → `edit-post`/`edit-site` (full screens). Lower layers MUST NOT depend on higher ones.
+-   **Package layering**: Three editor layers — `block-editor` (generic, WP-agnostic) → `editor` (WordPress post-type-aware) → `edit-post`/`edit-site` (full screens). Lower layers MUST NOT depend on higher ones.
 -   **Block data model**: Blocks are in-memory tree structures during editing, serialized as HTML with comment delimiters (`<!-- wp:name -->`). Work with the block tree via APIs, not the serialized HTML.
 -   **Data layer**: Uses `@wordpress/data` (Redux-like stores). Edit entities through `core-data` actions (`editEntityRecord` / `saveEditedEntityRecord`), not direct state manipulation.
 -   **Styles system**: Three-layer merge — WordPress defaults < `theme.json` < user preferences. Use Block Supports API and CSS custom properties (`--wp--preset--*`), not hardcoded values.
@@ -71,7 +71,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 -   PHP features in `lib/compat/` MUST target a specific `wordpress-X.Y/` subdirectory.
 -   Avoid using private APIs in bundled packages (packages without `wpScript` or `wpModuleExports`). Private APIs are intended for Core usage; bundled packages may also be imported via npm into plugin scripts, causing incompatibilities.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
--   `@wordpress/scripts` (the `build` package) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
+-   `@wordpress/build` (`packages/wp-build`) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
 
 ## PR instructions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## What?

Improves the AGENTS.md setup for coding agents working on Gutenberg.

## Why?

Claude Code only reads `CLAUDE.md`, not `AGENTS.md`, so it was getting zero project context. The existing `AGENTS.md` also lacked sections on architectural decisions and common pitfalls, which are high-value for reducing agent mistakes.

## How?

1. **CLAUDE.md symlinks** — Created at root, `packages/components/`, and `packages/ui/` pointing to their respective `AGENTS.md` files.
2. **Architectural decisions section** — Covers package layering, block data model, data layer, styles system, and modularity. Links to full architecture docs.
3. **Common pitfalls section** — Covers `lib/compat/` targeting, private APIs in bundled packages, `block-editor` WP-agnosticism, and `@wordpress/scripts` genericity.

## Testing Instructions

1. Verify symlinks resolve correctly: `ls -la CLAUDE.md` should show `-> AGENTS.md`
2. Start a fresh Claude Code session in the repo and confirm it picks up the context from `CLAUDE.md`
3. Review the new sections in `AGENTS.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)