### PR TITLE
Real-time collaboration: Fix style mounting in RTC overlay

### DIFF
--- a/packages/editor/src/components/collaborators-overlay/overlay.tsx
+++ b/packages/editor/src/components/collaborators-overlay/overlay.tsx
@@ -1,5 +1,3 @@
-// @ts-expect-error No exported types
-import { useStyleOverride } from '@wordpress/block-editor';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
 import { useEffect, useState } from '@wordpress/element';
@@ -221,11 +219,6 @@ export function Overlay( {
 	postId,
 	postType,
 }: OverlayProps ) {
-	useStyleOverride( {
-		id: 'collaborators-overlay',
-		css: COLLABORATORS_OVERLAY_STYLES,
-	} );
-
 	// Use state for the overlay element so that the hook re-runs once the ref is attached.
 	const [ overlayElement, setOverlayElement ] =
 		useState< HTMLDivElement | null >( null );
@@ -258,6 +251,7 @@ export function Overlay( {
 	// scrollable elements like cursor indicators.
 	return (
 		<div className="collaborators-overlay-full" ref={ mergedRef }>
+			<style>{ COLLABORATORS_OVERLAY_STYLES }</style>
 			{ cursors.map( ( cursor ) => (
 				<div
 					key={ cursor.clientId }


### PR DESCRIPTION
## What?

Styling for the RTC overlay is inconsistent. Interacting with the page can cause `useStyleOverride()` to unmount styles causing user cursors to stack at the top of the page:

<img width="1112" height="446" alt="users-on-top" src="https://github.com/user-attachments/assets/867de808-a40a-4bea-9a72-48a42c6f0d98" />
 
This appears to happen after the first interaction with the page. Below, 0-10s shows styles correctly loaded for a user cursor, then after a click, 11s-25s shows the styles missing:

https://github.com/user-attachments/assets/839ff6bb-6f3b-49f2-8f7c-a1e5e6d91e7b

## Why?

We very recently introduced style injection via `useStyleOverride()` in https://github.com/WordPress/gutenberg/pull/75398, which changed how our styles were injected. This PR attempts to fix that style injection.

## How?

`useStyleOverride()` has [pretty complex logic](https://github.com/Automattic/gutenberg/blob/a1e584016c73874686e73a07d59491a0e8e0c1ab/packages/block-editor/src/hooks/utils.js#L153-L225) and appears to be unmounting styles in our slotfill pattern. I'm not clear on why it doesn't work here, but it appears to have been intended for [block style injections](https://github.com/WordPress/gutenberg/pull/63656) which might have a different lifecycle.

The fix replaces the hook-based approach with a plain `<style>` element rendered directly in the component's JSX. Since the `Overlay` already renders inside the iframe document (via `BlockCanvasCover.Slot`), the `<style>` tag ends up in the correct document automatically.

## Testing Instructions

To reproduce on `trunk`:

1. Go to WordPress Admin -> Settings -> Writing, and check the "Enable real-time collaboration" checkbox. Click the "Save Changes" button.
2. Open the same post in two or more separate tabs.
3. With each user, click onto the page. You should see after interacting with the page the other user's cursor boxes appear at the top of the page.

In this PR, step 3 should no longer show large cursors at the top of the page and show user cursors where they are actually present.

## Screenshots

|Before|After|
|-|-|
|  <img width="1118" height="448" alt="Screenshot 2026-02-18 at 12 47 04 PM" src="https://github.com/user-attachments/assets/38a52f96-e926-4ab6-adba-33f5a7ebe630" /> | <img width="1114" height="385" alt="Screenshot 2026-02-18 at 12 48 50 PM" src="https://github.com/user-attachments/assets/80ac78b7-c0f5-4168-98f6-1b4ab4cea088" /> |

