### PR TITLE
RTC: Compact on request with encodeStateAsUpdate

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -1,3 +1,5 @@
 https://github.com/WordPress/wordpress-develop/pull/10894
 
 * https://github.com/WordPress/gutenberg/pull/75366
+* https://github.com/WordPress/gutenberg/pull/75681
+* https://github.com/WordPress/gutenberg/pull/75682

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -434,17 +434,14 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			}
 
 			// Determine if this client should perform compaction.
-			$compaction_request = null;
-			if ( $is_compactor && $total_updates > self::COMPACTION_THRESHOLD ) {
-				$compaction_request = $updates_after_cursor;
-			}
+			$should_compact = $is_compactor && $total_updates > self::COMPACTION_THRESHOLD;
 
 			return array(
-				'compaction_request' => $compaction_request,
-				'end_cursor'         => $this->storage->get_cursor( $room ),
-				'room'               => $room,
-				'total_updates'      => $total_updates,
-				'updates'            => $typed_updates,
+				'end_cursor'     => $this->storage->get_cursor( $room ),
+				'room'           => $room,
+				'should_compact' => $should_compact,
+				'total_updates'  => $total_updates,
+				'updates'        => $typed_updates,
 			);
 		}
 	}

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -313,6 +313,7 @@ function poll(): void {
 				// full document state to replace all prior updates on the server.
 				if ( room.should_compact ) {
 					roomState.log( 'Server requested compaction update' );
+					roomState.updateQueue.clear();
 					roomState.updateQueue.add(
 						roomState.createCompactionUpdate()
 					);

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -50,6 +50,7 @@ interface RegisterRoomOptions {
 
 interface RoomState {
 	clientId: number;
+	createCompactionUpdate: () => SyncUpdate;
 	endCursor: number;
 	localAwarenessState: LocalAwarenessState;
 	log: LogFunction;
@@ -61,31 +62,6 @@ interface RoomState {
 }
 
 const roomStates: Map< string, RoomState > = new Map();
-
-/**
- * Create a compaction update by merging existing updates. This preserves
- * the original operation metadata (client IDs, logical clocks) so that
- * Yjs deduplication works correctly when the compaction is applied.
- *
- * @param updates The updates to merge
- */
-function createCompactionUpdate( updates: SyncUpdate[] ): SyncUpdate {
-	// Extract only compaction and update types for merging (skip sync-step updates).
-	// Decode base64 updates to Uint8Array for merging.
-	const mergeable = updates
-		.filter( ( u ) =>
-			[ SyncUpdateType.COMPACTION, SyncUpdateType.UPDATE ].includes(
-				u.type
-			)
-		)
-		.map( ( u ) => base64ToUint8Array( u.data ) );
-
-	// Merge all updates while preserving operation metadata.
-	return createSyncUpdate(
-		Y.mergeUpdates( mergeable ),
-		SyncUpdateType.COMPACTION
-	);
-}
 
 /**
  * Create sync step 1 update (announce our state vector).
@@ -306,11 +282,11 @@ function poll(): void {
 				roomState.updateQueue.addBulk( responseUpdates );
 
 				// Respond to compaction requests from server. The server asks only one
-				// client at a time to compact (lowest active client ID). We merge the
-				// received updates (the server has given us everything it has).
-				if ( room.compaction_request ) {
+				// client at a time to compact (lowest active client ID). We encode our
+				// full document state to replace all prior updates on the server.
+				if ( room.should_compact ) {
 					roomState.updateQueue.add(
-						createCompactionUpdate( room.compaction_request )
+						roomState.createCompactionUpdate()
 					);
 				}
 			} );
@@ -387,6 +363,11 @@ function registerRoom( {
 
 	const roomState: RoomState = {
 		clientId: doc.clientID,
+		createCompactionUpdate: () =>
+			createSyncUpdate(
+				Y.encodeStateAsUpdate( doc ),
+				SyncUpdateType.COMPACTION
+			),
 		endCursor: 0,
 		localAwarenessState: awareness.getLocalState() ?? {},
 		log,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -64,6 +64,33 @@ interface RoomState {
 const roomStates: Map< string, RoomState > = new Map();
 
 /**
+ * Create a compaction update by merging existing updates. This preserves
+ * the original operation metadata (client IDs, logical clocks) so that
+ * Yjs deduplication works correctly when the compaction is applied.
+ *
+ * Deprecated: The server is moving towards full state updates for compaction.
+ *
+ * @param updates The updates to merge
+ */
+function createDeprecatedCompactionUpdate( updates: SyncUpdate[] ): SyncUpdate {
+	// Extract only compaction and update types for merging (skip sync-step updates).
+	// Decode base64 updates to Uint8Array for merging.
+	const mergeable = updates
+		.filter( ( u ) =>
+			[ SyncUpdateType.COMPACTION, SyncUpdateType.UPDATE ].includes(
+				u.type
+			)
+		)
+		.map( ( u ) => base64ToUint8Array( u.data ) );
+
+	// Merge all updates while preserving operation metadata.
+	return createSyncUpdate(
+		Y.mergeUpdates( mergeable ),
+		SyncUpdateType.COMPACTION
+	);
+}
+
+/**
  * Create sync step 1 update (announce our state vector).
  *
  * @param doc The Yjs document
@@ -285,8 +312,17 @@ function poll(): void {
 				// client at a time to compact (lowest active client ID). We encode our
 				// full document state to replace all prior updates on the server.
 				if ( room.should_compact ) {
+					roomState.log( 'Server requested compaction update' );
 					roomState.updateQueue.add(
 						roomState.createCompactionUpdate()
+					);
+				} else if ( room.compaction_request ) {
+					// Deprecated
+					roomState.log( 'Server requested (old) compaction update' );
+					roomState.updateQueue.add(
+						createDeprecatedCompactionUpdate(
+							room.compaction_request
+						)
 					);
 				}
 			} );

--- a/packages/sync/src/providers/http-polling/types.ts
+++ b/packages/sync/src/providers/http-polling/types.ts
@@ -31,6 +31,7 @@ interface SyncEnvelopeFromClient {
 
 interface SyncEnvelopeFromServer {
 	awareness: AwarenessState;
+	compaction_request?: SyncUpdate[]; // deprecated
 	end_cursor: number; // use as `after` in next request
 	should_compact?: boolean;
 	room: string;

--- a/packages/sync/src/providers/http-polling/types.ts
+++ b/packages/sync/src/providers/http-polling/types.ts
@@ -31,8 +31,8 @@ interface SyncEnvelopeFromClient {
 
 interface SyncEnvelopeFromServer {
 	awareness: AwarenessState;
-	compaction_request?: SyncUpdate[];
 	end_cursor: number; // use as `after` in next request
+	should_compact?: boolean;
 	room: string;
 	updates: SyncUpdate[];
 }


### PR DESCRIPTION
## What?

In the default polling provider, perform compaction using `Y.encodeStateAsUpdate` instead of using a server response.

## Why?

We have observed some bugginess with the default polling provider that seems aligned with compaction events. In particular, we saw instances of content duplication and we suspect that race conditions between the compaction updates and subsequent updates by the client led to this problem.

## How?

Instead of sending updates from the server that need compaction, use `Y.encodeStateAsUpdate` to compact using the client's current state. This is a much better approach than combining an arbitrary range of updates from the server's update history.

## Testing Instructions
