### PR TITLE
Client-side media processing: Disable in Gutenberg just for now

### DIFF
--- a/lib/compat/plugin/media.php
+++ b/lib/compat/plugin/media.php
@@ -6,6 +6,9 @@
  * It is disabled by default in the plugin until known issues are resolved,
  * but can still be enabled via the filter.
  *
+ * Remove this file when the linked issues are resolved and the plugin
+ * is ready to match Core's default.
+ *
  * @see https://github.com/WordPress/gutenberg/issues/75302
  * @see https://github.com/WordPress/gutenberg/issues/75605
  *

--- a/lib/compat/plugin/media.php
+++ b/lib/compat/plugin/media.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Disables client-side media processing by default in the Gutenberg plugin.
+ *
+ * Client-side media processing is being polished during the 7.0 cycle.
+ * It is disabled by default in the plugin until known issues are resolved,
+ * but can still be enabled via the filter.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/75302
+ * @see https://github.com/WordPress/gutenberg/issues/75605
+ *
+ * @package gutenberg
+ */
+
+// @core-merge: Do not merge this into WordPress core.
+add_filter( 'wp_client_side_media_processing_enabled', '__return_false' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -110,6 +110,9 @@ require __DIR__ . '/compat/wordpress-7.0/blocks.php';
 require __DIR__ . '/compat/wordpress-7.0/kses.php';
 require __DIR__ . '/compat/wordpress-7.0/media.php';
 
+// Gutenberg plugin compat: disable client-side media processing by default.
+require __DIR__ . '/compat/plugin/media.php';
+
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -96,6 +96,11 @@ $GLOBALS['wp_tests_options'] = array(
 // Enable the widget block editor.
 tests_add_filter( 'gutenberg_use_widgets_block_editor', '__return_true' );
 
+// Enable client-side media processing for tests.
+// The Gutenberg plugin disables this by default (lib/compat/plugin/media.php),
+// but tests need the media functions to be loaded.
+tests_add_filter( 'wp_client_side_media_processing_enabled', '__return_true', 20 );
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -235,11 +235,14 @@ HTML;
 	 * @covers ::gutenberg_override_attachments_rest_controller
 	 */
 	public function test_compat_rest_controller_used_when_filter_disabled() {
+		// Remove the test bootstrap override so the disable filter takes effect.
+		remove_filter( 'wp_client_side_media_processing_enabled', '__return_true', 20 );
 		add_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
 
 		$result = gutenberg_override_attachments_rest_controller( array(), 'attachment' );
 
 		remove_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
+		add_filter( 'wp_client_side_media_processing_enabled', '__return_true', 20 );
 
 		$this->assertSame(
 			array( 'rest_controller_class' => 'Gutenberg_REST_Attachments_Controller_6_9' ),

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -202,25 +202,31 @@ HTML;
 	}
 
 	/**
-	 * Tests that client-side media processing is enabled by default.
+	 * Tests that client-side media processing is disabled by default in the Gutenberg plugin.
+	 *
+	 * The core compat layer defaults to true, but the Gutenberg plugin
+	 * adds a filter to disable it by default (lib/compat/plugin/media.php)
+	 * until known issues are resolved.
 	 *
 	 * @covers ::gutenberg_is_client_side_media_processing_enabled
 	 */
-	public function test_client_side_media_processing_enabled_by_default() {
-		$this->assertTrue( gutenberg_is_client_side_media_processing_enabled() );
+	public function test_client_side_media_processing_disabled_by_default_in_plugin() {
+		// Remove the test bootstrap override to check the plugin's actual default.
+		remove_filter( 'wp_client_side_media_processing_enabled', '__return_true', 20 );
+		$enabled = gutenberg_is_client_side_media_processing_enabled();
+		// Restore the test bootstrap override.
+		add_filter( 'wp_client_side_media_processing_enabled', '__return_true', 20 );
+
+		$this->assertFalse( $enabled );
 	}
 
 	/**
-	 * Tests that client-side media processing can be disabled via filter.
+	 * Tests that client-side media processing can be enabled via filter.
 	 *
 	 * @covers ::gutenberg_is_client_side_media_processing_enabled
 	 */
-	public function test_client_side_media_processing_can_be_disabled() {
-		add_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
-		$enabled = gutenberg_is_client_side_media_processing_enabled();
-		remove_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
-
-		$this->assertFalse( $enabled );
+	public function test_client_side_media_processing_can_be_enabled() {
+		$this->assertTrue( gutenberg_is_client_side_media_processing_enabled() );
 	}
 
 	/**
@@ -242,11 +248,12 @@ HTML;
 	}
 
 	/**
-	 * Tests that the 6.9 compat REST controller is not used when filter is enabled (default).
+	 * Tests that the 6.9 compat REST controller is not used when filter is enabled.
 	 *
 	 * @covers ::gutenberg_override_attachments_rest_controller
 	 */
 	public function test_compat_rest_controller_not_used_when_filter_enabled() {
+		// Feature is enabled via test bootstrap filter at priority 20.
 		$result = gutenberg_override_attachments_rest_controller( array(), 'attachment' );
 
 		$this->assertSame( array(), $result );


### PR DESCRIPTION
## What?

Follows:

* #75112

Disable the client-side media experiment in Gutenberg (for now)

Note: this is intended as a quick-fix to ensure GB 22.6 is in a stable state. If there's a better approach to this, feel free to close this PR out!

## Why?

The client-side media experiment was stabilised in #75112 and in time for the WP 7.0 feature freeze. However, there are still a couple of outstanding bugs that need to be resolved, and currently things in `trunk` are not quite ready to be used on production sites.

To give a little more time in Gutenberg releases to polish the remaining bugs, this PR proposes switching the default for client-side media to false. This will allow GB 22.6 to ship without client-side media processing enabled, and we can revisit re-enabling it in Gutenberg for 22.7 and beyond.

## How?

Add a filter to disable the feature in Gutenberg, but also add a filter to enable it in tests.

## Testing Instructions

With this PR checked out, open up the post editor and drag and drop a PDF file to the editor. If the file block shows the same filename as exists in the filesystem, it will have worked.

## Screenshots or screencast <!-- if applicable -->

### Before

Note the bug in client-side media processing is present, that strips the names of files when uploaded:

<img width="368" alt="image" src="https://github.com/user-attachments/assets/d51aa415-d584-4238-abeb-ec325fc50786" />

### After

With this PR applied, the client-side media experiment should be switched off, so filenames should persist as expected:

<img width="368" height="88" alt="image" src="https://github.com/user-attachments/assets/e5349d48-fecd-4619-bde9-ed2eab80ba0c" />