### PR TITLE
Sort registry files by handle/ID.

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -837,6 +837,9 @@ async function inferStyleDependencies( scriptDependencies, packageName ) {
  * @param {Record<string, string>} replacements PHP template replacements.
  */
 async function generateModuleRegistrationPhp( modules, replacements ) {
+	// Sort modules by ID for deterministic output.
+	modules.sort( ( a, b ) => a.id.localeCompare( b.id ) );
+
 	// Generate modules array for registry
 	const modulesArray = modules
 		.map(
@@ -870,6 +873,9 @@ async function generateModuleRegistrationPhp( modules, replacements ) {
  * @param {Record<string, string>} replacements PHP template replacements.
  */
 async function generateScriptRegistrationPhp( scripts, replacements ) {
+	// Sort scripts by handle for deterministic output.
+	scripts.sort( ( a, b ) => a.handle.localeCompare( b.handle ) );
+
 	// Generate scripts array for registry
 	const scriptsArray = scripts
 		.map(
@@ -916,6 +922,9 @@ async function generateConstantsPhp( replacements ) {
  * @param {Record<string, string>} replacements PHP template replacements.
  */
 async function generateStyleRegistrationPhp( styles, replacements ) {
+	// Sort styles by handle for deterministic output.
+	styles.sort( ( a, b ) => a.handle.localeCompare( b.handle ) );
+
 	// Generate styles array for registry
 	const stylesArray = styles
 		.map(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Sorts script and style registry files by handle; sorts modules registry file by ID.


## Why?

This ensures the diff in the built version of WordPress is showing just the effected files rather than affected by order of operations.

## How?

Adding sort statements to the beginning of the `generate*RegistrationPhp` functions.

## Testing Instructions

This is modifying the WordPress build so will need to be checked in WordPress-Develop.

1. Update the package.json file hash to the latest commit in this pull request.
2. Run the build, this should trigger the GB repo to update to the new hash
3. Check the registry files to ensure that the arrays are sorted by handle/ID.
4. Ensure that dependencies registered after the dependent are included in enqueues


As these are using `wp_register_*` functions, the final step should be fine but will need verification.

While testing I ran the following as an mu-plugin at the files were output in the expected order:

```php
add_action( 'wp_enqueue_scripts', function() {
	wp_register_style( 'pwcc', false, ['pwaa'] );
	wp_add_inline_style( 'pwcc', '/* pwcc inline styles */' );

	wp_register_style( 'pwaa', false, [] );
	wp_add_inline_style( 'pwaa', '/* pwaa inline styles */' );


	wp_enqueue_style( 'pwcc' );
} );
```



### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A