### PR TITLE
Query: Remove content role from block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -806,7 +806,7 @@ An advanced block that allows displaying post types based on different query par
 
 -	**Name:** core/query
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, contentRole, interactivity, layout, ~~html~~
+-	**Supports:** align (full, wide), anchor, interactivity, layout, ~~html~~
 -	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
 
 ## No Results

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -54,8 +54,7 @@
 		"align": [ "wide", "full" ],
 		"html": false,
 		"layout": true,
-		"interactivity": true,
-		"contentRole": true
+		"interactivity": true
 	},
 	"editorStyle": "wp-block-query-editor"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue for the Query block where in patterns it allowed content to be inserted at the root of a query block.

## Why?
The query block has a very specific internal structure with Post Template, No Results and Pagination, so allowing content blocks to be inserted in ContentOnly mode at the root level doesn't really work so well.

When used in a pattern the block prioritises allowing the user to switch between different patterns instead, which continues to work in this PR.

For deeper changes the user can 'Edit pattern' or detach/disconnect, which is still available after this change.

## How?
Remove `contentRole: true` property from block supports

## Testing Instructions
1. Open up a template like 'Blog home' in TT5 that contains a query pattern
2. Note that 'Change design' is still available on the toolbar for the pattern
3. With the pattern selected, note that there's no `+` appender at the end of the pattern in this PR, while there is in trunk
4. Try selecting a 'Sorry, but nothing was found.' paragraph if your query pattern has it (if not you may need to change design to one that does have this) and note that it's still editable in this PR as it is in trunk.
5. Similarly it should be possible to update the 'Read more' excerpt text, but you'll need to have a design selected that has an Excerpt

## Screenshots
### Before
(with the query pattern selected, there's an appender that allows adding blocks at the root of a query)

<img width="672" height="338" alt="Screenshot 2026-02-20 at 12 29 25 pm" src="https://github.com/user-attachments/assets/0a572a86-a5a7-4092-8982-8ff3241ef16d" />


### After
(no appender with the query pattern selected)

<img width="665" height="328" alt="Screenshot 2026-02-20 at 12 28 23 pm" src="https://github.com/user-attachments/assets/1293e187-fce3-464e-bed9-0e7a0f304093" />

