### PR TITLE
Tab: Fixed the color reset to ensure correctness.

### DIFF
--- a/packages/block-library/src/tabs-menu-item/controls.js
+++ b/packages/block-library/src/tabs-menu-item/controls.js
@@ -214,6 +214,13 @@ export default function Controls( {
 									customActiveBackgroundColor: value,
 								} );
 							},
+							resetAllFilter: () => {
+								setActiveBackgroundColor( undefined );
+								setAttributes( {
+									customActiveBackgroundColor: undefined,
+								} );
+							},
+							clearable: true,
 						},
 						{
 							label: __( 'Active text' ),
@@ -225,6 +232,13 @@ export default function Controls( {
 									customActiveTextColor: value,
 								} );
 							},
+							resetAllFilter: () => {
+								setActiveTextColor( undefined );
+								setAttributes( {
+									customActiveTextColor: undefined,
+								} );
+							},
+							clearable: true,
 						},
 						{
 							label: __( 'Hover background' ),
@@ -237,6 +251,13 @@ export default function Controls( {
 									customHoverBackgroundColor: value,
 								} );
 							},
+							resetAllFilter: () => {
+								setHoverBackgroundColor( undefined );
+								setAttributes( {
+									customHoverBackgroundColor: undefined,
+								} );
+							},
+							clearable: true,
 						},
 						{
 							label: __( 'Hover text' ),
@@ -248,6 +269,13 @@ export default function Controls( {
 									customHoverTextColor: value,
 								} );
 							},
+							resetAllFilter: () => {
+								setHoverTextColor( undefined );
+								setAttributes( {
+									customHoverTextColor: undefined,
+								} );
+							},
+							clearable: true,
 						},
 					] }
 					panelId={ clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixed the color reset to ensure correctness.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Tab block.
3. The tab label color is reset correctly when it is set.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


### Before

https://github.com/user-attachments/assets/2525a168-85eb-4411-8e07-0a9a368494e3



### After

https://github.com/user-attachments/assets/1bbc1223-d2be-4230-bece-6961789bb662

