### PR TITLE
Site Editor: Ensure editor settings are populated with server-side settings ASAP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63153,6 +63153,7 @@
 				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/compose": "file:../../packages/compose",
+				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/editor": "file:../../packages/editor",
 				"@wordpress/element": "file:../../packages/element",

--- a/packages/edit-site/src/components/sidebar-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles/index.js
@@ -7,6 +7,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { seen } from '@wordpress/icons';
@@ -14,6 +15,7 @@ import { seen } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesUIWrapper, GlobalStylesActionMenu } =
@@ -82,6 +84,10 @@ export default function SidebarGlobalStyles() {
 	);
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ section, onChangeSection ] = useSection();
+	const settings = useSelect(
+		( select ) => select( editSiteStore ).getSettings(),
+		[]
+	);
 
 	return (
 		<Page
@@ -101,6 +107,7 @@ export default function SidebarGlobalStyles() {
 			<GlobalStylesUIWrapper
 				path={ section }
 				onPathChange={ onChangeSection }
+				editorSettings={ settings }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/sidebar-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles/index.js
@@ -107,7 +107,7 @@ export default function SidebarGlobalStyles() {
 			<GlobalStylesUIWrapper
 				path={ section }
 				onPathChange={ onChangeSection }
-				editorSettings={ settings }
+				settings={ settings }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -10,10 +10,7 @@ import {
 import { dispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { createRoot, StrictMode } from '@wordpress/element';
-import {
-	privateApis as editorPrivateApis,
-	store as editorStore,
-} from '@wordpress/editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	registerLegacyWidgetBlock,
@@ -86,7 +83,6 @@ export function initializeEditor( id, settings ) {
 	}
 
 	dispatch( editSiteStore ).updateSettings( settings );
-	dispatch( editorStore ).updateEditorSettings( settings );
 
 	// Prevent the default browser action for files dropped outside of dropzones.
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -10,7 +10,10 @@ import {
 import { dispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { createRoot, StrictMode } from '@wordpress/element';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	privateApis as editorPrivateApis,
+	store as editorStore,
+} from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	registerLegacyWidgetBlock,
@@ -83,6 +86,7 @@ export function initializeEditor( id, settings ) {
 	}
 
 	dispatch( editSiteStore ).updateSettings( settings );
+	dispatch( editorStore ).updateEditorSettings( settings );
 
 	// Prevent the default browser action for files dropped outside of dropzones.
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );

--- a/packages/editor/src/components/global-styles-sidebar/index.js
+++ b/packages/editor/src/components/global-styles-sidebar/index.js
@@ -171,7 +171,7 @@ export default function GlobalStylesSidebar() {
 				<GlobalStylesUI
 					path={ stylesPath }
 					onPathChange={ setStylesPath }
-					editorSettings={ editorSettings }
+					settings={ editorSettings }
 				/>
 			</DefaultSidebar>
 			<WelcomeGuideStyles />

--- a/packages/editor/src/components/global-styles-sidebar/index.js
+++ b/packages/editor/src/components/global-styles-sidebar/index.js
@@ -29,6 +29,7 @@ export default function GlobalStylesSidebar() {
 		showListViewByDefault,
 		hasRevisions,
 		activeComplementaryArea,
+		editorSettings,
 	} = useSelect( ( select ) => {
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getStylesPath, getShowStylebook } = unlock(
@@ -60,6 +61,7 @@ export default function GlobalStylesSidebar() {
 				!! globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count,
 			activeComplementaryArea:
 				select( interfaceStore ).getActiveComplementaryArea( 'core' ),
+			editorSettings: select( editorStore ).getEditorSettings(),
 		};
 	}, [] );
 	const { setStylesPath, setShowStylebook, resetStylesNavigation } = unlock(
@@ -169,6 +171,7 @@ export default function GlobalStylesSidebar() {
 				<GlobalStylesUI
 					path={ stylesPath }
 					onPathChange={ setStylesPath }
+					editorSettings={ editorSettings }
 				/>
 			</DefaultSidebar>
 			<WelcomeGuideStyles />

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -16,36 +16,32 @@ import { useGlobalStyles } from './hooks';
 
 /**
  * Hook to fetch server CSS and settings for BlockEditorProvider that are not Global Styles.
+ *
+ * @param {Object} editorSettings The editor settings object. Falls back to the
+ *                                editor store settings if not provided.
  */
-function useServerData() {
-	const {
-		styles,
-		__unstableResolvedAssets,
-		colors,
-		gradients,
-		__experimentalDiscussionSettings,
-		mediaUploadHandler,
-		fontLibraryEnabled,
-	} = useSelect( ( select ) => {
-		const { getEditorSettings } = select( editorStore );
-		const { canUser } = select( coreStore );
-		const editorSettings = getEditorSettings();
+function useServerData( editorSettings ) {
+	const editorStoreSettings = useSelect(
+		( select ) => select( editorStore ).getEditorSettings(),
+		[]
+	);
+	const settings = editorSettings || editorStoreSettings;
 
+	const styles = settings?.styles;
+	const __unstableResolvedAssets = settings?.__unstableResolvedAssets;
+	const colors = settings?.colors;
+	const gradients = settings?.gradients;
+	const __experimentalDiscussionSettings =
+		settings?.__experimentalDiscussionSettings;
+	const fontLibraryEnabled = settings?.fontLibraryEnabled ?? true;
+
+	const mediaUploadHandler = useSelect( ( select ) => {
+		const { canUser } = select( coreStore );
 		const canUserUploadMedia = canUser( 'create', {
 			kind: 'postType',
 			name: 'attachment',
 		} );
-
-		return {
-			styles: editorSettings?.styles,
-			__unstableResolvedAssets: editorSettings?.__unstableResolvedAssets,
-			colors: editorSettings?.colors,
-			gradients: editorSettings?.gradients,
-			__experimentalDiscussionSettings:
-				editorSettings?.__experimentalDiscussionSettings,
-			mediaUploadHandler: canUserUploadMedia ? uploadMedia : undefined,
-			fontLibraryEnabled: editorSettings?.fontLibraryEnabled ?? true,
-		};
+		return canUserUploadMedia ? uploadMedia : undefined;
 	}, [] );
 
 	// Filter out global styles to get only server-provided styles
@@ -87,14 +83,19 @@ function useServerData() {
 	return { serverCSS, serverSettings, fontLibraryEnabled };
 }
 
-export default function GlobalStylesUIWrapper( { path, onPathChange } ) {
+export default function GlobalStylesUIWrapper( {
+	path,
+	onPathChange,
+	editorSettings,
+} ) {
 	const {
 		user: userConfig,
 		base: baseConfig,
 		setUser: setUserConfig,
 		isReady,
 	} = useGlobalStyles();
-	const { serverCSS, serverSettings, fontLibraryEnabled } = useServerData();
+	const { serverCSS, serverSettings, fontLibraryEnabled } =
+		useServerData( editorSettings );
 
 	// Show loading state while data is being fetched
 	if ( ! isReady ) {

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -10,23 +10,15 @@ import { uploadMedia } from '@wordpress/media-utils';
 /**
  * Internal dependencies
  */
-import { store as editorStore } from '../../store';
 import { GlobalStylesBlockLink } from './block-link';
 import { useGlobalStyles } from './hooks';
 
 /**
  * Hook to fetch server CSS and settings for BlockEditorProvider that are not Global Styles.
  *
- * @param {Object} editorSettings The editor settings object. Falls back to the
- *                                editor store settings if not provided.
+ * @param {Object} settings The editor settings object.
  */
-function useServerData( editorSettings ) {
-	const editorStoreSettings = useSelect(
-		( select ) => select( editorStore ).getEditorSettings(),
-		[]
-	);
-	const settings = editorSettings || editorStoreSettings;
-
+function useServerData( settings ) {
 	const styles = settings?.styles;
 	const __unstableResolvedAssets = settings?.__unstableResolvedAssets;
 	const colors = settings?.colors;
@@ -86,7 +78,7 @@ function useServerData( editorSettings ) {
 export default function GlobalStylesUIWrapper( {
 	path,
 	onPathChange,
-	editorSettings,
+	settings,
 } ) {
 	const {
 		user: userConfig,
@@ -95,7 +87,7 @@ export default function GlobalStylesUIWrapper( {
 		isReady,
 	} = useGlobalStyles();
 	const { serverCSS, serverSettings, fontLibraryEnabled } =
-		useServerData( editorSettings );
+		useServerData( settings );
 
 	// Show loading state while data is being fetched
 	if ( ! isReady ) {

--- a/packages/lazy-editor/src/index.tsx
+++ b/packages/lazy-editor/src/index.tsx
@@ -4,3 +4,4 @@
 export { Editor } from './components/editor';
 export { Preview } from './components/preview';
 export { useEditorAssets, loadEditorAssets } from './hooks/use-editor-assets';
+export { useEditorSettings } from './hooks/use-editor-settings';

--- a/routes/styles/package.json
+++ b/routes/styles/package.json
@@ -11,6 +11,7 @@
 		"@wordpress/base-styles": "file:../../packages/base-styles",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/editor": "file:../../packages/editor",
 		"@wordpress/element": "file:../../packages/element",

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -6,9 +6,12 @@ import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { seen } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
+import { useEditorSettings } from '@wordpress/lazy-editor';
 
 /**
  * Internal dependencies
@@ -23,6 +26,16 @@ function Stage() {
 	const navigate = useNavigate();
 	const search = useSearch( { strict: false } ) as any;
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const globalStylesId = useSelect(
+		( select ) =>
+			(
+				select( coreStore ) as any
+			 ).__experimentalGetCurrentGlobalStylesId(),
+		[]
+	);
+	const { editorSettings } = useEditorSettings( {
+		stylesId: globalStylesId,
+	} );
 
 	const section = ( search.section ?? '/' ) as string;
 	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState(
@@ -78,6 +91,7 @@ function Stage() {
 			<GlobalStylesUIWrapper
 				path={ section }
 				onPathChange={ onChangeSection }
+				editorSettings={ editorSettings }
 			/>
 		</Page>
 	);

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -91,7 +91,7 @@ function Stage() {
 			<GlobalStylesUIWrapper
 				path={ section }
 				onPathChange={ onChangeSection }
-				editorSettings={ editorSettings }
+				settings={ editorSettings }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Populate the Site Editor's editor settings with server-side settings ASAP.

## Why?

This change fixes a WordPress.com issue where disabling the font library only works on large viewports.

The Site Editor renders different component trees depending on viewport size.

The [styles routes](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/site-editor-routes/styles.js#L57-L69), for example, render `Editor` on desktop viewports as [part of the preview](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/site-editor-routes/styles.js#L54), and on mobile [when in edit canvas](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/site-editor-routes/styles.js#L23-L25). `Editor` syncs server side settings (I think) [through its provider](https://github.com/WordPress/gutenberg/blob/fd269ede1a7f5bbcfe1d00f1b346a7bbcc56d1c6/packages/editor/src/components/provider/index.js#L361-L364). But that component is not rendered when viewing the Styles panel on mobile.

The font library can be [disabled](https://github.com/WordPress/gutenberg/blob/fd269ede1a7f5bbcfe1d00f1b346a7bbcc56d1c6/docs/reference-guides/filters/editor-filters.md#disable-the-font-library) server side via `block_editor_settings_all` filter:

```php
add_filter( 'block_editor_settings_all', 'example_disable_font_library' );

function example_disable_font_library( $settings ) {
	$settings['fontLibraryEnabled'] = false;
	return $settings;
}
```

When opening the Styles panel on desktop, `Editor` is rendered, the server-side settings are populated, and the font library is not displayed. Resizing the viewport to a mobile size, the font library remains hidden.

However, if opening the Styles panel directly on mobile, `Editor` is not rendered, the server-side settings are ignored, and the font library is displayed. Then, expanding the viewport to a desktop size, the `Editor` kicks in, and the font library gets hidden.

## How?

By syncing the server-side settings during the site editor initialization, we ensure those settings are available immediately, regardless of which component tree is rendered.

I must note that I'm not entirely sure this is the right approach, and I wonder if there's a better location for the `updateEditorSettings` call.

I also have concerns that this might surface other issues, similar to the font library one, that have remained concealed on mobile by not populating server-side settings.

A lighter approach could be to only populate the `fontLibraryEnabled` in the Styles panel.

## Testing Instructions

### Visualize the issue BEFORE APPLYING THIS CHANGE

1. Create an mu-plugin to disable the font library:

```php
add_filter( 'block_editor_settings_all', 'example_disable_font_library' );

function example_disable_font_library( $settings ) {
	$settings['fontLibraryEnabled'] = false;
	return $settings;
}
```

2. On a **desktop** viewport, navigate to Appearance → Editor → Styles → Typography.
3. 👀 Ensure the font library is not displayed. ✅ 
4. Resize to a **mobile** viewport.
5. 👀 Ensure the font library is not displayed. ✅ 
6. Reload the page (starting on a **mobile** viewport).
7. 👀 Note how the font library is visible. ❌ 
8. Resize to a **desktop** viewport.
9. 👀 Note how the font library is not displayed anymore. ✅  

### Test the fix AFTER APPLYING THIS CHANGE

1. Create the mu-plugin to disable the font library if needed.
2. On a **desktop** viewport, navigate to Appearance → Editor → Styles → Typography.
3. 👀 Ensure the font library is not displayed. ✅ 
4. Resize to a **mobile** viewport.
5. 👀 Ensure the font library is not displayed. ✅ 
6. Reload the page (starting on a **mobile** viewport).
7. 👀 Ensure the font library is not displayed. ✅ 
8. Resize to a **desktop** viewport.
9. 👀 Ensure the font library is not displayed. ✅ 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="250" alt="copons20260220 wordpress com_wp-admin_site-editor php_p=%2Fstyles section=%2Ftypography" src="https://github.com/user-attachments/assets/667f81af-3aac-4ae5-93f9-494f12f6c9a0" /> | <img width="250" alt="copons20260220 wordpress com_wp-admin_site-editor php_p=%2Fstyles (1)" src="https://github.com/user-attachments/assets/2afefbed-6a58-474d-83d3-d8c7908588b1" /> |

### Before

https://github.com/user-attachments/assets/d2ac17ea-7d8d-42c0-a388-c3b68be802b0

### After

https://github.com/user-attachments/assets/60b060cd-fd90-4472-9bed-d97a3f909c53