### PR TITLE
ExternalLink: Prevent Twemoji from replacing arrow

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `ExternalLink`: Add `wp-exclude-emoji` class to prevent Twemoji from replacing the arrow icon ([#75538](https://github.com/WordPress/gutenberg/pull/75538)).
 -   `TimePicker`: Fix date parsing for years below 1000 by implementing ISO 8601 compliant year formatting with zero-padding ([#75343](https://github.com/WordPress/gutenberg/pull/75343)).
 -   `Text`: Remove `text-wrap: balance` fallback. Only `text-wrap: pretty` is now used ([#75089](https://github.com/WordPress/gutenberg/pull/75089)).
 -   `RangeControl`: support forced-colors mode ([#75165](https://github.com/WordPress/gutenberg/pull/75165)).

--- a/packages/components/src/external-link/index.tsx
+++ b/packages/components/src/external-link/index.tsx
@@ -67,7 +67,11 @@ function UnforwardedExternalLink(
 				{ children }
 			</span>
 			<span
-				className="components-external-link__icon"
+				className={ clsx(
+					'components-external-link__icon',
+					// This class prevents the arrow from being replaced by a Twemoji image.
+					'wp-exclude-emoji'
+				) }
 				aria-label={
 					/* translators: accessibility text */
 					__( '(opens in a new tab)' )

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -99,7 +99,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
             </span>
             <span
               aria-label="(opens in a new tab)"
-              class="components-external-link__icon"
+              class="components-external-link__icon wp-exclude-emoji"
             >
               ↗
             </span>
@@ -326,7 +326,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
             </span>
             <span
               aria-label="(opens in a new tab)"
-              class="components-external-link__icon"
+              class="components-external-link__icon wp-exclude-emoji"
             >
               ↗
             </span>


### PR DESCRIPTION
## What?

Closes #75378

Adds the [`wp-exclude-emoji` class](https://wordpress.org/documentation/article/what-are-emoji/#converting-to-images) to the `ExternalLink` arrow span to prevent WordPress's bundled Twemoji script from replacing the ↗ arrow character with an emoji image.

## Why?

In contexts where Twemoji is active (currently the site editor), the ↗ / ↖ arrow glyphs rendered by `ExternalLink` get replaced by Twemoji images, resulting in a visually broken appearance.

## How?

Adds `wp-exclude-emoji` to the arrow `<span>`'s class list. This is a class recognized by WordPress's Twemoji integration (`wp-emoji-release.min.js`) that tells it to skip emoji replacement for the element's contents.

## Testing Instructions

1. Open the site editor (only `wp-admin/site-editor.php`, not `wp-admin/admin.php?page=site-editor-v2`).
2. Find any `ExternalLink` instance, for example Design ▸ Styles ▸ Additional CSS (from hamburger menu).
3. Verify the external link arrow (↗) renders as a plain text glyph, not as a Twemoji image.

## Screenshots or screencast

| Before | After |
|--------|-------|
|<img width="720" height="376" alt="Twemoji replacement, before" src="https://github.com/user-attachments/assets/185d9d0c-850e-4c8c-a279-4d134b043aeb" />|<img width="722" height="378" alt="Twemoji replacement, after" src="https://github.com/user-attachments/assets/515c19f2-162e-41df-8e8d-99f7f790aea1" />|
