### PR TITLE
Tabs: Add `@since 7.0.0` annotations

### DIFF
--- a/packages/block-library/src/tab/index.php
+++ b/packages/block-library/src/tab/index.php
@@ -8,6 +8,8 @@
 /**
  * Render callback for core/tab.
  *
+ * @since 7.0.0
+ *
  * @param array     $attributes Block attributes.
  * @param string    $content    Block content.
  *

--- a/packages/block-library/src/tab/index.php
+++ b/packages/block-library/src/tab/index.php
@@ -59,7 +59,7 @@ function block_core_tab_render( array $attributes, string $content ): string {
  *
  * @hook init
  *
- * @since 6.9.0
+ * @since 7.0.0
  */
 function register_block_core_tab() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -69,7 +69,7 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 /**
  * Registers the `core/tabs-menu-item` block on the server.
  *
- * @since 6.9.0
+ * @since 7.0.0
  */
 function register_block_core_tabs_menu_item() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -10,6 +10,8 @@
  *
  * Applies IAPI directives and tab-specific attributes to the saved content.
  *
+ * @since 7.0.0
+ *
  * @param array     $attributes Block attributes.
  * @param string    $content    Block content.
  * @param \WP_Block $block      WP_Block instance.

--- a/packages/block-library/src/tabs-menu/index.php
+++ b/packages/block-library/src/tabs-menu/index.php
@@ -63,7 +63,7 @@ function block_core_tabs_menu_render_callback( array $attributes, string $conten
 /**
  * Registers the `core/tabs-menu` block on the server.
  *
- * @since 6.9.0
+ * @since 7.0.0
  */
 function register_block_core_tabs_menu() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/tabs-menu/index.php
+++ b/packages/block-library/src/tabs-menu/index.php
@@ -8,6 +8,8 @@
 /**
  * Render callback for core/tabs-menu.
  *
+ * @since 7.0.0
+ *
  * @param array     $attributes Block attributes.
  * @param string    $content    Block content (contains the tabs-menu-item template).
  * @param \WP_Block $block      WP_Block instance.

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -156,7 +156,7 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 /**
  * Registers the `core/tabs` block on the server.
  *
- * @since 6.8.0
+ * @since 7.0.0
  */
 function register_block_core_tabs() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -8,6 +8,8 @@
 /**
  * Extract tabs list from tab-panel innerblocks.
  *
+ * @since 7.0.0
+ *
  * @param array $innerblocks Parsed inner blocks of tabs block.
  *
  * @return array List of tabs with id, label, index.
@@ -56,6 +58,8 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
  * It is more performant to do this here, once, rather than in the tabs render and tabs context filters.
  * In this way core/tabs is both a provider and a consumer of the core/tabs-list context.
  *
+ * @since 7.0.0
+ *
  * @param array $context      Default block context.
  * @param array $parsed_block The block being rendered.
  *
@@ -74,6 +78,8 @@ add_filter( 'render_block_context', 'block_core_tabs_provide_context', 10, 2 );
 
 /**
  * Render callback for core/tabs.
+ *
+ * @since 7.0.0
  *
  * @param array     $attributes Block attributes.
  * @param string    $content    Block content.


### PR DESCRIPTION
## What?
The Tab block was stabilized in https://github.com/WordPress/gutenberg/pull/75424, so we should add/update the `@since` annotation.

This pull request updates the PHPDoc comments for several block registration and render functions in the Tab-related blocks of the codebase. The main changes are to update the `@since` version tags to `7.0.0` and to add missing `@since` annotations to function documentation blocks for improved clarity and consistency.
