### PR TITLE
Duotone: add sgomes as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,10 @@
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
 
 # Duotone
-/lib/block-supports/duotone.php
-/packages/block-editor/src/components/duotone-control
-/packages/block-editor/src/hooks/duotone.js
-/packages/components/src/duotone-picker
+/lib/block-supports/duotone.php									@sgomes
+/packages/block-editor/src/components/duotone-control	@sgomes
+/packages/block-editor/src/hooks/duotone.js			@sgomes
+/packages/components/src/duotone-picker					@sgomes
 
 # Editor
 /packages/annotations                           @atimmer


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds myself as an owner for Duotone, as there seem to be no owners at this point.

If I should be adding a different owner instead, please let me know, and I'll be happy to make the change!

## Why?
I currently have #74748 open for updating Gutenberg Duotone to more closely match Core, and there are no owners for Duotone at the moment.

## How?
This PR has no code changes.

### Testing Instructions for Keyboard
This PR has no code changes.