### PR TITLE
DateCalendar, DateRangeCalendar: use lighter gray for disabled dates

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Enhancements
 
 -   Improve visual emphasis of the selected item in the ToggleGroupControl component ([#75138](https://github.com/WordPress/gutenberg/pull/75138)).
+-   `DateCalendar`, `DateRangeCalendar`: use lighter gray for disabled dates ([#75683](https://github.com/WordPress/gutenberg/pull/75683)).
 
 ### Internal
 

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -4,7 +4,8 @@
 
 /* Root of the component. */
 // Internal variables
-$wp-components-calendar-outline-focus: var(--wp-admin-border-width-focus) solid $components-color-accent;
+$wp-components-calendar-outline-focus: var(--wp-admin-border-width-focus)
+	solid $components-color-accent;
 $wp-components-calendar-button-height: $grid-unit-40;
 $wp-components-calendar-button-width: $grid-unit-40;
 $wp-components-calendar-nav-height: $grid-unit-40;
@@ -39,7 +40,8 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	// date follows the same color as the button's text, since the button
 	// inherits its text color.
 	&:has(.components-calendar__day-button:disabled) {
-		color: $components-color-disabled;
+		// Use a lighter shade of gray for less visual prominence.
+		color: $components-color-gray-400;
 	}
 	&:has(.components-calendar__day-button:hover:not(:disabled)),
 	&:has(.components-calendar__day-button:focus-visible) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Use a lighter shade of gray for the text color of disabled dates in the `DateCalendar` and `DateRangeCalendar` components.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To help end users distinguish more clearly disabled dates from the non-disabled ones.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using `gray-400` instead of `gray-600`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load the Storybook examples for `DateCalendar` and `DateRangeCalendar`, play around with the examples dedicated to the disabled dates.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

> [!Note]
> I've included all types of disabled UI in the screenshot:
> - CHANGED: the individual disabeld dates are displayed in a lighter color
> - UNCHANGED:
>    - the disabled color prev/next month chevrons;
>    - the disabled background color of a selected but disabled date

|Before|After|
|-|-|
| ![Screenshot 2026-02-18 at 13 48 02](https://github.com/user-attachments/assets/f73b5b19-a827-4255-a455-8f49abf5e3c1) | ![Screenshot 2026-02-18 at 14 03 25](https://github.com/user-attachments/assets/f0e8343a-5f2a-4e00-847b-1c7a78d60d24) |
