### PR TITLE
Add warning/error icon to Navigation List View

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -10,7 +10,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 	Tooltip,
-	VisuallyHidden,
 	Icon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -60,7 +59,7 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { useBlockIcon = () => null } = useListViewContext();
+	const { BlockIconComponent } = useListViewContext();
 	const { hasPatternName, blockVisibility } = useSelect(
 		( select ) => {
 			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
@@ -73,13 +72,6 @@ function ListViewBlockSelectButton(
 		[ clientId ]
 	);
 
-	// Call useBlockIcon hook - always defined (defaults to no-op that returns null)
-	// Note: useBlockIcon can be a custom hook that uses React hooks,
-	// which is valid since we're calling it during render
-	// The hook comes from stable context (memoized in ListView), so identity is preserved
-	// eslint-disable-next-line react-compiler/react-compiler
-	const iconOverride = useBlockIcon( block );
-
 	const shouldShowLockIcon = isLocked;
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
@@ -87,18 +79,8 @@ function ListViewBlockSelectButton(
 	// Determine visibility label from blockVisibility metadata
 	const visibilityLabel = getBlockVisibilityLabel( blockVisibility );
 
-	// Compute icon for BlockIcon component
-	let blockIcon;
-	if ( iconOverride ) {
-		blockIcon = {
-			src: iconOverride.src,
-			foreground: iconOverride.foreground,
-		};
-	} else if ( hasPatternName ) {
-		blockIcon = symbol;
-	} else {
-		blockIcon = blockInformation?.icon;
-	}
+	// Compute default icon for BlockIcon component
+	const defaultIcon = hasPatternName ? symbol : blockInformation?.icon;
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -139,9 +121,17 @@ function ListViewBlockSelectButton(
 			aria-expanded={ isExpanded }
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
-			<BlockIcon icon={ blockIcon } showColors context="list-view" />
-			{ iconOverride?.label && (
-				<VisuallyHidden>{ iconOverride.label }</VisuallyHidden>
+			{ BlockIconComponent ? (
+				<BlockIconComponent
+					block={ block }
+					defaultIcon={ defaultIcon }
+				/>
+			) : (
+				<BlockIcon
+					icon={ defaultIcon }
+					showColors
+					context="list-view"
+				/>
 			) }
 			<HStack
 				alignment="center"

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -10,16 +10,12 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 	Tooltip,
+	VisuallyHidden,
+	Icon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import {
-	Icon,
-	lockSmall as lock,
-	pinSmall,
-	unseen,
-	symbol,
-} from '@wordpress/icons';
+import { lockSmall as lock, pinSmall, unseen, symbol } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 
@@ -35,6 +31,7 @@ import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { getBlockVisibilityLabel } from '../block-visibility';
+import { useListViewContext } from './context';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -62,6 +59,7 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
+	const { blockIconOverrides } = useListViewContext();
 	const { hasPatternName, blockVisibility } = useSelect(
 		( select ) => {
 			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
@@ -74,12 +72,28 @@ function ListViewBlockSelectButton(
 		[ clientId ]
 	);
 
+	// Check if there's a custom icon override for this block
+	const iconOverride = blockIconOverrides?.get( clientId );
+
 	const shouldShowLockIcon = isLocked;
 	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 
 	// Determine visibility label from blockVisibility metadata
 	const visibilityLabel = getBlockVisibilityLabel( blockVisibility );
+
+	// Compute icon for BlockIcon component
+	let blockIcon;
+	if ( iconOverride ) {
+		blockIcon = {
+			src: iconOverride.src,
+			foreground: iconOverride.foreground,
+		};
+	} else if ( hasPatternName ) {
+		blockIcon = symbol;
+	} else {
+		blockIcon = blockInformation?.icon;
+	}
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -120,11 +134,10 @@ function ListViewBlockSelectButton(
 			aria-expanded={ isExpanded }
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
-			<BlockIcon
-				icon={ hasPatternName ? symbol : blockInformation?.icon }
-				showColors
-				context="list-view"
-			/>
+			<BlockIcon icon={ blockIcon } showColors context="list-view" />
+			{ iconOverride?.label && (
+				<VisuallyHidden>{ iconOverride.label }</VisuallyHidden>
+			) }
 			<HStack
 				alignment="center"
 				className="block-editor-list-view-block-select-button__label-wrapper"

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -38,7 +38,7 @@ const { Badge } = unlock( componentsPrivateApis );
 function ListViewBlockSelectButton(
 	{
 		className,
-		block: { clientId },
+		block,
 		onClick,
 		onContextMenu,
 		onMouseDown,
@@ -53,13 +53,14 @@ function ListViewBlockSelectButton(
 	},
 	ref
 ) {
+	const { clientId } = block;
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const { blockIconOverrides } = useListViewContext();
+	const { useBlockIcon = () => null } = useListViewContext();
 	const { hasPatternName, blockVisibility } = useSelect(
 		( select ) => {
 			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
@@ -72,8 +73,12 @@ function ListViewBlockSelectButton(
 		[ clientId ]
 	);
 
-	// Check if there's a custom icon override for this block
-	const iconOverride = blockIconOverrides?.get( clientId );
+	// Call useBlockIcon hook - always defined (defaults to no-op that returns null)
+	// Note: useBlockIcon can be a custom hook that uses React hooks,
+	// which is valid since we're calling it during render
+	// The hook comes from stable context (memoized in ListView), so identity is preserved
+	// eslint-disable-next-line react-compiler/react-compiler
+	const iconOverride = useBlockIcon( block );
 
 	const shouldShowLockIcon = isLocked;
 	const isSticky = blockInformation?.positionType === 'sticky';

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -83,6 +83,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {string}         props.description            Optional accessible description for the tree grid component.
  * @param {?Function}      props.onSelect               Optional callback to be invoked when a block is selected. Receives the block object that was selected.
  * @param {?ComponentType} props.additionalBlockContent Component that renders additional block content UI.
+ * @param {?Map}           props.blockIconOverrides     Optional Map of clientId to icon config ({ src, foreground, label }) for overriding block icons.
  * @param {Ref}            ref                          Forwarded ref
  */
 function ListViewComponent(
@@ -98,6 +99,7 @@ function ListViewComponent(
 		description,
 		onSelect,
 		additionalBlockContent: AdditionalBlockContent,
+		blockIconOverrides,
 	},
 	ref
 ) {
@@ -300,6 +302,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			AdditionalBlockContent,
+			blockIconOverrides,
 			insertedBlock,
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
@@ -318,6 +321,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			instanceId,
 			AdditionalBlockContent,
+			blockIconOverrides,
 			insertedBlock,
 			setInsertedBlock,
 			rootClientId,
@@ -420,6 +424,7 @@ export default forwardRef( ( props, ref ) => {
 			onSelect={ null }
 			additionalBlockContent={ null }
 			blockSettingsMenu={ undefined }
+			blockIconOverrides={ undefined }
 		/>
 	);
 } );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -83,7 +83,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {string}         props.description            Optional accessible description for the tree grid component.
  * @param {?Function}      props.onSelect               Optional callback to be invoked when a block is selected. Receives the block object that was selected.
  * @param {?ComponentType} props.additionalBlockContent Component that renders additional block content UI.
- * @param {?Function}      props.useBlockIcon           Optional hook that receives a block and returns icon config ({ src, foreground, label }) or null.
+ * @param {?ComponentType} props.blockIcon              Optional component that renders a custom BlockIcon. Receives block and defaultIcon props.
  * @param {Ref}            ref                          Forwarded ref
  */
 function ListViewComponent(
@@ -99,7 +99,7 @@ function ListViewComponent(
 		description,
 		onSelect,
 		additionalBlockContent: AdditionalBlockContent,
-		useBlockIcon,
+		blockIcon: BlockIconComponent,
 	},
 	ref
 ) {
@@ -302,7 +302,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			AdditionalBlockContent,
-			useBlockIcon,
+			BlockIconComponent,
 			insertedBlock,
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
@@ -321,7 +321,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			instanceId,
 			AdditionalBlockContent,
-			useBlockIcon,
+			BlockIconComponent,
 			insertedBlock,
 			setInsertedBlock,
 			rootClientId,
@@ -424,7 +424,7 @@ export default forwardRef( ( props, ref ) => {
 			onSelect={ null }
 			additionalBlockContent={ null }
 			blockSettingsMenu={ undefined }
-			useBlockIcon={ undefined }
+			BlockIconComponent={ undefined }
 		/>
 	);
 } );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -83,7 +83,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {string}         props.description            Optional accessible description for the tree grid component.
  * @param {?Function}      props.onSelect               Optional callback to be invoked when a block is selected. Receives the block object that was selected.
  * @param {?ComponentType} props.additionalBlockContent Component that renders additional block content UI.
- * @param {?Map}           props.blockIconOverrides     Optional Map of clientId to icon config ({ src, foreground, label }) for overriding block icons.
+ * @param {?Function}      props.useBlockIcon           Optional hook that receives a block and returns icon config ({ src, foreground, label }) or null.
  * @param {Ref}            ref                          Forwarded ref
  */
 function ListViewComponent(
@@ -99,7 +99,7 @@ function ListViewComponent(
 		description,
 		onSelect,
 		additionalBlockContent: AdditionalBlockContent,
-		blockIconOverrides,
+		useBlockIcon,
 	},
 	ref
 ) {
@@ -302,7 +302,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			AdditionalBlockContent,
-			blockIconOverrides,
+			useBlockIcon,
 			insertedBlock,
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
@@ -321,7 +321,7 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			instanceId,
 			AdditionalBlockContent,
-			blockIconOverrides,
+			useBlockIcon,
 			insertedBlock,
 			setInsertedBlock,
 			rootClientId,
@@ -424,7 +424,7 @@ export default forwardRef( ( props, ref ) => {
 			onSelect={ null }
 			additionalBlockContent={ null }
 			blockSettingsMenu={ undefined }
-			blockIconOverrides={ undefined }
+			useBlockIcon={ undefined }
 		/>
 	);
 } );

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -18,4 +18,8 @@ export { InvalidDraftDisplay } from './invalid-draft-display';
 export { useEnableLinkStatusValidation } from './use-enable-link-status-validation';
 export { useIsDraggingWithin } from './use-is-dragging-within';
 export { selectLabelText } from './select-label-text';
-export { useLinkPreview } from './use-link-preview';
+export {
+	useLinkPreview,
+	getActionableStatus,
+	computeBadges,
+} from './use-link-preview';

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -36,6 +36,7 @@ jest.mock( '../../../lock-unlock', () => ( {
 import {
 	computeDisplayUrl,
 	computeBadges,
+	getActionableStatus,
 	useLinkPreview,
 } from '../use-link-preview';
 
@@ -294,6 +295,143 @@ it( 'should show "Page" badge for internal custom links', () => {
 	expect( badges ).not.toContainEqual( {
 		label: 'Custom',
 		intent: 'default',
+	} );
+} );
+
+describe( 'getActionableStatus', () => {
+	describe( 'error states', () => {
+		it( 'should return error for missing entity', () => {
+			const status = getActionableStatus( {
+				url: '/some-page',
+				type: 'page',
+				hasBinding: true,
+				isEntityAvailable: false,
+			} );
+
+			expect( status ).toEqual( {
+				label: 'Missing page',
+				intent: 'error',
+			} );
+		} );
+
+		it( 'should return error for no URL', () => {
+			const status = getActionableStatus( {
+				url: '',
+			} );
+
+			expect( status ).toEqual( {
+				label: 'No link selected',
+				intent: 'error',
+			} );
+		} );
+
+		it( 'should return error for trash status', () => {
+			const status = getActionableStatus( {
+				url: '/my-page',
+				type: 'page',
+				entityStatus: 'trash',
+			} );
+
+			expect( status ).toEqual( {
+				label: 'Trash',
+				intent: 'error',
+			} );
+		} );
+	} );
+
+	describe( 'warning states', () => {
+		it( 'should return warning for draft status', () => {
+			const status = getActionableStatus( {
+				url: '/my-draft',
+				type: 'post',
+				entityStatus: 'draft',
+			} );
+
+			expect( status ).toEqual( {
+				label: 'Draft',
+				intent: 'warning',
+			} );
+		} );
+
+		it( 'should return warning for pending status', () => {
+			const status = getActionableStatus( {
+				url: '/my-post',
+				type: 'post',
+				entityStatus: 'pending',
+			} );
+
+			expect( status ).toEqual( {
+				label: 'Pending',
+				intent: 'warning',
+			} );
+		} );
+
+		it( 'should return warning for scheduled status', () => {
+			const status = getActionableStatus( {
+				url: '/my-post',
+				type: 'post',
+				entityStatus: 'future',
+			} );
+
+			expect( status ).toEqual( {
+				label: 'Scheduled',
+				intent: 'warning',
+			} );
+		} );
+	} );
+
+	describe( 'no action needed', () => {
+		it( 'should return null for published status', () => {
+			const status = getActionableStatus( {
+				url: '/my-page',
+				type: 'page',
+				entityStatus: 'publish',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+
+		it( 'should return null for private status', () => {
+			const status = getActionableStatus( {
+				url: '/my-page',
+				type: 'page',
+				entityStatus: 'private',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+
+		it( 'should return null for external links', () => {
+			const status = getActionableStatus( {
+				url: 'https://example.com',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+
+		it( 'should return null for internal links without entity status', () => {
+			const status = getActionableStatus( {
+				url: '/some-page',
+				type: 'page',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+	} );
+
+	describe( 'priority', () => {
+		it( 'should prioritize missing entity over no URL', () => {
+			// This shouldn't happen in practice, but test priority
+			const status = getActionableStatus( {
+				url: '',
+				type: 'page',
+				hasBinding: true,
+				isEntityAvailable: false,
+			} );
+
+			expect( status.intent ).toBe( 'error' );
+			expect( status.label ).toBe( 'Missing page' );
+		} );
 	} );
 } );
 

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -75,6 +75,59 @@ export function computeDisplayUrl( { linkUrl, siteUrl } = {} ) {
 }
 
 /**
+ * Get actionable status for a navigation item.
+ * Returns status information only for items that require user action (error or warning states).
+ *
+ * @param {Object}  options                   - Options object
+ * @param {string}  options.url               - Link URL
+ * @param {string}  options.type              - Entity type (page, post, etc.)
+ * @param {string}  options.entityStatus      - Entity status (publish, draft, etc.)
+ * @param {boolean} options.hasBinding        - Whether link has entity binding
+ * @param {boolean} options.isEntityAvailable - Whether bound entity exists
+ * @return {Object|null} Object with label and intent, or null if no action needed
+ */
+export function getActionableStatus( {
+	url,
+	type,
+	entityStatus,
+	hasBinding,
+	isEntityAvailable,
+} ) {
+	// Check for error states first (highest priority)
+	if ( hasBinding && ! isEntityAvailable ) {
+		return {
+			label: sprintf(
+				/* translators: %s is the entity type (e.g., "page", "post", "category") */
+				__( 'Missing %s' ),
+				type
+			),
+			intent: 'error',
+		};
+	}
+
+	if ( ! url ) {
+		return { label: __( 'No link selected' ), intent: 'error' };
+	}
+
+	// Check for warning/error states in entity status
+	if ( entityStatus ) {
+		const actionableStatuses = {
+			draft: { label: __( 'Draft' ), intent: 'warning' },
+			pending: { label: __( 'Pending' ), intent: 'warning' },
+			future: { label: __( 'Scheduled' ), intent: 'warning' },
+			trash: { label: __( 'Trash' ), intent: 'error' },
+		};
+
+		if ( actionableStatuses[ entityStatus ] ) {
+			return actionableStatuses[ entityStatus ];
+		}
+	}
+
+	// No action needed
+	return null;
+}
+
+/**
  * Compute badges for the link preview.
  *
  * @param {Object}  options                   - Options object
@@ -123,28 +176,25 @@ export function computeBadges( {
 		}
 	}
 
-	// Status badge
-	if ( hasBinding && ! isEntityAvailable ) {
-		badges.push( {
-			label: sprintf(
-				/* translators: %s is the entity type (e.g., "page", "post", "category") */
-				__( 'Missing %s' ),
-				type
-			),
-			intent: 'error',
-		} );
-	} else if ( ! url ) {
-		badges.push( { label: __( 'No link selected' ), intent: 'error' } );
+	// Status badge - reuse getActionableStatus for error/warning states
+	const actionableStatus = getActionableStatus( {
+		url,
+		type,
+		entityStatus,
+		hasBinding,
+		isEntityAvailable,
+	} );
+
+	if ( actionableStatus ) {
+		// Add error or warning status badge
+		badges.push( actionableStatus );
 	} else if ( entityStatus ) {
-		const statusMap = {
+		// Only add success/default badges if no actionable status
+		const nonActionableStatusMap = {
 			publish: { label: __( 'Published' ), intent: 'success' },
-			future: { label: __( 'Scheduled' ), intent: 'warning' },
-			draft: { label: __( 'Draft' ), intent: 'warning' },
-			pending: { label: __( 'Pending' ), intent: 'warning' },
 			private: { label: __( 'Private' ), intent: 'default' },
-			trash: { label: __( 'Trash' ), intent: 'error' },
 		};
-		const badge = statusMap[ entityStatus ];
+		const badge = nonActionableStatusMap[ entityStatus ];
 		if ( badge ) {
 			badges.push( badge );
 		}

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -12,7 +12,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select as dataSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext, useMemo } from '@wordpress/element';
 import { info, error } from '@wordpress/icons';
@@ -163,11 +163,10 @@ const MainContent = ( {
 
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
-	// Get all navigation-link blocks with their entity data
-	const navigationLinksWithEntity = useSelect(
+	// Get all navigation-link blocks
+	const navigationLinks = useSelect(
 		( select ) => {
 			const { getBlocks } = select( blockEditorStore );
-			const { getEntityRecord } = select( coreStore );
 			const allBlocks = getBlocks( clientId );
 
 			// Recursively get all navigation-link and navigation-submenu blocks
@@ -180,43 +179,7 @@ const MainContent = ( {
 						block.innerBlocks.length > 0
 							? getAllNavigationLinks( block.innerBlocks )
 							: [];
-					if ( ! isNavigationLink ) {
-						return children;
-					}
-
-					// Get entity data if the link has an ID and type
-					const { id, type, kind } = block.attributes || {};
-					let entityRecord = null;
-					let isEntityAvailable = true;
-
-					// Fetch entity record for any link with id/kind/type (bound or not)
-					if ( id && kind && type ) {
-						const isPostType = kind === 'post-type';
-						const isTaxonomy = kind === 'taxonomy';
-
-						if ( isPostType || isTaxonomy ) {
-							const entityType = isTaxonomy
-								? 'taxonomy'
-								: 'postType';
-							const typeForAPI =
-								type === 'tag' ? 'post_tag' : type;
-							entityRecord = getEntityRecord(
-								entityType,
-								typeForAPI,
-								id
-							);
-							isEntityAvailable = !! entityRecord;
-						}
-					}
-
-					return [
-						{
-							block,
-							entityRecord,
-							isEntityAvailable,
-						},
-						...children,
-					];
+					return isNavigationLink ? [ block, ...children ] : children;
 				} );
 			};
 
@@ -228,33 +191,52 @@ const MainContent = ( {
 	// Compute icon overrides for navigation links that need status indicators
 	const blockIconOverrides = useMemo( () => {
 		const overrides = new Map();
+		const { getEntityRecord } = dataSelect( coreStore );
 
-		navigationLinksWithEntity.forEach(
-			( { block, entityRecord, isEntityAvailable } ) => {
-				const { url, type, metadata, id } = block.attributes || {};
-				const hasUrlBinding = !! metadata?.bindings?.url && !! id;
+		navigationLinks.forEach( ( block ) => {
+			const { url, type, metadata, id, kind } = block.attributes || {};
+			const hasUrlBinding = !! metadata?.bindings?.url && !! id;
 
-				const status = getActionableStatus( {
-					url,
-					type,
-					entityStatus: entityRecord?.status,
-					hasBinding: hasUrlBinding,
-					isEntityAvailable,
-				} );
+			// Get entity record if block has id/kind/type
+			let entityRecord = null;
+			let isEntityAvailable = true;
 
-				if ( status ) {
-					const isError = status.intent === 'error';
-					overrides.set( block.clientId, {
-						src: isError ? error : info,
-						foreground: isError ? '#660c0c' : '#f0b849',
-						label: status.label,
-					} );
+			if ( id && kind && type ) {
+				const isPostType = kind === 'post-type';
+				const isTaxonomy = kind === 'taxonomy';
+
+				if ( isPostType || isTaxonomy ) {
+					const entityType = isTaxonomy ? 'taxonomy' : 'postType';
+					const typeForAPI = type === 'tag' ? 'post_tag' : type;
+					entityRecord = getEntityRecord(
+						entityType,
+						typeForAPI,
+						id
+					);
+					isEntityAvailable = !! entityRecord;
 				}
 			}
-		);
+
+			const status = getActionableStatus( {
+				url,
+				type,
+				entityStatus: entityRecord?.status,
+				hasBinding: hasUrlBinding,
+				isEntityAvailable,
+			} );
+
+			if ( status ) {
+				const isError = status.intent === 'error';
+				overrides.set( block.clientId, {
+					src: isError ? error : info,
+					foreground: isError ? '#660c0c' : '#f0b849',
+					label: status.label,
+				} );
+			}
+		} );
 
 		return overrides;
-	}, [ navigationLinksWithEntity ] );
+	}, [ navigationLinks ] );
 
 	if ( currentMenuId && isNavigationMenuMissing ) {
 		return (

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -14,7 +14,9 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
+import { info, error } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -28,6 +30,7 @@ import {
 	LinkUI,
 	updateAttributes,
 	useEntityBinding,
+	getActionableStatus,
 } from '../../navigation-link/shared';
 
 const actionLabel =
@@ -160,6 +163,99 @@ const MainContent = ( {
 
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
+	// Get all navigation-link blocks with their entity data
+	const navigationLinksWithEntity = useSelect(
+		( select ) => {
+			const { getBlocks } = select( blockEditorStore );
+			const { getEntityRecord } = select( coreStore );
+			const allBlocks = getBlocks( clientId );
+
+			// Recursively get all navigation-link and navigation-submenu blocks
+			const getAllNavigationLinks = ( blocks ) => {
+				return blocks.flatMap( ( block ) => {
+					const isNavigationLink =
+						block.name === 'core/navigation-link' ||
+						block.name === 'core/navigation-submenu';
+					const children =
+						block.innerBlocks.length > 0
+							? getAllNavigationLinks( block.innerBlocks )
+							: [];
+					if ( ! isNavigationLink ) {
+						return children;
+					}
+
+					// Get entity data if the link has an ID and type
+					const { id, type, kind } = block.attributes || {};
+					let entityRecord = null;
+					let isEntityAvailable = true;
+
+					// Fetch entity record for any link with id/kind/type (bound or not)
+					if ( id && kind && type ) {
+						const isPostType = kind === 'post-type';
+						const isTaxonomy = kind === 'taxonomy';
+
+						if ( isPostType || isTaxonomy ) {
+							const entityType = isTaxonomy
+								? 'taxonomy'
+								: 'postType';
+							const typeForAPI =
+								type === 'tag' ? 'post_tag' : type;
+							entityRecord = getEntityRecord(
+								entityType,
+								typeForAPI,
+								id
+							);
+							isEntityAvailable = !! entityRecord;
+						}
+					}
+
+					return [
+						{
+							block,
+							entityRecord,
+							isEntityAvailable,
+						},
+						...children,
+					];
+				} );
+			};
+
+			return getAllNavigationLinks( allBlocks );
+		},
+		[ clientId ]
+	);
+
+	// Compute icon overrides for navigation links that need status indicators
+	const blockIconOverrides = useMemo( () => {
+		const overrides = new Map();
+
+		navigationLinksWithEntity.forEach(
+			( { block, entityRecord, isEntityAvailable } ) => {
+				const { url, type, metadata, id } = block.attributes || {};
+				const hasUrlBinding = !! metadata?.bindings?.url && !! id;
+
+				const status = getActionableStatus( {
+					url,
+					type,
+					entityStatus: entityRecord?.status,
+					hasBinding: hasUrlBinding,
+					isEntityAvailable,
+				} );
+
+				if ( status ) {
+					const isError = status.intent === 'error';
+					overrides.set( block.clientId, {
+						src: isError ? error : info,
+						foreground: isError ? '#660c0c' : '#f0b849',
+						label: status.label,
+					} );
+				}
+			}
+		);
+
+		return overrides;
+	}, [ navigationLinksWithEntity ] );
+
 	if ( currentMenuId && isNavigationMenuMissing ) {
 		return (
 			<DeletedNavigationWarning onCreateNew={ onCreateNew } isNotice />
@@ -195,6 +291,7 @@ const MainContent = ( {
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
 				additionalBlockContent={ AdditionalBlockContent }
+				blockIconOverrides={ blockIconOverrides }
 				onSelect={ openListViewContentPanel }
 			/>
 		</div>

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -5,12 +5,14 @@ import {
 	privateApis as blockEditorPrivateApis,
 	InspectorControls,
 	store as blockEditorStore,
+	BlockIcon,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	Spinner,
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
+	VisuallyHidden,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -33,17 +35,19 @@ import {
 } from '../../navigation-link/shared';
 
 /**
- * Hook to get custom icon for navigation link blocks.
+ * Component that renders a custom BlockIcon for navigation link blocks with status indicators.
  *
- * @param {Object} block - The block object
- * @return {Object|null} Icon config or null
+ * @param {Object} props             - Component props
+ * @param {Object} props.block       - The block object
+ * @param {*}      props.defaultIcon - The default icon to use if no status indicator needed
+ * @return {React.JSX.Element} BlockIcon component
  */
-function useNavigationBlockIcon( block ) {
+function NavigationBlockIcon( { block, defaultIcon } ) {
 	const { clientId, attributes, name } = block;
 	const { url, type, metadata, id } = attributes || {};
 	const hasUrlBinding = !! metadata?.bindings?.url && !! id;
 
-	// Always call hooks before any conditional returns
+	// Get entity binding data
 	const { isBoundEntityAvailable, entityRecord } = useEntityBinding( {
 		clientId,
 		attributes,
@@ -54,7 +58,9 @@ function useNavigationBlockIcon( block ) {
 		name !== 'core/navigation-link' &&
 		name !== 'core/navigation-submenu'
 	) {
-		return null;
+		return (
+			<BlockIcon icon={ defaultIcon } showColors context="list-view" />
+		);
 	}
 
 	const status = getActionableStatus( {
@@ -65,16 +71,26 @@ function useNavigationBlockIcon( block ) {
 		isEntityAvailable: isBoundEntityAvailable,
 	} );
 
+	// No status indicator needed, use default
 	if ( ! status ) {
-		return null;
+		return (
+			<BlockIcon icon={ defaultIcon } showColors context="list-view" />
+		);
 	}
 
+	// Render status indicator icon
 	const isError = status.intent === 'error';
-	return {
+	const statusIcon = {
 		src: isError ? error : info,
 		foreground: isError ? '#660c0c' : '#f0b849',
-		label: status.label,
 	};
+
+	return (
+		<>
+			<BlockIcon icon={ statusIcon } showColors context="list-view" />
+			<VisuallyHidden>{ status.label }</VisuallyHidden>
+		</>
+	);
 }
 
 const actionLabel =
@@ -242,9 +258,7 @@ const MainContent = ( {
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
 				additionalBlockContent={ AdditionalBlockContent }
-				// Passing a hook as a prop is safe here since it's memoized in context
-				// eslint-disable-next-line react-compiler/react-compiler
-				useBlockIcon={ useNavigationBlockIcon }
+				blockIcon={ NavigationBlockIcon }
 				onSelect={ openListViewContentPanel }
 			/>
 		</div>

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -12,11 +12,10 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { useSelect, useDispatch, select as dataSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { useContext, useMemo } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { info, error } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -32,6 +31,51 @@ import {
 	useEntityBinding,
 	getActionableStatus,
 } from '../../navigation-link/shared';
+
+/**
+ * Hook to get custom icon for navigation link blocks.
+ *
+ * @param {Object} block - The block object
+ * @return {Object|null} Icon config or null
+ */
+function useNavigationBlockIcon( block ) {
+	const { clientId, attributes, name } = block;
+	const { url, type, metadata, id } = attributes || {};
+	const hasUrlBinding = !! metadata?.bindings?.url && !! id;
+
+	// Always call hooks before any conditional returns
+	const { isBoundEntityAvailable, entityRecord } = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
+
+	// Only handle navigation link blocks
+	if (
+		name !== 'core/navigation-link' &&
+		name !== 'core/navigation-submenu'
+	) {
+		return null;
+	}
+
+	const status = getActionableStatus( {
+		url,
+		type,
+		entityStatus: entityRecord?.status,
+		hasBinding: hasUrlBinding,
+		isEntityAvailable: isBoundEntityAvailable,
+	} );
+
+	if ( ! status ) {
+		return null;
+	}
+
+	const isError = status.intent === 'error';
+	return {
+		src: isError ? error : info,
+		foreground: isError ? '#660c0c' : '#f0b849',
+		label: status.label,
+	};
+}
 
 const actionLabel =
 	/* translators: %s: The name of a menu. */ __( "Switch to '%s'" );
@@ -163,81 +207,6 @@ const MainContent = ( {
 
 	const { navigationMenu } = useNavigationMenu( currentMenuId );
 
-	// Get all navigation-link blocks
-	const navigationLinks = useSelect(
-		( select ) => {
-			const { getBlocks } = select( blockEditorStore );
-			const allBlocks = getBlocks( clientId );
-
-			// Recursively get all navigation-link and navigation-submenu blocks
-			const getAllNavigationLinks = ( blocks ) => {
-				return blocks.flatMap( ( block ) => {
-					const isNavigationLink =
-						block.name === 'core/navigation-link' ||
-						block.name === 'core/navigation-submenu';
-					const children =
-						block.innerBlocks.length > 0
-							? getAllNavigationLinks( block.innerBlocks )
-							: [];
-					return isNavigationLink ? [ block, ...children ] : children;
-				} );
-			};
-
-			return getAllNavigationLinks( allBlocks );
-		},
-		[ clientId ]
-	);
-
-	// Compute icon overrides for navigation links that need status indicators
-	const blockIconOverrides = useMemo( () => {
-		const overrides = new Map();
-		const { getEntityRecord } = dataSelect( coreStore );
-
-		navigationLinks.forEach( ( block ) => {
-			const { url, type, metadata, id, kind } = block.attributes || {};
-			const hasUrlBinding = !! metadata?.bindings?.url && !! id;
-
-			// Get entity record if block has id/kind/type
-			let entityRecord = null;
-			let isEntityAvailable = true;
-
-			if ( id && kind && type ) {
-				const isPostType = kind === 'post-type';
-				const isTaxonomy = kind === 'taxonomy';
-
-				if ( isPostType || isTaxonomy ) {
-					const entityType = isTaxonomy ? 'taxonomy' : 'postType';
-					const typeForAPI = type === 'tag' ? 'post_tag' : type;
-					entityRecord = getEntityRecord(
-						entityType,
-						typeForAPI,
-						id
-					);
-					isEntityAvailable = !! entityRecord;
-				}
-			}
-
-			const status = getActionableStatus( {
-				url,
-				type,
-				entityStatus: entityRecord?.status,
-				hasBinding: hasUrlBinding,
-				isEntityAvailable,
-			} );
-
-			if ( status ) {
-				const isError = status.intent === 'error';
-				overrides.set( block.clientId, {
-					src: isError ? error : info,
-					foreground: isError ? '#660c0c' : '#f0b849',
-					label: status.label,
-				} );
-			}
-		} );
-
-		return overrides;
-	}, [ navigationLinks ] );
-
 	if ( currentMenuId && isNavigationMenuMissing ) {
 		return (
 			<DeletedNavigationWarning onCreateNew={ onCreateNew } isNotice />
@@ -273,7 +242,9 @@ const MainContent = ( {
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
 				additionalBlockContent={ AdditionalBlockContent }
-				blockIconOverrides={ blockIconOverrides }
+				// Passing a hook as a prop is safe here since it's memoized in context
+				// eslint-disable-next-line react-compiler/react-compiler
+				useBlockIcon={ useNavigationBlockIcon }
 				onSelect={ openListViewContentPanel }
 			/>
 		</div>

--- a/packages/block-library/src/navigation/edit/test/list-view-indicators.test.js
+++ b/packages/block-library/src/navigation/edit/test/list-view-indicators.test.js
@@ -1,0 +1,144 @@
+/**
+ * Internal dependencies
+ */
+import {
+	computeBadges,
+	getActionableStatus,
+} from '../../../navigation-link/shared';
+
+// These tests verify the integration between computeBadges and getActionableStatus
+// to ensure indicators show correctly for navigation items in list view.
+
+describe( 'List View Indicators Integration', () => {
+	describe( 'Error status indicators', () => {
+		it( 'should return error status for missing entity', () => {
+			const badges = computeBadges( {
+				url: '/some-page',
+				type: 'page',
+				hasBinding: true,
+				isEntityAvailable: false,
+			} );
+
+			const status = getActionableStatus( {
+				url: '/some-page',
+				type: 'page',
+				hasBinding: true,
+				isEntityAvailable: false,
+			} );
+
+			expect( status ).not.toBeNull();
+			expect( status.intent ).toBe( 'error' );
+			expect( status.label ).toBe( 'Missing page' );
+
+			// Verify badge and status are consistent
+			const errorBadge = badges.find(
+				( badge ) => badge.intent === 'error'
+			);
+			expect( errorBadge.label ).toBe( status.label );
+		} );
+
+		it( 'should return error status for no URL', () => {
+			const status = getActionableStatus( {
+				url: '',
+			} );
+
+			expect( status ).not.toBeNull();
+			expect( status.intent ).toBe( 'error' );
+			expect( status.label ).toBe( 'No link selected' );
+		} );
+
+		it( 'should return error status for trash', () => {
+			const status = getActionableStatus( {
+				url: '/my-page',
+				type: 'page',
+				entityStatus: 'trash',
+			} );
+
+			expect( status ).not.toBeNull();
+			expect( status.intent ).toBe( 'error' );
+			expect( status.label ).toBe( 'Trash' );
+		} );
+	} );
+
+	describe( 'Warning status indicators', () => {
+		it( 'should return warning status for draft entity', () => {
+			const status = getActionableStatus( {
+				url: '/my-draft',
+				type: 'post',
+				entityStatus: 'draft',
+			} );
+
+			expect( status ).not.toBeNull();
+			expect( status.intent ).toBe( 'warning' );
+			expect( status.label ).toBe( 'Draft' );
+		} );
+
+		it( 'should return warning status for pending entity', () => {
+			const status = getActionableStatus( {
+				url: '/my-post',
+				type: 'post',
+				entityStatus: 'pending',
+			} );
+
+			expect( status ).not.toBeNull();
+			expect( status.intent ).toBe( 'warning' );
+			expect( status.label ).toBe( 'Pending' );
+		} );
+
+		it( 'should return warning status for scheduled entity', () => {
+			const status = getActionableStatus( {
+				url: '/my-post',
+				type: 'post',
+				entityStatus: 'future',
+			} );
+
+			expect( status ).not.toBeNull();
+			expect( status.intent ).toBe( 'warning' );
+			expect( status.label ).toBe( 'Scheduled' );
+		} );
+	} );
+
+	describe( 'No indicator for valid items', () => {
+		it( 'should return null for published entity', () => {
+			const status = getActionableStatus( {
+				url: '/my-page',
+				type: 'page',
+				entityStatus: 'publish',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+
+		it( 'should return null for external links', () => {
+			const status = getActionableStatus( {
+				url: 'https://example.com',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+
+		it( 'should return null for private posts', () => {
+			const status = getActionableStatus( {
+				url: '/my-page',
+				type: 'page',
+				entityStatus: 'private',
+			} );
+
+			expect( status ).toBeNull();
+		} );
+	} );
+
+	describe( 'Priority when multiple issues present', () => {
+		it( 'should prioritize missing entity over no URL', () => {
+			const status = getActionableStatus( {
+				url: '',
+				type: 'page',
+				hasBinding: true,
+				isEntityAvailable: false,
+			} );
+
+			expect( status.intent ).toBe( 'error' );
+			expect( status.label ).toBe( 'Missing page' );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72622

<!-- In a few words, what is the PR actually doing? -->
Allows Editable Navigation List View to surface errors/warnings that need addressed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
UX - it's not clear from the list view that anything is wrong.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Allow the icon to be overridden by a warning or error indicator

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### Invalid entity shows Red Triangle Error Icon
1. Add a broken entity link to a navigation via the code editor
```
<!-- wp:navigation-link {"label":"Broken Binding","type":"page","id":99999999,"url":"http://localhost:8888/doesn't-exist","kind":"post-type","metadata":{"bindings":{"url":{"source":"core/post-data","args":{"field":"link"}}}}} /-->
```
2. List View should show red triangle error icon

### Missing Link shows Red Triangle Error Icon
1. Add a navigation link with no link via the code editor:
```
<!-- wp:navigation-link {"label":"Empty URL","url":""} /-->
```
2. List View should show red triangle error icon

### Draft pages shows yellow warning icon
1. Add a draft link to the navigation 
- Click add Page to open the link control flow
- Click Create Page
- Add a title
- Uncheck "Publish"
- Save
2. List View should show yellow warning icon
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="966" height="384" alt="Canvas and Inspector Sidebar showing the navigation list view with some warning and error icons" src="https://github.com/user-attachments/assets/e484fe01-89c0-461e-bba6-13b45c9fa67e" />
