### PR TITLE
List View tab: Ensure it's populated when first selecting a container block

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -52,6 +52,22 @@ export default function InspectorControlsTabs( {
 		hasUserSelectionRef.current = false;
 	}, [ clientId ] );
 
+	// Initialize List View panels when the tab is selected and clientId changes
+	useEffect( () => {
+		if (
+			selectedTabId === TAB_LIST_VIEW.name &&
+			! hasUserSelectionRef.current
+		) {
+			setAllListViewPanelsOpen();
+			incrementListViewExpandRevision();
+		}
+	}, [
+		clientId,
+		selectedTabId,
+		setAllListViewPanelsOpen,
+		incrementListViewExpandRevision,
+	] );
+
 	// Auto-select first available tab unless user has made a selection
 	useEffect( () => {
 		if (


### PR DESCRIPTION

## What?

Fixes an issue where selecting a container block that uses the list view support (e.g. the List block) results in the List View tab being empty, until switching tabs and back to the list view tab.

Kudos @tellthemachines for spotting it. I think the issue might have been introduced in https://github.com/WordPress/gutenberg/pull/75246

## Why?

It seems that the logic we've been using to first select the List View tab doesn't also auto increment / expand the list view. Whereas that logic _does_ happen when switching tabs.

## How?

Add a `useEffect` that runs when the user hasn't yet made a selection, but that fires when the `clientId` or `selectedTab` changes. This way when the selected tab is changed to the list view, it'll make sure that the list view is populated.

I'm still not 100% sure how the expandRevision stuff works, but from a quick look at the code and #75246 I think this fix is probably pretty good as it makes things consistent.

## Testing Instructions

* Add a List block
* Give it a couple of list items
* Select the parent List block and look at the sidebar
* With this PR applied, you should see the List View tab is populated
* Without it, the List View tab is empty until you switch tabs manually
* Note: with this PR applied, you should still be able to click on an item in the list view to _go_ to that block

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/0882d934-1dd7-4ce9-8c18-b12f8a842096

### After

https://github.com/user-attachments/assets/938c8fd8-895c-4fd4-a1d9-9c4050ac2488