### PR TITLE
Media Utils: Auto-select uploaded files in media modal experiment

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -373,6 +373,19 @@ export function MediaUploadModal( {
 					}
 				);
 
+				// Auto-select the newly uploaded items
+				const uploadedIds = attachments
+					.map( ( attachment ) => String( attachment.id ) )
+					.filter( Boolean );
+
+				if ( multiple ) {
+					// In multiple mode, add to existing selection
+					setSelection( ( prev ) => [ ...prev, ...uploadedIds ] );
+				} else {
+					// In single mode, replace selection with the first uploaded item
+					setSelection( uploadedIds.slice( 0, 1 ) );
+				}
+
 				// Invalidate the entity records resolution to refresh the view
 				invalidateResolution( 'getEntityRecords', [
 					'postType',
@@ -381,7 +394,7 @@ export function MediaUploadModal( {
 				] );
 			}
 		},
-		[ createSuccessNotice, invalidateResolution, queryArgs ]
+		[ createSuccessNotice, invalidateResolution, queryArgs, multiple ]
 	);
 
 	// Shared upload error handler


### PR DESCRIPTION
## What?
Closes #75593
Auto-selects uploaded files in the media modal experiment after upload completes.

## Why?

Currently, when users upload files through the media modal experiment, the files are uploaded and the view refreshes, but the newly uploaded files are not auto-selected. This differs from the core media library behavior where uploaded files are automatically selected.

This creates a better user experience by matching the expected behavior from the core media library.

## How?

Modified the `handleUploadComplete` callback in `MediaUploadModal` to:
- Extract IDs from successfully uploaded attachments
- Update the selection state based on the selection mode:
  - **Multiple mode**: Append uploaded IDs to existing selection
  - **Single mode**: Replace selection with the first uploaded item

## Testing Instructions

1. Enable the media modal experiment (`window.__experimentalDataViewsMediaModal = true`)
2. Open the media modal (e.g., by adding an image block)
3. Upload one or more files using drag-and-drop or the upload button
4. Verify that uploaded files are automatically selected once upload completes
5. For multiple selection: Verify uploaded files are added to any existing selection
6. For single selection: Verify only the first uploaded file is selected

## Screenshots

Before: Uploaded files appear in the view but are not selected


https://github.com/user-attachments/assets/ab70d300-0d8f-4153-bf87-d1315322d630


After: Uploaded files are automatically selected


https://github.com/user-attachments/assets/e7941b01-0219-48b0-9713-0101fde30c17

