### PR TITLE
Navigation block: submenu text improved

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -763,7 +763,7 @@ function Navigation( {
 		submenuVisibility !== 'click' &&
 		submenuVisibility !== 'always'
 			? __(
-					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
+					'This setting limits keyboard access to submenus. Enable “Click” or “Show arrow” to allow keyboard navigation.'
 			  )
 			: '';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75702

This PR is changing submenu text in navigation block to be shorter and more informative.

## Why?

To make this text not off.

## How?
Just by text change.

## Testing Instructions
1. Open Gutenberg editor
2. Add navigation block
3. Add menu and submenu in page navigation
4. Disable show arrow option in display settings

## Screenshots

|Before|After|
|<img width="576" height="758" alt="image" src="https://github.com/user-attachments/assets/e4804f9b-0376-4c90-9f7f-200a6424b404" />|<img width="276" height="641" alt="image" src="https://github.com/user-attachments/assets/3ecec21b-6086-4631-b3f2-59ca84f0e149" />|