### PR TITLE
BorderControl: Sync indicator color when only border width is set

### DIFF
--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -163,7 +163,10 @@ const BorderControlDropdown = (
 		...otherProps
 	} = useBorderControlDropdown( props );
 
-	const { color, style } = border || {};
+	const { color, style, width } = border || {};
+	const indicatorColor =
+		color ?? ( width ? 'var(--wp--preset--color--contrast)' : undefined );
+
 	const colorObject = getColorObject( color, colors );
 
 	const toggleAriaLabel = getToggleAriaLabel(
@@ -193,7 +196,7 @@ const BorderControlDropdown = (
 			<span className={ indicatorWrapperClassName }>
 				<ColorIndicator
 					className={ indicatorClassName }
-					colorValue={ color }
+					colorValue={ indicatorColor }
 				/>
 			</span>
 		</Button>


### PR DESCRIPTION
Closes #75468

## What?

Fixes a UI desynchronization issue where setting a border width without explicitly selecting a border color renders a visible border (using the computed text color), but the Border color indicator in the sidebar does not reflect this fallback.

## Why?

When a border width is applied without selecting a color:

- The browser renders the border using the computed text color (`currentColor`).
- However, the BorderControl indicator falls back to the admin theme color (blue).
- This creates a visual mismatch between the rendered block style and the control indicator.

Users may think the border is using a different color than what is actually rendered.

## How?

- Updates the `BorderControlDropdown` indicator logic to reflect the effective fallback color when a width is set but no explicit color is selected.
- Uses the theme contrast preset (`var(--wp--preset--color--contrast)`) to match the computed text color.
- Does not modify block serialization or save output — this change is limited to the UI layer.

## Testing Instructions

1. Insert a Paragraph block.
2. Set a border width (e.g., 4px).
3. Do not select a border color.

### Expected Result

- A visible border is rendered using the computed text color.
- The Border color indicator reflects the correct fallback color.
- No incorrect admin blue indicator appears.


<img width="1916" height="862" alt="Screenshot 2026-02-13 143501" src="https://github.com/user-attachments/assets/39211d17-b01e-4e07-8a85-8bae5e317ac9" />
