### PR TITLE
Real-time collaboration: Improve collaboration within the same rich text

### DIFF
--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -31,6 +31,7 @@ export interface WPBlockSelection {
 export interface WPSelection {
 	selectionEnd: WPBlockSelection;
 	selectionStart: WPBlockSelection;
+	initialPosition?: number | null;
 }
 
 /**

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -39,7 +39,7 @@ export interface Block {
 }
 
 // A block as represented in the CRDT document (Y.Map).
-interface YBlockRecord extends YMapRecord {
+export interface YBlockRecord extends YMapRecord {
 	attributes: YBlockAttributes;
 	clientId: string;
 	innerBlocks: YBlocks;

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -95,7 +95,7 @@ function convertYSelectionToBlockSelection(
  * @param selectionHistory The selection history to check
  * @return The most recent selection that exists in the document, or null if no selection exists.
  */
-function findSelectionFromHistory(
+export function findSelectionFromHistory(
 	ydoc: Y.Doc,
 	selectionHistory: YFullSelection[]
 ): WPSelection | null {

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -148,24 +148,6 @@ export function findSelectionFromHistory(
 }
 
 /**
- * Given a Y.Doc and a selection history, convert only the latest (first) entry
- * in the history to a WPSelection.
- * @param ydoc             The Y.Doc to resolve positions against
- * @param selectionHistory The selection history to check
- * @return The latest selection converted to WPSelection, or null if it cannot be converted or the history is empty.
- */
-export function getLatestSelectionFromHistory(
-	ydoc: Y.Doc,
-	selectionHistory: YFullSelection[]
-): WPSelection | null {
-	if ( selectionHistory.length === 0 ) {
-		return null;
-	}
-
-	return convertYFullSelectionToWPSelection( selectionHistory[ 0 ], ydoc );
-}
-
-/**
  * Restore the selection to the most recent selection in history that is
  * available in the document.
  * @param selectionHistory The selection history to restore
@@ -235,4 +217,49 @@ export function restoreSelection(
 		// where the user's cursor ended.
 		resetSelection( selectionEnd, selectionEnd, 0 );
 	}
+}
+
+/**
+ * If the latest selection has been shifted by remote edits, resolve and return
+ * it as a WPSelection. Returns null when the history is empty or neither
+ * endpoint has moved.
+ *
+ * @param ydoc             The Y.Doc to resolve positions against
+ * @param selectionHistory The selection history to check
+ * @return The shifted WPSelection, or null if nothing moved.
+ */
+export function getShiftedSelection(
+	ydoc: Y.Doc,
+	selectionHistory: YFullSelection[]
+): WPSelection | null {
+	if ( selectionHistory.length === 0 ) {
+		return null;
+	}
+
+	const { start, end } = selectionHistory[ 0 ];
+
+	// Block-level selections have no offset that can shift.
+	if (
+		start.type === YSelectionType.BlockSelection ||
+		end.type === YSelectionType.BlockSelection
+	) {
+		return null;
+	}
+
+	const selectionStart = convertYSelectionToBlockSelection( start, ydoc );
+	const selectionEnd = convertYSelectionToBlockSelection( end, ydoc );
+
+	if ( ! selectionStart || ! selectionEnd ) {
+		return null;
+	}
+
+	// Only dispatch if at least one endpoint actually moved.
+	const startShifted = selectionStart.offset !== start.offset;
+	const endShifted = selectionEnd.offset !== end.offset;
+
+	if ( ! startShifted && ! endShifted ) {
+		return null;
+	}
+
+	return { selectionStart, selectionEnd };
 }

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -89,6 +89,41 @@ function convertYSelectionToBlockSelection(
 }
 
 /**
+ * Convert a YFullSelection to a WPSelection by resolving relative positions
+ * and verifying the blocks exist in the document.
+ * @param yFullSelection The YFullSelection to convert
+ * @param ydoc           The Y.Doc to resolve positions against
+ * @return The converted WPSelection, or null if the conversion fails
+ */
+function convertYFullSelectionToWPSelection(
+	yFullSelection: YFullSelection,
+	ydoc: Y.Doc
+): WPSelection | null {
+	const { start, end } = yFullSelection;
+	const startBlock = findBlockByClientIdInDoc( start.clientId, ydoc );
+	const endBlock = findBlockByClientIdInDoc( end.clientId, ydoc );
+
+	if ( ! startBlock || ! endBlock ) {
+		return null;
+	}
+
+	const startBlockSelection = convertYSelectionToBlockSelection(
+		start,
+		ydoc
+	);
+	const endBlockSelection = convertYSelectionToBlockSelection( end, ydoc );
+
+	if ( startBlockSelection === null || endBlockSelection === null ) {
+		return null;
+	}
+
+	return {
+		selectionStart: startBlockSelection,
+		selectionEnd: endBlockSelection,
+	};
+}
+
+/**
  * Given a Y.Doc and a selection history, find the most recent selection
  * that exists in the document. Skip any selections that are not in the document.
  * @param ydoc             The Y.Doc to find the selection in
@@ -99,37 +134,35 @@ export function findSelectionFromHistory(
 	ydoc: Y.Doc,
 	selectionHistory: YFullSelection[]
 ): WPSelection | null {
-	// Try each position until we find one that exists in the document
 	for ( const positionToTry of selectionHistory ) {
-		const { start, end } = positionToTry;
-		const startBlock = findBlockByClientIdInDoc( start.clientId, ydoc );
-		const endBlock = findBlockByClientIdInDoc( end.clientId, ydoc );
-
-		if ( ! startBlock || ! endBlock ) {
-			// This block no longer exists, skip it.
-			continue;
-		}
-
-		const startBlockSelection = convertYSelectionToBlockSelection(
-			start,
+		const result = convertYFullSelectionToWPSelection(
+			positionToTry,
 			ydoc
 		);
-		const endBlockSelection = convertYSelectionToBlockSelection(
-			end,
-			ydoc
-		);
-
-		if ( startBlockSelection === null || endBlockSelection === null ) {
-			continue;
+		if ( result !== null ) {
+			return result;
 		}
-
-		return {
-			selectionStart: startBlockSelection,
-			selectionEnd: endBlockSelection,
-		};
 	}
 
 	return null;
+}
+
+/**
+ * Given a Y.Doc and a selection history, convert only the latest (first) entry
+ * in the history to a WPSelection.
+ * @param ydoc             The Y.Doc to resolve positions against
+ * @param selectionHistory The selection history to check
+ * @return The latest selection converted to WPSelection, or null if it cannot be converted or the history is empty.
+ */
+export function getLatestSelectionFromHistory(
+	ydoc: Y.Doc,
+	selectionHistory: YFullSelection[]
+): WPSelection | null {
+	if ( selectionHistory.length === 0 ) {
+		return null;
+	}
+
+	return convertYFullSelectionToWPSelection( selectionHistory[ 0 ], ydoc );
 }
 
 /**

--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -130,7 +130,7 @@ function convertYFullSelectionToWPSelection(
  * @param selectionHistory The selection history to check
  * @return The most recent selection that exists in the document, or null if no selection exists.
  */
-export function findSelectionFromHistory(
+function findSelectionFromHistory(
 	ydoc: Y.Doc,
 	selectionHistory: YFullSelection[]
 ): WPSelection | null {

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -34,7 +34,11 @@ import {
 	WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from '../sync';
 import type { WPSelection } from '../types';
-import { updateSelectionHistory } from './crdt-selection';
+import {
+	findSelectionFromHistory,
+	getSelectionHistory,
+	updateSelectionHistory,
+} from './crdt-selection';
 import {
 	createYMap,
 	getRootMap,
@@ -414,6 +418,25 @@ export function getPostChangesFromCRDTDoc(
 			...editedRecord.meta,
 			...allowedMetaChanges,
 		};
+	}
+
+	// When remote content changes are detected, recalculate the local user's
+	// selection using Y.RelativePosition to account for text shifts. The ydoc
+	// has already been updated with remote content at this point, so converting
+	// relative positions to absolute gives corrected offsets. Including the
+	// selection in PostChanges ensures it dispatches atomically with content.
+	const selectionHistory = getSelectionHistory( ydoc );
+	if ( selectionHistory.length > 0 ) {
+		const recalculatedSelection = findSelectionFromHistory(
+			ydoc,
+			selectionHistory
+		);
+		if ( recalculatedSelection ) {
+			changes.selection = {
+				...recalculatedSelection,
+				initialPosition: 0,
+			};
+		}
 	}
 
 	return changes;

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -35,7 +35,7 @@ import {
 } from '../sync';
 import type { WPSelection } from '../types';
 import {
-	findSelectionFromHistory,
+	getLatestSelectionFromHistory,
 	getSelectionHistory,
 	updateSelectionHistory,
 } from './crdt-selection';
@@ -427,10 +427,11 @@ export function getPostChangesFromCRDTDoc(
 	// selection in PostChanges ensures it dispatches atomically with content.
 	const selectionHistory = getSelectionHistory( ydoc );
 	if ( selectionHistory.length > 0 ) {
-		const recalculatedSelection = findSelectionFromHistory(
+		const recalculatedSelection = getLatestSelectionFromHistory(
 			ydoc,
 			selectionHistory
 		);
+
 		if ( recalculatedSelection ) {
 			changes.selection = {
 				...recalculatedSelection,

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -35,8 +35,8 @@ import {
 } from '../sync';
 import type { WPSelection } from '../types';
 import {
-	getLatestSelectionFromHistory,
 	getSelectionHistory,
+	getShiftedSelection,
 	updateSelectionHistory,
 } from './crdt-selection';
 import {
@@ -426,18 +426,12 @@ export function getPostChangesFromCRDTDoc(
 	// relative positions to absolute gives corrected offsets. Including the
 	// selection in PostChanges ensures it dispatches atomically with content.
 	const selectionHistory = getSelectionHistory( ydoc );
-	if ( selectionHistory.length > 0 ) {
-		const recalculatedSelection = getLatestSelectionFromHistory(
-			ydoc,
-			selectionHistory
-		);
-
-		if ( recalculatedSelection ) {
-			changes.selection = {
-				...recalculatedSelection,
-				initialPosition: 0,
-			};
-		}
+	const shiftedSelection = getShiftedSelection( ydoc, selectionHistory );
+	if ( shiftedSelection ) {
+		changes.selection = {
+			...shiftedSelection,
+			initialPosition: 0,
+		};
 	}
 
 	return changes;

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -22,6 +22,7 @@ import {
 	type YPostRecord,
 } from '../crdt';
 import type { YBlock, YBlocks } from '../crdt-blocks';
+import { updateSelectionHistory } from '../crdt-selection';
 import { createYMap, getRootMap, type YMapWrap } from '../crdt-utils';
 import type { Post, Type } from '../../entity-types';
 
@@ -629,5 +630,135 @@ describe( 'crdt', () => {
 				WORDPRESS_META_KEY_FOR_CRDT_DOC_PERSISTENCE
 			);
 		} );
+
+		describe( 'selection recalculation', () => {
+			it( 'includes recalculated selection when text is inserted before cursor', () => {
+				const ytext = addBlockToDoc( map, 'block-1', 'Hello world' );
+
+				// Record a selection at offset 5 (cursor between "Hello" and " world").
+				updateSelectionHistory( doc, {
+					selectionStart: {
+						clientId: 'block-1',
+						attributeKey: 'content',
+						offset: 5,
+					},
+					selectionEnd: {
+						clientId: 'block-1',
+						attributeKey: 'content',
+						offset: 5,
+					},
+				} );
+
+				// Simulate remote insertion: insert "XXX" at position 0.
+				ytext.insert( 0, 'XXX' );
+
+				const editedRecord = {
+					title: 'CRDT Title',
+					status: 'draft',
+					blocks: [],
+				} as unknown as Post;
+
+				const changes = getPostChangesFromCRDTDoc(
+					doc,
+					editedRecord,
+					mockPostType
+				);
+
+				expect( changes.selection ).toBeDefined();
+				expect( changes.selection?.selectionStart.offset ).toBe( 8 ); // 5 + 3
+				expect( changes.selection?.selectionStart.clientId ).toBe(
+					'block-1'
+				);
+				expect( changes.selection?.selectionStart.attributeKey ).toBe(
+					'content'
+				);
+				expect( changes.selection?.selectionEnd.offset ).toBe( 8 );
+			} );
+
+			it( 'includes recalculated selection when text is deleted before cursor', () => {
+				const ytext = addBlockToDoc( map, 'block-1', 'Hello world' );
+
+				// Record a selection at offset 8 (cursor between "Hello wo" and "rld").
+				updateSelectionHistory( doc, {
+					selectionStart: {
+						clientId: 'block-1',
+						attributeKey: 'content',
+						offset: 8,
+					},
+					selectionEnd: {
+						clientId: 'block-1',
+						attributeKey: 'content',
+						offset: 8,
+					},
+				} );
+
+				// Simulate remote deletion: delete "Hello" (5 chars at position 0).
+				ytext.delete( 0, 5 );
+
+				const editedRecord = {
+					title: 'CRDT Title',
+					status: 'draft',
+					blocks: [],
+				} as unknown as Post;
+
+				const changes = getPostChangesFromCRDTDoc(
+					doc,
+					editedRecord,
+					mockPostType
+				);
+
+				expect( changes.selection ).toBeDefined();
+				expect( changes.selection?.selectionStart.offset ).toBe( 3 ); // 8 - 5
+			} );
+
+			it( 'does not include selection when selection history is empty', () => {
+				addBlockToDoc( map, 'block-1', 'Hello world' );
+
+				const editedRecord = {
+					title: 'CRDT Title',
+					status: 'draft',
+					blocks: [],
+				} as unknown as Post;
+
+				const changes = getPostChangesFromCRDTDoc(
+					doc,
+					editedRecord,
+					mockPostType
+				);
+
+				expect( changes.selection ).toBeUndefined();
+			} );
+		} );
 	} );
 } );
+
+/**
+ * Helper to create a block with a Y.Text content attribute
+ * in the CRDT document.
+ *
+ * @param map
+ * @param clientId Block client ID.
+ * @param content  Initial text content.
+ */
+function addBlockToDoc(
+	map: Y.Map< unknown >,
+	clientId: string,
+	content: string
+): Y.Text {
+	let blocks = map.get( 'blocks' );
+	if ( ! ( blocks instanceof Y.Array ) ) {
+		blocks = new Y.Array< YBlock >();
+		map.set( 'blocks', blocks );
+	}
+
+	const block = new Y.Map() as YBlock;
+	block.set( 'clientId', clientId );
+	const attrs = new Y.Map();
+	const ytext = new Y.Text( content );
+	attrs.set( 'content', ytext );
+	block.set( 'attributes', attrs );
+	block.set( 'innerBlocks', new Y.Array() );
+	( blocks as YBlocks ).push( [ block ] );
+
+	return ytext;
+}

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -21,7 +21,7 @@ import {
 	type PostChanges,
 	type YPostRecord,
 } from '../crdt';
-import type { YBlock, YBlocks } from '../crdt-blocks';
+import type { YBlock, YBlockRecord, YBlocks } from '../crdt-blocks';
 import { updateSelectionHistory } from '../crdt-selection';
 import { createYMap, getRootMap, type YMapWrap } from '../crdt-utils';
 import type { Post, Type } from '../../entity-types';
@@ -741,7 +741,7 @@ describe( 'crdt', () => {
  * @param content  Initial text content.
  */
 function addBlockToDoc(
-	map: Y.Map< unknown >,
+	map: YMapWrap< YPostRecord >,
 	clientId: string,
 	content: string
 ): Y.Text {
@@ -751,7 +751,7 @@ function addBlockToDoc(
 		map.set( 'blocks', blocks );
 	}
 
-	const block = new Y.Map() as YBlock;
+	const block = createYMap< YBlockRecord >();
 	block.set( 'clientId', clientId );
 	const attrs = new Y.Map();
 	const ytext = new Y.Text( content );


### PR DESCRIPTION
## What?

Allow two users to type at the same time within a block.

![simultaneous-typing](https://github.com/user-attachments/assets/735fcbe1-c0c8-4ae4-a33f-dd620064897e)

Fixes https://github.com/WordPress/gutenberg/issues/74563, which demonstrates the behavior before this PR:

> When two users have selections with the same `Y.Text` (e.g. `core/paragraph` text), other users' editors do not update selection position when it has changed.
> 
> Here are some examples of that behavior:
> 
> ### 1. Stationary cursor "moves backward"
> 
> 
> ![Image](https://github.com/user-attachments/assets/10366ce8-7a1c-41a7-9601-a7b9778b8215)
>
> Above, my user has a cursor set at the beginning of "second". When another user types earlierin the paragraph, my selection stays in the same location. Because the text is being added before my selection position, my cursor "travels backwards" within the paragraph.
> 
> ### 2. Selection range moves
> 
> Similarly, if a range is selected, this also stays stationary during text changes:
> 
> ![Image](https://github.com/user-attachments/assets/fec56567-ab5b-496f-9cae-9c0cb452156d)
>
> This is the same problem as above. Because the `selectionStart`/`selectionEnd` properties don't adjust to the changes in the underlying text, the selection can move backwords within the logical text.
> 
> ### 3. Unexpected selection changes in rich text with line breaks
> 
> This problem persists when there are line breaks in a shared rich text object:
> 
> ![Image](https://github.com/user-attachments/assets/8438d9b9-b340-4714-8e7f-834ab49ed987)

This PR addresses these issues and allows fluid selection updates with CRDT changes.

## Why?

Users expect editing within the same block to work, and cursors to adjust to real-time changes in the same text.

## How?

The cursor drift issue happens because the editor stores cursor positions as absolute offsets (e.g. "index `5` in the paragraph"), but when a remote peer inserts or deletes text before that position, the offset becomes stale. The cursor stays at index 5 even though the text it was anchored to has shifted.

The fix utilizes existing stored relative position data and updates selection to match when text changes occur.

When a user interacts with the editor, their cursor position is saved to a selection history as a `Y.RelativePosition`. These relative positions automatically account for text mutations and the relative position converted back to absolute will return the corrected offset. The main change is in `getPostChangesFromCRDTDoc()`, which extracts changes from the CRDT document when remote updates arrive. After extracting content changes, it now also recalculates the local user's cursor by converting their stored relative position back to an absolute offset, and includes this recalculated selection in the returned changes.

Because the recalculated selection is bundled into the same `EDIT_ENTITY_RECORD` dispatch as the content changes, both arrive in the store atomically.

## Limitations

This strategy of recalculating absolute position doesn't work in two scenarios:

### Limitation 1: Current block is split before the cursor

https://github.com/user-attachments/assets/8acf11d9-2ebf-47a6-b95c-20159ecbc8e1

User 1 has their cursor near the front of the block, and user 2 is typing later in the block. When user 1 hits enter and the block breaks into two, user 2's cursor stays within the same block. Ideally, the cursor should stay with the same logical text and move into the second paragraph.

This is tricky to solve. When the block is broken, a new `Y.Text` object is created for the new block's content which is now a separate data structure from the block the user was typing in. The anchor text is gone, so the absolute position just resolves to the end of the first block.

### Limitation 2: Current block is merged into another block

https://github.com/user-attachments/assets/3ca6fba1-74fc-4183-a45f-d50140925137

User 1 has their cursor at the beginning of the block and user 2 is typing later in the block. When user 1 hits backspace and the block is merged into the previous block, user 2's cursor disappears. Ideally, the cursor should stay in the same logical text and move into the previous block with the rest of the content.

Similar to above, this is difficult because the second block's structure is destroyed when the block is merged and the Y.Text in the prior block is changed. Making this work would require understanding where text content has been merged into other blocks and recalculating position.

---

Both of these are real issues, but will require more intensive tree-watching, changing our `mergeCrdtBlocks` logic to be more intelligent about block additions/deletions, or listening for specific Gutenberg signals that a block split or merge has occurred. In any case, I think this PR represents a huge improvement over [current behavior](https://github.com/WordPress/gutenberg/issues/74563) and can be merged without addressing these cases yet.

## Testing Instructions

1. Check out this PR. Ensure real-time collaboration is enabled via: WordPress Admin -> Settings -> Writing, and check the "Enable real-time collaboration" checkbox. Click the "Save Changes" button.
2. Open a post in two separate tabs. Ideally, this can be done on a shared site so that another real human can test at the same time.
3. Within the same block, have one user at the beginning of the block start typing.
4. Have a second user start typing later in the block.
5. Verify that both user's text appears in the block, and that the cursor position moves intuitively with the content.
