### PR TITLE
Center navigation preview content in preview pane

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -334,6 +334,8 @@ function VisualEditor( {
 		// Disable resizing in zoomed-out mode.
 		! isZoomedOut;
 
+	const isNavigationPreview = postType === NAVIGATION_POST_TYPE && isPreview;
+
 	// Calculate the minimum height including scroll offset to fit all notes.
 	const calculatedMinHeight = useMemo( () => {
 		if ( ! localRef.current ) {
@@ -352,6 +354,8 @@ function VisualEditor( {
 		! isPreview && renderingMode === 'post-only' && ! isDesignPostType
 	);
 
+	const centerContentCSS = `display:flex;align-items:center;justify-content:center;`;
+
 	const iframeStyles = useMemo( () => {
 		return [
 			...( styles ?? [] ),
@@ -366,19 +370,32 @@ function VisualEditor( {
 				}}.is-root-container{display:flow-root;${
 					// Some themes will have `min-height: 100vh` for the root container,
 					// which isn't a requirement in auto resize mode.
-					enableResizing ? 'min-height:0!important;' : ''
+					enableResizing || isNavigationPreview
+						? 'min-height:0!important;'
+						: ''
 				}}
 				${ paddingStyle ? paddingStyle : '' }
 				${
 					enableResizing
-						? `.block-editor-iframe__html{background:var(--wp-editor-canvas-background);display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}`
+						? `.block-editor-iframe__html{background:var(--wp-editor-canvas-background);min-height:100vh;${ centerContentCSS }}.block-editor-iframe__body{width:100%;}`
+						: ''
+				}${
+					isNavigationPreview
+						? `.block-editor-iframe__body{${ centerContentCSS }}`
 						: ''
 				}`,
-				// The CSS above centers the body content vertically when resizing is enabled and applies a background
+				// The CSS for enableResizing centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
+				// The CSS for isNavigationPreview centers the body content vertically and horizontally when the navigation is in preview mode.
 			},
 		];
-	}, [ styles, enableResizing, calculatedMinHeight, paddingStyle ] );
+	}, [
+		styles,
+		enableResizing,
+		isNavigationPreview,
+		calculatedMinHeight,
+		paddingStyle,
+	] );
 
 	const typewriterRef = useTypewriter();
 	contentRef = useMergeRefs( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/75734

<!-- In a few words, what is the PR actually doing? -->
Centers navigation block in preview pane.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Better design
- Prevents large jump in content position (top left to centered)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Inject CSS to center navigation block using the iframeStyles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to your navigations in the site editor: http://localhost:8888/wp-admin/site-editor.php?p=%2Fnavigation
- Select a navigation
- The navigation block preview should be centered in the canvas

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1208" height="1079" alt="Navigation aligned top left" src="https://github.com/user-attachments/assets/0013ec1d-fae7-41a0-b8d4-faa41038edd2" />|<img width="1209" height="1057" alt="Navigation aligned center" src="https://github.com/user-attachments/assets/069dc23a-2c1e-4b06-b626-499ab74bd1dc" />|


