### PR TITLE
Vips and worker-threads packages: remove private flag so that packages can be published to npm

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2088,6 +2088,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/vips",
+		"slug": "packages-vips",
+		"markdown_source": "../packages/vips/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/warning",
 		"slug": "packages-warning",
 		"markdown_source": "../packages/warning/README.md",
@@ -2103,6 +2109,12 @@
 		"title": "@wordpress/wordcount",
 		"slug": "packages-wordcount",
 		"markdown_source": "../packages/wordcount/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/worker-threads",
+		"slug": "packages-worker-threads",
+		"markdown_source": "../packages/worker-threads/README.md",
 		"parent": "packages"
 	},
 	{

--- a/packages/vips/package.json
+++ b/packages/vips/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/vips",
 	"version": "1.0.0-prerelease",
-	"private": true,
 	"description": "Utils for working with libvips.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/worker-threads/package.json
+++ b/packages/worker-threads/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/worker-threads",
 	"version": "1.0.0-prerelease",
-	"private": true,
 	"description": "Utilities for type-safe Web Worker communication with RPC.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What? Why? How?

Hopefully fixes https://github.com/WordPress/gutenberg/issues/75718

The `@wordpress/vips` and `@wordpress/worker-threads` packages aren't available on npm, which appears to be the cause of failures reported in #75718.

In order to allow these packages to be installed, remove the `private` flag for these packages. This should hopefully unblock publishing to npm, and then once published, 🤞 #75718 should be resolved.

## Testing Instructions

Shouldn't change anything in Gutenberg, but if you'd like, smoke test that uploading media in Gutenberg works as expected.