### PR TITLE
Fix Overlay core patterns not showing on design tab

### DIFF
--- a/packages/editor/src/components/post-transform-panel/hooks.js
+++ b/packages/editor/src/components/post-transform-panel/hooks.js
@@ -50,8 +50,9 @@ function filterPatterns( patterns, template ) {
 
 	// Filter out core/directory patterns not included in theme.json.
 	// Exception: navigation-overlay patterns should always show core patterns.
+	// We only want them to show here, we want them excluded everywhere else
+	// to avoid showing them in the inserter or the patterns page.
 	const filterOutExcludedPatternSources = ( pattern ) => {
-		// Allow core patterns for navigation-overlay template parts
 		if (
 			template.area === 'navigation-overlay' &&
 			pattern.blockTypes?.includes(

--- a/packages/editor/src/components/post-transform-panel/hooks.js
+++ b/packages/editor/src/components/post-transform-panel/hooks.js
@@ -49,8 +49,19 @@ function filterPatterns( patterns, template ) {
 		index === items.findIndex( ( item ) => currentItem.name === item.name );
 
 	// Filter out core/directory patterns not included in theme.json.
-	const filterOutExcludedPatternSources = ( pattern ) =>
-		! EXCLUDED_PATTERN_SOURCES.includes( pattern.source );
+	// Exception: navigation-overlay patterns should always show core patterns.
+	const filterOutExcludedPatternSources = ( pattern ) => {
+		// Allow core patterns for navigation-overlay template parts
+		if (
+			template.area === 'navigation-overlay' &&
+			pattern.blockTypes?.includes(
+				'core/template-part/navigation-overlay'
+			)
+		) {
+			return true;
+		}
+		return ! EXCLUDED_PATTERN_SOURCES.includes( pattern.source );
+	};
 
 	// Looks for patterns that have the same template type as the current template,
 	// or have a block type that matches the current template area.

--- a/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
+++ b/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
@@ -219,12 +219,11 @@ test.describe( 'Navigation Overlay Template Part', () => {
 			} );
 			await expect( designTab ).toBeVisible();
 
-			await designTab.click();
+			await expect( page.getByRole( 'option' ).first() ).toBeVisible();
 
-			// Find and click the "Overlay with site info and CTA" pattern
-			const ctaPattern = page
-				.getByRole( 'option' )
-				.filter( { hasText: /site info and CTA/i } );
+			const ctaPattern = page.getByRole( 'option', {
+				name: /Overlay with site info and CTA/i,
+			} );
 			await expect( ctaPattern ).toBeVisible();
 			await ctaPattern.click();
 

--- a/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
+++ b/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
@@ -246,10 +246,8 @@ test.describe( 'Navigation Overlay Template Part', () => {
 			} );
 			await openMenuButton.click();
 
-			const siteTitleFrontend = page.getByRole( 'link', {
-				name: new RegExp( '.+' ),
-			} );
-			await expect( siteTitleFrontend.first() ).toBeVisible();
+			const ctaButton = page.getByText( 'Get started today!' );
+			await expect( ctaButton ).toBeVisible();
 		} );
 	} );
 } );

--- a/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
+++ b/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
@@ -207,5 +207,50 @@ test.describe( 'Navigation Overlay Template Part', () => {
 			await closeButtons.last().click();
 			await expect( openMenuButton ).toBeVisible();
 		} );
+
+		test( 'As a site builder, I want to insert a core navigation overlay pattern with CTA and see it on the frontend', async ( {
+			page,
+			editor,
+		} ) => {
+			await page.getByRole( 'tab', { name: 'Template Part' } ).click();
+
+			const designTab = page.getByRole( 'button', {
+				name: 'Design',
+			} );
+			await expect( designTab ).toBeVisible();
+
+			await designTab.click();
+
+			// Find and click the "Overlay with site info and CTA" pattern
+			const ctaPattern = page
+				.getByRole( 'option' )
+				.filter( { hasText: /site info and CTA/i } );
+			await expect( ctaPattern ).toBeVisible();
+			await ctaPattern.click();
+
+			const siteTitleBlock = editor.canvas.getByRole( 'document', {
+				name: /Block: Site Title/i,
+			} );
+			await expect( siteTitleBlock ).toBeVisible();
+
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Back', exact: true } )
+				.click();
+
+			await editor.saveSiteEditorEntities();
+
+			await page.goto( '/' );
+
+			const openMenuButton = page.getByRole( 'button', {
+				name: 'Open menu',
+			} );
+			await openMenuButton.click();
+
+			const siteTitleFrontend = page.getByRole( 'link', {
+				name: new RegExp( '.+' ),
+			} );
+			await expect( siteTitleFrontend.first() ).toBeVisible();
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/75510

Built on top of https://github.com/WordPress/gutenberg/pull/75581

Fixes navigation overlay core patterns not appearing in the Design panel when editing navigation-overlay template parts.

## Why?

Navigation overlay patterns registered with source: 'core' in lib/overlay-patterns.php were not appearing in the Design panel of the template part editor. These core patterns provide essential overlay designs that should always be available regardless of the active theme.

## How?

The filterPatterns function was filtering out ALL patterns with source: 'core' via the   EXCLUDED_PATTERN_SOURCES constant. While this filtering is intentional for most contexts (to show theme-specific patterns), navigation-overlay template parts are an exception, they should always show the core overlay patterns since themes typically don't provide their own.

Added an exception to the filterOutExcludedPatternSources function to allow core patterns specifically for navigation-overlay template parts.

## Testing Instructions

Before

1. Activate a theme that doesn't provide navigation overlay patterns (e.g., Empty Theme)
2. Go to Site Editor → Patterns → Template Parts
3. Create a navigation block with overlayMenu: 'always'
4. Click "Create overlay"
5. In the Template Part inspector sidebar, open the Design panel
6. ❌ Only see theme patterns (if any), no core patterns

After

1. Follow the same steps
2. ✅ See 5 core navigation overlay patterns in the Design panel:
   - Navigation Overlay
   - Overlay with black background
   - Overlay with orange background
   - Overlay with site info and CTA
   - Overlay with centered navigation
3. Select any pattern and verify it inserts correctly
4. Save and verify it appears on the frontend when opening the navigation overlay
5. Run the new e2e test:
`npm run test:e2e -- test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js`

<img width="1492" height="952" alt="Screenshot 2026-02-17 at 13 00 14" src="https://github.com/user-attachments/assets/bec1e1c5-a9f2-43cb-9621-34aa5d66f2da" />
