### PR TITLE
Commands: Add category property to command registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58029,6 +58029,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/warning": "file:../warning",
 				"clsx": "^2.1.1",
 				"cmdk": "^1.0.0"
 			},

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -136,6 +136,7 @@ const getTransformCommands = () =>
 					/* translators: %s: Block or block variation name. */
 					label: sprintf( __( 'Transform to %s' ), title ),
 					icon: blockIcon?.src,
+					category: 'command',
 					callback: ( { close } ) => {
 						onBlockTransform( name );
 						close();
@@ -326,6 +327,7 @@ const getQuickActionsCommands = () =>
 			commands: commands.map( ( command ) => ( {
 				...command,
 				name: 'core/block-editor/action-' + command.name,
+				category: 'command',
 				callback: ( { close } ) => {
 					command.callback();
 					close();

--- a/packages/commands/CHANGELOG.md
+++ b/packages/commands/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add `category` property to command config, used to visually differentiate commands in the Command Palette.
+
 ## 1.39.0 (2026-01-29)
 
 ## 1.38.0 (2026-01-16)

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -10,6 +10,7 @@ There are two ways to register commands: static or dynamic. Both methods receive
 -   `label`: A human-readable label
 -   `icon`: An SVG icon
 -   `callback`: A callback function that is called when the command is selected
+-   `category`: (Optional) The category of the command. See [Command categories](#command-categories) below
 -   `context`: (Optional) The context of the command
 -   `keywords`: (Optional) An array of keywords for search matching
 
@@ -36,6 +37,17 @@ At the moment, three contexts have been implemented:
 As the usage of the Command Palette expands, more contexts will be added.
 
 Attaching a command or command loader to a given context is as simple as adding the `context` property (with the right context value from the available contexts above) to the `useCommand` or `useCommandLoader` calls.
+
+## Command categories
+
+Each command can be assigned a `category` that describes what kind of action it performs. Categories are used by the Command Palette to visually differentiate commands. The following categories are available:
+
+-   `command`: Executes code or toggles a command (e.g., Add block, duplicating a block).
+-   `view`: Navigates to an area in the admin or opens a panel (e.g., "Go to: Templates").
+-   `edit`: Navigates to edit a document (e.g., editing a template, editing a page).
+-   `action`: A generic fallback for commands that don't fit the other categories. This is also the default when an invalid category is provided.
+
+If no `category` is specified, the command will have `action` set. If an invalid value is provided, a warning is emitted in development mode and the category defaults to `action`.
 
 ## WordPress Data API
 
@@ -104,6 +116,7 @@ useCommand( {
 	name: 'myplugin/my-command-name',
 	label: __( 'Add new post' ),
 	icon: plus,
+	category: 'command',
 	callback: ( { close } ) => {
 		document.location.href = 'post-new.php';
 		close();
@@ -160,6 +173,7 @@ function usePageSearchCommandLoader( { search } ) {
 					? record.title?.rendered
 					: __( '(no title)' ),
 				icon: page,
+				category: 'edit',
 				callback: ( { close } ) => {
 					const args = {
 						p: '/page',
@@ -203,6 +217,7 @@ useCommands( [
 		name: 'myplugin/add-post',
 		label: __( 'Add new post' ),
 		icon: plus,
+		category: 'command',
 		callback: ( { close } ) => {
 			document.location.href = 'post-new.php';
 			close();
@@ -212,6 +227,7 @@ useCommands( [
 		name: 'myplugin/edit-posts',
 		label: __( 'Edit posts' ),
 		icon: pencil,
+		category: 'view',
 		callback: ( { close } ) => {
 			document.location.href = 'edit.php';
 			close();

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -52,6 +52,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/warning": "file:../warning",
 		"clsx": "^2.1.1",
 		"cmdk": "^1.0.0"
 	},

--- a/packages/commands/src/hooks/use-command-loader.js
+++ b/packages/commands/src/hooks/use-command-loader.js
@@ -54,6 +54,7 @@ import { store as commandsStore } from '../store';
  *                     ? record.title?.rendered
  *                     : __( '(no title)' ),
  *                 icon: page,
+ *                 category: 'edit',
  *                 callback: ( { close } ) => {
  *                     const args = {
  * 							p: '/page',

--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -23,6 +23,7 @@ import { store as commandsStore } from '../store';
  *     name: 'myplugin/my-command-name',
  *     label: __( 'Add new post' ),
  *	   icon: plus,
+ *     category: 'command',
  *     callback: ({ close }) => {
  *         document.location.href = 'post-new.php';
  *         close();
@@ -44,6 +45,7 @@ export function useCommand( command ) {
 		registerCommand( {
 			name: command.name,
 			context: command.context,
+			category: command.category,
 			label: command.label,
 			searchLabel: command.searchLabel,
 			icon: command.icon,
@@ -59,6 +61,7 @@ export function useCommand( command ) {
 		command.searchLabel,
 		command.icon,
 		command.context,
+		command.category,
 		command.keywords,
 		command.disabled,
 		registerCommand,
@@ -81,6 +84,7 @@ export function useCommand( command ) {
  *         name: 'myplugin/add-post',
  *         label: __( 'Add new post' ),
  *         icon: plus,
+ *         category: 'command',
  *         callback: ({ close }) => {
  *             document.location.href = 'post-new.php';
  *             close();
@@ -90,6 +94,7 @@ export function useCommand( command ) {
  *         name: 'myplugin/edit-posts',
  *         label: __( 'Edit posts' ),
  *         icon: pencil,
+ *         category: 'view',
  *         callback: ({ close }) => {
  *             document.location.href = 'edit.php';
  *             close();
@@ -124,6 +129,7 @@ export function useCommands( commands ) {
 			registerCommand( {
 				name: command.name,
 				context: command.context,
+				category: command.category,
 				label: command.label,
 				searchLabel: command.searchLabel,
 				icon: command.icon,

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -1,11 +1,6 @@
 /** @typedef {import('@wordpress/keycodes').WPKeycodeModifier} WPKeycodeModifier */
 
 /**
- * WordPress dependencies
- */
-import warning from '@wordpress/warning';
-
-/**
  * @typedef {'command'|'view'|'edit'|'workflow'|'action'} WPCommandCategory
  */
 
@@ -64,14 +59,8 @@ const REGISTERABLE_CATEGORIES = new Set( [
 export function registerCommand( config ) {
 	let { category } = config;
 
+	// Defaults to 'action' if no category is provided or if the category is invalid. Future versions will emit a warning.
 	if ( ! category || ! REGISTERABLE_CATEGORIES.has( category ) ) {
-		warning(
-			'Command "' +
-				config.name +
-				'" has invalid category "' +
-				category +
-				'". Defaulting to "action".'
-		);
 		category = 'action';
 	}
 

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -1,18 +1,42 @@
 /** @typedef {import('@wordpress/keycodes').WPKeycodeModifier} WPKeycodeModifier */
 
 /**
+ * WordPress dependencies
+ */
+import warning from '@wordpress/warning';
+
+/**
+ * @typedef {'command'|'view'|'edit'|'workflow'|'action'} WPCommandCategory
+ */
+
+/**
+ * Command categories allowed via registerCommand.
+ * The 'workflow' category is reserved for internal use
+ * and cannot be registered through this API.
+ *
+ * @type {Set<WPCommandCategory>}
+ */
+const REGISTERABLE_CATEGORIES = new Set( [
+	'command',
+	'view',
+	'edit',
+	'action',
+] );
+
+/**
  * Configuration of a registered keyboard shortcut.
  *
  * @typedef {Object} WPCommandConfig
  *
- * @property {string}            name        Command name.
- * @property {string}            label       Command label.
- * @property {string=}           searchLabel Command search label.
- * @property {string=}           context     Command context.
- * @property {React.JSX.Element} icon        Command icon.
- * @property {Function}          callback    Command callback.
- * @property {boolean}           disabled    Whether to disable the command.
- * @property {string[]=}         keywords    Command keywords for search matching.
+ * @property {string}             name        Command name.
+ * @property {string}             label       Command label.
+ * @property {string=}            searchLabel Command search label.
+ * @property {string=}            context     Command context.
+ * @property {WPCommandCategory=} category    Command category.
+ * @property {React.JSX.Element}  icon        Command icon.
+ * @property {Function}           callback    Command callback.
+ * @property {boolean}            disabled    Whether to disable the command.
+ * @property {string[]=}          keywords    Command keywords for search matching.
  */
 
 /**
@@ -38,9 +62,23 @@
  * @return {Object} action.
  */
 export function registerCommand( config ) {
+	let { category } = config;
+
+	if ( ! category || ! REGISTERABLE_CATEGORIES.has( category ) ) {
+		warning(
+			'Command "' +
+				config.name +
+				'" has invalid category "' +
+				category +
+				'". Defaulting to "action".'
+		);
+		category = 'action';
+	}
+
 	return {
 		type: 'REGISTER_COMMAND',
 		...config,
+		category,
 	};
 }
 

--- a/packages/commands/src/store/reducer.js
+++ b/packages/commands/src/store/reducer.js
@@ -21,6 +21,7 @@ function commands( state = {}, action ) {
 					label: action.label,
 					searchLabel: action.searchLabel,
 					context: action.context,
+					category: action.category,
 					callback: action.callback,
 					icon: action.icon,
 					keywords: action.keywords,

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -28,6 +28,7 @@ const getViewSiteCommand = () =>
 					name: 'core/view-site',
 					label: __( 'View site' ),
 					icon: external,
+					category: 'view',
 					callback: ( { close } ) => {
 						close();
 						window.open( homeUrl, '_blank' );
@@ -54,6 +55,7 @@ export function useAdminNavigationCommands( menuCommands ) {
 				name: menuCommand.name,
 				label,
 				searchLabel: label,
+				category: 'view',
 				callback: ( { close } ) => {
 					document.location = menuCommand.url;
 					close();

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -152,6 +152,7 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 						? decodeEntities( record.title?.rendered )
 						: __( '(no title)' ),
 					icon: icons[ postType ],
+					category: 'edit',
 				};
 
 				if (
@@ -260,6 +261,7 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 							? record.title?.rendered
 							: __( '(no title)' ),
 						icon: icons[ templateType ],
+						category: 'edit',
 						callback: ( { close } ) => {
 							if ( isSiteEditor ) {
 								history.navigate(
@@ -288,6 +290,7 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 					name: 'core/edit-site/open-template-parts',
 					label: __( 'Go to: Template parts' ),
 					icon: symbolFilled,
+					category: 'view',
 					callback: ( { close } ) => {
 						if ( isSiteEditor ) {
 							history.navigate(
@@ -346,6 +349,7 @@ const getSiteEditorBasicNavigationCommands = () =>
 					name: 'core/edit-site/open-styles',
 					label: __( 'Go to: Styles' ),
 					icon: styles,
+					category: 'view',
 					callback: ( { close } ) => {
 						if ( isSiteEditor ) {
 							history.navigate( '/styles' );
@@ -365,6 +369,7 @@ const getSiteEditorBasicNavigationCommands = () =>
 					name: 'core/edit-site/open-navigation',
 					label: __( 'Go to: Navigation' ),
 					icon: navigation,
+					category: 'view',
 					callback: ( { close } ) => {
 						if ( isSiteEditor ) {
 							history.navigate( '/navigation' );
@@ -384,6 +389,7 @@ const getSiteEditorBasicNavigationCommands = () =>
 					name: 'core/edit-site/open-templates',
 					label: __( 'Go to: Templates' ),
 					icon: layout,
+					category: 'view',
 					callback: ( { close } ) => {
 						if ( isSiteEditor ) {
 							history.navigate( mapRoute( '/template' ) );
@@ -405,6 +411,7 @@ const getSiteEditorBasicNavigationCommands = () =>
 					name: 'core/edit-site/open-patterns',
 					label: __( 'Go to: Patterns' ),
 					icon: symbol,
+					category: 'view',
 					callback: ( { close } ) => {
 						if ( canCreateTemplate ) {
 							if ( isSiteEditor ) {
@@ -470,6 +477,7 @@ const getGlobalStylesOpenCssCommands = () =>
 					name: 'core/open-styles-css',
 					label: __( 'Open custom CSS' ),
 					icon: brush,
+					category: 'view',
 					callback: ( { close } ) => {
 						close();
 

--- a/packages/edit-post/src/commands/use-commands.js
+++ b/packages/edit-post/src/commands/use-commands.js
@@ -25,6 +25,7 @@ export default function useCommands() {
 			? __( 'Exit fullscreen' )
 			: __( 'Enter fullscreen' ),
 		icon: fullscreen,
+		category: 'command',
 		callback: ( { close } ) => {
 			toggle( 'core/edit-post', 'fullscreenMode' );
 			close();

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -103,6 +103,7 @@ const getEditorCommandLoader = () =>
 			name: 'core/open-shortcut-help',
 			label: __( 'Keyboard shortcuts' ),
 			icon: keyboard,
+			category: 'view',
 			callback: ( { close } ) => {
 				close();
 				openModal( 'editor/keyboard-shortcut-help' );
@@ -114,6 +115,7 @@ const getEditorCommandLoader = () =>
 			label: isDistractionFree
 				? __( 'Exit Distraction free' )
 				: __( 'Enter Distraction free' ),
+			category: 'command',
 			callback: ( { close } ) => {
 				toggleDistractionFree();
 				close();
@@ -123,6 +125,7 @@ const getEditorCommandLoader = () =>
 		commands.push( {
 			name: 'core/open-preferences',
 			label: __( 'Editor preferences' ),
+			category: 'view',
 			callback: ( { close } ) => {
 				close();
 				openModal( 'editor/preferences' );
@@ -134,6 +137,7 @@ const getEditorCommandLoader = () =>
 			label: isFocusMode
 				? __( 'Exit Spotlight mode' )
 				: __( 'Enter Spotlight mode' ),
+			category: 'command',
 			callback: ( { close } ) => {
 				toggleSpotlightMode();
 				close();
@@ -146,6 +150,7 @@ const getEditorCommandLoader = () =>
 				? __( 'Close List View' )
 				: __( 'Open List View' ),
 			icon: listView,
+			category: 'command',
 			callback: ( { close } ) => {
 				setIsListViewOpened( ! isListViewOpen );
 				close();
@@ -164,6 +169,7 @@ const getEditorCommandLoader = () =>
 		commands.push( {
 			name: 'core/toggle-top-toolbar',
 			label: __( 'Top toolbar' ),
+			category: 'command',
 			callback: ( { close } ) => {
 				toggleTopToolbar();
 				close();
@@ -178,6 +184,7 @@ const getEditorCommandLoader = () =>
 						? __( 'Open code editor' )
 						: __( 'Exit code editor' ),
 				icon: code,
+				category: 'command',
 				callback: ( { close } ) => {
 					switchEditorMode(
 						editorMode === 'visual' ? 'text' : 'visual'
@@ -192,6 +199,7 @@ const getEditorCommandLoader = () =>
 			label: showBlockBreadcrumbs
 				? __( 'Hide block breadcrumbs' )
 				: __( 'Show block breadcrumbs' ),
+			category: 'command',
 			callback: ( { close } ) => {
 				toggle( 'core', 'showBlockBreadcrumbs' );
 				close();
@@ -211,6 +219,7 @@ const getEditorCommandLoader = () =>
 			name: 'core/open-settings-sidebar',
 			label: __( 'Show or hide the Settings panel' ),
 			icon: isRTL() ? drawerLeft : drawerRight,
+			category: 'command',
 			callback: ( { close } ) => {
 				const activeSidebar = getActiveComplementaryArea( 'core' );
 				close();
@@ -226,6 +235,7 @@ const getEditorCommandLoader = () =>
 			name: 'core/open-block-inspector',
 			label: __( 'Show or hide the Block settings panel' ),
 			icon: blockDefault,
+			category: 'command',
 			callback: ( { close } ) => {
 				const activeSidebar = getActiveComplementaryArea( 'core' );
 				close();
@@ -243,6 +253,7 @@ const getEditorCommandLoader = () =>
 				? __( 'Disable pre-publish checks' )
 				: __( 'Enable pre-publish checks' ),
 			icon: formatListBullets,
+			category: 'command',
 			callback: ( { close } ) => {
 				close();
 				toggle( 'core', 'isPublishSidebarEnabled' );
@@ -263,6 +274,7 @@ const getEditorCommandLoader = () =>
 				name: 'core/preview-link',
 				label: __( 'Preview in a new tab' ),
 				icon: external,
+				category: 'view',
 				callback: async ( { close } ) => {
 					close();
 					const postId = getCurrentPostId();
@@ -294,6 +306,7 @@ const getEditedEntityContextualCommands = () =>
 				name: 'core/rename-pattern',
 				label: __( 'Rename pattern' ),
 				icon: pencil,
+				category: 'edit',
 				callback: ( { close } ) => {
 					openModal( patternRenameModalName );
 					close();
@@ -303,6 +316,7 @@ const getEditedEntityContextualCommands = () =>
 				name: 'core/duplicate-pattern',
 				label: __( 'Duplicate pattern' ),
 				icon: symbol,
+				category: 'command',
 				callback: ( { close } ) => {
 					openModal( patternDuplicateModalName );
 					close();
@@ -367,6 +381,7 @@ const getPageContentFocusCommands = () =>
 					decodeEntities( template.title )
 				),
 				icon: layout,
+				category: 'edit',
 				callback: ( { close } ) => {
 					onNavigateToEntityRecord( {
 						postId: templateId,
@@ -382,6 +397,7 @@ const getPageContentFocusCommands = () =>
 				name: 'core/switch-to-previous-entity',
 				label: __( 'Go back' ),
 				icon: page,
+				category: 'view',
 				callback: ( { close } ) => {
 					goBack();
 					close();
@@ -438,6 +454,7 @@ const getManipulateDocumentCommands = () =>
 				name: 'core/reset-template',
 				label,
 				icon: isRTL() ? rotateRight : rotateLeft,
+				category: 'command',
 				callback: ( { close } ) => {
 					revertTemplate( template );
 					close();


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/75616

## Summary

- Adds a `category` field to the command registration API (`command`, `view`, `edit`, `action`)
- Validates categories on registration using `@wordpress/warning`, defaulting invalid values to `action`
- Reserves the `workflow` category for a future dedicated API (rejected by `registerCommand`)
- Annotates all existing core commands with appropriate categories
- Documents the new option in the package README and JSDoc examples

## Categories

| Category | Description | Examples |
|----------|-------------|---------|
| `command` | Executes code or toggles a setting | Toggle fullscreen, duplicate block, transform block |
| `view` | Navigates to an admin area or opens a panel | "Go to: Templates", preview in new tab |
| `edit` | Navigates to edit a document | Edit template, rename pattern |
| `action` | Generic fallback (default for invalid values) | — |
| `workflow` | Added but reserved to workflows | — |

## Testing steps

 Since we're not consuming this one yet, the goal is to make sure there are no console warnings (all core entities are registered) and that code still works fine.

The main review should focus on the semantics of this PR (naming, shapes, placement, validation).