### PR TITLE
Icons: Make full height icon label title case

### DIFF
--- a/packages/icons/src/manifest.php
+++ b/packages/icons/src/manifest.php
@@ -502,7 +502,7 @@ return array(
 		'filePath' => 'library/format-uppercase.svg',
 	),
 	'full-height'                    => array(
-		'label'    => _x( 'Full height', 'icon label', 'gutenberg' ),
+		'label'    => _x( 'Full Height', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/full-height.svg',
 	),
 	'fullscreen'                     => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Only this icon was sentence case, but the icon label should be `Title Case`, not `Sentence case`.

<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions

Nothing