### PR TITLE
ui/IconButton: make icon always 24px regardless of `size` prop

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `Tabs`: Replace hardcoded font values with design tokens on tab buttons ([#75537](https://github.com/WordPress/gutenberg/pull/75537)).
 -   `Field`: Fix default gap spacing ([#75446](https://github.com/WordPress/gutenberg/pull/75446)).
 -   `Button`: Fix disabled styles while `focusableWhenDisabled={false}` ([#75568](https://github.com/WordPress/gutenberg/pull/75568)).
+-   `IconButton`: make icon always `24px` regardless of `size` prop ([#75677](https://github.com/WordPress/gutenberg/pull/75677)).
 
 ### Enhancements
 

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -43,7 +43,8 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 					>
 						<Icon
 							icon={ icon }
-							size={ size === 'small' ? 22 : 24 }
+							size={ 24 }
+							className={ styles.icon }
 						/>
 					</Tooltip.Trigger>
 					<Tooltip.Popup>

--- a/packages/ui/src/icon-button/style.module.css
+++ b/packages/ui/src/icon-button/style.module.css
@@ -6,4 +6,11 @@
 		--wp-ui-button-padding-inline: 0;
 		--wp-ui-button-min-width: unset;
 	}
+
+	.icon {
+		/* Compensate for the button's 1px border so the icon extends
+			 edge-to-edge and doesn't inflate the button's dimensions
+			 (e.g. 24px icon inside a 24px-tall small button). */
+		margin: -1px;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Tweak the `IconButton` so that the icon is always displayed at a 24px size, even when `IconButton` has the `size` prop set to `small`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Follow design specs

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use a negative `1px` margin to allow the internal `Icon` component to be `24px` without causing the button wrapper to grow wider.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In storybook, navigate to the `IconButton` component examlpe
- Make sure that, regardless of the value chosen for the `size` prop, the icon is always rendered at a `24px` by `24px` size
- Make sure that, when `size="small"`, the outer size of the button is still `24px` by `24px`

|Before|After|
|-|-|
| ![Screenshot 2026-02-18 at 12 48 14](https://github.com/user-attachments/assets/53bf5072-6f6c-41cb-9a8a-19c868ae002a) | ![Screenshot 2026-02-18 at 12 47 54](https://github.com/user-attachments/assets/87009325-0d79-4d62-87ad-698a5ad7424e) |
