### PR TITLE
Post featured image: Simplify background class assignment.

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -166,10 +166,8 @@ function get_block_core_post_featured_image_overlay_element_markup( $attributes 
 	}
 
 	// Apply overlay and gradient classes.
-	if ( $has_dim_background ) {
-		$class_names[] = 'has-background-dim';
-		$class_names[] = "has-background-dim-{$attributes['dimRatio']}";
-	}
+	$class_names[] = 'has-background-dim';
+	$class_names[] = "has-background-dim-{$attributes['dimRatio']}";
 
 	if ( $has_solid_overlay ) {
 		$class_names[] = "has-{$attributes['overlayColor']}-background-color";


### PR DESCRIPTION
## What?

This pull request removes an unnecessary check in the Post featured image block.

We already check in line 153:
```php
if ( ! $has_dim_background ) {
	return '';
}
```

So we can remove this additional condition in line 169:

```php
if ( $has_dim_background ) {
	// ...
}
```



