### PR TITLE
Post Terms: Avoid unbound queries when the post context isn't available

### DIFF
--- a/packages/block-library/src/post-terms/use-post-terms.js
+++ b/packages/block-library/src/post-terms/use-post-terms.js
@@ -12,7 +12,7 @@ export default function usePostTerms( { postId, term } ) {
 	return useSelect(
 		( select ) => {
 			const visible = term?.visibility?.publicly_queryable;
-			if ( ! visible ) {
+			if ( ! visible || ! postId ) {
 				return {
 					postTerms: EMPTY_ARRAY,
 					isLoading: false,


### PR DESCRIPTION
## What?

PR fixes potential performance issue with `usePostTerms` hook, it should bail out early if `postId` isn't available, instead it was making unbound queries for taxonomy, selecting all terms.

## Why?
Unbound queries can be expensive for sites with many terms in the taxonomy. I've got a couple of thousand categories locally for performance testing, and it was taking seconds to render some templates.

## Testing Instructions
1. Open any template in the site editor that uses this block - Single Posts.
2. Confirm there's no query for the taxonomy.
3. Add a block to a post.
4. Confirm that the correct terms are queried for this post.

### Testing Instructions for Keyboard
Same.
