### PR TITLE
Snackbar: Fix scaling issue with snackbars that update their content via a common id

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -231,6 +231,10 @@
 	display: flex;
 	flex-direction: column;
 	pointer-events: none;
+
+	.components-snackbar {
+		margin-inline: auto;
+	}
 }
 
 // These are additional styles for all captions, when the theme opts in to block styles.

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -224,15 +224,13 @@
 @mixin snackbar-container() {
 	position: fixed;
 	bottom: 24px;
-	left: 50%;
-	right: auto;
-	transform: translateX(-50%);
-	width: max-content;
-	max-width: calc(100vw - 32px);
+	left: 0;
+	right: 0;
+	padding-inline: 16px;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+	pointer-events: none;
 }
 
 // These are additional styles for all captions, when the theme opts in to block styles.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `SnackbarList`: Fix scaling distortion when a snackbar's content is updated in place via a shared notice ID ([#75709](https://github.com/WordPress/gutenberg/pull/75709)).
+
 ## 32.2.0 (2026-02-18)
 
 ### Bug Fixes

--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -86,7 +86,8 @@ export function SnackbarList( {
 
 					return (
 						<motion.div
-							layout={ ! isReducedMotion } // See https://www.framer.com/docs/animation/#layout-animations
+							layout={ isReducedMotion ? false : 'position' } // See https://www.framer.com/docs/animation/#layout-animations
+							style={ { width: '100%' } }
 							initial="init"
 							animate="open"
 							exit="exit"

--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -87,6 +87,10 @@ export function SnackbarList( {
 					return (
 						<motion.div
 							layout={ isReducedMotion ? false : 'position' } // See https://www.framer.com/docs/animation/#layout-animations
+							// Ensures a stable full-width bounding box so that
+							// `layout="position"` only ever detects vertical
+							// shifts, preventing horizontal animation when
+							// notice text changes in place.
 							style={ { width: '100%' } }
 							initial="init"
 							animate="open"

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -16,7 +16,6 @@
 	width: 100%;
 	max-width: 600px;
 	box-sizing: border-box;
-	margin-inline: auto;
 	cursor: pointer;
 
 	// Re-enable pointer events, which are disabled by the

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -16,6 +16,7 @@
 	width: 100%;
 	max-width: 600px;
 	box-sizing: border-box;
+	margin-inline: auto;
 	cursor: pointer;
 
 	// Re-enable pointer events, which are disabled by the


### PR DESCRIPTION
## What?

Fixes a snackbar scaling issue introduced in https://github.com/WordPress/gutenberg/pull/75294, which updated the snackbar positioning to be centered.

Note: I'm not 100% across how the snackbar is meant to work, so this PR might not necessarily be the right approach.

## Why?

For snackbars that use an id and then update their content, #75294 resulted in a scaling issue caused by Framer Motion. As far as I can tell, setting the transforms conflicted with how Motion calculates the size / bounding box and resulted in an animation being applied where previously there was none.

## How?

The goal in this change is to try to ensure that the snackbar gets animated vertically but not horizontally and not to apply scaling. This is suggested in the Motions docs here: https://motion.dev/docs/react-layout-animations#the-content-stretches-undesirably

* Set the layout animation to use `position`
* Ensure the motion div is `100%` width so that Motion only detects vertical changes (as it'll always consider the snackbar full width)
* Then, in the mixin styles, remove the transforms, and treat the whole area as full width
* For the snackbar component itself (within the mixin), give it horizontal margin of `auto` so that it's centered

The result should _hopefully_ be much the same as in #75294, but without applying scaling for snackbars that update their content via a common id. Examples are the snackbars used in the media modal experiment and in the template activation experiment.

## Testing Instructions

### Re-testing #75294

Steps copied from that PR:

1. Open Post Editor and trigger a snackbar notice.
2. Confirm snackbar is anchored to viewport and appears bottom-middle.
3. Open Site Editor and repeat:
  * Confirm snackbar is centered and does not overlap sidebar-heavy regions.
4. Open Widgets/Boot contexts and repeat:
  * Confirm bottom-middle placement remains consistent.
5. Confirm snackbar dismiss/auto-dismiss behavior is unchanged.

### Testing this change fixes the media modal

* Activate the media modal experiment in Gutenberg settings
* Go to add a featured image to a post or page
* Drag and upload an image
* The snackbar in the media modal should not scale strangely as the text of the snackbar changes

Also, in the above cases, test the snackbar notices on mobile to make sure they still look okay (full width, with a little padding around the edges horizontally)

### Alternate testing

If you'd like to test this simply using the browser dev console, that's possible, too. You can try this script in your browser console with the post editor open:

<details>
<summary>Script to try out snackbars that update their content</summary>

```js
const { dispatch } = window.wp.data;
  const notices = dispatch('core/notices');

  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

  const NOTICE_ID = 'snackbar-update-demo';
  const OPTS = { type: 'snackbar', isDismissible: true, explicitDismiss: true };

  async function demonstrateSnackbarUpdate() {
      // Step 1: initial notice.
      notices.createNotice('info', 'Uploading 1 file', { ...OPTS, id: NOTICE_ID });

      await wait(1500);

      // Step 2: same ID, different text width — triggers in-place layout animation.
      notices.createNotice('success', 'Uploaded 1 file successfully.', { ...OPTS, id: NOTICE_ID });

      await wait(2000);

      // Step 3: cycle through width extremes on the same ID to make the distortion obvious.
      const updates = [
          { status: 'info',    text: 'Short.' },
          { status: 'success', text: 'A much longer snackbar message that really shows the distortion.' },
          { status: 'info',    text: 'Short again.' },
          { status: 'success', text: 'Medium length message here.' },
      ];

      for (const { status, text } of updates) {
          notices.createNotice(status, text, { ...OPTS, id: NOTICE_ID });
          await wait(1500);
      }
  }

  demonstrateSnackbarUpdate();
```
</details>

And for regression testing, here's a similar script that was shared on the original PR:

<details>
<summary>Script to try out snackbars that fire sequentially</summary>

```js
const { dispatch } = window.wp.data;
const notices = dispatch('core/notices');

const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

async function runSnackbars() {
	const snackbars = [
		{ id: 'snackbar-short', message: 'Saved.' },
		{ id: 'snackbar-medium', message: 'Post saved successfully.' },
		{
			id: 'snackbar-long',
			message:
				'Post saved successfully. All changes have been stored and are now available to visitors.',
		},
		{
			id: 'snackbar-very-long',
			message:
				'Post saved successfully. All changes have been stored, revisions updated, metadata synchronized, and the content is now publicly available across the site.',
		},
	];

	// Dispatch snackbars every 2 seconds.
	for (const snackbar of snackbars) {
		notices.createNotice('success', snackbar.message, {
			id: snackbar.id,
			type: 'snackbar',
			isDismissible: true,
		});

		await wait(2000);
	}

	// Wait for snackbars to auto-dismiss (~5s default).
	await wait(6000);

	// Final snackbar.
	notices.createNotice('success', '✅ All notifications completed.', {
		id: 'snackbar-final',
		type: 'snackbar',
	});
}

runSnackbars();
```
</details>

## Screenshots or screencast <!-- if applicable -->

These screengrabs are from running the artificial script above.

### Before

https://github.com/user-attachments/assets/7090eea6-ce47-4519-8eb1-a2e3616c4704

### After

https://github.com/user-attachments/assets/be3e4460-c194-41ee-948d-c5bec95bf021
