### PR TITLE
Theme: Add build plugins to inject design token fallbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63241,6 +63241,7 @@
 				"@storybook/addon-docs": "^10.1.11",
 				"@storybook/icons": "^2.0.1",
 				"@storybook/react-vite": "^10.1.11",
+				"@wordpress/theme": "file:../packages/theme",
 				"storybook": "^10.1.11",
 				"storybook-addon-tag-badges": "^3.0.4",
 				"terser": "^5.37.0"

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+-   Added PostCSS, esbuild, and Vite build plugins that inject fallback values for design system tokens (`--wpds-*`). Available as package exports: `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`, `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks`, `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks` ([#75589](https://github.com/WordPress/gutenberg/pull/75589)).
 -   Add `--wpds-cursor-control` design token for interactive non-link elements ([#75697](https://github.com/WordPress/gutenberg/pull/75697)).
 
 ## 0.7.0 (2026-02-18)

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -43,6 +43,21 @@
 			"import": "./build-module/prebuilt/js/design-tokens.mjs",
 			"default": "./build/prebuilt/js/design-tokens.cjs"
 		},
+		"./postcss-plugins/postcss-ds-token-fallbacks": {
+			"types": "./src/postcss-plugins/postcss-ds-token-fallbacks.d.mts",
+			"import": "./src/postcss-plugins/postcss-ds-token-fallbacks.mjs",
+			"default": "./src/postcss-plugins/postcss-ds-token-fallbacks.mjs"
+		},
+		"./esbuild-plugins/esbuild-ds-token-fallbacks": {
+			"types": "./src/esbuild-plugins/esbuild-ds-token-fallbacks.d.mts",
+			"import": "./src/esbuild-plugins/esbuild-ds-token-fallbacks.mjs",
+			"default": "./src/esbuild-plugins/esbuild-ds-token-fallbacks.mjs"
+		},
+		"./vite-plugins/vite-ds-token-fallbacks": {
+			"types": "./src/vite-plugins/vite-ds-token-fallbacks.d.mts",
+			"import": "./src/vite-plugins/vite-ds-token-fallbacks.mjs",
+			"default": "./src/vite-plugins/vite-ds-token-fallbacks.mjs"
+		},
 		"./stylelint-plugins/no-unknown-ds-tokens": {
 			"types": "./build-types/stylelint-plugins/no-unknown-ds-tokens.d.ts",
 			"import": "./src/stylelint-plugins/no-unknown-ds-tokens.mjs",

--- a/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.d.mts
+++ b/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.d.mts
@@ -1,4 +1,2 @@
-import type { Plugin } from 'esbuild';
-
-declare const plugin: Plugin;
+declare const plugin: import('esbuild').Plugin;
 export default plugin;

--- a/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.d.mts
+++ b/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.d.mts
@@ -1,0 +1,4 @@
+import type { Plugin } from 'esbuild';
+
+declare const plugin: Plugin;
+export default plugin;

--- a/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.mjs
+++ b/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.mjs
@@ -1,0 +1,44 @@
+import { readFile } from 'fs/promises';
+import { addFallbackToVar } from '../postcss-plugins/ds-token-fallbacks.mjs';
+
+const LOADER_MAP = {
+	'.js': 'jsx',
+	'.jsx': 'jsx',
+	'.ts': 'tsx',
+	'.tsx': 'tsx',
+	'.mjs': 'jsx',
+};
+
+/**
+ * esbuild plugin that injects design-system token fallbacks into JS/TS files.
+ *
+ * Replaces bare `var(--wpds-*)` references in string literals with
+ * `var(--wpds-*, <fallback>)` so components render correctly without
+ * a ThemeProvider.
+ */
+const plugin = {
+	name: 'ds-token-fallbacks-js',
+	setup( build ) {
+		build.onLoad( { filter: /\.[mc]?[jt]sx?$/ }, async ( args ) => {
+			// Skip node_modules.
+			if ( args.path.includes( 'node_modules' ) ) {
+				return undefined;
+			}
+
+			const source = await readFile( args.path, 'utf8' );
+
+			if ( ! source.includes( '--wpds-' ) ) {
+				return undefined;
+			}
+
+			const ext = args.path.match( /(\.[^.]+)$/ )?.[ 1 ] || '.js';
+
+			return {
+				contents: addFallbackToVar( source ),
+				loader: LOADER_MAP[ ext ] || 'jsx',
+			};
+		} );
+	},
+};
+
+export default plugin;

--- a/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.mjs
+++ b/packages/theme/src/esbuild-plugins/esbuild-ds-token-fallbacks.mjs
@@ -7,6 +7,9 @@ const LOADER_MAP = {
 	'.ts': 'tsx',
 	'.tsx': 'tsx',
 	'.mjs': 'jsx',
+	'.mts': 'tsx',
+	'.cjs': 'jsx',
+	'.cts': 'tsx',
 };
 
 /**

--- a/packages/theme/src/postcss-plugins/postcss-ds-token-fallbacks.d.mts
+++ b/packages/theme/src/postcss-plugins/postcss-ds-token-fallbacks.d.mts
@@ -1,4 +1,2 @@
-import type { PluginCreator } from 'postcss';
-
-declare const plugin: PluginCreator<never>;
+declare const plugin: import('postcss').PluginCreator< never >;
 export default plugin;

--- a/packages/theme/src/postcss-plugins/postcss-ds-token-fallbacks.d.mts
+++ b/packages/theme/src/postcss-plugins/postcss-ds-token-fallbacks.d.mts
@@ -1,0 +1,4 @@
+import type { PluginCreator } from 'postcss';
+
+declare const plugin: PluginCreator<never>;
+export default plugin;

--- a/packages/theme/src/postcss-plugins/postcss-ds-token-fallbacks.mjs
+++ b/packages/theme/src/postcss-plugins/postcss-ds-token-fallbacks.mjs
@@ -1,0 +1,16 @@
+import { addFallbackToVar } from './ds-token-fallbacks.mjs';
+
+const plugin = () => ( {
+	postcssPlugin: 'postcss-ds-token-fallbacks',
+	/** @param {import('postcss').Declaration} decl */
+	Declaration( decl ) {
+		const updated = addFallbackToVar( decl.value );
+		if ( updated !== decl.value ) {
+			decl.value = updated;
+		}
+	},
+} );
+
+plugin.postcss = true;
+
+export default plugin;

--- a/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.d.mts
+++ b/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.d.mts
@@ -1,4 +1,2 @@
-import type { Plugin } from 'vite';
-
-declare const plugin: () => Plugin;
+declare const plugin: () => import('vite').Plugin;
 export default plugin;

--- a/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.d.mts
+++ b/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.d.mts
@@ -1,0 +1,4 @@
+import type { Plugin } from 'vite';
+
+declare const plugin: () => Plugin;
+export default plugin;

--- a/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.mjs
+++ b/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.mjs
@@ -13,10 +13,13 @@ const plugin = () => ( {
 		if ( ! /\.[mc]?[jt]sx?$/.test( id ) ) {
 			return null;
 		}
+		if ( id.includes( 'node_modules' ) ) {
+			return null;
+		}
 		if ( ! code.includes( '--wpds-' ) ) {
 			return null;
 		}
-		return addFallbackToVar( code );
+		return { code: addFallbackToVar( code ), map: null };
 	},
 } );
 

--- a/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.mjs
+++ b/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.mjs
@@ -19,6 +19,8 @@ const plugin = () => ( {
 		if ( ! code.includes( '--wpds-' ) ) {
 			return null;
 		}
+		// Sourcemap omitted: replacements are small, inline substitutions
+		// that preserve line structure, so the debugging impact is negligible.
 		return { code: addFallbackToVar( code ), map: null };
 	},
 } );

