### PR TITLE
Post time to read: Migrate to Text-Align Block Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -772,8 +772,8 @@ Show minutes required to finish reading the post. Can also show a word count. ([
 
 -	**Name:** core/post-time-to-read
 -	**Category:** theme
--	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** averageReadingSpeed, displayAsRange, displayMode, textAlign
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** averageReadingSpeed, displayAsRange, displayMode
 
 ## Title
 

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -8,9 +8,6 @@
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"attributes": {
-		"textAlign": {
-			"type": "string"
-		},
 		"displayAsRange": {
 			"type": "boolean",
 			"default": true
@@ -45,6 +42,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -10,15 +10,15 @@ const v1 = {
 		},
 		displayAsRange: {
 			type: 'boolean',
-			default: true
+			default: true,
 		},
 		displayMode: {
 			type: 'string',
-			default: 'time'
+			default: 'time',
 		},
 		averageReadingSpeed: {
 			type: 'number',
-			default: 189
+			default: 189,
 		}
 	},
 	supports: {
@@ -28,7 +28,7 @@ const v1 = {
 			padding: true,
 			__experimentalDefaultControls: {
 				margin: false,
-				padding: false
+				padding: false,
 			}
 		},
 		typography: {
@@ -41,7 +41,7 @@ const v1 = {
 			__experimentalTextDecoration: true,
 			__experimentalLetterSpacing: true,
 			__experimentalDefaultControls: {
-				fontSize: true
+				fontSize: true,
 			}
 		},
 		interactivity: {
@@ -51,7 +51,7 @@ const v1 = {
 			radius: true,
 			color: true,
 			width: true,
-			style: true
+			style: true,
 		}
 	},
 	migrate: migrateTextAlign,

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -23,14 +23,14 @@ const v1 = {
 	},
 	supports: {
 		anchor: true,
-		spacing: {
-			margin: true,
-			padding: true,
+		color: {
+			gradients: true,
 			__experimentalDefaultControls: {
-				margin: false,
-				padding: false,
+				background: true,
+				text: true,
 			},
 		},
+		html: false,
 		typography: {
 			fontSize: true,
 			lineHeight: true,

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -29,7 +29,7 @@ const v1 = {
 			__experimentalDefaultControls: {
 				margin: false,
 				padding: false,
-			}
+			},
 		},
 		typography: {
 			fontSize: true,
@@ -42,7 +42,7 @@ const v1 = {
 			__experimentalLetterSpacing: true,
 			__experimentalDefaultControls: {
 				fontSize: true,
-			}
+			},
 		},
 		interactivity: {
 			clientNavigation: true,
@@ -52,7 +52,7 @@ const v1 = {
 			color: true,
 			width: true,
 			style: true,
-		}
+		},
 	},
 	migrate: migrateTextAlign,
 	isEligible( attributes ) {

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -19,7 +19,7 @@ const v1 = {
 		averageReadingSpeed: {
 			type: 'number',
 			default: 189,
-		}
+		},
 	},
 	supports: {
 		anchor: true,

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -14,7 +14,7 @@ const v1 = {
 		},
 		displayMode: {
 			type: 'string',
-			default: "time"
+			default: 'time'
 		},
 		averageReadingSpeed: {
 			type: 'number',

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -45,7 +45,7 @@ const v1 = {
 			}
 		},
 		interactivity: {
-			clientNavigation: true
+			clientNavigation: true,
 		},
 		__experimentalBorder: {
 			radius: true,

--- a/packages/block-library/src/post-time-to-read/deprecated.js
+++ b/packages/block-library/src/post-time-to-read/deprecated.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v1 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		displayAsRange: {
+			type: 'boolean',
+			default: true
+		},
+		displayMode: {
+			type: 'string',
+			default: "time"
+		},
+		averageReadingSpeed: {
+			type: 'number',
+			default: 189
+		}
+	},
+	supports: {
+		anchor: true,
+		spacing: {
+			margin: true,
+			padding: true,
+			__experimentalDefaultControls: {
+				margin: false,
+				padding: false
+			}
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true
+			}
+		},
+		interactivity: {
+			clientNavigation: true
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true
+		}
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+	save: () => null,
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -19,9 +19,7 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
-	const { displayAsRange, displayMode, averageReadingSpeed } =
-		attributes;
-
+	const { displayAsRange, displayMode, averageReadingSpeed } = attributes;
 	const { postId, postType } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -1,19 +1,9 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
@@ -29,7 +19,7 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
-	const { textAlign, displayAsRange, displayMode, averageReadingSpeed } =
+	const { displayAsRange, displayMode, averageReadingSpeed } =
 		attributes;
 
 	const { postId, postType } = context;
@@ -128,22 +118,10 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		averageReadingSpeed,
 	] );
 
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 
 	return (
 		<>
-			<BlockControls group="block">
-				<AlignmentControl
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
-				/>
-			</BlockControls>
 			{ displayMode === 'time' && (
 				<InspectorControls>
 					<ToolsPanel

--- a/packages/block-library/src/post-time-to-read/index.js
+++ b/packages/block-library/src/post-time-to-read/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import variations from './variations';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -19,6 +20,7 @@ export const settings = {
 	edit,
 	variations,
 	example: {},
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.html
@@ -1,0 +1,5 @@
+<!-- wp:post-time-to-read {"textAlign":"left"} /-->
+
+<!-- wp:post-time-to-read {"textAlign":"center"} /-->
+
+<!-- wp:post-time-to-read {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.json
@@ -1,0 +1,44 @@
+[
+	{
+		"name": "core/post-time-to-read",
+		"isValid": true,
+		"attributes": {
+			"isLink": false,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-time-to-read",
+		"isValid": true,
+		"attributes": {
+			"isLink": false,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-time-to-read",
+		"isValid": true,
+		"attributes": {
+			"isLink": false,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.json
@@ -3,8 +3,9 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
-			"isLink": false,
-			"linkTarget": "_self",
+			"averageReadingSpeed": 189,
+		    "displayAsRange": true,
+		    "displayMode": "time",
 			"style": {
 				"typography": {
 					"textAlign": "left"
@@ -17,8 +18,9 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
-			"isLink": false,
-			"linkTarget": "_self",
+			"averageReadingSpeed": 189,
+		    "displayAsRange": true,
+		    "displayMode": "time",
 			"style": {
 				"typography": {
 					"textAlign": "center"
@@ -31,8 +33,9 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
-			"isLink": false,
-			"linkTarget": "_self",
+			"averageReadingSpeed": 189,
+		    "displayAsRange": true,
+		    "displayMode": "time",
 			"style": {
 				"typography": {
 					"textAlign": "right"

--- a/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/post-time-to-read",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-time-to-read",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-time-to-read",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:post-time-to-read {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:post-time-to-read {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:post-time-to-read {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Time to Read` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Time to Read`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Time to Read` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Time to Read` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Time to Read` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Time to Read` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

