### PR TITLE
Fix flaky Quick Edit e2e test

### DIFF
--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -277,6 +277,7 @@ test.describe( 'Page List', () => {
 
 					await page
 						.getByRole( 'option', { name: 'Sample Page' } )
+						.first()
 						.click();
 				},
 				assertEditedState: async ( page ) => {

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -357,10 +357,15 @@ test.describe( 'Page List', () => {
 			await page.getByRole( 'button', { name: 'Layout' } ).click();
 			await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 
-			// Trigger Quick Edit action on Privacy Policy row
+			// Trigger Quick Edit action on Privacy Policy row.
 			const row = page
-				.getByRole( 'row', { name: /Privacy Policy/ } )
-				.first();
+				.getByRole( 'row', {
+					name: /Privacy Policy/,
+				} )
+				.filter( {
+					// Targets newly created pages which are published by default.
+					has: page.getByRole( 'cell', { name: 'Published' } ),
+				} );
 			await row.getByRole( 'button', { name: 'Quick Edit' } ).click();
 		} );
 


### PR DESCRIPTION
## What?
Closes #75667. Which was marked flaky 100+ in one day.

PR tries to fix the flaky Quick Edit e2e test by using better locators. Using a display order doesn't ensure we're getting the right page.

The main problem is that cleanup sometimes fails in CI, resulting in a duplicate test page. Unfortunately, similar race conditions are hard to debug.

## Testing Instructions
CI checks should be green; there should be no related flaky test reports.