### PR TITLE
ui/Button: fix disabled styles and variable composition

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 
 -   `Field`: Fix default gap spacing ([#75446](https://github.com/WordPress/gutenberg/pull/75446)).
+-   `Button`: Fix disabled styles while `focusableWhenDisabled={false}` ([#75568](https://github.com/WordPress/gutenberg/pull/75568)).
 
 ### Enhancements
 
@@ -23,6 +24,7 @@
 ### Internal
 
 -   `Button`, `InputLayout`, `Tabs`: use semantic dimension tokens ([#74557](https://github.com/WordPress/gutenberg/pull/74557)).
+-   `Button`: Fix overriding of internal CSS variables ([#75568](https://github.com/WordPress/gutenberg/pull/75568)).
 
 ## 0.6.0 (2026-01-29)
 

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -70,20 +70,22 @@
 			text-decoration: inherit;
 		}
 
-		/* States */
+		/* States — use property declarations (not variable reassignment) so that
+		   higher CSS layers can safely override the custom property values without
+		   breaking state handling. */
 		&:not([data-disabled]):is(:hover, :active, :focus) {
 			/* hover/active/focus states apply when the button is not disabled. A non
 			disabled, loading button will have hover/active/focus styles */
-			--wp-ui-button-background-color: var(--wp-ui-button-background-color-active);
-			--wp-ui-button-foreground-color: var(--wp-ui-button-foreground-color-active);
-			--wp-ui-button-border-color: var(--wp-ui-button-border-color-active);
+			background-color: var(--wp-ui-button-background-color-active);
+			color: var(--wp-ui-button-foreground-color-active);
+			border-color: var(--wp-ui-button-border-color-active);
 		}
 
 		&[data-disabled]:not(.is-loading) {
 			/* A loading button, even when disabled, won't "look" disabled */
-			--wp-ui-button-background-color: var(--wp-ui-button-background-color-disabled);
-			--wp-ui-button-foreground-color: var(--wp-ui-button-foreground-color-disabled);
-			--wp-ui-button-border-color: var(--wp-ui-button-border-color-disabled);
+			background-color: var(--wp-ui-button-background-color-disabled);
+			color: var(--wp-ui-button-foreground-color-disabled);
+			border-color: var(--wp-ui-button-border-color-disabled);
 
 			@media ( forced-colors: active ) {
 				border-color: GrayText;
@@ -201,6 +203,12 @@
 
 	.is-loading {
 		color: transparent;
+
+		/* Keep text transparent when a loading button is hovered — needed because
+		 the hover state now sets `color` as a property declaration. */
+		&:not([data-disabled]):is(:hover, :active, :focus) {
+			color: transparent;
+		}
 
 		* {
 			opacity: 0;

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -71,7 +71,7 @@
 		}
 
 		/* States */
-		&:not([aria-disabled="true"]):is(:hover, :active, :focus) {
+		&:not([data-disabled]):is(:hover, :active, :focus) {
 			/* hover/active/focus states apply when the button is not disabled. A non
 			disabled, loading button will have hover/active/focus styles */
 			--wp-ui-button-background-color: var(--wp-ui-button-background-color-active);
@@ -79,7 +79,7 @@
 			--wp-ui-button-border-color: var(--wp-ui-button-border-color-active);
 		}
 
-		&[aria-disabled="true"]:not(.is-loading) {
+		&[data-disabled]:not(.is-loading) {
 			/* A loading button, even when disabled, won't "look" disabled */
 			--wp-ui-button-background-color: var(--wp-ui-button-background-color-disabled);
 			--wp-ui-button-foreground-color: var(--wp-ui-button-foreground-color-disabled);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fix a couple of issues the `@wordpress/ui` `Button` component's styles to ensure correct `disabled` styles and better composability with overriding variables via higher-priority CSS layers.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- `disabled` styles are currently broken when the `focusableWhenDisabled={false}`;
- we need to improve CSS variable override functionality for the upcoming work on `ConfirmDialog` and its [dedicated destructive button variant](https://github.com/WordPress/gutenberg/pull/74463#issuecomment-3732898516)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Use the appropriate HTML attribute to target the disabled state (from `aria-disabled` to `data-disabled`, as per Base UI docs)
- Rework how internal CSS variables are assigned and consumed: Custom properties = configurable values. CSS properties = state machine. This allows compositing / overriding CSS variables in a correct way.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Verify that `Button` and `IconButton` look visually disabled (ie greyed out) when the `disabled` prop is set to `true` and the `focusableWhenDisabled` is set to `false`
- Verify that all other visual states haven't regressed (including loading states)
- Review the code

## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
| ![Screenshot 2026-02-16 at 14 04 05](https://github.com/user-attachments/assets/9727081d-6916-45b0-b4e8-deec73986173) | ![Screenshot 2026-02-16 at 14 05 34](https://github.com/user-attachments/assets/f7d64186-bc6f-4fef-b609-f5206de7dd11) |
