### PR TITLE
Fix remote theme patterns not rendering on the front end

### DIFF
--- a/lib/compat/wordpress-7.2/block-patterns.php
+++ b/lib/compat/wordpress-7.2/block-patterns.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Block pattern registration fixes for WordPress 7.2.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers remote theme patterns on init so they are available on the front end.
+ *
+ * Remote theme patterns (from the Pattern Directory) were previously only registered
+ * within the REST API endpoint (WP_REST_Block_Patterns_Controller::get_items()),
+ * meaning they were available in the Site Editor but not on the front end when
+ * referenced in template files via the pattern block.
+ *
+ * The core function _register_remote_theme_patterns() cannot be reused here because
+ * it relies on rest_do_request(), which enforces the edit_posts permission check on
+ * the Pattern Directory endpoint — causing it to silently fail for anonymous visitors.
+ *
+ * This function fetches patterns directly from the WordPress.org API, bypassing the
+ * REST permission layer while sharing the same transient cache used by the REST
+ * controller (WP_REST_Pattern_Directory_Controller).
+ *
+ * @since 7.2.0
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/64104
+ */
+function gutenberg_register_remote_theme_patterns() {
+	/** This filter is documented in wp-includes/block-patterns.php */
+	if ( ! apply_filters( 'should_load_remote_block_patterns', true ) ) {
+		return;
+	}
+
+	if ( ! wp_theme_has_theme_json() ) {
+		return;
+	}
+
+	$pattern_settings = wp_get_theme_directory_pattern_slugs();
+	if ( empty( $pattern_settings ) ) {
+		return;
+	}
+
+	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
+
+	// Build query args matching the format used by WP_REST_Pattern_Directory_Controller.
+	$query_args = array(
+		'slug'       => $pattern_settings,
+		'locale'     => get_user_locale(),
+		'wp-version' => wp_get_wp_version(),
+	);
+
+	// Compute the transient key using the same logic as the REST controller
+	// so that the cache is shared between the editor and the front end.
+	$slugs = wp_parse_list( $query_args['slug'] );
+	sort( $slugs );
+	$cache_query_args         = $query_args;
+	$cache_query_args['slug'] = $slugs;
+	$transient_key            = 'wp_remote_block_patterns_' . md5( serialize( $cache_query_args ) );
+
+	$raw_patterns = get_site_transient( $transient_key );
+
+	if ( ! $raw_patterns ) {
+		$api_url = 'http://api.wordpress.org/patterns/1.0/?' . build_query( $query_args );
+		if ( wp_http_supports( array( 'ssl' ) ) ) {
+			$api_url = set_url_scheme( $api_url, 'https' );
+		}
+
+		// Default to a short TTL to mitigate cache stampedes on high-traffic sites.
+		$cache_ttl      = 5;
+		$wporg_response = wp_remote_get( $api_url );
+		$raw_patterns   = json_decode( wp_remote_retrieve_body( $wporg_response ) );
+
+		if ( is_wp_error( $wporg_response ) ) {
+			$raw_patterns = $wporg_response;
+		} elseif ( ! is_array( $raw_patterns ) ) {
+			$raw_patterns = new WP_Error(
+				'pattern_api_failed',
+				sprintf(
+					/* translators: %s: Support forums URL. */
+					__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.', 'gutenberg' ),
+					__( 'https://wordpress.org/support/forums/', 'gutenberg' )
+				)
+			);
+		} else {
+			$cache_ttl = HOUR_IN_SECONDS;
+		}
+
+		set_site_transient( $transient_key, $raw_patterns, $cache_ttl );
+	}
+
+	if ( is_wp_error( $raw_patterns ) ) {
+		return;
+	}
+
+	foreach ( $raw_patterns as $raw_pattern ) {
+		// Transform from the raw API response format to the format expected
+		// by wp_normalize_remote_block_pattern(), matching the sanitization
+		// performed by WP_REST_Pattern_Directory_Controller::prepare_item_for_response().
+		$pattern = array(
+			'title'          => sanitize_text_field( $raw_pattern->title->rendered ),
+			'content'        => wp_kses_post( $raw_pattern->pattern_content ),
+			'categories'     => array_map( 'sanitize_title', $raw_pattern->category_slugs ),
+			'keywords'       => array_map( 'sanitize_text_field', explode( ',', $raw_pattern->meta->wpop_keywords ) ),
+			'description'    => sanitize_text_field( $raw_pattern->meta->wpop_description ),
+			'viewport_width' => absint( $raw_pattern->meta->wpop_viewport_width ),
+			'block_types'    => array_map( 'sanitize_text_field', $raw_pattern->meta->wpop_block_types ),
+			'source'         => 'pattern-directory/theme',
+		);
+
+		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
+		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
+
+		// Some patterns might be already registered as core patterns with the `core` prefix.
+		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );
+		if ( ! $is_registered ) {
+			register_block_pattern( $pattern_name, $normalized_pattern );
+		}
+	}
+}
+add_action( 'init', 'gutenberg_register_remote_theme_patterns' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -125,6 +125,9 @@ require __DIR__ . '/compat/wordpress-7.1/media.php';
 require __DIR__ . '/compat/wordpress-7.1/preload.php';
 require __DIR__ . '/compat/wordpress-7.1/icons.php';
 
+// WordPress 7.2 compat.
+require __DIR__ . '/compat/wordpress-7.2/block-patterns.php';
+
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/64104

<!-- In a few words, what is the PR actually doing? -->
  Adds `gutenberg_register_remote_theme_patterns()` which registers remote theme patterns (from the Pattern Directory)
  on `init`, so they are available when rendering templates on the front end.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
  When a theme registers a remote pattern via `theme.json` and references it in a template file (e.g., `<!-- wp:pattern
  {"slug":"clients-section"} /-->`), the pattern displays in the Site Editor but not on the front end.

  This happens because `_register_remote_theme_patterns()` is only called from the REST API endpoint
  (`WP_REST_Block_Patterns_Controller::get_items()`). The Site Editor triggers this endpoint, but front-end rendering
  does not — so remote patterns are never registered.

  Additionally, the core function cannot simply be hooked to `init` because it uses `rest_do_request()` internally,
  which enforces the `edit_posts` permission check — causing it to silently fail for anonymous visitors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
  The new `gutenberg_register_remote_theme_patterns()` function:
  - Fetches patterns directly from the WordPress.org API via `wp_remote_get()`, bypassing the REST permission layer
  - Shares the same transient cache (1-hour TTL) used by `WP_REST_Pattern_Directory_Controller`, avoiding duplicate HTTP
   requests
  - Applies the same sanitization as the REST controller's `prepare_item_for_response()`
  - Respects the `should_load_remote_block_patterns` filter

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
  1. Activate the Twenty Twenty-Four theme
  2. Set reading settings to "Your latest posts" (Settings → Reading)
  3. Edit `wp-content/themes/twentytwentyfour/templates/home.html` and add:
       ```
       <!-- wp:pattern {"slug":"clients-section"} /-->
       ```
  4. Visit the front end — the "Clients Section" pattern should be visible

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
  This change affects server-side pattern registration only. No UI or keyboard interaction changes.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1919" height="1029" alt="スクリーンショット 2026-02-18 001926" src="https://github.com/user-attachments/assets/adeede08-5f7f-4cbd-bdde-0e3714d22d26" /> |<img width="1901" height="1025" alt="スクリーンショット 2026-02-18 002230" src="https://github.com/user-attachments/assets/fc5e0661-8e41-486c-bc77-2a8dd4259546" />|


