### PR TITLE
Fix auto draft bug for Y.text titles

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -198,7 +198,7 @@ export function applyPostChangesToCRDTDoc(
 				// Draft" template title is not synced.
 				if (
 					key === 'title' &&
-					( ! currentValue || '' === currentValue.toString() ) &&
+					! currentValue?.toString() &&
 					'Auto Draft' === rawValue
 				) {
 					rawValue = '';

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -198,7 +198,7 @@ export function applyPostChangesToCRDTDoc(
 				// Draft" template title is not synced.
 				if (
 					key === 'title' &&
-					! currentValue &&
+					( ! currentValue || '' === currentValue.toString() ) &&
 					'Auto Draft' === rawValue
 				) {
 					rawValue = '';

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -104,6 +104,28 @@ describe( 'crdt', () => {
 			expect( title?.toString() ).toBe( '' );
 		} );
 
+		it( 'skips "Auto Draft" template title when current value is empty Y.Text', () => {
+			// First set an empty title (simulates a prior sync that cleared it).
+			applyPostChangesToCRDTDoc(
+				doc,
+				{ title: '' } as PostChanges,
+				mockPostType
+			);
+
+			const title = map.get( 'title' );
+			expect( title ).toBeInstanceOf( Y.Text );
+			expect( title?.toString() ).toBe( '' );
+
+			// Now sync "Auto Draft" — should still be suppressed.
+			applyPostChangesToCRDTDoc(
+				doc,
+				{ title: 'Auto Draft' } as PostChanges,
+				mockPostType
+			);
+
+			expect( map.get( 'title' )?.toString() ).toBe( '' );
+		} );
+
 		it( 'handles excerpt with RenderedText format', () => {
 			const changes = {
 				excerpt: {


### PR DESCRIPTION
## What?

The Auto Draft bug for titles can rear it head again. Also a test has been added to ensure this is caught in the future.

Credit to @chriszarate for raising this [here](https://github.com/WordPress/gutenberg/pull/75448#discussion_r2804553341).

## Why?

The title was converted to use Y.text, and as a result it'll never be falsey after the first sync even if it's empty. That means the Auto Draft bug, wherein the title might become Auto Draft after the initial save could rear it's head again.

## How?

If the current value of the title is not undefined, then confirm it's empty as part of the Auto Draft bug fix. This'll ensure that the title will be set to an empty string instead of being Auto Draft.

## Testing Instructions

1. Run the tests as that's the best way to catch this. 

### Testing Instructions for Keyboard

N/A
