### PR TITLE
Field, Fieldset: Add tests for the Details component

### DIFF
--- a/packages/ui/src/form/primitives/field/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/field/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import * as Field from '../index';
 
@@ -32,5 +32,26 @@ describe( 'Field', () => {
 		expect( labelRef.current ).toBeInstanceOf( HTMLLabelElement );
 		expect( descriptionRef.current ).toBeInstanceOf( HTMLParagraphElement );
 		expect( detailsRef.current ).toBeInstanceOf( HTMLDivElement );
+	} );
+
+	it( 'renders details with a semantically associated description for the control', () => {
+		render(
+			<Field.Root>
+				<Field.Label>Field Label</Field.Label>
+				<Field.Control render={ <input /> } />
+				<Field.Details>
+					<a href="#details">Details</a>
+				</Field.Details>
+			</Field.Root>
+		);
+
+		expect(
+			screen.getByRole( 'textbox', {
+				name: 'Field Label',
+				description: 'More details follow the field.',
+			} )
+		).toBeVisible();
+
+		expect( screen.getByRole( 'link', { name: 'Details' } ) ).toBeVisible();
 	} );
 } );

--- a/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
@@ -117,6 +117,12 @@ describe( 'Fieldset', () => {
 				description: 'More details follow.',
 			} )
 		).toBeVisible();
+
+		expect(
+			screen.getByRole( 'link', {
+				name: 'Learn more about these options',
+			} )
+		).toBeVisible();
 	} );
 
 	it( 'forwards className to the details element', () => {


### PR DESCRIPTION
## What?

Adds test coverage for the `Details` component in `Field` and `Fieldset`.

## Why?

`Field.Details` was introduced without dedicated tests for their behavior — only ref forwarding was covered. These tests verify that the details content renders and that the visually hidden description is semantically associated with the control/group.

## How?

- `Field`: Adds a test asserting that `Field.Details` renders a visually hidden description associated with the control via `aria-describedby`, and that the details content (including links) is visible.
- `Fieldset`: Extends the existing details test to also verify that the link content within the details is rendered.

## Testing Instructions

✅ Tests pass