### PR TITLE
Navigation Overlays: Add .wp-block-template-part class by default 

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -771,7 +771,7 @@ class WP_Navigation_Block_Renderer {
 
 		if ( $has_custom_overlay ) {
 			$custom_overlay_markup = sprintf(
-				'<div class="wp-block-navigation__overlay-container">%s</div>',
+				'<div class="wp-block-navigation__overlay-container wp-block-template-part">%s</div>',
 				$overlay_blocks_html
 			);
 		}


### PR DESCRIPTION
Issue https://github.com/WordPress/gutenberg/issues/74967

## What?

Adds the `.wp-block-template-part` class to navigation overlay containers.

## Why?

Navigation overlays are template parts but were missing the standard `.wp-block-template-part` class. This class helps:

- Identify template parts easily for styling purposes
- Improve CSS specificity when targeting template parts
- Enable potential performance optimizations for loading styles only when the template part is on the page

## How?

Adds the `wp-block-template-part` class to the overlay container `<div>` in [WP_Navigation_Block_Renderer::get_responsive_container_markup()]

## Testing Instructions

1. Create a navigation block with a custom overlay template part
2. View the page source/inspect the overlay container
3. Verify the container has both `wp-block-navigation__overlay-container` and `wp-block-template-part` classes

## ScreenShot

<img width="2480" height="1066" alt="image" src="https://github.com/user-attachments/assets/d9b2bdbd-cb63-4c5d-a308-42275b0dbd2f" />

