### PR TITLE
Button: Add full width on mobile toggle

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -102,7 +102,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Category:** design
 -	**Parent:** core/buttons
 -	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
+-	**Attributes:** backgroundColor, gradient, isFullWidthOnMobile, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
 
 ## Buttons
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -63,6 +63,10 @@
 		},
 		"gradient": {
 			"type": "string"
+		},
+		"isFullWidthOnMobile": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -12,6 +12,9 @@ import {
 	ToolbarButton,
 	Popover,
 	ExternalLink,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	ToggleControl,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -44,6 +47,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { unlock } from '../lock-unlock';
 import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 import { getWidthClasses, isPercentageWidth } from './utils';
@@ -114,6 +118,42 @@ function useEnter( props ) {
 	}, [] );
 }
 
+function FullWidthOnMobilePanel( { isFullWidthOnMobile, setAttributes } ) {
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	return (
+		<ToolsPanel
+			label={ __( 'Settings' ) }
+			resetAll={ () =>
+				setAttributes( {
+					isFullWidthOnMobile: false,
+				} )
+			}
+			dropdownMenuProps={ dropdownMenuProps }
+		>
+			<ToolsPanelItem
+				label={ __( 'Full width on mobile' ) }
+				isShownByDefault
+				hasValue={ () => !! isFullWidthOnMobile }
+				onDeselect={ () =>
+					setAttributes( { isFullWidthOnMobile: false } )
+				}
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Full width on mobile' ) }
+					checked={ isFullWidthOnMobile }
+					onChange={ () =>
+						setAttributes( {
+							isFullWidthOnMobile: ! isFullWidthOnMobile,
+						} )
+					}
+				/>
+			</ToolsPanelItem>
+		</ToolsPanel>
+	);
+}
+
 function ButtonEdit( props ) {
 	const {
 		attributes,
@@ -133,6 +173,7 @@ function ButtonEdit( props ) {
 		style,
 		text,
 		url,
+		isFullWidthOnMobile,
 		metadata,
 	} = attributes;
 	const width = style?.dimensions?.width;
@@ -322,7 +363,9 @@ function ButtonEdit( props ) {
 		<>
 			<div
 				{ ...blockProps }
-				className={ classes }
+				className={ clsx( classes, {
+					'is-full-width-on-mobile': isFullWidthOnMobile,
+				} ) }
 				style={ { ...blockProps.style, ...widthStyle } }
 			>
 				<RichText
@@ -427,6 +470,12 @@ function ButtonEdit( props ) {
 						/>
 					</Popover>
 				) }
+			<InspectorControls>
+				<FullWidthOnMobilePanel
+					isFullWidthOnMobile={ isFullWidthOnMobile }
+					setAttributes={ setAttributes }
+				/>
+			</InspectorControls>
 			<InspectorControls group="advanced">
 				<HTMLElementControl
 					tagName={ tagName }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -28,6 +28,7 @@ export default function save( { attributes } ) {
 		text,
 		title,
 		url,
+		isFullWidthOnMobile,
 	} = attributes;
 	const TagName = tagName || 'a';
 	const isButtonTag = 'button' === TagName;
@@ -63,8 +64,14 @@ export default function save( { attributes } ) {
 	// if it had already been assigned, for the sake of backward-compatibility.
 	// A title will no longer be assigned for new or updated button block links.
 
+	const blockProps = useBlockProps.save( {
+		className: clsx( {
+			'is-full-width-on-mobile': isFullWidthOnMobile,
+		} ),
+	} );
+
 	return (
-		<div { ...useBlockProps.save() }>
+		<div { ...blockProps }>
 			<RichText.Content
 				tagName={ TagName }
 				type={ isButtonTag ? buttonType : null }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/breakpoints" as *;
+
 // This variable is repeated across Button, Buttons, and Buttons editor styles.
 $blocks-block__margin: 0.5em;
 
@@ -95,6 +97,16 @@ $blocks-block__margin: 0.5em;
 	&.wp-block-button__width-100 {
 		width: 100%;
 		flex-basis: 100%;
+	}
+
+	&.is-full-width-on-mobile {
+		@media (max-width: #{ ($break-medium - 1) }) {
+			width: 100%;
+			flex-basis: 100%;
+			.wp-block-button__link {
+				width: 100%;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a new `isFullWidthOnMobile` boolean attribute to the `core/button` block
- Adds a "Full width on mobile" `ToggleControl` in the block Settings panel (alongside the existing Width control)
- When enabled, applies the `is-full-width-on-mobile` class which makes the button expand to 100% width below the standard 782px mobile breakpoint
- Follows the same pattern as `isStackedOnMobile` in `core/columns`

Editor:
<img width="1034" height="342" alt="image" src="https://github.com/user-attachments/assets/6de19488-724d-445a-a663-7f21eb0c442d" />
<img width="348" height="276" alt="image" src="https://github.com/user-attachments/assets/17fff717-4895-4997-a76f-596c05960b5b" />

Frontend:
<img width="848" height="316" alt="image" src="https://github.com/user-attachments/assets/c0983c04-e7db-47e7-8c44-95002fb182a0" />
<img width="355" height="243" alt="image" src="https://github.com/user-attachments/assets/9a25f4dd-a38a-43e9-973d-702b692c331a" />


## Why

Buttons often need to be full-width on mobile for better tap targets and UX, while remaining their natural width on desktop. Currently users have no way to achieve this without custom CSS.

## No deprecation needed

The attribute defaults to `false`. Existing saved buttons produce identical output since the class is never added unless explicitly toggled on.

## Test plan

- [ ] Add a Button block, open Settings panel, verify "Full width on mobile" toggle appears below Width
- [ ] Enable the toggle, check the HTML output includes the `is-full-width-on-mobile` class
- [ ] Resize browser below 782px — button should expand to full width
- [ ] Resize above 782px — button returns to natural width
- [ ] Reset all in the Settings panel clears both Width and Full width on mobile
- [ ] Save and reload — toggle state persists correctly

Generated with [Claude Code](https://claude.com/claude-code)