### PR TITLE
RTC: Add cap check for single taxonomy term entities

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75366
 * https://github.com/WordPress/gutenberg/pull/75681
 * https://github.com/WordPress/gutenberg/pull/75682
+* https://github.com/WordPress/gutenberg/pull/75708

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -275,6 +275,12 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				return current_user_can( 'edit_post', absint( $object_id ) );
 			}
 
+			// Handle single taxonomy term entities with a defined object ID.
+			if ( 'taxonomy' === $entity_kind && is_numeric( $object_id ) ) {
+				$taxonomy = get_taxonomy( $entity_name );
+				return isset( $taxonomy->cap->assign_terms ) && current_user_can( $taxonomy->cap->assign_terms );
+			}
+
 			// All of the remaining checks are for collections. If an object ID is
 			// provided, reject the request.
 			if ( null !== $object_id ) {


### PR DESCRIPTION
## What?

Add cap check in the default sync provider for single taxonomy term entities.

## Why?

@ingeniumed observed that a singular category entity (specifically the `Uncategorized` category) was being loaded during the pre-publish step. Prior to v22.6.0-RC1, we did not observe this entity being loaded and there is no capability check for singular taxonomy term entities in the default sync provider.

As a result, the sync request fails the `permission_callback` and results in a disconnection dialog:

https://github.com/user-attachments/assets/4447138d-8c3a-4595-8f26-9986156c3c2d

Adding a capability check resolves this issue. In the future, we can explore handling permission errors like these more gracefully.

## How?

- Add cap check to default sync provider input.
- This fix has already been added to the [backport PR](https://github.com/WordPress/wordpress-develop/pull/10894).

## Testing Instructions

1. Check out this PR.
2. Settings > Writing > Enable real-time collaboration.
3. Open a post for editing and publish.
4. Repeat for editor and author roles.