### PR TITLE
Try shuffle block styles for all editable blocks in contentOnly mode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -121,7 +121,8 @@ export function PrivateBlockToolbar( {
 
 		const _isZoomOut = isZoomOut();
 		const _isSectionBlock = isSectionBlock( selectedBlockClientId );
-		const _showSwitchSectionStyleButton = _isZoomOut || _isSectionBlock;
+		const _showSwitchSectionStyleButton =
+			_isZoomOut || _isSectionBlock || editingMode === 'contentOnly';
 
 		const _currentDeviceType =
 			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

For button groups in particular, but perhaps for any block with style variations, it might be useful to expose the style switcher in contentOnly mode. This PR tries enabling it for all editable blocks with style variations.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some patterns to a page or template.
2. Check that the "shuffle styles" button displays for any block that has a style variation (Button, Image, Heading...)

<img width="635" height="157" alt="Screenshot 2026-02-18 at 3 10 21 pm" src="https://github.com/user-attachments/assets/90ea4009-2119-4380-bee0-26d9a7e7e273" />
