### PR TITLE
Tabs: Sanitize tab_id

### DIFF
--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -21,7 +21,7 @@
 function block_core_tabs_menu_item_render_callback( array $attributes, string $content, \WP_Block $block ): string {
 	// Get tab-specific context
 	$tab_index = $block->context['core/tabs-menu-item-index'] ?? 0;
-	$tab_id    = $block->context['core/tabs-menu-item-id'] ?? '';
+	$tab_id    = sanitize_html_class( $block->context['core/tabs-menu-item-id'] ?? '' );
 	$tab_label = $block->context['core/tabs-menu-item-label'] ?? '';
 
 	if ( empty( $tab_id ) ) {

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -21,7 +21,7 @@
 function block_core_tabs_menu_item_render_callback( array $attributes, string $content, \WP_Block $block ): string {
 	// Get tab-specific context
 	$tab_index = $block->context['core/tabs-menu-item-index'] ?? 0;
-	$tab_id    = sanitize_html_class( $block->context['core/tabs-menu-item-id'] ?? '' );
+	$tab_id    = $block->context['core/tabs-menu-item-id'] ?? '';
 	$tab_label = $block->context['core/tabs-menu-item-label'] ?? '';
 
 	if ( empty( $tab_id ) ) {
@@ -36,8 +36,8 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 		$tag_processor->remove_attribute( 'hidden' );
 
 		// Set tab-specific attributes
-		$tag_processor->set_attribute( 'id', 'tab__' . $tab_id );
-		$tag_processor->set_attribute( 'aria-controls', $tab_id );
+		$tag_processor->set_attribute( 'id', esc_attr( 'tab__' . $tab_id ) );
+		$tag_processor->set_attribute( 'aria-controls', esc_attr( $tab_id ) );
 
 		// Add IAPI directives
 		$tag_processor->set_attribute( 'data-wp-on--click', 'actions.handleTabClick' );

--- a/packages/block-library/src/tabs-menu-item/index.php
+++ b/packages/block-library/src/tabs-menu-item/index.php
@@ -36,8 +36,8 @@ function block_core_tabs_menu_item_render_callback( array $attributes, string $c
 		$tag_processor->remove_attribute( 'hidden' );
 
 		// Set tab-specific attributes
-		$tag_processor->set_attribute( 'id', esc_attr( 'tab__' . $tab_id ) );
-		$tag_processor->set_attribute( 'aria-controls', esc_attr( $tab_id ) );
+		$tag_processor->set_attribute( 'id', 'tab__' . $tab_id );
+		$tag_processor->set_attribute( 'aria-controls', $tab_id );
 
 		// Add IAPI directives
 		$tag_processor->set_attribute( 'data-wp-on--click', 'actions.handleTabClick' );

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -40,7 +40,7 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
 
 					$tabs_list[] = array(
 						'id'    => esc_attr( $tab_id ),
-						'label' => esc_html( (string) $tab_label ),
+						'label' => $tab_label,
 						'index' => $tab_index,
 					);
 					++$tab_index;

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -34,7 +34,6 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
 							$tab_id = $tag_processor->get_attribute( 'id' ) ?? '';
 						}
 					}
-
 					if ( empty( $tab_id ) ) {
 						$tab_id = 'tab-' . $tab_index;
 					}

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -35,14 +35,12 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
 						}
 					}
 
-					$tab_id = sanitize_html_class( $tab_id );
-
 					if ( empty( $tab_id ) ) {
 						$tab_id = 'tab-' . $tab_index;
 					}
 
 					$tabs_list[] = array(
-						'id'    => $tab_id,
+						'id'    => esc_attr( $tab_id ),
 						'label' => esc_html( (string) $tab_label ),
 						'index' => $tab_index,
 					);

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -34,6 +34,9 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
 							$tab_id = $tag_processor->get_attribute( 'id' ) ?? '';
 						}
 					}
+
+					$tab_id = sanitize_html_class( $tab_id );
+
 					if ( empty( $tab_id ) ) {
 						$tab_id = 'tab-' . $tab_index;
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Adds input sanitization to the Tabs Menu Item block's render callback to prevent injection vulnerabilities.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `core/tabs-menu-item` block's PHP render callback was outputting user-controlled data without sanitization.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Wraps the `tab_id` in `esc_attr`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert a Tabs block
2. Add more than one tab
3. Ensure the correct tab ID is used in the tabs markup for each tab
4. Ensure the Tabs block still works as expected