### PR TITLE
Workflows: Use pull_request_target for cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -7,6 +7,7 @@ on:
     # We also want to attempt cherry-picking when a PR is labeled after the PR
     # is merged. Using pull_request_target instead of pull_request so that
     # the workflow has access to repository secrets for fork PRs.
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
     pull_request_target:
         types: [labeled]
         branches:

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -5,8 +5,9 @@ on:
         branches:
             - trunk
     # We also want to attempt cherry-picking when a PR is labeled after the PR
-    # is merged.
-    pull_request:
+    # is merged. Using pull_request_target instead of pull_request so that
+    # the workflow has access to repository secrets for fork PRs.
+    pull_request_target:
         types: [labeled]
         branches:
             - trunk


### PR DESCRIPTION
## Summary
- The cherry-pick workflow fails on fork PRs when triggered by the `labeled` event because `pull_request` events from forks don't have access to repository secrets (`GUTENBERG_TOKEN`), causing the checkout step to fail with `Input required and not supplied: token`.
- Switches the trigger from `pull_request` to [`pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) so the workflow runs in the context of the base repository with access to secrets.
- This is safe because the workflow only operates on already-merged commits (guarded by `github.event.pull_request.merged == true`).

Fixes: https://github.com/WordPress/gutenberg/actions/runs/22221270711/job/64277381091

## Test plan
- [ ] Merge this PR
- [ ] Add a `Backport to WP 7.0 Beta/RC` label to a merged fork PR
- [ ] Verify the cherry-pick workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)