### PR TITLE
Update wordpress/vips in root package.json to use a relative path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"@types/uuid": "8.3.1",
 				"@vitejs/plugin-react": "5.1.2",
 				"@wordpress/build": "file:./packages/wp-build",
-				"@wordpress/vips": "1.0.0-prerelease",
+				"@wordpress/vips": "file:./packages/vips",
 				"ajv": "8.17.1",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@types/uuid": "8.3.1",
 		"@vitejs/plugin-react": "5.1.2",
 		"@wordpress/build": "file:./packages/wp-build",
-		"@wordpress/vips": "1.0.0-prerelease",
+		"@wordpress/vips": "file:./packages/vips",
 		"ajv": "8.17.1",
 		"babel-jest": "29.7.0",
 		"babel-loader": "9.2.1",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow-up to #75752

Update wordpress/vips in root package.json to use a relative path.

## Why?

Within Gutenberg, WordPress packages are used locally from relative paths, instead of being installed by npm.

## How?

Update to use a relative path.

## Testing Instructions

This shouldn't change anything in GB, but to be extra careful you could test that uploading media in the block editor still works.