### PR TITLE
Update Navigation block tests to use non-deprecated API

### DIFF
--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -66,29 +66,29 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @expectedDeprecated block_core_navigation_block_contains_core_navigation
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation /-->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
-		$this->assertTrue( block_core_navigation_block_contains_core_navigation( $inner_blocks ) );
+		$this->assertTrue( block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
 
 	/**
-	 * @expectedDeprecated block_core_navigation_block_contains_core_navigation
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation_deep() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- /wp:group --><!-- wp:group --><!-- wp:group --><!-- wp:navigation /--><!-- /wp:group --><!-- /wp:group -->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
-		$this->assertTrue( block_core_navigation_block_contains_core_navigation( $inner_blocks ) );
+		$this->assertTrue( block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
 
 	/**
-	 * @expectedDeprecated block_core_navigation_block_contains_core_navigation
+	 * @covers ::block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation_no_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- wp:group --><!-- /wp:group --><!-- /wp:group -->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
-		$this->assertFalse( block_core_navigation_block_contains_core_navigation( $inner_blocks ) );
+		$this->assertFalse( block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
 }

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -13,7 +13,7 @@
  */
 class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	/**
-	 * @covers ::gutenberg_block_core_navigation_from_block_get_post_ids
+	 * @covers gutenberg_block_core_navigation_from_block_get_post_ids
 	 */
 	public function test_block_core_navigation_get_post_ids_from_block() {
 		$parsed_blocks = parse_blocks(
@@ -28,7 +28,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::gutenberg_block_core_navigation_from_block_get_post_ids
+	 * @covers gutenberg_block_core_navigation_from_block_get_post_ids
 	 */
 	public function test_block_core_navigation_get_post_ids_from_block_nested() {
 		$parsed_blocks = parse_blocks(
@@ -53,7 +53,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::gutenberg_block_core_navigation_from_block_get_post_ids
+	 * @covers gutenberg_block_core_navigation_from_block_get_post_ids
 	 */
 	public function test_block_core_navigation_get_post_ids_from_block_with_submenu() {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation-submenu {"label":"Test","type":"post","id":789,"url":"http://' . WP_TESTS_DOMAIN . '/blog/test-3","kind":"post-type","isTopLevelItem":true} -->\n<!-- wp:navigation-link {"label":"(no title)","type":"post","id":755,"url":"http://' . WP_TESTS_DOMAIN . '/blog/755","kind":"post-type","isTopLevelLink":false} /-->\n<!-- /wp:navigation-submenu -->' );
@@ -66,7 +66,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation /-->' );
@@ -75,7 +75,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation_deep() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- /wp:group --><!-- wp:group --><!-- wp:group --><!-- wp:navigation /--><!-- /wp:group --><!-- /wp:group -->' );
@@ -84,7 +84,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::block_core_navigation_block_tree_has_block_type
+	 * @covers block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation_no_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- wp:group --><!-- /wp:group --><!-- /wp:group -->' );


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/75659 (if required)


## What?
Update the three `Render_Block_Navigation_Test` tests that asserted "block tree contains core/navigation" to call `block_core_navigation_block_tree_has_block_type()` instead of the deprecated `block_core_navigation_block_contains_core_navigation()`.

## Why?
`block_core_navigation_block_contains_core_navigation` was deprecated in 7.0.0 ([#73967](https://github.com/WordPress/gutenberg/pull/73967)); the replacement is `block_core_navigation_block_tree_has_block_type()`. Calling the deprecated function triggers a deprecation notice, and the WordPress test suite treats unexpected deprecations as failures, so these tests were failing.

## How?
- Replaced calls to `block_core_navigation_block_contains_core_navigation( $inner_blocks )` with `block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' )` in the three tests.
- Updated `@covers` annotations to reference `block_core_navigation_block_tree_has_block_type` so the tests document coverage of the new API.