### PR TITLE
wp-build: Add configurable script registration priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"scriptGlobal": "wp",
 		"packageNamespace": "wordpress",
 		"handlePrefix": "wp",
+		"scriptRegistrationPriority": 10,
 		"pages": [
 			{
 				"id": "site-editor-v2",

--- a/packages/wp-build/lib/php-generator.mjs
+++ b/packages/wp-build/lib/php-generator.mjs
@@ -30,11 +30,15 @@ export async function getPhpReplacements( rootDir, baseUrlExpression ) {
 	// @ts-expect-error specific override to package.json
 	const name = rootPackageJson.wpPlugin?.name || 'gutenberg';
 	const version = rootPackageJson.version;
+	const scriptPriority =
+		// @ts-expect-error specific override to package.json
+		rootPackageJson.wpPlugin?.scriptRegistrationPriority ?? 9;
 
 	return {
 		'{{PREFIX}}': name,
 		'{{VERSION}}': version,
 		'{{BASE_URL}}': baseUrlExpression,
+		'{{SCRIPT_PRIORITY}}': String( scriptPriority ),
 	};
 }
 

--- a/packages/wp-build/templates/script-registration.php.template
+++ b/packages/wp-build/templates/script-registration.php.template
@@ -85,5 +85,5 @@ if ( ! function_exists( '{{PREFIX}}_register_package_scripts' ) ) {
 		}
 	}
 
-	add_action( 'wp_default_scripts', '{{PREFIX}}_register_package_scripts' );
+	add_action( 'wp_default_scripts', '{{PREFIX}}_register_package_scripts', {{SCRIPT_PRIORITY}} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75440

<!-- In a few words, what is the PR actually doing? -->

Expands on #75460 by adding a `scriptRegistrationPriority` parameter to `wpPlugin`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #75440
Without this, Gutenberg registers scripts with the same priority as the other plugins, which causes a mismatch of the `private-apis` versions, crashing the page of the plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The configurable `scriptRegistrationPriority` allows Gutenberg to raise its priority above other plugins while other plugins that use wp-build continue with a priority above core's. The default priority is 9, so other plugins do not need to change this value, only Gutenberg needs to raise it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1 - Clone https://github.com/dhasilva/minimal-wp-build-test locally
2 - Uncomment [these lines](https://github.com/dhasilva/minimal-wp-build-test/blob/trunk/minimal-wp-build-test.php#L39-L46) to avoid an unrelated problem
4 - `pnpm install` and build the test plugin with `pnpm run build`
5 - Go to Tools > Minimal WP-Build Test
6 - Check that you see the error in the linked issue
7 - Symlink wp-build to the plugin's dependencies:
```
cd <your-wp-plugins-folder>/minimal-wp-build-test
rm -rf node_modules/@wordpress/build
ln -s <your-gutenberg-folder>/packages/wp-build node_modules/@wordpress/build
```
8 - Rebuild the test plugin: `pnpm run build`
9 - Check `/build/scripts.php`, it should register scripts with priority 9: `add_action( 'wp_default_scripts', 'minimal_wp_build_test_register_package_scripts', 9 );`
10 - Rebuild Gutenberg
11 - Check Gutenbergs' /build/scripts.php, it should have priority 10
12 - Go to Tools > Minimal WP-Build Test again
13 - Check that the page loads 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="541" height="730" alt="Screenshot from 2026-02-17 21-18-14" src="https://github.com/user-attachments/assets/6c4a1633-cf66-456b-a2b8-4d72e1f3a120" />|<img width="541" height="730" alt="Screenshot from 2026-02-17 21-16-49" src="https://github.com/user-attachments/assets/f8800305-399e-4775-8c18-e1aa9caaeffa" />|
