### PR TITLE
Post Excerpt: Add text columns support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -726,7 +726,7 @@ Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk
 
 -	**Name:** core/post-excerpt
 -	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textColumns), ~~html~~
 -	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
 
 ## Featured Image

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -46,6 +46,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textColumns": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/25459

## What?

Adopts text columns block support for the Post Excerpt block.

## Why?

Enables more control over design and layout.

## How?

Opt into the `typography.textColumns` block support

## Testing Instructions

1. Add a Post Excerpt block to a post or page
2. In the site editor apply text columns for the post excerpt block type
3. Save and confirm the correct columns show in both editor and frontend
4. Back in the editor, select the post excerpt block you added 
5. Apply a custom column count to the block instance
6. Save and confirm the instance column count is applied in both editor and frontend

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/d703e0fc-689b-4552-bb8a-2c246187e316

