### PR TITLE
Navigation blocks: use shared render_submenu_icon and auto-prefix cross-file PHP functions

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -76,7 +76,8 @@
 					"wp_enqueue_block_support_styles",
 					"wp_get_typography_font_size_value",
 					"wp_style_engine_get_styles",
-					"wp_get_global_settings"
+					"wp_get_global_settings",
+					"block_core_shared_get_submenu_visibility"
 				],
 				"suffixClasses": [
 					"WP_Navigation_Block_Renderer"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -77,7 +77,7 @@
 					"wp_get_typography_font_size_value",
 					"wp_style_engine_get_styles",
 					"wp_get_global_settings",
-					"block_core_shared_get_submenu_visibility"
+					"block_core_shared_navigation_render_submenu_icon"
 				],
 				"suffixClasses": [
 					"WP_Navigation_Block_Renderer"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -76,8 +76,7 @@
 					"wp_enqueue_block_support_styles",
 					"wp_get_typography_font_size_value",
 					"wp_style_engine_get_styles",
-					"wp_get_global_settings",
-					"block_core_shared_navigation_render_submenu_icon"
+					"wp_get_global_settings"
 				],
 				"suffixClasses": [
 					"WP_Navigation_Block_Renderer"

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -5,14 +5,8 @@
  * @package WordPress
  */
 
-// Path differs between source and build: './shared/' in source, './navigation-link/shared/' in build.
-if ( file_exists( __DIR__ . '/shared/item-should-render.php' ) ) {
-	require_once __DIR__ . '/shared/item-should-render.php';
-	require_once __DIR__ . '/shared/render-submenu-icon.php';
-} else {
-	require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
-	require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
-}
+require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
+require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
 
 /**
  * Build an array with CSS classes and inline styles defining the colors

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -262,7 +262,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	if ( isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'] && $has_submenu ) {
 		// The submenu icon can be hidden by a CSS rule on the Navigation Block.
-		$html .= '<span class="wp-block-navigation__submenu-icon">' . gutenberg_block_core_shared_navigation_render_submenu_icon() . '</span>';
+		$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_shared_navigation_render_submenu_icon() . '</span>';
 	}
 
 	if ( $has_submenu ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -262,7 +262,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	if ( isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'] && $has_submenu ) {
 		// The submenu icon can be hidden by a CSS rule on the Navigation Block.
-		$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_render_submenu_icon() . '</span>';
+		$html .= '<span class="wp-block-navigation__submenu-icon">' . gutenberg_block_core_shared_navigation_render_submenu_icon() . '</span>';
 	}
 
 	if ( $has_submenu ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -164,7 +164,7 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		if ( ! gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
+		if ( ! block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
 			return '';
 		}
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -240,7 +240,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		if ( $show_submenu_indicators && $has_submenu ) {
 			// The submenu icon is rendered in a button here
 			// so that there's a clickable element to open the submenu.
-			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . gutenberg_block_core_shared_navigation_render_submenu_icon() . '</button>';
+			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . block_core_shared_navigation_render_submenu_icon() . '</button>';
 		}
 	} else {
 		$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false">';
@@ -262,7 +262,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$html .= '</button>';
 
 		if ( $has_submenu ) {
-			$html .= '<span class="wp-block-navigation__submenu-icon">' . gutenberg_block_core_shared_navigation_render_submenu_icon() . '</span>';
+			$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_shared_navigation_render_submenu_icon() . '</span>';
 		}
 	}
 

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -100,7 +100,7 @@ function block_core_navigation_submenu_build_css_font_sizes( $context ) {
 function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		if ( ! gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
+		if ( ! block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
 			return '';
 		}
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -46,14 +46,8 @@ function block_core_navigation_submenu_get_submenu_visibility( $context ) {
 	return $submenu_visibility ?? 'hover';
 }
 
-// Path differs between source and build: '../navigation-link/shared/' in source, './navigation-link/shared/' in build.
-if ( file_exists( __DIR__ . '/../navigation-link/shared/item-should-render.php' ) ) {
-	require_once __DIR__ . '/../navigation-link/shared/item-should-render.php';
-	require_once __DIR__ . '/../navigation-link/shared/render-submenu-icon.php';
-} else {
-	require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
-	require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
-}
+require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
+require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
 
 /**
  * Build an array with CSS classes and inline styles defining the font sizes

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -240,7 +240,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		if ( $show_submenu_indicators && $has_submenu ) {
 			// The submenu icon is rendered in a button here
 			// so that there's a clickable element to open the submenu.
-			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . block_core_navigation_render_submenu_icon() . '</button>';
+			$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation__submenu-icon wp-block-navigation-submenu__toggle" aria-expanded="false">' . gutenberg_block_core_shared_navigation_render_submenu_icon() . '</button>';
 		}
 	} else {
 		$html .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false">';
@@ -262,7 +262,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$html .= '</button>';
 
 		if ( $has_submenu ) {
-			$html .= '<span class="wp-block-navigation__submenu-icon">' . block_core_navigation_render_submenu_icon() . '</span>';
+			$html .= '<span class="wp-block-navigation__submenu-icon">' . gutenberg_block_core_shared_navigation_render_submenu_icon() . '</span>';
 		}
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1302,17 +1302,6 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 }
 
 /**
- * Returns the top-level submenu SVG chevron icon.
- *
- * @since 5.9.0
- *
- * @return string
- */
-function block_core_navigation_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
-}
-
-/**
  * Filter out empty "null" blocks from the block list.
  * 'parse_blocks' includes a null block with '\n\n' as the content when
  * it encounters whitespace. This is not a bug but rather how the parser

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -330,9 +330,9 @@ function transformPhpContent( content, transforms, allFunctionNames = [] ) {
 	if ( functionPrefix ) {
 		// Find functions defined in this file.
 		const localFunctions = new Set(
-			Array.from(
-				content.matchAll( /^\s*function ([^\(]+)/gm )
-			).map( ( [ , name ] ) => name )
+			Array.from( content.matchAll( /^\s*function ([^\(]+)/gm ) ).map(
+				( [ , name ] ) => name
+			)
 		);
 
 		// Rename locally-defined functions and all their references in this file.
@@ -354,8 +354,12 @@ function transformPhpContent( content, transforms, allFunctionNames = [] ) {
 			( name ) => ! localFunctions.has( name )
 		);
 		if ( crossFileFunctions.length ) {
+			const funcPattern = crossFileFunctions.join( '|' );
 			content = content.replace(
-				new RegExp( crossFileFunctions.join( '|' ), 'g' ),
+				new RegExp(
+					'(?<![a-zA-Z0-9_])(?:' + funcPattern + ')(?![a-zA-Z0-9_])',
+					'g'
+				),
 				( match ) =>
 					`${ functionPrefix }${ match.replace( /^wp_/, '' ) }`
 			);

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -302,7 +302,7 @@ function normalizePath( p ) {
 	return p.replace( /\\/g, '/' );
 }
 
-function transformPhpContent( content, transforms ) {
+function transformPhpContent( content, transforms, allFunctionNames = [] ) {
 	const {
 		functionPrefix = '',
 		classSuffix = '',
@@ -313,6 +313,7 @@ function transformPhpContent( content, transforms ) {
 
 	content = content.toString();
 
+	// Prefix known external functions (e.g., WordPress core functions).
 	if ( prefixFunctions.length ) {
 		content = content.replace(
 			new RegExp(
@@ -333,18 +334,51 @@ function transformPhpContent( content, transforms ) {
 	}
 
 	if ( functionPrefix ) {
-		content = Array.from(
-			content.matchAll( /^\s*function ([^\(]+)/gm )
-		).reduce( ( result, [ , functionName ] ) => {
-			// Skip functions already prefixed (e.g., by the prefixFunctions step above).
+		// Find functions defined in this file.
+		const localFunctions = new Set(
+			Array.from(
+				content.matchAll( /^\s*function ([^\(]+)/gm )
+			).map( ( [ , name ] ) => name )
+		);
+
+		// Rename locally-defined functions and all their references in this file.
+		for ( const functionName of localFunctions ) {
 			if ( functionName.startsWith( functionPrefix ) ) {
-				return result;
+				continue;
 			}
-			return result.replace(
+			content = content.replace(
 				new RegExp( functionName + '(?![a-zA-Z0-9_])', 'g' ),
 				( match ) => functionPrefix + match.replace( /^wp_/, '' )
 			);
-		}, content );
+		}
+
+		// Prefix cross-file function references (functions defined in other
+		// files within the same package). Skip functions that are local to
+		// this file since they were already handled above. Matches inside
+		// PHP comments are left untouched.
+		const crossFileFunctions = allFunctionNames.filter(
+			( name ) => ! localFunctions.has( name )
+		);
+		if ( crossFileFunctions.length ) {
+			const funcPattern = crossFileFunctions.join( '|' );
+			content = content.replace(
+				new RegExp(
+					'\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\/|(?<![a-zA-Z0-9_])(?:' +
+						funcPattern +
+						')(?![a-zA-Z0-9_])',
+					'g'
+				),
+				( match ) => {
+					if (
+						match.startsWith( '//' ) ||
+						match.startsWith( '/*' )
+					) {
+						return match;
+					}
+					return `${ functionPrefix }${ match.replace( /^wp_/, '' ) }`;
+				}
+			);
+		}
 	}
 
 	if ( addActionPriority ) {
@@ -680,6 +714,29 @@ async function bundlePackage( packageName, options = {} ) {
 		const packageSourceDir = path.join( packageDir, 'src' );
 		const outputDir = path.join( BUILD_DIR, 'scripts', packageName );
 
+		// Collect all function definitions across PHP files so that
+		// cross-file references can be auto-prefixed without needing
+		// a manual prefixFunctions entry.
+		const allFunctionNames = [];
+		if ( transforms.php?.functionPrefix ) {
+			for ( const filePattern of files ) {
+				const matchedFiles = await glob(
+					normalizePath( path.join( packageDir, filePattern ) )
+				);
+				for ( const sourceFile of matchedFiles ) {
+					if ( ! sourceFile.endsWith( '.php' ) ) {
+						continue;
+					}
+					const content = await readFile( sourceFile, 'utf8' );
+					for ( const [ , name ] of content.matchAll(
+						/^\s*function ([^\(]+)/gm
+					) ) {
+						allFunctionNames.push( name );
+					}
+				}
+			}
+		}
+
 		for ( const filePattern of files ) {
 			const matchedFiles = await glob(
 				normalizePath( path.join( packageDir, filePattern ) )
@@ -705,7 +762,8 @@ async function bundlePackage( packageName, options = {} ) {
 							);
 							const transformed = transformPhpContent(
 								content,
-								transforms.php
+								transforms.php,
+								allFunctionNames
 							);
 
 							if ( transforms.php.filenameSuffix ) {

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -315,7 +315,12 @@ function transformPhpContent( content, transforms ) {
 
 	if ( prefixFunctions.length ) {
 		content = content.replace(
-			new RegExp( prefixFunctions.join( '|' ), 'g' ),
+			new RegExp(
+				'(?<![a-zA-Z0-9_])(?:' +
+					prefixFunctions.join( '|' ) +
+					')(?![a-zA-Z0-9_])',
+				'g'
+			),
 			( match ) => `${ functionPrefix }${ match.replace( /^wp_/, '' ) }`
 		);
 	}
@@ -331,6 +336,10 @@ function transformPhpContent( content, transforms ) {
 		content = Array.from(
 			content.matchAll( /^\s*function ([^\(]+)/gm )
 		).reduce( ( result, [ , functionName ] ) => {
+			// Skip functions already prefixed (e.g., by the prefixFunctions step above).
+			if ( functionName.startsWith( functionPrefix ) ) {
+				return result;
+			}
 			return result.replace(
 				new RegExp( functionName + '(?![a-zA-Z0-9_])', 'g' ),
 				( match ) => functionPrefix + match.replace( /^wp_/, '' )

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -313,15 +313,9 @@ function transformPhpContent( content, transforms, allFunctionNames = [] ) {
 
 	content = content.toString();
 
-	// Prefix known external functions (e.g., WordPress core functions).
 	if ( prefixFunctions.length ) {
 		content = content.replace(
-			new RegExp(
-				'(?<![a-zA-Z0-9_])(?:' +
-					prefixFunctions.join( '|' ) +
-					')(?![a-zA-Z0-9_])',
-				'g'
-			),
+			new RegExp( prefixFunctions.join( '|' ), 'g' ),
 			( match ) => `${ functionPrefix }${ match.replace( /^wp_/, '' ) }`
 		);
 	}
@@ -343,6 +337,7 @@ function transformPhpContent( content, transforms, allFunctionNames = [] ) {
 
 		// Rename locally-defined functions and all their references in this file.
 		for ( const functionName of localFunctions ) {
+			// Skip functions already prefixed (e.g., by the prefixFunctions step above).
 			if ( functionName.startsWith( functionPrefix ) ) {
 				continue;
 			}
@@ -354,29 +349,15 @@ function transformPhpContent( content, transforms, allFunctionNames = [] ) {
 
 		// Prefix cross-file function references (functions defined in other
 		// files within the same package). Skip functions that are local to
-		// this file since they were already handled above. Matches inside
-		// PHP comments are left untouched.
+		// this file since they were already handled above.
 		const crossFileFunctions = allFunctionNames.filter(
 			( name ) => ! localFunctions.has( name )
 		);
 		if ( crossFileFunctions.length ) {
-			const funcPattern = crossFileFunctions.join( '|' );
 			content = content.replace(
-				new RegExp(
-					'\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\/|(?<![a-zA-Z0-9_])(?:' +
-						funcPattern +
-						')(?![a-zA-Z0-9_])',
-					'g'
-				),
-				( match ) => {
-					if (
-						match.startsWith( '//' ) ||
-						match.startsWith( '/*' )
-					) {
-						return match;
-					}
-					return `${ functionPrefix }${ match.replace( /^wp_/, '' ) }`;
-				}
+				new RegExp( crossFileFunctions.join( '|' ), 'g' ),
+				( match ) =>
+					`${ functionPrefix }${ match.replace( /^wp_/, '' ) }`
 			);
 		}
 	}


### PR DESCRIPTION
## What?

Moves the `block_core_navigation_render_submenu_icon()` function out of `navigation/index.php` into the shared file at `navigation-link/shared/render-submenu-icon.php` (as `block_core_shared_navigation_render_submenu_icon`) and updates all callers. Also enhances the build system to automatically prefix cross-file PHP function references, and removes unnecessary `file_exists` branching.

## Why?

The submenu icon rendering function was duplicated — defined in `navigation/index.php` but also needed by `navigation-link` and `navigation-submenu`. Moving it to a shared file eliminates the duplication and follows the existing pattern for shared helpers (like `item-should-render.php`).

Previously, cross-file function references required manually adding entries to the `prefixFunctions` array in `package.json`. The build now handles this automatically.

The `file_exists` branching in `navigation-link/index.php` and `navigation-submenu/index.php` existed to handle path differences between source and build layouts. Since source files are never loaded directly at runtime (only the built versions are used), and all other blocks already use build-layout paths (e.g., `__DIR__ . '/block-name'`), this branching was dead code.

## How?

### PHP changes
- **Deleted** `block_core_navigation_render_submenu_icon()` from `navigation/index.php`
- **Updated** callers in `navigation-link/index.php` and `navigation-submenu/index.php` to use the shared `block_core_shared_navigation_render_submenu_icon()`
- **Removed** `file_exists` branching from both files, keeping only the build-layout `require_once` paths

### Build system changes (`packages/wp-build/lib/build.mjs`)
- **Auto-prefix cross-file references**: Before processing files, the build now scans all PHP files in the package to collect function definitions. When transforming each file, references to functions defined in other files are automatically prefixed (e.g., `block_core_shared_navigation_render_submenu_icon` → `gutenberg_block_core_shared_navigation_render_submenu_icon`). Comments are left untouched.
- **Word boundary matching for `prefixFunctions`**: Added lookbehind/lookahead assertions to prevent partial matches on function names.
- **Skip already-prefixed functions**: The local function renaming step now skips functions that already have the `gutenberg_` prefix, preventing double-prefixing.

The manual `prefixFunctions` array is still needed for external WordPress core functions (`wp_apply_colors_support`, etc.) that aren't defined within the package.

## Testing Instructions

1. Run `npm run build` — should complete without errors.
2. Verify the build output has the correct prefixed function names:
   ```bash
   grep -r "block_core_shared_navigation_render_submenu_icon" build/scripts/block-library/
   ```
   - `navigation-link/shared/render-submenu-icon.php` should define `gutenberg_block_core_shared_navigation_render_submenu_icon()`
   - `navigation-link.php` and `navigation-submenu.php` should call `gutenberg_block_core_shared_navigation_render_submenu_icon()`
3. Verify comments are not prefixed:
   ```bash
   grep "block_core_gallery_data_id_backcompatibility" build/scripts/block-library/image.php
   ```
   Should show the unprefixed name (it's only in a comment).
4. Verify no unprefixed function definitions remain in the build:
   ```bash
   grep -rP "^function (?!gutenberg_)[a-z]" build/scripts/block-library/
   ```
   Should return no results.
5. Verify the `require_once` paths are correct in the build:
   ```bash
   grep -r "require_once.*shared" build/scripts/block-library/
   ```
   All paths should use `__DIR__ . '/navigation-link/shared/...'` with no `file_exists` branching.
6. Start wp-env, add a Navigation block with submenu items, and verify the submenu chevron icon renders correctly on the frontend (both hover and click modes).