### PR TITLE
RTC: Pick user fields instead of spreading the entire object

### DIFF
--- a/packages/core-data/src/awareness/utils.ts
+++ b/packages/core-data/src/awareness/utils.ts
@@ -175,11 +175,16 @@ export function generateCollaboratorInfo(
 	currentCollaborator: User< 'view' >,
 	existingColors: string[]
 ): CollaboratorInfo {
+	// eslint-disable-next-line camelcase
+	const { avatar_urls, id, name, slug } = currentCollaborator;
 	return {
-		...currentCollaborator,
+		avatar_urls, // eslint-disable-line camelcase
 		browserType: getBrowserName(),
 		color: getNewCollaboratorColor( existingColors ),
 		enteredAt: Date.now(),
+		id,
+		name,
+		slug,
 	};
 }
 


### PR DESCRIPTION
## What?
When assembling awareness data, pick user fields instead of spreading the entire object.

<!-- In a few words, what is the PR actually doing? -->

## Why?

This ensures that unnecessary user fields are not transmitted with awareness data:

<img width="742" height="524" alt="Screenshot 2026-02-13 at 10 47 33" src="https://github.com/user-attachments/assets/bbe68783-24dd-4080-9d9a-dbd966c30ecc" />

## How?

Pick specific fields instead of spreading the entire object.

## Testing Instructions

1. Checkout this branch.
2. Settings > Writing > Enable real-time collaboration
3. Open a post for editing.
4. Filter network requests by "sync"
5. Inspect the response and ensure that only necessary fields are included in awareness data
   - e.g., `rooms[0].awareness.xxxxxxxx.collaboratorInfo`

### Testing Instructions for Keyboard
n/a