### PR TITLE
DataViews: Fix datetime filter showing UTC instead of local time

### DIFF
--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
-import type { FormatDatetime, NormalizedField, SortDirection } from '../types';
+import type { NormalizedField, SortDirection } from '../types';
 import type { FieldType } from '../types/private';
 import isValidElements from './utils/is-valid-elements';
 import {
@@ -21,6 +21,7 @@ import {
 } from '../constants';
 import isValidRequired from './utils/is-valid-required';
 import render from './utils/render-default';
+import parseDateTime from './utils/parse-date-time';
 
 const format = {
 	datetime: getSettings().formats.datetime,
@@ -39,14 +40,8 @@ function getValueFormatted< Item >( {
 		return '';
 	}
 
-	let formatDatetime: Required< FormatDatetime >;
-	if ( field.type !== 'datetime' ) {
-		formatDatetime = format;
-	} else {
-		formatDatetime = field.format as Required< FormatDatetime >;
-	}
-
-	return dateI18n( formatDatetime.datetime, getDate( value ) );
+	const dateValue = parseDateTime( value );
+	return dateValue !== null ? dateValue.toLocaleString() : '';
 }
 
 const sort = ( a: any, b: any, direction: SortDirection ) => {

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { getSettings } from '@wordpress/date';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
-import type { NormalizedField, SortDirection } from '../types';
+import type { FormatDatetime, NormalizedField, SortDirection } from '../types';
 import type { FieldType } from '../types/private';
 import isValidElements from './utils/is-valid-elements';
 import {
@@ -21,7 +21,6 @@ import {
 } from '../constants';
 import isValidRequired from './utils/is-valid-required';
 import render from './utils/render-default';
-import parseDateTime from './utils/parse-date-time';
 
 const format = {
 	datetime: getSettings().formats.datetime,
@@ -40,8 +39,19 @@ function getValueFormatted< Item >( {
 		return '';
 	}
 
-	const dateValue = parseDateTime( value );
-	return dateValue !== null ? dateValue.toLocaleString() : '';
+	let formatDatetime: Required< FormatDatetime >;
+	if ( field.type !== 'datetime' ) {
+		formatDatetime = format;
+	} else {
+		formatDatetime = field.format as Required< FormatDatetime >;
+	}
+
+	// Use the browser's local timezone to display the datetime value.
+	// The filter input (datetime-local) operates in browser local time, converting
+	// the user's selection to a UTC ISO string for storage. We must convert back to
+	// local time here so the filter chip shows the same time the user originally selected.
+	const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	return dateI18n( formatDatetime.datetime, getDate( value ), localTimezone );
 }
 
 const sort = ( a: any, b: any, direction: SortDirection ) => {


### PR DESCRIPTION

## What?
Closes: #75511 
Fixes the datetime filter to display values in the user's local timezone instead of UTC.

## Why?

When using a filter on a `datetime` field, the selected date/time was being displayed in UTC instead of the user's local timezone. 

## How?

Updated the `getValueFormatted` function in `packages/dataviews/src/field-types/datetime.tsx` to use `parseDateTime()` and `.toLocaleString()` instead of `dateI18n()`, ensuring proper timezone conversion for display.

## Testing Instructions

1. Ensure that you are not in UTC timezone
2. Run Storybook: `npm run storybook:dev`
3. Open the story at "DataViews > Field Types > Datetime"
4. Click to add a filter on the "Datetime" field
5. Select a date and time
6. Close the filter
7. Verify that the displayed value shows your selection in your local timezone, not UTC


## Screenshots or screencast <!-- if applicable -->

**Before this fix:** The filter would show the time in UTC  


https://github.com/user-attachments/assets/79e30d84-6b7a-4d03-8e76-9d8e802abc31


**After this fix:** The filter shows the time in your local timezone


https://github.com/user-attachments/assets/b787f49e-e64c-49ed-9afd-f67ad81f9411

