### PR TITLE
GitHub actions: Exclude lib/theme.json from backport changelog check

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -9,6 +9,7 @@ on:
             - 'lib/**'
             - '!lib/load.php'
             - '!lib/experiments-page.php'
+            - '!lib/theme.json'
             - '!lib/experimental/**'
             - 'phpunit/**'
             - '!phpunit/experimental/**'


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/75653#issuecomment-3918132908

## What?

`lib/theme.json` is now automatically copied to core during the build process, so there is no need to manually backport changes to this file to core.

## Testing Instructions

Nothing