### PR TITLE
PHP-Only Block Registration: Remove client-side schema validation

### DIFF
--- a/lib/compat/wordpress-7.0/auto-register.php
+++ b/lib/compat/wordpress-7.0/auto-register.php
@@ -73,6 +73,11 @@ function gutenberg_mark_auto_generate_control_attributes( array $args ): array {
 		if ( isset( $attr_schema['role'] ) && 'local' === $attr_schema['role'] ) {
 			continue;
 		}
+		// Skip unsupported types (only 'string', 'number', 'integer', 'boolean' are supported).
+		$type = $attr_schema['type'] ?? null;
+		if ( ! in_array( $type, array( 'string', 'number', 'integer', 'boolean' ), true ) ) {
+			continue;
+		}
 		$args['attributes'][ $attr_key ]['autoGenerateControl'] = true;
 	}
 

--- a/packages/block-editor/src/hooks/generate-fields-from-attributes.js
+++ b/packages/block-editor/src/hooks/generate-fields-from-attributes.js
@@ -4,6 +4,11 @@
  * This utility enables PHP-only blocks to have auto-generated inspector controls
  * by converting block attribute definitions into DataForm field definitions.
  *
+ * Attribute schema validation is performed by `wp_mark_auto_generate_control_attributes()`
+ * function, which marks eligible attributes with the `autoGenerateControl` flag. This
+ * function processes only those pre-validated attributes.
+ * See https://github.com/WordPress/wordpress-develop/blob/8f6d31266deecd7eea258bd3d45597355cce13d0/src/wp-includes/block-supports/auto-register.php#L30
+ *
  * @param {Object} attributes - Block type attributes from block registration
  * @return {{ fields: Array, form: Object }} fieldsKey and formKey values
  */
@@ -38,13 +43,6 @@ export function generateFieldsFromAttributes( attributes ) {
  */
 function createFieldFromAttribute( name, def ) {
 	const type = def.type;
-
-	// Skip unsupported types (object, union types, etc.)
-	// Supported: string→text, number, integer, boolean (1:1 with DataForm)
-	if ( ! [ 'string', 'number', 'integer', 'boolean' ].includes( type ) ) {
-		return null;
-	}
-
 	const field = {
 		id: name,
 		label: def.label || name,

--- a/packages/block-editor/src/hooks/test/generate-fields-from-attributes.js
+++ b/packages/block-editor/src/hooks/test/generate-fields-from-attributes.js
@@ -117,33 +117,6 @@ describe( 'generateFieldsFromAttributes', () => {
 		} );
 	} );
 
-	it( 'should skip unsupported attribute types', () => {
-		const attributes = markForAutoInspectorControl( {
-			message: {
-				type: 'string',
-				default: 'Hello',
-			},
-			items: {
-				type: 'array',
-				default: [],
-			},
-			config: {
-				type: 'object',
-				default: {},
-			},
-			unionType: {
-				type: [ 'string', 'null' ],
-				default: null,
-			},
-		} );
-
-		const result = generateFieldsFromAttributes( attributes );
-
-		// Only string attribute should generate a field
-		expect( result.fields ).toHaveLength( 1 );
-		expect( result.fields[ 0 ].id ).toBe( 'message' );
-	} );
-
 	it( 'should return empty fields array for empty attributes', () => {
 		const result = generateFieldsFromAttributes( {} );
 

--- a/phpunit/block-supports/auto-register-test.php
+++ b/phpunit/block-supports/auto-register-test.php
@@ -130,7 +130,7 @@ class Tests_Block_Supports_Auto_Register_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$result = wp_mark_auto_generate_control_attributes( $settings );
+		$result = gutenberg_mark_auto_generate_control_attributes( $settings );
 
 		$this->assertTrue( $result['attributes']['text']['autoGenerateControl'] );
 		$this->assertTrue( $result['attributes']['price']['autoGenerateControl'] );

--- a/phpunit/block-supports/auto-register-test.php
+++ b/phpunit/block-supports/auto-register-test.php
@@ -109,4 +109,36 @@ class Tests_Block_Supports_Auto_Register_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $settings, $result );
 	}
+
+	/**
+	 * Tests that only allowed attributes are marked.
+	 */
+	public function test_excludes_unsupported_types() {
+		$settings = array(
+			'supports'   => array( 'autoRegister' => true ),
+			'attributes' => array(
+				// Supported types
+				'text'     => array( 'type' => 'string' ),
+				'price'    => array( 'type' => 'number' ),
+				'count'    => array( 'type' => 'integer' ),
+				'enabled'  => array( 'type' => 'boolean' ),
+				// Unsupported types
+				'metadata' => array( 'type' => 'object' ),
+				'items'    => array( 'type' => 'array' ),
+				'config'   => array( 'type' => 'null' ),
+				'unknown'  => array( 'type' => 'unknown' ),
+			),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertTrue( $result['attributes']['text']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['price']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['count']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['enabled']['autoGenerateControl'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['metadata'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['items'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['config'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['unknown'] );
+	}
 }


### PR DESCRIPTION
- Follow-up on #75543
- See https://github.com/WordPress/gutenberg/pull/75543#issuecomment-3913887421

## What?

This PR moves the attribute type checking to the server side and removes the check on the client side.

This PR backports the changes made in [the core PR](https://github.com/WordPress/wordpress-develop/pull/10932) to Gutenberg, and also includes unit test updates.

## Why?

To improve code maintainability.

## Testing Instructions

Register a block using the following code. This block contains disallowed attributes.

<details><summary>Details</summary>

```php
function gutenberg_register_php_only_blocks() {
	register_block_type(
		'my-plugin/example',
		array(
			'title'           => 'My Example Block',
			'attributes'      => array(
				'title'         => array(
					'type'    => 'string',
					'default' => 'Hello World',
				),
				'count'         => array(
					'type'    => 'integer',
					'default' => 5,
				),
				'enabled'       => array(
					'type'    => 'boolean',
					'default' => true,
				),
				'size'          => array(
					'type'    => 'string',
					'enum'    => array( 'small', 'medium', 'large' ),
					'default' => 'medium',
				),
				// This should be skipped (role='local').
				'internalState' => array(
					'type'    => 'string',
					'role'    => 'local',
					'default' => 'hidden',
				),
				// This should be skipped (unsupported type: 'array').
				'items'         => array(
					'type'    => 'array',
					'default' => array(),
				),
				// This should be skipped (unsupported type: 'object').
				'metadata'      => array(
					'type'    => 'object',
					'default' => array(),
				),
				// This should be skipped (no type specified).
				'noType'        => array(
					'default' => 'test',
				),
			),
			'render_callback' => function ( $attributes ) {
				return sprintf(
					'<div>%s: %d items (%s)</div>',
					esc_html( $attributes['title'] ),
					$attributes['count'],
					$attributes['size']
				);
			},
			'supports'        => array(
				'autoRegister' => true,
			),
		)
	);
}

add_action( 'init', 'gutenberg_register_php_only_blocks' );
```

</details> 

Insert the block into a post. Verify that the sidebar controls only display with the allowed attributes, i.e., `title`, `count`, `enabled`, and `size`: