### PR TITLE
Update navigation block tests to use gutenberg version of block_core_navigation_block_tree_has_block_type

### DIFF
--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -66,29 +66,29 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers block_core_navigation_block_tree_has_block_type
+	 * @covers gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation /-->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
-		$this->assertTrue( block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
+		$this->assertTrue( gutenberg_block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
 
 	/**
-	 * @covers block_core_navigation_block_tree_has_block_type
+	 * @covers gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation_deep() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- /wp:group --><!-- wp:group --><!-- wp:group --><!-- wp:navigation /--><!-- /wp:group --><!-- /wp:group -->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
-		$this->assertTrue( block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
+		$this->assertTrue( gutenberg_block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
 
 	/**
-	 * @covers block_core_navigation_block_tree_has_block_type
+	 * @covers gutenberg_block_core_navigation_block_tree_has_block_type
 	 */
 	public function test_block_core_navigation_block_contains_core_navigation_no_navigation() {
 		$parsed_blocks = parse_blocks( '<!-- wp:group --><!-- wp:group --><!-- /wp:group --><!-- /wp:group -->' );
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
-		$this->assertFalse( block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
+		$this->assertFalse( gutenberg_block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
 }


### PR DESCRIPTION
## What?
Follow up to #75660

I see e2e tests are still failing in trunk on the `WP previous major version` CI config.

That's a config that doesn't run in PRs, so it would have been difficult to catch the issue.

I noticed there are other tests that aren't failing that use the `gutenberg_` prefixed version of this function:
https://github.com/WordPress/gutenberg/blob/810847b084506daf342b63b6c8f1966a36c02772/phpunit/blocks/class-wp-navigation-block-renderer-test.php#L256-L281

I'm attempting the same approach here.
