### PR TITLE
Block Bindings: Expose `featuredMedia` information from `core/post-data` source

### DIFF
--- a/backport-changelog/7.0/10737.md
+++ b/backport-changelog/7.0/10737.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10737
+
+* https://github.com/WordPress/gutenberg/pull/74610

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -40,7 +40,7 @@ function gutenberg_block_bindings_post_data_get_value_for_featured_image( $value
 	}
 
 	if ( 'featured_media.url' === $source_args['field'] ) {
-		if ( 'core/cover' === $block_instance->name ) {
+		if ( 'core/cover' === $block_instance->name && isset( $block_instance->attributes['sizeSlug'] ) ) {
 			$size_slug = $block_instance->attributes['sizeSlug'];
 			return get_the_post_thumbnail_url( $post_id, $size_slug );
 		}

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -21,9 +21,9 @@
  * @return mixed The value computed for the source.
  */
 function gutenberg_block_bindings_post_data_get_value_for_featured_image( mixed $value, string $name, array $source_args, WP_Block $block_instance ) {
-	if ( $name !== 'core/post-data' ) {
-        return $value;
-    }
+	if ( 'core/post-data' !== $name ) {
+		return $value;
+	}
 	if ( $value ) {
 		return $value;
 	}

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -42,9 +42,10 @@ function gutenberg_block_bindings_post_data_get_value_for_featured_image( $value
 	if ( 'featured_media.url' === $source_args['field'] ) {
 		if ( 'core/cover' === $block_instance->name ) {
 			$size_slug = $block_instance->attributes['sizeSlug'];
+			return get_the_post_thumbnail_url( $post_id, $size_slug );
 		}
 
-		return get_the_post_thumbnail_url( $post_id, $size_slug ?? null );
+		return get_the_post_thumbnail_url( $post_id );
 	}
 }
 add_action( 'block_bindings_source_value', 'gutenberg_block_bindings_post_data_get_value_for_featured_image', 10, 4 );

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -24,7 +24,12 @@ function gutenberg_block_bindings_post_data_get_value_for_featured_image( $value
 	if ( 'core/post-data' !== $name ) {
 		return $value;
 	}
+	// Return early if we already have a value.
 	if ( $value ) {
+		return $value;
+	}
+	// Return early if no field is specified.
+	if ( empty( $source_args['field'] ) ) {
 		return $value;
 	}
 

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Post Data source for the block bindings.
+ *
+ * @since 7.0.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+/**
+ * Gets value for Post Data source.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param mixed    $value          The computed value for the source.
+ * @param string   $name           The name of the source.
+ * @param array    $source_args    Array containing source arguments used to look up the override value.
+ *                                 Example: array( "field" => "foo" ).
+ * @param WP_Block $block_instance The block instance.
+ * @return mixed The value computed for the source.
+ */
+function gutenberg_block_bindings_post_data_get_value_for_featured_image( mixed $value, string $name, array $source_args, WP_Block $block_instance ) {
+	if ( $name !== 'core/post-data' ) {
+        return $value;
+    }
+	if ( $value ) {
+		return $value;
+	}
+
+	$post_id = $block_instance->context['postId'] ?? null;
+
+	if ( 'featured_media.id' === $source_args['field'] ) {
+		return get_post_thumbnail_id( $post_id );
+	}
+
+	if ( 'featured_media.url' === $source_args['field'] ) {
+		return get_the_post_thumbnail_url( $post_id, $source_args['size'] ?? null );
+	}
+}
+add_action( 'block_bindings_source_value', 'gutenberg_block_bindings_post_data_get_value_for_featured_image', 10, 4 );

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -40,7 +40,11 @@ function gutenberg_block_bindings_post_data_get_value_for_featured_image( $value
 	}
 
 	if ( 'featured_media.url' === $source_args['field'] ) {
-		return get_the_post_thumbnail_url( $post_id, $source_args['size'] ?? null );
+		if ( 'core/cover' === $block_instance->name ) {
+			$size_slug = $block_instance->attributes['sizeSlug'];
+		}
+
+		return get_the_post_thumbnail_url( $post_id, $size_slug ?? null );
 	}
 }
 add_action( 'block_bindings_source_value', 'gutenberg_block_bindings_post_data_get_value_for_featured_image', 10, 4 );

--- a/lib/compat/wordpress-7.0/post-data-block-bindings.php
+++ b/lib/compat/wordpress-7.0/post-data-block-bindings.php
@@ -20,7 +20,7 @@
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
-function gutenberg_block_bindings_post_data_get_value_for_featured_image( mixed $value, string $name, array $source_args, WP_Block $block_instance ) {
+function gutenberg_block_bindings_post_data_get_value_for_featured_image( $value, string $name, array $source_args, WP_Block $block_instance ) {
 	if ( 'core/post-data' !== $name ) {
 		return $value;
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -73,6 +73,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.0/template-activate.php';
 	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.0/global-styles.php';
+	require __DIR__ . '/compat/wordpress-7.0/post-data-block-bindings.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -18,6 +18,16 @@ const postDataFields = [
 		type: 'string',
 	},
 	{
+		label: __( 'Post Featured Media ID' ),
+		args: { field: 'featured_media.id' },
+		type: 'number',
+	},
+	{
+		label: __( 'Post Featured Media URL' ),
+		args: { field: 'featured_media.url' },
+		type: 'string',
+	},
+	{
 		label: __( 'Post Modified Date' ),
 		args: { field: 'modified' },
 		type: 'string',
@@ -56,7 +66,8 @@ export default {
 			postType = context?.postType;
 		}
 
-		const { getEditedEntityRecord } = select( coreDataStore );
+		const { getEditedEntityRecord, getEntityRecord } =
+			select( coreDataStore );
 		const entityDataValues = getEditedEntityRecord(
 			'postType',
 			postType,
@@ -65,6 +76,24 @@ export default {
 
 		const newValues = {};
 		for ( const [ attributeName, binding ] of Object.entries( bindings ) ) {
+			if ( binding.args.field === 'featured_media.id' ) {
+				newValues[ attributeName ] = entityDataValues?.featured_media;
+				continue;
+			}
+
+			if ( binding.args.field === 'featured_media.url' ) {
+				const featuredMedia = getEntityRecord(
+					'postType',
+					'attachment',
+					entityDataValues?.featured_media,
+					{
+						context: 'view',
+					}
+				);
+				newValues[ attributeName ] = featuredMedia?.source_url;
+				continue;
+			}
+
 			const postDataField = postDataFields.find(
 				( field ) => field.args.field === binding.args.field
 			);
@@ -139,12 +168,7 @@ export default {
 
 		return true;
 	},
-	getFieldsList( { context, select } ) {
-		const selectedBlock = select( blockEditorStore ).getSelectedBlock();
-		if ( selectedBlock?.name !== 'core/post-date' ) {
-			return [];
-		}
-
+	getFieldsList( { context } ) {
 		if ( ! context || ! context.postId || ! context.postType ) {
 			return [];
 		}


### PR DESCRIPTION
## What?
WIP, spun off from https://github.com/WordPress/gutenberg/pull/74610.

Add two new fields, `featured_media.id` and `featured_media.url` (which reflect the given post's featured image) to the `core/post-data` source.

## Why?
Essentially, to introduce a syntax that supports composite data types in block bindings, e.g.

```json
{
	"metadata": {
		"bindings": {
			"id": {
				"source": "core/post-data",
				"args": { "field": "featured_media.id" }
			},
			"href": {
				"source": "core/post-data",
				"args": { "field": "featured_media.url" }
			}
		}
	}
}
```

## How?
(By simply adding those new fields to the existing Block Bindings source.)

## Testing Instructions
Verify that it's possible to bind an Image block's `url` and `id` attributes to the newly added `core/post-data` fields, and that the block then correctly shows the post's featured image (both in the editor and on the frontend).

## TODO

- [ ] Change `featured_media` to `featuredMedia`?
- [ ] Need to hide incompatible data types. Previously done by only enabling the `core/post-data` source for the Date block. Needs a different solution now.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
