### PR TITLE
DataForm: Fix focus loss and refactor Card layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,7 +17,7 @@
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 - DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
 - DataForm: Fix color picker styles. [#75427](https://github.com/WordPress/gutenberg/pull/75427)
-- DataForm: Fix focus loss when collapsing in Card view. [#](https://github.com/WordPress/gutenberg/pull/)
+- DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 
 ### Enhancements
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
+
 ## 12.0.0 (2026-02-18)
 
 ### Breaking Changes
@@ -17,7 +21,6 @@
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 - DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
 - DataForm: Fix color picker styles. [#75427](https://github.com/WordPress/gutenberg/pull/75427)
-- DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 
 ### Enhancements
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 - DataViews: Fix title truncation in list layout. [#75063](https://github.com/WordPress/gutenberg/pull/75063)
 - DataViews: Fix fields async validation. [#74948](https://github.com/WordPress/gutenberg/pull/74948)
 - DataForm: Fix color picker styles. [#75427](https://github.com/WordPress/gutenberg/pull/75427)
+- DataForm: Fix focus loss when collapsing in Card view. [#](https://github.com/WordPress/gutenberg/pull/)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -7,6 +7,7 @@ import {
 	CardBody,
 	CardHeader as OriginalCardHeader,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import {
 	useCallback,
 	useContext,
@@ -15,6 +16,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
@@ -34,98 +36,6 @@ import { DEFAULT_LAYOUT } from '../normalize-form';
 import { getSummaryFields } from '../get-summary-fields';
 import useReportValidity from '../../../hooks/use-report-validity';
 import ValidationBadge from '../validation-badge';
-
-const NonCollapsibleCardHeader = ( {
-	children,
-	...props
-}: {
-	children: React.ReactNode;
-} ) => (
-	<OriginalCardHeader isBorderless { ...props }>
-		<div
-			style={ {
-				height: '40px', // This is to match the chevron's __next40pxDefaultSize
-				width: '100%',
-				display: 'flex',
-				justifyContent: 'space-between',
-				alignItems: 'center',
-			} }
-		>
-			{ children }
-		</div>
-	</OriginalCardHeader>
-);
-
-export function useCardHeader( layout: NormalizedCardLayout ) {
-	const { isOpened, isCollapsible } = layout;
-	const [ isOpen, setIsOpen ] = useState( isOpened );
-	const [ touched, setTouched ] = useState( false );
-
-	// Sync internal state when the isOpened prop changes.
-	// This is unlikely to happen in production, but it helps with storybook controls.
-	useEffect( () => {
-		setIsOpen( isOpened );
-	}, [ isOpened ] );
-
-	const toggle = useCallback( () => {
-		// Mark as touched when collapsing (going from open to closed)
-		if ( isOpen ) {
-			setTouched( true );
-		}
-		setIsOpen( ( prev ) => ! prev );
-	}, [ isOpen ] );
-
-	const CollapsibleCardHeader = useCallback(
-		( {
-			children,
-			...props
-		}: {
-			children: React.ReactNode;
-			[ key: string ]: any;
-		} ) => (
-			<OriginalCardHeader
-				{ ...props }
-				onClick={ toggle }
-				style={ {
-					cursor: 'pointer',
-					...props.style,
-				} }
-				isBorderless
-			>
-				<div
-					style={ {
-						width: '100%',
-						display: 'flex',
-						justifyContent: 'space-between',
-						alignItems: 'center',
-					} }
-				>
-					{ children }
-				</div>
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					icon={ isOpen ? chevronUp : chevronDown }
-					aria-expanded={ isOpen }
-					aria-label={ isOpen ? 'Collapse' : 'Expand' }
-				/>
-			</OriginalCardHeader>
-		),
-		[ toggle, isOpen ]
-	);
-
-	const effectiveIsOpen = isCollapsible ? isOpen : true;
-	const CardHeaderComponent = isCollapsible
-		? CollapsibleCardHeader
-		: NonCollapsibleCardHeader;
-
-	return {
-		isOpen: effectiveIsOpen,
-		CardHeader: CardHeaderComponent,
-		touched,
-		setTouched,
-	};
-}
 
 function isSummaryFieldVisible< Item >(
 	summaryField: NormalizedField< Item >,
@@ -189,6 +99,10 @@ export default function FormCardField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedCardLayout;
 	const cardBodyRef = useRef< HTMLDivElement >( null );
+	const bodyId = useInstanceId(
+		FormCardField,
+		'dataforms-layouts-card-card-body'
+	);
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -198,7 +112,27 @@ export default function FormCardField< Item >( {
 		[ field ]
 	);
 
-	const { isOpen, CardHeader, touched, setTouched } = useCardHeader( layout );
+	const { isOpened, isCollapsible } = layout;
+	const [ internalIsOpen, setIsOpen ] = useState( isOpened );
+	const [ touched, setTouched ] = useState( false );
+
+	// Sync internal state when the isOpened prop changes.
+	// This is unlikely to happen in production, but it helps with storybook controls.
+	useEffect( () => {
+		setIsOpen( isOpened );
+	}, [ isOpened ] );
+
+	const toggle = useCallback( () => {
+		setIsOpen( ( prev ) => {
+			// Mark as touched when collapsing (going from open to closed)
+			if ( prev ) {
+				setTouched( true );
+			}
+			return ! prev;
+		} );
+	}, [] );
+
+	const isOpen = isCollapsible ? internalIsOpen : true;
 
 	// Mark the card as touched when any field inside it is blurred.
 	// This aligns with how validated controls show errors on blur.
@@ -228,24 +162,55 @@ export default function FormCardField< Item >( {
 		inlineEnd: 'medium' as const,
 	};
 
-	if ( !! field.children ) {
-		const withHeader = !! field.label && layout.withHeader;
+	// For the single-field case, resolve the field definition and layout component.
+	let label = field.label;
+	let SingleFieldLayout;
 
-		const sizeCardBody = {
-			blockStart: withHeader
-				? ( 'none' as const )
-				: ( 'medium' as const ),
-			blockEnd: 'medium' as const,
-			inlineStart: 'medium' as const,
-			inlineEnd: 'medium' as const,
-		};
+	if ( ! field.children ) {
+		const fieldDefinition = fields.find(
+			( fieldDef ) => fieldDef.id === field.id
+		);
 
-		return (
-			<Card className="dataforms-layouts-card__field" size={ sizeCard }>
-				{ withHeader && (
-					<CardHeader className="dataforms-layouts-card__field-header">
+		if ( ! fieldDefinition || ! fieldDefinition.Edit ) {
+			return null;
+		}
+
+		SingleFieldLayout = getFormFieldLayout( 'regular' )?.component;
+		if ( ! SingleFieldLayout ) {
+			return null;
+		}
+
+		label = fieldDefinition.label;
+	}
+	const withHeader = !! label && layout.withHeader;
+	const sizeCardBody = {
+		blockStart: withHeader ? ( 'none' as const ) : ( 'medium' as const ),
+		blockEnd: 'medium' as const,
+		inlineStart: 'medium' as const,
+		inlineEnd: 'medium' as const,
+	};
+	return (
+		<Card className="dataforms-layouts-card__field" size={ sizeCard }>
+			{ withHeader && (
+				<OriginalCardHeader
+					className="dataforms-layouts-card__field-header"
+					onClick={ isCollapsible ? toggle : undefined }
+					style={ {
+						cursor: isCollapsible ? 'pointer' : undefined,
+					} }
+					isBorderless
+				>
+					<div
+						style={ {
+							height: isCollapsible ? undefined : '40px',
+							width: '100%',
+							display: 'flex',
+							justifyContent: 'space-between',
+							alignItems: 'center',
+						} }
+					>
 						<span className="dataforms-layouts-card__field-header-label">
-							{ field.label }
+							{ label }
 						</span>
 						{ validationBadge }
 						{ visibleSummaryFields.length > 0 &&
@@ -262,95 +227,59 @@ export default function FormCardField< Item >( {
 									) }
 								</div>
 							) }
-					</CardHeader>
-				) }
-				{ ( isOpen || ! withHeader ) && (
-					// If it doesn't have a header, keep it open.
-					// Otherwise, the card will not be visible.
-					<CardBody
-						size={ sizeCardBody }
-						className="dataforms-layouts-card__field-control"
-						ref={ cardBodyRef }
-						onBlur={ handleBlur }
-					>
-						{ field.description && (
-							<div className="dataforms-layouts-card__field-description">
-								{ field.description }
-							</div>
-						) }
-						<DataFormLayout
-							data={ data }
-							form={ form }
-							onChange={ onChange }
-							validity={ validity?.children }
+					</div>
+					{ isCollapsible && (
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							icon={ isOpen ? chevronUp : chevronDown }
+							aria-expanded={ isOpen }
+							aria-controls={ bodyId }
+							aria-label={
+								isOpen ? __( 'Collapse' ) : __( 'Expand' )
+							}
 						/>
-					</CardBody>
-				) }
-			</Card>
-		);
-	}
-
-	const fieldDefinition = fields.find(
-		( fieldDef ) => fieldDef.id === field.id
-	);
-
-	if ( ! fieldDefinition || ! fieldDefinition.Edit ) {
-		return null;
-	}
-
-	const RegularLayout = getFormFieldLayout( 'regular' )?.component;
-	if ( ! RegularLayout ) {
-		return null;
-	}
-	const withHeader = !! fieldDefinition.label && layout.withHeader;
-
-	const sizeCardBody = {
-		blockStart: withHeader ? ( 'none' as const ) : ( 'medium' as const ),
-		blockEnd: 'medium' as const,
-		inlineStart: 'medium' as const,
-		inlineEnd: 'medium' as const,
-	};
-
-	return (
-		<Card className="dataforms-layouts-card__field" size={ sizeCard }>
-			{ withHeader && (
-				<CardHeader className="dataforms-layouts-card__field-header">
-					<span className="dataforms-layouts-card__field-header-label">
-						{ fieldDefinition.label }
-					</span>
-					{ validationBadge }
-					{ visibleSummaryFields.length > 0 && layout.withHeader && (
-						<div className="dataforms-layouts-card__field-summary">
-							{ visibleSummaryFields.map( ( summaryField ) => (
-								<summaryField.render
-									key={ summaryField.id }
-									item={ data }
-									field={ summaryField }
-								/>
-							) ) }
-						</div>
 					) }
-				</CardHeader>
+				</OriginalCardHeader>
 			) }
 			{ ( isOpen || ! withHeader ) && (
 				// If it doesn't have a header, keep it open.
 				// Otherwise, the card will not be visible.
 				<CardBody
+					id={ bodyId }
 					size={ sizeCardBody }
 					className="dataforms-layouts-card__field-control"
 					ref={ cardBodyRef }
 					onBlur={ handleBlur }
 				>
-					<RegularLayout
-						data={ data }
-						field={ field }
-						onChange={ onChange }
-						hideLabelFromVision={
-							hideLabelFromVision || withHeader
-						}
-						markWhenOptional={ markWhenOptional }
-						validity={ validity }
-					/>
+					{ field.children ? (
+						<>
+							{ field.description && (
+								<div className="dataforms-layouts-card__field-description">
+									{ field.description }
+								</div>
+							) }
+							<DataFormLayout
+								data={ data }
+								form={ form }
+								onChange={ onChange }
+								validity={ validity?.children }
+							/>
+						</>
+					) : (
+						SingleFieldLayout && (
+							<SingleFieldLayout
+								data={ data }
+								field={ field }
+								onChange={ onChange }
+								hideLabelFromVision={
+									hideLabelFromVision || withHeader
+								}
+								markWhenOptional={ markWhenOptional }
+								validity={ validity }
+							/>
+						)
+					) }
 				</CardBody>
 			) }
 		</Card>

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -162,11 +162,28 @@ export default function FormCardField< Item >( {
 		inlineEnd: 'medium' as const,
 	};
 
-	// For the single-field case, resolve the field definition and layout component.
 	let label = field.label;
-	let SingleFieldLayout;
+	let withHeader: boolean;
+	let bodyContent: React.ReactNode;
 
-	if ( ! field.children ) {
+	if ( field.children ) {
+		withHeader = !! label && layout.withHeader;
+		bodyContent = (
+			<>
+				{ field.description && (
+					<div className="dataforms-layouts-card__field-description">
+						{ field.description }
+					</div>
+				) }
+				<DataFormLayout
+					data={ data }
+					form={ form }
+					onChange={ onChange }
+					validity={ validity?.children }
+				/>
+			</>
+		);
+	} else {
 		const fieldDefinition = fields.find(
 			( fieldDef ) => fieldDef.id === field.id
 		);
@@ -175,20 +192,32 @@ export default function FormCardField< Item >( {
 			return null;
 		}
 
-		SingleFieldLayout = getFormFieldLayout( 'regular' )?.component;
+		const SingleFieldLayout = getFormFieldLayout( 'regular' )?.component;
 		if ( ! SingleFieldLayout ) {
 			return null;
 		}
 
 		label = fieldDefinition.label;
+		withHeader = !! label && layout.withHeader;
+		bodyContent = (
+			<SingleFieldLayout
+				data={ data }
+				field={ field }
+				onChange={ onChange }
+				hideLabelFromVision={ hideLabelFromVision || withHeader }
+				markWhenOptional={ markWhenOptional }
+				validity={ validity }
+			/>
+		);
 	}
-	const withHeader = !! label && layout.withHeader;
+
 	const sizeCardBody = {
 		blockStart: withHeader ? ( 'none' as const ) : ( 'medium' as const ),
 		blockEnd: 'medium' as const,
 		inlineStart: 'medium' as const,
 		inlineEnd: 'medium' as const,
 	};
+
 	return (
 		<Card className="dataforms-layouts-card__field" size={ sizeCard }>
 			{ withHeader && (
@@ -254,34 +283,7 @@ export default function FormCardField< Item >( {
 					ref={ cardBodyRef }
 					onBlur={ handleBlur }
 				>
-					{ field.children ? (
-						<>
-							{ field.description && (
-								<div className="dataforms-layouts-card__field-description">
-									{ field.description }
-								</div>
-							) }
-							<DataFormLayout
-								data={ data }
-								form={ form }
-								onChange={ onChange }
-								validity={ validity?.children }
-							/>
-						</>
-					) : (
-						SingleFieldLayout && (
-							<SingleFieldLayout
-								data={ data }
-								field={ field }
-								onChange={ onChange }
-								hideLabelFromVision={
-									hideLabelFromVision || withHeader
-								}
-								markWhenOptional={ markWhenOptional }
-								validity={ validity }
-							/>
-						)
-					) }
+					{ bodyContent }
 				</CardBody>
 			) }
 		</Card>

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -202,6 +202,8 @@ export default function FormCardField< Item >( {
 				>
 					<div
 						style={ {
+							// Match the expand/collapse button's height to avoid layout
+							// differences when that button is not displayed.
 							height: isCollapsible ? undefined : '40px',
 							width: '100%',
 							display: 'flex',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes #73242

## What?

Part of this PR is extracted from https://github.com/WordPress/gutenberg/pull/73723 in case we can add it just in time for 7.0 today. If we'll merge on time [props will be given](https://github.com/WordPress/gutenberg/pull/73723) to everyone worked in the linked PR.

It also refactors the component a bit because it seems quite hard to follow IMO.


## Testing Instructions
1. DataForm panel should look and work exactly as before, with the focus loss issue fixed though.


