### PR TITLE
Pattern Editing: Fix nested patterns/sections

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -511,7 +511,12 @@ export const getParentSectionBlock = ( state, clientId ) => {
 export function isSectionBlock( state, clientId ) {
 	// If the section is being edited or a parent section is being edited,
 	// this block is temporarily not considered a section.
-	if ( isWithinEditedContentOnlySection( state, clientId ) ) {
+	// Only the top level section is considered the section,
+	// a nested section is managed by its parent section.
+	if (
+		isWithinEditedContentOnlySection( state, clientId ) ||
+		getParentSectionBlock( state, clientId )
+	) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -511,11 +511,7 @@ export const getParentSectionBlock = ( state, clientId ) => {
 export function isSectionBlock( state, clientId ) {
 	// If the section is being edited or a parent section is being edited,
 	// this block is temporarily not considered a section.
-	if (
-		state.editedContentOnlySection &&
-		( isWithinEditedContentOnlySection( state, clientId ) ||
-			clientId === state.editedContentOnlySection )
-	) {
+	if ( isWithinEditedContentOnlySection( state, clientId ) ) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -489,6 +489,10 @@ export const getParentSectionBlock = ( state, clientId ) => {
 	// If sections are nested, return the top level section block.
 	// Don't return early.
 	while ( ( current = state.blocks.parents.get( current ) ) ) {
+		if ( state.editedContentOnlySection === current ) {
+			return undefined;
+		}
+
 		if ( isSectionBlock( state, current ) ) {
 			result = current;
 		}
@@ -505,7 +509,13 @@ export const getParentSectionBlock = ( state, clientId ) => {
  * @return {boolean} Whether the block is a contentOnly section.
  */
 export function isSectionBlock( state, clientId ) {
-	if ( clientId === state.editedContentOnlySection ) {
+	// If the section is being edited or a parent section is being edited,
+	// this block is temporarily not considered a section.
+	if (
+		state.editedContentOnlySection &&
+		( isWithinEditedContentOnlySection( state, clientId ) ||
+			clientId === state.editedContentOnlySection )
+	) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -475,51 +475,17 @@ export const getContentLockingParent = ( state, clientId ) => {
 };
 
 /**
- * Retrieves the client ID of the parent section block.
+ * Checks whether a block meets the raw criteria to be a section block,
+ * without considering contextual factors like nesting or the edited
+ * content-only section. Used internally by `isSectionBlock` and
+ * `getParentSectionBlock` to avoid circular calls between them.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client Id of the block.
  *
- * @return {?string} Client ID of the ancestor block that is a contentOnly section.
+ * @return {boolean} Whether the block is a candidate section block.
  */
-export const getParentSectionBlock = ( state, clientId ) => {
-	let current = clientId;
-	let result;
-
-	// If sections are nested, return the top level section block.
-	// Don't return early.
-	while ( ( current = state.blocks.parents.get( current ) ) ) {
-		if ( state.editedContentOnlySection === current ) {
-			return undefined;
-		}
-
-		if ( isSectionBlock( state, current ) ) {
-			result = current;
-		}
-	}
-	return result;
-};
-
-/**
- * Returns whether the block is a contentOnly section.
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId Client Id of the block.
- *
- * @return {boolean} Whether the block is a contentOnly section.
- */
-export function isSectionBlock( state, clientId ) {
-	// If the section is being edited or a parent section is being edited,
-	// this block is temporarily not considered a section.
-	// Only the top level section is considered the section,
-	// a nested section is managed by its parent section.
-	if (
-		isWithinEditedContentOnlySection( state, clientId ) ||
-		getParentSectionBlock( state, clientId )
-	) {
-		return false;
-	}
-
+function isSectionBlockCandidate( state, clientId ) {
 	const blockName = getBlockName( state, clientId );
 	if ( blockName === 'core/block' ) {
 		return true;
@@ -557,6 +523,60 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	return false;
+}
+
+/**
+ * Retrieves the client ID of the parent section block.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client Id of the block.
+ *
+ * @return {?string} Client ID of the ancestor block that is a contentOnly section.
+ */
+export const getParentSectionBlock = ( state, clientId ) => {
+	// If this block is within the edited content-only section,
+	// it has no parent section — it's temporarily fully editable.
+	if ( isWithinEditedContentOnlySection( state, clientId ) ) {
+		return undefined;
+	}
+
+	let current = clientId;
+	let result;
+
+	// If sections are nested, return the top level section block.
+	// Don't return early.
+	while ( ( current = state.blocks.parents.get( current ) ) ) {
+		if ( isSectionBlockCandidate( state, current ) ) {
+			result = current;
+		}
+	}
+	return result;
+};
+
+/**
+ * Returns whether the block is a contentOnly section.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client Id of the block.
+ *
+ * @return {boolean} Whether the block is a contentOnly section.
+ */
+export function isSectionBlock( state, clientId ) {
+	// isWithinEditedContentOnlySection -
+	// If the section is being edited or a parent section is being edited,
+	// this block is temporarily not considered a section.
+	//
+	// getParentSectionBlock -
+	// Only the top level section is considered the section,
+	// a nested section is managed by its parent section.
+	if (
+		isWithinEditedContentOnlySection( state, clientId ) ||
+		getParentSectionBlock( state, clientId )
+	) {
+		return false;
+	}
+
+	return isSectionBlockCandidate( state, clientId );
 }
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -513,12 +513,12 @@ function isSectionBlockCandidate( state, clientId ) {
 	// TemplateLock cascades to all inner parent blocks. Only the top-level
 	// block that's contentOnly templateLocked is the true contentLocker,
 	// all the others are mere imitators.
-	const hasContentOnlyTempateLock =
+	const hasContentOnlyTemplateLock =
 		getTemplateLock( state, clientId ) === 'contentOnly';
 	const rootClientId = getBlockRootClientId( state, clientId );
 	const hasRootContentOnlyTemplateLock =
 		getTemplateLock( state, rootClientId ) === 'contentOnly';
-	if ( hasContentOnlyTempateLock && ! hasRootContentOnlyTemplateLock ) {
+	if ( hasContentOnlyTemplateLock && ! hasRootContentOnlyTemplateLock ) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1623,45 +1623,6 @@ describe( 'private selectors', () => {
 			).toBeUndefined();
 		} );
 
-		it( 'returns undefined when a middle ancestor is the editedContentOnlySection', () => {
-			// Structure: outer-pattern > middle-pattern > deep-block
-			// middle-pattern is the edited section (not the root).
-			const state = {
-				blocks: {
-					byClientId: new Map( [
-						[ 'outer-pattern', { name: 'core/group' } ],
-						[ 'middle-pattern', { name: 'core/group' } ],
-						[ 'deep-block', { name: 'core/paragraph' } ],
-					] ),
-					attributes: new Map( [
-						[
-							'outer-pattern',
-							{ metadata: { patternName: 'outer' } },
-						],
-						[
-							'middle-pattern',
-							{ metadata: { patternName: 'middle' } },
-						],
-						[ 'deep-block', {} ],
-					] ),
-					parents: new Map( [
-						[ 'outer-pattern', '' ],
-						[ 'middle-pattern', 'outer-pattern' ],
-						[ 'deep-block', 'middle-pattern' ],
-					] ),
-				},
-				blockListSettings: {},
-				settings: {},
-				editedContentOnlySection: 'middle-pattern',
-			};
-			// The walk encounters middle-pattern (the edited section) before
-			// reaching outer-pattern, so it returns undefined early — outer-pattern
-			// above the edited section is not returned.
-			expect(
-				getParentSectionBlock( state, 'deep-block' )
-			).toBeUndefined();
-		} );
-
 		it( 'returns the correct parent when editedContentOnlySection is set but not in ancestry', () => {
 			// Structure: pattern-a > inner-block, pattern-b (sibling)
 			const state = {

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1415,6 +1415,37 @@ describe( 'private selectors', () => {
 			expect( isSectionBlock( state, 'block-1' ) ).toBe( true );
 		} );
 
+		it( 'returns false when nested inside another section block', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'outer-pattern', { name: 'core/group' } ],
+						[ 'inner-pattern', { name: 'core/group' } ],
+					] ),
+					attributes: new Map( [
+						[
+							'outer-pattern',
+							{ metadata: { patternName: 'outer' } },
+						],
+						[
+							'inner-pattern',
+							{ metadata: { patternName: 'inner' } },
+						],
+					] ),
+					parents: new Map( [
+						[ 'outer-pattern', '' ],
+						[ 'inner-pattern', 'outer-pattern' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: undefined,
+			};
+			// inner-pattern is nested inside outer-pattern (also a section),
+			// so it is not considered a section itself.
+			expect( isSectionBlock( state, 'inner-pattern' ) ).toBe( false );
+		} );
+
 		it( 'returns false when the block itself is the editedContentOnlySection', () => {
 			const state = {
 				...createState( {

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -23,6 +23,7 @@ import {
 	isBlockHiddenAtViewport,
 	getViewportModalClientIds,
 	isSectionBlock,
+	getParentSectionBlock,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -1412,6 +1413,252 @@ describe( 'private selectors', () => {
 				disableContentOnlyForUnsyncedPatterns: false,
 			} );
 			expect( isSectionBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'returns false when the block itself is the editedContentOnlySection', () => {
+			const state = {
+				...createState( {
+					patternName: 'my-pattern',
+				} ),
+				editedContentOnlySection: 'block-1',
+			};
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'returns false when the block is nested within the editedContentOnlySection', () => {
+			// Create a nested structure: outer-pattern > block-1 (with patternName)
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'outer-pattern', { name: 'core/group' } ],
+						[ 'block-1', { name: 'core/group' } ],
+					] ),
+					attributes: new Map( [
+						[
+							'outer-pattern',
+							{ metadata: { patternName: 'outer' } },
+						],
+						[ 'block-1', { metadata: { patternName: 'inner' } } ],
+					] ),
+					parents: new Map( [
+						[ 'outer-pattern', '' ],
+						[ 'block-1', 'outer-pattern' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: 'outer-pattern',
+			};
+			// block-1 has a patternName, so would normally be a section,
+			// but since its parent (outer-pattern) is being edited, it's not.
+			expect( isSectionBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'returns true for section blocks outside the editedContentOnlySection', () => {
+			// Create a structure with two sibling patterns
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'pattern-a', { name: 'core/group' } ],
+						[ 'pattern-b', { name: 'core/group' } ],
+					] ),
+					attributes: new Map( [
+						[ 'pattern-a', { metadata: { patternName: 'a' } } ],
+						[ 'pattern-b', { metadata: { patternName: 'b' } } ],
+					] ),
+					parents: new Map( [
+						[ 'pattern-a', '' ],
+						[ 'pattern-b', '' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: 'pattern-a',
+			};
+			// pattern-b is not the edited section and not within it
+			expect( isSectionBlock( state, 'pattern-b' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getParentSectionBlock', () => {
+		it( 'returns undefined when there are no parent section blocks', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'block-1', { name: 'core/paragraph' } ],
+					] ),
+					attributes: new Map( [ [ 'block-1', {} ] ] ),
+					parents: new Map( [ [ 'block-1', '' ] ] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: undefined,
+			};
+			expect( getParentSectionBlock( state, 'block-1' ) ).toBeUndefined();
+		} );
+
+		it( 'returns the parent section block clientId', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'pattern-block', { name: 'core/group' } ],
+						[ 'inner-block', { name: 'core/paragraph' } ],
+					] ),
+					attributes: new Map( [
+						[
+							'pattern-block',
+							{ metadata: { patternName: 'my-pattern' } },
+						],
+						[ 'inner-block', {} ],
+					] ),
+					parents: new Map( [
+						[ 'pattern-block', '' ],
+						[ 'inner-block', 'pattern-block' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: undefined,
+			};
+			expect( getParentSectionBlock( state, 'inner-block' ) ).toBe(
+				'pattern-block'
+			);
+		} );
+
+		it( 'returns undefined when the parent is the editedContentOnlySection', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'pattern-block', { name: 'core/group' } ],
+						[ 'inner-block', { name: 'core/paragraph' } ],
+					] ),
+					attributes: new Map( [
+						[
+							'pattern-block',
+							{ metadata: { patternName: 'my-pattern' } },
+						],
+						[ 'inner-block', {} ],
+					] ),
+					parents: new Map( [
+						[ 'pattern-block', '' ],
+						[ 'inner-block', 'pattern-block' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: 'pattern-block',
+			};
+			// Since pattern-block is the edited section, it's no longer
+			// considered a parent section for inner-block
+			expect(
+				getParentSectionBlock( state, 'inner-block' )
+			).toBeUndefined();
+		} );
+
+		it( 'returns undefined for deeply nested blocks when an ancestor is the editedContentOnlySection', () => {
+			// Structure: outer-pattern > nested-pattern > deep-block
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'outer-pattern', { name: 'core/group' } ],
+						[ 'nested-pattern', { name: 'core/group' } ],
+						[ 'deep-block', { name: 'core/paragraph' } ],
+					] ),
+					attributes: new Map( [
+						[
+							'outer-pattern',
+							{ metadata: { patternName: 'outer' } },
+						],
+						[
+							'nested-pattern',
+							{ metadata: { patternName: 'nested' } },
+						],
+						[ 'deep-block', {} ],
+					] ),
+					parents: new Map( [
+						[ 'outer-pattern', '' ],
+						[ 'nested-pattern', 'outer-pattern' ],
+						[ 'deep-block', 'nested-pattern' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: 'outer-pattern',
+			};
+			// When outer-pattern is being edited, nested-pattern is no longer
+			// a section (tested above), so deep-block has no parent section
+			expect(
+				getParentSectionBlock( state, 'deep-block' )
+			).toBeUndefined();
+		} );
+
+		it( 'returns undefined when a middle ancestor is the editedContentOnlySection', () => {
+			// Structure: outer-pattern > middle-pattern > deep-block
+			// middle-pattern is the edited section (not the root).
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'outer-pattern', { name: 'core/group' } ],
+						[ 'middle-pattern', { name: 'core/group' } ],
+						[ 'deep-block', { name: 'core/paragraph' } ],
+					] ),
+					attributes: new Map( [
+						[
+							'outer-pattern',
+							{ metadata: { patternName: 'outer' } },
+						],
+						[
+							'middle-pattern',
+							{ metadata: { patternName: 'middle' } },
+						],
+						[ 'deep-block', {} ],
+					] ),
+					parents: new Map( [
+						[ 'outer-pattern', '' ],
+						[ 'middle-pattern', 'outer-pattern' ],
+						[ 'deep-block', 'middle-pattern' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: 'middle-pattern',
+			};
+			// The walk encounters middle-pattern (the edited section) before
+			// reaching outer-pattern, so it returns undefined early — outer-pattern
+			// above the edited section is not returned.
+			expect(
+				getParentSectionBlock( state, 'deep-block' )
+			).toBeUndefined();
+		} );
+
+		it( 'returns the correct parent when editedContentOnlySection is set but not in ancestry', () => {
+			// Structure: pattern-a > inner-block, pattern-b (sibling)
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'pattern-a', { name: 'core/group' } ],
+						[ 'inner-block', { name: 'core/paragraph' } ],
+						[ 'pattern-b', { name: 'core/group' } ],
+					] ),
+					attributes: new Map( [
+						[ 'pattern-a', { metadata: { patternName: 'a' } } ],
+						[ 'inner-block', {} ],
+						[ 'pattern-b', { metadata: { patternName: 'b' } } ],
+					] ),
+					parents: new Map( [
+						[ 'pattern-a', '' ],
+						[ 'inner-block', 'pattern-a' ],
+						[ 'pattern-b', '' ],
+					] ),
+				},
+				blockListSettings: {},
+				settings: {},
+				editedContentOnlySection: 'pattern-b',
+			};
+			// pattern-a is not being edited, so inner-block still has pattern-a as parent
+			expect( getParentSectionBlock( state, 'inner-block' ) ).toBe(
+				'pattern-a'
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Alternative to #75762

Fixes some quirks for patterns that are nested inside other patterns.

Fixes the following issues:

**Problem**: A nested unsynced pattern that has a content block as its root block had its own 'Edit pattern' button on its toolbar. If the user opens the block inspector, that also shows an 'Edit pattern' button, but that one's for the parent pattern, which can cause confusion.
**Solution**: Only the parent pattern should have an 'Edit pattern' button, when clicked it initiates editing for all nested unsynced patterns.

**Problem**: When 'Edit pattern' is clicked, nested patterns were not fully editable and still showed an 'Edit pattern' button.
**Solution**: Similar to above, nested unsynced patterns are entirely managed by their parent pattern.

## Code changes

`isSectionBlock` now returns `false` if the current clientId has a parent section or an edited parent section.

`getParentSectionBlock` also returns `undefined` if there's a parent edited section.


## Testing Instructions
1. Insert an unsynced pattern.
2. With the unsynced pattern selected, click 'Edit pattern' on the toolbar.
3. Insert another unsynced pattern inside the first unsynced pattern (especially one that has a cover as its root block, 'Hero, full width image' is an example in TT5).
3. Check that the nested pattern can be edited fully while still editing the parent pattern
4. Click the 'Exit pattern' button from the block inspector
5. Select the nested pattern
6. It should not have an 'Edit pattern' button on its toolbar, it acts like any other child block of the parent pattern.

## Screenshots or screencast <!-- if applicable -->
### Before

Nested unsynced pattern has its own 'Edit pattern' toolbar button, and when clicking 'Edit pattern' on the parent, the nested patterns inner blocks are still not fully editable

https://github.com/user-attachments/assets/b6c26f5d-6f87-46e1-bea9-daea29c93741

### After

Nested unsynced patterns are now managed by their parent. They have no 'Edit pattern' button of their own. When 'Edit pattern' is clicked on the parent, the nested pattern is fully editable.

https://github.com/user-attachments/assets/3a85320d-5042-40f2-9f9d-334bf13d9c1e

