### PR TITLE
DataViews table layout: improve space taken by action columns

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -303,7 +303,7 @@ export function PrimaryActions< Item >( {
 		return null;
 	}
 	return (
-		<>
+		<div className="dataviews-primary-actions">
 			{ actions.map( ( action ) => (
 				<ButtonTrigger
 					key={ action.id }
@@ -326,6 +326,6 @@ export function PrimaryActions< Item >( {
 					closeModal={ () => setActiveModalAction( null ) }
 				/>
 			) }
-		</>
+		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -5,3 +5,7 @@
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }
+
+.dataviews-primary-actions {
+	display: contents;
+}

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -79,16 +79,18 @@
 
 		.dataviews-primary-actions {
 			display: flex;
+			align-items: center;
 			position: absolute;
 			right: 100%;
-			top: 50%;
-			transform: translateY(-50%);
+			top: -$grid-unit-15;
+			bottom: -$grid-unit-15;
 			gap: $grid-unit-05;
 			opacity: 0;
 			pointer-events: none;
 			white-space: nowrap;
 			background-color: var(--wp-dataviews-color-background, $white);
-			padding-inline: $grid-unit-05;
+			padding-inline: $grid-unit-10;
+			border-left: 1px solid $gray-100;
 		}
 
 		@media (hover: none) {
@@ -124,6 +126,16 @@
 			.dataviews-primary-actions {
 				opacity: 1;
 				pointer-events: auto;
+			}
+
+			.dataviews-view-table__actions-column--stuck::after {
+				display: none;
+			}
+		}
+
+		&.is-selected {
+			.dataviews-view-table__actions-column--stuck::after {
+				display: none;
 			}
 		}
 	}
@@ -253,12 +265,22 @@
 		th {
 			padding: $grid-unit-05 $grid-unit-10;
 		}
+
+		tr .dataviews-primary-actions {
+			top: -$grid-unit-05;
+			bottom: -$grid-unit-05;
+		}
 	}
 
 	&.has-comfortable-density {
 		td,
 		th {
 			padding: $grid-unit-20 $grid-unit-15;
+		}
+
+		tr .dataviews-primary-actions {
+			top: -$grid-unit-20;
+			bottom: -$grid-unit-20;
 		}
 	}
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -73,14 +73,29 @@
 			border-bottom: 0;
 		}
 
-		.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+		.dataviews-item-actions {
+			position: relative;
+		}
+
+		.dataviews-primary-actions {
+			display: flex;
+			position: absolute;
+			right: 100%;
+			top: 50%;
+			transform: translateY(-50%);
+			gap: $grid-unit-05;
 			opacity: 0;
+			pointer-events: none;
+			white-space: nowrap;
+			background-color: var(--wp-dataviews-color-background, $white);
+			padding-inline: $grid-unit-05;
 		}
 
 		@media (hover: none) {
 			// Show quick-actions on devices that do not support hover.
-			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+			.dataviews-primary-actions {
 				opacity: 1;
+				pointer-events: auto;
 			}
 		}
 
@@ -96,14 +111,19 @@
 			.dataviews-view-table__actions-column--sticky {
 				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
 			}
+
+			.dataviews-primary-actions {
+				background-color: color-mix(in srgb, rgb(var(--wp-admin-theme-color--rgb)) 4%, $white);
+			}
 		}
 
 		// Show action buttons on hover/focus for all rows
 		&:focus-within,
 		&.is-hovered,
 		&:hover {
-			.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+			.dataviews-primary-actions {
 				opacity: 1;
+				pointer-events: auto;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/75668, https://github.com/WordPress/gutenberg/issues/80375

## What?

Reduces the actions column width in the DataViews table layout by absolutely positioning primary action buttons so they only appear as an overlay on hover, instead of reserving permanent column space.

| | Before | After |
| --- | --- | --- |
| Rest | <img width="1539" height="1104" alt="Screenshot 2026-02-18 at 11 32 21" src="https://github.com/user-attachments/assets/27213f41-ef77-4aef-8dc6-b368e815b02e" /> |  <img width="1539" height="1104" alt="Screenshot 2026-02-18 at 11 28 27" src="https://github.com/user-attachments/assets/11600cec-1dc1-4849-8359-a9a1cf888e04" /> |
| Hover | <img width="1462" height="1104" alt="Screenshot 2026-02-18 at 11 37 35" src="https://github.com/user-attachments/assets/6986253e-59cc-41ea-a952-6b59aa575150" /> | <img width="1462" height="1104" alt="Screenshot 2026-02-18 at 11 38 51" src="https://github.com/user-attachments/assets/34fef69d-fdda-4627-859d-e65327006249" /> |
| Select | <img width="1539" height="1104" alt="Screenshot 2026-02-18 at 11 32 32" src="https://github.com/user-attachments/assets/4f91b2d0-3970-428f-a1cf-7cd1a1e67529" />  | <img width="1539" height="1104" alt="Screenshot 2026-02-18 at 11 28 39" src="https://github.com/user-attachments/assets/6be79454-a959-49be-a5fd-c45d16862ad0" /> |

## Why?

When there are multiple primary actions in the table layout, the actions column takes up excessive horizontal space.

## How?

- Wraps primary action buttons in a `<div className="dataviews-primary-actions">` in the PrimaryActions component.
- Sets `display: contents` on the wrapper by default so it’s transparent to flex layout in other contexts (activity layout, etc.).
- In the table layout, overrides the wrapper to `display: flex; position: absolute; right: 100%` — positioning it to the left of the kebab menu button. Hidden with `opacity: 0` by default, revealed on hover/focus.
- The actions column now only sizes to the kebab menu button width. No layout shift occurs because primary actions are always out of normal flow.

## Testing Instructions

- Open the Pages list in the site editor.
- Observe the actions column is narrow (just the kebab menu button).
- Hover a row — primary action buttons should appear to the left of the kebab.
- Select a row — the primary actions overlay should match the selected row’s tinted background.
- Verify that other layouts are unaffected (e.g., via Storybook for the activity layout).


https://github.com/user-attachments/assets/0dc9584b-e18b-4947-ae0b-2e425e50c984

