### PR TITLE
Tabs: Make Example preview translatable

### DIFF
--- a/packages/block-library/src/tabs/block.json
+++ b/packages/block-library/src/tabs/block.json
@@ -56,55 +56,6 @@
 		},
 		"renaming": true
 	},
-	"example": {
-		"attributes": {
-			"className": "is-example"
-		},
-		"innerBlocks": [
-			{
-				"name": "core/tabs-menu",
-				"attributes": {},
-				"innerBlocks": [
-					{
-						"name": "core/tabs-menu-item",
-						"attributes": {}
-					}
-				]
-			},
-			{
-				"name": "core/tab-panel",
-				"attributes": {},
-				"innerBlocks": [
-					{
-						"name": "core/tab",
-						"attributes": {
-							"label": "Tab 1"
-						},
-						"innerBlocks": [
-							{
-								"name": "core/paragraph",
-								"attributes": {
-									"content": "Pariatur commodo sint mollit. Veniam Lorem labore voluptate fugiat. Ad nulla est labore cillum cillum qui nostrud do incididunt eiusmod."
-								}
-							}
-						]
-					},
-					{
-						"name": "core/tab",
-						"attributes": {
-							"label": "Tab 2"
-						}
-					},
-					{
-						"name": "core/tab",
-						"attributes": {
-							"label": "Tab 3"
-						}
-					}
-				]
-			}
-		]
-	},
 	"providesContext": {
 		"core/tabs-activeTabIndex": "activeTabIndex",
 		"core/tabs-editorActiveTabIndex": "editorActiveTabIndex"

--- a/packages/block-library/src/tabs/index.js
+++ b/packages/block-library/src/tabs/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { tabs as icon } from '@wordpress/icons';
 
 /**
@@ -17,6 +18,37 @@ export { metadata, name };
 
 export const settings = {
 	icon,
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/tabs-menu',
+				innerBlocks: [ { name: 'core/tabs-menu-item' } ],
+			},
+			{
+				name: 'core/tab-panel',
+				innerBlocks: [ 1, 2, 3 ].map( ( index ) => ( {
+					name: 'core/tab',
+					attributes: {
+						label: sprintf(
+							/** translators: %s: tab index number */
+							__( 'Tab %s' ),
+							index
+						),
+					},
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: {
+								content: __(
+									'In a village of La Mancha, the name of which I have no desire to call to mind, there lived not long since one of those gentlemen that keep a lance in the lance-rack, an old buckler, a lean hack, and a greyhound for coursing.'
+								),
+							},
+						},
+					],
+				} ) ),
+			},
+		],
+	},
 	edit,
 	save,
 };

--- a/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read__deprecated-v1.json
@@ -3,9 +3,9 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
+			"displayAsRange": true,
+			"displayMode": "time",
 			"averageReadingSpeed": 189,
-		    "displayAsRange": true,
-		    "displayMode": "time",
 			"style": {
 				"typography": {
 					"textAlign": "left"
@@ -18,9 +18,9 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
+			"displayAsRange": true,
+			"displayMode": "time",
 			"averageReadingSpeed": 189,
-		    "displayAsRange": true,
-		    "displayMode": "time",
 			"style": {
 				"typography": {
 					"textAlign": "center"
@@ -33,9 +33,9 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
+			"displayAsRange": true,
+			"displayMode": "time",
 			"averageReadingSpeed": 189,
-		    "displayAsRange": true,
-		    "displayMode": "time",
 			"style": {
 				"typography": {
 					"textAlign": "right"

--- a/test/integration/fixtures/blocks/core__tabs.html
+++ b/test/integration/fixtures/blocks/core__tabs.html
@@ -1,5 +1,5 @@
-<!-- wp:tabs {"className":"is-example"} -->
-<div class="wp-block-tabs is-example">
+<!-- wp:tabs -->
+<div class="wp-block-tabs">
 	<!-- wp:tabs-menu -->
 	<div class="wp-block-tabs-menu" role="tablist">
 		<!-- wp:tabs-menu-item -->

--- a/test/integration/fixtures/blocks/core__tabs.json
+++ b/test/integration/fixtures/blocks/core__tabs.json
@@ -3,8 +3,7 @@
 		"name": "core/tabs",
 		"isValid": true,
 		"attributes": {
-			"activeTabIndex": 0,
-			"className": "is-example"
+			"activeTabIndex": 0
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__tabs.parsed.json
+++ b/test/integration/fixtures/blocks/core__tabs.parsed.json
@@ -1,9 +1,7 @@
 [
 	{
 		"blockName": "core/tabs",
-		"attrs": {
-			"className": "is-example"
-		},
+		"attrs": {},
 		"innerBlocks": [
 			{
 				"blockName": "core/tabs-menu",
@@ -88,9 +86,9 @@
 				]
 			}
 		],
-		"innerHTML": "\n<div class=\"wp-block-tabs is-example\">\n\t\n\n\t\n</div>\n",
+		"innerHTML": "\n<div class=\"wp-block-tabs\">\n\t\n\n\t\n</div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-tabs is-example\">\n\t",
+			"\n<div class=\"wp-block-tabs\">\n\t",
 			null,
 			"\n\n\t",
 			null,

--- a/test/integration/fixtures/blocks/core__tabs.serialized.html
+++ b/test/integration/fixtures/blocks/core__tabs.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:tabs {"className":"is-example"} -->
-<div class="wp-block-tabs is-example"><!-- wp:tabs-menu -->
+<!-- wp:tabs -->
+<div class="wp-block-tabs"><!-- wp:tabs-menu -->
 <div role="tablist" class="wp-block-tabs-menu"><!-- wp:tabs-menu-item -->
 <button class="wp-block-tabs-menu-item wp-block-tabs-menu-item__template" hidden type="button" role="tab"><span class="screen-reader-text">Tab menu item</span></button>
 <!-- /wp:tabs-menu-item --></div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Because the example content is hard-coded in block.json, it cannot be localized that content. Move it to a JS file and apply a translation function.

## Testing Instructions

Open the insert and hover the Tabs block. Confirm that the preview is displayed correctly.


## Screenshots or screencast <!-- if applicable -->

<img width="299" height="309" alt="image" src="https://github.com/user-attachments/assets/5a40909e-0aaf-4cce-b5f2-0ff28ce5038c" />