### PR TITLE
Playlist Block: Accessibility of compound labels

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -250,17 +250,21 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 							withoutInteractiveFormatting
 						/>
 						{ showArtists && (
-							<RichText
-								tagName="span"
-								className="wp-block-playlist-track__artist"
-								value={ artist }
-								placeholder={ __( 'Add artist' ) }
-								onChange={ ( value ) =>
-									setAttributes( { artist: value } )
-								}
-								allowedFormats={ [] }
-								withoutInteractiveFormatting
-							/>
+							<>
+								<span className="screen-reader-text">,</span>
+								<RichText
+									tagName="span"
+									className="wp-block-playlist-track__artist"
+									value={ artist }
+									placeholder={ __( 'Add artist' ) }
+									onChange={ ( value ) =>
+										setAttributes( { artist: value } )
+									}
+									allowedFormats={ [] }
+									withoutInteractiveFormatting
+								/>
+								<span className="screen-reader-text">,</span>
+							</>
 						) }
 					</span>
 					<span className="wp-block-playlist-track__length">
@@ -274,6 +278,7 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 						) }
 						{ length }
 					</span>
+					<span className="screen-reader-text">.</span>
 					<span className="screen-reader-text">
 						{ __( 'Select to play this track' ) }
 					</span>

--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -40,7 +40,9 @@ function render_block_core_playlist_track( $attributes ) {
 		$html .= '<span class="wp-block-playlist-track__title">' . wp_kses_post( $title ) . '</span>';
 	}
 	if ( $artist ) {
+		$html .= '<span class="screen-reader-text">,</span>';
 		$html .= '<span class="wp-block-playlist-track__artist">' . wp_kses_post( $artist ) . '</span>';
+		$html .= '<span class="screen-reader-text">,</span>';
 	}
 	$html .= '</span>';
 
@@ -51,6 +53,7 @@ function render_block_core_playlist_track( $attributes ) {
 		$html .= '</span>';
 	}
 
+	$html .= '<span class="screen-reader-text">.</span>';
 	$html .= '<span class="screen-reader-text">' . esc_html__( 'Select to play this track' ) . '</span>';
 	$html .= '</button>';
 	$html .= '</li>';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75584 

<!-- In a few words, what is the PR actually doing? -->

## Why?
Fixes the flow of the screen reader which earlier didn't have appropriate pauses in the sentence for the Playlist track Items

## How?
Adds pauses to improve the flow for the screen reader and makes it easier to understand

## Testing Instructions
1. Open a post or page.
2. Insert a playlist block.
3. Add some tracks, save and preview the page
4. Enable screen reader and navigate to the track list.