### PR TITLE
Heading Block: Fix preview display

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -33,7 +33,11 @@ export const settings = {
 		attributes: {
 			content: __( 'Code is Poetry' ),
 			level: 2,
-			textAlign: 'center',
+			style: {
+				typography: {
+					textAlign: 'center',
+				},
+			},
 		},
 	},
 	__experimentalLabel( attributes, { context } ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The textAlign attribute of the Heading block example has been moved to typography. #74383

The preview display had changed from before, so this fixes it.

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="293" height="315" alt="before" src="https://github.com/user-attachments/assets/18b8d4c5-e019-46f9-86c7-11c4ab72d49e" /> | <img width="298" height="310" alt="after" src="https://github.com/user-attachments/assets/1d2722bc-af9c-436a-8fbb-b61266df050b" /> |