### PR TITLE
Update usage of RefObject types (React 19 compat)

### DIFF
--- a/packages/boot/src/components/navigation/navigation-screen/index.tsx
+++ b/packages/boot/src/components/navigation/navigation-screen/index.tsx
@@ -56,7 +56,7 @@ export default function NavigationScreen( {
 	content: ReactNode;
 	description?: ReactNode;
 	backMenuItem?: string;
-	backButtonRef?: RefObject< HTMLButtonElement >;
+	backButtonRef?: RefObject< HTMLButtonElement | null >;
 	animationDirection?: 'forward' | 'backward';
 	navigationKey?: string;
 	onNavigate: ( {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   Update Testing Library packages used in unit tests ([#75340](https://github.com/WordPress/gutenberg/pull/75340)).
 -   Clean up type declarations using the `React` namespace ([#75499](https://github.com/WordPress/gutenberg/pull/75499) and ([#75508](https://github.com/WordPress/gutenberg/pull/75508))).
 -   Always specify initial values for `useRef` calls ([#75513](https://github.com/WordPress/gutenberg/pull/75513)).
+-   Update `RefObject` type usage for React 19 compatibility ([#75567](https://github.com/WordPress/gutenberg/pull/75567)).
 
 ## 32.1.0 (2026-01-29)
 

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -216,7 +216,7 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 }
 
 function useOnClickOutside(
-	ref: React.RefObject< HTMLElement >,
+	ref: React.RefObject< HTMLElement | null >,
 	handler: AutocompleterUIProps[ 'reset' ]
 ) {
 	useEffect( () => {

--- a/packages/components/src/autocomplete/types.ts
+++ b/packages/components/src/autocomplete/types.ts
@@ -106,7 +106,7 @@ export type WPCompleter< TCompleterOption = any > = {
 	className?: string;
 };
 
-type ContentRef = React.RefObject< HTMLElement >;
+type ContentRef = React.RefObject< HTMLElement | null >;
 
 export type AutocompleterUIProps = {
 	/**

--- a/packages/components/src/custom-gradient-picker/types.ts
+++ b/packages/components/src/custom-gradient-picker/types.ts
@@ -100,7 +100,7 @@ export type ControlPointButtonProps = {
 export type ControlPointsProps = {
 	disableRemove: boolean;
 	disableAlpha: boolean;
-	gradientPickerDomRef: React.RefObject< HTMLDivElement >;
+	gradientPickerDomRef: React.RefObject< HTMLDivElement | null >;
 	ignoreMarkerPosition?: number;
 	value: ControlPoint[];
 	onChange: ( controlPoints: ControlPoint[] ) => void;

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -127,7 +127,7 @@ export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	onChange: ( newElements?: T[] ) => void;
 	isGradient: T extends Gradient ? true : false;
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
-	addColorRef: React.RefObject< HTMLButtonElement >;
+	addColorRef: React.RefObject< HTMLButtonElement | null >;
 	editingElement?: EditingElement;
 	popoverProps?: PaletteEditProps[ 'popoverProps' ];
 	setEditingElement: ( newEditingElement?: EditingElement ) => void;

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -72,5 +72,5 @@ export type SuffixItemProps = Pick<
 	SearchControlProps,
 	'value' | 'onChange' | 'onClose'
 > & {
-	searchRef: React.RefObject< HTMLInputElement >;
+	searchRef: React.RefObject< HTMLInputElement | null >;
 };

--- a/packages/components/src/slot-fill/types.ts
+++ b/packages/components/src/slot-fill/types.ts
@@ -113,7 +113,7 @@ export type SlotFillProviderProps = {
 };
 
 export type SlotFillInstance = {};
-export type SlotRef = RefObject< HTMLElement >;
+export type SlotRef = RefObject< HTMLElement | null >;
 export type SlotRecord = { instance: SlotFillInstance } & (
 	| { type: 'children' }
 	| { type: 'portal'; ref: SlotRef; fillProps: FillProps }

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -15,10 +15,10 @@ import { isAppleOS } from '@wordpress/keycodes';
  *
  * @typedef {Object} WPKeyboardShortcutConfig
  *
- * @property {boolean}                      [bindGlobal] Handle keyboard events anywhere including inside textarea/input fields.
- * @property {string}                       [eventName]  Event name used to trigger the handler, defaults to keydown.
- * @property {boolean}                      [isDisabled] Disables the keyboard handler if the value is true.
- * @property {React.RefObject<HTMLElement>} [target]     React reference to the DOM element used to catch the keyboard event.
+ * @property {boolean}                             [bindGlobal] Handle keyboard events anywhere including inside textarea/input fields.
+ * @property {string}                              [eventName]  Event name used to trigger the handler, defaults to keydown.
+ * @property {boolean}                             [isDisabled] Disables the keyboard handler if the value is true.
+ * @property {React.RefObject<HTMLElement | null>} [target]     React reference to the DOM element used to catch the keyboard event.
  */
 
 /**

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Update Testing Library packages used in unit tests. [#75340](https://github.com/WordPress/gutenberg/pull/75340)
 - Always specify initial values for `useRef` calls. [#75513](https://github.com/WordPress/gutenberg/pull/75513)
 - Clean up type declarations using the `React` namespace. ([#75508](https://github.com/WordPress/gutenberg/pull/75508)
+- Update `RefObject` type usage for React 19 compatibility. [#75567](https://github.com/WordPress/gutenberg/pull/75567)
 
 ## 11.3.0 (2026-01-29)
 

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -161,8 +161,8 @@ function ValidatedDateControl< Item >( {
 	field: NormalizedField< Item >;
 	validity?: FieldValidity;
 	inputRefs:
-		| React.RefObject< HTMLInputElement >
-		| React.RefObject< HTMLInputElement >[];
+		| React.RefObject< HTMLInputElement | null >
+		| React.RefObject< HTMLInputElement | null >[];
 	isTouched: boolean;
 	setIsTouched: ( touched: boolean ) => void;
 	children: React.ReactNode;

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -51,7 +51,7 @@ interface OperatorSelectorProps {
 }
 
 interface FilterProps extends OperatorSelectorProps {
-	addFilterRef: RefObject< HTMLButtonElement >;
+	addFilterRef: RefObject< HTMLButtonElement | null >;
 	openedFilter: string | null;
 	fields: NormalizedField< any >[];
 }

--- a/packages/dataviews/src/components/dataviews-filters/toggle.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/toggle.tsx
@@ -92,7 +92,7 @@ function FilterVisibilityToggle( {
 	filtersCount,
 	children,
 }: {
-	buttonRef: React.RefObject< HTMLButtonElement >;
+	buttonRef: React.RefObject< HTMLButtonElement | null >;
 	filtersCount?: number;
 	children: React.ReactNode;
 } ) {


### PR DESCRIPTION
Spinoff from React 19 migration in #61521 that reduced the big number of modified files in that PR.

This patch updated the typings of `RefObject` so that they are compatible with both React 18 and React 19.

React 18 defines `RefObject` (approximately) as:
```ts
type RefObject<T> = {
  current: T | null;
}
```
You don't have to specify `null`, it's added automatically. React 19 is more "universal":
```ts
type RefObject<T> = {
  current: T;
}
```
If you want to allow `null` values, something you must do for refs that are passed to elements (`<div ref={ref}>`), you must specify the `| null` type yourself. That's exactly what this PR does.

The affected lines cause type errors with React 19 types, and are noops for React 18.