### PR TITLE
wp-build: Do not remove Core's default script modules registration

### DIFF
--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -42,5 +42,9 @@ if ( ! function_exists( '{{PREFIX}}_register_script_modules' ) ) {
 	}
 
 	add_action( 'wp_default_scripts', '{{PREFIX}}_register_script_modules' );
-	remove_action( 'wp_default_scripts', 'wp_default_script_modules' );
+
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		// Remove Core's default script modules registration so Gutenberg can replace them with its own.
+		remove_action( 'wp_default_scripts', 'wp_default_script_modules' );
+	}
 }

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -42,9 +42,4 @@ if ( ! function_exists( '{{PREFIX}}_register_script_modules' ) ) {
 	}
 
 	add_action( 'wp_default_scripts', '{{PREFIX}}_register_script_modules' );
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		// Remove Core's default script modules registration so Gutenberg can replace them with its own.
-		remove_action( 'wp_default_scripts', 'wp_default_script_modules' );
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75704

<!-- In a few words, what is the PR actually doing? -->
It deletes the removal of the default script modules registration

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Wp-build removes WordPress Core's built-in function that registers default script modules (like @wordpress/a11y), and it assumes that Gutenberg is installed and activated to replace it with its own modules, but if Gutenberg is not activated this replacement never happens, and the import of `@wordpress/a11y` fails, as the specifier is not mapped.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By deleting the removal entirely, as it is not necessary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1 - Clone https://github.com/dhasilva/minimal-wp-build-test locally
2 - `pnpm install` and build the test plugin with `pnpm run build`
3 - Go to Tools > Minimal WP-Build Test
4 - Check that you see the error in the linked issue
5 - Symlink wp-build to the plugin's dependencies:
```
cd <your-wp-plugins-folder>/minimal-wp-build-test
rm -rf node_modules/@wordpress/build
ln -s <your-gutenberg-folder>/packages/wp-build node_modules/@wordpress/build
```
6 - Rebuild the test plugin: `pnpm run build`
7 - Check `/build/modules.php`, it should have the added `if` block.
8 - Go to Tools > Minimal WP-Build Test again
9 - Check that the page loads
10 - Activate Gutenberg
11 Go to Tools > Minimal WP-Build Test again
12 - Check that the page loads

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1244" height="367" alt="Screenshot from 2026-02-18 20-26-27" src="https://github.com/user-attachments/assets/d6857079-545e-4a03-8ca0-a313eb703ef8" />|<img width="531" height="706" alt="Screenshot from 2026-02-18 20-37-43" src="https://github.com/user-attachments/assets/b750297d-9f87-46c3-a5da-7379038d1731" />|
