### PR TITLE
Remove useEffect guard rail to enforce minimum width.

### DIFF
--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -25,11 +25,10 @@ import {
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 	getDimensionsClassesAndStyles as useDimensionsProps,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -40,12 +39,9 @@ import { CustomInserterModal } from './components';
 import { unlock } from '../lock-unlock';
 
 export function Edit( { attributes, setAttributes } ) {
-	const { icon, ariaLabel, style } = attributes;
+	const { icon, ariaLabel } = attributes;
 
 	const [ isInserterOpen, setInserterOpen ] = useState( false );
-
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
 
 	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
 
@@ -57,30 +53,6 @@ export function Edit( { attributes, setAttributes } ) {
 	const allIcons = useSelect( ( select ) => {
 		return unlock( select( coreDataStore ) ).getIcons();
 	}, [] );
-
-	// Is the width value is 0, reset it to the minimum value.
-	useEffect( () => {
-		if (
-			! style?.dimensions?.width ||
-			parseFloat( style?.dimensions?.width ) === 0
-		) {
-			// To avoid interfering with undo/redo operations any changes in this
-			// effect must not make history and should be preceded by
-			// `__unstableMarkNextChangeAsNotPersistent()`.
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				style: {
-					...style,
-					dimensions: { ...style?.dimensions, width: '12px' },
-				},
-			} );
-		}
-	}, [
-		icon,
-		style,
-		setAttributes,
-		__unstableMarkNextChangeAsNotPersistent,
-	] );
 
 	const iconToDisplay =
 		allIcons?.length > 0


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75604 

This PR removes the useEffect guard rail to enforce a minimum width for the icon block. 

## Why?
With this approach it is not possible to actually reset the control which is a strange experience for the user. This kind of setting should be done at the Block Supports level.

## How?
Removed the useEffect that was being run when the user changes the width value.

## Testing Instructions
1. Insert block
2. Change the Width via the control.
3. Reset the value . The Icon will appear very large.
4. Confirm that the value is cleared and not still resettable.

## Screenshots or screencast <!-- if applicable -->
One thing to note that after resetting the value, the icon appears very large in the editor until the user changes the value again.


https://github.com/user-attachments/assets/97ba958f-9666-41d3-b08e-8e122ff8a91a

