### PR TITLE
Revert "CI: Use http-get in Storybook check wait-on"

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -46,5 +46,5 @@ jobs:
               run: |
                   npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
                   "npx http-server ./storybook/build --port 50240 --silent" \
-                  "npx wait-on http-get://127.0.0.1:50240 && \
+                  "npx wait-on tcp:127.0.0.1:50240 && \
                   npx test-storybook --url http://localhost:50240 --config-dir ./storybook"


### PR DESCRIPTION
This reverts commit fc63de9707bc7b37b595a3a86d48a4b7c5534ea8.

## What?

Somehow this got committed directly to trunk by accident, so just reverting it right now.