### PR TITLE
Pattern Editing: Revise 'Edit section' button naming

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -47,7 +47,7 @@ function IsolatedEditButton( {
 				variant="secondary"
 				onClick={ handleClick }
 			>
-				{ __( 'Edit section' ) }
+				{ __( 'Edit original' ) }
 			</Button>
 		</VStack>
 	);
@@ -76,8 +76,8 @@ function InlineEditButton( {
 				onClick={ handleClick }
 			>
 				{ editedContentOnlySection
-					? __( 'Exit section' )
-					: __( 'Edit section' ) }
+					? __( 'Exit pattern' )
+					: __( 'Edit pattern' ) }
 			</Button>
 		</VStack>
 	);

--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -33,9 +33,9 @@ export default function EditSectionButton( { clientId } ) {
 	);
 
 	// Don't show for synced patterns or template parts — they already have
-	// their own toolbar buttons ("Edit original" / "Edit section").
+	// their own toolbar buttons ("Edit original").
 	// Note: isSectionBlock returns false while the section is being edited,
-	// so we also check isEditingContentOnlySection to show "Exit section".
+	// so we also check isEditingContentOnlySection to show "Exit pattern".
 	if (
 		! clientId ||
 		( ! isSectionBlock && ! isEditingContentOnlySection ) ||
@@ -58,7 +58,7 @@ export default function EditSectionButton( { clientId } ) {
 	return (
 		<ToolbarGroup>
 			<ToolbarButton onClick={ handleClick }>
-				{ isEditing ? __( 'Exit section' ) : __( 'Edit section' ) }
+				{ isEditing ? __( 'Exit pattern' ) : __( 'Edit pattern' ) }
 			</ToolbarButton>
 		</ToolbarGroup>
 	);

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -249,7 +249,7 @@ export default function TemplatePartEdit( {
 									} );
 								} }
 							>
-								{ __( 'Edit section' ) }
+								{ __( 'Edit original' ) }
 							</ToolbarButton>
 						</BlockControls>
 					) }

--- a/test/e2e/specs/editor/various/block-hiding.spec.js
+++ b/test/e2e/specs/editor/various/block-hiding.spec.js
@@ -111,13 +111,13 @@ test.describe( 'Block Hiding', () => {
 			page.getByRole( 'dialog', { name: 'Hide block' } )
 		).toBeHidden();
 
-		// Now enter edit mode via "Edit section".
+		// Now enter edit mode via "Edit pattern".
 		await editor.canvas
 			.locator( 'role=document[name="Block: Group"i]' )
 			.click();
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Edit section' } )
+			.getByRole( 'button', { name: 'Edit pattern' } )
 			.click();
 
 		// Select a nested paragraph again.
@@ -167,13 +167,13 @@ test.describe( 'Block Hiding', () => {
 			page.getByRole( 'dialog', { name: 'Hide block' } )
 		).toBeHidden();
 
-		// Select the pattern block and enter edit mode via "Edit section".
+		// Select the pattern block and enter edit mode via "Edit pattern".
 		await editor.canvas
 			.locator( 'role=document[name="Block: Group"i]' )
 			.click();
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Edit section' } )
+			.getByRole( 'button', { name: 'Edit pattern' } )
 			.click();
 
 		// Select the nested paragraph again.

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -77,7 +77,7 @@ test.describe( 'Content-only lock', () => {
 		] );
 	} );
 
