### PR TITLE
Tabs: fix incorrect fixtures

### DIFF
--- a/test/integration/fixtures/blocks/core__navigation__deprecated-open-submenus-false.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-open-submenus-false.json
@@ -3,11 +3,11 @@
 		"name": "core/navigation",
 		"isValid": true,
 		"attributes": {
-			"hasIcon": true,
-			"icon": "handle",
-			"maxNestingLevel": 5,
 			"showSubmenuIcon": true,
 			"overlayMenu": "mobile",
+			"icon": "handle",
+			"hasIcon": true,
+			"maxNestingLevel": 5,
 			"submenuVisibility": "hover"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-open-submenus-true.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-open-submenus-true.json
@@ -3,11 +3,11 @@
 		"name": "core/navigation",
 		"isValid": true,
 		"attributes": {
-			"hasIcon": true,
-			"icon": "handle",
-			"maxNestingLevel": 5,
 			"showSubmenuIcon": true,
 			"overlayMenu": "mobile",
+			"icon": "handle",
+			"hasIcon": true,
+			"maxNestingLevel": 5,
 			"submenuVisibility": "click"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.html
@@ -1,3 +1,3 @@
 <!-- wp:tabs-menu-item -->
-<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 <!-- /wp:tabs-menu-item -->

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.parsed.json
@@ -3,9 +3,9 @@
 		"blockName": "core/tabs-menu-item",
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\n<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n",
+		"innerHTML": "\n<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n",
 		"innerContent": [
-			"\n<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n"
+			"\n<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__tabs-menu-item.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu-item.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:tabs-menu-item -->
-<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 <!-- /wp:tabs-menu-item -->

--- a/test/integration/fixtures/blocks/core__tabs-menu.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu.html
@@ -1,11 +1,11 @@
 <!-- wp:tabs-menu -->
 <div class="wp-block-tabs-menu" role="tablist">
 	<!-- wp:tabs-menu-item -->
-	<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+	<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 	<!-- /wp:tabs-menu-item -->
 
 	<!-- wp:tabs-menu-item -->
-	<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+	<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 	<!-- /wp:tabs-menu-item -->
 </div>
 <!-- /wp:tabs-menu -->

--- a/test/integration/fixtures/blocks/core__tabs-menu.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs-menu.parsed.json
@@ -7,18 +7,18 @@
 				"blockName": "core/tabs-menu-item",
 				"attrs": {},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t",
+				"innerHTML": "\n\t<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n\t",
 				"innerContent": [
-					"\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t"
+					"\n\t<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n\t"
 				]
 			},
 			{
 				"blockName": "core/tabs-menu-item",
 				"attrs": {},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t",
+				"innerHTML": "\n\t<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n\t",
 				"innerContent": [
-					"\n\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t"
+					"\n\t<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n\t"
 				]
 			}
 		],

--- a/test/integration/fixtures/blocks/core__tabs-menu.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs-menu.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:tabs-menu -->
 <div role="tablist" class="wp-block-tabs-menu"><!-- wp:tabs-menu-item -->
-<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 <!-- /wp:tabs-menu-item -->
 
 <!-- wp:tabs-menu-item -->
-<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 <!-- /wp:tabs-menu-item --></div>
 <!-- /wp:tabs-menu -->

--- a/test/integration/fixtures/blocks/core__tabs.html
+++ b/test/integration/fixtures/blocks/core__tabs.html
@@ -3,7 +3,7 @@
 	<!-- wp:tabs-menu -->
 	<div class="wp-block-tabs-menu" role="tablist">
 		<!-- wp:tabs-menu-item -->
-		<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+		<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 		<!-- /wp:tabs-menu-item -->
 	</div>
 	<!-- /wp:tabs-menu -->

--- a/test/integration/fixtures/blocks/core__tabs.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs.parsed.json
@@ -13,9 +13,9 @@
 						"blockName": "core/tabs-menu-item",
 						"attrs": {},
 						"innerBlocks": [],
-						"innerHTML": "\n\t\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t\t",
+						"innerHTML": "\n\t\t<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n\t\t",
 						"innerContent": [
-							"\n\t\t<a class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden><span class=\"screen-reader-text\">Tab menu item</span></a>\n\t\t"
+							"\n\t\t<button class=\"wp-block-tabs-menu-item wp-block-tabs-menu-item__template\" hidden type=\"button\" role=\"tab\"><span class=\"screen-reader-text\">Tab menu item</span></button>\n\t\t"
 						]
 					}
 				],

--- a/test/integration/fixtures/blocks/core__tabs.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs.serialized.html
@@ -1,7 +1,7 @@
 <!-- wp:tabs {"className":"is-example"} -->
 <div class="wp-block-tabs is-example"><!-- wp:tabs-menu -->
 <div role="tablist" class="wp-block-tabs-menu"><!-- wp:tabs-menu-item -->
-<a class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden><span class="screen-reader-text">Tab menu item</span></a>
+<button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 <!-- /wp:tabs-menu-item --></div>
 <!-- /wp:tabs-menu -->
 


### PR DESCRIPTION

## What?

We changed the element of the Tab Menu Item block from `a` to `button` in #75471, but the fixture file still used the old a element, which caused block validation to fail.

## Testing Instructions
All CI checks should be ✅