### PR TITLE
Post Navigation Link : Migrate to Text-Align Block Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -744,8 +744,8 @@ Displays the next or previous post link that is adjacent to the current post. ([
 
 -	**Name:** core/post-navigation-link
 -	**Category:** theme
--	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
+-	**Supports:** anchor, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight, textAlign), ~~html~~, ~~reusable~~
+-	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, type
 
 ## Post Template
 

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -7,9 +7,6 @@
 	"description": "Displays the next or previous post link that is adjacent to the current post.",
 	"textdomain": "default",
 	"attributes": {
-		"textAlign": {
-			"type": "string"
-		},
 		"type": {
 			"type": "string",
 			"default": "next"
@@ -46,6 +43,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/post-navigation-link/deprecated.js
+++ b/packages/block-library/src/post-navigation-link/deprecated.js
@@ -1,0 +1,72 @@
+/**
+ * Internal dependencies
+ */
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v1 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		type: {
+			type: 'string',
+			default: 'next',
+		},
+		label: {
+			type: 'string',
+			role: 'content',
+		},
+		showTitle: {
+			type: 'boolean',
+			default: false,
+		},
+		linkLabel: {
+			type: 'boolean',
+			default: false,
+		},
+		arrow: {
+			type: 'string',
+			default: 'none',
+		},
+		taxonomy: {
+			type: 'string',
+			default: '',
+		},
+	},
+	supports: {
+		anchor: true,
+		reusable: false,
+		html: false,
+		color: {
+			link: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+	save: () => null,
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -17,10 +12,7 @@ import {
 import {
 	InspectorControls,
 	RichText,
-	BlockControls,
-	AlignmentToolbar,
 	useBlockProps,
-	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -33,19 +25,9 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostNavigationLinkEdit( {
 	context: { postType },
-	attributes: {
-		type,
-		label,
-		showTitle,
-		textAlign,
-		linkLabel,
-		arrow,
-		taxonomy,
-	},
+	attributes: { type, label, showTitle, linkLabel, arrow, taxonomy },
 	setAttributes,
 } ) {
-	const blockEditingMode = useBlockEditingMode();
-	const showControls = blockEditingMode === 'default';
 	const isNext = type === 'next';
 	let placeholder = isNext ? __( 'Next' ) : __( 'Previous' );
 
@@ -66,11 +48,7 @@ export default function PostNavigationLinkEdit( {
 	}
 
 	const ariaLabel = isNext ? __( 'Next post' ) : __( 'Previous post' );
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 
 	const taxonomies = useSelect(
 		( select ) => {
@@ -220,16 +198,6 @@ export default function PostNavigationLinkEdit( {
 					) }
 				/>
 			</InspectorControls>
-			{ showControls && (
-				<BlockControls>
-					<AlignmentToolbar
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-			) }
 			<div { ...blockProps }>
 				{ ! isNext && displayArrow && (
 					<span

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -49,7 +49,6 @@ export default function PostNavigationLinkEdit( {
 
 	const ariaLabel = isNext ? __( 'Next post' ) : __( 'Previous post' );
 	const blockProps = useBlockProps();
-
 	const taxonomies = useSelect(
 		( select ) => {
 			const { getTaxonomies } = select( coreStore );

--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import variations from './variations';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -17,6 +18,7 @@ export { metadata, name };
 export const settings = {
 	edit,
 	variations,
+	deprecated,
 	example: {
 		attributes: {
 			label: __( 'Next post' ),

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.html
@@ -1,0 +1,5 @@
+<!-- wp:post-navigation-link {"type":"previous","textAlign":"left"} /-->
+
+<!-- wp:post-navigation-link {"type":"previous","textAlign":"center"} /-->
+
+<!-- wp:post-navigation-link {"type":"previous","textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.json
@@ -1,0 +1,56 @@
+[
+	{
+		"name": "core/post-navigation-link",
+		"isValid": true,
+		"attributes": {
+			"type": "previous",
+			"label": "",
+			"showTitle": false,
+			"linkLabel": false,
+			"arrow": "none",
+			"taxonomy": "",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-navigation-link",
+		"isValid": true,
+		"attributes": {
+			"type": "previous",
+			"label": "",
+			"showTitle": false,
+			"linkLabel": false,
+			"arrow": "none",
+			"taxonomy": "",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-navigation-link",
+		"isValid": true,
+		"attributes": {
+			"type": "previous",
+			"label": "",
+			"showTitle": false,
+			"linkLabel": false,
+			"arrow": "none",
+			"taxonomy": "",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.json
@@ -4,7 +4,6 @@
 		"isValid": true,
 		"attributes": {
 			"type": "previous",
-			"label": "",
 			"showTitle": false,
 			"linkLabel": false,
 			"arrow": "none",
@@ -22,7 +21,6 @@
 		"isValid": true,
 		"attributes": {
 			"type": "previous",
-			"label": "",
 			"showTitle": false,
 			"linkLabel": false,
 			"arrow": "none",
@@ -40,7 +38,6 @@
 		"isValid": true,
 		"attributes": {
 			"type": "previous",
-			"label": "",
 			"showTitle": false,
 			"linkLabel": false,
 			"arrow": "none",

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
@@ -13,8 +13,8 @@
 		"blockName": null,
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\r\n\r\n",
-		"innerContent": [ "\r\n\r\n" ]
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
 	},
 	{
 		"blockName": "core/post-navigation-link",
@@ -30,8 +30,8 @@
 		"blockName": null,
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\r\n\r\n",
-		"innerContent": [ "\r\n\r\n" ]
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
 	},
 	{
 		"blockName": "core/post-navigation-link",

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/post-navigation-link",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-navigation-link",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-navigation-link",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
@@ -2,8 +2,8 @@
 	{
 		"blockName": "core/post-navigation-link",
 		"attrs": {
-			"textAlign": "left",
-			"type": "previous"
+			"type": "previous",
+			"textAlign": "left"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",
@@ -13,14 +13,14 @@
 		"blockName": null,
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\n\n",
-		"innerContent": [ "\n\n" ]
+		"innerHTML": "\r\n\r\n",
+		"innerContent": [ "\r\n\r\n" ]
 	},
 	{
 		"blockName": "core/post-navigation-link",
 		"attrs": {
-			"textAlign": "center",
-			"type": "previous"
+			"type": "previous",
+			"textAlign": "center"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",
@@ -30,14 +30,14 @@
 		"blockName": null,
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\n\n",
-		"innerContent": [ "\n\n" ]
+		"innerHTML": "\r\n\r\n",
+		"innerContent": [ "\r\n\r\n" ]
 	},
 	{
 		"blockName": "core/post-navigation-link",
 		"attrs": {
-			"textAlign": "right",
-			"type": "previous"
+			"type": "previous",
+			"textAlign": "right"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.parsed.json
@@ -2,7 +2,8 @@
 	{
 		"blockName": "core/post-navigation-link",
 		"attrs": {
-			"textAlign": "left"
+			"textAlign": "left",
+			"type": "previous"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",
@@ -18,7 +19,8 @@
 	{
 		"blockName": "core/post-navigation-link",
 		"attrs": {
-			"textAlign": "center"
+			"textAlign": "center",
+			"type": "previous"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",
@@ -34,7 +36,8 @@
 	{
 		"blockName": "core/post-navigation-link",
 		"attrs": {
-			"textAlign": "right"
+			"textAlign": "right",
+			"type": "previous"
 		},
 		"innerBlocks": [],
 		"innerHTML": "",

--- a/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-navigation-link__deprecated-v1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:post-navigation-link {"type":"previous","style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:post-navigation-link {"type":"previous","style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:post-navigation-link {"type":"previous","style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Post Navigation Link` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Post Navigation Link`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Post Navigation Link` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Post Navigation Link` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Post Navigation Link` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Post Navigation Link` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)
