### PR TITLE
Project Management: Add components team as codeowners for components package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,7 +80,7 @@
 /test/php/gutenberg-coding-standards            @anton-vlasenko
 
 # UI Components
-/packages/components                            @ajitbohra
+/packages/components                            @ajitbohra @WordPress/gutenberg-components
 /packages/compose                               @ajitbohra
 /packages/element                               @ajitbohra
 /packages/notices                               @ajitbohra


### PR DESCRIPTION
## What?

Updates the GitHub [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file to add @WordPress/gutenberg-components as codeowners of the `@wordpress/components` package.

## Why?

The purpose of this team is to provide feedback to common UI components used and maintained in Gutenberg, and it should follow that the team should be looped into any proposed changes to those components. This is the same justification as used for adding code ownership for `@wordpress/ui` and `@wordpress/theme` in #73369, and the team's scope includes `@wordpress/components` as well.

The main counter-point to this argument would be that it increases the potential notification burden for an already-small team, which is largely the reason it hadn't been done until now. I'm sensitive to this point as well, so happy to opt against this change if there's concern and would invite feedback from the team.

## Testing Instructions

Verify that the syntax and team name is correct in the CODEOWNERS file based on the specification and related entries. The GitHub UI should also show the code owners file as valid ([screenshot](https://github.com/user-attachments/assets/292ca080-fc48-442c-b703-536b6c41a78f)).
