### PR TITLE
Icon Block: Move default width rule to theme.json instead of block.json

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -437,7 +437,7 @@ Insert an SVG icon. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/
 -	**Experimental:** true
 -	**Category:** media
 -	**Supports:** align (center, left, right), anchor, ariaLabel, color (background, text), dimensions (width), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** icon, style
+-	**Attributes:** icon
 
 ## Image
 

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -358,6 +358,11 @@
 					}
 				}
 			},
+			"core/icon": {
+				"dimensions": {
+					"width": "24px"
+				}
+			},
 			"core/site-logo": {
 				"variations": {
 					"rounded": {

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -12,14 +12,6 @@
 		"icon": {
 			"type": "string",
 			"role": "content"
-		},
-		"style": {
-			"type": "object",
-			"default": {
-				"dimensions": {
-					"width": "24px"
-				}
-			}
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -14,7 +14,6 @@ import {
 	ToolbarGroup,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	Placeholder,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -33,10 +32,32 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { SVG, Rect, Path } from '@wordpress/primitives';
+
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import HtmlRenderer from '../utils/html-renderer';
 import { CustomInserterModal } from './components';
 import { unlock } from '../lock-unlock';
+
+const IconPlaceholder = ( { className, style } ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 60 60"
+		preserveAspectRatio="none"
+		fill="none"
+		aria-hidden="true"
+		className={ clsx( 'wp-block-icon__placeholder', className ) }
+		style={ style }
+	>
+		<Rect width="60" height="60" fill="currentColor" fillOpacity={ 0.1 } />
+		<Path
+			vectorEffect="non-scaling-stroke"
+			stroke="currentColor"
+			strokeOpacity={ 0.25 }
+			d="M60 60 0 0"
+		/>
+	</SVG>
+);
 
 export function Edit( { attributes, setAttributes } ) {
 	const { icon, ariaLabel } = attributes;
@@ -165,8 +186,7 @@ export function Edit( { attributes, setAttributes } ) {
 						} }
 					/>
 				) : (
-					<Placeholder
-						withIllustration
+					<IconPlaceholder
 						className={ clsx(
 							borderProps.className,
 							spacingProps.className,
@@ -176,7 +196,7 @@ export function Edit( { attributes, setAttributes } ) {
 							...borderProps.style,
 							...spacingProps.style,
 							...dimensionsProps.style,
-							aspectRatio: '1',
+							height: 'auto',
 						} }
 					/>
 				) }

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -28,12 +28,11 @@ import {
 import { useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
+import { SVG, Rect, Path } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
  */
-import { SVG, Rect, Path } from '@wordpress/primitives';
-
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import HtmlRenderer from '../utils/html-renderer';
 import { CustomInserterModal } from './components';

--- a/packages/block-library/src/icon/editor.scss
+++ b/packages/block-library/src/icon/editor.scss
@@ -46,12 +46,6 @@
 	width: 250px;
 }
 
-// Provide special styling for the placeholder.
-// @todo this particular minimal style of placeholder could be componentized further.
-.wp-block-icon .components-placeholder {
-	padding: 0;
-	min-height: $grid-unit-30;
-	min-width: $grid-unit-30;
-	height: 100%;
-	width: 100%;
+.wp-block-icon__placeholder {
+	backdrop-filter: blur(100px);
 }

--- a/packages/block-library/src/icon/style.scss
+++ b/packages/block-library/src/icon/style.scss
@@ -13,8 +13,13 @@
 
 	svg {
 		box-sizing: border-box;
-		width: 100%;
-		height: 100%;
 		fill: currentColor;
 	}
+}
+
+// Use :where() so these defaults have zero specificity and can be overridden
+// by global styles, which target `.wp-block-icon svg` at higher specificity.
+:where(.wp-block-icon) svg {
+	width: 100%;
+	height: 100%;
 }

--- a/test/integration/fixtures/blocks/core__icon.json
+++ b/test/integration/fixtures/blocks/core__icon.json
@@ -2,13 +2,7 @@
 	{
 		"name": "core/icon",
 		"isValid": true,
-		"attributes": {
-			"style": {
-				"dimensions": {
-					"width": "24px"
-				}
-			}
-		},
+		"attributes": {},
 		"innerBlocks": []
 	}
 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #75604 (resetting width for the Icon block)

Ensure that resetting an Icon block (or inserting an Icon block) uses the global default width for the block.

To achieve this, set that global rule in the base `theme.json` (rule is applied at all times) instead of the `block.json` file (rule is baked into the block instance in post content, and is lost when the value is reset).

## Why?

For base or default styles for blocks, these should generally be provided in either `theme.json` or low-specificity CSS rules in a `style.scss` file, as they're intended to be applied at all times. If default values are injected into the block attributes themselves, then they are high-specificity which will override global styles, and the values are also ignored by the block supports' reset behaviour, which typically clears a value out.

With this change, the default value is preserved in `theme.json` instead of at the block level, and users can still override the default value in either their theme, or at the block level within global styles.

## How?

* Move the `width: 100%` and `height: 100%` rules to a low specificity `:where()` selector
* Move the default width value for this block to the base theme.json file
* Add a small ad-hoc placeholder SVG that matches what's used in the `Placeholder` component — this is so that we have a simple SVG for the placeholder state that will scale with the global styles (or block-level) width values

## Testing Instructions

* Insert an Icon block, and it should have an empty width value in the block's style tab, but the actual width will be `24px`
* Add an icon to the block, and play around with giving it a custom width and resetting the value
* Resetting should clear the value, but the block should return to its original default size of `24px`
* Double-check that this behaviour works correctly on the site frontend
* Open up global styles and make adjustments to the Icon block _globally_
* This should take effect on Icon blocks across the site, with local-to-the-block width values overriding global styles

## Before

Resetting the value means that the SVG renders _really_ big!

https://github.com/user-attachments/assets/78a91d63-a93f-43c7-afbf-c35048582145

## After

https://github.com/user-attachments/assets/1b19a20e-6764-43ba-bbe6-ab536ee76c51

And in global styles, the default value should be populated:

<img width="547" height="400" alt="image" src="https://github.com/user-attachments/assets/45ecde54-18cb-415d-b0fa-c5d9dac9ce4e" />