### PR TITLE
fix: prevent page jump when clicking anchor links in editor

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -74,6 +74,9 @@ function Edit( {
 				return;
 			}
 
+			//FIX: Prevent the browser from jumping/scrolling when clicking an anchor link
+			event.preventDefault();
+
 			setAddingLink( true );
 			setOpenedBy( {
 				el: link,


### PR DESCRIPTION
## Description
This PR fixes an issue where clicking an anchor link (e.g., `href="#"` or `href="#section"`) inside the editor causes the page to scroll/jump unexpectedly.

## Motivation
When a user tries to edit an existing anchor link, the browser's default behavior triggers a scroll event before the Link UI popover can be used effectively. This disrupts the editing flow and causes the user to lose their place in the document.

Fixes #72505.

## Changes
- Updated `packages/format-library/src/link/index.js` to include `event.preventDefault()` in the `handleClick` handler.
- This ensures the editor intercepts the click event, preventing the browser's default navigation/scroll behavior while still opening the Link UI.

## Testing Instructions
1. Create a new Post.
2. Add enough content to make the page scrollable.
3. Select text near the bottom and add a link with `href="#"`.
4. Click the link text.
5. Verify that the Link UI popover opens **without** the page jumping to the top.