### PR TITLE
Unify selection API: route all selection through onChangeSelection

### DIFF
--- a/packages/block-editor/src/components/provider/README.md
+++ b/packages/block-editor/src/components/provider/README.md
@@ -31,6 +31,20 @@ In the context of an editor, an example usage of this distinction is for managin
 
 A callback invoked when the blocks have been modified in a non-persistent manner. Contrasted with `onChange`, a "non-persistent" change is one which is part of a composed input. Any sequence of updates to the same block attribute are treated as non-persistent, except for the first.
 
+### `selection`
+
+-   **Type:** `Object`
+-   **Required** `no`
+
+The current selection state, typically containing `selectionStart`, `selectionEnd`, and `initialPosition`. Used to restore cursor position when blocks are reset from an external source (e.g. undo/redo).
+
+### `onChangeSelection`
+
+-   **Type:** `Function`
+-   **Required** `no`
+
+A callback invoked when the selection changes within the block editor. Receives the new selection state as the first argument and an options object as the second. The options object contains an `isBlockChange` boolean indicating whether the selection change accompanied a block content change.
+
 ### `children`
 
 -   **Type:** `Element`

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -270,10 +270,9 @@ describe( 'useBlockSync hook', () => {
 			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
-		expect( onInput ).toHaveBeenCalledWith(
-			[ { clientId: 'a', innerBlocks: [], attributes: { foo: 2 } } ],
-			expect.objectContaining( { selection: expect.any( Object ) } )
-		);
+		expect( onInput ).toHaveBeenCalledWith( [
+			{ clientId: 'a', innerBlocks: [], attributes: { foo: 2 } },
+		] );
 		expect( onChange ).not.toHaveBeenCalled();
 	} );
 
@@ -304,10 +303,9 @@ describe( 'useBlockSync hook', () => {
 			.dispatch( blockEditorStore )
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
-		expect( onChange ).toHaveBeenCalledWith(
-			[ { clientId: 'a', innerBlocks: [], attributes: { foo: 2 } } ],
-			expect.objectContaining( { selection: expect.any( Object ) } )
-		);
+		expect( onChange ).toHaveBeenCalledWith( [
+			{ clientId: 'a', innerBlocks: [], attributes: { foo: 2 } },
+		] );
 		expect( onInput ).not.toHaveBeenCalled();
 	} );
 
@@ -395,17 +393,14 @@ describe( 'useBlockSync hook', () => {
 			.updateBlockAttributes( 'a', { foo: 2 } );
 
 		expect( replaceInnerBlocks ).not.toHaveBeenCalled();
-		expect( onChange ).toHaveBeenCalledWith(
-			[
-				{
-					name: 'test/test-block',
-					clientId: 'a',
-					innerBlocks: [],
-					attributes: { foo: 2 },
-				},
-			],
-			expect.objectContaining( { selection: expect.any( Object ) } )
-		);
+		expect( onChange ).toHaveBeenCalledWith( [
+			{
+				name: 'test/test-block',
+				clientId: 'a',
+				innerBlocks: [],
+				attributes: { foo: 2 },
+			},
+		] );
 		expect( onInput ).not.toHaveBeenCalled();
 	} );
 
@@ -439,10 +434,7 @@ describe( 'useBlockSync hook', () => {
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 2 } },
 		];
 
