### PR TITLE
DataViews: fix spacing for title in patterns page

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- DataViews: Fix first/last column header text misalignment in table layout when no bulk actions are present. [#75372](https://github.com/WordPress/gutenberg/issues/75372)
 - DataForm: Fix text selection in panel layout summary rows by replacing `::after` overlay with accessible card pattern. [#75565](https://github.com/WordPress/gutenberg/pull/75565)
 - DataViews: Improve styling for filters when long values are in use. [#75369](https://github.com/WordPress/gutenberg/pull/75369)
 - DataForm: Fix label case for regular layout. [#75292](https://github.com/WordPress/gutenberg/pull/75292)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
+- DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
 
 ## 12.0.0 (2026-02-18)
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -155,12 +155,12 @@
 
 			&:has(.dataviews-view-table-header-button):first-child {
 				// Table cell padding minus the header button padding.
-				padding-left: $grid-unit-50;
+				padding-left: $grid-unit-20;
 			}
 
 			&:has(.dataviews-view-table-header-button):last-child {
 				// Table cell padding minus the header button padding.
-				padding-right: $grid-unit-50;
+				padding-right: $grid-unit-20;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/75372

## What?

Fix spacing for 1st column in patterns page:

<img width="2010" height="1192" alt="Screenshot 2026-02-18 at 17 21 37" src="https://github.com/user-attachments/assets/779a77f1-d73f-4811-ab53-5d26ce3bf241" />

## Why?

See https://github.com/WordPress/gutenberg/issues/75372. When bulk selection was disabled there was a weird spacing.

## How?

Changed `$grid-unit-50` (40px) to `$grid-unit-20` (16px) for both `:first-child` and `:last-child` header cells containing a header button.

Why it works: The header button has `$grid-unit-10` (8px) of internal left/right padding. So the total visual text offset becomes 16 + 8 = 24px, matching the body cell’s $grid-unit-30 (24px) first/last child padding.

## Testing Instructions

- Visit the site editor's screens and verify there's no visual regressions.
- Using the local storybook, make changes to the table layout story: remove bulk support in actions, align column at the start/end ([example](https://github.com/WordPress/gutenberg/pull/73398), etc. and make sure everything looks aligned.

Different configurations I've tried (align start/end with/without bulk actions):

| | |
| --- | --- |
| <img width="1382" height="1192" alt="Screenshot 2026-02-18 at 17 20 24" src="https://github.com/user-attachments/assets/48d5723b-38a2-47d1-a7e5-f9b3edb2a5ef" /> | <img width="1382" height="1192" alt="Screenshot 2026-02-18 at 17 19 59" src="https://github.com/user-attachments/assets/8659f65d-e2c6-4a9f-9bae-55f85ab6b3b3" /> |
| <img width="1382" height="1192" alt="Screenshot 2026-02-18 at 17 19 35" src="https://github.com/user-attachments/assets/c8aea83e-1ed4-40be-afef-8d605546bb97" /> | <img width="1382" height="1192" alt="Screenshot 2026-02-18 at 17 18 51" src="https://github.com/user-attachments/assets/0831a4f1-8206-4f94-bf4f-15ea07712813" /> |
