### PR TITLE
Navigation link: add support to style current menu item via theme.json

### DIFF
--- a/backport-changelog/7.1/11174.md
+++ b/backport-changelog/7.1/11174.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11174
+
+* https://github.com/WordPress/gutenberg/pull/75736

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3281,21 +3281,6 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		/*
-		 * Check if we're processing a block pseudo-selector.
-		 * $block_metadata['path'] = array( 'styles', 'blocks', 'core/button', ':hover' );
-		 */
-		$is_processing_block_pseudo = false;
-		if ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 4 ) {
-			$block_name        = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
-			$last_path_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ]; // ':hover'
-
-			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) &&
-				in_array( $last_path_element, static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ], true ) ) {
-				$is_processing_block_pseudo = true;
-			}
-		}
-
-		/*
 		 * Check for allowed pseudo classes (e.g. ":hover") from the $selector ("a:hover").
 		 * This also resets the array keys.
 		 */
@@ -3324,12 +3309,6 @@ class WP_Theme_JSON_Gutenberg {
 			&& in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ], true )
 		) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, $this->theme_json, $selector, $use_root_padding );
-		} elseif ( $is_processing_block_pseudo ) {
-			// Process block pseudo-selector styles using $node, which already points to the
-			// correct data via _wp_array_get( $this->theme_json, $block_metadata['path'] ).
-			// This works for both top-level pseudo-selectors (e.g. core/button :hover) and
-			// compound state+pseudo paths (e.g. core/navigation-link @current :hover).
-			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} else {
 			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3327,13 +3327,11 @@ class WP_Theme_JSON_Gutenberg {
 		) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} elseif ( $is_processing_block_pseudo ) {
-			// Process block pseudo-selector styles.
-			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector.
-			$block_name  = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
-			$block_data  = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
-			$pseudo_data = $block_data[ $block_pseudo_selector ] ?? array();
-
-			$declarations = static::compute_style_properties( $pseudo_data, $settings, null, $this->theme_json, $selector, $use_root_padding );
+			// Process block pseudo-selector styles using $node, which already points to the
+			// correct data via _wp_array_get( $this->theme_json, $block_metadata['path'] ).
+			// This works for both top-level pseudo-selectors (e.g. core/button :hover) and
+			// compound state+pseudo paths (e.g. core/navigation-link @current :hover).
+			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} else {
 			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -616,40 +616,23 @@ class WP_Theme_JSON_Gutenberg {
 
 	/**
 	 * Custom states for blocks that map to CSS class selectors rather than
-	 * CSS pseudo-selectors. Keys use the '@' prefix (e.g. '@current') to
+	 * CSS pseudo-selectors. Values use the '@' prefix (e.g. '@current') to
 	 * distinguish them from real CSS pseudo-selectors.
 	 *
-	 * Each state is an array with:
-	 *   - 'selector'      (string) The CSS selector for the state.
-	 *   - 'selector_type' (string) How the selector is applied:
-	 *       - 'append'     (default) Appends to the block's base selector via
-	 *                      append_to_selector(), e.g. for a descendant or
-	 *                      compound relationship with the block's own element.
-	 *       - 'standalone' Uses the selector as-is, independent of the block's
-	 *                      base selector. Needed when the target element is
-	 *                      shared across multiple block types and cannot be
-	 *                      expressed relative to a single block's root selector.
+	 * The CSS selector for each state is defined in the block's block.json
+	 * under `selectors.states`, e.g.:
 	 *
-	 * Blocks listed here also inherit their VALID_BLOCK_PSEUDO_SELECTORS as
-	 * valid sub-states within each custom state, producing compound selectors
-	 * such as `.wp-block-navigation-item.current-menu-item:hover`.
+	 *   "selectors": { "states": { "@current": ".some-css-selector" } }
+	 *
+	 * This constant controls which states are valid in theme.json for a given
+	 * block. Blocks listed here also inherit their VALID_BLOCK_PSEUDO_SELECTORS
+	 * as valid sub-states, producing compound selectors such as
+	 * `.wp-block-navigation-item.current-menu-item:hover`.
 	 *
 	 * @var array
 	 */
 	const VALID_BLOCK_CUSTOM_STATES = array(
-		'core/navigation-link' => array(
-			'@current' => array(
-				'selector'      => '.wp-block-navigation-item.current-menu-item',
-				/*
-				 * 'standalone' is required here because .wp-block-navigation-item
-				 * is a shared class added by both core/navigation-link and
-				 * core/navigation-submenu to their <li> wrappers. Using 'append'
-				 * would scope the selector to .wp-block-navigation-link only,
-				 * missing submenu items that are also marked current.
-				 */
-				'selector_type' => 'standalone',
-			),
-		),
+		'core/navigation-link' => array( '@current' ),
 	);
 
 	/**
@@ -1105,7 +1088,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Add custom states for blocks that support them (e.g. '@current' for navigation).
 			if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $block ] ) ) {
-				foreach ( array_keys( static::VALID_BLOCK_CUSTOM_STATES[ $block ] ) as $custom_state ) {
+				foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $block ] as $custom_state ) {
 					$custom_state_schema = $styles_non_top_level;
 					// The same pseudo-selectors valid for the block at the top level
 					// are also valid within each custom state.
@@ -1343,6 +1326,11 @@ class WP_Theme_JSON_Gutenberg {
 
 			if ( ! empty( $style_selectors ) ) {
 				static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
+			}
+
+			// If the block has custom states defined in block.json, store their selectors.
+			if ( ! empty( $block_type->selectors['states'] ) && is_array( $block_type->selectors['states'] ) ) {
+				static::$blocks_metadata[ $block_name ]['states'] = $block_type->selectors['states'];
 			}
 		}
 
@@ -3103,13 +3091,12 @@ class WP_Theme_JSON_Gutenberg {
 
 				// Handle custom states (e.g. '@current' for navigation).
 				if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $name ] ) ) {
-					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state => $state_config ) {
-						if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) ) {
-							$class_selector      = $state_config['selector'];
-							$selector_type       = $state_config['selector_type'] ?? 'append';
-							$custom_css_selector = 'standalone' === $selector_type
-								? $class_selector
-								: static::append_to_selector( $selector, $class_selector );
+					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state ) {
+						if (
+							isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) &&
+							isset( $selectors[ $name ]['states'][ $custom_state ] )
+						) {
+							$custom_css_selector = $selectors[ $name ]['states'][ $custom_state ];
 							$nodes[]             = array(
 								'name'       => $name,
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -610,7 +610,27 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(
-		'core/button' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/button'          => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-link' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+	);
+
+	/**
+	 * Custom states for blocks that map to CSS class selectors rather than
+	 * CSS pseudo-selectors. Keys use the '@' prefix (e.g. '@current') to
+	 * distinguish them from real CSS pseudo-selectors. Values are the CSS
+	 * selector fragment to append to the block's base selector (including
+	 * any leading space for descendant selectors).
+	 *
+	 * Blocks listed here also inherit their VALID_BLOCK_PSEUDO_SELECTORS as
+	 * valid sub-states within each custom state, producing compound selectors
+	 * such as `.wp-block-navigation-link.current-menu-item:hover`.
+	 *
+	 * @var array
+	 */
+	const VALID_BLOCK_CUSTOM_STATES = array(
+		'core/navigation-link' => array(
+			'@current' => '.current-menu-item',
+		),
 	);
 
 	/**
@@ -1061,6 +1081,21 @@ class WP_Theme_JSON_Gutenberg {
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 				foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
 					$schema_styles_blocks[ $block ][ $pseudo_selector ] = $styles_non_top_level;
+				}
+			}
+
+			// Add custom states for blocks that support them (e.g. '@current' for navigation).
+			if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $block ] ) ) {
+				foreach ( array_keys( static::VALID_BLOCK_CUSTOM_STATES[ $block ] ) as $custom_state ) {
+					$custom_state_schema = $styles_non_top_level;
+					// The same pseudo-selectors valid for the block at the top level
+					// are also valid within each custom state.
+					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
+						foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo ) {
+							$custom_state_schema[ $pseudo ] = $styles_non_top_level;
+						}
+					}
+					$schema_styles_blocks[ $block ][ $custom_state ] = $custom_state_schema;
 				}
 			}
 		}
@@ -3043,6 +3078,42 @@ class WP_Theme_JSON_Gutenberg {
 								'variations' => $variation_selectors,
 								'css'        => static::append_to_selector( $selector, $pseudo_selector ),
 							);
+						}
+					}
+				}
+
+				// Handle custom states (e.g. '@current' for navigation).
+				if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $name ] ) ) {
+					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state => $class_selector ) {
+						if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) ) {
+							$custom_css_selector = static::append_to_selector( $selector, $class_selector );
+							$nodes[]             = array(
+								'name'       => $name,
+								'path'       => array( 'styles', 'blocks', $name, $custom_state ),
+								'selector'   => $custom_css_selector,
+								'selectors'  => $feature_selectors,
+								'duotone'    => $duotone_selector,
+								'variations' => $variation_selectors,
+								'css'        => $custom_css_selector,
+							);
+
+							// Sub-pseudo-selectors within the custom state.
+							if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] ) ) {
+								foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] as $pseudo ) {
+									if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ][ $pseudo ] ) ) {
+										$compound_css_selector = static::append_to_selector( $custom_css_selector, $pseudo );
+										$nodes[]               = array(
+											'name'       => $name,
+											'path'       => array( 'styles', 'blocks', $name, $custom_state, $pseudo ),
+											'selector'   => $compound_css_selector,
+											'selectors'  => $feature_selectors,
+											'duotone'    => $duotone_selector,
+											'variations' => $variation_selectors,
+											'css'        => $compound_css_selector,
+										);
+									}
+								}
+							}
 						}
 					}
 				}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -619,11 +619,16 @@ class WP_Theme_JSON_Gutenberg {
 	 * CSS pseudo-selectors. Keys use the '@' prefix (e.g. '@current') to
 	 * distinguish them from real CSS pseudo-selectors.
 	 *
-	 * Selector values control how the CSS selector is built:
-	 * - Leading space (e.g. ' .child'): appended to the block's base selector
-	 *   as a descendant selector.
-	 * - No leading space (e.g. '.some-class'): used as a standalone selector,
-	 *   independent of the block's base selector.
+	 * Each state is an array with:
+	 *   - 'selector'      (string) The CSS selector for the state.
+	 *   - 'selector_type' (string) How the selector is applied:
+	 *       - 'append'     (default) Appends to the block's base selector via
+	 *                      append_to_selector(), e.g. for a descendant or
+	 *                      compound relationship with the block's own element.
+	 *       - 'standalone' Uses the selector as-is, independent of the block's
+	 *                      base selector. Needed when the target element is
+	 *                      shared across multiple block types and cannot be
+	 *                      expressed relative to a single block's root selector.
 	 *
 	 * Blocks listed here also inherit their VALID_BLOCK_PSEUDO_SELECTORS as
 	 * valid sub-states within each custom state, producing compound selectors
@@ -633,7 +638,17 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const VALID_BLOCK_CUSTOM_STATES = array(
 		'core/navigation-link' => array(
-			'@current' => '.wp-block-navigation-item.current-menu-item',
+			'@current' => array(
+				'selector'      => '.wp-block-navigation-item.current-menu-item',
+				/*
+				 * 'standalone' is required here because .wp-block-navigation-item
+				 * is a shared class added by both core/navigation-link and
+				 * core/navigation-submenu to their <li> wrappers. Using 'append'
+				 * would scope the selector to .wp-block-navigation-link only,
+				 * missing submenu items that are also marked current.
+				 */
+				'selector_type' => 'standalone',
+			),
 		),
 	);
 
