### PR TITLE
Block editor cross origin isolation: attempt to gracefully deal with race conditions

### DIFF
--- a/packages/block-editor/src/hooks/test/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/test/cross-origin-isolation.js
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe( 'cross-origin-isolation', () => {
+	let originalCrossOriginIsolated;
+	let originalBody;
+	let observeSpy;
+
+	beforeEach( () => {
+		// Save original values
+		originalCrossOriginIsolated = window.crossOriginIsolated;
+		originalBody = document.body;
+
+		// Clear any existing filters
+		jest.clearAllMocks();
+
+		// Spy on MutationObserver.observe
+		observeSpy = jest.spyOn( window.MutationObserver.prototype, 'observe' );
+	} );
+
+	afterEach( () => {
+		// Restore original values
+		if ( originalCrossOriginIsolated !== undefined ) {
+			Object.defineProperty( window, 'crossOriginIsolated', {
+				value: originalCrossOriginIsolated,
+				writable: true,
+				configurable: true,
+			} );
+		}
+
+		if ( originalBody ) {
+			Object.defineProperty( document, 'body', {
+				value: originalBody,
+				writable: true,
+				configurable: true,
+			} );
+		}
+
+		observeSpy.mockRestore();
+		jest.resetModules();
+	} );
+
+	it( 'should not observe when crossOriginIsolated is false', () => {
+		Object.defineProperty( window, 'crossOriginIsolated', {
+			value: false,
+			writable: true,
+			configurable: true,
+		} );
+
+		// Re-import the module to trigger the side effects
+		jest.isolateModules( () => {
+			require( '../cross-origin-isolation' );
+		} );
+
+		expect( observeSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should observe document.body when crossOriginIsolated is true and body exists', () => {
+		Object.defineProperty( window, 'crossOriginIsolated', {
+			value: true,
+			writable: true,
+			configurable: true,
+		} );
+
+		Object.defineProperty( document, 'readyState', {
+			value: 'complete',
+			writable: true,
+			configurable: true,
+		} );
+
+		// Re-import the module to trigger the side effects
+		jest.isolateModules( () => {
+			require( '../cross-origin-isolation' );
+		} );
+
+		expect( observeSpy ).toHaveBeenCalledWith( document.body, {
+			childList: true,
+			attributes: true,
+			subtree: true,
+		} );
+	} );
+
+	it( 'should wait for DOMContentLoaded when body is not available and document is loading', () => {
+		Object.defineProperty( window, 'crossOriginIsolated', {
+			value: true,
+			writable: true,
+			configurable: true,
+		} );
+
+		// Simulate document still loading
+		Object.defineProperty( document, 'readyState', {
+			value: 'loading',
+			writable: true,
+			configurable: true,
+		} );
+
+		// Temporarily remove body
+		Object.defineProperty( document, 'body', {
+			value: null,
+			writable: true,
+			configurable: true,
+		} );
+
+		const addEventListenerSpy = jest.spyOn( document, 'addEventListener' );
+
+		// Re-import the module to trigger the side effects
+		jest.isolateModules( () => {
+			require( '../cross-origin-isolation' );
+		} );
+
+		// Should not observe immediately
+		expect( observeSpy ).not.toHaveBeenCalled();
+
+		// Should have added DOMContentLoaded listener
+		expect( addEventListenerSpy ).toHaveBeenCalledWith(
+			'DOMContentLoaded',
+			expect.any( Function )
+		);
+
+		addEventListenerSpy.mockRestore();
+	} );
+
+	it( 'should not throw error when body is null and document is complete', () => {
+		Object.defineProperty( window, 'crossOriginIsolated', {
+			value: true,
+			writable: true,
+			configurable: true,
+		} );
+
+		Object.defineProperty( document, 'readyState', {
+			value: 'complete',
+			writable: true,
+			configurable: true,
+		} );
+
+		// Temporarily remove body
+		Object.defineProperty( document, 'body', {
+			value: null,
+			writable: true,
+			configurable: true,
+		} );
+
+		// This should not throw an error
+		expect( () => {
+			jest.isolateModules( () => {
+				require( '../cross-origin-isolation' );
+			} );
+		} ).not.toThrow();
+
+		// Should not attempt to observe null
+		expect( observeSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle iframe contentDocument errors gracefully', () => {
+		Object.defineProperty( window, 'crossOriginIsolated', {
+			value: true,
+			writable: true,
+			configurable: true,
+		} );
+
+		// Re-import the module
+		jest.isolateModules( () => {
+			require( '../cross-origin-isolation' );
+		} );
+
+		// Create an iframe that throws when accessing contentDocument
+		const iframe = document.createElement( 'iframe' );
+		Object.defineProperty( iframe, 'contentDocument', {
+			get() {
+				throw new Error( 'Cross-origin access denied' );
+			},
+		} );
+
+		// This should not throw an error
+		expect( () => {
+			document.body.appendChild( iframe );
+			iframe.dispatchEvent( new Event( 'load' ) );
+		} ).not.toThrow();
+	} );
+
+	it( 'should register embed preview filter when cross-origin isolated', () => {
+		Object.defineProperty( window, 'crossOriginIsolated', {
+			value: true,
+			writable: true,
+			configurable: true,
+		} );
+
+		const hasFilter = jest.spyOn(
+			require( '@wordpress/hooks' ),
+			'hasFilter'
+		);
+
+		// Re-import the module to register filters
+		jest.isolateModules( () => {
+			require( '../cross-origin-isolation' );
+		} );
+
+		// The module should register a filter when cross-origin isolated
+		// We can't easily test the filter itself without a full React environment,
+		// but we can verify the module loads without errors
+		expect( () => {
+			require( '@wordpress/hooks' ).hasFilter(
+				'editor.BlockEdit',
+				'media-experiments/disable-embed-previews'
+			);
+		} ).not.toThrow();
+
+		hasFilter.mockRestore();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #74333

Fix what I _think_ might be a race condition with the cross origin isolation code that fires for the client side media processing experiment.

## Why?

If you have the Safe SVG plugin active and the client side media processing experiment active at the same time, it turns out the post editor will fail with a WSOD. This PR is very quickly put together based on a quick investigation with Claude, so I'm not super confident that we've covered the root cause. However, the solution seems plausible enough for now, so I thought I'd open this PR as quickly as I could given the timing for WP 7.0.

All of which is to say: I'm not 100% sure I understand what's causing the bug exactly, but here's how it's being worked around:

## How?

* In the cross origin isolation code, attempt to observe the body of the document, but if not able to and the document isn't ready, wait for the DOM content to be loaded and then attempt again
* Fail silently when unable to observe `iframeNode.contentDocument`

## Testing Instructions

* Install and activate the Safe SVG plugin (this one from 10up: https://github.com/10up/safe-svg, https://wordpress.org/plugins/safe-svg/)
* Activate the client side media processing experiment from Gutenberg's experiments page
* Go to open the post editor and notice that it fails on trunk, but appears to pass with this PR
* Bonus points: Upload some images to the post and inspect the Network tab in dev tools, you should see some `sideload` requests, which indicates that the client side media processing works.


## Screenshots or screencast <!-- if applicable -->

This is the error I was seeing:

<img width="1332" height="901" alt="image" src="https://github.com/user-attachments/assets/9383d6fd-823a-485c-914b-52c6e4c7552f" />