-		expect( onChange1 ).toHaveBeenCalledWith(
-			updatedBlocks1,
-			expect.objectContaining( { selection: expect.any( Object ) } )
-		);
+		expect( onChange1 ).toHaveBeenCalledWith( updatedBlocks1 );
 
 		const newBlocks = [
 			{ clientId: 'b', innerBlocks: [], attributes: { foo: 1 } },
@@ -472,10 +464,9 @@ describe( 'useBlockSync hook', () => {
 		expect( onChange1 ).not.toHaveBeenCalled();
 
 		// The second callback should be called with the new change.
-		expect( onChange2 ).toHaveBeenCalledWith(
-			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
-			expect.objectContaining( { selection: expect.any( Object ) } )
-		);
+		expect( onChange2 ).toHaveBeenCalledWith( [
+			{ clientId: 'b', innerBlocks: [], attributes: { foo: 3 } },
+		] );
 	} );
 
 	it( 'should use fresh callbacks if onChange/onInput have been updated when no previous changes have been made', async () => {
@@ -525,10 +516,9 @@ describe( 'useBlockSync hook', () => {
 		expect( onChange1 ).not.toHaveBeenCalled();
 
 		// Only the new callback should be called.
-		expect( onChange2 ).toHaveBeenCalledWith(
-			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
-			expect.objectContaining( { selection: expect.any( Object ) } )
-		);
+		expect( onChange2 ).toHaveBeenCalledWith( [
+			{ clientId: 'b', innerBlocks: [], attributes: { foo: 3 } },
+		] );
 	} );
 
 	it( 'preserves external client IDs in onChange callback for inner block controllers', async () => {
@@ -595,8 +585,7 @@ describe( 'useBlockSync hook', () => {
 						} ),
 					] ),
 				} ),
-			] ),
-			expect.objectContaining( { selection: expect.any( Object ) } )
+			] )
 		);
 	} );
 

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -416,21 +416,6 @@ export default function useBlockSync( {
 							? restoreExternalIds( blocks, idMappingRef.current )
 							: blocks;
 
-						// Build selection state for the undo level.
-						const selectionInfo = {
-							selectionStart: newSelectionStart,
-							selectionEnd: newSelectionEnd,
-							initialPosition:
-								getSelectedBlocksInitialCaretPosition(),
-						};
-						// Restore external IDs in selection for inner block controllers.
-						const selectionForParent = clientId
-							? restoreSelectionIds(
-									selectionInfo,
-									idMappingRef.current
-							  )
-							: selectionInfo;
-
 						pendingChangesRef.current.outgoing.push(
 							blocksForParent
 						);
@@ -438,18 +423,16 @@ export default function useBlockSync( {
 						const updateParent = isPersistent
 							? onChangeRef.current
 							: onInputRef.current;
-						updateParent( blocksForParent, {
-							selection: selectionForParent,
-						} );
+						updateParent( blocksForParent );
 					}
 
+					// Report selection via onChangeSelection for both
+					// block changes and selection-only changes.
 					if (
 						selectionChanged &&
-						! blocksChanged &&
 						newSelectionStart?.clientId &&
 						! isRestoringSelectionRef.current
 					) {
-						// Report selection via onChangeSelection.
 						// Each useBlockSync only reports if the selected block
 						// is within its own scope.
 						// Inner block controllers own the block if the internal
@@ -479,7 +462,8 @@ export default function useBlockSync( {
 											selectionInfo,
 											idMappingRef.current
 									  )
-									: selectionInfo
+									: selectionInfo,
+								{ isBlockChange: blocksChanged }
 							);
 						}
 					}

--- a/packages/compose/src/hooks/use-state-with-history/index.ts
+++ b/packages/compose/src/hooks/use-state-with-history/index.ts
@@ -16,6 +16,7 @@ function undoRedoReducer< T >(
 		| { type: 'UNDO' }
 		| { type: 'REDO' }
 		| { type: 'RECORD'; value: T; isStaged: boolean }
+		| { type: 'AMEND'; value: T }
 ): UndoRedoState< T > {
 	switch ( action.type ) {
 		case 'UNDO': {
@@ -55,6 +56,20 @@ function undoRedoReducer< T >(
 				value: action.value,
 			};
 		}
+		case 'AMEND': {
+			state.manager.amendRecord( [
+				{
+					id: 'object',
+					changes: {
+						prop: { from: state.value, to: action.value },
+					},
+				},
+			] );
+			return {
+				...state,
+				value: action.value,
+			};
+		}
 	}
 
 	return state;
@@ -87,6 +102,12 @@ export default function useStateWithHistory< T >( initialValue: T ) {
 				type: 'RECORD',
 				value: newValue,
 				isStaged,
+			} );
+		}, [] ),
+		amendValue: useCallback( ( newValue: T ) => {
+			dispatch( {
+				type: 'AMEND',
+				value: newValue,
 			} );
 		}, [] ),
 		hasUndo: state.manager.hasUndo(),

