### PR TITLE
Custom CSS: Decode HTML entities in nested selectors

### DIFF
--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -21,6 +21,10 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	}
 
 	$custom_css = trim( $parsed_block['attrs']['style']['css'] ?? '' );
+	// Decode HTML entities (e.g. &amp; → &) that may be introduced
+	// during block serialisation so that nested selectors using &
+	// are processed correctly by process_blocks_custom_css().
+	$custom_css = html_entity_decode( $custom_css, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 
 	if ( empty( $custom_css ) ) {
 		return $parsed_block;

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -415,6 +415,41 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that HTML-encoded ampersands in nested CSS selectors are decoded
+	 * before processing, so that `&amp;` becomes `&` and nested selectors work.
+	 *
+	 * Block serialisation may encode `&` as `&amp;` in the stored CSS attribute.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_decodes_html_entities_in_nested_selectors() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-encoded-amp',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-encoded-amp',
+			'attrs'     => array(
+				'style' => array(
+					'css' => '&amp;:hover { color: red; }',
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added when CSS contains encoded ampersand.' );
+
+		// Verify the inline style contains the decoded nested selector.
+		$expected_class = preg_replace( '/.*?(wp-custom-css-\S+).*/', '$1', $result['attrs']['className'] );
+		$inline_css     = wp_styles()->get_data( 'wp-block-custom-css', 'after' );
+
+		$this->assertNotEmpty( $inline_css, 'Inline CSS should be registered.' );
+		$this->assertStringContainsString( '.' . $expected_class . ':hover', implode( '', $inline_css ), 'Decoded & should produce a valid nested selector in the output CSS.' );
+	}
+
+	/**
 	 * Tests that valid CSS without HTML markup is accepted.
 	 *
 	 * @covers ::gutenberg_render_custom_css_support_styles


### PR DESCRIPTION
## Summary
- Block serialisation may encode `&` as `&amp;` in the stored custom CSS attribute, breaking nested CSS selectors like `&:hover` and `& .child`
- Adds `html_entity_decode()` before CSS processing so `process_blocks_custom_css()` handles nested selectors correctly
- Adds a unit test verifying that encoded ampersands in nested selectors are decoded and produce valid output CSS

## Test plan
- [ ] Verify blocks with custom CSS using nested selectors (`&:hover`, `& .child-class`) render correctly on the front end
- [ ] Verify plain custom CSS (no nested selectors) continues to work as before
- [ ] Verify CSS containing HTML markup is still rejected
- [ ] CI PHP unit tests pass