-	test( 'should be able to edit all blocks via Edit section button and exit via Exit section button', async ( {
+	test( 'should be able to edit all blocks via Edit pattern button and exit via Exit pattern button', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -106,10 +106,10 @@ test.describe( 'Content-only lock', () => {
 		await editor.canvas
 			.locator( 'role=document[name="Block: Group"i]' )
 			.click();
-		// Click "Edit section" button to temporarily edit as blocks.
+		// Click "Edit pattern" button to temporarily edit as blocks.
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Edit section' } )
+			.getByRole( 'button', { name: 'Edit pattern' } )
 			.click();
 		// Selected a nest paragraph verify Block is not content locked
 		// Styles can be changed and nested blocks can be removed
@@ -121,10 +121,10 @@ test.describe( 'Content-only lock', () => {
 			page.locator( '.color-block-support-panel' )
 		).toBeAttached();
 		await editor.clickBlockOptionsMenuItem( 'Delete' );
-		// Click "Exit section" button to exit edit mode
+		// Click "Exit pattern" button to exit edit mode
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Exit section' } )
+			.getByRole( 'button', { name: 'Exit pattern' } )
 			.click();
 
 		// Select a locked nested paragraph block again
@@ -137,7 +137,7 @@ test.describe( 'Content-only lock', () => {
 		).not.toBeAttached();
 	} );
 
-	test( 'allows editing all blocks via Edit section toolbar button and exiting via Exit section toolbar button', async ( {
+	test( 'allows editing all blocks via Edit pattern toolbar button and exiting via Exit pattern toolbar button', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -171,8 +171,8 @@ test.describe( 'Content-only lock', () => {
 		await editor.canvas
 			.locator( 'role=document[name="Block: Group"i]' )
 			.click();
-		// Click "Edit section" in the block toolbar.
-		await editor.clickBlockToolbarButton( 'Edit section' );
+		// Click "Edit pattern" in the block toolbar.
+		await editor.clickBlockToolbarButton( 'Edit pattern' );
 		// Select a nested paragraph — verify block is not content locked.
 		// Style panels are visible when the block is unlocked for editing.
 		await editor.canvas
@@ -193,8 +193,8 @@ test.describe( 'Content-only lock', () => {
 		await editor.selectBlocks(
 			editor.canvas.locator( 'role=document[name="Block: Group"i]' )
 		);
-		// Click "Exit section" in the block toolbar.
-		await editor.clickBlockToolbarButton( 'Exit section' );
+		// Click "Exit pattern" in the block toolbar.
+		await editor.clickBlockToolbarButton( 'Exit pattern' );
 
 		// Select a locked nested paragraph block again.
 		await editor.canvas
@@ -248,11 +248,11 @@ test.describe( 'Content-only lock', () => {
 		} );
 		await separator.dblclick( { force: true } );
 
-		// Wait for edit mode to be entered - "Edit section" button should disappear
+		// Wait for edit mode to be entered - "Edit pattern" button should disappear
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Edit section' } )
+				.getByRole( 'button', { name: 'Edit pattern' } )
 		).toBeHidden();
 
 		// Select first paragraph to verify it's not content locked

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -335,7 +335,7 @@ test.describe( 'Unsynced pattern', () => {
 		).toHaveCount( 2 );
 	} );
 
-	test( 'supports editing pattern via Edit section button', async ( {
+	test( 'supports editing pattern via Edit pattern button', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -384,12 +384,12 @@ test.describe( 'Unsynced pattern', () => {
 		// Click on the pattern in List View to select it.
 		await listView.getByRole( 'gridcell', { name: 'My pattern' } ).click();
 
-		// Open settings sidebar and click "Edit section" button.
+		// Open settings sidebar and click "Edit pattern" button.
 		await editor.openDocumentSettingsSidebar();
 
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Edit section' } )
+			.getByRole( 'button', { name: 'Edit pattern' } )
 			.click();
 
 		// Expand the inner Group to see all blocks including separator.
@@ -413,10 +413,10 @@ test.describe( 'Unsynced pattern', () => {
 			} )
 		).toBeVisible();
 
-		// Exit pattern editing by clicking the "Exit section" button.
+		// Exit pattern editing by clicking the "Exit pattern" button.
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Exit section' } )
+			.getByRole( 'button', { name: 'Exit pattern' } )
 			.click();
 
 		// Verify pattern is back to content-only mode (separator hidden again).
@@ -450,7 +450,7 @@ test.describe( 'Unsynced pattern', () => {
 		).toBeVisible();
 	} );
 
-	test( 'supports editing pattern via Edit section toolbar button', async ( {
+	test( 'supports editing pattern via Edit pattern toolbar button', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -499,8 +499,8 @@ test.describe( 'Unsynced pattern', () => {
 		// Click on the pattern in List View to select it.
 		await listView.getByRole( 'gridcell', { name: 'My pattern' } ).click();
 
-		// Click "Edit section" in the block toolbar.
-		await editor.clickBlockToolbarButton( 'Edit section' );
+		// Click "Edit pattern" in the block toolbar.
+		await editor.clickBlockToolbarButton( 'Edit pattern' );
 
 		// Expand the inner Group to see all blocks including separator.
 		await listView
@@ -523,8 +523,8 @@ test.describe( 'Unsynced pattern', () => {
 			} )
 		).toBeVisible();
 
-		// Exit pattern editing by clicking "Exit section" in the block toolbar.
-		await editor.clickBlockToolbarButton( 'Exit section' );
+		// Exit pattern editing by clicking "Exit pattern" in the block toolbar.
+		await editor.clickBlockToolbarButton( 'Exit pattern' );
 
 		// Verify pattern is back to content-only mode (separator hidden again).
 		await expect(

--- a/test/e2e/specs/site-editor/template-part-focus-mode.spec.js
+++ b/test/e2e/specs/site-editor/template-part-focus-mode.spec.js
@@ -34,7 +34,7 @@ test.describe( 'Template Part Focus mode', () => {
 			.click();
 
 		// Navigate to Focus mode
-		await editor.clickBlockToolbarButton( 'Edit section' );
+		await editor.clickBlockToolbarButton( 'Edit original' );
 
 		// Check if focus mode is active
 		await expect( page.locator( 'h1' ) ).toContainText( 'Header' );


### PR DESCRIPTION
Follow up to #75602

Looking for feedback on this change, with the potential for a quick merge before beta if there's agreement. If there's no agreement, I'd be happy to hold off or treat this as 'blessed' if agreement arrives too late.

## What?
For pattern editing, there's a button that allows the user to make deeper edits to a pattern, template part or contentOnly template locked group of blocks.

This button is currently labelled 'Edit section', but I haven't grown to love it for a few reasons:
- Nothing else in the block editor UI ever refers to 'sections', so it feels like an unfamiliar term
- For synced patterns and template parts, the button navigates the user to the isolated editor, whereas for unsynced patterns and template locked blocks it edits inline using the spotlight mode. Yet the button label is the same and doesn't reflect the different action.
- Synced patterns still have an 'Edit original' button on the toolbar, but have 'Edit section' in the inspector, which is inconsistent. Template parts have just 'Edit' in the toolbar and 'Edit section' in the inspector, also inconsistent.

## How?
The revision I'm proposing is:
- Template parts and Synced patterns use the 'Edit original' label in both the inspector and toolbar to indicate the user is editing the original source of the pattern / template part.
- Unsynced patterns and contentOnly template locked blocks use the 'Edit pattern' label to indicate they're edited inline. While template locked blocks aren't 'patterns', this is the best I could come up with. They essentially behave the same as unsynced patterns, so I think it align them.

## Testing Instructions
1. Template parts - click 'Edit original', note you're taken to the isolated editor
2. Synced patterns - click 'Edit original', note you're taken tot he isolated editor
3. Unsynced patterns - click 'Edit pattern', note the pattern is now fully editable inline. Click 'Exit pattern', the pattern is now back to contentOnly mode
4. ContentOnly template lock - click 'Edit pattern', note the pattern is now fully editable inline. Click 'Exit pattern', the pattern is now back to contentOnly mode

## Screenshots or screencast <!-- if applicable -->

### Synced pattern
<img width="500" alt="Screenshot 2026-02-18 at 3 19 35 pm" src="https://github.com/user-attachments/assets/a5596c29-ac4a-4b5d-891c-83ec76bc3af9" />

### Template part
<img width="500" alt="Screenshot 2026-02-18 at 3 19 59 pm" src="https://github.com/user-attachments/assets/f42c8806-67a6-4ac8-b86c-fb0b3ef926e2" />

### Unsynced pattern
<img width="500" alt="Screenshot 2026-02-18 at 3 19 16 pm" src="https://github.com/user-attachments/assets/63ad40e9-cc36-4567-9a6f-66305f857e98" />

### contentOnly template lock
<img width="500" alt="Screenshot 2026-02-18 at 3 20 49 pm" src="https://github.com/user-attachments/assets/a4570f59-5a07-4c50-9882-238ff6d0c6bf" />
