### PR TITLE
Try enabling style variation transforms for blocks in contentOnly mode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-styles-dropdown.js
+++ b/packages/block-editor/src/components/block-toolbar/block-styles-dropdown.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DropdownMenu, ToolbarGroup, ToolbarItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import BlockStylesMenu from '../block-switcher/block-styles-menu';
+
+export default function BlockStylesDropdown( {
+	clientIds,
+	children,
+	label,
+	text,
+} ) {
+	return (
+		<ToolbarGroup>
+			<ToolbarItem>
+				{ ( toggleProps ) => (
+					<DropdownMenu
+						className="block-editor-block-switcher"
+						label={ label }
+						popoverProps={ {
+							placement: 'bottom-start',
+							className: 'block-editor-block-switcher__popover',
+						} }
+						icon={ children }
+						text={ text }
+						toggleProps={ {
+							description: __( 'Change block style' ),
+							...toggleProps,
+						} }
+						menuProps={ { orientation: 'both' } }
+					>
+						{ ( { onClose } ) => (
+							<div className="block-editor-block-switcher__container">
+								<BlockStylesMenu
+									hoveredBlock={ {
+										clientId: clientIds[ 0 ],
+									} }
+									onSwitch={ onClose }
+								/>
+							</div>
+						) }
+					</DropdownMenu>
+				) }
+			</ToolbarItem>
+		</ToolbarGroup>
+	);
+}

--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -71,7 +71,7 @@ function getBlockIconVariant( { select, clientIds } ) {
 
 	if ( _showBlockSwitcher ) {
 		return 'switcher';
-	} else if ( isContentOnlyMode && hasBlockStyles ) {
+	} else if ( isContentOnlyMode && hasBlockStyles && ! hasPatternOverrides ) {
 		return 'styles-only';
 	} else if ( _showPatternOverrides ) {
 		return 'pattern-overrides';

--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -13,6 +13,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import BlockSwitcher from '../block-switcher';
 import BlockIcon from '../block-icon';
+import BlockStylesDropdown from './block-styles-dropdown';
 import PatternOverridesDropdown from './pattern-overrides-dropdown';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { store as blockEditorStore } from '../../store';
@@ -55,8 +56,9 @@ function getBlockIconVariant( { select, clientIds } ) {
 	);
 	const canRemove = canRemoveBlocks( clientIds );
 	const canEdit = clientIds.every( ( clientId ) => canEditBlock( clientId ) );
-	const isDefaultEditingMode =
-		getBlockEditingMode( clientIds[ 0 ] ) === 'default';
+	const editingMode = getBlockEditingMode( clientIds[ 0 ] );
+	const isDefaultEditingMode = editingMode === 'default';
+	const isContentOnlyMode = editingMode === 'contentOnly';
 	const _hideTransformsForSections = hasPatternNameInSelection;
 	const _showBlockSwitcher =
 		! _hideTransformsForSections &&
@@ -69,6 +71,8 @@ function getBlockIconVariant( { select, clientIds } ) {
 
 	if ( _showBlockSwitcher ) {
 		return 'switcher';
+	} else if ( isContentOnlyMode && hasBlockStyles ) {
+		return 'styles-only';
 	} else if ( _showPatternOverrides ) {
 		return 'pattern-overrides';
 	}
@@ -147,6 +151,18 @@ export default function BlockToolbarIcon( { clientIds, isSynced } ) {
 			>
 				{ BlockIconElement }
 			</BlockSwitcher>
+		);
+	}
+
+	if ( variant === 'styles-only' ) {
+		return (
+			<BlockStylesDropdown
+				clientIds={ clientIds }
+				label={ label }
+				text={ text }
+			>
+				{ BlockIconElement }
+			</BlockStylesDropdown>
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up from [this comment](https://github.com/WordPress/gutenberg/pull/75658#issuecomment-3925620142).

Enables the style variation transforms for blocks in contentOnly mode that have style variations.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some patterns to a page or template.
2. Click on the block name/icon in the toolbar, and check whether the transforms menu appears. It should only contain style variations. With TT5, try it on Heading, Image, Paragraph and Button blocks.



https://github.com/user-attachments/assets/2e37de3b-031a-46e6-b3ea-02b6a2ecd70f


