### PR TITLE
RTC: Remove IS_GUTENBERG_PLUGIN checks for collaborative editing

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -340,13 +340,11 @@ export const deleteEntityRecord =
 
 				await dispatch( removeItems( kind, name, recordId, true ) );
 
-				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-					if ( entityConfig.syncConfig ) {
-						const objectType = `${ kind }/${ name }`;
-						const objectId = recordId;
+				if ( entityConfig.syncConfig ) {
+					const objectType = `${ kind }/${ name }`;
+					const objectId = recordId;
 
-						getSyncManager()?.unload( objectType, objectId );
-					}
+					getSyncManager()?.unload( objectType, objectId );
 				}
 			} catch ( _error ) {
 				hasError = true;
@@ -427,35 +425,33 @@ export const editEntityRecord =
 				return acc;
 			}, {} ),
 		};
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-			if ( entityConfig.syncConfig ) {
-				const objectType = `${ kind }/${ name }`;
-				const objectId = recordId;
+		if ( entityConfig.syncConfig ) {
+			const objectType = `${ kind }/${ name }`;
+			const objectId = recordId;
 
-				// Determine whether this edit should create a new undo level.
-				//
-				// In Gutenberg, block changes flow through two callbacks:
-				// - `onInput`: For transient/in-progress changes (e.g., typing each
-				//   character). These use `isCached: true` and get merged into
-				//   the current undo item.
-				// - `onChange`: For persistent/completed changes (e.g., formatting
-				//   transforms, block insertions). These use `isCached: false` and
-				//   should create a new undo level.
-				//
-				// Additionally, `undoIgnore: true` means the change should not
-				// affect the undo history at all (e.g., selection-only changes).
-				const isNewUndoLevel = options.undoIgnore
-					? false
-					: ! options.isCached;
+			// Determine whether this edit should create a new undo level.
+			//
+			// In Gutenberg, block changes flow through two callbacks:
+			// - `onInput`: For transient/in-progress changes (e.g., typing each
+			//   character). These use `isCached: true` and get merged into
+			//   the current undo item.
+			// - `onChange`: For persistent/completed changes (e.g., formatting
+			//   transforms, block insertions). These use `isCached: false` and
+			//   should create a new undo level.
+			//
+			// Additionally, `undoIgnore: true` means the change should not
+			// affect the undo history at all (e.g., selection-only changes).
+			const isNewUndoLevel = options.undoIgnore
+				? false
+				: ! options.isCached;
 
-				getSyncManager()?.update(
-					objectType,
-					objectId,
-					editsWithMerges,
-					LOCAL_EDITOR_ORIGIN,
-					{ isNewUndoLevel }
-				);
-			}
+			getSyncManager()?.update(
+				objectType,
+				objectId,
+				editsWithMerges,
+				LOCAL_EDITOR_ORIGIN,
+				{ isNewUndoLevel }
+			);
 		}
 		if ( ! options.undoIgnore ) {
 			select.getUndoManager().addRecord(
@@ -796,16 +792,14 @@ export const saveEntityRecord =
 						true,
 						edits
 					);
-					if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-						if ( entityConfig.syncConfig ) {
-							getSyncManager()?.update(
-								`${ kind }/${ name }`,
-								recordId,
-								updatedRecord,
-								LOCAL_EDITOR_ORIGIN,
-								{ isSave: true }
-							);
-						}
+					if ( entityConfig.syncConfig ) {
+						getSyncManager()?.update(
+							`${ kind }/${ name }`,
+							recordId,
+							updatedRecord,
+							LOCAL_EDITOR_ORIGIN,
+							{ isSave: true }
+						);
 					}
 				}
 			} catch ( _error ) {

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -40,12 +40,8 @@ type EntityRecordKey = string | number;
  * @return The undo manager.
  */
 export function getUndoManager( state: State ) {
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		// undoManager is undefined until the first sync-enabled entity is loaded.
-		return getSyncManager()?.undoManager ?? state.undoManager;
-	}
-
-	return state.undoManager;
+	// undoManager is undefined until the first sync-enabled entity is loaded.
+	return getSyncManager()?.undoManager ?? state.undoManager;
 }
 
 /**

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -128,7 +128,7 @@ describe( 'getEntityRecord', () => {
 		);
 	} );
 
-	it( 'loads entity with sync manager when IS_GUTENBERG_PLUGIN is true', async () => {
+	it( 'loads entity with sync manager', async () => {
 		const POST_RECORD = { id: 1, title: 'Test Post' };
 		const POST_RESPONSE = {
 			json: () => Promise.resolve( POST_RECORD ),

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -152,10 +152,8 @@ function PostLockedModal() {
 	}
 
 	// Avoid sending the modal if sync is supported, but retain functionality around locks etc.
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		if ( isCollaborationEnabled ) {
-			return null;
-		}
+	if ( isCollaborationEnabled ) {
+		return null;
 	}
 
 	const userDisplayName = user.name;

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -9,10 +9,6 @@ Relevant docs and discussions:
 -   https://github.com/WordPress/gutenberg/discussions/65012
 -   https://docs.yjs.dev/
 
-## Availability
-
-Real-time collaboration is automatically enabled when using the Gutenberg plugin. The `core-data` package checks for `IS_GUTENBERG_PLUGIN` to determine whether entity syncing is available.
-
 ## The data flow
 
 Each entity with sync enabled is represented by a CRDT (Yjs) document. Local edits (unsaved changes) to an entity record are applied to its CRDT document, which is synced with other peers via a provider. Those peers use the CRDT document to update their local state.


### PR DESCRIPTION

## What?

Remove `IS_GUTENBERG_PLUGIN` checks for collaborative editing.

## Why?

In order to make collaborative editing available in WP 7.0 Beta 1, these checks need to be removed. Otherwise the code paths inside these checks are disabled.

## How?

Remove `IS_GUTENBERG_PLUGIN` checks for collaborative editing.

