### PR TITLE
Post Terms: Migrate to Text-Align Block Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -762,8 +762,8 @@ Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages
 
 -	**Name:** core/post-terms
 -	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefix, separator, suffix, term, textAlign
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** prefix, separator, suffix, term
 
 ## Time to Read
 

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -10,9 +10,6 @@
 		"term": {
 			"type": "string"
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"separator": {
 			"type": "string",
 			"default": ", "
@@ -51,6 +48,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/post-terms/deprecated.js
+++ b/packages/block-library/src/post-terms/deprecated.js
@@ -1,0 +1,86 @@
+/**
+ * Internal dependencies
+ */
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v1 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		term: {
+			type: 'string',
+		},
+		separator: {
+			type: 'string',
+			default: ', ',
+		},
+		prefix: {
+			type: 'string',
+			default: '',
+			role: 'content',
+		},
+		suffix: {
+			type: 'string',
+			default: '',
+			role: 'content',
+		},
+	},
+	supports: {
+		anchor: true,
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+	save: () => null,
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -58,7 +58,7 @@ export default function PostTermsEdit( {
 	const hasPost = postId && postType;
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockProps = useBlockProps( {
-		className: term ? `taxonomy-${ term }` : undefined,
+		className: term && `taxonomy-${ term }`,
 	} );
 
 	return (

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -57,7 +57,9 @@ export default function PostTermsEdit( {
 	} );
 	const hasPost = postId && postType;
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: term ? `taxonomy-${ term }` : undefined,
+	} );
 
 	return (
 		<>

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -1,19 +1,11 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
-	AlignmentToolbar,
 	InspectorControls,
-	BlockControls,
 	useBlockProps,
 	useBlockDisplayInformation,
 	RichText,
-	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { Spinner, TextControl } from '@wordpress/components';
@@ -45,10 +37,8 @@ export default function PostTermsEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { term, textAlign, separator, prefix, suffix } = attributes;
+	const { term, separator, prefix, suffix } = attributes;
 	const { postId, postType } = context;
-	const blockEditingMode = useBlockEditingMode();
-	const showControls = blockEditingMode === 'default';
 
 	const selectedTerm = useSelect(
 		( select ) => {
@@ -67,25 +57,10 @@ export default function PostTermsEdit( {
 	} );
 	const hasPost = postId && postType;
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-			[ `taxonomy-${ term }` ]: term,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 
 	return (
 		<>
-			{ showControls && (
-				<BlockControls>
-					<AlignmentToolbar
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-			) }
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize

--- a/packages/block-library/src/post-terms/index.js
+++ b/packages/block-library/src/post-terms/index.js
@@ -11,6 +11,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import enhanceVariations from './hooks';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -18,6 +19,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	deprecated,
 };
 
 export const init = () => {

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.html
@@ -1,0 +1,5 @@
+<!-- wp:post-terms {"term":"category","textAlign":"left"} /-->
+
+<!-- wp:post-terms {"term":"category","textAlign":"center"} /-->
+
+<!-- wp:post-terms {"term":"category","textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.json
@@ -5,6 +5,7 @@
 		"attributes": {
 			"prefix": "",
 			"separator": ", ",
+			"suffix": "",
 			"term": "category",
 			"style": {
 				"typography": {
@@ -18,6 +19,9 @@
 		"name": "core/post-terms",
 		"isValid": true,
 		"attributes": {
+			"prefix": "",
+			"separator": ", ",
+			"suffix": "",
 			"term": "category",
 			"style": {
 				"typography": {
@@ -31,6 +35,9 @@
 		"name": "core/post-terms",
 		"isValid": true,
 		"attributes": {
+			"prefix": "",
+			"separator": ", ",
+			"suffix": "",
 			"term": "category",
 			"style": {
 				"typography": {

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.json
@@ -3,6 +3,8 @@
 		"name": "core/post-terms",
 		"isValid": true,
 		"attributes": {
+			"prefix": "",
+			"separator": ", ",
 			"term": "category",
 			"style": {
 				"typography": {

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.json
@@ -1,0 +1,41 @@
+[
+	{
+		"name": "core/post-terms",
+		"isValid": true,
+		"attributes": {
+			"term": "category",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-terms",
+		"isValid": true,
+		"attributes": {
+			"term": "category",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-terms",
+		"isValid": true,
+		"attributes": {
+			"term": "category",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
@@ -10,6 +10,13 @@
 		"innerContent": []
 	},
 	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
 		"blockName": "core/post-terms",
 		"attrs": {
 			"term": "category",
@@ -20,7 +27,14 @@
 		"innerContent": []
 	},
 	{
-		"blockName": "core/post-terms",
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "post-terms",
 		"attrs": {
 			"term": "category",
 			"textAlign": "right"

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
@@ -1,0 +1,44 @@
+[
+	{
+		"blockName": "core/post-terms",
+		"attrs": {
+			"term": "category",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": "core/post-terms",
+		"attrs": {
+			"term": "category",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": "core/post-terms",
+		"attrs": {
+			"term": "category",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
@@ -3,11 +3,7 @@
 		"blockName": "core/post-terms",
 		"attrs": {
 			"term": "category",
-			"style": {
-				"typography": {
-					"textAlign": "left"
-				}
-			}
+			"textAlign": "left"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",
@@ -17,11 +13,7 @@
 		"blockName": "core/post-terms",
 		"attrs": {
 			"term": "category",
-			"style": {
-				"typography": {
-					"textAlign": "center"
-				}
-			}
+			"textAlign": "center"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",
@@ -31,11 +23,7 @@
 		"blockName": "core/post-terms",
 		"attrs": {
 			"term": "category",
-			"style": {
-				"typography": {
-					"textAlign": "right"
-				}
-			}
+			"textAlign": "right"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.parsed.json
@@ -34,7 +34,7 @@
 		"innerContent": [ "\n\n" ]
 	},
 	{
-		"blockName": "post-terms",
+		"blockName": "core/post-terms",
 		"attrs": {
 			"term": "category",
 			"textAlign": "right"

--- a/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-terms__deprecated-v1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:post-terms {"term":"category","style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:post-terms {"term":"category","style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:post-terms {"term":"category","style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Post Terms` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Post Terms`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Post Terms` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Post Terms` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Post Terms` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Post Terms` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

