### PR TITLE
try allowing any content block to be inserted if another content block exists in contentOnly mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -5,7 +5,6 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
-	getDefaultBlockName,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
 	switchToBlockType,
@@ -1705,10 +1704,8 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const blockEditingMode = getBlockEditingMode( state, rootClientId ?? '' );
-	if (
-		blockEditingMode === 'disabled' &&
-		blockName !== getDefaultBlockName()
-	) {
+	const isContentRoleBlock = isContentBlock( blockName );
+	if ( blockEditingMode === 'disabled' && ! isContentRoleBlock ) {
 		return false;
 	}
 
@@ -1722,7 +1719,6 @@ const canInsertBlockTypeUnmemoized = (
 
 	// It shouldn't be possible to insert inside a section block unless in
 	// some cases when the block is a content block.
-	const isContentRoleBlock = isContentBlock( blockName );
 	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
 	const sectionClientId = isParentSectionBlock
 		? rootClientId
@@ -1749,15 +1745,15 @@ const canInsertBlockTypeUnmemoized = (
 			rootClientId
 		)
 	) {
-		// Allow inserting the default block anywhere that another default block already exists
+		// Allow inserting the default block anywhere that another default block already exists,
+		// or allow inserting any content block if another content block already exists
 		// when in contentOnly mode.
-		if ( blockName === getDefaultBlockName() ) {
+		if ( isContentRoleBlock ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
-			const hasDefaultBlock = existingBlocks.some(
-				( clientId ) =>
-					getBlockName( state, clientId ) === getDefaultBlockName()
+			const hasContentBlock = existingBlocks.some( ( clientId ) =>
+				isContentBlock( getBlockName( state, clientId ) )
 			);
-			if ( ! hasDefaultBlock ) {
+			if ( ! hasContentBlock ) {
 				return false;
 			}
 		} else {
@@ -1938,26 +1934,27 @@ export function canRemoveBlock( state, clientId ) {
 
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	const blockName = getBlockName( state, clientId );
+	const isBlockContentRole = isContentBlock( blockName );
 	// Check if the parent container allows insertion/removal in contentOnly mode.
 	if (
 		( isParentSectionBlock ||
 			rootBlockEditingMode === 'contentOnly' ||
-			blockName === getDefaultBlockName() ) &&
+			isBlockContentRole ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
 			rootClientId
 		)
 	) {
-		// Allow removing the default block when other default blocks exist
+		// Allow removing any content block if other content blocks exist
 		// in contentOnly mode.
-		if ( blockName === getDefaultBlockName() ) {
+		if ( isBlockContentRole ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
-			const defaultBlocks = existingBlocks.filter(
-				( id ) => getBlockName( state, id ) === getDefaultBlockName()
+			const contentBlocks = existingBlocks.filter( ( id ) =>
+				isContentBlock( getBlockName( state, id ) )
 			);
-			// Allow removal if there are other default blocks besides this one
-			if ( defaultBlocks.length > 1 ) {
+			// Allow removal if there are other content blocks besides this one
+			if ( contentBlocks.length > 1 ) {
 				return true;
 			}
 		} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Trying something out to address feedback on contentOnly mode [here](https://github.com/WordPress/gutenberg/issues/73775#issuecomment-3913566755) and [here](https://github.com/WordPress/gutenberg/pull/73222#issuecomment-3914077821).

In contentOnly mode, where a content block exists, it should be possible to insert other content blocks.

This might not work too well for patterns that use container-type content blocks such as Cover and Quote for structural purposes, but let's try it out and see if it improves things!


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some patterns to a page or template
2. Try adding and removing different types of content from them
