### PR TITLE
IconButton: Hide tooltip when truly disabled

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `IconButton`: Hide tooltip when the button is truly disabled ([#75754](https://github.com/WordPress/gutenberg/pull/75754)).
+
 ### Internal
 
 -   Update `@base-ui/react` from 1.0.0 to 1.2.0 ([#75698](https://github.com/WordPress/gutenberg/pull/75698)).

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -17,6 +17,8 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 			className,
 			// Prevent accidental forwarding of `children`
 			children: _children,
+			disabled,
+			focusableWhenDisabled,
 			icon,
 			size,
 			shortcut,
@@ -31,12 +33,15 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 				<Tooltip.Root>
 					<Tooltip.Trigger
 						ref={ ref }
+						disabled={ disabled && ! focusableWhenDisabled }
 						render={
 							<Button
 								{ ...restProps }
 								size={ size }
 								aria-label={ label }
 								aria-keyshortcuts={ shortcut?.ariaKeyShortcut }
+								disabled={ disabled }
+								focusableWhenDisabled={ focusableWhenDisabled }
 							/>
 						}
 						className={ classes }

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -33,6 +33,39 @@ describe( 'IconButton', () => {
 		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
+	describe( 'tooltip with disabled state', () => {
+		it( 'does not show tooltip when truly disabled', async () => {
+			const user = userEvent.setup();
+
+			render( <IconButton label="Save" icon={ <svg /> } disabled /> );
+
+			const button = screen.getByRole( 'button', { name: 'Save' } );
+			await user.hover( button );
+
+			expect( screen.queryByText( 'Save' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows tooltip when focusably disabled', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<IconButton
+					label="Save"
+					icon={ <svg /> }
+					disabled
+					focusableWhenDisabled
+				/>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Save' } );
+			await user.hover( button );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Save' ) ).toBeVisible();
+			} );
+		} );
+	} );
+
 	describe( 'shortcut', () => {
 		it( 'sets aria-keyshortcuts attribute on the button', () => {
 			const { rerender } = render(


### PR DESCRIPTION
## What?

Follow-up to #75698.

Passes the `disabled` and `focusableWhenDisabled` props through to the underlying `Tooltip.Trigger` and `Button`, so that the tooltip is suppressed when the button is truly disabled.

## Why?

When an `IconButton` is disabled without `focusableWhenDisabled` the tooltip shouldn't appear on hover. Previously, the `disabled` state wasn't forwarded to `Tooltip.Trigger`, so the tooltip would still show.

While most buttons should remain accessible when disabled, some do justify a true disabled. For example, if an `InputControl` had an icon button in it's suffix, and the entire `InputControl` was disabled, that is the kind of case where it would be best that the button be truly disabled. And in this case, it's also better for the tooltip to also be disabled.

I should also note that the current Button component in `@wordpress/components` works this way, too.

## Testing Instructions

✅ Unit tests pass.

Check stories for `IconButton`.