### PR TITLE
Notes: Fix new note creation from the List View

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-menu-item.js
+++ b/packages/editor/src/components/collab-sidebar/comment-menu-item.js
@@ -71,7 +71,7 @@ const AddCommentMenuItemFill = ( { onClick, isDistractionFree } ) => {
 					clientId={ clientId }
 					isDistractionFree={ isDistractionFree }
 					onClick={ () => {
-						onClick();
+						onClick( clientId );
 						onClose();
 					} }
 				/>


### PR DESCRIPTION
## What?
Closes #75451.

PR adds special handling when the "Add Note" action is triggered from the List View, where block selection isn't required to open the Options dropdown for a block.

## Testing Instructions
1. Open a post or page. 
2. Add a couple of blocks.
3. Try adding a new note for a block via List View, without selecting a block.
4. Selection should move to the block, and a new note form should be displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d77e38ce-440f-49fa-bd1c-e937939eb494


