### PR TITLE
Fix: Suppress spinner output when using --json flag in wp-env

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Suppress spinner and success message output when using `--json` flag to ensure clean, parseable JSON output.
+
 ## 11.0.0 (2026-02-18)
 
 ### Bug Fixes

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -32,17 +32,23 @@ const wpYellow = boldWhite.bgHex( '#f0b849' );
 const withSpinner =
 	( command ) =>
 	( ...args ) => {
-		const spinner = ora().start();
+		const isJSON = args[ 0 ].json;
+		const spinner = ora();
+		if ( ! isJSON ) {
+			spinner.start();
+		}
 		args[ 0 ].spinner = spinner;
 		let time = process.hrtime();
 		return command( ...args ).then(
 			( message ) => {
 				time = process.hrtime( time );
-				spinner.succeed(
-					`${ message || spinner.text } (in ${ time[ 0 ] }s ${ (
-						time[ 1 ] / 1e6
-					).toFixed( 0 ) }ms)`
-				);
+				if ( ! isJSON ) {
+					spinner.succeed(
+						`${ message || spinner.text } (in ${ time[ 0 ] }s ${ (
+							time[ 1 ] / 1e6
+						).toFixed( 0 ) }ms)`
+					);
+				}
 				process.exit( 0 );
 			},
 			( error ) => {

--- a/packages/env/lib/test/cli.js
+++ b/packages/env/lib/test/cli.js
@@ -9,11 +9,11 @@ const env = require( '../env' );
  * Mocked dependencies
  */
 jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
-jest.mock( 'ora', () => () => ( {
-	start() {
-		return { text: '', succeed: jest.fn(), fail: jest.fn() };
-	},
-} ) );
+jest.mock( 'ora', () => () => {
+	const spinner = { text: '', succeed: jest.fn(), fail: jest.fn() };
+	spinner.start = () => spinner;
+	return spinner;
+} );
 jest.mock( '../env', () => {
 	const actual = jest.requireActual( '../env' );
 	return {


### PR DESCRIPTION
## What?

Follow up to #75020 to fix JSON output pollution.

## Why?

The `status --json` command and any future commands with `--json` support were outputting spinner animation and success messages to stdout, making the JSON output unparseable by tools like `jq`.

## How?

Modified the `withSpinner` wrapper in `cli.js` to:
1. Only start the spinner when `--json` is not set
2. Skip the success message output when `--json` is set

This ensures clean, parseable JSON output when the flag is used.

## Testing Instructions

1. Run `npx wp-env status --json | jq .` — should parse cleanly without errors
2. Run `npx wp-env status` (without flag) — should still show spinner and timing message as before
3. Run `npx wp-env status --json --debug` — should output clean JSON (no debug logs mixed in)