### PR TITLE
Update Edit control for template field

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/adaptive-select.tsx
+++ b/packages/dataviews/src/components/dataform-controls/adaptive-select.tsx
@@ -15,6 +15,7 @@ export default function AdaptiveSelect< Item >(
 	const { elements } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item: props.data,
 	} );
 	if ( elements.length >= ELEMENTS_THRESHOLD ) {
 		return <Combobox { ...props } />;

--- a/packages/dataviews/src/components/dataform-controls/array.tsx
+++ b/packages/dataviews/src/components/dataform-controls/array.tsx
@@ -28,6 +28,7 @@ export default function ArrayControl< Item >( {
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item: data,
 	} );
 
 	// Convert stored values to element objects for the token field

--- a/packages/dataviews/src/components/dataform-controls/combobox.tsx
+++ b/packages/dataviews/src/components/dataform-controls/combobox.tsx
@@ -34,6 +34,7 @@ export default function Combobox< Item >( {
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item: data,
 	} );
 
 	if ( isLoading ) {

--- a/packages/dataviews/src/components/dataform-controls/radio.tsx
+++ b/packages/dataviews/src/components/dataform-controls/radio.tsx
@@ -26,6 +26,7 @@ export default function Radio< Item >( {
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item: data,
 	} );
 	const value = getValue( { item: data } );
 

--- a/packages/dataviews/src/components/dataform-controls/select.tsx
+++ b/packages/dataviews/src/components/dataform-controls/select.tsx
@@ -36,6 +36,7 @@ export default function Select< Item >( {
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item: data,
 	} );
 
 	if ( isLoading ) {

--- a/packages/dataviews/src/components/dataform-controls/toggle-group.tsx
+++ b/packages/dataviews/src/components/dataform-controls/toggle-group.tsx
@@ -38,6 +38,7 @@ export default function ToggleGroup< Item >( {
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item: data,
 	} );
 
 	if ( isLoading ) {

--- a/packages/dataviews/src/field-types/utils/render-from-elements.tsx
+++ b/packages/dataviews/src/field-types/utils/render-from-elements.tsx
@@ -11,6 +11,7 @@ export default function RenderFromElements< Item >( {
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
 		getElements: field.getElements,
+		item,
 	} );
 
 	const value = field.getValue( { item } );

--- a/packages/dataviews/src/hooks/use-elements.ts
+++ b/packages/dataviews/src/hooks/use-elements.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,12 +10,14 @@ import type { Option } from '../types';
 
 const EMPTY_ARRAY: Option[] = [];
 
-export default function useElements( {
+export default function useElements< Item >( {
 	elements,
 	getElements,
+	item,
 }: {
 	elements?: Option[];
-	getElements?: () => Promise< Option[] >;
+	getElements?: ( args?: { item: Item } ) => Promise< Option[] >;
+	item?: Item;
 } ) {
 	const staticElements =
 		Array.isArray( elements ) && elements.length > 0
@@ -23,6 +25,8 @@ export default function useElements( {
 			: EMPTY_ARRAY;
 	const [ records, setRecords ] = useState< Option[] >( staticElements );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const itemRef = useRef( item );
+	itemRef.current = item;
 
 	useEffect( () => {
 		if ( ! getElements ) {
@@ -32,7 +36,11 @@ export default function useElements( {
 
 		let cancelled = false;
 		setIsLoading( true );
-		getElements()
+		getElements(
+			itemRef.current !== undefined
+				? { item: itemRef.current }
+				: undefined
+		)
 			.then( ( fetchedElements ) => {
 				if ( ! cancelled ) {
 					const dynamicElements =

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -548,7 +548,7 @@ function validateFormField< Item >(
 		typeof formField.field.getElements === 'function'
 	) {
 		handleElementsValidationAsync(
-			formField.field.getElements(),
+			formField.field.getElements( { item } ),
 			formField,
 			promiseHandler
 		);

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -63,7 +63,7 @@ export interface NormalizedFilter {
 	/**
 	 * Retrieval function to get the elements.
 	 */
-	getElements?: () => Promise< Option[] >;
+	getElements?: ( args?: { item: any } ) => Promise< Option[] >;
 
 	/**
 	 * Whether the filter has elements.

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -255,7 +255,7 @@ export type Field< Item > = {
 	/**
 	 * Retrieval function for elements.
 	 */
-	getElements?: () => Promise< Option[] >;
+	getElements?: ( args?: { item: Item } ) => Promise< Option[] >;
 
 	/**
 	 * Filter config for the field.

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -26,17 +26,21 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 	const isBulk = postId.length > 1;
 
 	const [ localEdits, setLocalEdits ] = useState( {} );
-	const { record, hasFinishedResolution } = useSelect(
+	const { record, hasFinishedResolution, isTemplateReadOnly } = useSelect(
 		( select ) => {
 			const {
 				getEditedEntityRecord,
 				hasFinishedResolution: hasFinished,
 			} = select( coreDataStore );
 
+			const { getPostsPageId } = unlock( select( coreDataStore ) );
+			const isPostsPage = +getPostsPageId() === +postId[ 0 ];
+
 			if ( isBulk ) {
 				return {
 					record: null,
 					hasFinishedResolution: true,
+					isTemplateReadOnly: isPostsPage,
 				};
 			}
 
@@ -47,6 +51,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 					'getEditedEntityRecord',
 					args
 				),
+				isTemplateReadOnly: isPostsPage,
 			};
 		},
 		[ postType, postId, isBulk ]
@@ -66,9 +71,17 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 						),
 					};
 				}
+
+				if ( field.id === 'template' ) {
+					return {
+						...field,
+						readOnly: isTemplateReadOnly,
+					};
+				}
+
 				return field;
 			} ),
-		[ _fields ]
+		[ _fields, isTemplateReadOnly ]
 	);
 
 	const form = useMemo( () => {

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -12,13 +12,11 @@ import {
 } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import usePatternSettings from '../page-patterns/use-pattern-settings';
 
 const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
 
@@ -96,14 +94,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 				label: __( 'Discussion' ),
 				children: [ 'comment_status', 'ping_status' ],
 			},
-			{
-				label: __( 'Template' ),
-				id: 'template',
-				layout: {
-					type: 'regular',
-					labelPosition: 'side',
-				},
-			},
+			'template',
 		];
 
 		return {
@@ -162,32 +153,6 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 		closeModal?.();
 	};
 
-	const { ExperimentalBlockEditorProvider } = unlock(
-		blockEditorPrivateApis
-	);
-	const settings = usePatternSettings();
-
-	/**
-	 * The template field depends on the block editor settings.
-	 * This is a workaround to ensure that the block editor settings are available.
-	 * For more information, see: https://github.com/WordPress/gutenberg/issues/67521
-	 */
-	const fieldsWithDependency = useMemo( () => {
-		return fields.map( ( field ) => {
-			if ( field.id === 'template' ) {
-				return {
-					...field,
-					Edit: ( data ) => (
-						<ExperimentalBlockEditorProvider settings={ settings }>
-							<field.Edit { ...data } />
-						</ExperimentalBlockEditorProvider>
-					),
-				};
-			}
-			return field;
-		} );
-	}, [ fields, settings ] );
-
 	return (
 		<Modal
 			overlayClassName="dataviews-action-modal__quick-edit"
@@ -207,7 +172,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 				{ hasFinishedResolution && (
 					<DataForm
 						data={ { ...record, ...localEdits } }
-						fields={ fieldsWithDependency }
+						fields={ fields }
 						form={ form }
 						onChange={ onChange }
 					/>

--- a/packages/fields/src/fields/template/index.ts
+++ b/packages/fields/src/fields/template/index.ts
@@ -62,6 +62,11 @@ const templateField: Field< BasePost > = {
 
 		let currentTemplateElement: Option | undefined;
 		if ( postType ) {
+			// TODO: this template id is computed differently than the templateId in the editor inspector
+			// Compare with
+			// https://github.com/WordPress/gutenberg/blob/8c2a7c775f5b5fb19d8dca66a09d18977cf42b7d/packages/editor/src/components/post-template/panel.js#L21
+			// The editor inspector computes it from the editor store (that we cannot use in this package),
+			// that ends up being using the getTemplateId private selector from core data.
 			const templateId = await resolveSelect(
 				coreDataStore
 			).getDefaultTemplateId( {

--- a/packages/fields/src/fields/template/index.ts
+++ b/packages/fields/src/fields/template/index.ts
@@ -2,19 +2,37 @@
  * WordPress dependencies
  */
 import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { resolveSelect } from '@wordpress/data';
+import type { WpTemplate } from '@wordpress/core-data';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
 import type { BasePost } from '../../types';
-import { TemplateEdit } from './template-edit';
+
+const EMPTY_ARRAY: [] = [];
 
 const templateField: Field< BasePost > = {
 	id: 'template',
 	type: 'text',
 	label: __( 'Template' ),
-	Edit: TemplateEdit,
+	getElements: async () => {
+		const templates: WpTemplate[] =
+			( await resolveSelect( coreDataStore ).getEntityRecords(
+				'postType',
+				'wp_template',
+				{
+					per_page: -1,
+					post_type: 'page', // TODO: this should be data.type
+				}
+			) ) ?? EMPTY_ARRAY;
+		return templates.map( ( { slug, title } ) => ( {
+			value: slug,
+			label: title.rendered || slug,
+		} ) );
+	},
 	enableSorting: false,
 	filterBy: false,
 };

--- a/packages/fields/src/fields/template/index.ts
+++ b/packages/fields/src/fields/template/index.ts
@@ -18,14 +18,14 @@ const templateField: Field< BasePost > = {
 	id: 'template',
 	type: 'text',
 	label: __( 'Template' ),
-	getElements: async () => {
+	getElements: async ( args ) => {
 		const templates: WpTemplate[] =
 			( await resolveSelect( coreDataStore ).getEntityRecords(
 				'postType',
 				'wp_template',
 				{
 					per_page: -1,
-					post_type: 'page', // TODO: this should be data.type
+					post_type: args?.item?.type || 'page',
 				}
 			) ) ?? EMPTY_ARRAY;
 		return templates.map( ( { slug, title } ) => ( {

--- a/packages/fields/src/fields/template/index.ts
+++ b/packages/fields/src/fields/template/index.ts
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import type { Field } from '@wordpress/dataviews';
+import type { Field, Option } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { resolveSelect } from '@wordpress/data';
 import type { WpTemplate } from '@wordpress/core-data';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -19,6 +20,9 @@ const templateField: Field< BasePost > = {
 	type: 'text',
 	label: __( 'Template' ),
 	getElements: async ( args ) => {
+		// LIST OF CUSTOM TEMPLATES
+		// This uses the same logic as the editor inspector
+		// (useAvailableTemplates hook at packages/editor/src/components/post-template/hooks.js).
 		const templates: WpTemplate[] =
 			( await resolveSelect( coreDataStore ).getEntityRecords(
 				'postType',
@@ -28,10 +32,63 @@ const templateField: Field< BasePost > = {
 					post_type: args?.item?.type || 'page',
 				}
 			) ) ?? EMPTY_ARRAY;
-		return templates.map( ( { slug, title } ) => ( {
-			value: slug,
-			label: title.rendered || slug,
-		} ) );
+		const templateElements = templates
+			.filter(
+				( template ) => template.is_custom && !! template.content.raw // Skip empty templates.
+			)
+			.map( ( { slug, title } ) => ( {
+				value: slug,
+				label: title.rendered || slug,
+			} ) );
+
+		// CURRENT TEMPLATE
+		// This uses the same logic as the editor inspector
+		// (BlockThemeControl at packages/editor/src/components/post-template/block-theme.js)
+		let slugToCheck;
+		const postType = args?.item?.type;
+		const slug = args?.item?.slug;
+		// In `draft` status we might not have a slug available, so we use the `single`
+		// post type templates slug(ex page, single-post, single-product etc..).
+		// Pages do not need the `single` prefix in the slug to be prioritized
+		// through template hierarchy.
+		if ( slug ) {
+			slugToCheck =
+				postType === 'page'
+					? `${ postType }-${ slug }`
+					: `single-${ postType }-${ slug }`;
+		} else {
+			slugToCheck = postType === 'page' ? 'page' : `single-${ postType }`;
+		}
+
+		let currentTemplateElement: Option | undefined;
+		if ( postType ) {
+			const templateId = await resolveSelect(
+				coreDataStore
+			).getDefaultTemplateId( {
+				slug: slugToCheck,
+			} );
+
+			const currentTemplate = ( await resolveSelect(
+				coreDataStore
+			).getEntityRecord( 'postType', 'wp_template', templateId ) ) as
+				| WpTemplate
+				| undefined;
+			if ( currentTemplate ) {
+				currentTemplateElement = {
+					// If the template field is empty it means it'll be matched to a template from the hierarchy,
+					// which is the current template. Instead of using the currentTemplate.slug as value,
+					// we want to use the empty string so that this element is the one selected in the control.
+					// And, inversely, when selecting this element, the user will be resetting the template
+					// to the default value.
+					value: '',
+					label: decodeEntities( currentTemplate.title.rendered ),
+				};
+			}
+		}
+
+		return [ currentTemplateElement, ...templateElements ].filter(
+			( item ): item is Option => !! item
+		);
 	},
 	enableSorting: false,
 	filterBy: false,


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/75421
Follow-up to https://github.com/WordPress/gutenberg/pull/75290

## What?

This PR updates the template edit component to rely on the field elements. In doing so, it also updates the rendered value of the template in DataViews.

| Before | After |
| --- | --- |
| <img width="2055" height="1230" alt="Screenshot 2026-02-13 at 14 05 10" src="https://github.com/user-attachments/assets/ce7b01f7-29a6-4737-a2cf-8d832c221718" /> | <img width="2055" height="1230" alt="Screenshot 2026-02-13 at 14 05 20" src="https://github.com/user-attachments/assets/b49f664c-41fd-407b-8a2c-86709d396537" />| 
| <img width="2055" height="1230" alt="Screenshot 2026-02-13 at 14 17 13" src="https://github.com/user-attachments/assets/8b4d7f4f-fe67-4ad3-af22-f3f903dd2952" /> | <img width="2055" height="1230" alt="Screenshot 2026-02-13 at 14 17 20" src="https://github.com/user-attachments/assets/b453029d-202a-44e8-98bc-9bffe1e055a4" /> |

## Why?

The template field was rendered as a regular field with a custom button, but that interaction and the visuals are at odds with the new trigger mechanism for the panel introduced at https://github.com/WordPress/gutenberg/pull/75290. That's the primary aspect this PR is trying to solve.

Additionally, as a bonus, by leveraging the field elements, this PR displays the template name in the DataViews layout.

## How?

- Add the `item` as a new parameter to `getElements`, so fields can calculate elements based on the data.
- Updates the template field to declare elements (the templates) and remove its Edit control.

## Testing Instructions

Visit the Site Editor's Pages screen, and interact with the template field. Verify that it's always displaying the proper value of the template (e.g., go to the pages editor and compare with the value there).

## TODO

1. Template names:
    1. What template name should we display for pages that use the default? It's blank in current DataViews, "Default template" in wp-admin, and the name of the resolved template in the editor inspector (e.g., "Pages"). This PR went with the latter.
    2. What template name should display for the homepage page? It's blank in current DataViews, "Default template" in wp-admin, and "Blog page" in the editor inspector. This needs fixing in this PR.

~2. Make the template not editable if the page is set as the "blog page", like in the editor inspector.~ Fix https://github.com/WordPress/gutenberg/pull/75518#issuecomment-3898715309

There was some logic to making the page not editable if it was the homepage as well, but the editor inspector allows users to change it — so there's no reason for QuickEdit not to. wp-admin allows editing the template for both.

Edit the template of the posts page:

https://github.com/user-attachments/assets/45fc9c3a-b64b-437a-a31d-1196189a2f23

Edit the template of the homepage:

https://github.com/user-attachments/assets/82cab354-79de-465a-b2b3-d7ea7a01faaa

Edit the templates for the posts page & homepage via wp-admin:

https://github.com/user-attachments/assets/d539ab49-c53e-460f-b91f-37d245c98d3e



