### PR TITLE
[Real-time collaboration] Fix <CollaboratorsPresence> layout issue

### DIFF
--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss
@@ -4,8 +4,8 @@
 .editor-collaborators-presence {
 	display: flex;
 	align-items: center;
+	flex-shrink: 0;
 	height: $button-size-compact;
-	min-width: 0;
 	background: $gray-100;
 	border-radius: $grid-unit-05;
 	margin-right: $grid-unit-10;
@@ -45,5 +45,4 @@
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, 2px) var(--wp-admin-theme-color, #007cba);
 		outline: none;
 	}
-
 }


### PR DESCRIPTION
## What?
Prevents the `<CollaboratorsPresence>` container element from shrinking. The growth of the container is limited by the fact that we only allow it to show 3 avatars at most.

## Why?
This prevents the avatars from overlapping the container on the right side as it gets squished.

## How?
Adds `flex-shrink: 0` to the container.

## Testing Instructions
1. Enable real-time collaboration in `Settings > Writing`
2. Edit a post
3. Open it in a new tab so there are multiple editors
4. Make the window smaller so the container gets squished a little.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2536" height="1928" alt="CleanShot 2026-02-17 at 15 22 27@2x" src="https://github.com/user-attachments/assets/4ade671e-eaa1-48c5-ac00-2aacee7a8e85" />|<img width="2536" height="1928" alt="CleanShot 2026-02-17 at 15 21 46@2x" src="https://github.com/user-attachments/assets/dbaffcc8-6d76-4317-96e6-1142985e991c" />|
