### PR TITLE
Remove experimental property from Icon block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -434,7 +434,6 @@ Add custom HTML code and preview it as you edit. ([Source](https://github.com/Wo
 Insert an SVG icon. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/icon))
 
 -	**Name:** core/icon
--	**Experimental:** true
 -	**Category:** media
 -	**Supports:** align (center, left, right), anchor, ariaLabel, color (background, text), dimensions (width), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
 -	**Attributes:** icon

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -3,7 +3,6 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "core/icon",
 	"title": "Icon",
-	"__experimental": true,
 	"category": "media",
 	"description": "Insert an SVG icon.",
 	"keywords": [ "icon", "svg" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The `__experimental` property was missed in https://github.com/WordPress/gutenberg/pull/75576
