### PR TITLE
RTC: Update the y-protocols version and remove the unncessary diff types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18119,13 +18119,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/diff": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-			"integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/doctrine": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -57064,18 +57057,6 @@
 				"node": ">=0.4"
 			}
 		},
-		"node_modules/y-protocols": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-			"integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
-			"dependencies": {
-				"lib0": "^0.2.42"
-			},
-			"funding": {
-				"type": "GitHub Sponsors ❤",
-				"url": "https://github.com/sponsors/dmonad"
-			}
-		},
 		"node_modules/y18n": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
@@ -61303,12 +61284,11 @@
 				"diff": "^8.0.3",
 				"fast-deep-equal": "^3.1.3",
 				"lib0": "0.2.99",
-				"y-protocols": "^1.0.5",
+				"y-protocols": "^1.0.7",
 				"yjs": "13.6.29"
 			},
 			"devDependencies": {
 				"@jest/globals": "^30.2.0",
-				"@types/diff": "^7.0.2",
 				"@types/node": "^20.17.10"
 			},
 			"engines": {
@@ -62049,6 +62029,26 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"packages/sync/node_modules/y-protocols": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+			"integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+			"license": "MIT",
+			"dependencies": {
+				"lib0": "^0.2.85"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			},
+			"peerDependencies": {
+				"yjs": "^13.0.0"
 			}
 		},
 		"packages/theme": {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -51,12 +51,11 @@
 		"diff": "^8.0.3",
 		"fast-deep-equal": "^3.1.3",
 		"lib0": "0.2.99",
-		"y-protocols": "^1.0.5",
+		"y-protocols": "^1.0.7",
 		"yjs": "13.6.29"
 	},
 	"devDependencies": {
 		"@jest/globals": "^30.2.0",
-		"@types/diff": "^7.0.2",
 		"@types/node": "^20.17.10"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## What?

Remove the types for diff as that's not needed anymore. The y-protocols also need to be upgraded to a later version.

## Why?

The y-protocols is an older version going back to 2021. v1.0.7 was released 2 months ago. Thanks to the upgrade made to the diff package in #74633, the separate types package are unecessary. 

## How?

Upgrade the y-protocols package and remove the types for diff.

## Testing Instructions

- Test the regular RTC feature
- Run the e2e tests as well

### Testing Instructions for Keyboard

N/A
