### PR TITLE
Site Title : Migrate to Text-Align Block Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -956,8 +956,8 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 
 -	**Name:** core/site-title
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, levelOptions, linkTarget, textAlign
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** isLink, level, levelOptions, linkTarget
 
 ## Social Icon
 

--- a/packages/block-library/src/site-logo/transforms.js
+++ b/packages/block-library/src/site-logo/transforms.js
@@ -8,10 +8,18 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/site-title' ],
-			transform: ( { isLink, linkTarget } ) => {
+			transform: ( { isLink, linkTarget, style } ) => {
+				const textAlign = style?.typography?.textAlign;
 				return createBlock( 'core/site-title', {
 					isLink,
 					linkTarget,
+					...( textAlign && {
+						style: {
+							typography: {
+								textAlign,
+							},
+						},
+					} ),
 				} );
 			},
 		},

--- a/packages/block-library/src/site-logo/transforms.js
+++ b/packages/block-library/src/site-logo/transforms.js
@@ -8,18 +8,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/site-title' ],
-			transform: ( { isLink, linkTarget, style } ) => {
-				const textAlign = style?.typography?.textAlign;
+			transform: ( { isLink, linkTarget } ) => {
 				return createBlock( 'core/site-title', {
 					isLink,
 					linkTarget,
-					...( textAlign && {
-						style: {
-							typography: {
-								textAlign,
-							},
-						},
-					} ),
 				} );
 			},
 		},

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -44,7 +44,11 @@
 		},
 		"spacing": {
 			"padding": true,
-			"margin": true
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -15,9 +15,6 @@
 			"type": "array",
 			"default": [ 0, 1, 2, 3, 4, 5, 6 ]
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"isLink": {
 			"type": "boolean",
 			"default": true,
@@ -47,15 +44,12 @@
 		},
 		"spacing": {
 			"padding": true,
-			"margin": true,
-			"__experimentalDefaultControls": {
-				"margin": false,
-				"padding": false
-			}
+			"margin": true
 		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalTextTransform": true,
 			"__experimentalTextDecoration": true,

--- a/packages/block-library/src/site-title/deprecated.js
+++ b/packages/block-library/src/site-title/deprecated.js
@@ -2,6 +2,84 @@
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v2 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		level: {
+			type: 'number',
+			default: 2,
+		},
+		levelOptions: {
+			type: 'array',
+			default: [ 0, 1, 2, 3, 4, 5, 6 ],
+		},
+		isLink: {
+			type: 'boolean',
+			default: true,
+			role: 'content',
+		},
+		linkTarget: {
+			type: 'string',
+			default: '_self',
+			role: 'content',
+		},
+	},
+	supports: {
+		anchor: true,
+		align: [ 'wide', 'full' ],
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalWritingMode: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+	save: () => null,
+};
 
 const v1 = {
 	attributes: {
@@ -59,4 +137,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v1 ];
+export default [ v2, v1 ];

--- a/packages/block-library/src/site-title/deprecated.js
+++ b/packages/block-library/src/site-title/deprecated.js
@@ -11,7 +11,7 @@ const v2 = {
 		},
 		level: {
 			type: 'number',
-			default: 2,
+			default: 1,
 		},
 		levelOptions: {
 			type: 'array',

--- a/packages/block-library/src/site-title/deprecated.js
+++ b/packages/block-library/src/site-title/deprecated.js
@@ -42,8 +42,12 @@ const v2 = {
 			},
 		},
 		spacing: {
-			margin: true,
 			padding: true,
+			margin: true,
+			__experimentalDefaultControls: {
+				margin: false,
+				padding: false,
+			},
 		},
 		typography: {
 			fontSize: true,

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -58,7 +58,10 @@ export default function SiteTitleEdit( props ) {
 	}
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className:
+			! canUserEdit && ! title && 'wp-block-site-title__placeholder',
+	} );
 	const siteTitleContent = canUserEdit ? (
 		<TagName { ...blockProps }>
 			<RichText

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -11,7 +6,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
-	AlignmentControl,
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
@@ -30,13 +24,14 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
-export default function SiteTitleEdit( {
-	attributes,
-	setAttributes,
-	insertBlocksAfter,
-} ) {
-	const { level, levelOptions, textAlign, isLink, linkTarget } = attributes;
+export default function SiteTitleEdit( props ) {
+	useDeprecatedTextAlign( props );
+
+	const { attributes, setAttributes, insertBlocksAfter } = props;
+
+	const { level, levelOptions, isLink, linkTarget } = attributes;
 	const { canUserEdit, title } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -63,12 +58,7 @@ export default function SiteTitleEdit( {
 	}
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-			'wp-block-site-title__placeholder': ! canUserEdit && ! title,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 	const siteTitleContent = canUserEdit ? (
 		<TagName { ...blockProps }>
 			<RichText
@@ -113,12 +103,6 @@ export default function SiteTitleEdit( {
 						onChange={ ( newLevel ) =>
 							setAttributes( { level: newLevel } )
 						}
-					/>
-					<AlignmentControl
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
 					/>
 				</BlockControls>
 			) }

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.html
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.html
@@ -1,0 +1,5 @@
+<!-- wp:site-title {"textAlign":"left"} /-->
+
+<!-- wp:site-title {"textAlign":"center"} /-->
+
+<!-- wp:site-title {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
@@ -1,0 +1,47 @@
+[
+	{
+		"name": "core/site-title",
+		"isValid": true,
+		"attributes": {
+			"level": 1,
+			"isLink": true,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/site-title",
+		"isValid": true,
+		"attributes": {
+			"level": 1,
+			"isLink": true,
+			"linkTarget": "_blank",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/site-title",
+		"isValid": true,
+		"attributes": {
+			"level": 1,
+			"isLink": false,
+			"linkTarget": "_self",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
@@ -22,7 +22,7 @@
 			"level": 2,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
-			"linkTarget": "_blank",
+			"linkTarget": "_self",
 			"style": {
 				"typography": {
 					"textAlign": "center"
@@ -37,7 +37,7 @@
 		"attributes": {
 			"level": 2,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
-			"isLink": false,
+			"isLink": true,
 			"linkTarget": "_self",
 			"style": {
 				"typography": {

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
@@ -3,7 +3,8 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
-			"level": 1,
+			"level": 2,
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
 			"linkTarget": "_self",
 			"style": {
@@ -18,7 +19,8 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
-			"level": 1,
+			"level": 2,
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
 			"linkTarget": "_blank",
 			"style": {
@@ -33,7 +35,8 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
-			"level": 1,
+			"level": 2,
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": false,
 			"linkTarget": "_self",
 			"style": {

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.json
@@ -3,7 +3,7 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
-			"level": 2,
+			"level": 1,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
 			"linkTarget": "_self",
@@ -19,7 +19,7 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
-			"level": 2,
+			"level": 1,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
 			"linkTarget": "_self",
@@ -35,7 +35,7 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
-			"level": 2,
+			"level": 1,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
 			"linkTarget": "_self",

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.parsed.json
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/site-title",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/site-title",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/site-title",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:site-title {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:site-title {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:site-title {"style":{"typography":{"textAlign":"right"}}} /-->

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:site-title {"level":2,"style":{"typography":{"textAlign":"left"}}} /-->
+<!-- wp:site-title {"style":{"typography":{"textAlign":"left"}}} /-->
 
-<!-- wp:site-title {"level":2,"style":{"typography":{"textAlign":"center"}}} /-->
+<!-- wp:site-title {"style":{"typography":{"textAlign":"center"}}} /-->
 
-<!-- wp:site-title {"level":2,"style":{"typography":{"textAlign":"right"}}} /-->
+<!-- wp:site-title {"style":{"typography":{"textAlign":"right"}}} /-->

--- a/test/integration/fixtures/blocks/core__site-title__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__site-title__deprecated-v2.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:site-title {"style":{"typography":{"textAlign":"left"}}} /-->
+<!-- wp:site-title {"level":2,"style":{"typography":{"textAlign":"left"}}} /-->
 
-<!-- wp:site-title {"style":{"typography":{"textAlign":"center"}}} /-->
+<!-- wp:site-title {"level":2,"style":{"typography":{"textAlign":"center"}}} /-->
 
-<!-- wp:site-title {"style":{"typography":{"textAlign":"right"}}} /-->
+<!-- wp:site-title {"level":2,"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Site Title` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Site Title`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Site Title` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Site Title` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Site Title` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Site Title` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

