### PR TITLE
DataViews: minimize padding for primary action buttons

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Enhancements
 
 - DataViews: Adjust column spacing in table layout when no titleField is provided. [#75410](https://github.com/WordPress/gutenberg/pull/75410)
+- DataViews: minimize padding for primary actions. [#75721](https://github.com/WordPress/gutenberg/pull/75721)
 
 ## 12.0.0 (2026-02-18)
 

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -6,6 +6,9 @@
 	z-index: z-index(".dataviews-action-modal");
 }
 
+// TODO: the way forward here would be to use the new unstyle button coming
+// from wordpress/ui package, but we're not ready to use it yet.
+// See https://github.com/WordPress/gutenberg/pull/75721/
 .dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
 	padding: 0 $grid-unit-05;
 }

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -5,3 +5,7 @@
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }
+
+.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+	padding: 0 $grid-unit-05;
+}


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/75668
Alternative to https://github.com/WordPress/gutenberg/pull/75671

## What?

Reduces padding for primary action's buttons.

| | Before | After|
| --- | --- | ---|
Resting | <img width="1609" height="1230" alt="Screenshot 2026-02-19 at 12 09 05" src="https://github.com/user-attachments/assets/7d5edca8-a92e-4034-91cd-a438cf436916" /> | <img width="1612" height="1237" alt="Screenshot 2026-02-19 at 12 01 25" src="https://github.com/user-attachments/assets/86417520-47fd-49b4-8d04-729d37c20f27" />
Hover | <img width="1609" height="1230" alt="Screenshot 2026-02-19 at 12 09 10" src="https://github.com/user-attachments/assets/acec360c-4f87-421b-b737-9528498c5259" /> | <img width="1609" height="1230" alt="Screenshot 2026-02-19 at 12 20 11" src="https://github.com/user-attachments/assets/41ac9e2f-b185-4782-8c18-fa7e6f4c629d" />
Selection | <img width="1609" height="1230" alt="Screenshot 2026-02-19 at 12 08 58" src="https://github.com/user-attachments/assets/987c7030-cff8-4e3f-8905-fd896886cb23" /> | <img width="1612" height="1237" alt="Screenshot 2026-02-19 at 12 01 30" src="https://github.com/user-attachments/assets/178cc061-1ea0-43fe-a2b9-f14aa0da85ca" />


## Why?

To make the most of the space given to actions. See https://github.com/WordPress/gutenberg/issues/75668

## How?

- Adjust padding.

## Testing Instructions

- Visit Site Editor's Pages screen and verify the spacing changes.
- Visit storybook and compare spacing changes across layout (including activity layout, that is not used in the site editor yet).
