### PR TITLE
RTC: Fix change-detection E2E tests after RTC enabled by default

### DIFF
--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -426,7 +426,10 @@ export function createSyncManager( debug = false ): SyncManager {
 			// via its pre-persist hook.)
 			targetDoc.transact( () => {
 				applyChangesToCRDTDoc( targetDoc, record );
-				handlers.saveRecord();
+
+				if ( 'auto-draft' !== record.status ) {
+					handlers.saveRecord();
+				}
 			}, LOCAL_SYNC_MANAGER_ORIGIN );
 			return;
 		}

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -65,8 +65,13 @@ test.describe( 'Change detection', () => {
 			).toBeDisabled(),
 		] );
 
-		// With RTC enabled, all autosaves target an autosave revision.
-		expect( await changeDetectionUtils.getIsDirty() ).toBe( true );
+		// With RTC enabled, all autosaves target an autosave revision. Vary our
+		// expectation accordingly.
+		const isRTCEnabled = Boolean(
+			await page.evaluate( () => window._wpCollaborationEnabled )
+		);
+
+		expect( await changeDetectionUtils.getIsDirty() ).toBe( isRTCEnabled );
 	} );
 
 	test( 'Should prompt to confirm unsaved changes for autosaved draft for non-content fields', async ( {

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -65,8 +65,8 @@ test.describe( 'Change detection', () => {
 			).toBeDisabled(),
 		] );
 
-		// Autosave draft as same user should do full save, i.e. not dirty.
-		expect( await changeDetectionUtils.getIsDirty() ).toBe( false );
+		// With RTC enabled, all autosaves target an autosave revision.
+		expect( await changeDetectionUtils.getIsDirty() ).toBe( true );
 	} );
 
 	test( 'Should prompt to confirm unsaved changes for autosaved draft for non-content fields', async ( {
@@ -247,14 +247,15 @@ test.describe( 'Change detection', () => {
 					'Updating failed because you were offline. Please verify your connection and try again.'
 				)
 		).toBeVisible();
+
+		// Need to disable offline to allow reload and allow reconnect to sync provider.
+		await context.setOffline( false );
+
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Save draft' } )
 		).toBeEnabled();
-
-		// Need to disable offline to allow reload.
-		await context.setOffline( false );
 
 		expect( await changeDetectionUtils.getIsDirty() ).toBe( true );
 	} );


### PR DESCRIPTION
## What?

Fix change-detection E2E tests after RTC enabled by default.

## Why?

E2E tests began failing after they starting running against WordPress `trunk` with RTC enabled by default.

## How?

1. `Should autosave post`. The failing expectation is directly testing behavior that has now changed in WordPress `trunk`. 
   - In WordPress < 7.0, when a user holds the post lock and autosaves a post with `draft` or `auto-draft` status, that autosave does _not_ target an autosave revision. Instead a special case is triggered and the [autosave targets the post itself](https://github.com/WordPress/wordpress-develop/blob/6.9.1/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L235-L240).
   - This causes an issue for collaboration. When only one user's autosaves update the actual post, the post becomes out of sync with the persisted CRDT document. If a new user joins or refreshes, duplicate content results. We addressed this by [disabling this special case](https://github.com/wordpress/wordpress-develop/blob/fb6fba4042c535d79d129af83ddd7a35321685a9/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L236-L255) when RTC is enabled.
   - The expectation is hardcoded to this special case. Therefore I think it's justified to simply change the expectation.
1. `Should prompt to confirm unsaved changes for new post with initial edits`. Bug: The sync manager was calling `saveRecord` for all posts whenever a persisted CRDT document was not detected. It should only do this when the post is not `auto-draft`.
1. `Should prompt if save failed`. This one is straightforward. Move the reconnect command up above the expectation to allow the user to reconnect to the sync provider first.

## Testing Instructions
Run E2E tests