### PR TITLE
E2E Tests: Fix new-post saveable test for RTC auto-save

### DIFF
--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -94,6 +94,11 @@ test.describe( 'new editor state', () => {
 		page,
 		requestUtils,
 	} ) => {
+		// Save the original setting value (default to false if not set).
+		const settings = await requestUtils.getSiteSettings();
+		const originalRtcSetting =
+			settings.enable_real_time_collaboration ?? false;
+
 		// Disable real-time collaboration.
 		await requestUtils.updateSiteSettings( {
 			enable_real_time_collaboration: false,
@@ -107,6 +112,11 @@ test.describe( 'new editor state', () => {
 		);
 		await expect( saveDraftButton ).toBeVisible();
 		await expect( saveDraftButton ).toBeEnabled();
+
+		// Restore the original setting value.
+		await requestUtils.updateSiteSettings( {
+			enable_real_time_collaboration: originalRtcSetting,
+		} );
 	} );
 
 	test( 'should be saveable with sufficient initial edits (RTC enabled)', async ( {
@@ -114,6 +124,11 @@ test.describe( 'new editor state', () => {
 		page,
 		requestUtils,
 	} ) => {
+		// Save the original setting value (default to false if not set).
+		const settings = await requestUtils.getSiteSettings();
+		const originalRtcSetting =
+			settings.enable_real_time_collaboration ?? false;
+
 		// Enable real-time collaboration.
 		await requestUtils.updateSiteSettings( {
 			enable_real_time_collaboration: true,
@@ -125,9 +140,9 @@ test.describe( 'new editor state', () => {
 		const savedButton = page.locator( 'role=button[name="Saved"i]' );
 		await expect( savedButton ).toBeVisible();
 
-		// Restore the setting to avoid affecting other tests.
+		// Restore the original setting value.
 		await requestUtils.updateSiteSettings( {
-			enable_real_time_collaboration: false,
+			enable_real_time_collaboration: originalRtcSetting,
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -95,24 +95,21 @@ test.describe( 'new editor state', () => {
 	} ) => {
 		await admin.createNewPost( { title: 'Here is the title' } );
 
-		// Verify saveable by presence of the Save Draft button or Saved indicator.
-		// With real-time collaboration enabled, the post may be auto-saved.
-		const saveDraftButton = page.locator(
-			'role=button[name="Save draft"i]'
+		// Check if real-time collaboration is enabled.
+		const isRtcEnabled = await page.evaluate(
+			() => window._wpCollaborationEnabled === true
 		);
-		const savedButton = page.locator( 'role=button[name="Saved"i]' );
 
-		// Either the Save draft button is visible and enabled, or the Saved indicator is present.
-		const isSaveDraftVisible = await saveDraftButton
-			.isVisible()
-			.catch( () => false );
-		const isSavedVisible = await savedButton
-			.isVisible()
-			.catch( () => false );
-
-		expect( isSaveDraftVisible || isSavedVisible ).toBe( true );
-
-		if ( isSaveDraftVisible ) {
+		if ( isRtcEnabled ) {
+			// With RTC enabled, the post is auto-saved, so we expect "Saved".
+			const savedButton = page.locator( 'role=button[name="Saved"i]' );
+			await expect( savedButton ).toBeVisible();
+		} else {
+			// Without RTC, expect the traditional "Save draft" button.
+			const saveDraftButton = page.locator(
+				'role=button[name="Save draft"i]'
+			);
+			await expect( saveDraftButton ).toBeVisible();
 			await expect( saveDraftButton ).toBeEnabled();
 		}
 	} );

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -89,28 +89,45 @@ test.describe( 'new editor state', () => {
 		await expect( page.locator( 'body' ) ).toBeFocused();
 	} );
 
-	test( 'should be saveable with sufficient initial edits', async ( {
+	test( 'should be saveable with sufficient initial edits (RTC disabled)', async ( {
 		admin,
 		page,
+		requestUtils,
 	} ) => {
+		// Disable real-time collaboration.
+		await requestUtils.updateSiteSettings( {
+			enable_real_time_collaboration: false,
+		} );
+
 		await admin.createNewPost( { title: 'Here is the title' } );
 
-		// Check if real-time collaboration is enabled.
-		const isRtcEnabled = await page.evaluate(
-			() => window._wpCollaborationEnabled === true
+		// Without RTC, expect the traditional "Save draft" button.
+		const saveDraftButton = page.locator(
+			'role=button[name="Save draft"i]'
 		);
+		await expect( saveDraftButton ).toBeVisible();
+		await expect( saveDraftButton ).toBeEnabled();
+	} );
 
-		if ( isRtcEnabled ) {
-			// With RTC enabled, the post is auto-saved, so we expect "Saved".
-			const savedButton = page.locator( 'role=button[name="Saved"i]' );
-			await expect( savedButton ).toBeVisible();
-		} else {
-			// Without RTC, expect the traditional "Save draft" button.
-			const saveDraftButton = page.locator(
-				'role=button[name="Save draft"i]'
-			);
-			await expect( saveDraftButton ).toBeVisible();
-			await expect( saveDraftButton ).toBeEnabled();
-		}
+	test( 'should be saveable with sufficient initial edits (RTC enabled)', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Enable real-time collaboration.
+		await requestUtils.updateSiteSettings( {
+			enable_real_time_collaboration: true,
+		} );
+
+		await admin.createNewPost( { title: 'Here is the title' } );
+
+		// With RTC enabled, the post is auto-saved, so we expect "Saved".
+		const savedButton = page.locator( 'role=button[name="Saved"i]' );
+		await expect( savedButton ).toBeVisible();
+
+		// Restore the setting to avoid affecting other tests.
+		await requestUtils.updateSiteSettings( {
+			enable_real_time_collaboration: false,
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -97,7 +97,7 @@ test.describe( 'new editor state', () => {
 		// Save the original setting value (default to false if not set).
 		const settings = await requestUtils.getSiteSettings();
 		const originalRtcSetting =
-			settings.enable_real_time_collaboration ?? false;
+			settings.enable_real_time_collaboration ?? true;
 
 		// Disable real-time collaboration.
 		await requestUtils.updateSiteSettings( {
@@ -127,7 +127,7 @@ test.describe( 'new editor state', () => {
 		// Save the original setting value (default to false if not set).
 		const settings = await requestUtils.getSiteSettings();
 		const originalRtcSetting =
-			settings.enable_real_time_collaboration ?? false;
+			settings.enable_real_time_collaboration ?? true;
 
 		// Enable real-time collaboration.
 		await requestUtils.updateSiteSettings( {

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -119,7 +119,7 @@ test.describe( 'new editor state', () => {
 		} );
 	} );
 
-	test( 'should be saveable with sufficient initial edits (RTC enabled)', async ( {
+	test( 'should be immediately auto saved with sufficient initial edits (RTC enabled)', async ( {
 		admin,
 		page,
 		requestUtils,

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -95,11 +95,25 @@ test.describe( 'new editor state', () => {
 	} ) => {
 		await admin.createNewPost( { title: 'Here is the title' } );
 
-		// Verify saveable by presence of the Save Draft button.
+		// Verify saveable by presence of the Save Draft button or Saved indicator.
+		// With real-time collaboration enabled, the post may be auto-saved.
 		const saveDraftButton = page.locator(
 			'role=button[name="Save draft"i]'
 		);
-		await expect( saveDraftButton ).toBeVisible();
-		await expect( saveDraftButton ).toBeEnabled();
+		const savedButton = page.locator( 'role=button[name="Saved"i]' );
+
+		// Either the Save draft button is visible and enabled, or the Saved indicator is present.
+		const isSaveDraftVisible = await saveDraftButton
+			.isVisible()
+			.catch( () => false );
+		const isSavedVisible = await savedButton
+			.isVisible()
+			.catch( () => false );
+
+		expect( isSaveDraftVisible || isSavedVisible ).toBe( true );
+
+		if ( isSaveDraftVisible ) {
+			await expect( saveDraftButton ).toBeEnabled();
+		}
 	} );
 } );


### PR DESCRIPTION
## Summary

- Fix the `should be saveable with sufficient initial edits` E2E test that was failing due to real-time collaboration (RTC) being enabled by default
- With RTC enabled, posts created with initial content via URL parameters are now auto-saved immediately, showing "Saved" instead of "Save draft"
- Split into two separate tests that explicitly toggle the RTC setting to test both behaviors:
  - **RTC disabled**: expects traditional "Save draft" button
  - **RTC enabled**: expects "Saved" indicator (post is auto-saved)
- Each test saves and restores the original RTC setting to prevent test pollution

## Test plan

Run the E2E test:
```bash
npm run test:e2e -- test/e2e/specs/editor/various/new-post.spec.js
```

All 6 tests should pass.