### PR TITLE
Update gutenberg to match core after #75360 sync

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -8,24 +8,23 @@
 /**
  * Get the first style variation name from a className string that matches a registered style.
  *
- * @param string $class_name        CSS class string for a block.
- * @param array  $registered_styles Currently registered block styles.
- *
+ * @param string                              $class_name        CSS class string for a block.
+ * @param array<string, array<string, mixed>> $registered_styles Currently registered block styles.
  * @return string|null The name of the first registered variation, or null if none found.
  */
-function gutenberg_get_variation_name_from_class( $class_name, $registered_styles = array() ) {
-	if ( empty( $class_name ) ) {
+function gutenberg_get_block_style_variation_name_from_registered_style( string $class_name, array $registered_styles = array() ): ?string {
+	if ( ! $class_name ) {
 		return null;
 	}
 
 	$registered_names = array_filter( array_column( $registered_styles, 'name' ) );
 
 	$prefix = 'is-style-';
-	$len    = strlen( $prefix );
+	$length = strlen( $prefix );
 
 	foreach ( explode( ' ', $class_name ) as $class ) {
 		if ( str_starts_with( $class, $prefix ) ) {
-			$variation = substr( $class, $len );
+			$variation = substr( $class, $length );
 			if ( 'default' !== $variation && in_array( $variation, $registered_names, true ) ) {
 				return $variation;
 			}
@@ -938,16 +937,16 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.
 		$variation_block_gap_value = null;
 		$block_class_name          = $block['attrs']['className'] ?? '';
-		if ( ! empty( $block_class_name ) && str_contains( $block_class_name, 'is-style-' ) && ! empty( $block_name ) ) {
+		if ( $block_class_name && str_contains( $block_class_name, 'is-style-' ) && $block_name ) {
 			$styles_registry   = WP_Block_Styles_Registry::get_instance();
 			$registered_styles = $styles_registry->get_registered_styles_for_block( $block_name );
-			$variation_name    = gutenberg_get_variation_name_from_class( $block_class_name, $registered_styles );
+			$variation_name    = gutenberg_get_block_style_variation_name_from_registered_style( $block_class_name, $registered_styles );
 			if ( $variation_name ) {
 				$variation_block_gap_value = $global_styles['blocks'][ $block_name ]['variations'][ $variation_name ]['spacing']['blockGap'] ?? null;
 			}
 		}
 
-		$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? ( $global_styles['spacing']['blockGap'] ?? null );
+		$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -806,7 +806,6 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 */
 	public function test_layout_support_flag_uses_variation_block_gap_value() {
 		switch_theme( 'block-theme' );
-		add_theme_support( 'appearance-tools' );
 
 		$block_content = '<div class="wp-block-group is-style-custom-gap"></div>';
 		$block         = array(
@@ -838,8 +837,91 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			$actual_stylesheet,
 			'Generated CSS should contain the variation blockGap value of 99px.'
 		);
+	}
 
-		// Clean up.
-		remove_theme_support( 'appearance-tools' );
+	/**
+	 * Tests that gutenberg_get_block_style_variation_name_from_registered_style correctly extracts variation names from class strings.
+	 *
+	 * @covers ::gutenberg_get_block_style_variation_name_from_registered_style
+	 *
+	 * @dataProvider data_get_block_style_variation_name_from_registered_style
+	 *
+	 * @param string      $class_name        CSS class string to test.
+	 * @param array       $registered_styles Registered block styles.
+	 * @param string|null $expected_result   Expected variation name or null.
+	 */
+	public function test_get_block_style_variation_name_from_registered_style( $class_name, $registered_styles, $expected_result ) {
+		$result = gutenberg_get_block_style_variation_name_from_registered_style( $class_name, $registered_styles );
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * Data provider for test_get_block_style_variation_name_from_registered_style.
+	 *
+	 * @return array
+	 */
+	public function data_get_block_style_variation_name_from_registered_style() {
+		return array(
+			'empty class name'                             => array(
+				'class_name'        => '',
+				'registered_styles' => array(),
+				'expected_result'   => null,
+			),
+			'no matching registered styles'                => array(
+				'class_name'        => 'is-style-shadowed wp-block-button',
+				'registered_styles' => array(
+					array( 'name' => 'rounded' ),
+					array( 'name' => 'outlined' ),
+				),
+				'expected_result'   => null,
+			),
+			'single matching variation found'              => array(
+				'class_name'        => 'wp-block-button is-style-rounded',
+				'registered_styles' => array(
+					array( 'name' => 'rounded' ),
+					array( 'name' => 'outlined' ),
+				),
+				'expected_result'   => 'rounded',
+			),
+			'ignores default style only'                   => array(
+				'class_name'        => 'is-style-default wp-block-button',
+				'registered_styles' => array(
+					array( 'name' => 'default' ),
+					array( 'name' => 'rounded' ),
+				),
+				'expected_result'   => null,
+			),
+			'ignores default and returns next variation'   => array(
+				'class_name'        => 'is-style-default is-style-rounded wp-block-button',
+				'registered_styles' => array(
+					array( 'name' => 'default' ),
+					array( 'name' => 'rounded' ),
+					array( 'name' => 'outlined' ),
+				),
+				'expected_result'   => 'rounded',
+			),
+			'returns first matching variation when multiple present' => array(
+				'class_name'        => 'is-style-shadowed is-style-rounded',
+				'registered_styles' => array(
+					array( 'name' => 'rounded' ),
+					array( 'name' => 'outlined' ),
+					array( 'name' => 'shadowed' ),
+				),
+				'expected_result'   => 'shadowed',
+			),
+			'empty registered styles array'                => array(
+				'class_name'        => 'is-style-rounded',
+				'registered_styles' => array(),
+				'expected_result'   => null,
+			),
+			'registered styles with missing name property' => array(
+				'class_name'        => 'is-style-outlined wp-block-button',
+				'registered_styles' => array(
+					array( 'label' => 'Rounded' ),
+					array( 'name' => 'outlined' ),
+				),
+				'expected_result'   => 'outlined',
+			),
+		);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Brings feedback from https://github.com/WordPress/wordpress-develop/pull/10906 back into Gutenberg.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In your block theme folder, under styles > blocks, add a file with something like:
```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Large gap",
	"slug": "largegap",
	"blockTypes": ["core/group"],
	"styles": {
		"spacing": {
			"blockGap": "99px"
		}
	}
}
```
2. Add a Grid block to a page and set both an explicit column count and min column width for it.
3. Save and check the front end: the correct number of columns should display provided the screen is wide enough.
