### PR TITLE
DataForm: fix label colors

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -91,7 +91,7 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
-	color: $gray-900;
+	color: $gray-700;
 
 	.components-base-control__label {
 		display: inline;

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -91,7 +91,7 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
-	color: $gray-700;
+	color: $gray-900;
 
 	.components-base-control__label {
 		display: inline;

--- a/packages/dataviews/src/components/dataform-layouts/regular/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/regular/style.scss
@@ -10,7 +10,7 @@
 	.components-base-control__label,
 	.components-input-control__label,
 	.components-form-token-field__label {
-		color: $gray-700;
+		color: $gray-900;
 	}
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/regular/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/regular/style.scss
@@ -8,7 +8,8 @@
 	align-items: flex-start !important;
 
 	.components-base-control__label,
-	.components-input-control__label {
+	.components-input-control__label,
+	.components-form-token-field__label {
 		color: $gray-700;
 	}
 }


### PR DESCRIPTION
## What?

This makes all labels in regular layout use gray-900.

| Before | After |
| --- | --- |
| <img width="878" height="935" alt="Screenshot 2026-02-23 at 12 30 50" src="https://github.com/user-attachments/assets/996545fc-1281-4335-9eec-a4b7075ae8e1" /> | <img width="878" height="935" alt="Screenshot 2026-02-23 at 12 29 58" src="https://github.com/user-attachments/assets/44752df6-7222-4aef-b5c4-138cdfe45add" /> |


## Why?

As per design specs.

## How?

Update label styles to match the desired color.

I've also tried not adding any color at the DataForm level but the underlying controls are not normalized (some use gray-900, some others black, some use the CSS cascade, some others don't, etc.).

## Testing Instructions

- Visit the DataForm layout stories in storybook and verify the color is as expected.

