### PR TITLE
Interactivity API: Export `watch` from `@preact/signals`'s `effect`

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Export `watch()` function for subscribing to signal changes outside of directives.
+
 ## 6.39.0 (2026-01-29)
 
 ## 6.38.0 (2026-01-16)

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -6,7 +6,7 @@ if ( globalThis.SCRIPT_DEBUG ) {
  * External dependencies
  */
 import { h, cloneElement, render } from 'preact';
-import { batch } from '@preact/signals';
+import { batch, effect } from '@preact/signals';
 
 /**
  * Internal dependencies
@@ -45,6 +45,23 @@ export {
 } from './utils';
 
 export { useState, useRef } from 'preact/hooks';
+
+/**
+ * Subscribes to changes in any signal accessed inside the callback, re-running
+ * the callback whenever those signals change. Returns a cleanup function to
+ * stop watching.
+ *
+ * @example
+ * ```js
+ * const unwatch = watch( () => {
+ *   console.log( state.counter );
+ * } );
+ *
+ * // Later, to stop watching:
+ * unwatch();
+ * ```
+ */
+export const watch = effect;
 
 const requiredConsent =
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';


### PR DESCRIPTION
## What?

Export a `watch()` function from the `@wordpress/interactivity` package that subscribes to changes in any signal accessed inside a callback, re-running the callback whenever those signals change.

## Why?

Currently, the Interactivity API provides `data-wp-watch` as a directive tied to a DOM element's lifecycle for reacting to state changes. However, there is no programmatic API to observe signal changes independently of the DOM — for example, to run side effects at the store level, set up logging, or synchronize state between stores. The `watch()` function fills this gap by exposing `@preact/signals`'s `effect` under a WordPress-friendly name.

## How?

- Imports `effect` from `@preact/signals` and re-exports it as `watch` from `@wordpress/interactivity`.
- Adds documentation for `watch()` to the Interactivity API reference, including usage examples for basic watching, cleanup callbacks, and the `unwatch` dispose function.
- Adds a cross-reference from the `data-wp-watch` directive section to the new `watch()` function.

## Testing Instructions

1. Open any page on the frontend that loads the Interactivity API (e.g., a page with an interactive block like Search or Query Loop).
2. Open the browser DevTools console and paste the following code:
   ```js
   const { store, watch } = await import( '@wordpress/interactivity' );

   const { state } = store( 'myPlugin', {
       state: { counter: 0 }
   } );

   const unwatch = watch( () => {
       console.log( 'Counter is', state.counter );
   } );
   ```
3. Verify it immediately logs `Counter is 0`.
4. Type `state.counter++` in the console and verify it logs the updated value.
5. Call `unwatch()` and type `state.counter++` again — verify nothing is logged.
