### PR TITLE
Tabs: Remove name editing UI

### DIFF
--- a/packages/block-library/src/tabs/controls.js
+++ b/packages/block-library/src/tabs/controls.js
@@ -1,70 +1,14 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-import {
-	TextControl,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
-import { InspectorControls } from '@wordpress/block-editor';
-
-/**
  * Internal dependencies
  */
 import AddTabToolbarControl from '../tab/add-tab-toolbar-control';
 import RemoveTabToolbarControl from '../tab/remove-tab-toolbar-control';
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-export default function Controls( { attributes, setAttributes, clientId } ) {
-	const {
-		metadata = {
-			name: '',
-		},
-	} = attributes;
-
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
+export default function Controls( { clientId } ) {
 	return (
 		<>
 			<AddTabToolbarControl tabsClientId={ clientId } />
 			<RemoveTabToolbarControl tabsClientId={ clientId } />
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () => {
-						setAttributes( {
-							metadata: { ...metadata, name: '' },
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					<ToolsPanelItem
-						label={ __( 'Title' ) }
-						hasValue={ () => !! metadata.name }
-						onDeselect={ () => {
-							setAttributes( {
-								metadata: { ...metadata, name: '' },
-							} );
-						} }
-						isShownByDefault
-					>
-						<TextControl
-							label={ __( 'Title' ) }
-							help={ __(
-								'The tabs title is used by screen readers to describe the purpose and content of the tab panel.'
-							) }
-							value={ metadata.name }
-							onChange={ ( value ) => {
-								setAttributes( {
-									metadata: { ...metadata, name: value },
-								} );
-							} }
-							__next40pxDefaultSize
-						/>
-					</ToolsPanelItem>
-				</ToolsPanel>
-			</InspectorControls>
 		</>
 	);
 }

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -97,12 +97,6 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 		return '';
 	}
 
-	$title = $attributes['metadata']['name'] ?? '';
-	if ( empty( $title ) ) {
-		$title = 'Tab Contents';
-	}
-	$title = wp_sprintf( '<h3 class="wp-block-tabs__title">%s</h3>', esc_html( $title ) );
-
 	$is_vertical = false;
 
 	$tag_processor = new WP_HTML_Tag_Processor( $content );
@@ -134,9 +128,6 @@ function block_core_tabs_render_block_callback( array $attributes, string $conte
 	$tag_processor->set_attribute( 'data-wp-on--keydown', 'actions.handleTabKeyDown' );
 
 	$output = $tag_processor->get_updated_html();
-
-	// Insert the title after the first opening tag.
-	$output = preg_replace( '/^(<[^>]+>)/', '$1' . $title, $output );
 
 	/**
 	 * Builds a client side state for just this tabs instance.


### PR DESCRIPTION
## What?

The Tabs block has a control for editing the `name` metadata. This name is expected to be output as a visually hidden `h3` element on the front end.

<img width="306" height="205" alt="image" src="https://github.com/user-attachments/assets/d55ba3d5-9289-4e39-9e40-0e1141f8161f" />

However, I noticed that the regular expression [here](https://github.com/WordPress/gutenberg/pull/75554/changes#diff-24a7001d727811d5cab9dd98c2e8c3e19016af118512e70ac0a0fc2dd197e978L139) is incorrect, which means no HTML is being output at all. This is because there may be a line break at the beginning of the block content.

- `attributes.metadata.name` is expected to be used only by the editor and should not be exposed on the front end.
- The heading level is hard-coded, which is not ideal.

I understand the importance of associating headings with tab blocks, but for now, I propose removing all implementations of them.

## Testing Instructions

- Insert a Tabs block.
- Open the sidebar. 
- Make sure there is no Settings section.
- The HTML output on the front end remains unchanged.

cc @sethrubenstein
