### PR TITLE
Site Tagline : Migrate to Text-Align Block Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -947,8 +947,8 @@ Describe in a few words what this site is about. This is important for search re
 
 -	**Name:** core/site-tagline
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, levelOptions, textAlign
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** level, levelOptions
 
 ## Site Title
 

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -18,7 +18,14 @@
 		}
 	},
 	"example": {
-		"viewportWidth": 350
+		"viewportWidth": 350,
+		"attributes": {
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		}
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -8,9 +8,6 @@
 	"keywords": [ "description" ],
 	"textdomain": "default",
 	"attributes": {
-		"textAlign": {
-			"type": "string"
-		},
 		"level": {
 			"type": "number",
 			"default": 0
@@ -21,10 +18,7 @@
 		}
 	},
 	"example": {
-		"viewportWidth": 350,
-		"attributes": {
-			"textAlign": "center"
-		}
+		"viewportWidth": 350
 	},
 	"supports": {
 		"anchor": true,
@@ -49,6 +43,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalTextTransform": true,
 			"__experimentalTextDecoration": true,

--- a/packages/block-library/src/site-tagline/deprecated.js
+++ b/packages/block-library/src/site-tagline/deprecated.js
@@ -2,6 +2,75 @@
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v2 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		level: {
+			type: 'number',
+		},
+		levelOptions: {
+			type: 'array',
+			default: [ 0, 1, 2, 3, 4, 5, 6 ],
+		},
+	},
+	supports: {
+		anchor: true,
+		reusable: false,
+		html: false,
+		color: {
+			gradients: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+			__experimentalDefaultControls: {
+				margin: false,
+				padding: false,
+			},
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalWritingMode: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+	save: () => null,
+};
 
 const v1 = {
 	attributes: {
@@ -46,4 +115,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v1 ];
+export default [ v2, v1 ];

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -1,15 +1,9 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	AlignmentControl,
 	useBlockProps,
 	BlockControls,
 	HeadingLevelDropdown,
@@ -17,13 +11,13 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
-export default function SiteTaglineEdit( {
-	attributes,
-	setAttributes,
-	insertBlocksAfter,
-} ) {
-	const { textAlign, level, levelOptions } = attributes;
+export default function SiteTaglineEdit( props ) {
+	useDeprecatedTextAlign( props );
+
+	const { attributes, setAttributes, insertBlocksAfter } = props;
+	const { level, levelOptions } = attributes;
 	const { canUserEdit, tagline } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -51,12 +45,7 @@ export default function SiteTaglineEdit( {
 		} );
 	}
 
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-			'wp-block-site-tagline__placeholder': ! canUserEdit && ! tagline,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 	const siteTaglineContent = canUserEdit ? (
 		<RichText
 			allowedFormats={ [] }
@@ -85,12 +74,6 @@ export default function SiteTaglineEdit( {
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}
-				/>
-				<AlignmentControl
-					onChange={ ( newAlign ) =>
-						setAttributes( { textAlign: newAlign } )
-					}
-					value={ textAlign }
 				/>
 			</BlockControls>
 			{ siteTaglineContent }

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -45,7 +45,13 @@ export default function SiteTaglineEdit( props ) {
 		} );
 	}
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className:
+			! canUserEdit && ! tagline
+				? 'wp-block-site-tagline__placeholder'
+				: undefined,
+	} );
+
 	const siteTaglineContent = canUserEdit ? (
 		<RichText
 			allowedFormats={ [] }

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -47,9 +47,7 @@ export default function SiteTaglineEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		className:
-			! canUserEdit && ! tagline
-				? 'wp-block-site-tagline__placeholder'
-				: undefined,
+			! canUserEdit && ! tagline && 'wp-block-site-tagline__placeholder',
 	} );
 
 	const siteTaglineContent = canUserEdit ? (

--- a/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.html
+++ b/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.html
@@ -1,0 +1,5 @@
+<!-- wp:site-tagline {"textAlign":"left"} /-->
+
+<!-- wp:site-tagline {"textAlign":"center"} /-->
+
+<!-- wp:site-tagline {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.json
@@ -1,0 +1,41 @@
+[
+	{
+		"name": "core/site-tagline",
+		"isValid": true,
+		"attributes": {
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/site-tagline",
+		"isValid": true,
+		"attributes": {
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/site-tagline",
+		"isValid": true,
+		"attributes": {
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.parsed.json
+++ b/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/site-tagline",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/site-tagline",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/site-tagline",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:site-tagline {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:site-tagline {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:site-tagline {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Site Tagline` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Site Tagline`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Site Tagline` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Site Tagline` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Site Tagline` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Site Tagline` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)
