### PR TITLE
Fix undo E2E test

### DIFF
--- a/packages/core-data/src/utils/crdt-selection.ts
+++ b/packages/core-data/src/utils/crdt-selection.ts
@@ -170,7 +170,9 @@ export function restoreSelection(
 		const isBeginningOfEmptyBlock =
 			0 === selectionStart.offset &&
 			0 === selectionEnd.offset &&
-			isBlockEmpty;
+			isBlockEmpty &&
+			! selectionStart.attributeKey &&
+			! selectionEnd.attributeKey;
 
 		if ( isBeginningOfEmptyBlock ) {
 			// Case 2a: When the content in a block has been removed after an

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -177,6 +177,17 @@ test.describe( 'undo', () => {
 		await editor.canvas.locator( '[data-type="core/paragraph"]' ).click();
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
+
+		// Ensure the formatting action is committed before undoing.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '<strong>test</strong>',
+				},
+			},
+		] );
+
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -529,14 +540,21 @@ class UndoUtils {
 				return {};
 			}
 
+			const blockEditor = window.wp.data.select( 'core/block-editor' );
+			const selectionStart = blockEditor.getSelectionStart();
+			const selectionEnd = blockEditor.getSelectionEnd();
+
 			return {
 				blockIndex,
-				startOffset: window.wp.data
-					.select( 'core/block-editor' )
-					.getSelectionStart().offset,
-				endOffset: window.wp.data
-					.select( 'core/block-editor' )
-					.getSelectionEnd().offset,
+				// Block-only selection states can omit rich-text offsets.
+				startOffset:
+					typeof selectionStart.offset === 'number'
+						? selectionStart.offset
+						: 0,
+				endOffset:
+					typeof selectionEnd.offset === 'number'
+						? selectionEnd.offset
+						: 0,
 			};
 		} );
 	}

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -540,14 +540,14 @@ class UndoUtils {
 				return {};
 			}
 
-			const blockEditor = window.wp.data.select( 'core/block-editor' );
-			const selectionStart = blockEditor.getSelectionStart();
-			const selectionEnd = blockEditor.getSelectionEnd();
-
 			return {
 				blockIndex,
-				startOffset: selectionStart.offset,
-				endOffset: selectionEnd.offset,
+				startOffset: window.wp.data
+					.select( 'core/block-editor' )
+					.getSelectionStart().offset,
+				endOffset: window.wp.data
+					.select( 'core/block-editor' )
+					.getSelectionEnd().offset,
 			};
 		} );
 	}

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -177,7 +177,6 @@ test.describe( 'undo', () => {
 		await editor.canvas.locator( '[data-type="core/paragraph"]' ).click();
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
-
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -546,15 +546,8 @@ class UndoUtils {
 
 			return {
 				blockIndex,
-				// Block-only selection states can omit rich-text offsets.
-				startOffset:
-					typeof selectionStart.offset === 'number'
-						? selectionStart.offset
-						: 0,
-				endOffset:
-					typeof selectionEnd.offset === 'number'
-						? selectionEnd.offset
-						: 0,
+				startOffset: selectionStart.offset,
+				endOffset: selectionEnd.offset,
 			};
 		} );
 	}

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -178,16 +178,6 @@ test.describe( 'undo', () => {
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
 
-		// Ensure the formatting action is committed before undoing.
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/paragraph',
-				attributes: {
-					content: '<strong>test</strong>',
-				},
-			},
-		] );
-
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{


### PR DESCRIPTION
## Summary

- Add polling assertion to wait for formatting to be committed before testing undo, preventing race conditions
- Handle block-only selection states in `getSelection()` helper by defaulting offset to 0 when not a number

## Test plan

- npm run test:e2e -- test/e2e/specs/editor/various/undo.spec.js should work
- Manually verify that if you type something in a paragraph, press cmd+a cmd+b (make bold) +cmd + z (undo) the bold is undued.