### PR TITLE
Revert "Try fix failing patterns e2e test"

### DIFF
--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -737,14 +737,6 @@ test.describe( 'Synced pattern', () => {
 
 		// Save the reusable block and update the post.
 		await editorTopBar.getByRole( 'button', { name: 'Save' } ).click();
-		const entitiesSaveButton = page
-			.getByRole( 'region', { name: 'Editor publish' } )
-			.getByRole( 'button', { name: 'Save', exact: true } );
-		const isEntitiesSavePanelVisible = await entitiesSaveButton.isVisible();
-		// Handle multi-entity save panel if it appears.
-		if ( isEntitiesSavePanelVisible ) {
-			await entitiesSaveButton.click();
-		}
 		await page
 			.getByRole( 'button', { name: 'Dismiss this notice' } )
 			.filter( { hasText: 'Pattern updated.' } )


### PR DESCRIPTION
Reverts WordPress/gutenberg#75759

We changed RTC to be opt-in in core: https://core.trac.wordpress.org/changeset/61702

Let's avoid changing tests as it could be hiding real issues with RTC. We can re-evaluate when we enable RTC in Gutenberg itself in the future.