### PR TITLE
Notes: Fix block toolbar click action

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -80,7 +80,7 @@ const CommentAvatarIndicator = ( { onClick, thread } ) => {
 			<ToolbarButton
 				className="comment-avatar-indicator"
 				label={ __( 'View notes' ) }
-				onClick={ onClick }
+				onClick={ () => onClick() }
 				showTooltip
 			>
 				<HStack spacing="1">


### PR DESCRIPTION
## What?
A quick follow-up to #75566.

Fixed a minor regression: clicking "View notes" in the block toolbar wasn't handling note selection correctly. The `openTheSidebar` function now accepts an optional block `clientId` and shouldn't be passed directly as `onClick` callback.

## Testing Instructions
1. Open a post with notes.
2. Select a block with a note.
3. Click on the "View notes" indicator in the block toolbar.
4. Focus should move to the note.

### Testing Instructions for Keyboard
Same.