--- a/packages/compose/src/hooks/use-state-with-history/test/index.js
+++ b/packages/compose/src/hooks/use-state-with-history/test/index.js
@@ -28,6 +28,38 @@ const TestComponent = () => {
 	);
 };
 
+const AmendTestComponent = () => {
+	const { value, setValue, amendValue, hasUndo, undo, redo } =
+		useStateWithHistory( { text: 'foo', cursor: 0 } );
+
+	return (
+		<div>
+			<span data-testid="text">{ value.text }</span>
+			<span data-testid="cursor">{ value.cursor }</span>
+			<button
+				className="change"
+				onClick={ () =>
+					setValue( { text: 'bar', cursor: value.cursor }, false )
+				}
+			>
+				Change
+			</button>
+			<button
+				className="amend"
+				onClick={ () => amendValue( { ...value, cursor: 5 } ) }
+			>
+				Amend
+			</button>
+			<button className="undo" onClick={ undo } disabled={ ! hasUndo }>
+				Undo
+			</button>
+			<button className="redo" onClick={ redo }>
+				Redo
+			</button>
+		</div>
+	);
+};
+
 describe( 'useStateWithHistory', () => {
 	it( 'should allow undo/redo', async () => {
 		render( <TestComponent /> );
@@ -55,5 +87,32 @@ describe( 'useStateWithHistory', () => {
 		expect( input ).toHaveValue( 'bar' );
 		expect( buttonUndo ).toBeEnabled();
 		expect( buttonRedo ).toBeDisabled();
+	} );
+
+	it( 'should amend the latest undo entry', () => {
+		render( <AmendTestComponent /> );
+
+		expect( screen.getByTestId( 'text' ) ).toHaveTextContent( 'foo' );
+		expect( screen.getByTestId( 'cursor' ) ).toHaveTextContent( '0' );
+
+		// Make a persistent change.
+		fireEvent.click( screen.getByText( 'Change' ) );
+		expect( screen.getByTestId( 'text' ) ).toHaveTextContent( 'bar' );
+		expect( screen.getByTestId( 'cursor' ) ).toHaveTextContent( '0' );
+
+		// Amend cursor into the same undo entry.
+		fireEvent.click( screen.getByText( 'Amend' ) );
+		expect( screen.getByTestId( 'text' ) ).toHaveTextContent( 'bar' );
+		expect( screen.getByTestId( 'cursor' ) ).toHaveTextContent( '5' );
+
+		// Undo should restore both text and cursor together.
+		fireEvent.click( screen.getByText( 'Undo' ) );
+		expect( screen.getByTestId( 'text' ) ).toHaveTextContent( 'foo' );
+		expect( screen.getByTestId( 'cursor' ) ).toHaveTextContent( '0' );
+
+		// Redo should restore both text and cursor together.
+		fireEvent.click( screen.getByText( 'Redo' ) );
+		expect( screen.getByTestId( 'text' ) ).toHaveTextContent( 'bar' );
+		expect( screen.getByTestId( 'cursor' ) ).toHaveTextContent( '5' );
 	} );
 } );

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -458,21 +458,25 @@ export const editEntityRecord =
 			}
 		}
 		if ( ! options.undoIgnore ) {
-			select.getUndoManager().addRecord(
-				[
-					{
-						id: { kind, name, recordId },
-						changes: Object.keys( edits ).reduce( ( acc, key ) => {
-							acc[ key ] = {
-								from: editedRecord[ key ],
-								to: edits[ key ],
-							};
-							return acc;
-						}, {} ),
-					},
-				],
-				options.isCached
-			);
+			const undoRecord = [
+				{
+					id: { kind, name, recordId },
+					changes: Object.keys( edits ).reduce( ( acc, key ) => {
+						acc[ key ] = {
+							from: editedRecord[ key ],
+							to: edits[ key ],
+						};
+						return acc;
+					}, {} ),
+				},
+			];
+			if ( options.undoAmend ) {
+				select.getUndoManager().amendRecord( undoRecord );
+			} else {
+				select
+					.getUndoManager()
+					.addRecord( undoRecord, options.isCached );
+			}
 		}
 		dispatch( {
 			type: 'EDIT_ENTITY_RECORD',

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -89,13 +89,11 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			if ( noChange ) {
 				return __unstableCreateUndoLevel( kind, name, id );
 			}
-			const { selection, ...rest } = options;
 
 			// We create a new function here on every persistent edit
 			// to make sure the edit makes the post dirty and creates
 			// a new undo level.
 			const edits = {
-				selection,
 				content: ( { blocks: blocksForSerialization = [] } ) =>
 					__unstableSerializeAndClean( blocksForSerialization ),
 				...updateFootnotesFromMeta( newBlocks, meta ),
@@ -103,7 +101,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 
 			editEntityRecord( kind, name, id, edits, {
 				isCached: false,
-				...rest,
+				...options,
 			} );
 		},
 		[
@@ -119,15 +117,11 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 
 	const onInput = useCallback(
 		( newBlocks, options ) => {
-			const { selection, ...rest } = options;
-			const edits = {
-				selection,
-				...updateFootnotesFromMeta( newBlocks, meta ),
-			};
+			const edits = updateFootnotesFromMeta( newBlocks, meta );
 
 			editEntityRecord( kind, name, id, edits, {
 				isCached: true,
-				...rest,
+				...options,
 			} );
 		},
 		[ kind, name, id, meta, editEntityRecord ]

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -299,13 +299,13 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const { editEntityRecord } = useDispatch( coreStore );
 
 		const onChangeSelection = useCallback(
-			( newSelection ) => {
+			( newSelection, { isBlockChange } = {} ) => {
 				editEntityRecord(
 					'postType',
 					post.type,
 					post.id,
 					{ selection: newSelection },
-					{ undoIgnore: true }
+					isBlockChange ? { undoAmend: true } : { undoIgnore: true }
 				);
 			},
 			[ editEntityRecord, post.type, post.id ]

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -58,6 +58,17 @@ export function createUndoManager(): SyncUndoManager {
 		},
 
 		/**
+		 * Amend the latest undo record with additional changes.
+		 * This is a no-op for Yjs since it automatically tracks changes.
+		 *
+		 * @param _record A record of changes to merge.
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		amendRecord( _record: HistoryRecord< ObjectData > ): void {
+			// This is a no-op for Yjs since it automatically tracks changes.
+		},
+
+		/**
 		 * Add a Yjs map to the scope of the undo manager.
 		 *
 		 * @param {Y.Map< any >} ymap                     The Yjs map to add to the scope.

--- a/packages/undo-manager/src/index.ts
+++ b/packages/undo-manager/src/index.ts
@@ -183,6 +183,29 @@ export function createUndoManager< T = unknown >(): UndoManager< T > {
 			return redoRecord;
 		},
 
+		amendRecord( record: HistoryRecord< T > ): void {
+			if ( ! record?.length ) {
+				return;
+			}
+			if ( stagedRecord.length ) {
+				record.forEach( ( changes ) => {
+					stagedRecord = addHistoryChangesIntoRecord(
+						stagedRecord,
+						changes
+					);
+				} );
+			} else {
+				const index = history.length - 1 + offset;
+				if ( index >= 0 && index < history.length ) {
+					let entry = history[ index ];
+					record.forEach( ( changes ) => {
+						entry = addHistoryChangesIntoRecord( entry, changes );
+					} );
+					history[ index ] = entry;
+				}
+			}
+		},
+
 		hasUndo(): boolean {
 			return !! history[ history.length - 1 + offset ];
 		},

--- a/packages/undo-manager/src/test/index.js
+++ b/packages/undo-manager/src/test/index.js
@@ -215,6 +215,102 @@ describe( 'Undo Manager', () => {
 		] );
 	} );
 
+	describe( 'amendRecord', () => {
+		it( 'merges into the latest committed history entry', () => {
+			const manager = createUndoManager();
+
+			manager.addRecord( [
+				{ id: '1', changes: { value: { from: undefined, to: 1 } } },
+			] );
+			manager.amendRecord( [
+				{
+					id: '1',
+					changes: { selection: { from: undefined, to: 'sel1' } },
+				},
+			] );
+
+			expect( manager.undo() ).toEqual( [
+				{
+					id: '1',
+					changes: {
+						value: { from: undefined, to: 1 },
+						selection: { from: undefined, to: 'sel1' },
+					},
+				},
+			] );
+		} );
+
+		it( 'merges into the staged record', () => {
+			const manager = createUndoManager();
+
+			manager.addRecord(
+				[
+					{
+						id: '1',
+						changes: { value: { from: undefined, to: 1 } },
+					},
+				],
+				true
+			);
+			manager.amendRecord( [
+				{
+					id: '1',
+					changes: { selection: { from: undefined, to: 'sel1' } },
+				},
+			] );
+
+			// Flush the staged record by adding a non-staged record.
+			manager.addRecord();
+			expect( manager.undo() ).toEqual( [
+				{
+					id: '1',
+					changes: {
+						value: { from: undefined, to: 1 },
+						selection: { from: undefined, to: 'sel1' },
+					},
+				},
+			] );
+		} );
+
+		it( 'is a no-op when history is empty', () => {
+			const manager = createUndoManager();
+
+			manager.amendRecord( [
+				{
+					id: '1',
+					changes: { selection: { from: undefined, to: 'sel1' } },
+				},
+			] );
+
+			expect( manager.undo() ).toBeUndefined();
+		} );
+
+		it( 'merges changes for a different entity into the same record', () => {
+			const manager = createUndoManager();
+
+			manager.addRecord( [
+				{ id: '1', changes: { value: { from: undefined, to: 1 } } },
+			] );
+			manager.amendRecord( [
+				{
+					id: '2',
+					changes: { selection: { from: undefined, to: 'sel1' } },
+				},
+			] );
+
+			expect( manager.undo() ).toEqual( [
+				{
+					id: '1',
+					changes: { value: { from: undefined, to: 1 } },
+				},
+				{
+					id: '2',
+					changes: { selection: { from: undefined, to: 'sel1' } },
+				},
+			] );
+		} );
+	} );
+
 	it( 'should ignore empty records', () => {
 		const manager = createUndoManager();
 

--- a/packages/undo-manager/src/types.ts
+++ b/packages/undo-manager/src/types.ts
@@ -36,6 +36,18 @@ export interface UndoManager< T = unknown > {
 	addRecord: ( record?: HistoryRecord< T >, isStaged?: boolean ) => void;
 
 	/**
+	 * Amend the latest undo record with additional changes.
+	 *
+	 * Merges into the staged record if one exists, otherwise into the
+	 * most recent committed history entry. This is useful for grouping
+	 * related changes (e.g. selection) into the same undo level as a
+	 * preceding change (e.g. block content).
+	 *
+	 * @param record A record of changes to merge.
+	 */
+	amendRecord: ( record: HistoryRecord< T > ) => void;
+
+	/**
 	 * Undo the last recorded changes.
 	 *
 	 * @return The undone record or undefined if nothing to undo.

--- a/platform-docs/docs/basic-concepts/undo-redo.md
+++ b/platform-docs/docs/basic-concepts/undo-redo.md
@@ -22,18 +22,23 @@ import {
 } from "@wordpress/block-editor";
 
 function Editor() {
-	const { value, setValue, hasUndo, hasRedo, undo, redo } =
+	const { value, setValue, amendValue, hasUndo, hasRedo, undo, redo } =
 		useStateWithHistory( { blocks: [] } );
 
 	return (
         <BlockEditorProvider
             value={ value.blocks }
             selection={ value.selection }
-            onInput={ ( blocks, { selection } ) =>
-                setValue( { blocks, selection }, true )
+            onInput={ ( blocks ) =>
+                setValue( { blocks, selection: value.selection }, true )
             }
-            onChange={ ( blocks, { selection } ) =>
-                setValue( { blocks, selection }, false )
+            onChange={ ( blocks ) =>
+                setValue( { blocks, selection: value.selection }, false )
+            }
+            onChangeSelection={ ( selection, { isBlockChange } = {} ) =>
+                isBlockChange
+                    ? amendValue( { ...value, selection } )
+                    : setValue( { ...value, selection }, true )
             }
         >
             <div className="undo-redo-toolbar">
@@ -54,12 +59,15 @@ The `useStateWithHistory` hook returns an object with the following properties:
 
 - `value`: the current value of the state.
 - `setValue`: a function that can be used to update the state.
+- `amendValue`: a function that merges a new value into the most recent undo entry without creating a new one.
 - `hasUndo`: a boolean indicating whether there are any actions that can be undone.
 - `hasRedo`: a boolean indicating whether there are any actions that can be redone.
 - `undo`: a function that can be used to undo the last action.
 - `redo`: a function that can be used to redo the last action.
 
 Notice that in addition to the `blocks` property, the `value` object also tracks a `selection` property. This property is used to store and control the cursor position within the block editor. This allows the editor to restore the right position when undoing or redoing changes.
+
+Selection changes are reported separately via the `onChangeSelection` callback rather than being bundled with `onChange`/`onInput`. When a selection change accompanies a block change (`isBlockChange` is `true`), `amendValue` merges the selection into the most recent undo entry so that undoing restores both blocks and cursor position together. For selection-only changes (e.g. clicking to reposition the cursor), the update is recorded as staged so it doesn't create a separate undo step.
 
 ## Going Further...
 


### PR DESCRIPTION
## Summary

Builds on top of #75371 to unify the two selection signaling paths (onChange/onInput options vs onChangeSelection) into a single path through `onChangeSelection`.

- Adds `amendRecord` to the undo manager that merges changes into the latest undo entry, ensuring selection changes are grouped with their associated block changes for correct undo/redo
- Adds `undoAmend` option to `editEntityRecord` to trigger amendment instead of creating a new undo level
- Makes `useEntityBlockEditor` selection-agnostic by removing explicit selection handling from onChange/onInput
- Routes all selection changes in `useBlockSync` through `onChangeSelection` with an `isBlockChange` flag
- EditorProvider's `onChangeSelection` uses `undoAmend` for block-associated selection changes and `undoIgnore` for selection-only changes

## Test plan

- [ ] Undo manager unit tests pass (`npm run test:unit -- --testPathPattern='undo-manager'`)
- [ ] useBlockSync unit tests pass (`npm run test:unit -- --testPathPattern='use-block-sync'`)
- [ ] core-data unit tests pass (`npm run test:unit -- --testPathPattern='packages/core-data'`)
- [ ] E2E undo tests pass (`npm run test:e2e -- test/e2e/specs/editor/various/undo.spec.js`)
- [ ] Manual: undo/redo restores both blocks AND cursor position correctly
- [ ] Manual: selection-only changes (clicking between blocks) don't create undo levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)