### PR TITLE
Fix: Show and hook up submenu visibility for Page Lists within Navigation Blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -380,7 +380,9 @@ function Navigation( {
 	} = useInnerBlocks( clientId );
 
 	const hasSubmenus = !! innerBlocks.find(
-		( block ) => block.name === 'core/navigation-submenu'
+		( block ) =>
+			block.name === 'core/navigation-submenu' ||
+			block.name === 'core/page-list'
 	);
 
 	// Check if any overlay template parts exist

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -379,10 +379,31 @@ function Navigation( {
 		innerBlocks,
 	} = useInnerBlocks( clientId );
 
-	const hasSubmenus = !! innerBlocks.find(
-		( block ) =>
-			block.name === 'core/navigation-submenu' ||
-			block.name === 'core/page-list'
+	// Check for submenus using getBlocks to include controlled innerBlocks
+	const hasSubmenus = useSelect(
+		( select ) => {
+			// First check for navigation-submenu (fast, no selector needed)
+			const hasNavigationSubmenu = innerBlocks.some(
+				( block ) => block.name === 'core/navigation-submenu'
+			);
+			if ( hasNavigationSubmenu ) {
+				return true;
+			}
+
+			// Only check page-list if we didn't find a submenu already
+			const pageList = innerBlocks.find(
+				( block ) => block.name === 'core/page-list'
+			);
+			if ( ! pageList ) {
+				return false;
+			}
+
+			// We have a page-list, check its controlled innerBlocks
+			const { getBlocks } = select( blockEditorStore );
+			const pageListBlocks = getBlocks( pageList.clientId );
+			return pageListBlocks.length > 0;
+		},
+		[ innerBlocks ]
 	);
 
 	// Check if any overlay template parts exist

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -379,6 +379,10 @@ function Navigation( {
 		innerBlocks,
 	} = useInnerBlocks( clientId );
 
+	// Use a ref to store whether we've confirmed a page-list has submenus.
+	// Once confirmed, we don't need to keep checking the page-list blocks.
+	const hasPageListWithSubmenuRef = useRef( false );
+
 	// Check for submenus using getBlocks to include controlled innerBlocks
 	const hasSubmenus = useSelect(
 		( select ) => {
@@ -395,13 +399,25 @@ function Navigation( {
 				( block ) => block.name === 'core/page-list'
 			);
 			if ( ! pageList ) {
+				hasPageListWithSubmenuRef.current = false;
 				return false;
 			}
 
-			// We have a page-list, check its controlled innerBlocks
+			// If we've already confirmed page-list has submenus, return early
+			if ( hasPageListWithSubmenuRef.current ) {
+				return true;
+			}
+
+			// Check if the page-list has controlled innerBlocks
 			const { getBlocks } = select( blockEditorStore );
 			const pageListBlocks = getBlocks( pageList.clientId );
-			return pageListBlocks.length > 0;
+			if ( pageListBlocks.length > 0 ) {
+				hasPageListWithSubmenuRef.current = true;
+				return true;
+			}
+
+			// No pageList returned with confirmed submenus, so assume it will not have submenus
+			return false;
 		},
 		[ innerBlocks ]
 	);

--- a/packages/block-library/src/page-list-item/block.json
+++ b/packages/block-library/src/page-list-item/block.json
@@ -38,7 +38,8 @@
 		"customFontSize",
 		"showSubmenuIcon",
 		"style",
-		"openSubmenusOnClick"
+		"openSubmenusOnClick",
+		"submenuVisibility"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -40,8 +40,9 @@ export default function PageListItemEdit( { context, attributes } ) {
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
 
-	// Compute submenu visibility with backward compatibility
-	// Check old attribute first, then fall back to new attribute
+	// Get submenu visibility from context. The Navigation block handles
+	// backward compatibility by migrating openSubmenusOnClick to submenuVisibility
+	// via its deprecation handler before this context is received.
 	const submenuVisibility = context.submenuVisibility;
 
 	const openOnClick = submenuVisibility === 'click';
@@ -62,10 +63,13 @@ export default function PageListItemEdit( { context, attributes } ) {
 			className={ clsx( 'wp-block-pages-list__item', {
 				'has-child': hasChildren,
 				'wp-block-navigation-item': isNavigationChild,
+				// Class assignment logic matches PHP rendering in page-list/index.php lines 210-218
 				'open-on-click': openOnClick,
 				'open-on-hover': submenuVisibility === 'hover',
 				'open-always': submenuVisibility === 'always',
-				'open-on-hover-click': ! openOnClick && context.showSubmenuIcon,
+				// Must check hover mode explicitly to match PHP elseif structure (index.php:212)
+				'open-on-hover-click':
+					submenuVisibility === 'hover' && context.showSubmenuIcon,
 				'menu-item-home': id === frontPageId,
 			} ) }
 		>

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -42,12 +42,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 
 	// Compute submenu visibility with backward compatibility
 	// Check old attribute first, then fall back to new attribute
-	let submenuVisibility = 'hover';
-	if ( context.openSubmenusOnClick !== undefined ) {
-		submenuVisibility = context.openSubmenusOnClick ? 'click' : 'hover';
-	} else if ( context.submenuVisibility ) {
-		submenuVisibility = context.submenuVisibility;
-	}
+	const submenuVisibility = context.submenuVisibility;
 
 	const openOnClick = submenuVisibility === 'click';
 

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -63,7 +63,7 @@ export default function PageListItemEdit( { context, attributes } ) {
 			className={ clsx( 'wp-block-pages-list__item', {
 				'has-child': hasChildren,
 				'wp-block-navigation-item': isNavigationChild,
-				// Class assignment logic matches PHP rendering in page-list/index.php lines 210-218
+				// Class assignment logic matches PHP rendering in page-list/index.php
 				'open-on-click': openOnClick,
 				'open-always': submenuVisibility === 'always',
 				// Must check hover mode explicitly to match PHP elseif structure (index.php:212)

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -65,7 +65,6 @@ export default function PageListItemEdit( { context, attributes } ) {
 				'wp-block-navigation-item': isNavigationChild,
 				// Class assignment logic matches PHP rendering in page-list/index.php lines 210-218
 				'open-on-click': openOnClick,
-				'open-on-hover': submenuVisibility === 'hover',
 				'open-always': submenuVisibility === 'always',
 				// Must check hover mode explicitly to match PHP elseif structure (index.php:212)
 				'open-on-hover-click':

--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -40,6 +40,17 @@ export default function PageListItemEdit( { context, attributes } ) {
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const frontPageId = useFrontPageId();
 
+	// Compute submenu visibility with backward compatibility
+	// Check old attribute first, then fall back to new attribute
+	let submenuVisibility = 'hover';
+	if ( context.openSubmenusOnClick !== undefined ) {
+		submenuVisibility = context.openSubmenusOnClick ? 'click' : 'hover';
+	} else if ( context.submenuVisibility ) {
+		submenuVisibility = context.submenuVisibility;
+	}
+
+	const openOnClick = submenuVisibility === 'click';
+
 	const innerBlocksColors = getColors( context, true );
 
 	const navigationChildBlockProps =
@@ -56,13 +67,14 @@ export default function PageListItemEdit( { context, attributes } ) {
 			className={ clsx( 'wp-block-pages-list__item', {
 				'has-child': hasChildren,
 				'wp-block-navigation-item': isNavigationChild,
-				'open-on-click': context.openSubmenusOnClick,
-				'open-on-hover-click':
-					! context.openSubmenusOnClick && context.showSubmenuIcon,
+				'open-on-click': openOnClick,
+				'open-on-hover': submenuVisibility === 'hover',
+				'open-always': submenuVisibility === 'always',
+				'open-on-hover-click': ! openOnClick && context.showSubmenuIcon,
 				'menu-item-home': id === frontPageId,
 			} ) }
 		>
-			{ hasChildren && context.openSubmenusOnClick ? (
+			{ hasChildren && openOnClick ? (
 				<>
 					<button
 						type="button"
@@ -87,16 +99,15 @@ export default function PageListItemEdit( { context, attributes } ) {
 			) }
 			{ hasChildren && (
 				<>
-					{ ! context.openSubmenusOnClick &&
-						context.showSubmenuIcon && (
-							<button
-								className="wp-block-navigation-item__content wp-block-navigation-submenu__toggle wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"
-								aria-expanded="false"
-								type="button"
-							>
-								<ItemSubmenuIcon />
-							</button>
-						) }
+					{ ! openOnClick && context.showSubmenuIcon && (
+						<button
+							className="wp-block-navigation-item__content wp-block-navigation-submenu__toggle wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"
+							aria-expanded="false"
+							type="button"
+						>
+							<ItemSubmenuIcon />
+						</button>
+					) }
 					<ul { ...innerBlocksProps }></ul>
 				</>
 			) }

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -31,7 +31,8 @@
 		"customFontSize",
 		"showSubmenuIcon",
 		"style",
-		"openSubmenusOnClick"
+		"openSubmenusOnClick",
+		"submenuVisibility"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -183,7 +183,6 @@ export default function PageListEdit( {
 				context.backgroundColor
 			) ]: !! context.backgroundColor,
 			'open-on-click': context.submenuVisibility === 'click',
-			'open-on-hover': context.submenuVisibility === 'hover',
 			'open-always': context.submenuVisibility === 'always',
 		} ),
 		style: { ...context.style?.color },

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -182,6 +182,9 @@ export default function PageListEdit( {
 				'background-color',
 				context.backgroundColor
 			) ]: !! context.backgroundColor,
+			'open-on-click': context.submenuVisibility === 'click',
+			'open-on-hover': context.submenuVisibility === 'hover',
+			'open-always': context.submenuVisibility === 'always',
 		} ),
 		style: { ...context.style?.color },
 	} );

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -207,6 +207,8 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 		if ( $is_navigation_child ) {
 			$css_class .= ' wp-block-navigation-item';
 
+			// Class assignment logic matches JS editor rendering in page-list-item/edit.js lines 65-70
+			// Note: elseif ensures open-on-hover-click is mutually exclusive with open-on-click
 			if ( $open_on_click ) {
 				$css_class .= ' open-on-click';
 			} elseif ( $open_on_hover && $show_submenu_icons ) {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -6,6 +6,36 @@
  */
 
 /**
+ * Returns the submenu visibility value with backward compatibility
+ * for the deprecated openSubmenusOnClick attribute.
+ *
+ * @since 6.9.0
+ *
+ * @param array $context Block context from parent Navigation block.
+ * @return string The visibility mode: 'hover', 'click', or 'always'.
+ */
+function block_core_page_list_get_submenu_visibility( $context ) {
+	// If not a child of navigation block, return default 'hover'.
+	if ( ! array_key_exists( 'showSubmenuIcon', $context ) ) {
+		return 'hover';
+	}
+
+	$deprecated_open_submenus_on_click = $context['openSubmenusOnClick'] ?? null;
+
+	// For backward compatibility, prioritize the legacy attribute if present. If it has been loaded and saved in the editor, then
+	// the deprecated attribute will be replaced by submenuVisibility.
+	if ( null !== $deprecated_open_submenus_on_click ) {
+		// Convert boolean to string: true -> 'click', false -> 'hover'.
+		return ! empty( $deprecated_open_submenus_on_click ) ? 'click' : 'hover';
+	}
+
+	$submenu_visibility = $context['submenuVisibility'] ?? null;
+
+	// Use submenuVisibility for migrated/new blocks.
+	return $submenu_visibility ?? 'hover';
+}
+
+/**
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the pages markup in the front-end when it is a descendant of navigation.
  *
@@ -332,7 +362,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 
-	$open_submenus_on_click = array_key_exists( 'openSubmenusOnClick', $block->context ) ? $block->context['openSubmenusOnClick'] : false;
+	// Get submenu visibility with backward compatibility for openSubmenusOnClick.
+	$computed_visibility    = block_core_page_list_get_submenu_visibility( $block->context );
+	$open_submenus_on_click = 'click' === $computed_visibility;
 
 	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $block->context ) ? $block->context['showSubmenuIcon'] : false;
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -207,7 +207,7 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 		if ( $is_navigation_child ) {
 			$css_class .= ' wp-block-navigation-item';
 
-			// Class assignment logic matches JS editor rendering in page-list-item/edit.js lines 65-70
+			// Class assignment logic matches JS editor rendering in page-list-item/edit.js
 			// Note: elseif ensures open-on-hover-click is mutually exclusive with open-on-click
 			if ( $open_on_click ) {
 				$css_class .= ' open-on-click';

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -182,12 +182,18 @@ function block_core_page_list_build_css_font_sizes( $context ) {
  *
  * @return string List markup.
  */
-function block_core_page_list_render_nested_page_list( $open_submenus_on_click, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids = array(), $colors = array(), $depth = 0 ) {
+function block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids = array(), $colors = array(), $depth = 0 ) {
 	if ( empty( $nested_pages ) ) {
 		return;
 	}
 	$front_page_id = (int) get_option( 'page_on_front' );
 	$markup        = '';
+
+	// Compute visibility mode flags once
+	$open_on_click = 'click' === $submenu_visibility;
+	$open_on_hover = 'hover' === $submenu_visibility;
+	$open_always   = 'always' === $submenu_visibility;
+
 	foreach ( (array) $nested_pages as $page ) {
 		$css_class       = $page['is_active'] ? ' current-menu-item' : '';
 		$aria_current    = $page['is_active'] ? ' aria-current="page"' : '';
@@ -201,10 +207,14 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 		if ( $is_navigation_child ) {
 			$css_class .= ' wp-block-navigation-item';
 
-			if ( $open_submenus_on_click ) {
+			if ( $open_on_click ) {
 				$css_class .= ' open-on-click';
-			} elseif ( $show_submenu_icons ) {
+			} elseif ( $open_on_hover && $show_submenu_icons ) {
 				$css_class .= ' open-on-hover-click';
+			}
+
+			if ( $open_always ) {
+				$css_class .= ' open-always';
 			}
 		}
 
@@ -232,7 +242,7 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 
 		$markup .= '<li class="wp-block-pages-list__item' . esc_attr( $css_class ) . '"' . $style_attribute . '>';
 
-		if ( isset( $page['children'] ) && $is_navigation_child && $open_submenus_on_click ) {
+		if ( isset( $page['children'] ) && $is_navigation_child && $open_on_click ) {
 			$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="' . esc_attr( $navigation_child_content_class ) . ' wp-block-navigation-submenu__toggle" aria-expanded="false">' . wp_kses_post( $title ) .
 			'</button><span class="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
 		} else {
@@ -240,13 +250,13 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 		}
 
 		if ( isset( $page['children'] ) ) {
-			if ( $is_navigation_child && $show_submenu_icons && ! $open_submenus_on_click ) {
+			if ( $is_navigation_child && $show_submenu_icons && ! $open_on_click ) {
 				$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">';
 				$markup .= '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 				$markup .= '</button>';
 			}
 			$markup .= '<ul class="wp-block-navigation__submenu-container">';
-			$markup .= block_core_page_list_render_nested_page_list( $open_submenus_on_click, $show_submenu_icons, $is_navigation_child, $page['children'], $is_nested, $active_page_ancestor_ids, $colors, $depth + 1 );
+			$markup .= block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $page['children'], $is_nested, $active_page_ancestor_ids, $colors, $depth + 1 );
 			$markup .= '</ul>';
 		}
 		$markup .= '</li>';
@@ -363,14 +373,13 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 
 	// Get submenu visibility with backward compatibility for openSubmenusOnClick.
-	$computed_visibility    = block_core_page_list_get_submenu_visibility( $block->context );
-	$open_submenus_on_click = 'click' === $computed_visibility;
+	$submenu_visibility = block_core_page_list_get_submenu_visibility( $block->context );
 
 	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $block->context ) ? $block->context['showSubmenuIcon'] : false;
 
 	$wrapper_markup = $is_nested ? '%2$s' : '<ul %1$s>%2$s</ul>';
 
-	$items_markup = block_core_page_list_render_nested_page_list( $open_submenus_on_click, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids, $colors );
+	$items_markup = block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids, $colors );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -213,9 +213,7 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 				$css_class .= ' open-on-click';
 			} elseif ( $open_on_hover && $show_submenu_icons ) {
 				$css_class .= ' open-on-hover-click';
-			}
-
-			if ( $open_always ) {
+			} elseif ( $open_always ) {
 				$css_class .= ' open-always';
 			}
 		}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -15,11 +15,6 @@
  * @return string The visibility mode: 'hover', 'click', or 'always'.
  */
 function block_core_page_list_get_submenu_visibility( $context ) {
-	// If not a child of navigation block, return default 'hover'.
-	if ( ! array_key_exists( 'showSubmenuIcon', $context ) ) {
-		return 'hover';
-	}
-
 	$deprecated_open_submenus_on_click = $context['openSubmenusOnClick'] ?? null;
 
 	// For backward compatibility, prioritize the legacy attribute if present. If it has been loaded and saved in the editor, then
@@ -373,7 +368,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 
 	// Get submenu visibility with backward compatibility for openSubmenusOnClick.
-	$submenu_visibility = block_core_page_list_get_submenu_visibility( $block->context );
+	$submenu_visibility = $is_navigation_child ? block_core_page_list_get_submenu_visibility( $block->context ) : 'hover';
 
 	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $block->context ) ? $block->context['showSubmenuIcon'] : false;
 

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -107,7 +107,7 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 
 			// Find the submenu container
 			const submenu = page
-				.locator( 'role=navigation' )
+				.getByRole( 'navigation' )
 				.locator( 'ul.wp-block-navigation__submenu-container' );
 
 			// Submenu should be visible without hover
@@ -115,10 +115,10 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 
 			// Check that submenu items are visible
 			const teamLink = page
-				.locator( 'role=navigation' )
+				.getByRole( 'navigation' )
 				.getByRole( 'link', { name: 'Team' } );
 			const contactLink = page
-				.locator( 'role=navigation' )
+				.getByRole( 'navigation' )
 				.getByRole( 'link', { name: 'Contact' } );
 
 			await expect( teamLink ).toBeVisible();
@@ -126,73 +126,135 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 		} );
 	} );
 
-	test( 'Page List exposes submenu visibility UI when page-list is present', async ( {
+	test( 'Page List submenu visibility works correctly', async ( {
 		editor,
 		page,
 		admin,
 		requestUtils,
 	} ) => {
-		// Create parent and child pages for testing
-		const parentPage = await requestUtils.createPage( {
-			title: 'Test Parent Page',
-			status: 'publish',
-		} );
-
-		await requestUtils.createPage( {
-			title: 'Test Child Page',
-			status: 'publish',
-			parent: parentPage.id,
-		} );
-
-		// Create a new post with navigation + page-list
-		await admin.createNewPost();
-
-		// Insert navigation block with page-list
-		await editor.insertBlock( {
-			name: 'core/navigation',
-			innerBlocks: [
-				{
-					name: 'core/page-list',
-				},
-			],
-		} );
-
-		// Wait for navigation block to be visible
 		const navBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Navigation',
 		} );
-		await expect( navBlock ).toBeVisible();
-
-		// Wait for page list to load
 		const pageListBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Page List',
 		} );
-		await expect( pageListBlock ).toBeVisible( { timeout: 10000 } );
+		await test.step( 'Test setup', async () => {
+			// Create parent and child pages for testing
+			const parentPage = await requestUtils.createPage( {
+				title: 'Products',
+				status: 'publish',
+			} );
 
-		// Select navigation block and check settings
-		await editor.selectBlocks( navBlock );
-		await editor.openDocumentSettingsSidebar();
+			await requestUtils.createPage( {
+				title: 'Laptops',
+				status: 'publish',
+				parent: parentPage.id,
+			} );
 
-		// Click the Settings tab
-		const settingsTab = page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'tab', { name: 'Settings' } );
-		await settingsTab.click();
+			await requestUtils.createPage( {
+				title: 'Phones',
+				status: 'publish',
+				parent: parentPage.id,
+			} );
 
-		const settingsPanel = page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'tabpanel', { name: 'Settings' } );
+			// Create a new post with navigation + page-list
+			await admin.createNewPost();
 
-		// Check if Submenu Visibility control exists
-		const submenuVisibilityGroup = settingsPanel.getByRole( 'radiogroup', {
-			name: 'Submenu Visibility',
+			// Insert navigation block with page-list
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				innerBlocks: [
+					{
+						name: 'core/page-list',
+					},
+				],
+			} );
+
+			// Wait for navigation block to be visible
+			await expect( navBlock ).toBeVisible();
+
+			// Wait for page list to load
+			await expect( pageListBlock ).toBeVisible();
 		} );
 
-		const isVisible = await submenuVisibilityGroup.isVisible();
+		await test.step( 'Submenu Visibility control appears for page-list', async () => {
+			// Select navigation block and check settings
+			await editor.selectBlocks( navBlock );
+			await editor.openDocumentSettingsSidebar();
 
-		// FIXED: Submenu Visibility control now appears when navigation contains page-list
-		// This allows users to control submenu behavior for hierarchical pages
-		expect( isVisible ).toBe( true );
+			// Click the Settings tab
+			const settingsTab = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tab', { name: 'Settings' } );
+			await settingsTab.click();
+
+			const settingsPanel = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tabpanel', { name: 'Settings' } );
+
+			// Check if Submenu Visibility control exists
+			const submenuVisibilityGroup = settingsPanel.getByRole(
+				'radiogroup',
+				{
+					name: 'Submenu Visibility',
+				}
+			);
+
+			const isVisible = await submenuVisibilityGroup.isVisible();
+			expect( isVisible ).toBe( true );
+		} );
+
+		await test.step( 'Set submenu visibility to always', async () => {
+			const settingsPanel = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tabpanel', { name: 'Settings' } );
+
+			// Switch to vertical orientation first (required for Always option)
+			const verticalOption = settingsPanel.getByRole( 'radio', {
+				name: 'Vertical',
+			} );
+			await verticalOption.click();
+
+			// Select Always from Submenu Visibility
+			const submenuVisibilityGroup = settingsPanel.getByRole(
+				'radiogroup',
+				{
+					name: 'Submenu Visibility',
+				}
+			);
+
+			const alwaysOption = submenuVisibilityGroup.getByRole( 'radio', {
+				name: 'Always',
+			} );
+			await alwaysOption.click();
+		} );
+
+		await test.step( 'Publish the post', async () => {
+			// Publish the post
+			const postId = await editor.publishPost();
+
+			// Navigate to the frontend
+			await page.goto( `/?p=${ postId }` );
+		} );
+
+		await test.step( 'Setting Always makes submenus visible on frontend', async () => {
+			// Find the parent page link in navigation
+			const parentLink = page
+				.getByRole( 'navigation' )
+				.getByRole( 'link', { name: 'Products' } );
+			await expect( parentLink ).toBeVisible();
+
+			// Verify submenu items are visible
+			const laptopsLink = page
+				.getByRole( 'navigation' )
+				.getByRole( 'link', { name: 'Laptops' } );
+			const phonesLink = page
+				.getByRole( 'navigation' )
+				.getByRole( 'link', { name: 'Phones' } );
+
+			await expect( laptopsLink ).toBeVisible();
+			await expect( phonesLink ).toBeVisible();
+		} );
 
 		// Clean up
 		await requestUtils.deleteAllPages();

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -125,4 +125,76 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 			await expect( contactLink ).toBeVisible();
 		} );
 	} );
+
+	test( 'Page List exposes submenu visibility UI when page-list is present', async ( {
+		editor,
+		page,
+		admin,
+		requestUtils,
+	} ) => {
+		// Create parent and child pages for testing
+		const parentPage = await requestUtils.createPage( {
+			title: 'Test Parent Page',
+			status: 'publish',
+		} );
+
+		await requestUtils.createPage( {
+			title: 'Test Child Page',
+			status: 'publish',
+			parent: parentPage.id,
+		} );
+
+		// Create a new post with navigation + page-list
+		await admin.createNewPost();
+
+		// Insert navigation block with page-list
+		await editor.insertBlock( {
+			name: 'core/navigation',
+			innerBlocks: [
+				{
+					name: 'core/page-list',
+				},
+			],
+		} );
+
+		// Wait for navigation block to be visible
+		const navBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Navigation',
+		} );
+		await expect( navBlock ).toBeVisible();
+
+		// Wait for page list to load
+		const pageListBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Page List',
+		} );
+		await expect( pageListBlock ).toBeVisible( { timeout: 10000 } );
+
+		// Select navigation block and check settings
+		await editor.selectBlocks( navBlock );
+		await editor.openDocumentSettingsSidebar();
+
+		// Click the Settings tab
+		const settingsTab = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } );
+		await settingsTab.click();
+
+		const settingsPanel = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tabpanel', { name: 'Settings' } );
+
+		// Check if Submenu Visibility control exists
+		const submenuVisibilityGroup = settingsPanel.getByRole( 'radiogroup', {
+			name: 'Submenu Visibility',
+		} );
+
+		const isVisible = await submenuVisibilityGroup.isVisible();
+
+		// FIXED: Submenu Visibility control now appears when navigation contains page-list
+		// This allows users to control submenu behavior for hierarchical pages
+		expect( isVisible ).toBe( true );
+
+		// Clean up
+		await requestUtils.deleteAllPages();
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -200,10 +200,8 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 				}
 			);
 
