### PR TITLE
Playlist Block: Enable play/pause toggle for individual tracks

### DIFF
--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -51,7 +51,7 @@ function render_block_core_playlist_track( $attributes ) {
 		$html .= '</span>';
 	}
 
-	$html .= '<span class="screen-reader-text">' . esc_html__( 'Select to play this track' ) . '</span>';
+	$html .= '<span class="screen-reader-text">' . esc_html__( 'Select to play or pause this track' ) . '</span>';
 	$html .= '</button>';
 	$html .= '</li>';
 

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -27,8 +27,14 @@ store(
 		actions: {
 			changeTrack() {
 				const context = getContext();
-				context.currentId = context.uniqueId;
-				context.isPlaying = true;
+				// Toggle play/pause if clicking the same track
+				if ( context.currentId === context.uniqueId ) {
+					context.isPlaying = ! context.isPlaying;
+				} else {
+					// Switch to a different track and play it
+					context.currentId = context.uniqueId;
+					context.isPlaying = true;
+				}
 			},
 			isPlaying() {
 				const context = getContext();
@@ -61,6 +67,8 @@ store(
 				const { ref } = getElement();
 				if ( context.currentId && context.isPlaying ) {
 					ref.play();
+				} else if ( context.currentId && ! context.isPlaying ) {
+					ref.pause();
 				}
 			},
 		},


### PR DESCRIPTION
## What?
Closes #75582

Enables users to pause playback by clicking/activating the same track button that started playback in the Playlist block.

## Why?
Previously, users could start playback from any track, but could not pause from the same control - they had to navigate back to the main playlist control. This was inconsistent with expected behavior and created an accessibility barrier.

## How?
- Modified the `changeTrack` action in `view.js` to toggle `isPlaying` when clicking the current track, while maintaining the existing behavior of switching tracks when clicking a different track
- Updated the `autoPlay` callback to handle pausing the audio element when `isPlaying` is false
- Updated the screen reader text from "Select to play this track" to "Select to play or pause this track" to accurately communicate the control's functionality

## Testing Instructions
1. Insert a Playlist block with multiple audio tracks
2. Navigate by keyboard to any track
3. Press 'Space' or 'Enter' to start playback
4. Press 'Space' or 'Enter' again on the same track
5. Verify that the track pauses
6. Press 'Space' or 'Enter' again to resume playback
7. Navigate to a different track and press 'Space' or 'Enter'
8. Verify that the new track starts playing

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/4ec7cf2b-c147-4e24-8fbd-6b7e6b510c09



After:


https://github.com/user-attachments/assets/31ec1d68-c9c7-4608-841e-36ca3bca173c

