### PR TITLE
Gallery: Fix PHP warning in random order image reordering

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -236,8 +236,8 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	$i       = 0;
 	$content = preg_replace_callback(
 		$pattern,
-		static function ( $match ) use ( $reordered_blocks, &$i ) {
-			$new_image_block = $reordered_blocks[ $i ] ?? $match[0];
+		static function ( $matches ) use ( $reordered_blocks, &$i ) {
+			$new_image_block = $reordered_blocks[ $i ] ?? $matches[0];
 			++$i;
 			return $new_image_block;
 		},

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -222,24 +222,17 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	}
 	$image_blocks = $matches[0];
 
-	// Reorder image blocks according to the randomized `$image_ids` order
-	$reordered_blocks = array();
-	foreach ( $image_ids as $image_id ) {
-		foreach ( $image_blocks as $block ) {
-			if ( strpos( $block, $image_id ) !== false ) {
-				$reordered_blocks[] = $block;
-				break;
-			}
-		}
-	}
+	// Shuffle the matched image blocks directly. This avoids a mismatch between
+	// the number of regex matches and the reordered array: `$image_ids` only
+	// contains images with lightbox enabled (no link), while the regex matches
+	// all images in the gallery.
+	shuffle( $image_blocks );
 
 	$i       = 0;
 	$content = preg_replace_callback(
 		$pattern,
-		static function ( $matches ) use ( $reordered_blocks, &$i ) {
-			$new_image_block = $reordered_blocks[ $i ] ?? $matches[0];
-			++$i;
-			return $new_image_block;
+		static function () use ( $image_blocks, &$i ) {
+			return $image_blocks[ $i++ ];
 		},
 		$updated_content
 	);

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -236,8 +236,8 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	$i       = 0;
 	$content = preg_replace_callback(
 		$pattern,
-		static function () use ( $reordered_blocks, &$i ) {
-			$new_image_block = $reordered_blocks[ $i ];
+		static function ( $match ) use ( $reordered_blocks, &$i ) {
+			$new_image_block = $reordered_blocks[ $i ] ?? $match[0];
 			++$i;
 			return $new_image_block;
 		},


### PR DESCRIPTION
## What?

Fixes an "Undefined array key" PHP warning in the gallery block's random order feature, and simplifies the reordering logic. I also noticed that randomized sorting is broken when you have a mix of images with "links" and "no links".

## Why?

The previous code built `$reordered_blocks` by matching image IDs from the interactivity state against rendered HTML via `strpos`. However, `$image_ids` only contains images that have **lightbox enabled and no link** (since the interactivity state is only populated inside `block_core_image_render_lightbox`), while the regex matches **all** `<figure>` elements in the gallery. When any image has a link or doesn't have lightbox, `$reordered_blocks` ends up shorter than the regex match count, causing a PHP warning on every page load.

In environments where `display_errors` is on (such as WordPress Playground's WASM PHP runtime), these warnings are output as HTML before JSON responses, corrupting REST API calls.

## How?

Shuffles the regex-matched `$image_blocks` array directly instead of going through the interactivity state. This is simpler, works for all images regardless of lightbox state, and guarantees the array length matches the number of regex replacements.

## Testing Instructions

1. Create a gallery block with several images (mix of linked and unlinked)
2. Enable the "Random order" setting
3. View the post on the frontend with `WP_DEBUG` and `WP_DEBUG_DISPLAY` enabled
4. Verify no PHP warnings appear and images are randomized