### PR TITLE
Env: Improve help screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52763,38 +52763,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/supports-hyperlinks/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/supports-hyperlinks/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -53227,18 +53195,6 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/terminal-link": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.0.0.tgz",
-			"integrity": "sha512-rdBAY35jUvVapqCuhehjenLbYY73cVgRQ6podD6u9EDBomBBHjCOtmq2InPgPpTysOIOsQ5PdBzwSC/sKjv6ew==",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/terser": {
@@ -60248,7 +60204,6 @@
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
 				"simple-git": "^3.5.0",
-				"terminal-link": "^2.0.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -5,7 +5,6 @@
 const chalk = require( 'chalk' );
 const ora = require( 'ora' );
 const yargs = require( 'yargs' );
-const terminalLink = require( 'terminal-link' );
 
 /**
  * Internal dependencies
@@ -120,10 +119,7 @@ module.exports = function cli() {
 
 	yargs.command(
 		'start',
-		chalk`Starts WordPress on port {bold.underline ${ terminalLink(
-			'8888',
-			'http://localhost:8888'
-		) }} (override with WP_ENV_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file.`,
+		chalk`Starts WordPress, listening locally. The current working directory must be a WordPress installation, a plugin, a theme, or contain a {bold .wp-env.json} file. The config's port can be overridden via {bold WP_ENV_PORT}.`,
 		( args ) => {
 			args.option( 'update', {
 				type: 'boolean',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -308,6 +308,9 @@ module.exports = function cli() {
 		},
 		withSpinner( env.status )
 	);
+	// Wrap at 100 chars unless the terminal is narrower than that, but ensure
+	// formatting is applied even when stdout is not a terminal.
+	yargs.wrap( Math.min( 100, yargs.terminalWidth() ?? 100 ) );
 
 	return yargs;
 };

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -21,13 +21,6 @@ const {
 	EnvironmentNotInitializedError,
 } = require( './runtime' );
 
-// Colors.
-const boldWhite = chalk.bold.white;
-const wpPrimary = boldWhite.bgHex( '#00669b' );
-const wpGreen = boldWhite.bgHex( '#4ab866' );
-const wpRed = boldWhite.bgHex( '#d94f4f' );
-const wpYellow = boldWhite.bgHex( '#f0b849' );
-
 // Spinner.
 const withSpinner =
 	( command ) =>
@@ -101,7 +94,7 @@ const withSpinner =
 	};
 
 module.exports = function cli() {
-	yargs.usage( wpPrimary( '$0 <command>' ) );
+	yargs.usage( '$0 <command>' );
 	yargs.option( 'debug', {
 		type: 'boolean',
 		describe: 'Enable debug output.',
@@ -126,15 +119,13 @@ module.exports = function cli() {
 
 	yargs.command(
 		'start',
-		wpGreen(
-			chalk`Starts WordPress for development on port {bold.underline ${ terminalLink(
-				'8888',
-				'http://localhost:8888'
-			) }} (override with WP_ENV_PORT) and tests on port {bold.underline ${ terminalLink(
-				'8889',
-				'http://localhost:8889'
-			) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first install, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`
-		),
+		chalk`Starts WordPress for development on port {bold.underline ${ terminalLink(
+			'8888',
+			'http://localhost:8888'
+		) }} (override with WP_ENV_PORT) and tests on port {bold.underline ${ terminalLink(
+			'8889',
+			'http://localhost:8889'
+		) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first install, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`,
 		( args ) => {
 			args.option( 'update', {
 				type: 'boolean',
@@ -171,15 +162,13 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'stop',
-		wpRed(
-			'Stops running WordPress for development and tests and frees the ports.'
-		),
+		'Stops running WordPress for development and tests and frees the ports.',
 		() => {},
 		withSpinner( env.stop )
 	);
 	yargs.command(
 		'reset [environment]',
-		wpYellow( 'Resets the WordPress databases.' ),
+		'Resets the WordPress databases.',
 		( args ) => {
 			args.positional( 'environment', {
 				type: 'string',
@@ -197,7 +186,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'clean [environment]',
-		chalk.gray( '[Deprecated: use reset] Resets the WordPress databases.' ),
+		'[Deprecated: use reset] Resets the WordPress databases.',
 		( args ) => {
 			args.positional( 'environment', {
 				type: 'string',
@@ -278,9 +267,7 @@ module.exports = function cli() {
 
 	yargs.command(
 		'destroy',
-		wpRed(
-			'Destroy the WordPress environment. Deletes docker containers, volumes, networks, and images associated with the WordPress environment and removes local files.'
-		),
+		'Destroy the WordPress environment. Deletes docker containers, volumes, networks, and images associated with the WordPress environment and removes local files.',
 		( args ) => {
 			args.option( 'scripts', {
 				type: 'boolean',
@@ -297,9 +284,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'cleanup',
-		wpYellow(
-			'Cleanup the WordPress environment. Removes docker containers, volumes, networks, and local files, but preserves docker images for faster re-starts.'
-		),
+		'Cleanup the WordPress environment. Removes docker containers, volumes, networks, and local files, but preserves docker images for faster re-starts.',
 		( args ) => {
 			args.option( 'scripts', {
 				type: 'boolean',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -162,7 +162,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'reset [environment]',
-		'Resets the WordPress databases.',
+		chalk`{bold.red Resets} the WordPress databases.`,
 		( args ) => {
 			args.positional( 'environment', {
 				type: 'string',
@@ -224,7 +224,7 @@ module.exports = function cli() {
 
 	yargs.command(
 		'run <container> [command...]',
-		'Runs an arbitrary command in one of the underlying Docker containers. A double dash can be used to pass arguments to the container without parsing them. This is necessary if you are using an option that is defined below. You can use `bash` to open a shell session and both `composer` and `phpunit` are available in all WordPress and CLI containers. WP-CLI is also available in the CLI containers.',
+		chalk`Runs an arbitrary command in one of the underlying Docker containers. Use a double dash to pass arguments to it. You can use {bold bash} to open a shell session. {bold composer} and {bold phpunit} are available in all WordPress and CLI containers. {bold wp} is also available in the CLI containers.`,
 		( args ) => {
 			args.option( 'env-cwd', {
 				type: 'string',
@@ -261,7 +261,7 @@ module.exports = function cli() {
 
 	yargs.command(
 		'destroy',
-		'Destroy the WordPress environment. Deletes docker containers, volumes, networks, and images associated with the WordPress environment and removes local files.',
+		chalk`{bold.red Destroys} the WordPress environment. Deletes docker containers, volumes, networks, and images associated with the WordPress environment and removes local files.`,
 		( args ) => {
 			args.option( 'scripts', {
 				type: 'boolean',
@@ -278,7 +278,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'cleanup',
-		'Cleanup the WordPress environment. Removes docker containers, volumes, networks, and local files, but preserves docker images for faster re-starts.',
+		chalk`{bold.red Cleans up} the WordPress environment. Removes docker containers, volumes, networks, and local files, but preserves docker images for faster re-starts.`,
 		( args ) => {
 			args.option( 'scripts', {
 				type: 'boolean',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -95,6 +95,7 @@ const withSpinner =
 
 module.exports = function cli() {
 	yargs.usage( '$0 <command>' );
+	yargs.usage( '$0 <command> -- --help' );
 	yargs.option( 'debug', {
 		type: 'boolean',
 		describe: 'Enable debug output.',
@@ -122,7 +123,7 @@ module.exports = function cli() {
 		chalk`Starts WordPress on port {bold.underline ${ terminalLink(
 			'8888',
 			'http://localhost:8888'
-		) }} (override with WP_ENV_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first install, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`,
+		) }} (override with WP_ENV_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file.`,
 		( args ) => {
 			args.option( 'update', {
 				type: 'boolean',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -180,7 +180,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'clean [environment]',
-		'[Deprecated: use reset] Resets the WordPress databases.',
+		false,
 		( args ) => {
 			args.positional( 'environment', {
 				type: 'string',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -119,13 +119,10 @@ module.exports = function cli() {
 
 	yargs.command(
 		'start',
-		chalk`Starts WordPress for development on port {bold.underline ${ terminalLink(
+		chalk`Starts WordPress on port {bold.underline ${ terminalLink(
 			'8888',
 			'http://localhost:8888'
-		) }} (override with WP_ENV_PORT) and tests on port {bold.underline ${ terminalLink(
-			'8889',
-			'http://localhost:8889'
-		) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first install, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`,
+		) }} (override with WP_ENV_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first install, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`,
 		( args ) => {
 			args.option( 'update', {
 				type: 'boolean',
@@ -162,7 +159,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'stop',
-		'Stops running WordPress for development and tests and frees the ports.',
+		'Stops running WordPress and frees the ports.',
 		() => {},
 		withSpinner( env.stop )
 	);

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -55,7 +55,6 @@
 		"ora": "^4.0.2",
 		"rimraf": "^5.0.10",
 		"simple-git": "^3.5.0",
-		"terminal-link": "^2.0.0",
 		"yargs": "^17.3.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## What?

Before | After
-|-
<img width="1164" height="941" alt="env-before" src="https://github.com/user-attachments/assets/e8ca6594-9890-46af-8a43-73010236cc8c" /> | <img width="1185" height="941" alt="env-after" src="https://github.com/user-attachments/assets/629dc90a-6ce2-4763-a821-9c57892ea2fc" />

- Remove that broken background colouring, which has bothered me forever
- Use lighter formatting: bold and red, no background colours
- Raise the maximum text width from 80 to 100 chars
- Hide deprecated command `clean`
- Show `wp-env <command> -- --help` as a general usage form
- Trim/reword descriptions for `start` and `run`:
    - Remove mentions of test enviroment (see #75341)
        - Note: not all mentions are removed from the whole help screen. I'll let @youknowriad consider how to adapt certain examples.
    - Remove assumption of port 8888
    - Emphasise importance of config file

## Why?

To scratch an itch.