--- a/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.mjs
+++ b/packages/theme/src/vite-plugins/vite-ds-token-fallbacks.mjs
@@ -1,0 +1,23 @@
+import { addFallbackToVar } from '../postcss-plugins/ds-token-fallbacks.mjs';
+
+/**
+ * Vite plugin that injects design-system token fallbacks into JS/TS files.
+ *
+ * Replaces bare `var(--wpds-*)` references in string literals with
+ * `var(--wpds-*, <fallback>)` so components render correctly without
+ * a ThemeProvider.
+ */
+const plugin = () => ( {
+	name: 'ds-token-fallbacks-js',
+	transform( code, id ) {
+		if ( ! /\.[mc]?[jt]sx?$/.test( id ) ) {
+			return null;
+		}
+		if ( ! code.includes( '--wpds-' ) ) {
+			return null;
+		}
+		return addFallbackToVar( code );
+	},
+} );
+
+export default plugin;

--- a/packages/ui/src/stack/stack.tsx
+++ b/packages/ui/src/stack/stack.tsx
@@ -1,7 +1,20 @@
 import { useRender, mergeProps } from '@base-ui/react';
 import { forwardRef } from '@wordpress/element';
+import type { GapSize } from '@wordpress/theme';
 import { type StackProps } from './types';
 import styles from './style.module.css';
