### PR TITLE
Icon Block: Clean up selectors config

### DIFF
--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -59,19 +59,9 @@
 		}
 	},
 	"selectors": {
-		"root": ".wp-block-icon",
-		"color": {
-			"root": ".wp-block-icon svg"
-		},
-		"border": {
-			"root": ".wp-block-icon svg"
-		},
+		"root": ".wp-block-icon svg",
 		"spacing": {
-			"padding": ".wp-block-icon svg"
-		},
-		"dimensions": {
-			"root": ".wp-block-icon svg",
-			"width": ".wp-block-icon svg"
+			"margin": ".wp-block-icon"
 		}
 	},
 	"style": "wp-block-icon",

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -60,6 +60,7 @@
 	},
 	"selectors": {
 		"root": ".wp-block-icon svg",
+		"css": ".wp-block-icon",
 		"spacing": {
 			"margin": ".wp-block-icon"
 		}


### PR DESCRIPTION
## What?

Simplifies the `selectors` configuration in the Icon block's `block.json`.

## Why?

The old config explicitly listed per-feature selectors (`color.root`, `border.root`, `spacing.padding`, `dimensions.root`) that all pointed to `.wp-block-icon svg`. This can be expressed more concisely by setting the top-level `root` to `.wp-block-icon svg` and only overriding `spacing.margin` to `.wp-block-icon`, since margin is the one property that should target the outer wrapper.

The old config also included a `dimensions.width` selector key, which had no effect given in already matched the dimensions root.

## How?

Replaces the per-feature selector overrides with a single top-level `root` selector set to `.wp-block-icon svg`, and an explicit `spacing.margin` override set to `.wp-block-icon`.

## Testing

No functional changes. The resolved selector for each feature remains the same:

| Feature | Selector |
|---|---|
| color | `.wp-block-icon svg` |
| border | `.wp-block-icon svg` |
| spacing.padding | `.wp-block-icon svg` |
| spacing.margin | `.wp-block-icon` |
| dimensions | `.wp-block-icon svg |

Smoke test global styles on the icon block