@@ -3088,12 +3103,13 @@ class WP_Theme_JSON_Gutenberg {
 
 				// Handle custom states (e.g. '@current' for navigation).
 				if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $name ] ) ) {
-					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state => $class_selector ) {
+					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state => $state_config ) {
 						if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) ) {
-							// A leading space means a descendant selector; no leading space means standalone.
-							$custom_css_selector = str_starts_with( $class_selector, ' ' )
-							? static::append_to_selector( $selector, $class_selector )
-							: $class_selector;
+							$class_selector      = $state_config['selector'];
+							$selector_type       = $state_config['selector_type'] ?? 'append';
+							$custom_css_selector = 'standalone' === $selector_type
+								? $class_selector
+								: static::append_to_selector( $selector, $class_selector );
 							$nodes[]             = array(
 								'name'       => $name,
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -617,19 +617,23 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Custom states for blocks that map to CSS class selectors rather than
 	 * CSS pseudo-selectors. Keys use the '@' prefix (e.g. '@current') to
-	 * distinguish them from real CSS pseudo-selectors. Values are the CSS
-	 * selector fragment to append to the block's base selector (including
-	 * any leading space for descendant selectors).
+	 * distinguish them from real CSS pseudo-selectors.
+	 *
+	 * Selector values control how the CSS selector is built:
+	 * - Leading space (e.g. ' .child'): appended to the block's base selector
+	 *   as a descendant selector.
+	 * - No leading space (e.g. '.some-class'): used as a standalone selector,
+	 *   independent of the block's base selector.
 	 *
 	 * Blocks listed here also inherit their VALID_BLOCK_PSEUDO_SELECTORS as
 	 * valid sub-states within each custom state, producing compound selectors
-	 * such as `.wp-block-navigation-link.current-menu-item:hover`.
+	 * such as `.wp-block-navigation-item.current-menu-item:hover`.
 	 *
 	 * @var array
 	 */
 	const VALID_BLOCK_CUSTOM_STATES = array(
 		'core/navigation-link' => array(
-			'@current' => '.current-menu-item',
+			'@current' => '.wp-block-navigation-item.current-menu-item',
 		),
 	);
 
@@ -3086,7 +3090,10 @@ class WP_Theme_JSON_Gutenberg {
 				if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $name ] ) ) {
 					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state => $class_selector ) {
 						if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) ) {
-							$custom_css_selector = static::append_to_selector( $selector, $class_selector );
+							// A leading space means a descendant selector; no leading space means standalone.
+					$custom_css_selector = str_starts_with( $class_selector, ' ' )
+						? static::append_to_selector( $selector, $class_selector )
+						: $class_selector;
 							$nodes[]             = array(
 								'name'       => $name,
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3091,9 +3091,9 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state => $class_selector ) {
 						if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) ) {
 							// A leading space means a descendant selector; no leading space means standalone.
-					$custom_css_selector = str_starts_with( $class_selector, ' ' )
-						? static::append_to_selector( $selector, $class_selector )
-						: $class_selector;
+							$custom_css_selector = str_starts_with( $class_selector, ' ' )
+							? static::append_to_selector( $selector, $class_selector )
+							: $class_selector;
 							$nodes[]             = array(
 								'name'       => $name,
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3285,7 +3285,6 @@ class WP_Theme_JSON_Gutenberg {
 		 * $block_metadata['path'] = array( 'styles', 'blocks', 'core/button', ':hover' );
 		 */
 		$is_processing_block_pseudo = false;
-		$block_pseudo_selector      = null;
 		if ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 4 ) {
 			$block_name        = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
 			$last_path_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ]; // ':hover'
@@ -3293,7 +3292,6 @@ class WP_Theme_JSON_Gutenberg {
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) &&
 				in_array( $last_path_element, static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ], true ) ) {
 				$is_processing_block_pseudo = true;
-				$block_pseudo_selector      = $last_path_element;
 			}
 		}
 

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -87,7 +87,7 @@
 	},
 	"selectors": {
 		"states": {
-			"@current": ".wp-block-navigation .wp-block-navigation-item.current-menu-item"
+			"@current": ".wp-block-navigation .current-menu-item"
 		}
 	},
 	"editorStyle": "wp-block-navigation-link-editor",

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -85,6 +85,11 @@
 			"clientNavigation": true
 		}
 	},
