### PR TITLE
RTC: Update diff package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61300,7 +61300,7 @@
 				"@wordpress/hooks": "file:../hooks",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/undo-manager": "file:../undo-manager",
-				"diff": "^4.0.2",
+				"diff": "^8.0.3",
 				"fast-deep-equal": "^3.1.3",
 				"lib0": "0.2.99",
 				"y-protocols": "^1.0.5",
@@ -61657,6 +61657,15 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"packages/sync/node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"packages/sync/node_modules/expect": {
 			"version": "30.2.0",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/undo-manager": "file:../undo-manager",
-		"diff": "^4.0.2",
+		"diff": "^8.0.3",
 		"fast-deep-equal": "^3.1.3",
 		"lib0": "0.2.99",
 		"y-protocols": "^1.0.5",


### PR DESCRIPTION

## What?

Update the `diff` package to v8.

## Why?

After changing the CRDT type of `content` from primitive `string` to `Y.Text`, we encountered extreme performance issues when applying updates to that field. We use `diff` to compute `Delta` operations from two distinct strings so that we capture edits as atomic updates (instead of the entire string changing).

After some investigation, we realized we were using a very old version of `diff` and that performance had markedly improved in more recent versions.

## How?

Simple `package.json` update.

## Testing Instructions

1. Check out `trunk`.
2. Settings > Writing > Enable real-time collaboration.
3. Open a large post for editing.
4. Switch to the code editor.
5. Make changes and observe the responsive drop or occasionally freeze.
6. Switch to this branch.
7. Observe improved performance.
