### PR TITLE
useMergeRefs: migrate to TypeScript

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -467,11 +467,11 @@ return <div ref={ mergedRefs } />;
 
 _Parameters_
 
--   _refs_ `Array<TRef>`: The refs to be merged.
+-   _refs_ `Ref< T >[]`: The refs to be merged.
 
 _Returns_
 
--   `React.RefCallback<TypeFromRef<TRef>>`: The merged ref callback.
+-   `RefCallback< T >`: The merged ref callback.
 
 ### useObservableValue
 

--- a/packages/compose/src/hooks/use-merge-refs/index.ts
+++ b/packages/compose/src/hooks/use-merge-refs/index.ts
@@ -2,22 +2,13 @@
  * WordPress dependencies
  */
 import { useRef, useCallback, useLayoutEffect } from '@wordpress/element';
+import type { MutableRefObject, Ref, RefCallback } from 'react';
 
-/**
- * @template T
- * @typedef {T extends React.Ref<infer R> ? R : never} TypeFromRef
- */
-
-/**
- * @template T
- * @param {React.Ref<T>} ref
- * @param {T}            value
- */
-function assignRef( ref, value ) {
+function assignRef< T >( ref: Ref< T >, value: T ) {
 	if ( typeof ref === 'function' ) {
 		ref( value );
 	} else if ( ref && ref.hasOwnProperty( 'current' ) ) {
-		/** @type {React.MutableRefObject<T>} */ ( ref ).current = value;
+		( ref as MutableRefObject< T > ).current = value;
 	}
 }
 
@@ -59,17 +50,16 @@ function assignRef( ref, value ) {
  * return <div ref={ mergedRefs } />;
  * ```
  *
- * @template {React.Ref<any>} TRef
- * @param {Array<TRef>} refs The refs to be merged.
- *
- * @return {React.RefCallback<TypeFromRef<TRef>>} The merged ref callback.
+ * @param refs The refs to be merged.
+ * @return The merged ref callback.
  */
-export default function useMergeRefs( refs ) {
-	const element = useRef();
+export default function useMergeRefs< T >(
+	refs: Ref< T >[]
+): RefCallback< T > {
+	const element = useRef( null );
 	const isAttachedRef = useRef( false );
 	const didElementChangeRef = useRef( false );
-	/** @type {React.MutableRefObject<TRef[]>} */
-	const previousRefsRef = useRef( [] );
+	const previousRefsRef = useRef< Ref< T >[] >( [] );
 	const currentRefsRef = useRef( refs );
 
 	// Update on render before the ref callback is called, so the ref callback
@@ -104,7 +94,7 @@ export default function useMergeRefs( refs ) {
 
 	// There should be no dependencies so that `callback` is only called when
 	// the node changes.
-	return useCallback( ( value ) => {
+	return useCallback( ( value: T | null ) => {
 		// Update the element so it can be used when calling ref callbacks on a
 		// dependency change.
 		assignRef( element, value );

--- a/packages/editor/src/components/collaborators-overlay/overlay.tsx
+++ b/packages/editor/src/components/collaborators-overlay/overlay.tsx
@@ -95,7 +95,10 @@ export function Overlay( {
 	useEffect( rerenderCursorsAfterDelay, [ rerenderCursorsAfterDelay ] );
 
 	// Merge the refs to use the same element for both overlay and resize observation
-	const mergedRef = useMergeRefs( [ setOverlayElement, resizeObserverRef ] );
+	const mergedRef = useMergeRefs< HTMLDivElement | null >( [
+		setOverlayElement,
+		resizeObserverRef,
+	] );
 
 	useBlockHighlighting(
 		blockEditorDocument ?? null,


### PR DESCRIPTION
Migrates the `useMergeRefs` utility from JavaScript with tsdoc annotations to real TypeScript. Needed for the React 19 migration in #61521.