### PR TITLE
theme.json: Enable width setting for Icon block by default

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -323,6 +323,11 @@
 					"allowEditing": true
 				}
 			},
+			"core/icon": {
+				"dimensions": {
+					"width": true
+				}
+			},
 			"core/pullquote": {
 				"border": {
 					"color": true,


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/75604#issuecomment-3919038571

## What?

Themes that haven't opted into `appearanceTools` or the `settings.dimensions.width` can't change the Icon block's width from the default 24px width unless they write a CSS. I feel this significantly reduces the value of the Icon block.

It would probably be better to enable the width setting just for the Icon block, rather than at the root level.

## Testing Instructions

- Activate Twenty Twenty-One.
- Insert an Icon block
- Verify that you can change the icon width from the block sidebar.

## Screenshots or screencast <!-- if applicable -->

<img width="893" height="449" alt="image" src="https://github.com/user-attachments/assets/f4c1de8e-2874-44c7-ab34-017132a32a0b" />
