### PR TITLE
Fix : Dataviews date misalignment

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -39,6 +39,10 @@ import { Stack } from '@wordpress/ui';
  */
 import RelativeDateControl from './utils/relative-date-control';
 import {
+	formatDateValue,
+	getDatePlaceholder,
+} from '../dataviews-filters/utils';
+import {
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,
 	OPERATOR_BETWEEN,
@@ -428,10 +432,11 @@ function CalendarDateControl< Item >( {
 					<InputControl
 						__next40pxDefaultSize
 						ref={ validityTargetRef }
-						type="date"
+						type="text"
 						label={ __( 'Date' ) }
 						hideLabelFromVision
-						value={ value }
+						placeholder={ getDatePlaceholder() }
+						value={ value ? formatDateValue( value ) : '' }
 						onChange={ handleManualDateChange }
 						required={ !! field.isValid?.required }
 					/>
@@ -646,10 +651,15 @@ function CalendarDateRangeControl< Item >( {
 						<InputControl
 							__next40pxDefaultSize
 							ref={ fromInputRef }
-							type="date"
+							type="text"
 							label={ __( 'From' ) }
 							hideLabelFromVision
-							value={ value?.[ 0 ] }
+							placeholder={ getDatePlaceholder() }
+							value={
+								value?.[ 0 ]
+									? formatDateValue( value[ 0 ] )
+									: ''
+							}
 							onChange={ ( newValue ) =>
 								handleManualDateChange( 'from', newValue )
 							}
@@ -658,10 +668,15 @@ function CalendarDateRangeControl< Item >( {
 						<InputControl
 							__next40pxDefaultSize
 							ref={ toInputRef }
-							type="date"
+							type="text"
 							label={ __( 'To' ) }
 							hideLabelFromVision
-							value={ value?.[ 1 ] }
+							placeholder={ getDatePlaceholder() }
+							value={
+								value?.[ 1 ]
+									? formatDateValue( value[ 1 ] )
+									: ''
+							}
 							onChange={ ( newValue ) =>
 								handleManualDateChange( 'to', newValue )
 							}

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -25,6 +25,7 @@ import { Stack } from '@wordpress/ui';
 import SearchWidget from './search-widget';
 import InputWidget from './input-widget';
 import { getOperatorByName } from '../../utils/operators';
+import { formatDateValue } from './utils';
 import type {
 	Filter,
 	NormalizedField,
@@ -215,6 +216,9 @@ export default function Filter( {
 		// or, filterInView.value can also be array
 		// for the between operator, as in [ 1, 2 ]
 		const label = filterInView.value.map( ( v ) => {
+			if ( field?.type === 'date' && typeof v === 'string' ) {
+				return formatDateValue( v );
+			}
 			const formattedValue = field?.getValueFormatted( {
 				item: { [ field.id ]: v },
 				field,
@@ -237,13 +241,20 @@ export default function Filter( {
 		];
 	} else if ( filterInView?.value !== undefined ) {
 		// otherwise, filterInView.value is a single value
-		const label =
-			field !== undefined
-				? field.getValueFormatted( {
-						item: { [ field.id ]: filterInView.value },
-						field,
-				  } )
-				: String( filterInView.value );
+		let label;
+		if (
+			field?.type === 'date' &&
+			typeof filterInView.value === 'string'
+		) {
+			label = formatDateValue( filterInView.value );
+		} else if ( field !== undefined ) {
+			label = field.getValueFormatted( {
+				item: { [ field.id ]: filterInView.value },
+				field,
+			} );
+		} else {
+			label = String( filterInView.value );
+		}
 
 		activeElements = [
 			{

--- a/packages/dataviews/src/components/dataviews-filters/utils.ts
+++ b/packages/dataviews/src/components/dataviews-filters/utils.ts
@@ -23,3 +23,50 @@ export const getCurrentValue = (
 
 	return EMPTY_ARRAY;
 };
+
+/**
+ * Formats an ISO date string (YYYY-MM-DD) to a localized date string
+ * using the browser's locale.
+ *
+ * @param value - The ISO date string to format.
+ * @return The localized date string, or the original value if parsing fails.
+ */
+export function formatDateValue( value: string ) {
+	const [ year, month, day ] = value
+		.split( '-' )
+		.map( ( n ) => parseInt( n, 10 ) );
+	if ( year && month && day ) {
+		return new Date( year, month - 1, day ).toLocaleDateString();
+	}
+	return value;
+}
+
+/**
+ * Generates a localized date placeholder string (e.g., "dd/mm/yyyy" or "mm/dd/yyyy")
+ * based on the browser's locale.
+ *
+ * @return The localized date placeholder string.
+ */
+export function getDatePlaceholder(): string {
+	const formatter = new Intl.DateTimeFormat( undefined, {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	} );
+
+	const parts = formatter.formatToParts( new Date( 2024, 0, 15 ) );
+	return parts
+		.map( ( part ) => {
+			switch ( part.type ) {
+				case 'day':
+					return 'dd';
+				case 'month':
+					return 'mm';
+				case 'year':
+					return 'yyyy';
+				default:
+					return part.value;
+			}
+		} )
+		.join( '' );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes https://github.com/WordPress/gutenberg/issues/72655
- This PR changes the date input controls in the Dataviews component from native `type="date"` inputs to `type="text"` inputs with locale-aware formatting and placeholders.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->
Native `type="date"` inputs display dates in a browser-specific format (typically `yyyy-mm-dd`) . Users expect to see dates formatted according to their locale settings (e.g., `dd/mm/yyyy` in Europe, `mm/dd/yyyy` in the US). This change provides:

1. **Locale-aware date display** - Dates are now displayed in the user's preferred locale format
2. **Better placeholder guidance** - Input fields show locale-appropriate placeholders (e.g., `dd/mm/yyyy` or `mm/dd/yyyy`)
3. **Consistent experience** - Both single date picker and date range picker now share the same formatting logic

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Changes made:

1. **`dataviews-filters/utils.ts`:**
   - `formatDateValue(value: string)` - Formats an ISO date string (`yyyy-mm-dd`) to a locale-aware display string using `toLocaleDateString()`
   - `getDatePlaceholder()` - Generates a locale-aware placeholder string (e.g., `dd/mm/yyyy`, `mm/dd/yyyy`) using `Intl.DateTimeFormat`

2. **`dataform-controls/date.tsx`:**
   - Imported the new utility functions
   - Changed `InputControl` type from `"date"` to `"text"` for both single date and date range inputs
   - Added `placeholder` prop using `getDatePlaceholder()`
   - Applied `formatDateValue()` to display dates in the input value

3. **`dataviews-filters/filter.tsx`:**
   - Imported `formatDateValue` utility
   - Applied date formatting to filter label display for active date filters
   - Handles both single date values and date range arrays

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the WordPress admin area with Gutenberg active.
2. Navigate to any view that uses Dataviews with date filters (e.g., Posts list with date filter).
3. Open a date filter and observe:
   - The date input fields should display a placeholder in your browser's locale format (e.g., `dd/mm/yyyy` for UK, `mm/dd/yyyy` for US).
   - Select a date using the calendar widget or type a date in the input.
   - The date should display in your locale format instead of `yyyy-mm-dd`.
4. Test with a date range filter:
   - Both "From" and "To" inputs should show locale-aware placeholders.
   - Selected dates should display in locale format.
5. Verify that filter chips/tags for date filters show the formatted date value.

|Before (Russia w Date selected)|After (Russia w Date selected)|
|-|-|
| <img width="283" height="345" alt="Screenshot 2026-02-17 at 2 14 18 PM" src="https://github.com/user-attachments/assets/3e482761-f1f1-4314-a31c-23573dd68eef" /> | <img width="237" height="352" alt="Screenshot 2026-02-17 at 2 13 30 PM" src="https://github.com/user-attachments/assets/58155703-4eef-4bfd-b35f-cfeef4a0af17" /> |

|Before (Russia w/ Date selected)|After (Russia w/ Date selected)|
|-|-|
| <img width="180" height="355" alt="Screenshot 2026-02-17 at 2 14 26 PM" src="https://github.com/user-attachments/assets/02da6f64-5a0e-4378-89a1-f2399b11f5b2" /> | <img width="175" height="345" alt="Screenshot 2026-02-17 at 2 13 39 PM" src="https://github.com/user-attachments/assets/07f8827e-1b9c-4ed1-bae1-69612fdc695e" /> |

