### PR TITLE
Implement state UI for pseudo selectors on Global styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -23,3 +23,4 @@ export {
 	default as BackgroundPanel,
 	useHasBackgroundPanel,
 } from './background-panel';
+export { default as StateControl, useHasStates } from './state-control';

--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -23,4 +23,4 @@ export {
 	default as BackgroundPanel,
 	useHasBackgroundPanel,
 } from './background-panel';
-export { default as StateControl, useHasStates } from './state-control';
+export { default as StateControl } from './state-control';

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -9,38 +9,28 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
  * State control for managing block state styles (hover, focus, etc.).
  * Displays a dropdown menu to select between different states.
  *
- * @param {Object}   props                     Component props.
- * @param {Array}    props.states              Array of available states with value and label.
- * @param {string}   props.value               Currently selected state value.
- * @param {Function} props.onChange            Callback when selection changes.
- * @param {string}   [props.className]         Additional CSS class name.
- * @param {boolean}  [props.showDefaultOption] Whether to show the "Default" option. Default true.
+ * @param {Object}   props          Component props.
+ * @param {Array}    props.states   Array of available states with value and label.
+ * @param {string}   props.value    Currently selected state value.
+ * @param {Function} props.onChange Callback when selection changes.
  * @return {Element|null} State control component.
  */
 export default function StateControl( {
 	states = [],
 	value = 'default',
 	onChange,
-	className,
-	showDefaultOption = true,
 } ) {
-	// Don't render if there are no states
 	if ( ! states || states.length === 0 ) {
 		return null;
 	}
 
-	const stateOptions = showDefaultOption
-		? [
-				{ label: __( 'Default' ), value: 'default' },
-				...states.map( ( state ) => ( {
-					label: state.label,
-					value: state.value,
-				} ) ),
-		  ]
-		: states.map( ( state ) => ( {
-				label: state.label,
-				value: state.value,
-		  } ) );
+	const stateOptions = [
+		{ label: __( 'Default' ), value: 'default' },
+		...states.map( ( state ) => ( {
+			label: state.label,
+			value: state.value,
+		} ) ),
+	];
 
 	const getCurrentStateLabel = () => {
 		const currentOption = stateOptions.find(
@@ -50,90 +40,36 @@ export default function StateControl( {
 	};
 
 	return (
-		<div className={ className }>
-			<DropdownMenu
-				icon={ chevronDown }
-				label={ sprintf(
-					/* translators: %s: Current state (e.g. "Hover", "Focus") */
-					__( 'State: %s' ),
-					getCurrentStateLabel()
-				) }
-				text={ getCurrentStateLabel() }
-				toggleProps={ {
-					size: 'compact',
-					variant: 'tertiary',
-					iconPosition: 'right',
-				} }
-			>
-				{ ( { onClose } ) => (
-					<MenuGroup label={ __( 'State' ) }>
-						{ stateOptions.map( ( option ) => (
-							<MenuItem
-								key={ option.value }
-								onClick={ () => {
-									onChange( option.value );
-									onClose();
-								} }
-								icon={ value === option.value ? check : null }
-							>
-								{ option.label }
-							</MenuItem>
-						) ) }
-					</MenuGroup>
-				) }
-			</DropdownMenu>
-		</div>
+		<DropdownMenu
+			icon={ chevronDown }
+			label={ sprintf(
+				/* translators: %s: Current state (e.g. "Hover", "Focus") */
+				__( 'State: %s' ),
+				getCurrentStateLabel()
+			) }
+			text={ getCurrentStateLabel() }
+			toggleProps={ {
+				size: 'compact',
+				variant: 'tertiary',
+				iconPosition: 'right',
+			} }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup label={ __( 'State' ) }>
+					{ stateOptions.map( ( option ) => (
+						<MenuItem
+							key={ option.value }
+							onClick={ () => {
+								onChange( option.value );
+								onClose();
+							} }
+							icon={ value === option.value ? check : null }
+						>
+							{ option.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
+		</DropdownMenu>
 	);
-}
-
-/**
- * Hook to determine if a block or element has available states.
- *
- * @param {string} name Block name or element name.
- * @return {Array} Array of available states, or empty array if none.
- */
-export function useHasStates( name ) {
-	// These constants mirror the ones in global-styles-ui/src/utils.ts
-	// and lib/class-wp-theme-json-gutenberg.php
-	const VALID_ELEMENT_STATES = {
-		link: [
-			{ value: ':link', label: __( 'Link' ) },
-			{ value: ':any-link', label: __( 'Any Link' ) },
-			{ value: ':visited', label: __( 'Visited' ) },
-			{ value: ':hover', label: __( 'Hover' ) },
-			{ value: ':focus', label: __( 'Focus' ) },
-			{ value: ':focus-visible', label: __( 'Focus Visible' ) },
-			{ value: ':active', label: __( 'Active' ) },
-		],
-		button: [
-			{ value: ':link', label: __( 'Link' ) },
-			{ value: ':any-link', label: __( 'Any Link' ) },
-			{ value: ':visited', label: __( 'Visited' ) },
-			{ value: ':hover', label: __( 'Hover' ) },
-			{ value: ':focus', label: __( 'Focus' ) },
-			{ value: ':focus-visible', label: __( 'Focus Visible' ) },
-			{ value: ':active', label: __( 'Active' ) },
-		],
-	};
-
-	const VALID_BLOCK_STATES = {
-		'core/button': [
-			{ value: ':hover', label: __( 'Hover' ) },
-			{ value: ':focus', label: __( 'Focus' ) },
-			{ value: ':focus-visible', label: __( 'Focus Visible' ) },
-			{ value: ':active', label: __( 'Active' ) },
-		],
-	};
-
-	// Check if it's a block
-	if ( VALID_BLOCK_STATES[ name ] ) {
-		return VALID_BLOCK_STATES[ name ];
-	}
-
-	// Check if it's an element
-	if ( VALID_ELEMENT_STATES[ name ] ) {
-		return VALID_ELEMENT_STATES[ name ];
-	}
-
-	return [];
 }

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { check, chevronDown } from '@wordpress/icons';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+
+/**
+ * State control for managing block state styles (hover, focus, etc.).
+ * Displays a dropdown menu to select between different states.
+ *
+ * @param {Object}   props                     Component props.
+ * @param {Array}    props.states              Array of available states with value and label.
+ * @param {string}   props.value               Currently selected state value.
+ * @param {Function} props.onChange            Callback when selection changes.
+ * @param {string}   [props.className]         Additional CSS class name.
+ * @param {boolean}  [props.showDefaultOption] Whether to show the "Default" option. Default true.
+ * @return {Element|null} State control component.
+ */
+export default function StateControl( {
+	states = [],
+	value = 'default',
+	onChange,
+	className,
+	showDefaultOption = true,
+} ) {
+	// Don't render if there are no states
+	if ( ! states || states.length === 0 ) {
+		return null;
+	}
+
+	const stateOptions = showDefaultOption
+		? [
+				{ label: __( 'Default' ), value: 'default' },
+				...states.map( ( state ) => ( {
+					label: state.label,
+					value: state.value,
+				} ) ),
+		  ]
+		: states.map( ( state ) => ( {
+				label: state.label,
+				value: state.value,
+		  } ) );
+
+	const getCurrentStateLabel = () => {
+		const currentOption = stateOptions.find(
+			( option ) => option.value === value
+		);
+		return currentOption?.label || __( 'Default' );
+	};
+
+	return (
+		<div className={ className }>
+			<DropdownMenu
+				icon={ chevronDown }
+				label={ sprintf(
+					/* translators: %s: Current state (e.g. "Hover", "Focus") */
+					__( 'State: %s' ),
+					getCurrentStateLabel()
+				) }
+				text={ getCurrentStateLabel() }
+				toggleProps={ {
+					size: 'compact',
+					variant: 'tertiary',
+					iconPosition: 'right',
+				} }
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup label={ __( 'State' ) }>
+						{ stateOptions.map( ( option ) => (
+							<MenuItem
+								key={ option.value }
+								onClick={ () => {
+									onChange( option.value );
+									onClose();
+								} }
+								icon={ value === option.value ? check : null }
+							>
+								{ option.label }
+							</MenuItem>
+						) ) }
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+		</div>
+	);
+}
+
+/**
+ * Hook to determine if a block or element has available states.
+ *
+ * @param {string} name Block name or element name.
+ * @return {Array} Array of available states, or empty array if none.
+ */
+export function useHasStates( name ) {
+	// These constants mirror the ones in global-styles-ui/src/utils.ts
+	// and lib/class-wp-theme-json-gutenberg.php
+	const VALID_ELEMENT_STATES = {
+		link: [
+			{ value: ':link', label: __( 'Link' ) },
+			{ value: ':any-link', label: __( 'Any Link' ) },
+			{ value: ':visited', label: __( 'Visited' ) },
+			{ value: ':hover', label: __( 'Hover' ) },
+			{ value: ':focus', label: __( 'Focus' ) },
+			{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+			{ value: ':active', label: __( 'Active' ) },
+		],
+		button: [
+			{ value: ':link', label: __( 'Link' ) },
+			{ value: ':any-link', label: __( 'Any Link' ) },
+			{ value: ':visited', label: __( 'Visited' ) },
+			{ value: ':hover', label: __( 'Hover' ) },
+			{ value: ':focus', label: __( 'Focus' ) },
+			{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+			{ value: ':active', label: __( 'Active' ) },
+		],
+	};
+
+	const VALID_BLOCK_STATES = {
+		'core/button': [
+			{ value: ':hover', label: __( 'Hover' ) },
+			{ value: ':focus', label: __( 'Focus' ) },
+			{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+			{ value: ':active', label: __( 'Active' ) },
+		],
+	};
+
+	// Check if it's a block
+	if ( VALID_BLOCK_STATES[ name ] ) {
+		return VALID_BLOCK_STATES[ name ];
+	}
+
+	// Check if it's an element
+	if ( VALID_ELEMENT_STATES[ name ] ) {
+		return VALID_ELEMENT_STATES[ name ];
+	}
+
+	return [];
+}

--- a/packages/global-styles-engine/src/index.ts
+++ b/packages/global-styles-engine/src/index.ts
@@ -31,3 +31,5 @@ export {
 
 // Types
 export type * from './types';
+
+export { generatePreviewStateStyles as __unstableGeneratePreviewStateStyles } from './preview-state-styles';

--- a/packages/global-styles-engine/src/preview-state-styles.ts
+++ b/packages/global-styles-engine/src/preview-state-styles.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { generateGlobalStyles } from './core/render';
+import type { GlobalStylesConfig } from './types';
+
+/**
+ * Generates CSS for preview contexts to display a specific state (hover, focus, etc.).
+ * Takes state-specific styles and generates CSS as if they were the default styles,
+ * allowing previews to show how a block will appear in that state.
+ *
+ * @param stateStyles - The styles for the specific state (e.g., hover styles)
+ * @param blockName   - The block name (e.g., 'core/button')
+ * @return CSS string for the state preview
+ */
+export function generatePreviewStateStyles(
+	stateStyles: any,
+	blockName: string
+): string {
+	if ( ! stateStyles || ! blockName ) {
+		return '';
+	}
+
+	// Create a minimal theme.json-like config with the state styles
+	// positioned as if they were the default styles for this block
+	const previewConfig: GlobalStylesConfig = {
+		settings: {}, // Empty settings to satisfy the config structure
+		styles: {
+			blocks: {
+				[ blockName ]: stateStyles,
+			},
+		},
+	};
+
+	try {
+		const [ generatedStyles ] = generateGlobalStyles( previewConfig, [] );
+
+		return generatedStyles.map( ( style ) => style.css ).join( '\n' );
+	} catch ( error ) {
+		// If generation fails, return empty string to avoid breaking previews
+		return '';
+	}
+}

--- a/packages/global-styles-ui/src/block-preview-panel.tsx
+++ b/packages/global-styles-ui/src/block-preview-panel.tsx
@@ -7,6 +7,7 @@ import { BlockPreview } from '@wordpress/block-editor';
 import { getBlockType, getBlockFromExample } from '@wordpress/blocks';
 import { __experimentalSpacer as Spacer } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
+import { __unstableGeneratePreviewStateStyles as generatePreviewStateStyles } from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -16,11 +17,15 @@ import { getVariationClassName } from './utils';
 interface BlockPreviewPanelProps {
 	name: string;
 	variation?: string;
+	selectedState?: string;
+	stateStyles?: any;
 }
 
 const BlockPreviewPanel = ( {
 	name,
 	variation = '',
+	selectedState = 'default',
+	stateStyles,
 }: BlockPreviewPanelProps ) => {
 	const blockExample = getBlockType( name )?.example;
 	const blocks = useMemo( () => {
@@ -41,6 +46,15 @@ const BlockPreviewPanel = ( {
 
 		return getBlockFromExample( name, example );
 	}, [ name, blockExample, variation ] );
+
+	// Generate CSS for the selected state.
+	const stateCSS = useMemo( () => {
+		if ( selectedState === 'default' || ! stateStyles ) {
+			return '';
+		}
+
+		return generatePreviewStateStyles( stateStyles, name );
+	}, [ selectedState, stateStyles, name ] );
 
 	const viewportWidth = blockExample?.viewportWidth ?? 500;
 	// Same as height of InserterPreviewPanel.
@@ -78,6 +92,7 @@ const BlockPreviewPanel = ( {
 									align-items:center;
 								}
 								.is-root-container { width: 100%; }
+								${ stateCSS }
 							`,
 							},
 						]

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -355,7 +355,16 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 				selectedPseudoSelector={ selectedPseudoSelector }
 				onChangePseudoSelector={ setSelectedPseudoSelector }
 			/>
-			<BlockPreviewPanel name={ name } variation={ variation } />
+			<BlockPreviewPanel
+				name={ name }
+				variation={ variation }
+				selectedState={ selectedPseudoSelector }
+				stateStyles={
+					selectedPseudoSelector !== 'default'
+						? rawStyle?.[ selectedPseudoSelector ]
+						: undefined
+				}
+			/>
 			{ hasVariationsPanel && (
 				<div className="global-styles-ui-screen-variations">
 					<VStack spacing={ 3 }>

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -5,7 +5,7 @@
 import { getBlockType } from '@wordpress/blocks';
 // @ts-expect-error: Not typed yet.
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { useContext, useMemo } from '@wordpress/element';
+import { useContext, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
@@ -33,6 +33,7 @@ import {
 import { useStyle, useSetting } from './hooks';
 import { GlobalStylesContext } from './context';
 import { unlock } from './lock-unlock';
+import { getValidPseudoSelectors } from './utils';
 
 // Initial control values.
 const BACKGROUND_BLOCK_DEFAULT_VALUES = {
@@ -109,13 +110,51 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 	}
 	const prefix = prefixParts.join( '.' );
 
-	const [ style ] = useStyle( prefix, name, 'user', false );
-	const [ inheritedStyle, setStyle ] = useStyle(
+	// Pseudo selector state
+	const [ selectedPseudoSelector, setSelectedPseudoSelector ] =
+		useState< string >( 'default' );
+	const validPseudoSelectors = useMemo(
+		() => getValidPseudoSelectors( name ),
+		[ name ]
+	);
+
+	const [ rawStyle ] = useStyle( prefix, name, 'user', false );
+	const [ rawInheritedStyle, rawSetStyle ] = useStyle(
 		prefix,
 		name,
 		'merged',
 		false
 	);
+
+	// Extract style for the selected pseudo selector
+	const style = useMemo( () => {
+		if ( selectedPseudoSelector === 'default' ) {
+			return rawStyle || {};
+		}
+		return rawStyle?.[ selectedPseudoSelector ] || {};
+	}, [ rawStyle, selectedPseudoSelector ] );
+
+	const inheritedStyle = useMemo( () => {
+		if ( selectedPseudoSelector === 'default' ) {
+			return rawInheritedStyle || {};
+		}
+		return rawInheritedStyle?.[ selectedPseudoSelector ] || {};
+	}, [ rawInheritedStyle, selectedPseudoSelector ] );
+
+	// Wrapper for setStyle that handles pseudo selectors
+	const setStyle = ( newStyle: any ) => {
+		if ( selectedPseudoSelector === 'default' ) {
+			rawSetStyle( newStyle );
+		} else {
+			// Merge the new style into the pseudo selector
+			const updatedStyle = {
+				...rawStyle,
+				[ selectedPseudoSelector ]: newStyle,
+			};
+			rawSetStyle( updatedStyle );
+		}
+	};
+
 	const [ userSettings ] = useSetting( '', name, 'user' );
 	const [ rawSettings, setSettings ] = useSetting( '', name );
 	const settingsForBlockElement = useSettingsForBlockElement(
@@ -312,6 +351,9 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 				title={
 					variation ? currentBlockStyle?.label : blockType?.title
 				}
+				pseudoSelectors={ validPseudoSelectors }
+				selectedPseudoSelector={ selectedPseudoSelector }
+				onChangePseudoSelector={ setSelectedPseudoSelector }
 			/>
 			<BlockPreviewPanel name={ name } variation={ variation } />
 			{ hasVariationsPanel && (

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -33,7 +33,7 @@ import {
 import { useStyle, useSetting } from './hooks';
 import { GlobalStylesContext } from './context';
 import { unlock } from './lock-unlock';
-import { getValidPseudoSelectors } from './utils';
+import { getValidStates } from './utils';
 
 // Initial control values.
 const BACKGROUND_BLOCK_DEFAULT_VALUES = {
@@ -110,13 +110,9 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 	}
 	const prefix = prefixParts.join( '.' );
 
-	// Pseudo selector state
-	const [ selectedPseudoSelector, setSelectedPseudoSelector ] =
-		useState< string >( 'default' );
-	const validPseudoSelectors = useMemo(
-		() => getValidPseudoSelectors( name ),
-		[ name ]
-	);
+	// State selector state
+	const [ selectedState, setSelectedState ] = useState< string >( 'default' );
+	const validStates = useMemo( () => getValidStates( name ), [ name ] );
 
 	const [ rawStyle ] = useStyle( prefix, name, 'user', false );
 	const [ rawInheritedStyle, rawSetStyle ] = useStyle(
@@ -126,30 +122,30 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 		false
 	);
 
-	// Extract style for the selected pseudo selector
+	// Extract style for the selected state
 	const style = useMemo( () => {
-		if ( selectedPseudoSelector === 'default' ) {
+		if ( selectedState === 'default' ) {
 			return rawStyle || {};
 		}
-		return rawStyle?.[ selectedPseudoSelector ] || {};
-	}, [ rawStyle, selectedPseudoSelector ] );
+		return rawStyle?.[ selectedState ] || {};
+	}, [ rawStyle, selectedState ] );
 
 	const inheritedStyle = useMemo( () => {
-		if ( selectedPseudoSelector === 'default' ) {
+		if ( selectedState === 'default' ) {
 			return rawInheritedStyle || {};
 		}
-		return rawInheritedStyle?.[ selectedPseudoSelector ] || {};
-	}, [ rawInheritedStyle, selectedPseudoSelector ] );
+		return rawInheritedStyle?.[ selectedState ] || {};
+	}, [ rawInheritedStyle, selectedState ] );
 
-	// Wrapper for setStyle that handles pseudo selectors
+	// Wrapper for setStyle that handles states
 	const setStyle = ( newStyle: any ) => {
-		if ( selectedPseudoSelector === 'default' ) {
+		if ( selectedState === 'default' ) {
 			rawSetStyle( newStyle );
 		} else {
-			// Merge the new style into the pseudo selector
+			// Merge the new style into the state
 			const updatedStyle = {
 				...rawStyle,
-				[ selectedPseudoSelector ]: newStyle,
+				[ selectedState ]: newStyle,
 			};
 			rawSetStyle( updatedStyle );
 		}
@@ -351,17 +347,17 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 				title={
 					variation ? currentBlockStyle?.label : blockType?.title
 				}
-				pseudoSelectors={ validPseudoSelectors }
-				selectedPseudoSelector={ selectedPseudoSelector }
-				onChangePseudoSelector={ setSelectedPseudoSelector }
+				states={ validStates }
+				selectedState={ selectedState }
+				onChangeState={ setSelectedState }
 			/>
 			<BlockPreviewPanel
 				name={ name }
 				variation={ variation }
-				selectedState={ selectedPseudoSelector }
+				selectedState={ selectedState }
 				stateStyles={
-					selectedPseudoSelector !== 'default'
-						? rawStyle?.[ selectedPseudoSelector ]
+					selectedState !== 'default'
+						? rawStyle?.[ selectedState ]
 						: undefined
 				}
 			/>

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -99,8 +99,7 @@ export function ScreenHeader( {
 											) }
 											text={ getCurrentStateLabel() }
 											toggleProps={ {
-												__next40pxDefaultSize: true,
-												variant: 'tertiary',
+												size: 'compact',
 												iconPosition: 'right',
 											} }
 										>

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -21,11 +21,16 @@ import {
 	check,
 } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import type { PseudoSelectorDefinition } from './utils';
+
 interface ScreenHeaderProps {
 	title: string;
 	description?: string | React.ReactElement;
 	onBack?: () => void;
-	pseudoSelectors?: string[];
+	pseudoSelectors?: PseudoSelectorDefinition[];
 	selectedPseudoSelector?: string;
 	onChangePseudoSelector?: ( value: string ) => void;
 }
@@ -44,17 +49,10 @@ export function ScreenHeader( {
 	const stateOptions = hasPseudoSelectors
 		? [
 				{ label: __( 'Default' ), value: 'default' },
-				...pseudoSelectors.map( ( pseudo ) => {
-					// Convert :hover to Hover, :focus-visible to Focus Visible
-					const label = pseudo
-						.replace( /^:/, '' )
-						.replace( /-/g, ' ' )
-						.replace( /\b\w/g, ( char ) => char.toUpperCase() );
-					return {
-						label,
-						value: pseudo,
-					};
-				} ),
+				...pseudoSelectors.map( ( pseudo ) => ( {
+					label: pseudo.label,
+					value: pseudo.value,
+				} ) ),
 		  ]
 		: [];
 

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -14,7 +14,12 @@ import {
 	MenuItem,
 } from '@wordpress/components';
 import { isRTL, __, sprintf } from '@wordpress/i18n';
-import { chevronRight, chevronLeft, chevronDown } from '@wordpress/icons';
+import {
+	chevronRight,
+	chevronLeft,
+	chevronDown,
+	check,
+} from '@wordpress/icons';
 
 interface ScreenHeaderProps {
 	title: string;
@@ -73,7 +78,10 @@ export function ScreenHeader( {
 								onClick={ onBack }
 							/>
 							<Spacer>
-								<HStack spacing={ 2 } alignment="center">
+								<HStack
+									justify="space-between"
+									alignment="center"
+								>
 									<Heading
 										className="global-styles-ui-header"
 										level={ 2 }
@@ -91,11 +99,15 @@ export function ScreenHeader( {
 											) }
 											text={ getCurrentStateLabel() }
 											toggleProps={ {
-												size: 'compact',
+												__next40pxDefaultSize: true,
+												variant: 'tertiary',
+												iconPosition: 'right',
 											} }
 										>
 											{ ( { onClose } ) => (
-												<MenuGroup>
+												<MenuGroup
+													label={ __( 'State' ) }
+												>
 													{ stateOptions.map(
 														( option ) => (
 															<MenuItem
@@ -108,9 +120,11 @@ export function ScreenHeader( {
 																	);
 																	onClose();
 																} }
-																isPressed={
+																icon={
 																	selectedPseudoSelector ===
 																	option.value
+																		? check
+																		: null
 																}
 															>
 																{ option.label }

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -9,21 +9,57 @@ import {
 	__experimentalView as View,
 	__experimentalText as Text,
 	Navigator,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
 } from '@wordpress/components';
-import { isRTL, __ } from '@wordpress/i18n';
-import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { isRTL, __, sprintf } from '@wordpress/i18n';
+import { chevronRight, chevronLeft, chevronDown } from '@wordpress/icons';
 
 interface ScreenHeaderProps {
 	title: string;
 	description?: string | React.ReactElement;
 	onBack?: () => void;
+	pseudoSelectors?: string[];
+	selectedPseudoSelector?: string;
+	onChangePseudoSelector?: ( value: string ) => void;
 }
 
 export function ScreenHeader( {
 	title,
 	description,
 	onBack,
+	pseudoSelectors,
+	selectedPseudoSelector = 'default',
+	onChangePseudoSelector,
 }: ScreenHeaderProps ) {
+	const hasPseudoSelectors =
+		pseudoSelectors && pseudoSelectors.length > 0 && onChangePseudoSelector;
+
+	const stateOptions = hasPseudoSelectors
+		? [
+				{ label: __( 'Default' ), value: 'default' },
+				...pseudoSelectors.map( ( pseudo ) => {
+					// Convert :hover to Hover, :focus-visible to Focus Visible
+					const label = pseudo
+						.replace( /^:/, '' )
+						.replace( /-/g, ' ' )
+						.replace( /\b\w/g, ( char ) => char.toUpperCase() );
+					return {
+						label,
+						value: pseudo,
+					};
+				} ),
+		  ]
+		: [];
+
+	const getCurrentStateLabel = () => {
+		const currentOption = stateOptions.find(
+			( option ) => option.value === selectedPseudoSelector
+		);
+		return currentOption?.label || __( 'Default' );
+	};
+
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -37,13 +73,55 @@ export function ScreenHeader( {
 								onClick={ onBack }
 							/>
 							<Spacer>
-								<Heading
-									className="global-styles-ui-header"
-									level={ 2 }
-									size={ 13 }
-								>
-									{ title }
-								</Heading>
+								<HStack spacing={ 2 } alignment="center">
+									<Heading
+										className="global-styles-ui-header"
+										level={ 2 }
+										size={ 13 }
+									>
+										{ title }
+									</Heading>
+									{ hasPseudoSelectors && (
+										<DropdownMenu
+											icon={ chevronDown }
+											label={ sprintf(
+												/* translators: %s: Current state (e.g. "Hover", "Focus") */
+												__( 'State: %s' ),
+												getCurrentStateLabel()
+											) }
+											text={ getCurrentStateLabel() }
+											toggleProps={ {
+												size: 'compact',
+											} }
+										>
+											{ ( { onClose } ) => (
+												<MenuGroup>
+													{ stateOptions.map(
+														( option ) => (
+															<MenuItem
+																key={
+																	option.value
+																}
+																onClick={ () => {
+																	onChangePseudoSelector(
+																		option.value
+																	);
+																	onClose();
+																} }
+																isPressed={
+																	selectedPseudoSelector ===
+																	option.value
+																}
+															>
+																{ option.label }
+															</MenuItem>
+														)
+													) }
+												</MenuGroup>
+											) }
+										</DropdownMenu>
+									) }
+								</HStack>
 							</Spacer>
 						</HStack>
 						{ description && (

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -9,60 +9,37 @@ import {
 	__experimentalView as View,
 	__experimentalText as Text,
 	Navigator,
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
 } from '@wordpress/components';
-import { isRTL, __, sprintf } from '@wordpress/i18n';
-import {
-	chevronRight,
-	chevronLeft,
-	chevronDown,
-	check,
-} from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
+// @ts-expect-error: Not typed yet.
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import type { PseudoSelectorDefinition } from './utils';
+import type { StateDefinition } from './utils';
+import { unlock } from './lock-unlock';
+
+const { StateControl } = unlock( blockEditorPrivateApis );
 
 interface ScreenHeaderProps {
 	title: string;
 	description?: string | React.ReactElement;
 	onBack?: () => void;
-	pseudoSelectors?: PseudoSelectorDefinition[];
-	selectedPseudoSelector?: string;
-	onChangePseudoSelector?: ( value: string ) => void;
+	states?: StateDefinition[];
+	selectedState?: string;
+	onChangeState?: ( value: string ) => void;
 }
 
 export function ScreenHeader( {
 	title,
 	description,
 	onBack,
-	pseudoSelectors,
-	selectedPseudoSelector = 'default',
-	onChangePseudoSelector,
+	states,
+	selectedState = 'default',
+	onChangeState,
 }: ScreenHeaderProps ) {
-	const hasPseudoSelectors =
-		pseudoSelectors && pseudoSelectors.length > 0 && onChangePseudoSelector;
-
-	const stateOptions = hasPseudoSelectors
-		? [
-				{ label: __( 'Default' ), value: 'default' },
-				...pseudoSelectors.map( ( pseudo ) => ( {
-					label: pseudo.label,
-					value: pseudo.value,
-				} ) ),
-		  ]
-		: [];
-
-	const getCurrentStateLabel = () => {
-		const currentOption = stateOptions.find(
-			( option ) => option.value === selectedPseudoSelector
-		);
-		return currentOption?.label || __( 'Default' );
-	};
-
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -87,51 +64,11 @@ export function ScreenHeader( {
 									>
 										{ title }
 									</Heading>
-									{ hasPseudoSelectors && (
-										<DropdownMenu
-											icon={ chevronDown }
-											label={ sprintf(
-												/* translators: %s: Current state (e.g. "Hover", "Focus") */
-												__( 'State: %s' ),
-												getCurrentStateLabel()
-											) }
-											text={ getCurrentStateLabel() }
-											toggleProps={ {
-												size: 'compact',
-												iconPosition: 'right',
-											} }
-										>
-											{ ( { onClose } ) => (
-												<MenuGroup
-													label={ __( 'State' ) }
-												>
-													{ stateOptions.map(
-														( option ) => (
-															<MenuItem
-																key={
-																	option.value
-																}
-																onClick={ () => {
-																	onChangePseudoSelector(
-																		option.value
-																	);
-																	onClose();
-																} }
-																icon={
-																	selectedPseudoSelector ===
-																	option.value
-																		? check
-																		: null
-																}
-															>
-																{ option.label }
-															</MenuItem>
-														)
-													) }
-												</MenuGroup>
-											) }
-										</DropdownMenu>
-									) }
+									<StateControl
+										states={ states }
+										value={ selectedState }
+										onChange={ onChangeState }
+									/>
 								</HStack>
 							</Spacer>
 						</HStack>

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -6,21 +6,18 @@ import type { GlobalStylesConfig } from '@wordpress/global-styles-engine';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Pseudo selector definition with value and label.
+ * State definition with value and label.
  */
-export interface PseudoSelectorDefinition {
+export interface StateDefinition {
 	value: string;
 	label: string;
 }
 
 /**
- * Valid pseudo selectors for elements with their labels.
+ * Valid states for elements with their labels.
  * This mirrors the PHP constant in lib/class-wp-theme-json-gutenberg.php
  */
-export const VALID_ELEMENT_PSEUDO_SELECTORS: Record<
-	string,
-	PseudoSelectorDefinition[]
-> = {
+export const VALID_ELEMENT_STATES: Record< string, StateDefinition[] > = {
 	link: [
 		{ value: ':link', label: __( 'Link' ) },
 		{ value: ':any-link', label: __( 'Any Link' ) },
@@ -42,13 +39,10 @@ export const VALID_ELEMENT_PSEUDO_SELECTORS: Record<
 };
 
 /**
- * Valid pseudo selectors for blocks with their labels.
+ * Valid states for blocks with their labels.
  * This mirrors the PHP constant in lib/class-wp-theme-json-gutenberg.php
  */
-export const VALID_BLOCK_PSEUDO_SELECTORS: Record<
-	string,
-	PseudoSelectorDefinition[]
-> = {
+export const VALID_BLOCK_STATES: Record< string, StateDefinition[] > = {
 	'core/button': [
 		{ value: ':hover', label: __( 'Hover' ) },
 		{ value: ':focus', label: __( 'Focus' ) },
@@ -58,22 +52,20 @@ export const VALID_BLOCK_PSEUDO_SELECTORS: Record<
 };
 
 /**
- * Get the valid pseudo selectors for a given block or element.
+ * Get the valid states for a given block or element.
  *
  * @param name The block name (e.g., 'core/button') or element name (e.g., 'button')
- * @return Array of valid pseudo selector definitions, or empty array if none
+ * @return Array of valid state definitions, or empty array if none
  */
-export function getValidPseudoSelectors(
-	name: string
-): PseudoSelectorDefinition[] {
+export function getValidStates( name: string ): StateDefinition[] {
 	// Check if it's a block
-	if ( VALID_BLOCK_PSEUDO_SELECTORS[ name ] ) {
-		return VALID_BLOCK_PSEUDO_SELECTORS[ name ];
+	if ( VALID_BLOCK_STATES[ name ] ) {
+		return VALID_BLOCK_STATES[ name ];
 	}
 
 	// Check if it's an element
-	if ( VALID_ELEMENT_PSEUDO_SELECTORS[ name ] ) {
-		return VALID_ELEMENT_PSEUDO_SELECTORS[ name ];
+	if ( VALID_ELEMENT_STATES[ name ] ) {
+		return VALID_ELEMENT_STATES[ name ];
 	}
 
 	return [];

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -3,47 +3,69 @@
  */
 import { areGlobalStylesEqual } from '@wordpress/global-styles-engine';
 import type { GlobalStylesConfig } from '@wordpress/global-styles-engine';
+import { __ } from '@wordpress/i18n';
 
 /**
- * Valid pseudo selectors for elements.
+ * Pseudo selector definition with value and label.
+ */
+export interface PseudoSelectorDefinition {
+	value: string;
+	label: string;
+}
+
+/**
+ * Valid pseudo selectors for elements with their labels.
  * This mirrors the PHP constant in lib/class-wp-theme-json-gutenberg.php
  */
-export const VALID_ELEMENT_PSEUDO_SELECTORS: Record< string, string[] > = {
+export const VALID_ELEMENT_PSEUDO_SELECTORS: Record<
+	string,
+	PseudoSelectorDefinition[]
+> = {
 	link: [
-		':link',
-		':any-link',
-		':visited',
-		':hover',
-		':focus',
-		':focus-visible',
-		':active',
+		{ value: ':link', label: __( 'Link' ) },
+		{ value: ':any-link', label: __( 'Any Link' ) },
+		{ value: ':visited', label: __( 'Visited' ) },
+		{ value: ':hover', label: __( 'Hover' ) },
+		{ value: ':focus', label: __( 'Focus' ) },
+		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+		{ value: ':active', label: __( 'Active' ) },
 	],
 	button: [
-		':link',
-		':any-link',
-		':visited',
-		':hover',
-		':focus',
-		':focus-visible',
-		':active',
+		{ value: ':link', label: __( 'Link' ) },
+		{ value: ':any-link', label: __( 'Any Link' ) },
+		{ value: ':visited', label: __( 'Visited' ) },
+		{ value: ':hover', label: __( 'Hover' ) },
+		{ value: ':focus', label: __( 'Focus' ) },
+		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+		{ value: ':active', label: __( 'Active' ) },
 	],
 };
 
 /**
- * Valid pseudo selectors for blocks.
+ * Valid pseudo selectors for blocks with their labels.
  * This mirrors the PHP constant in lib/class-wp-theme-json-gutenberg.php
  */
-export const VALID_BLOCK_PSEUDO_SELECTORS: Record< string, string[] > = {
-	'core/button': [ ':hover', ':focus', ':focus-visible', ':active' ],
+export const VALID_BLOCK_PSEUDO_SELECTORS: Record<
+	string,
+	PseudoSelectorDefinition[]
+> = {
+	'core/button': [
+		{ value: ':hover', label: __( 'Hover' ) },
+		{ value: ':focus', label: __( 'Focus' ) },
+		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+		{ value: ':active', label: __( 'Active' ) },
+	],
 };
 
 /**
  * Get the valid pseudo selectors for a given block or element.
  *
  * @param name The block name (e.g., 'core/button') or element name (e.g., 'button')
- * @return Array of valid pseudo selectors, or empty array if none
+ * @return Array of valid pseudo selector definitions, or empty array if none
  */
-export function getValidPseudoSelectors( name: string ): string[] {
+export function getValidPseudoSelectors(
+	name: string
+): PseudoSelectorDefinition[] {
 	// Check if it's a block
 	if ( VALID_BLOCK_PSEUDO_SELECTORS[ name ] ) {
 		return VALID_BLOCK_PSEUDO_SELECTORS[ name ];

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -5,6 +5,59 @@ import { areGlobalStylesEqual } from '@wordpress/global-styles-engine';
 import type { GlobalStylesConfig } from '@wordpress/global-styles-engine';
 
 /**
+ * Valid pseudo selectors for elements.
+ * This mirrors the PHP constant in lib/class-wp-theme-json-gutenberg.php
+ */
+export const VALID_ELEMENT_PSEUDO_SELECTORS: Record< string, string[] > = {
+	link: [
+		':link',
+		':any-link',
+		':visited',
+		':hover',
+		':focus',
+		':focus-visible',
+		':active',
+	],
+	button: [
+		':link',
+		':any-link',
+		':visited',
+		':hover',
+		':focus',
+		':focus-visible',
+		':active',
+	],
+};
+
+/**
+ * Valid pseudo selectors for blocks.
+ * This mirrors the PHP constant in lib/class-wp-theme-json-gutenberg.php
+ */
+export const VALID_BLOCK_PSEUDO_SELECTORS: Record< string, string[] > = {
+	'core/button': [ ':hover', ':focus', ':focus-visible', ':active' ],
+};
+
+/**
+ * Get the valid pseudo selectors for a given block or element.
+ *
+ * @param name The block name (e.g., 'core/button') or element name (e.g., 'button')
+ * @return Array of valid pseudo selectors, or empty array if none
+ */
+export function getValidPseudoSelectors( name: string ): string[] {
+	// Check if it's a block
+	if ( VALID_BLOCK_PSEUDO_SELECTORS[ name ] ) {
+		return VALID_BLOCK_PSEUDO_SELECTORS[ name ];
+	}
+
+	// Check if it's an element
+	if ( VALID_ELEMENT_PSEUDO_SELECTORS[ name ] ) {
+		return VALID_ELEMENT_PSEUDO_SELECTORS[ name ];
+	}
+
+	return [];
+}
+
+/**
  * Removes all instances of properties from an object.
  *
  * @param object     The object to remove the properties from.

--- a/test/e2e/specs/site-editor/global-styles-button-states.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-button-states.spec.js
@@ -52,17 +52,11 @@ test.describe( 'Global Styles - Button States', () => {
 			.getByRole( 'menuitem', { name: 'Hover', exact: true } )
 			.click();
 
-		await page
-			.getByRole( 'button', { name: 'Color options', exact: true } )
-			.click();
-
 		await page.getByRole( 'button', { name: 'Background' } ).click();
 
-		const backgroundColorButton = page
-			.getByRole( 'button', { name: 'Color: Orange' } )
-			.first();
-
-		await backgroundColorButton.click();
+		await page
+			.getByRole( 'option', { name: 'Luminous vivid orange' } )
+			.click();
 
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
@@ -70,7 +64,7 @@ test.describe( 'Global Styles - Button States', () => {
 			.click();
 
 		await page
-			.getByRole( 'region', { name: 'Save panel' } )
+			.getByRole( 'region', { name: 'Editor publish' } )
 			.getByRole( 'button', { name: 'Save', exact: true } )
 			.click();
 
@@ -88,15 +82,11 @@ test.describe( 'Global Styles - Button States', () => {
 
 		await buttonBlock.fill( 'Test Button' );
 
-		await editor.publishPost();
-
-		const postId = await editor.getPostId();
+		const postId = await editor.publishPost();
 
 		await page.goto( `/?p=${ postId }` );
 
-		const frontendButton = page.getByRole( 'link', {
-			name: 'Test Button',
-		} );
+		const frontendButton = page.getByText( 'Test Button' );
 
 		await expect( frontendButton ).toBeVisible();
 
@@ -104,7 +94,7 @@ test.describe( 'Global Styles - Button States', () => {
 
 		await expect( frontendButton ).toHaveCSS(
 			'background-color',
-			'rgb(255, 165, 0)'
+			'rgb(255, 105, 0)'
 		);
 	} );
 } );

--- a/test/e2e/specs/site-editor/global-styles-button-states.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-button-states.spec.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Global Styles - Button States', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+	} );
+
+	test( 'As a user I want to set button hover background color and see it applied on the frontend', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Blocks' } )
+			.click();
+
+		await page
+			.getByRole( 'button', { name: 'Button', exact: true } )
+			.click();
+
+		const stateDropdown = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: /State:/ } );
+
+		await expect( stateDropdown ).toBeVisible();
+
+		await stateDropdown.click();
+
+		await page
+			.getByRole( 'menuitem', { name: 'Hover', exact: true } )
+			.click();
+
+		await page
+			.getByRole( 'button', { name: 'Color options', exact: true } )
+			.click();
+
+		await page.getByRole( 'button', { name: 'Background' } ).click();
+
+		const backgroundColorButton = page
+			.getByRole( 'button', { name: 'Color: Orange' } )
+			.first();
+
+		await backgroundColorButton.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save' } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Save panel' } )
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Dismiss this notice' } )
+		).toBeVisible();
+
+		await admin.createNewPost();
+
+		await editor.insertBlock( { name: 'core/buttons' } );
+
+		const buttonBlock = editor.canvas
+			.getByRole( 'document', { name: 'Block: Button' } )
+			.getByRole( 'textbox' );
+
+		await buttonBlock.fill( 'Test Button' );
+
+		await editor.publishPost();
+
+		const postId = await editor.getPostId();
+
+		await page.goto( `/?p=${ postId }` );
+
+		const frontendButton = page.getByRole( 'link', {
+			name: 'Test Button',
+		} );
+
+		await expect( frontendButton ).toBeVisible();
+
+		await frontendButton.hover();
+
+		await expect( frontendButton ).toHaveCSS(
+			'background-color',
+			'rgb(255, 165, 0)'
+		);
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->



Related to https://github.com/WordPress/gutenberg/issues/38277 <!-- #ISSUE-NUMBER or URL -->

Adds a UI for editing pseudo selector states (`:hover`, `:focus`, `:active`, etc.) in Global Styles for blocks and elements.

This is a starting point, that will need to be expanded to other areas if we feel like we need to (such as adding these controls to a single instance of the block) in subsequent PRs

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

 Users need to customize how blocks and elements appear in interactive states. While theme.json already supports pseudo selectors, there was no visual UI to edit them.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a "State" dropdown next to block/element titles in Global Styles. When a state is selected (e.g., "Hover"), all style controls below (colors, typography, etc.) edit that specific state. The block preview automatically updates to show the selected state, giving users a live preview of how the block will appear on the frontend.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

  - Run e2e test: `npm run test:e2e -- test/e2e/specs/site-editor/global-styles-button-states.spec.js`
  - Manually: 
      - Go to Global Styles → Blocks → Button. The State dropdown should appear next to "Button". Select "Hover" and change the background color. Verify the color applies on hover on preview and on the frontend.
      - Check that it works for the outline variation as well
      - Using create block theme, export the theme and check that theme.json has the proper rules for hover on button

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1497" height="727" alt="Screenshot 2026-02-18 at 12 09 39" src="https://github.com/user-attachments/assets/ef2c8b95-7a31-45fd-b8a5-86b47edb7b65" />
