### PR TITLE
Embed Block: Fix collapse in Stack blocks

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -29,7 +29,7 @@
 }
 
 // Fix for Stack blocks (vertical orientation) - embeds need explicit width to maintain aspect ratio.
-.wp-block-group.is-layout-flex.is-vertical .wp-block-embed {
+.wp-block-group.is-layout-flex.is-vertical > .wp-block-embed {
 	width: 100%;
 }
 

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -22,14 +22,14 @@
 	min-height: 240px;
 }
 
-// Allow embeds to grow and shrink inside flex group blocks (Stack/Row), preventing collapse while fitting available space.
-.wp-block-group.is-layout-flex .wp-block-embed {
+// Allow embeds to grow and shrink inside flex layouts (Stack/Row), preventing collapse while fitting available space.
+.is-layout-flex .wp-block-embed {
 	flex: 1 1 0%;
 	min-width: 0;
 }
 
-// Fix for Stack blocks (vertical orientation) - embeds need explicit width to maintain aspect ratio.
-.wp-block-group.is-layout-flex.is-vertical > .wp-block-embed {
+// Fix for vertical flex layouts (e.g., Stack blocks) - embeds need explicit width to maintain aspect ratio.
+.is-layout-flex.is-vertical .wp-block-embed {
 	width: 100%;
 }
 

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -28,6 +28,11 @@
 	min-width: 0;
 }
 
+// Fix for Stack blocks (vertical orientation) - embeds need explicit width to maintain aspect ratio.
+.wp-block-group.is-layout-flex.is-vertical .wp-block-embed {
+	width: 100%;
+}
+
 .wp-block-embed {
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 


### PR DESCRIPTION
## What?
Closes #75592
Fixes embed blocks collapsing to 0x0 in Stack blocks (vertical flex layouts).

## Why?

Follow-up to #73109, which fixed the issue for Row blocks but not Stack blocks.

Embeds with responsive aspect ratios collapse when placed inside Stack blocks (Group blocks with vertical flex orientation). While the previous fix added flex properties that work for horizontal layouts (Row blocks), vertical flex containers require an explicit width to prevent collapse while maintaining the aspect ratio.

## How?
Adds a CSS rule targeting embeds inside vertical flex layouts:

```scss
.wp-block-group.is-layout-flex.is-vertical .wp-block-embed {
    width: 100%;
}
```
## Testing Instructions

1. Copy the markup below into a post/page in the editor:

```html
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=U8dcFhF0Dlk","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.youtube.com/watch?v=U8dcFhF0Dlk
</div></figure>
<!-- /wp:embed -->

<!-- wp:embed {"url":"https://www.youtube.com/watch?v=U8dcFhF0Dlk","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.youtube.com/watch?v=U8dcFhF0Dlk
</div></figure>
<!-- /wp:embed --></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=U8dcFhF0Dlk","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.youtube.com/watch?v=U8dcFhF0Dlk
</div></figure>
<!-- /wp:embed -->

<!-- wp:embed {"url":"https://www.youtube.com/watch?v=U8dcFhF0Dlk","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.youtube.com/watch?v=U8dcFhF0Dlk
</div></figure>
<!-- /wp:embed --></div>
<!-- /wp:group -->
```
2. Verify that YouTube embeds display correctly in the editor (not collapsed to 0x0)
3. Publish the post/page
4. Verify that both embeds display correctly on the frontend

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before: Embeds collapse in Stack blocks
|Editor|Frontend|
|-|-|
|<img width="2553" height="1171" alt="image" src="https://github.com/user-attachments/assets/8b000940-968c-4fc5-84b1-1085e63c6ca3" />|<img width="1016" height="620" alt="image" src="https://github.com/user-attachments/assets/9b73db4e-3e8f-45e8-abe0-cb0a2984f1af" />|


After: Embeds display correctly maintaining their aspect ratio
|Editor|Frontend|
|-|-|
|<img width="2557" height="1220" alt="image" src="https://github.com/user-attachments/assets/d7082eea-c9ad-4cb2-8cd5-33636b62a984" />|<img width="1016" height="1748" alt="image" src="https://github.com/user-attachments/assets/fed8a514-e3e7-4e18-b486-31bde9f57c02" />|

