### PR TITLE
Automated Testing: Merge reports into HTML artifact

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -121,13 +121,20 @@ jobs:
                   pattern: flaky-tests-report*
                   delete-merged: true
 
-            - name: Download blob reports
+            - name: Merge blob reports
+              uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              continue-on-error: true
+              with:
+                  name: blob-reports-merged
+                  pattern: blob-reports--*
+                  delete-merged: true
+
+            - name: Download merged blob reports
               uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
               continue-on-error: true
               with:
+                  name: blob-reports-merged
                   path: all-blob-reports
-                  pattern: blob-reports--*
-                  merge-multiple: true
 
             - name: Merge blob reports into HTML report
               run: npx playwright merge-reports --reporter html ./all-blob-reports

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -68,6 +68,14 @@ jobs:
                   path: artifacts/test-results
                   if-no-files-found: ignore
 
+            - name: Archive blob reports (HTML)
+              uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+              if: ${{ !cancelled() }}
+              with:
+                  name: blob-reports--${{ matrix.part }}
+                  path: blob-report
+                  if-no-files-found: ignore
+
             - name: Archive flaky tests report
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               if: ${{ !cancelled() }}
@@ -81,10 +89,19 @@ jobs:
         if: ${{ !cancelled() }}
         needs: [e2e-playwright]
         runs-on: 'ubuntu-24.04'
-        permissions: {}
+        permissions:
+            contents: read
         outputs:
             has-flaky-test-report: ${{ !!steps.merge-flaky-tests-reports.outputs.artifact-id }}
         steps:
+            - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
             - name: Merge failures artifacts
               uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               # Don't fail the job if there aren't any artifacts to merge.
@@ -103,6 +120,26 @@ jobs:
                   name: flaky-tests-report
                   pattern: flaky-tests-report*
                   delete-merged: true
+
+            - name: Download blob reports
+              uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+              continue-on-error: true
+              with:
+                  path: all-blob-reports
+                  pattern: blob-reports--*
+                  merge-multiple: true
+
+            - name: Merge blob reports into HTML report
+              run: npx playwright merge-reports --reporter html ./all-blob-reports
+              continue-on-error: true
+
+            - name: Upload merged HTML report
+              uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+              continue-on-error: true
+              with:
+                  name: html-report--attempt-${{ github.run_attempt }}
+                  path: playwright-report
+                  if-no-files-found: ignore
 
     report-to-issues:
         name: Report to GitHub

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -17,7 +17,7 @@ const config = defineConfig( {
 		command: 'npm run wp-env-test -- start',
 	},
 	reporter: process.env.CI
-		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ] ]
+		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ], [ 'blob' ] ]
 		: 'list',
 	workers: 1,
 	globalSetup: fileURLToPath(


### PR DESCRIPTION
## What?
PR aims to improve artifacts generated by Playwright by consolidating all data into a single report. The HTML reporter received nice updates recently, such as ["Speedboard"](https://playwright.dev/docs/release-notes#version-157).

I think a new report system would help us better monitor our e2e tests.

P.S. This is a first pass to see how it could affect our CI runs.

## Testing Instructions
* CI checks should pass.
* E2E tests job should generate HTML report artifacts.

## Screenshot
<img width="995" height="1008" alt="CleanShot 2026-02-17 at 23 56 32" src="https://github.com/user-attachments/assets/e398b6cc-9047-4585-9ce9-49ce552a9b5e" />