+	"selectors": {
+		"states": {
+			"@current": ".wp-block-navigation-item.current-menu-item"
+		}
+	},
 	"editorStyle": "wp-block-navigation-link-editor",
 	"style": "wp-block-navigation-link"
 }

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -87,7 +87,7 @@
 	},
 	"selectors": {
 		"states": {
-			"@current": ".wp-block-navigation-item.current-menu-item"
+			"@current": ".wp-block-navigation .wp-block-navigation-item.current-menu-item"
 		}
 	},
 	"editorStyle": "wp-block-navigation-link-editor",

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6813,7 +6813,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
-		$this->assertStringContainsString( ':where(.wp-block-navigation .wp-block-navigation-item.current-menu-item)', $stylesheet );
+		$this->assertStringContainsString( ':where(.wp-block-navigation .current-menu-item)', $stylesheet );
 		$this->assertStringNotContainsString( ':where(.wp-block-navigation-link)', $stylesheet );
 	}
 
@@ -6851,7 +6851,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-navigation .wp-block-navigation-item.current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .wp-block-navigation-item.current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation .wp-block-navigation-item.current-menu-item:focus){background-color: yellow;color: green;}';
+		$expected = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation .current-menu-item:focus){background-color: yellow;color: green;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6882,6 +6882,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$stylesheet_bogus = $theme_json_bogus_state->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$expected_bogus   = ':root :where(.wp-block-navigation-link){color: black;}';
+		$this->assertSameCSS( $expected_bogus, $stylesheet_bogus );
 		$this->assertStringNotContainsString( '@bogus', $stylesheet_bogus );
 		$this->assertStringNotContainsString( 'yellow', $stylesheet_bogus );
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6813,7 +6813,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
-		$this->assertStringContainsString( ':where(.wp-block-navigation-item.current-menu-item)', $stylesheet );
+		$this->assertStringContainsString( ':where(.wp-block-navigation .wp-block-navigation-item.current-menu-item)', $stylesheet );
 		$this->assertStringNotContainsString( ':where(.wp-block-navigation-link)', $stylesheet );
 	}
 
