### PR TITLE
Removed Unused Global Documentation

### DIFF
--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -162,9 +162,6 @@ function gutenberg_maintain_templates_routes() {
 //    EditorProvider assumes templates are posts.
 add_action( 'init', 'gutenberg_setup_static_template' );
 
-/**
- * @global array $wp_post_types List of post types.
- */
 function gutenberg_setup_static_template() {
 	register_setting(
 		'reading',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The `global $wp_post_type` reference was removed in [#72764](https://github.com/WordPress/gutenberg/pull/72674), Therefore, the unused global documentation within the `gutenberg_setup_static_template` function should also be removed.

<!-- In a few words, what is the PR actually doing? -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removed `global` documentation in `gutenberg_setup_static_template` function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open `lib/compat/wordpress-7.0/template-activate.php`
2. Go to `gutenberg_setup_static_template` function
