### PR TITLE
RTC: Add minimum cap check to sync endpoint

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -175,6 +175,15 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		 * @return bool|WP_Error True if user has permission, otherwise WP_Error with details.
 		 */
 		public function check_permissions( WP_REST_Request $request ) {
+			// Minimum cap check. Is user logged in with a contributor role or higher?
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return new WP_Error(
+					'forbidden',
+					__( 'You do not have permission to perform this action', 'gutenberg' ),
+					array( 'status' => 401 )
+				);
+			}
+
 			$rooms = $request['rooms'];
 
 			foreach ( $rooms as $room ) {


### PR DESCRIPTION
## What?

Add minimum cap check to sync endpoint.

## Why?

We don't currently check permissions for collection entity sync request. Enforce a minimum cap check on all sync requests.

There is no danger of data mutation with collection syncing, but with the default provider, the user could create post meta without being authenticated.

## How?

Add cap check to `check_permissions` method.

## Testing Instructions

Attempt sync request.
