### PR TITLE
Comments Link: fix transforms textAlign

### DIFF
--- a/packages/block-library/src/post-comments-link/transforms.js
+++ b/packages/block-library/src/post-comments-link/transforms.js
@@ -8,9 +8,16 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/post-comments-count' ],
-			transform: ( { textAlign } ) => {
+			transform: ( { style } ) => {
+				const textAlign = style?.typography?.textAlign;
 				return createBlock( 'core/post-comments-count', {
-					style: { typography: { textAlign } },
+					...( textAlign && {
+						style: {
+							typography: {
+								textAlign,
+							},
+						},
+					} ),
 				} );
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow Up #75332
Ensure that textAlign is carried over when converting from a Comments Link to a Comments Count block.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Comments Link block. 
3. The textAlign is inherited when converted to a Comments Count block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/5e9e75a6-b9eb-4c04-8e00-ff1ff647eaa1


### After

https://github.com/user-attachments/assets/6e723801-e692-485c-8cfe-af4c7dff55d0


