### PR TITLE
Try fix failing patterns e2e test

### DIFF
--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -737,6 +737,14 @@ test.describe( 'Synced pattern', () => {
 
 		// Save the reusable block and update the post.
 		await editorTopBar.getByRole( 'button', { name: 'Save' } ).click();
+		const entitiesSaveButton = this.page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Save', exact: true } );
+		const isEntitiesSavePanelVisible = await entitiesSaveButton.isVisible();
+		// Handle multi-entity save panel if it appears.
+		if ( isEntitiesSavePanelVisible ) {
+			await entitiesSaveButton.click();
+		}
 		await page
 			.getByRole( 'button', { name: 'Dismiss this notice' } )
 			.filter( { hasText: 'Pattern updated.' } )

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -737,7 +737,7 @@ test.describe( 'Synced pattern', () => {
 
 		// Save the reusable block and update the post.
 		await editorTopBar.getByRole( 'button', { name: 'Save' } ).click();
-		const entitiesSaveButton = this.page
+		const entitiesSaveButton = page
 			.getByRole( 'region', { name: 'Editor publish' } )
 			.getByRole( 'button', { name: 'Save', exact: true } );
 		const isEntitiesSavePanelVisible = await entitiesSaveButton.isVisible();


### PR DESCRIPTION
## What?
PR tries to fix the failing patterns test. Based on trace artifacts, the test now includes a multi-entity saving flow that it didn't account for.

A post category is also modified, which causes the flow change. I'm not sure if it's related to RTC being enabled by default, and I'm having trouble reproducing it locally. cc @chriszarate

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/editor/various/patterns.spec.js
```

## Screenshot

<img width="1222" height="739" alt="CleanShot 2026-02-20 at 08 09 01" src="https://github.com/user-attachments/assets/358dfe9f-144a-4383-b04b-8d4cc0cf92a0" />


