### PR TITLE
Add word-break property to visually hidden styles to prevent screen reader issues

### DIFF
--- a/packages/a11y/src/script/add-container.js
+++ b/packages/a11y/src/script/add-container.js
@@ -20,7 +20,8 @@ export default function addContainer( ariaLive = 'polite' ) {
 			'overflow:hidden;' +
 			'clip-path:inset(50%);' +
 			'border:0;' +
-			'word-wrap:normal !important;'
+			'word-wrap:normal !important;' +
+			'word-break:normal !important;'
 	);
 	container.setAttribute( 'aria-live', ariaLive );
 	container.setAttribute( 'aria-relevant', 'additions text' );

--- a/packages/a11y/src/script/add-intro-text.ts
+++ b/packages/a11y/src/script/add-intro-text.ts
@@ -28,7 +28,8 @@ export default function addIntroText() {
 			'overflow:hidden;' +
 			'clip-path:inset(50%);' +
 			'border:0;' +
-			'word-wrap:normal !important;'
+			'word-wrap:normal !important;' +
+			'word-break:normal !important;'
 	);
 	introText.setAttribute( 'hidden', '' );
 

--- a/packages/block-editor/src/components/responsive-block-control/style.scss
+++ b/packages/block-editor/src/components/responsive-block-control/style.scss
@@ -11,6 +11,7 @@
 	position: absolute;
 	width: 1px;
 	word-wrap: normal !important;
+	word-break: normal !important;
 }
 
 .block-editor-responsive-block-control {

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -92,6 +92,7 @@
 	position: absolute;
 	width: 1px;
 	word-wrap: normal !important;
+	word-break: normal !important;
 }
 
 .screen-reader-text:focus {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Revert `word-break: break-word` addition ([#76230](https://github.com/WordPress/gutenberg/pull/76230)).
+-   `VisuallyHidden`: Add `word-break: normal` to prevent text wrapping issues in screen reader content ([#75539](https://github.com/WordPress/gutenberg/pull/75539)).
 
 ### Enhancements
 

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -9,7 +9,7 @@ exports[`Notice should match snapshot 1`] = `
       class="components-visually-hidden css-1ragr82-PolymorphicDiv emotion-0"
       data-wp-c16t="true"
       data-wp-component="VisuallyHidden"
-      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal; word-break: normal;"
     >
       Notice
     </div>

--- a/packages/components/src/visually-hidden/styles.ts
+++ b/packages/components/src/visually-hidden/styles.ts
@@ -15,4 +15,5 @@ export const visuallyHidden: CSSProperties = {
 	position: 'absolute',
 	width: '1px',
 	wordWrap: 'normal',
+	wordBreak: 'normal',
 };

--- a/packages/components/src/visually-hidden/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/visually-hidden/test/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`VisuallyHidden should render correctly 1`] = `
   class="components-visually-hidden css-1ragr82-PolymorphicDiv emotion-0"
   data-wp-c16t="true"
   data-wp-component="VisuallyHidden"
-  style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+  style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal; word-break: normal;"
 >
   This is hidden
 </div>

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -164,7 +164,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
                 class="components-visually-hidden emotion-6 emotion-7"
                 data-wp-c16t="true"
                 data-wp-component="VisuallyHidden"
-                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal; word-break: normal;"
               >
                 (opens in a new tab)
               </span>
@@ -391,7 +391,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
                 class="components-visually-hidden emotion-6 emotion-7"
                 data-wp-c16t="true"
                 data-wp-component="VisuallyHidden"
-                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal; word-break: normal;"
               >
                 (opens in a new tab)
               </span>

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `VisuallyHidden`: Add `word-break: normal` to prevent text wrapping issues in screen reader content ([#75539](https://github.com/WordPress/gutenberg/pull/75539)).
+
 ### New Features
 
 -   Add `Card` and `CollapsibleCard` primitives ([#76252](https://github.com/WordPress/gutenberg/pull/76252)).

--- a/packages/ui/src/visually-hidden/style.module.css
+++ b/packages/ui/src/visually-hidden/style.module.css
@@ -11,5 +11,6 @@
 		position: absolute;
 		width: 1px;
 		word-wrap: normal;
+		word-break: normal;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75533 

<!-- In a few words, what is the PR actually doing? -->
Adds the `word-break` property to visually hidden styles

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a summary here, too -->
Prevents potential screen reader issues caused by inherited `word-break` values and aligns Gutenberg behaviour with WordPress Core.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Sets `word-break: normal` in visually hidden utilities