### PR TITLE
Theme: Fix TypeScript 5.9 type error in generate-primitive-tokens script

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix TypeScript 5.9 type error in `generate-primitive-tokens` build script caused by `Object.entries` inferring `unknown` values when the key type is a union of string literals ([#75748](https://github.com/WordPress/gutenberg/pull/75748)).
+
 ### New Features
 
 -   Add `--wpds-cursor-control` design token for interactive non-link elements ([#75697](https://github.com/WordPress/gutenberg/pull/75697)).

--- a/packages/theme/bin/generate-primitive-tokens/index.ts
+++ b/packages/theme/bin/generate-primitive-tokens/index.ts
@@ -74,7 +74,9 @@ function generatePrimitiveColorTokens() {
 			) ) {
 				colorJson[ 'wpds-color' ].primitive[ scaleName ][ tokenName ] =
 					{
-						$value: transformColorStringToDTCGValue( tokenValue ),
+						$value: transformColorStringToDTCGValue(
+							tokenValue as string
+						),
 					};
 			}
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixed by Claude

## What?

Fixes a TypeScript compilation error in `packages/theme/bin/generate-primitive-tokens/index.ts` that was blocking the full `tsc --build` from completing.

## Why?

TypeScript 5.9 tightened the return type of `Object.entries()` for objects whose key type is a union of string literals rather than `string`. `ramp.ramp` is typed as `Record<keyof Ramp, string>` — since `keyof Ramp` is a union of specific literals, TypeScript no longer matches the typed `Object.entries<T>(o: { [s: string]: T })` overload. It falls back to the untyped overload, which in TS 5.9 resolves to `[string, unknown][]` instead of the previous `[string, any][]`. This made `tokenValue` `unknown`, which is not assignable to the `string` parameter of `transformColorStringToDTCGValue`.

The `as string` assertion is safe because `Record<keyof Ramp, string>` guarantees all values are strings.

## How?

Adds a `tokenValue as string` type assertion at the call site. No runtime behavior changes.

The compilation failure was also causing downstream "Cannot find module '@wordpress/theme'" errors in `packages/ui`, `packages/boot`, and `storybook/decorators` because the theme package's declaration files (`index.d.ts` etc.) were never emitted.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**On trunk — shows the failure:**        
- git checkout trunk
 - npm run clean:package-types
 - npx tsc --build
 - → 7 errors, starting with:
-  packages/theme/bin/generate-primitive-tokens/index.ts:77:48 - error TS2345:
-  Argument of type 'unknown' is not assignable to parameter of type 'string'.

**On this branch — shows the fix:**
-  git checkout fix/always-expand-nav-block-in-isolated-editor
-  npm run clean:package-types
-  npx tsc --build
-  → no errors

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
