### PR TITLE
Only show dot divider for parent selector in top toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -192,7 +192,10 @@
 			left: auto;
 			margin-left: -$border-width;
 
-			// Show the dot divider since the parent selector is inline.
+
+		}
+		// If the toolbar is collapsible, show the dot divider since the parent selector is inline.
+		.editor-collapsible-block-toolbar .block-editor-block-parent-selector {
 			&::after {
 				display: inline-flex;
 			}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -194,12 +194,6 @@
 
 
 		}
-		// If the toolbar is collapsible, show the dot divider since the parent selector is inline.
-		.editor-collapsible-block-toolbar .block-editor-block-parent-selector {
-			&::after {
-				display: inline-flex;
-			}
-		}
 
 		.block-editor-block-mover__move-button-container,
 		.block-editor-block-toolbar__block-controls .block-editor-block-mover {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -191,8 +191,6 @@
 			position: relative;
 			left: auto;
 			margin-left: -$border-width;
-
-
 		}
 
 		.block-editor-block-mover__move-button-container,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Removes dot appearing after parent selector when button text labels are enabled in floating block toolbar:

<img width="252" height="64" alt="Screenshot 2026-02-19 at 3 12 12 pm" src="https://github.com/user-attachments/assets/add898ec-e02b-4623-aa42-6a02b0f52ba4" />

The CSS removed only applies to the floating toolbar, because it's inside a `.components-popover.block-editor-block-list__block-popover` selector. The styles for the top toolbar dot are coming from elsewhere.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Options > Preferences > Accessibility > Show button text labels
2. Make sure floating toolbar with parent selector has no dot in it:

<img width="265" height="66" alt="Screenshot 2026-02-19 at 3 26 38 pm" src="https://github.com/user-attachments/assets/9280a140-1dd7-4fb8-a3b5-d053c826d42d" />

3. Options > Top toolbar
4. Make sure the dot displays as expected between parent and block selector:

<img width="300" height="55" alt="Screenshot 2026-02-19 at 3 27 18 pm" src="https://github.com/user-attachments/assets/fd16ae66-9006-4ede-b0a6-17a420004020" />
