### PR TITLE
Navigation: Update overlay template part naming to 'Navigation Overlay'

### DIFF
--- a/packages/block-library/src/navigation/edit/test/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/test/use-create-overlay.js
@@ -93,11 +93,11 @@ describe( 'useCreateOverlayTemplatePart', () => {
 	it( 'should save a new overlay with correct parameters when no overlays exist', async () => {
 		const overlayTemplateParts = [];
 		const createdOverlay = {
-			id: 'twentytwentyfive//overlay',
+			id: 'twentytwentyfive//navigation-overlay',
 			theme: 'twentytwentyfive',
-			slug: 'overlay',
+			slug: 'navigation-overlay',
 			title: {
-				rendered: 'Overlay',
+				rendered: 'Navigation Overlay',
 			},
 			area: 'navigation-overlay',
 		};
@@ -117,8 +117,8 @@ describe( 'useCreateOverlayTemplatePart', () => {
 			'postType',
 			'wp_template_part',
 			expect.objectContaining( {
-				slug: 'overlay',
-				title: 'Overlay',
+				slug: 'navigation-overlay',
+				title: 'Navigation Overlay',
 				content: expect.any( String ),
 				area: 'navigation-overlay',
 			} ),
@@ -129,21 +129,21 @@ describe( 'useCreateOverlayTemplatePart', () => {
 
 	it( 'should generate unique title when overlays already exist', async () => {
 		const existingOverlay = {
-			id: 'twentytwentyfive//overlay',
+			id: 'twentytwentyfive//navigation-overlay',
 			theme: 'twentytwentyfive',
-			slug: 'overlay',
+			slug: 'navigation-overlay',
 			title: {
-				rendered: 'Overlay',
+				rendered: 'Navigation Overlay',
 			},
 			area: 'navigation-overlay',
 		};
 		const overlayTemplateParts = [ existingOverlay ];
 		const createdOverlay = {
-			id: 'twentytwentyfive//overlay-2',
+			id: 'twentytwentyfive//navigation-overlay-2',
 			theme: 'twentytwentyfive',
-			slug: 'overlay-2',
+			slug: 'navigation-overlay-2',
 			title: {
-				rendered: 'Overlay 2',
+				rendered: 'Navigation Overlay 2',
 			},
 			area: 'navigation-overlay',
 		};
@@ -158,13 +158,13 @@ describe( 'useCreateOverlayTemplatePart', () => {
 			await createOverlayTemplatePart.current();
 		} );
 
-		// Verify it generates a unique title (Overlay 2) when Overlay already exists
+		// Verify it generates a unique title (Navigation Overlay 2) when Navigation Overlay already exists
 		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'wp_template_part',
 			expect.objectContaining( {
-				title: 'Overlay 2',
-				slug: 'overlay-2',
+				title: 'Navigation Overlay 2',
+				slug: 'navigation-overlay-2',
 				content: expect.any( String ),
 				area: 'navigation-overlay',
 			} ),
@@ -175,11 +175,11 @@ describe( 'useCreateOverlayTemplatePart', () => {
 	it( 'should use pattern content when pattern is found', async () => {
 		const overlayTemplateParts = [];
 		const createdOverlay = {
-			id: 'twentytwentyfive//overlay',
+			id: 'twentytwentyfive//navigation-overlay',
 			theme: 'twentytwentyfive',
-			slug: 'overlay',
+			slug: 'navigation-overlay',
 			title: {
-				rendered: 'Overlay',
+				rendered: 'Navigation Overlay',
 			},
 			area: 'navigation-overlay',
 		};
@@ -212,11 +212,11 @@ describe( 'useCreateOverlayTemplatePart', () => {
 	it( 'should use empty paragraph when pattern is not found', async () => {
 		const overlayTemplateParts = [];
 		const createdOverlay = {
-			id: 'twentytwentyfive//overlay',
+			id: 'twentytwentyfive//navigation-overlay',
 			theme: 'twentytwentyfive',
-			slug: 'overlay',
+			slug: 'navigation-overlay',
 			title: {
-				rendered: 'Overlay',
+				rendered: 'Navigation Overlay',
 			},
 			area: 'navigation-overlay',
 		};

--- a/packages/block-library/src/navigation/edit/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/use-create-overlay.js
@@ -39,7 +39,7 @@ export default function useCreateOverlayTemplatePart( overlayTemplateParts ) {
 			( templatePart ) => templatePart.title?.rendered
 		);
 		const uniqueTitle = getUniqueTemplatePartTitle(
-			__( 'Overlay' ),
+			__( 'Navigation Overlay' ),
 			templatePartsWithTitles
 		);
 		const cleanSlug = getCleanTemplatePartSlug( uniqueTitle );


### PR DESCRIPTION
## What

Updates the default naming pattern for navigation overlay template parts from "Overlay" / "Overlay 2" to "Navigation Overlay" / "Navigation Overlay 2".

Fixes #75242

## Why

The generic term "Overlay" doesn't clearly indicate that these are navigation-specific overlays. Users need to immediately understand what type of template part they're working with, especially when managing multiple template parts. Clear labels improve discoverability and help users build a better mental model of the feature.

## How

- Changed the base title in `useCreateOverlayTemplatePart` from `'Overlay'` to `'Navigation Overlay'`
- Updated corresponding unit tests to reflect the new naming pattern
- The `getUniqueTemplatePartTitle()` utility automatically handles unique naming (e.g., "Navigation Overlay 2", "Navigation Overlay 3")
- Slugs are automatically generated as `navigation-overlay`, `navigation-overlay-2`, etc.

## Testing Instructions

### Manual Testing
1. Start wp-env: `npm run wp-env start`
2. Build the project: `npm run build`
3. Open the Site Editor and add a Navigation block
4. Set overlay visibility to "Mobile" or "Always"
5. Click "Create overlay" button
6. **Expected**: The new template part should be named "Navigation Overlay"
7. Create a second overlay
8. **Expected**: It should be named "Navigation Overlay 2"
9. Check the breadcrumb shows "Navigation Overlay · Template Part"
10. Check the template parts list in Site Editor shows "Navigation Overlay" entries

### Automated Testing
- Unit tests pass: `npm run test:unit -- packages/block-library/src/navigation/edit/test/use-create-overlay.js`
- All 5 tests passing ✅
