### PR TITLE
Real-Time Collaboration: Add e2e tests for RTC

### DIFF
--- a/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
@@ -15,10 +15,10 @@ test.describe( 'Collaboration - Presence', () => {
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
-		// The CollaboratorsPresence component renders when other
+		// The collaborator presence button renders when other
 		// collaborators are present.
 		await expect(
-			page.locator( '.editor-collaborators-presence' )
+			page.getByRole( 'button', { name: /Collaborators list/ } )
 		).toBeVisible( { timeout: 10000 } );
 	} );
 
@@ -33,13 +33,11 @@ test.describe( 'Collaboration - Presence', () => {
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
-		// Wait for the presence button to appear.
-		const presenceButton = page.locator(
-			'.editor-collaborators-presence__button'
-		);
+		// Wait for the presence button to appear and click to open popover.
+		const presenceButton = page.getByRole( 'button', {
+			name: /Collaborators list/,
+		} );
 		await expect( presenceButton ).toBeVisible( { timeout: 10000 } );
-
-		// Click to open the collaborators popover.
 		await presenceButton.click();
 
 		// The popover should list the second collaborator by name.

--- a/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
@@ -12,6 +12,7 @@ test.describe( 'Collaboration - Presence', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Presence Test - Avatars',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
@@ -30,6 +31,7 @@ test.describe( 'Collaboration - Presence', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Presence Test - Name',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - Presence', () => {
+	test( 'Collaborator avatars appear when two users are editing', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Presence Test - Avatars',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		// The CollaboratorsPresence component renders when other
+		// collaborators are present.
+		await expect(
+			page.locator( '.editor-collaborators-presence' )
+		).toBeVisible( { timeout: 10000 } );
+	} );
+
+	test( 'Collaborator name shows in the popover list', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Presence Test - Name',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		// Wait for the presence button to appear.
+		const presenceButton = page.locator(
+			'.editor-collaborators-presence__button'
+		);
+		await expect( presenceButton ).toBeVisible( { timeout: 10000 } );
+
+		// Click to open the collaborators popover.
+		await presenceButton.click();
+
+		// The popover should list the second collaborator by name.
+		await expect( page.getByText( 'Test Collaborator' ) ).toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-sync.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-sync.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - Sync', () => {
+	test( 'User A adds a paragraph block, User B sees it', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Sync Test - A to B',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2 } = collaborationUtils;
+
+		// User A inserts a paragraph block.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello from User A' },
+		} );
+
+		// Ensure React flushes the block change to the entity/sync layer.
+		await collaborationUtils.flushReact( page );
+
+		// User B should see the paragraph after sync propagation.
+		await expect
+			.poll( () => editor2.getBlocks(), { timeout: 5000 } )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello from User A' },
+				},
+			] );
+	} );
+
+	test( 'User B adds a paragraph block, User A sees it', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Sync Test - B to A',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2 } = collaborationUtils;
+
+		// User B inserts a paragraph block via the data API.
+		await page2.evaluate( () => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: 'Hello from User B',
+			} );
+			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
+		} );
+
+		// Ensure React flushes on User B's page.
+		await collaborationUtils.flushReact( page2 );
+
+		// User A should see the paragraph after sync propagation.
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 5000 } )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello from User B' },
+				},
+			] );
+	} );
+
+	test( 'Both users add blocks simultaneously, both changes appear', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Sync Test - Simultaneous',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2, page2 } = collaborationUtils;
+
+		// Both users insert blocks concurrently.
+		await Promise.all( [
+			editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'From User A' },
+			} ),
+			page2.evaluate( () => {
+				const block = window.wp.blocks.createBlock( 'core/paragraph', {
+					content: 'From User B',
+				} );
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.insertBlock( block );
+			} ),
+		] );
+
+		// Ensure React flushes on both pages.
+		await Promise.all( [
+			collaborationUtils.flushReact( page ),
+			collaborationUtils.flushReact( page2 ),
+		] );
+
+		// Both users should eventually see both blocks.
+		for ( const ed of [ editor, editor2 ] ) {
+			await expect( async () => {
+				const blocks = await ed.getBlocks();
+				const contents = blocks.map(
+					( b: { attributes: Record< string, unknown > } ) =>
+						b.attributes.content
+				);
+				expect( contents ).toContain( 'From User A' );
+				expect( contents ).toContain( 'From User B' );
+			} ).toPass( { timeout: 5000 } );
+		}
+	} );
+
+	test( 'Title changes sync between users', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Sync Test - Title',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2 } = collaborationUtils;
+
+		// User A changes the title.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/editor' )
+				.editPost( { title: 'New Title from User A' } );
+		} );
+
+		// User B should see the updated title after sync propagation.
+		await expect
+			.poll(
+				() =>
+					page2.evaluate( () =>
+						window.wp.data
+							.select( 'core/editor' )
+							.getEditedPostAttribute( 'title' )
+					),
+				{ timeout: 5000 }
+			)
+			.toBe( 'New Title from User A' );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-sync.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-sync.spec.ts
@@ -8,7 +8,6 @@ test.describe( 'Collaboration - Sync', () => {
 		collaborationUtils,
 		requestUtils,
 		editor,
-		page,
 	} ) => {
 		const post = await requestUtils.createPost( {
 			title: 'Sync Test - A to B',
@@ -23,9 +22,6 @@ test.describe( 'Collaboration - Sync', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Hello from User A' },
 		} );
-
-		// Ensure React flushes the block change to the entity/sync layer.
-		await collaborationUtils.flushReact( page );
 
 		// User B should see the paragraph after sync propagation.
 		await expect
@@ -59,9 +55,6 @@ test.describe( 'Collaboration - Sync', () => {
 			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
 		} );
 
-		// Ensure React flushes on User B's page.
-		await collaborationUtils.flushReact( page2 );
-
 		// User A should see the paragraph after sync propagation.
 		await expect
 			.poll( () => editor.getBlocks(), { timeout: 5000 } )
@@ -77,7 +70,6 @@ test.describe( 'Collaboration - Sync', () => {
 		collaborationUtils,
 		requestUtils,
 		editor,
-		page,
 	} ) => {
 		const post = await requestUtils.createPost( {
 			title: 'Sync Test - Simultaneous',
@@ -101,12 +93,6 @@ test.describe( 'Collaboration - Sync', () => {
 					.dispatch( 'core/block-editor' )
 					.insertBlock( block );
 			} ),
-		] );
-
-		// Ensure React flushes on both pages.
-		await Promise.all( [
-			collaborationUtils.flushReact( page ),
-			collaborationUtils.flushReact( page2 ),
 		] );
 
 		// Both users should eventually see both blocks.

--- a/test/e2e/specs/editor/collaboration/collaboration-sync.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-sync.spec.ts
@@ -12,6 +12,7 @@ test.describe( 'Collaboration - Sync', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Sync Test - A to B',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
@@ -42,6 +43,7 @@ test.describe( 'Collaboration - Sync', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Sync Test - B to A',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
@@ -74,6 +76,7 @@ test.describe( 'Collaboration - Sync', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Sync Test - Simultaneous',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
@@ -117,6 +120,7 @@ test.describe( 'Collaboration - Sync', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Sync Test - Title',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - Undo/Redo', () => {
+	test( 'User A undo only affects their own changes, not User B changes', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Undo Test',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2, page2 } = collaborationUtils;
+
+		// User B adds a block.
+		await page2.evaluate( () => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: 'From User B',
+			} );
+			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
+		} );
+
+		// Wait for User B's block to appear on User A.
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 5000 } )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'From User B' },
+				},
+			] );
+
+		// User A adds their own block.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'From User A' },
+		} );
+
+		// Wait for both blocks to appear on User B.
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			const contents = blocks.map(
+				( b: { attributes: Record< string, unknown > } ) =>
+					b.attributes.content
+			);
+			expect( contents ).toContain( 'From User A' );
+			expect( contents ).toContain( 'From User B' );
+		} ).toPass( { timeout: 5000 } );
+
+		// User A performs undo via the data API.
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/editor' ).undo();
+		} );
+
+		// User A should see only User B's block (their own block is undone).
+		await expect( async () => {
+			const blocks = await editor.getBlocks();
+			const contents = blocks.map(
+				( b: { attributes: Record< string, unknown > } ) =>
+					b.attributes.content
+			);
+			expect( contents ).not.toContain( 'From User A' );
+			expect( contents ).toContain( 'From User B' );
+		} ).toPass( { timeout: 5000 } );
+
+		// User B should also see the undo result.
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			const contents = blocks.map(
+				( b: { attributes: Record< string, unknown > } ) =>
+					b.attributes.content
+			);
+			expect( contents ).not.toContain( 'From User A' );
+			expect( contents ).toContain( 'From User B' );
+		} ).toPass( { timeout: 5000 } );
+	} );
+
+	test( 'Redo restores the undone change', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Redo Test',
+			status: 'draft',
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		// User A adds a block.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Undoable content' },
+		} );
+
+		// Verify the block exists.
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 3000 } )
+			.toHaveLength( 1 );
+
+		// Undo via data API.
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/editor' ).undo();
+		} );
+
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 5000 } )
+			.toHaveLength( 0 );
+
+		// Redo via data API.
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/editor' ).redo();
+		} );
+
+		await expect
+			.poll( () => editor.getBlocks(), { timeout: 5000 } )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Undoable content' },
+				},
+			] );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
@@ -13,6 +13,7 @@ test.describe( 'Collaboration - Undo/Redo', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Undo Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 
@@ -90,6 +91,7 @@ test.describe( 'Collaboration - Undo/Redo', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Redo Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openCollaborativeSession( post.id );
 

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -51,29 +51,15 @@ export default class CollaborationUtils {
 	}
 
 	/**
-	 * Enable the real-time collaboration WordPress setting.
+	 * Set the real-time collaboration WordPress setting.
 	 *
 	 * Uses the form-based approach (similar to setGutenbergExperiments)
 	 * because this setting is registered on admin_init in the "writing"
 	 * group and is not exposed via /wp/v2/settings.
-	 */
-	async enableCollaboration() {
-		await this.setCollaborationOption( true );
-	}
-
-	/**
-	 * Disable the real-time collaboration WordPress setting.
-	 */
-	async disableCollaboration() {
-		await this.setCollaborationOption( false );
-	}
-
-	/**
-	 * Toggle the real-time collaboration setting via the Writing settings form.
 	 *
 	 * @param enabled Whether to enable or disable collaboration.
 	 */
-	private async setCollaborationOption( enabled: boolean ) {
+	async setCollaboration( enabled: boolean ) {
 		const response = await this.requestUtils.request.get(
 			'/wp-admin/options-writing.php'
 		);
@@ -252,7 +238,7 @@ export default class CollaborationUtils {
 			this.secondPage = null;
 			this.secondEditor = null;
 		}
-		await this.disableCollaboration();
+		await this.setCollaboration( false );
 		await this.requestUtils.deleteAllUsers();
 	}
 }

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -169,14 +169,14 @@ export default class CollaborationUtils {
 
 	/**
 	 * Wait for the collaboration runtime to be ready on a page.
-	 * Checks that `window._wpCollaborationEnabled` is true and wp.data is loaded.
+	 * Checks that `window.__wpSyncEnabled` is true and wp.data is loaded.
 	 *
 	 * @param page The Playwright page to wait on.
 	 */
 	private async waitForCollaborationReady( page: Page ) {
 		await page.waitForFunction(
 			() =>
-				( window as any )._wpCollaborationEnabled === true &&
+				( window as any ).__wpSyncEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
 			{ timeout: 15000 }

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -169,14 +169,14 @@ export default class CollaborationUtils {
 
 	/**
 	 * Wait for the collaboration runtime to be ready on a page.
-	 * Checks that `window.__wpSyncEnabled` is true and wp.data is loaded.
+	 * Checks that `window._wpCollaborationEnabled` is true and wp.data is loaded.
 	 *
 	 * @param page The Playwright page to wait on.
 	 */
 	private async waitForCollaborationReady( page: Page ) {
 		await page.waitForFunction(
 			() =>
-				( window as any ).__wpSyncEnabled === true &&
+				( window as any )._wpCollaborationEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
 			{ timeout: 15000 }

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -1,0 +1,294 @@
+/**
+ * External dependencies
+ */
+import type { Page, BrowserContext } from '@playwright/test';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Editor,
+	type Admin,
+	type RequestUtils,
+} from '@wordpress/e2e-test-utils-playwright';
+
+const SECOND_USER = {
+	username: 'collaborator',
+	email: 'collaborator@example.com',
+	firstName: 'Test',
+	lastName: 'Collaborator',
+	password: 'password',
+	roles: [ 'editor' ] as string[],
+};
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+
+export default class CollaborationUtils {
+	private admin: Admin;
+	private editor: Editor;
+	private requestUtils: RequestUtils;
+	private primaryPage: Page;
+
+	private secondContext: BrowserContext | null = null;
+	private secondPage: Page | null = null;
+	private secondEditor: Editor | null = null;
+
+	constructor( {
+		admin,
+		editor,
+		requestUtils,
+		page,
+	}: {
+		admin: Admin;
+		editor: Editor;
+		requestUtils: RequestUtils;
+		page: Page;
+	} ) {
+		this.admin = admin;
+		this.editor = editor;
+		this.requestUtils = requestUtils;
+		this.primaryPage = page;
+	}
+
+	/**
+	 * Enable the real-time collaboration WordPress setting.
+	 *
+	 * Uses the form-based approach (similar to setGutenbergExperiments)
+	 * because this setting is registered on admin_init in the "writing"
+	 * group and is not exposed via /wp/v2/settings.
+	 */
+	async enableCollaboration() {
+		await this.setCollaborationOption( true );
+	}
+
+	/**
+	 * Disable the real-time collaboration WordPress setting.
+	 */
+	async disableCollaboration() {
+		await this.setCollaborationOption( false );
+	}
+
+	/**
+	 * Toggle the real-time collaboration setting via the Writing settings form.
+	 *
+	 * @param enabled Whether to enable or disable collaboration.
+	 */
+	private async setCollaborationOption( enabled: boolean ) {
+		const response = await this.requestUtils.request.get(
+			'/wp-admin/options-writing.php'
+		);
+		const html = await response.text();
+		const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
+
+		const formData: Record< string, string | number > = {
+			option_page: 'writing',
+			action: 'update',
+			_wpnonce: nonce,
+			_wp_http_referer: '/wp-admin/options-writing.php',
+			submit: 'Save Changes',
+			default_category: 1,
+			default_post_format: 0,
+		};
+
+		if ( enabled ) {
+			formData.enable_real_time_collaboration = 1;
+		}
+
+		await this.requestUtils.request.post( '/wp-admin/options.php', {
+			form: formData,
+			failOnStatusCode: true,
+		} );
+	}
+
+	/**
+	 * Create the second collaborator user.
+	 */
+	async createSecondUser() {
+		await this.requestUtils.createUser( SECOND_USER );
+	}
+
+	/**
+	 * Open a collaborative editing session where both the primary user (admin)
+	 * and the second user (collaborator) are editing the same post.
+	 *
+	 * @param postId The post ID to collaboratively edit.
+	 */
+	async openCollaborativeSession( postId: number ) {
+		// Create a second browser context with the same baseURL.
+		this.secondContext = await this.admin.browser.newContext( {
+			baseURL: BASE_URL,
+		} );
+		this.secondPage = await this.secondContext.newPage();
+
+		// Login the second user via the WordPress login form.
+		await this.secondPage.goto( '/wp-login.php' );
+		await this.secondPage.fill( '#user_login', SECOND_USER.username );
+		await this.secondPage.fill( '#user_pass', SECOND_USER.password );
+		await this.secondPage.click( '#wp-submit' );
+		await this.secondPage.waitForURL( '**/wp-admin/**' );
+
+		// Navigate User 1 (admin) to the post editor.
+		await this.admin.visitAdminPage(
+			'post.php',
+			`post=${ postId }&action=edit`
+		);
+		await this.editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Wait for collaboration to be enabled on User 1's page.
+		await this.waitForCollaborationReady( this.primaryPage );
+
+		// Navigate User 2 to the same post editor.
+		await this.secondPage.goto(
+			`/wp-admin/post.php?post=${ postId }&action=edit`
+		);
+
+		// Dismiss welcome guide for User 2.
+		await this.secondPage.waitForFunction(
+			() => window?.wp?.data && window?.wp?.blocks
+		);
+		await this.secondPage.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-post', 'welcomeGuide', false );
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-post', 'fullscreenMode', false );
+		} );
+
+		// Create an Editor instance for the second page.
+		this.secondEditor = new Editor( { page: this.secondPage } );
+
+		// Wait for collaboration to be enabled on User 2's page.
+		await this.waitForCollaborationReady( this.secondPage );
+
+		// Wait for both users to discover each other via awareness.
+		// The collaborator count button appears when another user is
+		// detected through the sync polling.
+		await Promise.all( [
+			this.primaryPage.waitForFunction(
+				() => {
+					const btn = document.querySelector(
+						'[aria-label*="Collaborators list"]'
+					);
+					return btn !== null;
+				},
+				{ timeout: 15000 }
+			),
+			this.secondPage.waitForFunction(
+				() => {
+					const btn = document.querySelector(
+						'[aria-label*="Collaborators list"]'
+					);
+					return btn !== null;
+				},
+				{ timeout: 15000 }
+			),
+		] );
+
+		// Allow a full round of polling after awareness is established
+		// so both CRDT docs are synchronized.
+		await Promise.all( [
+			this.waitForSyncCycle( this.primaryPage ),
+			this.waitForSyncCycle( this.secondPage ),
+		] );
+	}
+
+	/**
+	 * Wait for the collaboration runtime to be ready on a page.
+	 * Checks that `window._wpCollaborationEnabled` is true and wp.data is loaded.
+	 *
+	 * @param page The Playwright page to wait on.
+	 */
+	private async waitForCollaborationReady( page: Page ) {
+		await page.waitForFunction(
+			() =>
+				( window as any )._wpCollaborationEnabled === true &&
+				window?.wp?.data &&
+				window?.wp?.blocks,
+			{ timeout: 15000 }
+		);
+	}
+
+	/**
+	 * Wait for sync polling cycles to complete on the given page.
+	 *
+	 * Note: The sync endpoint URL is URL-encoded in wp-env
+	 * (rest_route=%2Fwp-sync%2Fv1%2Fupdates), so we match the
+	 * encoded form.
+	 *
+	 * @param page   The Playwright page to wait on.
+	 * @param cycles Number of sync responses to wait for (default 3).
+	 */
+	async waitForSyncCycle( page: Page, cycles = 3 ) {
+		for ( let i = 0; i < cycles; i++ ) {
+			await page.waitForResponse(
+				( response ) =>
+					response.url().includes( 'wp-sync' ) &&
+					response.status() === 200,
+				{ timeout: 10000 }
+			);
+		}
+	}
+
+	/**
+	 * Ensure React has flushed block changes to the entity record.
+	 *
+	 * After dispatching to the block-editor store (e.g. insertBlock), the
+	 * BlockEditorProvider's onChange callback fires asynchronously during
+	 * the next React render cycle. This callback pushes block changes to
+	 * the entity record and sync manager. Without this flush, the CRDT
+	 * update may never be enqueued and the change won't propagate to the
+	 * other user.
+	 *
+	 * @param targetPage The page to flush React on.
+	 */
+	async flushReact( targetPage: Page ) {
+		await targetPage.evaluate(
+			() =>
+				new Promise< void >( ( resolve ) =>
+					requestAnimationFrame( () => resolve() )
+				)
+		);
+	}
+
+	/**
+	 * Get the second user's Page instance.
+	 */
+	get page2(): Page {
+		if ( ! this.secondPage ) {
+			throw new Error(
+				'Second page not available. Call openCollaborativeSession() first.'
+			);
+		}
+		return this.secondPage;
+	}
+
+	/**
+	 * Get the second user's Editor instance.
+	 */
+	get editor2(): Editor {
+		if ( ! this.secondEditor ) {
+			throw new Error(
+				'Second editor not available. Call openCollaborativeSession() first.'
+			);
+		}
+		return this.secondEditor;
+	}
+
+	/**
+	 * Clean up: close second browser context, disable collaboration, delete test users.
+	 */
+	async teardown() {
+		if ( this.secondContext ) {
+			await this.secondContext.close();
+			this.secondContext = null;
+			this.secondPage = null;
+			this.secondEditor = null;
+		}
+		await this.disableCollaboration();
+		await this.requestUtils.deleteAllUsers();
+	}
+}

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -122,9 +122,13 @@ export default class CollaborationUtils {
 
 		// Login the second user via the WordPress login form.
 		await this.secondPage.goto( '/wp-login.php' );
-		await this.secondPage.fill( '#user_login', SECOND_USER.username );
-		await this.secondPage.fill( '#user_pass', SECOND_USER.password );
-		await this.secondPage.click( '#wp-submit' );
+		await this.secondPage
+			.locator( '#user_login' )
+			.fill( SECOND_USER.username );
+		await this.secondPage
+			.locator( '#user_pass' )
+			.fill( SECOND_USER.password );
+		await this.secondPage.getByRole( 'button', { name: 'Log In' } ).click();
 		await this.secondPage.waitForURL( '**/wp-admin/**' );
 
 		// Navigate User 1 (admin) to the post editor.
@@ -168,24 +172,12 @@ export default class CollaborationUtils {
 		// The collaborator count button appears when another user is
 		// detected through the sync polling.
 		await Promise.all( [
-			this.primaryPage.waitForFunction(
-				() => {
-					const btn = document.querySelector(
-						'[aria-label*="Collaborators list"]'
-					);
-					return btn !== null;
-				},
-				{ timeout: 15000 }
-			),
-			this.secondPage.waitForFunction(
-				() => {
-					const btn = document.querySelector(
-						'[aria-label*="Collaborators list"]'
-					);
-					return btn !== null;
-				},
-				{ timeout: 15000 }
-			),
+			this.primaryPage
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 15000 } ),
+			this.secondPage
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 15000 } ),
 		] );
 
 		// Allow a full round of polling after awareness is established

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -12,7 +12,7 @@ import {
 	type RequestUtils,
 } from '@wordpress/e2e-test-utils-playwright';
 
-const SECOND_USER = {
+export const SECOND_USER = {
 	username: 'collaborator',
 	email: 'collaborator@example.com',
 	firstName: 'Test',
@@ -98,13 +98,6 @@ export default class CollaborationUtils {
 			form: formData,
 			failOnStatusCode: true,
 		} );
-	}
-
-	/**
-	 * Create the second collaborator user.
-	 */
-	async createSecondUser() {
-		await this.requestUtils.createUser( SECOND_USER );
 	}
 
 	/**
@@ -214,7 +207,7 @@ export default class CollaborationUtils {
 	 * @param page   The Playwright page to wait on.
 	 * @param cycles Number of sync responses to wait for (default 3).
 	 */
-	async waitForSyncCycle( page: Page, cycles = 3 ) {
+	private async waitForSyncCycle( page: Page, cycles = 3 ) {
 		for ( let i = 0; i < cycles; i++ ) {
 			await page.waitForResponse(
 				( response ) =>
@@ -223,27 +216,6 @@ export default class CollaborationUtils {
 				{ timeout: 10000 }
 			);
 		}
-	}
-
-	/**
-	 * Ensure React has flushed block changes to the entity record.
-	 *
-	 * After dispatching to the block-editor store (e.g. insertBlock), the
-	 * BlockEditorProvider's onChange callback fires asynchronously during
-	 * the next React render cycle. This callback pushes block changes to
-	 * the entity record and sync manager. Without this flush, the CRDT
-	 * update may never be enqueued and the change won't propagate to the
-	 * other user.
-	 *
-	 * @param targetPage The page to flush React on.
-	 */
-	async flushReact( targetPage: Page ) {
-		await targetPage.evaluate(
-			() =>
-				new Promise< void >( ( resolve ) =>
-					requestAnimationFrame( () => resolve() )
-				)
-		);
 	}
 
 	/**

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -7,7 +7,7 @@ export { expect } from '@wordpress/e2e-test-utils-playwright';
 /**
  * Internal dependencies
  */
-import CollaborationUtils from './collaboration-utils';
+import CollaborationUtils, { SECOND_USER } from './collaboration-utils';
 
 type Fixtures = {
 	collaborationUtils: CollaborationUtils;
@@ -25,7 +25,7 @@ export const test = base.extend< Fixtures >( {
 			page,
 		} );
 		await utils.enableCollaboration();
-		await utils.createSecondUser();
+		await requestUtils.createUser( SECOND_USER );
 		await use( utils );
 		await utils.teardown();
 	},

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { test as base } from '@wordpress/e2e-test-utils-playwright';
+export { expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import CollaborationUtils from './collaboration-utils';
+
+type Fixtures = {
+	collaborationUtils: CollaborationUtils;
+};
+
+export const test = base.extend< Fixtures >( {
+	collaborationUtils: async (
+		{ admin, editor, requestUtils, page },
+		use
+	) => {
+		const utils = new CollaborationUtils( {
+			admin,
+			editor,
+			requestUtils,
+			page,
+		} );
+		await utils.enableCollaboration();
+		await utils.createSecondUser();
+		await use( utils );
+		await utils.teardown();
+	},
+} );

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -24,7 +24,7 @@ export const test = base.extend< Fixtures >( {
 			requestUtils,
 			page,
 		} );
-		await utils.enableCollaboration();
+		await utils.setCollaboration( true );
 		await requestUtils.createUser( SECOND_USER );
 		await use( utils );
 		await utils.teardown();


### PR DESCRIPTION
## What?

Add e2e tests for the RTC feature.

## Why?

The RTC feature currently has zero e2e test coverage. These tests validate that multi-user editing, presence awareness, and undo/redo work correctly end-to-end with two browser contexts editing the same post simultaneously.

## How?

Creates a new `test/e2e/specs/editor/collaboration/` test directory with:

- **`fixtures/collaboration-utils.ts`** — A `CollaborationUtils` class that manages multi-user collaborative editing sessions. Handles enabling/disabling the collaboration setting via the Writing settings form, opening a second browser context with login, and waiting for both users to discover each other via awareness before tests begin.
- **`fixtures/index.ts`** — Custom Playwright fixture extending the base test with a `collaborationUtils` fixture (test-scoped for isolation).
- **`collaboration-sync.spec.ts`** — 4 tests: User A→B block sync, User B→A block sync, simultaneous block insertions from both users, and title change sync.
- **`collaboration-presence.spec.ts`** — 2 tests: Collaborator avatars appear in the header, and collaborator name is visible in the popover.
- **`collaboration-undo-redo.spec.ts`** — 2 tests: User A's undo only removes their own changes (not User B's), and redo restores the undone change.

Key reliability technique: session initialization waits for the "Collaborators list" button on both pages, ensuring CRDT rooms are fully connected and polling at the fast interval (250ms) before tests make changes.

## Testing Instructions

1. Ensure `wp-env` is running: `npm run wp-env start`
2. Run the collaboration tests: `npm run test:e2e -- test/e2e/specs/editor/collaboration/`
3. All 8 tests should pass.

### Testing Instructions for Keyboard

N/A — these are automated e2e tests, not UI changes.

## Screenshots or screencast

N/A — no visual UI changes.

Parent issue - https://github.com/WordPress/gutenberg/issues/74549