### PR TITLE
Patterns: add confirmation dialog before disconnecting/detaching

### DIFF
--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -112,23 +112,33 @@ function PatternsManageButton( { clientId, onClose } ) {
 			{ canDetach && (
 				<>
 					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
-						{ __( 'Detach pattern' ) }
+						{ isSyncedPattern
+							? __( 'Disconnect pattern' )
+							: __( 'Detach pattern' ) }
 					</MenuItem>
 					<ConfirmDialog
 						isOpen={ showConfirmDialog }
 						onConfirm={ handleDetach }
 						onCancel={ () => setShowConfirmDialog( false ) }
-						confirmButtonText={ __( 'Detach' ) }
+						confirmButtonText={
+							isSyncedPattern
+								? __( 'Disconnect' )
+								: __( 'Detach' )
+						}
 						size="medium"
-						title={ __( 'Detach pattern?' ) }
+						title={
+							isSyncedPattern
+								? __( 'Disconnect pattern?' )
+								: __( 'Detach pattern?' )
+						}
 						__experimentalHideHeader={ false }
 					>
 						{ isSyncedPattern
 							? __(
-									'The blocks will be separated from the original pattern and editing restrictions will be removed. Future changes to the pattern will not apply here.'
+									'The blocks will be separated from the original pattern and will be fully editable. Future changes to the pattern will not apply here.'
 							  )
 							: __(
-									'The blocks will no longer be associated with this pattern and editing restrictions will be removed.'
+									'Blocks will no longer be associated with this pattern and will be fully editable.'
 							  ) }
 					</ConfirmDialog>
 				</>

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -1,10 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import {
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -16,6 +20,8 @@ import { store as patternsStore } from '../store';
 import { unlock } from '../lock-unlock';
 
 function PatternsManageButton( { clientId, onClose } ) {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
 	const {
 		attributes,
 		canDetach,
@@ -85,31 +91,47 @@ function PatternsManageButton( { clientId, onClose } ) {
 		return null;
 	}
 
+	const handleDetach = () => {
+		if ( isSyncedPattern ) {
+			convertSyncedPatternToStatic( clientId );
+		}
+
+		if ( isUnsyncedPattern ) {
+			const { patternName, ...attributesWithoutPatternName } =
+				attributes?.metadata ?? {};
+			updateBlockAttributes( clientId, {
+				metadata: attributesWithoutPatternName,
+			} );
+		}
+		onClose?.();
+		setShowConfirmDialog( false );
+	};
+
 	return (
 		<>
 			{ canDetach && (
-				<MenuItem
-					onClick={ () => {
-						if ( isSyncedPattern ) {
-							convertSyncedPatternToStatic( clientId );
-						}
-
-						if ( isUnsyncedPattern ) {
-							const {
-								patternName,
-								...attributesWithoutPatternName
-							} = attributes?.metadata ?? {};
-							updateBlockAttributes( clientId, {
-								metadata: attributesWithoutPatternName,
-							} );
-						}
-						onClose?.();
-					} }
-				>
-					{ isSyncedPattern
-						? __( 'Disconnect pattern' )
-						: __( 'Detach pattern' ) }
-				</MenuItem>
+				<>
+					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
+						{ __( 'Detach pattern' ) }
+					</MenuItem>
+					<ConfirmDialog
+						isOpen={ showConfirmDialog }
+						onConfirm={ handleDetach }
+						onCancel={ () => setShowConfirmDialog( false ) }
+						confirmButtonText={ __( 'Detach' ) }
+						size="medium"
+						title={ __( 'Detach pattern?' ) }
+						__experimentalHideHeader={ false }
+					>
+						{ isSyncedPattern
+							? __(
+									'The blocks will be separated from the original pattern and editing restrictions will be removed. Future changes to the pattern will not apply here.'
+							  )
+							: __(
+									'The blocks will no longer be associated with this pattern and editing restrictions will be removed.'
+							  ) }
+					</ConfirmDialog>
+				</>
 			) }
 			<MenuItem href={ managePatternsUrl }>
 				{ __( 'Manage patterns' ) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -1,10 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import {
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -15,6 +19,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
 	const { canRemove, isVisible, managePatternsUrl } = useSelect(
 		( select ) => {
 			const { getBlock, canRemoveBlock } = select( blockEditorStore );
@@ -56,15 +62,35 @@ function ReusableBlocksManageButton( { clientId } ) {
 		return null;
 	}
 
+	const handleDetach = () => {
+		convertBlockToStatic( clientId );
+		setShowConfirmDialog( false );
+	};
+
 	return (
 		<>
 			<MenuItem href={ managePatternsUrl }>
 				{ __( 'Manage patterns' ) }
 			</MenuItem>
 			{ canRemove && (
-				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ __( 'Disconnect pattern' ) }
-				</MenuItem>
+				<>
+					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
+						{ __( 'Disconnect pattern' ) }
+					</MenuItem>
+					<ConfirmDialog
+						isOpen={ showConfirmDialog }
+						onConfirm={ handleDetach }
+						onCancel={ () => setShowConfirmDialog( false ) }
+						confirmButtonText={ __( 'Disconnect' ) }
+						size="medium"
+						title={ __( 'Disconnect pattern?' ) }
+						__experimentalHideHeader={ false }
+					>
+						{ __(
+							'Blocks will be separated from the original pattern and will be fully editable. Future changes to the pattern will not apply here.'
+						) }
+					</ConfirmDialog>
+				</>
 			) }
 		</>
 	);

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -1,14 +1,10 @@
 /**
  * WordPress dependencies
  */
-import {
-	MenuItem,
-	__experimentalConfirmDialog as ConfirmDialog,
-} from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -19,8 +15,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
-
 	const { canRemove, isVisible, managePatternsUrl } = useSelect(
 		( select ) => {
 			const { getBlock, canRemoveBlock } = select( blockEditorStore );
@@ -62,35 +56,15 @@ function ReusableBlocksManageButton( { clientId } ) {
 		return null;
 	}
 
-	const handleDetach = () => {
-		convertBlockToStatic( clientId );
-		setShowConfirmDialog( false );
-	};
-
 	return (
 		<>
 			<MenuItem href={ managePatternsUrl }>
 				{ __( 'Manage patterns' ) }
 			</MenuItem>
 			{ canRemove && (
-				<>
-					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
-						{ __( 'Detach pattern' ) }
-					</MenuItem>
-					<ConfirmDialog
-						isOpen={ showConfirmDialog }
-						onConfirm={ handleDetach }
-						onCancel={ () => setShowConfirmDialog( false ) }
-						confirmButtonText={ __( 'Detach' ) }
-						size="medium"
-						title={ __( 'Detach pattern?' ) }
-						__experimentalHideHeader={ false }
-					>
-						{ __(
-							'The blocks will be separated from the original pattern and editing restrictions will be removed. Future changes to the pattern will not apply here.'
-						) }
-					</ConfirmDialog>
-				</>
+				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
+					{ __( 'Disconnect pattern' ) }
+				</MenuItem>
 			) }
 		</>
 	);

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -1,10 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import {
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -15,6 +19,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
 	const { canRemove, isVisible, managePatternsUrl } = useSelect(
 		( select ) => {
 			const { getBlock, canRemoveBlock } = select( blockEditorStore );
@@ -56,15 +62,35 @@ function ReusableBlocksManageButton( { clientId } ) {
 		return null;
 	}
 
+	const handleDetach = () => {
+		convertBlockToStatic( clientId );
+		setShowConfirmDialog( false );
+	};
+
 	return (
 		<>
 			<MenuItem href={ managePatternsUrl }>
 				{ __( 'Manage patterns' ) }
 			</MenuItem>
 			{ canRemove && (
-				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ __( 'Disconnect pattern' ) }
-				</MenuItem>
+				<>
+					<MenuItem onClick={ () => setShowConfirmDialog( true ) }>
+						{ __( 'Detach pattern' ) }
+					</MenuItem>
+					<ConfirmDialog
+						isOpen={ showConfirmDialog }
+						onConfirm={ handleDetach }
+						onCancel={ () => setShowConfirmDialog( false ) }
+						confirmButtonText={ __( 'Detach' ) }
+						size="medium"
+						title={ __( 'Detach pattern?' ) }
+						__experimentalHideHeader={ false }
+					>
+						{ __(
+							'The blocks will be separated from the original pattern and editing restrictions will be removed. Future changes to the pattern will not apply here.'
+						) }
+					</ConfirmDialog>
+				</>
 			) }
 		</>
 	);

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -698,10 +698,10 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Detach' } )
+			.getByRole( 'button', { name: 'Disconnect' } )
 			.click();
 
 		// Check that the overrides remain.
@@ -744,10 +744,10 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Detach' } )
+			.getByRole( 'button', { name: 'Disconnect' } )
 			.click();
 
 		// Check that the overrides remain.

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies
- */
-const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
-
-/**
  * External dependencies
  */
 const path = require( 'path' );
+
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Pattern Overrides', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
@@ -698,7 +698,11 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
 
 		// Check that the overrides remain.
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -714,6 +718,7 @@ test.describe( 'Pattern Overrides', () => {
 
 	// See https://github.com/WordPress/gutenberg/pull/62014.
 	test( 'can convert a pattern block to regular blocks when the pattern supports overrides but not override values', async ( {
+		page,
 		admin,
 		requestUtils,
 		editor,
@@ -739,7 +744,11 @@ test.describe( 'Pattern Overrides', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
 
 		// Check that the overrides remain.
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Unsynced pattern', () => {
 		const dialog = page.getByRole( 'dialog', { name: 'Detach pattern?' } );
 		await expect( dialog ).toBeVisible();
 		await expect( dialog ).toContainText(
-			'The blocks will no longer be associated with this pattern and editing restrictions will be removed.'
+			'Blocks will no longer be associated with this pattern and will be fully editable.'
 		);
 
 		await dialog.getByRole( 'button', { name: 'Detach' } ).click();
@@ -873,10 +873,10 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Detach' } )
+			.getByRole( 'button', { name: 'Disconnect' } )
 			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -913,10 +913,10 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Detach' } )
+			.getByRole( 'button', { name: 'Disconnect' } )
 			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -1019,10 +1019,10 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 		await page
 			.getByRole( 'dialog' )
-			.getByRole( 'button', { name: 'Detach' } )
+			.getByRole( 'button', { name: 'Disconnect' } )
 			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -503,35 +503,6 @@ test.describe( 'Unsynced pattern', () => {
 		).toBeVisible();
 	} );
 
-	test( 'detaches an unsynced pattern via the block options menu', async ( {
-		editor,
-	} ) => {
-		// Insert a paragraph block with unsynced pattern metadata.
-		await editor.setContent(
-			`<!-- wp:paragraph {"metadata":{"patternName":"my-pattern","name":"My unsynced pattern"}} -->
-<p>Pattern content</p>
-<!-- /wp:paragraph -->`
-		);
-
-		// Select the paragraph block (the unsynced pattern).
-		await editor.selectBlocks(
-			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
-		);
-
-		// Open the block options menu and click "Detach pattern".
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
-
-		// Verify block content is preserved but patternName is removed from metadata.
-		const blocks = await editor.getBlocks();
-		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ].name ).toBe( 'core/paragraph' );
-		expect( blocks[ 0 ].attributes.content ).toBe( 'Pattern content' );
-		expect( blocks[ 0 ].attributes.metadata?.patternName ).toBeUndefined();
-		expect( blocks[ 0 ].attributes.metadata?.name ).toBe(
-			'My unsynced pattern'
-		);
-	} );
-
 	test( 'supports editing pattern via Edit pattern toolbar button', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -126,6 +126,46 @@ test.describe( 'Unsynced pattern', () => {
 			] );
 	} );
 
+	test( 'can detach unsynced pattern via block options and removes patternName', async ( {
+		editor,
+		page,
+	} ) => {
+		// Create an unsynced pattern block via setContent (paragraph with patternName in metadata).
+		await editor.setContent( `<!-- wp:paragraph {"metadata":{"patternName":"detach-test-pattern","name":"Detach test pattern"}} -->
+<p>Content to detach</p>
+<!-- /wp:paragraph -->` );
+
+		await editor.selectBlocks(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		);
+
+		// Verify "Detach pattern" appears in the block options menu and open the confirmation dialog.
+		await editor.showBlockToolbar();
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+
+		// Verify the confirmation dialog shows with unsynced-specific copy.
+		const dialog = page.getByRole( 'dialog', { name: 'Detach pattern?' } );
+		await expect( dialog ).toBeVisible();
+		await expect( dialog ).toContainText(
+			'The blocks will no longer be associated with this pattern and editing restrictions will be removed.'
+		);
+
+		await dialog.getByRole( 'button', { name: 'Detach' } ).click();
+
+		// Verify patternName was removed from metadata; content is unchanged.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Content to detach',
+				},
+			},
+		] );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.metadata?.patternName ).toBeUndefined();
+	} );
+
 	test( 'inserts unsynced patterns in content only mode', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -126,46 +126,6 @@ test.describe( 'Unsynced pattern', () => {
 			] );
 	} );
 
-	test( 'can detach unsynced pattern via block options and removes patternName', async ( {
-		editor,
-		page,
-	} ) => {
-		// Create an unsynced pattern block via setContent (paragraph with patternName in metadata).
-		await editor.setContent( `<!-- wp:paragraph {"metadata":{"patternName":"detach-test-pattern","name":"Detach test pattern"}} -->
-<p>Content to detach</p>
-<!-- /wp:paragraph -->` );
-
-		await editor.selectBlocks(
-			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
-		);
-
-		// Verify "Detach pattern" appears in the block options menu and open the confirmation dialog.
-		await editor.showBlockToolbar();
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
-
-		// Verify the confirmation dialog shows with unsynced-specific copy.
-		const dialog = page.getByRole( 'dialog', { name: 'Detach pattern?' } );
-		await expect( dialog ).toBeVisible();
-		await expect( dialog ).toContainText(
-			'Blocks will no longer be associated with this pattern and will be fully editable.'
-		);
-
-		await dialog.getByRole( 'button', { name: 'Detach' } ).click();
-
-		// Verify patternName was removed from metadata; content is unchanged.
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/paragraph',
-				attributes: {
-					content: 'Content to detach',
-				},
-			},
-		] );
-
-		const blocks = await editor.getBlocks();
-		expect( blocks[ 0 ].attributes.metadata?.patternName ).toBeUndefined();
-	} );
-
 	test( 'inserts unsynced patterns in content only mode', async ( {
 		editor,
 		page,
@@ -501,6 +461,40 @@ test.describe( 'Unsynced pattern', () => {
 				exact: true,
 			} )
 		).toBeVisible();
+	} );
+
+	test( 'detaches an unsynced pattern via the block options menu', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a paragraph block with unsynced pattern metadata.
+		await editor.setContent(
+			`<!-- wp:paragraph {"metadata":{"patternName":"my-pattern","name":"My unsynced pattern"}} -->
+<p>Pattern content</p>
+<!-- /wp:paragraph -->`
+		);
+
+		// Select the paragraph block (the unsynced pattern).
+		await editor.selectBlocks(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		);
+
+		// Open the block options menu and click "Detach pattern".
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
+
+		// Verify block content is preserved but patternName is removed from metadata.
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].name ).toBe( 'core/paragraph' );
+		expect( blocks[ 0 ].attributes.content ).toBe( 'Pattern content' );
+		expect( blocks[ 0 ].attributes.metadata?.patternName ).toBeUndefined();
+		expect( blocks[ 0 ].attributes.metadata?.name ).toBe(
+			'My unsynced pattern'
+		);
 	} );
 
 	test( 'supports editing pattern via Edit pattern toolbar button', async ( {

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -833,7 +833,11 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -844,6 +848,7 @@ test.describe( 'Synced pattern', () => {
 	} );
 
 	test( 'can be created, inserted, and converted to a regular block', async ( {
+		page,
 		editor,
 		requestUtils,
 	} ) => {
@@ -868,7 +873,11 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -924,6 +933,7 @@ test.describe( 'Synced pattern', () => {
 	} );
 
 	test( 'can be created from multiselection and converted back to regular blocks', async ( {
+		page,
 		editor,
 		pageUtils,
 	} ) => {
@@ -969,7 +979,11 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Detach' } )
+			.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{


### PR DESCRIPTION
## Summary

> [!TIP]
> This PR builds on https://github.com/WordPress/gutenberg/pull/75807 by adding the confirmation dialog. https://github.com/WordPress/gutenberg/pull/75807 renames the "Disconnect pattern" menu item to **"Detach pattern"** for unsynced patterns for the purposes of getting the change into the next WP 7 RC.



This PR:

- Adds a **confirmation dialog** before detaching, with context-aware copy


### Why


The confirmation dialog serves as _user education at the right moment_: it explains the consequences of detaching before the action happens, teaching users the distinction between "Edit pattern" (temporary, reversible) and "Detach pattern" (permanent).

## Test plan
For a synced pattern:

1. Insert a synced pattern into the editor
2. Open the block context menu (the three-dot ⋯ menu)
3. Confirm the option now reads "Detach pattern" (not "Disconnect pattern")
4. Click it — a confirmation dialog should appear with synced-specific messaging
5. Click "Detach" to confirm → the pattern should convert to regular, independent blocks
6. Try again, but this time click "Cancel" → nothing should change

For an unsynced pattern:

1. Insert an unsynced pattern into the editor
2. Open the block context menu
3. Confirm "Detach pattern" appears here too
4. Click it — the confirmation dialog should appear with different copy, specific to unsynced patterns
5. Click "Detach" to confirm → the pattern identity should be removed (the contentOnly lock gets stripped)



https://github.com/user-attachments/assets/ebf1d0fe-84be-43c7-a1ea-649284a8d61d



