### PR TITLE
Border Support: Fix editor split border style fallback

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -124,6 +124,9 @@
 html :where(.has-border-color) {
 	border-style: solid;
 }
+html :where([style*="border-color"]) {
+	border-style: solid;
+}
 html :where([style*="border-top-color"]) {
 	border-top-style: solid;
 }


### PR DESCRIPTION
## What?

Fixes a mismatch between the editor and frontend rendering of borders when individual border sides have a color but no explicit width in split border mode.

Alternative fix for #75415. See also #75431.

## Why?

There are low-specificity fallback styles in `packages/block-library/src/common.scss` that use CSS attribute selectors to apply `border-style: solid` whenever a border color or width is present in a block's inline style. For example:

```css
html :where([style*="border-right-color"]) {
    border-right-style: solid;
}
```

This ensures borders are visible without the user needing to explicitly set a border style.

On the **frontend**, the PHP style engine outputs individual longhand properties (`border-top-color`, `border-right-color`, etc.), so these selectors match correctly and borders render as expected.

In the **editor**, when all four sides share the same color value, React merges the identical per-side properties into a single `border-color` shorthand in the DOM. The existing attribute selectors don't match `border-color` (only `border-top-color`, `border-right-color`, etc.), so `border-style: solid` is never applied in the editor — even though it will be on the frontend.

This causes a visual mismatch: the editor appears to show no border on sides where only a color is set, while the frontend correctly renders them.

When the border is "linked" (all sides identical), the block receives a `.has-border-color` class which already has a matching fallback rule, so this issue only affects split/unlinked borders.

## How?

Adds a `[style*="border-color"]` fallback rule alongside the existing individual side selectors in `common.scss`. This ensures the editor matches the frontend rendering when React merges the per-side colors into shorthand.

This approach avoids modifying component data handling in `BorderBoxControl`, which would break valid use cases where a border side intentionally has only a color override (with width inherited from Global Styles, `theme.json`, or third-party stylesheets).

## Testing Instructions

### Basic scenario

1. Add a **Paragraph** block
2. Set a unified border (e.g., 2px width, black color)
3. Click the **unlink** button to switch to individual border controls
4. Clear the width from **Right**, **Bottom**, and **Left** borders
5. Confirm the editor preview matches the frontend — only the **top** border should be visible in both

### Inherited styles scenario

1. Navigate to **Global Styles** and set a border width (e.g., 10px) on the Paragraph block
2. In a post, add a **Paragraph** block
3. In the block's border controls, set a custom border color (e.g., red) without setting a width
4. Click the **unlink** button to switch to individual border controls
5. Clear the color from some sides
6. Confirm borders remain visible on sides that still have a color, using the inherited width from Global Styles
7. Save and confirm the frontend matches the editor
8. Reset the Global Styles changes when done

## Screenshots

### Before
<img width="705" height="181" alt="Screenshot 2026-02-14 at 11 36 42 pm" src="https://github.com/user-attachments/assets/c3d24e60-802e-4502-bdfe-b977e9baabfb" />


### After
<img width="675" height="172" alt="Screenshot 2026-02-14 at 11 36 59 pm" src="https://github.com/user-attachments/assets/a08f7398-22f4-4606-a814-6a38d6232d0d" />


### Frontend

<img width="667" height="134" alt="Screenshot 2026-02-14 at 11 37 12 pm" src="https://github.com/user-attachments/assets/7a2504ec-aa6d-4742-837a-313629ba1c09" />

