### PR TITLE
Icon block: Fetch all icons on demand

### DIFF
--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -70,14 +70,18 @@ export function Edit( { attributes, setAttributes } ) {
 	const borderProps = useBorderProps( attributes );
 	const dimensionsProps = useDimensionsProps( attributes );
 
-	const allIcons = useSelect( ( select ) => {
-		return unlock( select( coreDataStore ) ).getIcons();
-	}, [] );
+	const { selectedIcon, allIcons } = useSelect(
+		( select ) => {
+			const { getIcon, getIcons } = unlock( select( coreDataStore ) );
+			return {
+				selectedIcon: icon ? getIcon( icon ) : null,
+				allIcons: isInserterOpen ? getIcons() : [],
+			};
+		},
+		[ icon, isInserterOpen ]
+	);
 
-	const iconToDisplay =
-		allIcons?.length > 0
-			? allIcons?.find( ( { name } ) => name === icon )?.content
-			: '';
+	const iconToDisplay = selectedIcon?.content ?? '';
 
 	const blockControls = (
 		<>

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -38,6 +38,8 @@ import HtmlRenderer from '../utils/html-renderer';
 import { CustomInserterModal } from './components';
 import { unlock } from '../lock-unlock';
 
+const EMPTY_ARRAY = [];
+
 const IconPlaceholder = ( { className, style } ) => (
 	<SVG
 		xmlns="http://www.w3.org/2000/svg"
@@ -75,7 +77,7 @@ export function Edit( { attributes, setAttributes } ) {
 			const { getIcon, getIcons } = unlock( select( coreDataStore ) );
 			return {
 				selectedIcon: icon ? getIcon( icon ) : null,
-				allIcons: isInserterOpen ? getIcons() : [],
+				allIcons: isInserterOpen ? getIcons() : EMPTY_ARRAY,
 			};
 		},
 		[ icon, isInserterOpen ]

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -162,7 +162,7 @@ export function receiveEditorAssets( assets ) {
 }
 
 /**
- * Returns an action object used to receive icons.
+ * Returns an action object used to receive all available icons.
  *
  * @param {Array} icons List of icons.
  *
@@ -172,5 +172,19 @@ export function receiveIcons( icons ) {
 	return {
 		type: 'RECEIVE_ICONS',
 		icons,
+	};
+}
+
+/**
+ * Returns an action object used to receive a single icon.
+ *
+ * @param {Object} icon Icon object (name, label, content).
+ *
+ * @return {Object} Action object.
+ */
+export function receiveIcon( icon ) {
+	return {
+		type: 'RECEIVE_ICON',
+		icon,
 	};
 }

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -174,17 +174,3 @@ export function receiveIcons( icons ) {
 		icons,
 	};
 }
-
-/**
- * Returns an action object used to receive a single icon.
- *
- * @param {Object} icon Icon object (name, label, content).
- *
- * @return {Object} Action object.
- */
-export function receiveIcon( icon ) {
-	return {
-		type: 'RECEIVE_ICON',
-		icon,
-	};
-}

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -311,11 +311,23 @@ export function getEditorAssets( state: State ): Record< string, any > | null {
 }
 
 /**
- * Returns the list of available icons.
+ * Returns the list of all available icons.
  *
  * @param state Data state.
  * @return The list of icons or empty array if not loaded.
  */
 export function getIcons( state: State ): Icon[] {
 	return state.icons ?? [];
+}
+
+/**
+ * Returns a single icon by name.
+ *
+ * @param state Data state.
+ * @param name  Icon name (e.g. 'core/arrow-left').
+ * @return The icon object or undefined if not loaded.
+ */
+export function getIcon( state: State, name: string ): Icon | undefined {
+	const icons = state.icons ?? [];
+	return icons.find( ( i ) => i.name === name );
 }

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -317,7 +317,7 @@ export function getEditorAssets( state: State ): Record< string, any > | null {
  * @return The list of icons or empty array if not loaded.
  */
 export function getIcons( state: State ): Icon[] {
-	return state.icons ?? [];
+	return Object.values( state.icons ?? {} );
 }
 
 /**
@@ -328,6 +328,5 @@ export function getIcons( state: State ): Icon[] {
  * @return The icon object or undefined if not loaded.
  */
 export function getIcon( state: State, name: string ): Icon | undefined {
-	const icons = state.icons ?? [];
-	return icons.find( ( i ) => i.name === name );
+	return state.icons?.[ name ];
 }

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -19,6 +19,8 @@ import logEntityDeprecation from './utils/log-entity-deprecation';
 
 type EntityRecordKey = string | number;
 
+const EMPTY_ARRAY = [] as [];
+
 /**
  * Returns the previous edit from the current undo offset
  * for the entity records edits history, if any.
@@ -316,9 +318,16 @@ export function getEditorAssets( state: State ): Record< string, any > | null {
  * @param state Data state.
  * @return The list of icons or empty array if not loaded.
  */
-export function getIcons( state: State ): Icon[] {
-	return Object.values( state.icons ?? {} );
-}
+export const getIcons = createSelector(
+	( state: State ): Icon[] => {
+		const icons = state.icons;
+		if ( ! icons || Object.keys( icons ).length === 0 ) {
+			return EMPTY_ARRAY;
+		}
+		return Object.values( icons );
+	},
+	( state: State ) => [ state.icons ]
+);
 
 /**
  * Returns a single icon by name.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -663,25 +663,19 @@ export function editorAssets( state = null, action ) {
 /**
  * Reducer managing icons.
  *
- * @param {Array}  state  Current state.
+ * @param {Object} state  Current state (keyed by icon name).
  * @param {Object} action Action object.
  *
- * @return {Array} Updated state.
+ * @return {Object} Updated state.
  */
-export function icons( state = [], action ) {
+export function icons( state = {}, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_ICONS':
-			return action.icons;
-		case 'RECEIVE_ICON': {
-			const existingIndex = state.findIndex(
-				( i ) => i.name === action.icon.name
-			);
-			if ( existingIndex >= 0 ) {
-				const next = [ ...state ];
-				next[ existingIndex ] = action.icon;
-				return next;
+		case 'RECEIVE_ICONS': {
+			const next = { ...state };
+			for ( const icon of action.icons ) {
+				next[ icon.name ] = icon;
 			}
-			return [ ...state, action.icon ];
+			return next;
 		}
 	}
 	return state;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -671,6 +671,9 @@ export function editorAssets( state = null, action ) {
 export function icons( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_ICONS': {
+			if ( ! action.icons?.length ) {
+				return state;
+			}
 			const next = { ...state };
 			for ( const icon of action.icons ) {
 				next[ icon.name ] = icon;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -672,6 +672,17 @@ export function icons( state = [], action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_ICONS':
 			return action.icons;
+		case 'RECEIVE_ICON': {
+			const existingIndex = state.findIndex(
+				( i ) => i.name === action.icon.name
+			);
+			if ( existingIndex >= 0 ) {
+				const next = [ ...state ];
+				next[ existingIndex ] = action.icon;
+				return next;
+			}
+			return [ ...state, action.icon ];
+		}
 	}
 	return state;
 }

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1257,7 +1257,7 @@ export const getEditorAssets =
 	};
 
 /**
- * Requests icons from the REST API.
+ * Requests all available icons from the REST API.
  */
 export const getIcons =
 	() =>
@@ -1266,4 +1266,18 @@ export const getIcons =
 			path: '/wp/v2/icons',
 		} );
 		dispatch.receiveIcons( icons );
+	};
+
+/**
+ * Requests a single icon by name from the REST API.
+ *
+ * @param {string} iconName Icon name (e.g. 'core/arrow-left').
+ */
+export const getIcon =
+	( iconName ) =>
+	async ( { dispatch } ) => {
+		const icon = await apiFetch( {
+			path: `/wp/v2/icons/${ iconName }`,
+		} );
+		dispatch.receiveIcon( icon );
 	};

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1279,5 +1279,5 @@ export const getIcon =
 		const icon = await apiFetch( {
 			path: `/wp/v2/icons/${ iconName }`,
 		} );
-		dispatch.receiveIcon( icon );
+		dispatch.receiveIcons( [ icon ] );
 	};

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -53,7 +53,7 @@ export interface State {
 	registeredPostMeta: Record< string, Object >;
 	editorSettings: Record< string, any > | null;
 	editorAssets: Record< string, any > | null;
-	icons: Icon[];
+	icons: Record< string, Icon >;
 	syncConnectionStatuses?: Record< string, ConnectionStatus >;
 }
 


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/75715#issuecomment-3925035525

## What?
The Icon Block loads all icons on initial render. This PR loads all icons the first time the icon picker is opened.

## Why?

Performance improvement

## How?

Create a new private selector to get a single icon by name.

## Testing Instructions

- Open the Developer Tools and open the Network tab.
- Filter the network name by `/wp-json/wp/v2/icon`.
- Open a new post. No network request is triggered.
- Click the "Choose icon" button.
- A request is made to fetch all icons.
- Select an icon, savethe post, and reload your browser.
- A request is made to fetch only the selected icon.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a347abfe-5afa-4324-8f92-2c434fda2fbb