### PR TITLE
Cross-origin isolation tests: Try enabling client-side media processing explicitly for the e2e test suite

### DIFF
--- a/packages/e2e-tests/plugins/enable-client-side-media-processing.php
+++ b/packages/e2e-tests/plugins/enable-client-side-media-processing.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin: Enable Client-Side Media Processing
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-enable-client-side-media-processing
+ */
+
+add_filter( 'wp_client_side_media_processing_enabled', '__return_true' );

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -35,7 +35,10 @@ test.use( {
 	},
 } );
 
-test.describe( 'Cross-origin isolation', () => {
+// Client-side media processing (and cross-origin isolation) is temporarily
+// disabled in the Gutenberg plugin. Skip until re-enabled.
+// See https://github.com/WordPress/gutenberg/pull/75756
+test.describe.skip( 'Cross-origin isolation', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -35,17 +35,31 @@ test.use( {
 	},
 } );
 
-// Client-side media processing (and cross-origin isolation) is temporarily
-// disabled in the Gutenberg plugin. Skip until re-enabled.
-// See https://github.com/WordPress/gutenberg/pull/75756
-test.describe.skip( 'Cross-origin isolation', () => {
+test.describe( 'Cross-origin isolation', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// Client-side media processing (and cross-origin isolation) is
+		// temporarily disabled in the Gutenberg plugin.
+		// See https://github.com/WordPress/gutenberg/pull/75756
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-enable-client-side-media-processing'
+		);
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-enable-client-side-media-processing'
+		);
+	} );
+
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should be cross-origin isolated by default', async ( { page } ) => {
-		// Verify that cross-origin isolation IS enabled (default state
-		// now that client-side media processing is graduated).
+	test( 'should be cross-origin isolated when client-side media processing is enabled', async ( {
+		page,
+	} ) => {
+		// Verify that cross-origin isolation IS enabled when
+		// client-side media processing is active.
 		const isCrossOriginIsolated = await page.evaluate(
 			() => window.crossOriginIsolated
 		);


### PR DESCRIPTION
## What?

Follows:

* #75756 

Try explicitly enabling the client-side media processing for the cross origin isolation e2e tests

## Why?

With #75756 we're defaulting to the client-side media processing feature being disabled, however it would still be good to ensure this feature is covered via tests.

If this PR feels flaky (or doesn't work) an alternative would be to skip the suite entirely for now.

## How?

* Add a tiny test plugin to enable the client-side media processing
* Enable it just for the test suite

## Testing Instructions

See if the e2es pass