### PR TITLE
Navigation: Add 'expectedDeprecated' annotations

### DIFF
--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -66,7 +66,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers :: block_core_navigation_block_contains_core_navigation
+	 * @expectedDeprecated block_core_navigation_block_contains_core_navigation
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation /-->' );
@@ -74,12 +74,18 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$this->assertTrue( block_core_navigation_block_contains_core_navigation( $inner_blocks ) );
 	}
 
+	/**
+	 * @expectedDeprecated block_core_navigation_block_contains_core_navigation
+	 */
 	public function test_block_core_navigation_block_contains_core_navigation_deep() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- /wp:group --><!-- wp:group --><!-- wp:group --><!-- wp:navigation /--><!-- /wp:group --><!-- /wp:group -->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
 		$this->assertTrue( block_core_navigation_block_contains_core_navigation( $inner_blocks ) );
 	}
 
+	/**
+	 * @expectedDeprecated block_core_navigation_block_contains_core_navigation
+	 */
 	public function test_block_core_navigation_block_contains_core_navigation_no_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- wp:group --><!-- /wp:group --><!-- /wp:group -->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );


### PR DESCRIPTION
## What?
PR tries to fix failing PHPUnit tests on CI by adding `expectedDeprecated` annotation. See: https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/#annotations.

Not sure why this only started failing recently.

## Testing Instructions
CI checks are passing.