@@ -6851,7 +6851,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-navigation-item.current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation-item.current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation-item.current-menu-item:focus){background-color: yellow;color: green;}';
+		$expected = ':root :where(.wp-block-navigation .wp-block-navigation-item.current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .wp-block-navigation-item.current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation .wp-block-navigation-item.current-menu-item:focus){background-color: yellow;color: green;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6813,8 +6813,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
-		$this->assertStringContainsString( ':where(.wp-block-navigation .current-menu-item)', $stylesheet );
-		$this->assertStringNotContainsString( ':where(.wp-block-navigation-link)', $stylesheet );
+		$expected   = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}';
+		$this->assertSameCSS( $expected, $stylesheet );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6788,6 +6788,131 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
+	/**
+	 * Test that block custom states (e.g. @current) are processed correctly.
+	 */
+	public function test_block_custom_states_are_processed() {
+		// Only @current styles — no base block styles — so we can assert the
+		// output uses the current-menu-item selector and not the block selector.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-link' => array(
+							'@current' => array(
+								'color' => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$this->assertStringContainsString( ':where(.wp-block-navigation-item.current-menu-item)', $stylesheet );
+		$this->assertStringNotContainsString( ':where(.wp-block-navigation-link)', $stylesheet );
+	}
+
+	/**
+	 * Test that block custom states compound correctly with pseudo-selectors (e.g. @current + :hover).
+	 */
+	public function test_block_custom_states_compound_with_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-link' => array(
+							'@current' => array(
+								'color'  => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+								':hover' => array(
+									'color' => array(
+										'text'       => 'blue',
+										'background' => 'white',
+									),
+								),
+								':focus' => array(
+									'color' => array(
+										'text'       => 'green',
+										'background' => 'yellow',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = ':root :where(.wp-block-navigation-item.current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation-item.current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation-item.current-menu-item:focus){background-color: yellow;color: green;}';
+		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+	}
+
+	/**
+	 * Test that non-whitelisted custom states are ignored, and that custom states
+	 * are ignored on blocks that do not declare support for them.
+	 */
+	public function test_block_custom_states_ignores_non_whitelisted() {
+		// A non-whitelisted state key on a block that supports custom states.
+		$theme_json_bogus_state = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-link' => array(
+							'color'  => array(
+								'text' => 'black',
+							),
+							'@bogus' => array(
+								'color' => array(
+									'text' => 'yellow',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet_bogus = $theme_json_bogus_state->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$this->assertStringNotContainsString( '@bogus', $stylesheet_bogus );
+		$this->assertStringNotContainsString( 'yellow', $stylesheet_bogus );
+
+		// A valid custom state key on a block that does not support custom states.
+		$theme_json_unsupported_block = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color'    => array(
+								'text' => 'black',
+							),
+							'@current' => array(
+								'color' => array(
+									'text' => 'red',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet_unsupported = $theme_json_unsupported_block->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$expected               = ':root :where(p){color: black;}';
+		$this->assertSameCSS( $expected, $stylesheet_unsupported );
+		$this->assertStringNotContainsString( '@current', $stylesheet_unsupported );
+		$this->assertStringNotContainsString( 'current-menu-item', $stylesheet_unsupported );
+	}
+
 	public function test_merge_incoming_data_block_level_inherits_global_default_setting() {
 		$defaults = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1877,6 +1877,40 @@
 				}
 			}
 		},
+		"stylesBlocksPseudoSelectorsProperties": {
+			"type": "object",
+			"properties": {
+				":hover": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus-visible": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":active": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesBlocksCustomStatesProperties": {
+			"description": "Custom class-based block states using the '@' prefix. Each state supports style properties as well as the same pseudo-selectors available to the block.",
+			"type": "object",
+			"properties": {
+				"@current": {
+					"description": "Styles applied to the current/active item (e.g. .current-menu-item in navigation).",
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesPropertiesComplete"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						}
+					]
+				}
+			}
+		},
 		"stylesElementsPseudoSelectorsPropertyNames": {
 			"enum": [
 				":active",
@@ -2191,7 +2225,17 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/navigation-link": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksCustomStatesProperties"
+						}
+					]
 				},
 				"core/navigation-submenu": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1844,12 +1844,7 @@
 			}
 		},
 		"stylesBlocksPseudoSelectorsPropertyNames": {
-			"enum": [
-				":hover",
-				":focus",
-				":focus-visible",
-				":active"
-			]
+			"enum": [ ":hover", ":focus", ":focus-visible", ":active" ]
 		},
 		"stylesElementsPseudoSelectorsProperties": {
 			"type": "object",
@@ -1873,23 +1868,6 @@
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				},
 				":visited": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				}
-			}
-		},
-		"stylesBlocksPseudoSelectorsProperties": {
-			"type": "object",
-			"properties": {
-				":hover": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				":focus": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				":focus-visible": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				":active": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #42299
Related #38277
Alternative to #54460

Adds theme.json support for styling the current navigation item (`@current`) and its interactive states in the `core/navigation-link` block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Theme authors need a way to style the active/current menu item differently from the rest of the navigation, including controlling its hover, focus, and active states.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
No UI changes are included; this is theme.json only.

A new `VALID_BLOCK_CUSTOM_STATES` constant whitelists `@`-prefixed states per block in theme.json, playing the same role that `VALID_BLOCK_PSEUDO_SELECTORS` plays for CSS pseudo-selectors — the `@` prefix distinguishes these class-based states from real CSS pseudo-selectors. 

Each block declares its state CSS selectors in `block.json` under `selectors.states`, following the existing [Selectors API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/) pattern, which `get_blocks_metadata()` reads into block metadata and `get_block_nodes()` uses to generate CSS. 

Blocks listed in `VALID_BLOCK_CUSTOM_STATES` also inherit their `VALID_BLOCK_PSEUDO_SELECTORS` as valid sub-states, producing compound selectors like `.wp-block-navigation-item.current-menu-item:hover`.

We've had initial discussions on how the UI for this scenario would look like [over here](https://github.com/WordPress/gutenberg/pull/75627#issuecomment-3926949649).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

Add the following snippets to your theme.json under styles.blocks and verify the correct CSS is generated on the frontend:

Current item base styles:
```
"core/navigation-link": {
  "@current": {
    "color": { "text": "#ff0000" }
  }
}
```

Current item hover:
```
"core/navigation-link": {
  "@current": {
    ":hover": {
      "color": { "text": "#0000ff" }
    }
  }
}
```

Current item focus:
```
"core/navigation-link": {
  "@current": {
    ":focus": {
      "color": { "text": "#00aa00" }
    }
  }
}
```

All combined:
```
"core/navigation-link": {
  "@current": {
    "color": { "text": "#ff0000" },
    "typography": { "fontWeight": "700" },
    ":hover": {
      "color": { "text": "#0000ff" }
    },
    ":focus": {
      "color": { "text": "#00aa00" }
    },
    ":active": {
      "color": { "text": "#ff6600" }
    }
  }
}
```

Test for both items with submenus and without. Try other styles that aren't just the text color.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


<img width="1423" height="404" alt="Screenshot 2026-02-19 at 18 02 17" src="https://github.com/user-attachments/assets/6f32a0fb-825c-4c12-b79c-474c5249abc7" />
<img width="1338" height="442" alt="Screenshot 2026-02-19 at 18 02 23" src="https://github.com/user-attachments/assets/32f615b1-f76f-4b47-91dc-a59b016793c8" />