### PR TITLE
Tab Block: Ensure label formatting works correctly

### DIFF
--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -59,7 +59,7 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 	// Replace the button content with the actual tab label
 	$output = preg_replace(
 		'/(<button[^>]*>).*?(<\/button>)/s',
-		'$1' . '<span>' . esc_html( html_entity_decode( $tab_label ) ) . '</span>' . '$2',
+		'$1' . '<span>' . $tab_label . '</span>' . '$2',
 		$output
 	);
 

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -59,7 +59,7 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 	// Replace the button content with the actual tab label
 	$output = preg_replace(
 		'/(<button[^>]*>).*?(<\/button>)/s',
-		'$1' . '<span>' . $tab_label . '</span>' . '$2',
+		'$1' . '<span>' . wp_kses_post( $tab_label ) . '</span>' . '$2',
 		$output
 	);
 

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -40,7 +40,7 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
 
 					$tabs_list[] = array(
 						'id'    => $tab_id,
-						'label' => esc_html( (string) $tab_label ),
+						'label' => $tab_label,
 						'index' => $tab_index,
 					);
 					++$tab_index;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Removes escaping for tab labels to ensure label formatting works correctly.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I believe the tag label format is escaped when it's saved to the attributes.

If you use `esc_html` or similar when rendering, it won't render correctly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes escaping for tab labels.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Tab block.
3. Change the label and format. For example, bold text.
4. You can confirm that it is formatted correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


### Before

https://github.com/user-attachments/assets/b936b885-4ba8-49ac-b28f-0a120d6c2347


### After

https://github.com/user-attachments/assets/55296e99-3033-46cc-a902-a15799bad4db

