### PR TITLE
Format Library: Fix code format when opening backtick is added after closing

### DIFF
--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -27,25 +27,51 @@ export const code = {
 			return value;
 		}
 
-		if ( start - 2 < 0 ) {
+		const searchStartIndex = start - 2;
+
+		// First, try to find a backtick before (closing backtick scenario).
+		if ( searchStartIndex >= 0 ) {
+			const indexBefore = text.lastIndexOf( BACKTICK, searchStartIndex );
+
+			if ( indexBefore !== -1 ) {
+				const startIndex = indexBefore;
+				const endIndex = searchStartIndex;
+
+				if ( startIndex !== endIndex ) {
+					value = remove( value, startIndex, startIndex + 1 );
+					value = remove( value, endIndex, endIndex + 1 );
+					value = applyFormat(
+						value,
+						{ type: name },
+						startIndex,
+						endIndex
+					);
+
+					return value;
+				}
+			}
+		}
+
+		// If not found before, try to find a backtick after (opening backtick scenario).
+		const indexAfter = text.indexOf( BACKTICK, start );
+
+		if ( indexAfter === -1 ) {
 			return value;
 		}
 
-		const indexBefore = text.lastIndexOf( BACKTICK, start - 2 );
-		if ( indexBefore === -1 ) {
-			return value;
-		}
-
-		const startIndex = indexBefore;
-		const endIndex = start - 2;
+		const startIndex = start - 1;
+		const endIndex = indexAfter;
 
 		if ( startIndex === endIndex ) {
 			return value;
 		}
 
-		value = remove( value, startIndex, startIndex + 1 );
+		// Remove closing backtick first (at higher index) to avoid index shifting issues
 		value = remove( value, endIndex, endIndex + 1 );
-		value = applyFormat( value, { type: name }, startIndex, endIndex );
+		// Then remove opening backtick
+		value = remove( value, startIndex, startIndex + 1 );
+		// Apply format (note: endIndex - 1 because we removed the closing backtick first)
+		value = applyFormat( value, { type: name }, startIndex, endIndex - 1 );
 
 		return value;
 	},


### PR DESCRIPTION
## What?
Closes #40347

Fixes the backtick parsing issue where typing backticks in reverse order doesn't apply inline code formatting.

## Why?

The inline code format's input rule only searched backwards for a matching backtick, which worked when typing the closing backtick second (normal order). However, when users added the closing backtick first and then added the opening backtick before it, the formatting wasn't applied.

## How?

Modified the `__unstableInputRule` function in `packages/format-library/src/code/index.js` to:

1. First try to find a backtick before the current position (existing behavior)
2. If not found, try to find a backtick after the current position (new behavior)  
3. When removing backticks in the forward search case, remove the closing backtick first to avoid index shifting issues

## Testing Instructions

1. Create a new paragraph block
2. Type a word (e.g., "test")
3. Add a closing backtick at the end (text should be "test`")
4. Move cursor to the beginning
5. Add an opening backtick (text should become "`test`")
6. Verify that "test" is now formatted as inline code


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
The backticks remain as plain text when added in reverse order.

https://github.com/user-attachments/assets/b7c74ca4-ad71-43d9-9b05-518bc0e3cd25


### After  
The text between backticks is correctly formatted as inline code regardless of the order backticks are typed.

https://github.com/user-attachments/assets/79887a78-7386-44f1-9f71-33e674aa2a63