-			const isVisible = await submenuVisibilityGroup.isVisible();
-			expect( isVisible ).toBe( true );
+			await expect( submenuVisibilityGroup ).toBeVisible();
 		} );
-
 		await test.step( 'Set submenu visibility to always', async () => {
 			const settingsPanel = page
 				.getByRole( 'region', { name: 'Editor settings' } )

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -6,6 +6,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Navigation block - Submenu Visibility', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllMenus();
+		await requestUtils.deleteAllPages();
 	} );
 
 	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
@@ -256,8 +257,5 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 			await expect( laptopsLink ).toBeVisible();
 			await expect( phonesLink ).toBeVisible();
 		} );
-
-		// Clean up
-		await requestUtils.deleteAllPages();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -173,8 +173,11 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 			// Wait for navigation block to be visible
 			await expect( navBlock ).toBeVisible();
 
-			// Wait for page list to load
+			// Wait for page list to load and populate with pages
 			await expect( pageListBlock ).toBeVisible();
+			await expect( pageListBlock ).toContainText( 'Products' );
+			await expect( pageListBlock ).toContainText( 'Laptops' );
+			await expect( pageListBlock ).toContainText( 'Phones' );
 		} );
 
 		await test.step( 'Submenu Visibility control appears for page-list', async () => {


### PR DESCRIPTION
## What?

Fixes submenu visibility functionality for page-list blocks in navigation blocks.

## Why?

Two related bugs existed:

1. **Missing UI Control**: When a navigation block contained a page-list (instead of navigation-submenu blocks), the Submenu Visibility control didn't appear in the block settings sidebar, even though page-list can display hierarchical pages with submenus.

2. **"Always" Mode Not Working**: Even when the UI control was made visible, setting submenu visibility to "always" didn't work for page-list blocks - submenus remained hidden instead of being always visible.

### Root Causes

**Bug 1** was introduced in commit [`513ff939978`](https://github.com/WordPress/gutenberg/commit/513ff939978) (Nov 26, 2021) - "Only show submenu options and Show arrow button when relevant. (#36826)"

This commit added a `hasSubmenus` check to conditionally show submenu-related controls, but it only checked for `navigation-submenu` blocks:

```javascript
const firstSubmenu = !! blocks.find(
    ( block ) => block.name === 'core/navigation-submenu'
);
```

This ignored `page-list` blocks entirely, even though they can display hierarchical pages with submenus. Page-list had existed since Feb 8, 2021 (commit `218bff339cf`), 9 months before this check was added. This effectively removed submenu control functionality from page-list blocks for the past **3+ years**.

**Bug #2** existed because the page-list PHP rendering only handled two visibility modes ('click' and 'hover') but didn't implement the 'always' case, so the required CSS class was never added to the markup.

## How?

### JavaScript Fix (Bug #1)
Updated `hasSubmenus` check in `packages/block-library/src/navigation/edit/index.js` to detect both `navigation-submenu` AND `page-list` blocks:

```javascript
const hasSubmenus = !! innerBlocks.find(
    ( block ) =>
        block.name === 'core/navigation-submenu' ||
        block.name === 'core/page-list'
);
```

### PHP Fixes (Bugs 1 & 2)

**Added context support** (`packages/block-library/src/page-list/block.json`):
- Added `submenuVisibility` to `usesContext` for forward compatibility

**Updated rendering logic** (`packages/block-library/src/page-list/index.php`):
- Changed `block_core_page_list_render_nested_page_list()` to accept full `$submenu_visibility` string ('hover', 'click', 'always') instead of boolean
- Added handling for 'always' visibility mode - adds `open-always` CSS class to list items
- Added backward compatibility helper function `block_core_page_list_get_submenu_visibility()` that checks deprecated `openSubmenusOnClick` attribute

### Testing

Added comprehensive e2e test with multiple steps:
1. Verifies Submenu Visibility control appears when navigation contains page-list
2. Sets visibility to "always" and verifies submenus are visible on frontend without hover/click

## Testing Instructions

### Manual Testing

1. Create a parent page and a couple child pages
2. Insert a Navigation block
3. Add a Page List block inside the navigation
4. Select the navigation block and open Settings sidebar
5. **Verify**: Submenu Visibility control should appear (Bug #1 fix)
6. Switch to Vertical orientation
7. Set Submenu Visibility to "Always"
8. Publish and view on frontend
9. **Verify**: Child pages should be visible without hover/click (Bug #2 fix)

### Automated Testing

```bash
npm run test:e2e:playwright -- navigation-submenu-visibility.spec.js
```

All tests should pass ✅

## Screenshots

<!-- Add screenshots showing the UI control and frontend behavior if desired -->

## Related

- Builds on backward compatibility work from #75435
- Fixes long-standing issue that existed since Nov 2021 (3+ years)