+
+// Static map so that the build-time token fallback plugin can inject fallback
+// values into each `var()` call.
+const gapTokens: Record< GapSize, string > = {
+	xs: 'var(--wpds-dimension-gap-xs)',
+	sm: 'var(--wpds-dimension-gap-sm)',
+	md: 'var(--wpds-dimension-gap-md)',
+	lg: 'var(--wpds-dimension-gap-lg)',
+	xl: 'var(--wpds-dimension-gap-xl)',
+	'2xl': 'var(--wpds-dimension-gap-2xl)',
+	'3xl': 'var(--wpds-dimension-gap-3xl)',
+};
 
 /**
  * A flexible layout component using CSS Flexbox for consistent spacing and alignment.
@@ -12,7 +25,7 @@ export const Stack = forwardRef< HTMLDivElement, StackProps >( function Stack(
 	ref
 ) {
 	const style: React.CSSProperties = {
-		gap: gap && `var(--wpds-dimension-gap-${ gap })`,
+		gap: gap && gapTokens[ gap ],
 		alignItems: align,
 		justifyContent: justify,
 		flexDirection: direction,

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -21,6 +21,26 @@ import babel from 'esbuild-plugin-babel';
 import { camelCase } from 'change-case';
 import { NodePackageImporter } from 'sass-embedded';
 
+// Optional dependency: @wordpress/theme provides plugins that inject fallback
+// values for design system tokens. Fails gracefully when the package is not
+// installed (it is an optional peerDependency).
+let dsTokenFallbacks;
+let dsTokenFallbacksJs;
+try {
+	const { default: postcssPlugin } = await import(
+		// eslint-disable-next-line import/no-unresolved
+		'@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks'
+	);
+	const { default: esbuildPlugin } = await import(
+		// eslint-disable-next-line import/no-unresolved
+		'@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks'
+	);
+	dsTokenFallbacks = postcssPlugin;
+	dsTokenFallbacksJs = esbuildPlugin;
+} catch {
+	// @wordpress/theme is optional; skip token fallbacks if not available.
+}
+
 /**
  * Internal dependencies
  */
@@ -150,8 +170,9 @@ function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 
 		let moduleExports = null;
 
