### PR TITLE
Tabs: Inherit text color for tabs-menu-item blocks

### DIFF
--- a/packages/block-library/src/tabs-menu-item/style.scss
+++ b/packages/block-library/src/tabs-menu-item/style.scss
@@ -1,5 +1,6 @@
 .wp-block-tabs-menu-item {
 	box-sizing: border-box;
+	color: inherit;
 	display: block;
 	width: max-content;
 	text-decoration: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The Tabs Menu Item block uses a button, so we need to explicitly tell it to inherit text color from the parent.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
So that the text color matches the theme.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add:

```
color: inherit;
```

## Testing Instructions
1. Select a dark theme
2. Add a tabs block
3. Add two tabs
4. Confirm that the tabs have the same color as the rest of the site.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="757" height="199" alt="Screenshot 2026-02-17 at 12 53 28" src="https://github.com/user-attachments/assets/8113edd0-045b-45ef-b7e0-f1ee50b091cf" /> | <img width="480" height="168" alt="Screenshot 2026-02-17 at 12 52 57" src="https://github.com/user-attachments/assets/26a9c2ed-f7d8-4478-a0eb-cd36bb591c80" /> |

