### PR TITLE
Improve organization and clarity of Navigation Overlay inspector controls

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
 
@@ -23,6 +28,7 @@ import OverlayMenuPreviewControls from './overlay-menu-preview-controls';
  * @param {Function} props.setAttributes             Function to update block attributes.
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
  * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
+ * @param {string}   props.overlay                   Currently selected overlay template part ID.
  * @param {string}   props.containerStyle            Optional style for the preview container.
  * @return {React.JSX.Element}                       The overlay menu preview button or null if not responsive.
  */
@@ -35,6 +41,7 @@ export default function OverlayMenuPreviewButton( {
 	setAttributes,
 	overlayMenuPreviewClasses,
 	overlayMenuPreviewId,
+	overlay,
 	containerStyle,
 } ) {
 	if ( ! isResponsive ) {
@@ -43,6 +50,7 @@ export default function OverlayMenuPreviewButton( {
 
 	return (
 		<>
+			<h3>{ __( 'Overlay icons' ) }</h3>
 			<Button
 				__next40pxDefaultSize
 				className={ overlayMenuPreviewClasses }
@@ -54,16 +62,30 @@ export default function OverlayMenuPreviewButton( {
 				{ hasIcon && (
 					<>
 						<OverlayMenuIcon icon={ icon } />
-						<Icon icon={ close } />
+						{ ! overlay && <Icon icon={ close } /> }
 					</>
 				) }
 				{ ! hasIcon && (
 					<>
 						<span>{ __( 'Menu' ) }</span>
-						<span>{ __( 'Close' ) }</span>
+						{ ! overlay && <span>{ __( 'Close' ) }</span> }
 					</>
 				) }
 			</Button>
+			<HStack
+				alignment="flex-start"
+				className="wp-block-navigation__overlay-help-text-wrapper"
+			>
+				<Text
+					variant="muted"
+					isBlock
+					className="wp-block-navigation__overlay-help-text"
+				>
+					{ __(
+						'Configure the visual appearance and display of the menu button.'
+					) }
+				</Text>
+			</HStack>
 			{ overlayMenuPreview && (
 				<VStack
 					id={ overlayMenuPreviewId }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -4,6 +4,7 @@
 import {
 	PanelBody,
 	__experimentalVStack as VStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -61,19 +62,6 @@ export default function OverlayPanel( {
 				/>
 
 				{ overlayMenu !== 'never' && (
-					<OverlayMenuPreviewButton
-						isResponsive={ isResponsive }
-						overlayMenuPreview={ overlayMenuPreview }
-						setOverlayMenuPreview={ setOverlayMenuPreview }
-						hasIcon={ hasIcon }
-						icon={ icon }
-						setAttributes={ setAttributes }
-						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
-						overlayMenuPreviewId={ overlayMenuPreviewId }
-					/>
-				) }
-
-				{ overlayMenu !== 'never' && (
 					<OverlayTemplatePartSelector
 						overlay={ overlay }
 						setAttributes={ setAttributes }
@@ -83,14 +71,36 @@ export default function OverlayPanel( {
 					/>
 				) }
 
+				{ overlayMenu !== 'never' && (
+					<OverlayMenuPreviewButton
+						isResponsive={ isResponsive }
+						overlayMenuPreview={ overlayMenuPreview }
+						setOverlayMenuPreview={ setOverlayMenuPreview }
+						hasIcon={ hasIcon }
+						icon={ icon }
+						setAttributes={ setAttributes }
+						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
+						overlayMenuPreviewId={ overlayMenuPreviewId }
+						overlay={ overlay }
+					/>
+				) }
+
 				{ overlayMenu !== 'never' &&
 					overlay &&
 					hasOverlays &&
 					! isCreatingOverlay && (
-						<OverlayPreview
-							overlay={ overlay }
-							currentTheme={ currentTheme }
-						/>
+						<>
+							<h3>{ __( 'Preview' ) }</h3>
+							<OverlayPreview
+								overlay={ overlay }
+								currentTheme={ currentTheme }
+							/>
+							<Text variant="muted">
+								{ __(
+									'Visual preview of your overlay template.'
+								) }
+							</Text>
+						</>
 					) }
 			</VStack>
 		</PanelBody>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75244 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Organize and reorder the controls for Navigation overlay

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a new label for Overlay Icons
- Reordered the Overlay template dropdown to appear above icons
- Added a new preview label for templates
- The 'X' icon is removed for customized overlays
- Added short descriptions for both


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a navigation block.
3. Open block setings and select controls

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="189" height="601" alt="image" src="https://github.com/user-attachments/assets/0df26439-368e-426f-9638-7a152e38909f" />|<img width="192" height="753" alt="image" src="https://github.com/user-attachments/assets/f3aa1380-4ba3-4c26-8531-f50652ffe46c" />