-		// Transform the code: CSS modules and minification.
+		// Transform the code: token fallbacks, CSS modules and minification.
 		const plugins = [
+			dsTokenFallbacks,
 			cssModules &&
 				postcssModules( {
 					generateScopedName: '[contenthash]__[local]',
@@ -1251,6 +1272,7 @@ async function transpilePackage( packageName ) {
 		},
 	};
 	const plugins = [
+		dsTokenFallbacksJs,
 		needsEmotionPlugin && emotionPlugin,
 		wasmInlinePlugin,
 		externalizeAllExceptCssPlugin,

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1272,6 +1272,10 @@ async function transpilePackage( packageName ) {
 		},
 	};
 	const plugins = [
+		// Note: dsTokenFallbacksJs and emotionPlugin both use esbuild's onLoad
+		// hook, which is non-composable — the first to return contents wins. If a
+		// file contains --wpds-* tokens, the Emotion transform will be skipped.
+		// Avoid using design tokens in Emotion styles until Emotion is removed.
 		dsTokenFallbacksJs,
 		needsEmotionPlugin && emotionPlugin,
 		wasmInlinePlugin,

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1434,12 +1434,13 @@ async function compileStyles( packageName ) {
 						embedded: true,
 						...getSassOptions( packageDir ),
 						async transform( source ) {
-							// Process with autoprefixer for LTR version
-							const ltrResult = await postcss( [
-								autoprefixer( { grid: true } ),
-							] ).process( source, { from: undefined } );
+							const ltrResult = await postcss(
+								[
+									dsTokenFallbacks,
+									autoprefixer( { grid: true } ),
+								].filter( Boolean )
+							).process( source, { from: undefined } );
 
-							// Process with rtlcss for RTL version
 							const rtlResult = await postcss( [
 								rtlcss(),
 							] ).process( ltrResult.css, { from: undefined } );

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -6,6 +6,8 @@ import {
 } from 'vite';
 import react from '@vitejs/plugin-react';
 import type { StorybookConfig } from '@storybook/react-vite';
+import dsTokenFallbacks from '@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks';
+import dsTokenFallbacksJs from '@wordpress/theme/vite-plugins/vite-ds-token-fallbacks';
 
 const { NODE_ENV = 'development' } = process.env;
 
@@ -77,6 +79,7 @@ const config: StorybookConfig = {
 	viteFinal: async ( viteConfig ) => {
 		return mergeConfig( viteConfig, {
 			plugins: [
+				dsTokenFallbacksJs(),
 				react( {
 					jsxImportSource: '@emotion/react',
 					babel: {
@@ -173,6 +176,13 @@ const config: StorybookConfig = {
 				'globalThis.SCRIPT_DEBUG': JSON.stringify(
 					NODE_ENV === 'development'
 				),
+			},
+			css: {
+				postcss: {
+					// Vite bundles its own PostCSS, creating a deep
+					// type incompatibility with the top-level PostCSS.
+					plugins: [ dsTokenFallbacks as any ],
+				},
 			},
 			optimizeDeps: {
 				esbuildOptions: {

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -24,6 +24,7 @@
 		"@storybook/addon-docs": "^10.1.11",
 		"@storybook/icons": "^2.0.1",
 		"@storybook/react-vite": "^10.1.11",
+		"@wordpress/theme": "file:../packages/theme",
 		"storybook": "^10.1.11",
 		"storybook-addon-tag-badges": "^3.0.4",
 		"terser": "^5.37.0"


### PR DESCRIPTION
Fix (part 1/2) for https://core.trac.wordpress.org/ticket/64698

## What?

Stacked on #75586

Adds PostCSS, esbuild, and Vite build plugins that inject fallback values into CSS and JS files using the token fallback map from #75586.

## Why?

#75586 generates a map of `--wpds-*` tokens to their fallback values, but nothing consumes it yet. This PR wires up the actual injection — transforming `var(--wpds-color-fg-default)` into `var(--wpds-color-fg-default, #1e1e1e)` at build time, both in stylesheets and in JS string literals.

## How?

Three thin plugin wrappers, all importing the same `addFallbackToVar` function from #75586:

- **PostCSS plugin** (`postcss-ds-token-fallbacks.mjs`) — walks CSS declarations, replaces bare `var(--wpds-*)` with fallback-injected versions. Used by `wp-build` for CSS and by Storybook via Vite's PostCSS integration.
- **esbuild plugin** (`esbuild-ds-token-fallbacks.mjs`) — `onLoad` hook that transforms JS/TS source files containing `--wpds-` references. Used by `wp-build` for JS transpilation.
- **Vite plugin** (`vite-ds-token-fallbacks.mjs`) — `transform` hook, same idea as the esbuild plugin but for Vite's pipeline. Used by Storybook.

Each plugin skips files that don't contain `--wpds-` for zero overhead on unrelated modules.

### Integration points

- **`wp-build`** (`packages/wp-build/lib/build.mjs`) — both the PostCSS and esbuild plugins are loaded as optional dependencies (`@wordpress/theme` is an optional peerDependency of `wp-build`). Fails gracefully if not installed.
- **Storybook** (`storybook/main.ts`) — the Vite plugin is added to `viteFinal` plugins, and the PostCSS plugin is added to `css.postcss.plugins`. `@wordpress/theme` is added as a devDependency of the storybook package.

## Testing Instructions

Here is some test code to see the replacement in action:

```diff
diff --git a/packages/components/src/button/style.scss b/packages/components/src/button/style.scss
index 38e328eed82..f87441fe0be 100644
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -59,8 +59,8 @@
 
 	&.is-primary {
 		white-space: nowrap;
-		background: $components-color-accent;
-		color: $components-color-accent-inverted;
+		background: var(--wpds-color-bg-interactive-brand-strong);
+		color: var(--wpds-color-fg-interactive-brand-strong);
 		text-decoration: none;
 		text-shadow: none;
 
diff --git a/storybook/package-styles/design-tokens.lazy.scss b/storybook/package-styles/design-tokens.lazy.scss
index 2877dcf2377..bc63e599e2b 100644
--- a/storybook/package-styles/design-tokens.lazy.scss
+++ b/storybook/package-styles/design-tokens.lazy.scss
@@ -1 +1 @@
-@import "../../packages/theme/src/prebuilt/css/design-tokens.css";
+// @import "../../packages/theme/src/prebuilt/css/design-tokens.css";
diff --git a/storybook/preview.jsx b/storybook/preview.jsx
index 0af2bddd701..ce47d47f080 100644
--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -64,7 +64,7 @@ export const decorators = [
 	WithGlobalCSS,
 	WithRTL,
 	WithMaxWidthWrapper,
-	WithDesignSystemTheme,
+	// WithDesignSystemTheme,
 ];
 
 export const parameters = {
```

The test code adds a DS token usage in `@wordpress/components` primary `Button`, and disables all the design tokens stylesheet injection in Storybook. The modified `Button`, as well as all the `@wordpress/ui` components, should render with their fallback values even with the design tokens stylesheet unavailable in Storybook.

You can also test in the Gutenberg app, for example by rendering a `@wordpress/ui` component in the UI, or adding a design token to any component code.