### PR TITLE
Add useBlocker to private APIs for enhanced routing control

### DIFF
--- a/packages/route/src/private-apis.ts
+++ b/packages/route/src/private-apis.ts
@@ -12,6 +12,7 @@ import {
 	Outlet,
 	redirect,
 	RouterProvider,
+	useBlocker,
 	useCanGoBack,
 	useLoaderData,
 	useLocation,
@@ -52,6 +53,7 @@ lock( privateApis, {
 	useMatches,
 	useRouter,
 	useRouterState,
+	useBlocker,
 
 	// History utilities
 	parseHref,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This PR adds `useBlocker`. `useBlocker` is a good primitive to prevent navigation. For more context, [see docs](https://tanstack.com/router/v1/docs/guide/navigation-blocking).