### PR TITLE
Block Editor: Avoid block removal when calling 'moveBlockToPosition'

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1083,6 +1083,9 @@ export const blocks = pipe(
 				if ( fromRootClientId === toRootClientId ) {
 					const subState = state.get( toRootClientId );
 					const fromIndex = subState.indexOf( clientIds[ 0 ] );
+					if ( fromIndex === -1 ) {
+						return state;
+					}
 					const newState = new Map( state );
 					newState.set(
 						toRootClientId,

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1841,6 +1841,43 @@ describe( 'state', () => {
 			] );
 		} );
 
+		it( 'should not remove last block when fromRootClientId is incorrect', () => {
+			const original = blocks( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{
+						clientId: 'chicken',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'ribs',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [
+							{
+								clientId: 'nested',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					},
+				],
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				clientIds: [ 'nested' ],
+				fromRootClientId: '',
+				toRootClientId: '',
+				index: 0,
+			} );
+
+			// The state should be unchnaged - no blocks moved or removed.
+			expect( state.order.get( '' ) ).toEqual( [ 'chicken', 'ribs' ] );
+		} );
+
 		describe( 'blocks', () => {
 			describe( 'byClientId', () => {
 				it( 'should ignore updates to non-existent block', () => {


### PR DESCRIPTION
## What?
Closes #75720.

PR updates `MOVE_BLOCKS_TO_POSITION` reducer to bail out early if it's moving blocks within the same root, but the `clientId` doesn't exist in that root.

## Why?
When `fromRootClientId === toRootClientId`, the reducer looks up the block's position with `indexOf`. If the block isn't actually in that parent, `indexOf` returns `-1`. The `splice(-1, 1)` interprets `-1` as "last element" and removes it.

## Testing Instructions
I've added unit tests; manual testing instructions are in #75720.

### Testing Instructions for Keyboard
Same.