### PR TITLE
Re-enable Font Library e2e tests

### DIFF
--- a/test/e2e/specs/admin/font-library.spec.js
+++ b/test/e2e/specs/admin/font-library.spec.js
@@ -29,9 +29,7 @@ test.describe( 'Font Library', () => {
 			);
 		} );
 
-		// Temporarily skipped: font-library wp-admin page throws a fatal 500 error (possibly route related).
-		// See https://github.com/WordPress/gutenberg/pull/75661#issuecomment-3919166528
-		test.skip( 'should allow user to add and remove multiple local font files', async ( {
+		test( 'should allow user to add and remove multiple local font files', async ( {
 			page,
 			editor,
 			admin,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a follow-up to #75661.

PR re-enables skipped Font Library e2e test. The issue was resolved upstream (or is it downstream?).

## Testing Instructions
CI checks agree.