### PR TITLE
Prefix usages of JSX namespaces with React.JSX

### DIFF
--- a/packages/boot/src/components/navigation/items.tsx
+++ b/packages/boot/src/components/navigation/items.tsx
@@ -16,7 +16,7 @@ import type { IconType } from '../../store/types';
  *
  * @param element - The element to check
  */
-function isSvg( element: unknown ): element is JSX.Element {
+function isSvg( element: unknown ): element is React.JSX.Element {
 	return (
 		isValidElement( element ) &&
 		( element.type === SVG || element.type === 'svg' )

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -10,7 +10,7 @@ import type { ReactNode, ComponentType } from 'react';
  * - SVG icons from @wordpress/icons
  * - Data URLs for images
  */
-export type IconType = string | JSX.Element | ReactNode;
+export type IconType = string | React.JSX.Element | ReactNode;
 
 export interface MenuItem {
 	id: string;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,7 +22,7 @@
 -   `Disabled`, `Modal`, `Popover`, `Tooltip`: Move context code to separate files to help docgen prop extraction ([#75316](https://github.com/WordPress/gutenberg/pull/75316)).
 -   Update Emotion dependencies to ensure compatibility with React 19 ([#75324](https://github.com/WordPress/gutenberg/pull/75324)).
 -   Update Testing Library packages used in unit tests ([#75340](https://github.com/WordPress/gutenberg/pull/75340)).
--   Clean up type declarations using the `React` namespace ([#75499](https://github.com/WordPress/gutenberg/pull/75499)).
+-   Clean up type declarations using the `React` namespace ([#75499](https://github.com/WordPress/gutenberg/pull/75499) and ([#75508](https://github.com/WordPress/gutenberg/pull/75508))).
 -   Always specify initial values for `useRef` calls ([#75513](https://github.com/WordPress/gutenberg/pull/75513)).
 
 ## 32.1.0 (2026-01-29)

--- a/packages/components/src/alignment-matrix-control/test/index.tsx
+++ b/packages/components/src/alignment-matrix-control/test/index.tsx
@@ -18,7 +18,7 @@ const getCell = ( name: string ) => {
 };
 
 const renderAndInitCompositeStore = async (
-	jsx: JSX.Element,
+	jsx: React.JSX.Element,
 	focusedCell = 'center center'
 ) => {
 	const view = render( jsx );

--- a/packages/components/src/animate/types.ts
+++ b/packages/components/src/animate/types.ts
@@ -28,5 +28,5 @@ type DistributiveTypeAndOptions< T extends { type?: any } > = T extends any
 	: never;
 
 export type AnimateProps = DistributiveTypeAndOptions< GetAnimateOptions > & {
-	children: ( props: { className?: string } ) => JSX.Element;
+	children: ( props: { className?: string } ) => React.JSX.Element;
 };

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -66,7 +66,7 @@ export function useAutocomplete( {
 		null
 	);
 	const [ AutocompleterUI, setAutocompleterUI ] = useState<
-		( ( props: AutocompleterUIProps ) => JSX.Element | null ) | null
+		( ( props: AutocompleterUIProps ) => React.JSX.Element | null ) | null
 	>( null );
 
 	const backspacingRef = useRef( false );

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -239,7 +239,7 @@ const Fill = ( { children }: { children: React.ReactNode } ) => {
 
 				// Render all context providers forwarded by the Slot via fillProps.
 				return forwardedContext.reduce(
-					( inner: JSX.Element, [ Provider, props ] ) => (
+					( inner: React.JSX.Element, [ Provider, props ] ) => (
 						<Provider { ...props }>{ inner }</Provider>
 					),
 					innerMarkup

--- a/packages/components/src/context/context-connect.ts
+++ b/packages/components/src/context/context-connect.ts
@@ -34,7 +34,7 @@ type ContextConnectOptions = {
  * @return The connected WordPressComponent
  */
 export function contextConnect<
-	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null,
+	C extends ( props: any, ref: ForwardedRef< any > ) => ReactNode,
 >(
 	Component: C &
 		AcceptsTwoArgs<
@@ -55,7 +55,7 @@ export function contextConnect<
  * @return The connected WordPressComponent
  */
 export function contextConnectWithoutRef< P >(
-	Component: ( props: P ) => JSX.Element | null,
+	Component: ( props: P ) => ReactNode,
 	namespace: string
 ) {
 	return _contextConnect( Component, namespace );
@@ -65,7 +65,7 @@ export function contextConnectWithoutRef< P >(
 // The hope is that we can improve render performance by removing functional
 // component wrappers.
 function _contextConnect<
-	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null,
+	C extends ( props: any, ref: ForwardedRef< any > ) => ReactNode,
 	O extends ContextConnectOptions,
 >(
 	Component: C,

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -24,7 +24,7 @@ export type WordPressComponentProps<
 	( IsPolymorphic extends true
 		? {
 				/** The HTML element or React component to render the component as. */
-				as?: T | keyof JSX.IntrinsicElements;
+				as?: T | keyof React.JSX.IntrinsicElements;
 		  }
 		: {} );
 

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -36,10 +36,8 @@ export type WordPressComponent<
 	< TT extends React.ElementType >(
 		props: WordPressComponentProps< O, TT, IsPolymorphic > &
 			( IsPolymorphic extends true ? { as: TT } : {} )
-	): JSX.Element | null;
-	(
-		props: WordPressComponentProps< O, T, IsPolymorphic >
-	): JSX.Element | null;
+	): React.ReactNode;
+	( props: WordPressComponentProps< O, T, IsPolymorphic > ): React.ReactNode;
 	displayName?: string;
 	/**
 	 * A CSS selector used to fake component interpolation in styled components

--- a/packages/components/src/draggable/types.ts
+++ b/packages/components/src/draggable/types.ts
@@ -16,7 +16,7 @@ export type DraggableProps = {
 		 * `onDragEnd` handler.
 		 */
 		onDraggableEnd: ( event: DragEvent ) => void;
-	} ) => JSX.Element | null;
+	} ) => React.JSX.Element | null;
 	/**
 	 * Whether to append the cloned element to the `ownerDocument` body.
 	 * By default, elements sourced by id are appended to the element's wrapper.

--- a/packages/components/src/drop-zone/types.ts
+++ b/packages/components/src/drop-zone/types.ts
@@ -10,7 +10,7 @@ export type DropZoneProps = {
 	 *
 	 * @default "upload"
 	 */
-	icon?: JSX.Element;
+	icon?: React.JSX.Element;
 	/**
 	 * A string to be shown within the drop zone area.
 	 *

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -58,7 +58,7 @@ type ToggleProps = Partial<
 		'label' | 'text'
 	>
 > & {
-	as?: React.ElementType | keyof JSX.IntrinsicElements;
+	as?: React.ElementType | keyof React.JSX.IntrinsicElements;
 	'data-toolbar-item'?: boolean;
 };
 

--- a/packages/components/src/h-stack/test/index.tsx
+++ b/packages/components/src/h-stack/test/index.tsx
@@ -41,7 +41,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should not pass through invalid props to the `as` component', () => {
-		const AsComponent = ( props: JSX.IntrinsicElements[ 'div' ] ) => {
+		const AsComponent = ( props: React.JSX.IntrinsicElements[ 'div' ] ) => {
 			return <div { ...props } />;
 		};
 

--- a/packages/components/src/heading/hook.ts
+++ b/packages/components/src/heading/hook.ts
@@ -20,7 +20,7 @@ export function useHeading(
 		...otherProps
 	} = useContextSystem( props, 'Heading' );
 
-	const as = ( asProp || `h${ level }` ) as keyof JSX.IntrinsicElements;
+	const as = ( asProp || `h${ level }` ) as keyof React.JSX.IntrinsicElements;
 
 	const a11yProps: {
 		role?: string;

--- a/packages/components/src/higher-order/with-notices/types.ts
+++ b/packages/components/src/higher-order/with-notices/types.ts
@@ -31,5 +31,5 @@ export type WithNoticeProps = {
 		 */
 		removeAllNotices: () => void;
 	};
-	noticeUI: false | JSX.Element;
+	noticeUI: false | React.JSX.Element;
 };

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -22,8 +22,8 @@ import type { IconKey as DashiconIconKey } from '../dashicon/types';
 export type IconType =
 	| DashiconIconKey
 	| ComponentType< { size?: number } >
-	| ( ( props: { size?: number } ) => JSX.Element )
-	| JSX.Element;
+	| ( ( props: { size?: number } ) => React.JSX.Element )
+	| React.JSX.Element;
 
 type AdditionalProps< T > = T extends ComponentType< infer U >
 	? U

--- a/packages/components/src/menu-item/types.ts
+++ b/packages/components/src/menu-item/types.ts
@@ -27,7 +27,7 @@ export type MenuItemProps = Pick< ButtonAsButtonProps, 'isDestructive' > & {
 	 *
 	 * @default null
 	 */
-	icon?: JSX.Element | null;
+	icon?: React.JSX.Element | null;
 	/**
 	 * Determines where to display the provided `icon`.
 	 */

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -513,7 +513,7 @@ const Fill = ( { children }: { children: React.ReactNode } ) => {
 				const { forwardedContext = [] } = fillProps;
 
 				return forwardedContext.reduce(
-					( inner: JSX.Element, [ Provider, props ] ) => (
+					( inner: React.JSX.Element, [ Provider, props ] ) => (
 						<Provider { ...props }>{ inner }</Provider>
 					),
 					innerMarkup

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -70,7 +70,7 @@ export type ModalProps = {
 	/**
 	 * If this property is added, an icon will be added before the title.
 	 */
-	icon?: JSX.Element;
+	icon?: React.JSX.Element;
 	/**
 	 * If this property is set to false, the modal will not display a close icon
 	 * and cannot be dismissed.

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -218,7 +218,7 @@ If provided, renders `a` instead of `button`.
 
 ### `icon`
 
--   Type: `JSX.Element`
+-   Type: `React.JSX.Element`
 -   Required: No
 
 If no `children` are passed, this prop allows to specify a custom icon for the menu item.

--- a/packages/components/src/navigation/types.ts
+++ b/packages/components/src/navigation/types.ts
@@ -180,7 +180,7 @@ export type NavigationItemBaseProps = {
 	 * If no `children` are passed, this prop allows to specify a custom icon for
 	 * the menu item.
 	 */
-	icon?: JSX.Element;
+	icon?: React.JSX.Element;
 	/**
 	 * The unique identifier of the item.
 	 */

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -117,7 +117,7 @@ The CSS class to apply to the wrapper element.
 
 -   Required: No
 
-###### `icon`: `JSX.Element`
+###### `icon`: `React.JSX.Element`
 
 An icon to be shown next to the title.
 

--- a/packages/components/src/panel/types.ts
+++ b/packages/components/src/panel/types.ts
@@ -70,7 +70,7 @@ export type PanelBodyProps = {
 	/**
 	 * An icon to be shown next to the title.
 	 */
-	icon?: JSX.Element;
+	icon?: React.JSX.Element;
 	/**
 	 * Whether or not the panel will start open.
 	 */
@@ -104,7 +104,7 @@ export type PanelBodyTitleProps = Omit< ButtonAsButtonProps, 'icon' > & {
 	/**
 	 * An icon to be shown next to the title.
 	 */
-	icon?: JSX.Element;
+	icon?: React.JSX.Element;
 	/**
 	 * Whether or not the `PanelBody` is currently opened or not.
 	 */

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -104,7 +104,7 @@ function UnforwardedResizableBox(
 		...props
 	}: ResizableBoxProps,
 	ref: ForwardedRef< Resizable >
-): JSX.Element {
+) {
 	return (
 		<Resizable
 			className={ clsx(

--- a/packages/components/src/resizable-box/resize-tooltip/index.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/index.tsx
@@ -46,7 +46,7 @@ function ResizeTooltip(
 		...props
 	}: ResizeTooltipProps,
 	ref: ForwardedRef< HTMLDivElement >
-): JSX.Element | null {
+) {
 	const { label, resizeListener } = useResizeLabel( {
 		axis,
 		fadeTimeout,

--- a/packages/components/src/resizable-box/resize-tooltip/label.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/label.tsx
@@ -35,7 +35,7 @@ type LabelProps = React.DetailedHTMLProps<
 function Label(
 	{ label, position = POSITIONS.corner, zIndex = 1000, ...props }: LabelProps,
 	ref: ForwardedRef< HTMLDivElement >
-): JSX.Element | null {
+) {
 	const showLabel = !! label;
 
 	const isBottom = position === POSITIONS.bottom;

--- a/packages/components/src/resizable-box/resize-tooltip/utils.ts
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.ts
@@ -19,7 +19,7 @@ interface UseResizeLabelProps {
 	/** The label value. */
 	label?: string;
 	/** Element to be rendered for resize listening events. */
-	resizeListener: JSX.Element;
+	resizeListener: React.JSX.Element;
 }
 
 interface UseResizeLabelArgs {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -35,7 +35,7 @@ export type ToggleGroupControlOptionIconProps = Pick<
 	 * Icon displayed as the content of the option. Usually one of the icons from
 	 * the `@wordpress/icons` package, or a custom React `<svg>` icon.
 	 */
-	icon: JSX.Element;
+	icon: React.JSX.Element;
 	/**
 	 * The text to accessibly label the icon option. Will also be shown in a tooltip.
 	 */

--- a/packages/components/src/tree-grid/types.ts
+++ b/packages/components/src/tree-grid/types.ts
@@ -61,7 +61,7 @@ export type RovingTabIndexItemProps = {
 	 * </TreeGridCell>
 	 * ```
 	 */
-	children?: ( props: RovingTabIndexItemPassThruProps ) => JSX.Element;
+	children?: ( props: RovingTabIndexItemPassThruProps ) => React.JSX.Element;
 	/**
 	 * If `children` is not a function, this component will be used instead.
 	 */

--- a/packages/components/src/v-stack/test/index.tsx
+++ b/packages/components/src/v-stack/test/index.tsx
@@ -41,7 +41,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should not pass through invalid props to the `as` component', () => {
-		const AsComponent = ( props: JSX.IntrinsicElements[ 'div' ] ) => {
+		const AsComponent = ( props: React.JSX.IntrinsicElements[ 'div' ] ) => {
 			return <div { ...props } />;
 		};
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -32,6 +32,7 @@
 - DataForm: Use public `ColorPicker` component instead of internal `Picker` in color control. [#75394](https://github.com/WordPress/gutenberg/pull/75394)
 - Update Testing Library packages used in unit tests. [#75340](https://github.com/WordPress/gutenberg/pull/75340)
 - Always specify initial values for `useRef` calls. [#75513](https://github.com/WordPress/gutenberg/pull/75513)
+- Clean up type declarations using the `React` namespace. ([#75508](https://github.com/WordPress/gutenberg/pull/75508)
 
 ## 11.3.0 (2026-01-29)
 

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -287,7 +287,7 @@ const GridItem = forwardRef( function GridItem< Item >(
 	props: GridItemProps< Item > & {
 		ref?: React.ForwardedRef< HTMLDivElement >;
 	}
-) => JSX.Element;
+) => React.ReactNode;
 
 interface CompositeGridProps< Item > {
 	data: Item[];

--- a/packages/editor/src/components/style-book/color-examples.tsx
+++ b/packages/editor/src/components/style-book/color-examples.tsx
@@ -24,7 +24,7 @@ const ColorExamples = ( {
 	type,
 	templateColumns = '1fr 1fr',
 	itemHeight = '52px',
-}: ColorExampleProps ): JSX.Element | null => {
+}: ColorExampleProps ) => {
 	if ( ! colors ) {
 		return null;
 	}

--- a/packages/editor/src/components/style-book/duotone-examples.tsx
+++ b/packages/editor/src/components/style-book/duotone-examples.tsx
@@ -8,11 +8,7 @@ import { __experimentalGrid as Grid } from '@wordpress/components';
  */
 import type { Duotone } from './types';
 
-const DuotoneExamples = ( {
-	duotones,
-}: {
-	duotones: Duotone[];
-} ): JSX.Element | null => {
+const DuotoneExamples = ( { duotones }: { duotones: Duotone[] } ) => {
 	if ( ! duotones ) {
 		return null;
 	}

--- a/packages/editor/src/components/style-book/types.ts
+++ b/packages/editor/src/components/style-book/types.ts
@@ -17,7 +17,7 @@ export type BlockExample = {
 	name: string;
 	title: string;
 	category: string;
-	content?: JSX.Element;
+	content?: React.JSX.Element;
 	blocks?: Block | Block[];
 };
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -294,7 +294,7 @@ _Parameters_
 
 _Returns_
 
--   `JSX.Element`: Dangerously-rendering component.
+-   Dangerously-rendering component.
 
 ### render
 

--- a/packages/element/src/raw-html.ts
+++ b/packages/element/src/raw-html.ts
@@ -31,10 +31,7 @@ export type RawHTMLProps = {
  *
  * @return Dangerously-rendering component.
  */
-export default function RawHTML( {
-	children,
-	...props
-}: RawHTMLProps ): JSX.Element {
+export default function RawHTML( { children, ...props }: RawHTMLProps ) {
 	let rawHtml = '';
 
 	// Cast children as an array, and concatenate each element if it is a string.

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -30,7 +30,7 @@ interface Action< Item > {
 	label: string;
 	isEligible?: ( item: Item ) => boolean;
 	modalFocusOnMount?: string;
-	RenderModal: ( props: RenderModalProps< Item > ) => JSX.Element;
+	RenderModal: ( props: RenderModalProps< Item > ) => React.JSX.Element;
 }
 
 const duplicatePost: Action< BasePost > = {

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -29,7 +29,7 @@ interface Action< Item > {
 	label: string;
 	isEligible?: ( item: Item ) => boolean;
 	modalFocusOnMount?: string;
-	RenderModal: ( props: RenderModalProps< Item > ) => JSX.Element;
+	RenderModal: ( props: RenderModalProps< Item > ) => React.JSX.Element;
 }
 
 function isItemValid( item: BasePost ): boolean {

--- a/packages/global-styles-ui/src/font-library/google-fonts-confirm-dialog.tsx
+++ b/packages/global-styles-ui/src/font-library/google-fonts-confirm-dialog.tsx
@@ -11,7 +11,7 @@ import {
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 
-function GoogleFontsConfirmDialog(): JSX.Element {
+function GoogleFontsConfirmDialog() {
 	const handleConfirm = (): void => {
 		window.localStorage.setItem(
 			'wp-font-library-google-fonts-permission',

--- a/packages/media-fields/src/types.ts
+++ b/packages/media-fields/src/types.ts
@@ -8,7 +8,7 @@ export type MediaKind = 'image' | 'video' | 'audio' | 'application';
 export interface MediaType {
 	type: MediaKind;
 	label: string;
-	icon: JSX.Element;
+	icon: React.JSX.Element;
 }
 
 // TODO: Update the Attachment type separately.

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -44,7 +44,7 @@ _Parameters_
 
 _Returns_
 
--   `JSX.Element`: Children wrapped in the I18nProvider.
+-   Children wrapped in the I18nProvider.
 
 ### useI18n
 

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -73,7 +73,7 @@ type I18nProviderProps = PropsWithChildren< { i18n: I18n } >;
  * @param props i18n provider props.
  * @return Children wrapped in the I18nProvider.
  */
-export function I18nProvider( props: I18nProviderProps ): JSX.Element {
+export function I18nProvider( props: I18nProviderProps ) {
 	const { children, i18n = defaultI18n } = props;
 	const [ update, forceUpdate ] = useReducer( () => [], [] );
 


### PR DESCRIPTION
Another spinoff from React 19 upgrade #61521, a follow-up to #75499 which migrated `JSX` to `React.JSX` in jsdoc comments. This PR does the same `JSX` to `React.JSX` migration, but in native TypeScript code:
1. Changes `JSX.Element` to `React.JSX.Element` at many places
2. Fixes some type signatures where the intent is to type a React component or a `forwardRef` function. The return type of these functions is not `React.JSX.Element`, but `React.ReactNode`! The `ReactNode` includes also `null` type.
3. Removes some redundant return type annotation: React function components don't need explicit type for the (obvious) return type, it can be inferred easily.