### PR TITLE
RTC: Add session activity notifications

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -26,10 +26,16 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		 * Awareness timeout in seconds. Clients that haven't updated
 		 * their awareness state within this time are considered disconnected.
 		 *
+		 * Background tabs poll every 30 s, but Chrome's intensive throttling
+		 * (after ~5 min in background) can delay polls to ~60 s. The timeout
+		 * must exceed that to avoid false disconnects.
+		 *
+		 * @see https://developer.chrome.com/blog/timer-throttling-in-chrome-88
+		 *
 		 * @since 7.0.0
 		 * @var int
 		 */
-		const AWARENESS_TIMEOUT = 30;
+		const AWARENESS_TIMEOUT = 70;
 
 		/**
 		 * Threshold used to signal clients to send a compaction update.

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -36,6 +36,10 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	protected equalityFieldChecks = {
 		...baseEqualityFieldChecks,
 		editorState: this.areEditorStatesEqual,
+		lastSaveEvent: (
+			a?: PostEditorState[ 'lastSaveEvent' ],
+			b?: PostEditorState[ 'lastSaveEvent' ]
+		) => a?.savedAt === b?.savedAt,
 	};
 
 	public constructor(

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -36,10 +36,6 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	protected equalityFieldChecks = {
 		...baseEqualityFieldChecks,
 		editorState: this.areEditorStatesEqual,
-		lastSaveEvent: (
-			a?: PostEditorState[ 'lastSaveEvent' ],
-			b?: PostEditorState[ 'lastSaveEvent' ]
-		) => a?.savedAt === b?.savedAt,
 	};
 
 	public constructor(

--- a/packages/core-data/src/awareness/types.ts
+++ b/packages/core-data/src/awareness/types.ts
@@ -94,3 +94,9 @@ export type EqualityFieldCheck< State, FieldName extends keyof State > = (
 	value1?: State[ FieldName ],
 	value2?: State[ FieldName ]
 ) => boolean;
+
+export interface PostSaveEvent {
+	savedAt: number;
+	savedByClientId: number;
+	postStatus: string | undefined;
+}

--- a/packages/core-data/src/awareness/types.ts
+++ b/packages/core-data/src/awareness/types.ts
@@ -34,21 +34,11 @@ export interface EditorState {
 }
 
 /**
- * Represents a save event broadcast via the awareness system.
- * `status` is the WordPress post status at the time of the save.
- */
-export interface SaveEvent {
-	savedAt: number;
-	status: string;
-}
-
-/**
  * The post editor state extends the base state with information used to render
  * presence indicators in the post editor.
  */
 export interface PostEditorState extends BaseState {
 	editorState?: EditorState;
-	lastSaveEvent?: SaveEvent;
 }
 
 /**

--- a/packages/core-data/src/awareness/types.ts
+++ b/packages/core-data/src/awareness/types.ts
@@ -34,11 +34,21 @@ export interface EditorState {
 }
 
 /**
+ * Represents a save event broadcast via the awareness system.
+ * `status` is the WordPress post status at the time of the save.
+ */
+export interface SaveEvent {
+	savedAt: number;
+	status: string;
+}
+
+/**
  * The post editor state extends the base state with information used to render
  * presence indicators in the post editor.
  */
 export interface PostEditorState extends BaseState {
 	editorState?: EditorState;
+	lastSaveEvent?: SaveEvent;
 }
 
 /**

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -155,4 +155,37 @@ export function useIsDisconnected(
 ): boolean {
 	return usePostEditorAwarenessState( postId, postType )
 		.isCurrentCollaboratorDisconnected;
+}
+
+/**
+ * Hook that returns a callback to broadcast a save event to all collaborators
+ * via the awareness system. When called, it sets the `lastSaveEvent` field on
+ * the local awareness state so that other collaborators can display a notification.
+ *
+ * @param postId   The ID of the post.
+ * @param postType The type of the post.
+ */
+export function useBroadcastSaveEvent(
+	postId: number | null,
+	postType: string | null
+): ( status: string ) => void {
+	return useCallback(
+		( status: string ) => {
+			if ( null === postId || null === postType ) {
+				return;
+			}
+
+			const awareness =
+				getSyncManager()?.getAwareness< PostEditorAwareness >(
+					`postType/${ postType }`,
+					postId.toString()
+				);
+
+			awareness?.setLocalStateField( 'lastSaveEvent', {
+				savedAt: Date.now(),
+				status,
+			} );
+		},
+		[ postId, postType ]
+	);
 }

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -10,6 +10,7 @@ import type { Y } from '@wordpress/sync';
 import { getSyncManager } from '../sync';
 import type {
 	PostEditorAwarenessState as ActiveCollaborator,
+	PostSaveEvent,
 	YDocDebugData,
 } from '../awareness/types';
 import type { SelectionState } from '../types';
@@ -156,12 +157,6 @@ export function useIsDisconnected(
 ): boolean {
 	return usePostEditorAwarenessState( postId, postType )
 		.isCurrentCollaboratorDisconnected;
-}
-
-export interface PostSaveEvent {
-	savedAt: number;
-	savedByClientId: number;
-	postStatus: string | undefined;
 }
 
 /**

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -161,6 +161,7 @@ export function useIsDisconnected(
 export interface PostSaveEvent {
 	savedAt: number;
 	savedByClientId: number;
+	postStatus: string | undefined;
 }
 
 /**
@@ -194,6 +195,7 @@ export function useLastPostSave(
 		}
 
 		const stateMap = awareness.doc.getMap( 'state' );
+		const recordMap = awareness.doc.getMap( 'document' );
 
 		// Only notify for saves that occur after the observer is
 		// set up. This prevents false notifications when the Y.Doc
@@ -210,7 +212,10 @@ export function useLastPostSave(
 					typeof savedByClientId === 'number' &&
 					savedAt > setupTime
 				) {
-					setLastSave( { savedAt, savedByClientId } );
+					const postStatus = recordMap.get( 'status' ) as
+						| string
+						| undefined;
+					setLastSave( { savedAt, savedByClientId, postStatus } );
 				}
 			}
 		};

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
+import type { Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies
@@ -157,35 +158,69 @@ export function useIsDisconnected(
 		.isCurrentCollaboratorDisconnected;
 }
 
+export interface PostSaveEvent {
+	savedAt: number;
+	savedByClientId: number;
+}
+
 /**
- * Hook that returns a callback to broadcast a save event to all collaborators
- * via the awareness system. When called, it sets the `lastSaveEvent` field on
- * the local awareness state so that other collaborators can display a notification.
+ * Hook that subscribes to the CRDT state map and returns the most recent
+ * save event (timestamp + client ID). The state map is updated by
+ * `markEntityAsSaved` in `@wordpress/sync`
  *
  * @param postId   The ID of the post.
  * @param postType The type of the post.
  */
-export function useBroadcastSaveEvent(
+export function useLastPostSave(
 	postId: number | null,
 	postType: string | null
-): ( status: string ) => void {
-	return useCallback(
-		( status: string ) => {
-			if ( null === postId || null === postType ) {
-				return;
+): PostSaveEvent | null {
+	const [ lastSave, setLastSave ] = useState< PostSaveEvent | null >( null );
+
+	useEffect( () => {
+		if ( null === postId || null === postType ) {
+			setLastSave( null );
+			return;
+		}
+
+		const awareness = getSyncManager()?.getAwareness< PostEditorAwareness >(
+			`postType/${ postType }`,
+			postId.toString()
+		);
+
+		if ( ! awareness ) {
+			setLastSave( null );
+			return;
+		}
+
+		const stateMap = awareness.doc.getMap( 'state' );
+
+		// Only notify for saves that occur after the observer is
+		// set up. This prevents false notifications when the Y.Doc
+		// syncs historical state on page load or peer reconnect.
+		const setupTime = Date.now();
+
+		const observer = ( event: Y.YMapEvent< unknown > ) => {
+			if ( event.keysChanged.has( 'savedAt' ) ) {
+				const savedAt = stateMap.get( 'savedAt' ) as number;
+				const savedByClientId = stateMap.get( 'savedBy' ) as number;
+
+				if (
+					typeof savedAt === 'number' &&
+					typeof savedByClientId === 'number' &&
+					savedAt > setupTime
+				) {
+					setLastSave( { savedAt, savedByClientId } );
+				}
 			}
+		};
 
-			const awareness =
-				getSyncManager()?.getAwareness< PostEditorAwareness >(
-					`postType/${ postType }`,
-					postId.toString()
-				);
+		stateMap.observe( observer );
 
-			awareness?.setLocalStateField( 'lastSaveEvent', {
-				savedAt: Date.now(),
-				status,
-			} );
-		},
-		[ postId, postType ]
-	);
+		return () => {
+			stateMap.unobserve( observer );
+		};
+	}, [ postId, postType ] );
+
+	return lastSave;
 }

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -6,6 +6,7 @@ import { RECEIVE_INTERMEDIATE_RESULTS } from './utils';
 import {
 	useActiveCollaborators,
 	useResolvedSelection,
+	useBroadcastSaveEvent,
 } from './hooks/use-post-editor-awareness-state';
 import { lock } from './lock-unlock';
 
@@ -15,4 +16,5 @@ lock( privateApis, {
 	RECEIVE_INTERMEDIATE_RESULTS,
 	useActiveCollaborators,
 	useResolvedSelection,
+	useBroadcastSaveEvent,
 } );

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -6,7 +6,7 @@ import { RECEIVE_INTERMEDIATE_RESULTS } from './utils';
 import {
 	useActiveCollaborators,
 	useResolvedSelection,
-	useBroadcastSaveEvent,
+	useLastPostSave,
 } from './hooks/use-post-editor-awareness-state';
 import { lock } from './lock-unlock';
 
@@ -16,5 +16,5 @@ lock( privateApis, {
 	RECEIVE_INTERMEDIATE_RESULTS,
 	useActiveCollaborators,
 	useResolvedSelection,
-	useBroadcastSaveEvent,
+	useLastPostSave,
 } );

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -1,0 +1,620 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useCollaboratorNotifications } from '../use-collaborator-notifications';
+
+// --- Mocks ---
+
+const mockCreateNotice = jest.fn();
+const mockBroadcastSaveEvent = jest.fn();
+let mockActiveCollaborators: any[] = [];
+let mockEditorState = {
+	isSaving: false,
+	isAutosaving: false,
+	didSaveSucceed: true,
+	postStatus: 'draft',
+	isCollaborationEnabled: true,
+};
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/hooks', () => ( {
+	applyFilters: jest.fn(
+		( _hook: string, defaultValue: unknown ) => defaultValue
+	),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
+} ) );
+
+// Mock the editor store to prevent deep import chain (blocks, rich-text, etc.)
+jest.mock( '../../../store', () => ( {
+	store: 'core/editor',
+} ) );
+
+// Mock the private APIs and unlock mechanism
+jest.mock( '@wordpress/core-data', () => ( {
+	privateApis: {},
+} ) );
+
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: jest.fn( () => ( {
+		useActiveCollaborators: jest.fn( () => mockActiveCollaborators ),
+		useBroadcastSaveEvent: jest.fn( () => mockBroadcastSaveEvent ),
+	} ) ),
+} ) );
+
+// --- Helpers ---
+
+const BASE_ENTERED_AT = 1704067200000;
+
+function makeCollaborator( overrides: Record< string, unknown > = {} ) {
+	return {
+		clientId: 1,
+		isMe: false,
+		isConnected: true,
+		collaboratorInfo: {
+			id: 100,
+			name: 'Alice',
+			slug: 'alice',
+			avatar_urls: {},
+			browserType: 'Chrome',
+			enteredAt: BASE_ENTERED_AT + 1000,
+		},
+		...overrides,
+	};
+}
+
+function makeMe( overrides: Record< string, unknown > = {} ) {
+	return makeCollaborator( {
+		clientId: 999,
+		isMe: true,
+		collaboratorInfo: {
+			id: 1,
+			name: 'Me',
+			slug: 'me',
+			avatar_urls: {},
+			browserType: 'Chrome',
+			enteredAt: BASE_ENTERED_AT + 5000, // joined later than Alice
+		},
+		...overrides,
+	} );
+}
+
+// --- Setup ---
+
+function buildMockSelect() {
+	return () => ( {
+		isSavingPost: () => mockEditorState.isSaving,
+		isAutosavingPost: () => mockEditorState.isAutosaving,
+		didPostSaveRequestSucceed: () => mockEditorState.didSaveSucceed,
+		getCurrentPostAttribute: ( attr: string ) =>
+			attr === 'status' ? mockEditorState.postStatus : undefined,
+		isCollaborationEnabledForCurrentPost: () =>
+			mockEditorState.isCollaborationEnabled,
+	} );
+}
+
+beforeEach( () => {
+	mockActiveCollaborators = [];
+	mockEditorState = {
+		isSaving: false,
+		isAutosaving: false,
+		didSaveSucceed: true,
+		postStatus: 'draft',
+		isCollaborationEnabled: true,
+	};
+	mockCreateNotice.mockClear();
+	mockBroadcastSaveEvent.mockClear();
+	( applyFilters as jest.Mock ).mockImplementation(
+		( _hook: string, defaultValue: unknown ) => defaultValue
+	);
+	( useSelect as jest.Mock ).mockImplementation( ( selector: Function ) =>
+		selector( buildMockSelect() )
+	);
+	( useDispatch as jest.Mock ).mockReturnValue( {
+		createNotice: mockCreateNotice,
+	} );
+} );
+
+// --- Tests ---
+
+describe( 'useCollaboratorNotifications', () => {
+	describe( 'initial mount', () => {
+		it( 'does not fire join notifications for collaborators already present on mount', () => {
+			mockActiveCollaborators = [ makeMe(), makeCollaborator() ];
+
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire any notification when no collaborators are present', () => {
+			mockActiveCollaborators = [];
+
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire join notifications when collaborators load after an initially empty state', () => {
+			// Simulates the store hydrating: first render has no collaborators,
+			// second render receives the full list.
+			mockActiveCollaborators = [];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [ makeMe(), makeCollaborator() ];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'collaborator join notifications', () => {
+		it( 'does not fire a join notification for the current user', () => {
+			mockActiveCollaborators = [];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [ makeMe() ];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'skips join notification for collaborators who joined before current user', () => {
+			// Alice joined BEFORE the current user (smaller enteredAt)
+			const me = makeMe(); // enteredAt: BASE_ENTERED_AT + 5000
+			const aliceJoinedFirst = makeCollaborator( {
+				collaboratorInfo: {
+					id: 100,
+					name: 'Alice',
+					slug: 'alice',
+					avatar_urls: {},
+					browserType: 'Chrome',
+					enteredAt: BASE_ENTERED_AT + 1000, // joined earlier than me
+				},
+			} );
+
+			mockActiveCollaborators = [ me ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Alice appears in the state — but she was there before us
+			mockActiveCollaborators = [ me, aliceJoinedFirst ];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'fires join notification for a collaborator who joined after current user', () => {
+			const me = makeMe(); // enteredAt: BASE_ENTERED_AT + 5000
+			const bobJoinedAfter = makeCollaborator( {
+				clientId: 2,
+				collaboratorInfo: {
+					id: 200,
+					name: 'Bob',
+					slug: 'bob',
+					avatar_urls: {},
+					browserType: 'Firefox',
+					enteredAt: BASE_ENTERED_AT + 10000, // joined after me
+				},
+			} );
+
+			mockActiveCollaborators = [ me ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [ me, bobJoinedAfter ];
+			rerender();
+
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Bob has joined the post.',
+				expect.objectContaining( {
+					id: 'collab-user-entered-200',
+				} )
+			);
+		} );
+	} );
+
+	describe( 'collaborator leave notifications', () => {
+		it( 'fires a leave notification when a collaborator disconnects (isConnected → false)', () => {
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Alice disconnects — still in the list but greyed out.
+			mockActiveCollaborators = [
+				makeMe(),
+				{ ...alice, isConnected: false },
+			];
+			rerender();
+
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Alice has left the post.',
+				expect.objectContaining( {
+					type: 'snackbar',
+					isDismissible: false,
+					id: 'collab-user-exited-100',
+				} )
+			);
+		} );
+
+		it( 'does not fire a duplicate leave notification when a disconnected collaborator is removed from the list', () => {
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Alice disconnects (greyed out).
+			mockActiveCollaborators = [
+				makeMe(),
+				{ ...alice, isConnected: false },
+			];
+			rerender();
+			mockCreateNotice.mockClear();
+
+			// After the 5s delay Alice is fully removed from the list.
+			mockActiveCollaborators = [ makeMe() ];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'fires a leave notification when a connected collaborator is removed from the list directly', () => {
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Alice disappears from the list without going through isConnected=false
+			// (e.g. polling detects the disconnect and removes in one update).
+			mockActiveCollaborators = [ makeMe() ];
+			rerender();
+
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Alice has left the post.',
+				expect.objectContaining( {
+					type: 'snackbar',
+					isDismissible: false,
+					id: 'collab-user-exited-100',
+				} )
+			);
+		} );
+
+		it( 'does not fire a leave notification for the current user', () => {
+			const me = makeMe();
+			mockActiveCollaborators = [ me, makeCollaborator() ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// "Me" disconnects
+			mockActiveCollaborators = [
+				{ ...me, isConnected: false },
+				makeCollaborator(),
+			];
+			rerender();
+
+			// Should not notify about self
+			const selfLeaveCall = mockCreateNotice.mock.calls.find(
+				( [ , message ] ) => message.includes( 'Me' )
+			);
+			expect( selfLeaveCall ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'post updated notifications', () => {
+		it( 'fires a post updated notification when a collaborator saves (draft)', () => {
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Alice saves the post (draft status)
+			mockActiveCollaborators = [
+				makeMe(),
+				{
+					...alice,
+					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
+				},
+			];
+			rerender();
+
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Draft saved by Alice.',
+				expect.objectContaining( {
+					type: 'snackbar',
+					isDismissible: false,
+					id: 'collab-post-updated-100',
+				} )
+			);
+		} );
+
+		it( 'fires a post updated notification with "Post updated" for published status', () => {
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [
+				makeMe(),
+				{
+					...alice,
+					lastSaveEvent: {
+						savedAt: Date.now(),
+						status: 'publish',
+					},
+				},
+			];
+			rerender();
+
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Post updated by Alice.',
+				expect.objectContaining( {
+					id: 'collab-post-updated-100',
+				} )
+			);
+		} );
+
+		it( 'does not fire a post updated notification on the initial mount even with a saveEvent', () => {
+			mockActiveCollaborators = [
+				makeMe(),
+				{
+					...makeCollaborator(),
+					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
+				},
+			];
+
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire a post updated notification for a newly appeared collaborator with a historical save event', () => {
+			const me = makeMe();
+			mockActiveCollaborators = [ me ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Alice appears for the first time carrying a save event from
+			// before our session — should not trigger a notification.
+			mockActiveCollaborators = [
+				me,
+				{
+					...makeCollaborator( {
+						collaboratorInfo: {
+							id: 100,
+							name: 'Alice',
+							slug: 'alice',
+							avatar_urls: {},
+							browserType: 'Chrome',
+							enteredAt: BASE_ENTERED_AT + 10000,
+						},
+					} ),
+					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
+				},
+			];
+			rerender();
+
+			// The join notification fires, but no save notification.
+			expect( mockCreateNotice ).toHaveBeenCalledTimes( 1 );
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Alice has joined the post.',
+				expect.objectContaining( {
+					id: 'collab-user-entered-100',
+				} )
+			);
+		} );
+
+		it( 'does not fire duplicate notifications for the same savedAt timestamp', () => {
+			const savedAt = Date.now();
+			const alice = {
+				...makeCollaborator(),
+				lastSaveEvent: { savedAt, status: 'draft' },
+			};
+
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Simulate a re-render with the same saveEvent
+			mockActiveCollaborators = [ makeMe(), { ...alice } ];
+			rerender();
+
+			// The initial mount should record it, not notify.
+			// A subsequent rerender with the same savedAt should not notify either.
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'WordPress filter: editor.collaborationNotifications', () => {
+		it( 'suppresses join notifications when userEntered is false', () => {
+			( applyFilters as jest.Mock ).mockReturnValue( {
+				userEntered: false,
+				userExited: true,
+				postUpdated: true,
+			} );
+
+			mockActiveCollaborators = [ makeMe() ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [
+				makeMe(),
+				makeCollaborator( {
+					collaboratorInfo: {
+						id: 100,
+						name: 'Alice',
+						slug: 'alice',
+						avatar_urls: {},
+						browserType: 'Chrome',
+						enteredAt: BASE_ENTERED_AT + 10000,
+					},
+				} ),
+			];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'suppresses leave notifications when userExited is false', () => {
+			( applyFilters as jest.Mock ).mockReturnValue( {
+				userEntered: true,
+				userExited: false,
+				postUpdated: true,
+			} );
+
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [ makeMe() ];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'suppresses post updated notifications when postUpdated is false', () => {
+			( applyFilters as jest.Mock ).mockReturnValue( {
+				userEntered: true,
+				userExited: true,
+				postUpdated: false,
+			} );
+
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockActiveCollaborators = [
+				makeMe(),
+				{
+					...alice,
+					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
+				},
+			];
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'save event broadcasting', () => {
+		it( 'broadcasts save event when save transitions from in-progress to complete', () => {
+			mockActiveCollaborators = [];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Save starts
+			mockEditorState = {
+				...mockEditorState,
+				isSaving: true,
+				isAutosaving: false,
+			};
+			rerender();
+
+			// Save completes
+			mockEditorState = {
+				...mockEditorState,
+				isSaving: false,
+				isAutosaving: false,
+				didSaveSucceed: true,
+				postStatus: 'draft',
+			};
+			rerender();
+
+			expect( mockBroadcastSaveEvent ).toHaveBeenCalledWith( 'draft' );
+		} );
+
+		it( 'does not broadcast save event for autosaves', () => {
+			mockActiveCollaborators = [];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// Autosave starts
+			mockEditorState = {
+				...mockEditorState,
+				isSaving: true,
+				isAutosaving: true,
+			};
+			rerender();
+
+			// Autosave completes
+			mockEditorState = {
+				...mockEditorState,
+				isSaving: false,
+				isAutosaving: false,
+			};
+			rerender();
+
+			expect( mockBroadcastSaveEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not broadcast when collaboration is not enabled', () => {
+			mockEditorState = {
+				...mockEditorState,
+				isCollaborationEnabled: false,
+			};
+			mockActiveCollaborators = [];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			mockEditorState = {
+				...mockEditorState,
+				isSaving: true,
+				isCollaborationEnabled: false,
+			};
+			rerender();
+
+			mockEditorState = {
+				...mockEditorState,
+				isSaving: false,
+			};
+			rerender();
+
+			expect( mockBroadcastSaveEvent ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -7,7 +7,6 @@ import { renderHook } from '@testing-library/react';
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -28,12 +27,6 @@ let mockEditorState = {
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 	useDispatch: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/hooks', () => ( {
-	applyFilters: jest.fn(
-		( _hook: string, defaultValue: unknown ) => defaultValue
-	),
 } ) );
 
 jest.mock( '@wordpress/notices', () => ( {
@@ -113,9 +106,6 @@ beforeEach( () => {
 		isCollaborationEnabled: true,
 	};
 	mockCreateNotice.mockClear();
-	( applyFilters as jest.Mock ).mockImplementation(
-		( _hook: string, defaultValue: unknown ) => defaultValue
-	);
 	( useSelect as jest.Mock ).mockImplementation( ( selector: Function ) =>
 		selector( buildMockSelect() )
 	);
@@ -455,79 +445,6 @@ describe( 'useCollaboratorNotifications', () => {
 			mockLastPostSave = {
 				savedAt: Date.now(),
 				savedByClientId: 12345,
-			};
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-	} );
-
-	describe( 'WordPress filter: editor.collaborationNotifications', () => {
-		it( 'suppresses join notifications when userEntered is false', () => {
-			( applyFilters as jest.Mock ).mockReturnValue( {
-				userEntered: false,
-				userExited: true,
-				postUpdated: true,
-			} );
-
-			mockActiveCollaborators = [ makeMe() ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			mockActiveCollaborators = [
-				makeMe(),
-				makeCollaborator( {
-					collaboratorInfo: {
-						id: 100,
-						name: 'Alice',
-						slug: 'alice',
-						avatar_urls: {},
-						browserType: 'Chrome',
-						enteredAt: BASE_ENTERED_AT + 10000,
-					},
-				} ),
-			];
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'suppresses leave notifications when userExited is false', () => {
-			( applyFilters as jest.Mock ).mockReturnValue( {
-				userEntered: true,
-				userExited: false,
-				postUpdated: true,
-			} );
-
-			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			mockActiveCollaborators = [ makeMe() ];
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'suppresses post updated notifications when postUpdated is false', () => {
-			( applyFilters as jest.Mock ).mockReturnValue( {
-				userEntered: true,
-				userExited: true,
-				postUpdated: false,
-			} );
-
-			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			mockLastPostSave = {
-				savedAt: Date.now(),
-				savedByClientId: alice.clientId,
 			};
 			rerender();
 

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -17,12 +17,10 @@ import { useCollaboratorNotifications } from '../use-collaborator-notifications'
 // --- Mocks ---
 
 const mockCreateNotice = jest.fn();
-const mockBroadcastSaveEvent = jest.fn();
 let mockActiveCollaborators: any[] = [];
+let mockLastPostSave: { savedAt: number; savedByClientId: number } | null =
+	null;
 let mockEditorState = {
-	isSaving: false,
-	isAutosaving: false,
-	didSaveSucceed: true,
 	postStatus: 'draft',
 	isCollaborationEnabled: true,
 };
@@ -55,7 +53,7 @@ jest.mock( '@wordpress/core-data', () => ( {
 jest.mock( '../../../lock-unlock', () => ( {
 	unlock: jest.fn( () => ( {
 		useActiveCollaborators: jest.fn( () => mockActiveCollaborators ),
-		useBroadcastSaveEvent: jest.fn( () => mockBroadcastSaveEvent ),
+		useLastPostSave: jest.fn( () => mockLastPostSave ),
 	} ) ),
 } ) );
 
@@ -100,9 +98,6 @@ function makeMe( overrides: Record< string, unknown > = {} ) {
 
 function buildMockSelect() {
 	return () => ( {
-		isSavingPost: () => mockEditorState.isSaving,
-		isAutosavingPost: () => mockEditorState.isAutosaving,
-		didPostSaveRequestSucceed: () => mockEditorState.didSaveSucceed,
 		getCurrentPostAttribute: ( attr: string ) =>
 			attr === 'status' ? mockEditorState.postStatus : undefined,
 		isCollaborationEnabledForCurrentPost: () =>
@@ -112,15 +107,12 @@ function buildMockSelect() {
 
 beforeEach( () => {
 	mockActiveCollaborators = [];
+	mockLastPostSave = null;
 	mockEditorState = {
-		isSaving: false,
-		isAutosaving: false,
-		didSaveSucceed: true,
 		postStatus: 'draft',
 		isCollaborationEnabled: true,
 	};
 	mockCreateNotice.mockClear();
-	mockBroadcastSaveEvent.mockClear();
 	( applyFilters as jest.Mock ).mockImplementation(
 		( _hook: string, defaultValue: unknown ) => defaultValue
 	);
@@ -339,14 +331,11 @@ describe( 'useCollaboratorNotifications', () => {
 				useCollaboratorNotifications( 123, 'post' )
 			);
 
-			// Alice saves the post (draft status)
-			mockActiveCollaborators = [
-				makeMe(),
-				{
-					...alice,
-					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
-				},
-			];
+			// State map reports Alice saved
+			mockLastPostSave = {
+				savedAt: Date.now(),
+				savedByClientId: alice.clientId,
+			};
 			rerender();
 
 			expect( mockCreateNotice ).toHaveBeenCalledWith(
@@ -361,22 +350,20 @@ describe( 'useCollaboratorNotifications', () => {
 		} );
 
 		it( 'fires a post updated notification with "Post updated" for published status', () => {
+			mockEditorState = {
+				...mockEditorState,
+				postStatus: 'publish',
+			};
 			const alice = makeCollaborator();
 			mockActiveCollaborators = [ makeMe(), alice ];
 			const { rerender } = renderHook( () =>
 				useCollaboratorNotifications( 123, 'post' )
 			);
 
-			mockActiveCollaborators = [
-				makeMe(),
-				{
-					...alice,
-					lastSaveEvent: {
-						savedAt: Date.now(),
-						status: 'publish',
-					},
-				},
-			];
+			mockLastPostSave = {
+				savedAt: Date.now(),
+				savedByClientId: alice.clientId,
+			};
 			rerender();
 
 			expect( mockCreateNotice ).toHaveBeenCalledWith(
@@ -388,76 +375,89 @@ describe( 'useCollaboratorNotifications', () => {
 			);
 		} );
 
-		it( 'does not fire a post updated notification on the initial mount even with a saveEvent', () => {
-			mockActiveCollaborators = [
-				makeMe(),
-				{
-					...makeCollaborator(),
-					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
-				},
-			];
-
-			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not fire a post updated notification for a newly appeared collaborator with a historical save event', () => {
+		it( 'does not fire a notification when the current user saves', () => {
 			const me = makeMe();
-			mockActiveCollaborators = [ me ];
+			mockActiveCollaborators = [ me, makeCollaborator() ];
 			const { rerender } = renderHook( () =>
 				useCollaboratorNotifications( 123, 'post' )
 			);
 
-			// Alice appears for the first time carrying a save event from
-			// before our session — should not trigger a notification.
-			mockActiveCollaborators = [
-				me,
-				{
-					...makeCollaborator( {
-						collaboratorInfo: {
-							id: 100,
-							name: 'Alice',
-							slug: 'alice',
-							avatar_urls: {},
-							browserType: 'Chrome',
-							enteredAt: BASE_ENTERED_AT + 10000,
-						},
-					} ),
-					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
-				},
-			];
+			// State map reports "me" saved
+			mockLastPostSave = {
+				savedAt: Date.now(),
+				savedByClientId: me.clientId,
+			};
 			rerender();
 
-			// The join notification fires, but no save notification.
-			expect( mockCreateNotice ).toHaveBeenCalledTimes( 1 );
-			expect( mockCreateNotice ).toHaveBeenCalledWith(
-				'info',
-				'Alice has joined the post.',
-				expect.objectContaining( {
-					id: 'collab-user-entered-100',
-				} )
-			);
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
 		} );
 
 		it( 'does not fire duplicate notifications for the same savedAt timestamp', () => {
+			const alice = makeCollaborator();
+			mockActiveCollaborators = [ makeMe(), alice ];
 			const savedAt = Date.now();
-			const alice = {
-				...makeCollaborator(),
-				lastSaveEvent: { savedAt, status: 'draft' },
-			};
 
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// First save event
+			mockLastPostSave = {
+				savedAt,
+				savedByClientId: alice.clientId,
+			};
+			rerender();
+			mockCreateNotice.mockClear();
+
+			// Rerender with same savedAt — should not notify again
+			rerender();
+
+			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire a notification when a peer reconnects without a new save', () => {
+			const alice = makeCollaborator();
 			mockActiveCollaborators = [ makeMe(), alice ];
 			const { rerender } = renderHook( () =>
 				useCollaboratorNotifications( 123, 'post' )
 			);
 
-			// Simulate a re-render with the same saveEvent
-			mockActiveCollaborators = [ makeMe(), { ...alice } ];
+			// Alice disconnects and reconnects — useLastPostSave filters
+			// pre-existing state map values via its baseline check, so
+			// lastPostSave stays null.
+			mockActiveCollaborators = [
+				makeMe(),
+				{ ...alice, isConnected: false },
+			];
+			rerender();
+			mockCreateNotice.mockClear();
+
+			mockActiveCollaborators = [
+				makeMe(),
+				{ ...alice, clientId: 50, isConnected: true },
+			];
 			rerender();
 
-			// The initial mount should record it, not notify.
-			// A subsequent rerender with the same savedAt should not notify either.
+			// Only the leave/join notices should have fired, no save notice.
+			const saveNotice = mockCreateNotice.mock.calls.find(
+				( [ , msg ] ) => ( msg as string ).includes( 'saved' )
+			);
+			expect( saveNotice ).toBeUndefined();
+		} );
+
+		it( 'does not fire a notification when the saver is not in the collaborator list', () => {
+			mockActiveCollaborators = [ makeMe(), makeCollaborator() ];
+			const { rerender } = renderHook( () =>
+				useCollaboratorNotifications( 123, 'post' )
+			);
+
+			// State map reports a save by unknown clientId
+			mockLastPostSave = {
+				savedAt: Date.now(),
+				savedByClientId: 12345,
+			};
+			rerender();
+
 			expect( mockCreateNotice ).not.toHaveBeenCalled();
 		} );
 	} );
@@ -525,96 +525,13 @@ describe( 'useCollaboratorNotifications', () => {
 				useCollaboratorNotifications( 123, 'post' )
 			);
 
-			mockActiveCollaborators = [
-				makeMe(),
-				{
-					...alice,
-					lastSaveEvent: { savedAt: Date.now(), status: 'draft' },
-				},
-			];
+			mockLastPostSave = {
+				savedAt: Date.now(),
+				savedByClientId: alice.clientId,
+			};
 			rerender();
 
 			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-	} );
-
-	describe( 'save event broadcasting', () => {
-		it( 'broadcasts save event when save transitions from in-progress to complete', () => {
-			mockActiveCollaborators = [];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// Save starts
-			mockEditorState = {
-				...mockEditorState,
-				isSaving: true,
-				isAutosaving: false,
-			};
-			rerender();
-
-			// Save completes
-			mockEditorState = {
-				...mockEditorState,
-				isSaving: false,
-				isAutosaving: false,
-				didSaveSucceed: true,
-				postStatus: 'draft',
-			};
-			rerender();
-
-			expect( mockBroadcastSaveEvent ).toHaveBeenCalledWith( 'draft' );
-		} );
-
-		it( 'does not broadcast save event for autosaves', () => {
-			mockActiveCollaborators = [];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// Autosave starts
-			mockEditorState = {
-				...mockEditorState,
-				isSaving: true,
-				isAutosaving: true,
-			};
-			rerender();
-
-			// Autosave completes
-			mockEditorState = {
-				...mockEditorState,
-				isSaving: false,
-				isAutosaving: false,
-			};
-			rerender();
-
-			expect( mockBroadcastSaveEvent ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not broadcast when collaboration is not enabled', () => {
-			mockEditorState = {
-				...mockEditorState,
-				isCollaborationEnabled: false,
-			};
-			mockActiveCollaborators = [];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			mockEditorState = {
-				...mockEditorState,
-				isSaving: true,
-				isCollaborationEnabled: false,
-			};
-			rerender();
-
-			mockEditorState = {
-				...mockEditorState,
-				isSaving: false,
-			};
-			rerender();
-
-			expect( mockBroadcastSaveEvent ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -18,7 +18,7 @@ import {
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-const { useActiveCollaborators, useBroadcastSaveEvent } = unlock( privateApis );
+const { useActiveCollaborators, useLastPostSave } = unlock( privateApis );
 
 /**
  * Notice IDs for each notification type. Using stable IDs prevents duplicate
@@ -77,20 +77,11 @@ export function useCollaboratorNotifications(
 		postType
 	) as PostEditorAwarenessState[];
 
-	const broadcastSaveEvent = useBroadcastSaveEvent( postId, postType );
+	const lastPostSave = useLastPostSave( postId, postType );
 
-	const {
-		isSaving,
-		isAutosaving,
-		didSaveSucceed,
-		postStatus,
-		isCollaborationEnabled,
-	} = useSelect( ( select ) => {
+	const { postStatus, isCollaborationEnabled } = useSelect( ( select ) => {
 		const editorSel = select( editorStore );
 		return {
-			isSaving: editorSel.isSavingPost(),
-			isAutosaving: editorSel.isAutosavingPost(),
-			didSaveSucceed: editorSel.didPostSaveRequestSucceed(),
 			postStatus: editorSel.getCurrentPostAttribute( 'status' ) as
 				| string
 				| undefined,
@@ -111,33 +102,10 @@ export function useCollaboratorNotifications(
 	);
 
 	const prevCollaborators = usePrevious( activeCollaborators );
-	const prevIsSaving = usePrevious( isSaving );
-	const prevIsAutosaving = usePrevious( isAutosaving );
-
-	// Broadcast our own saves to collaborators via awareness.
-	useEffect( () => {
-		if (
-			prevIsSaving &&
-			! isSaving &&
-			! prevIsAutosaving &&
-			didSaveSucceed &&
-			isCollaborationEnabled &&
-			postStatus
-		) {
-			broadcastSaveEvent( postStatus );
-		}
-	}, [
-		isSaving,
-		prevIsSaving,
-		prevIsAutosaving,
-		didSaveSucceed,
-		postStatus,
-		isCollaborationEnabled,
-		broadcastSaveEvent,
-	] );
+	const prevPostSave = usePrevious( lastPostSave );
 
 	/*
-	 * Detect collaborator joins, leaves, and remote saves.
+	 * Detect collaborator joins and leaves.
 	 */
 	useEffect( () => {
 		if ( ! isCollaborationEnabled ) {
@@ -153,9 +121,6 @@ export function useCollaboratorNotifications(
 			return;
 		}
 
-		/*
-		 * Convenience wrapper to keep notice calls concise.
-		 */
 		function notify( noticeId: string, message: string ) {
 			void createNotice( 'info', message, {
 				id: noticeId,
@@ -235,44 +200,57 @@ export function useCollaboratorNotifications(
 				);
 			}
 		}
-
-		// Detect remote save events from other collaborators.
-		if ( notificationsConfig.postUpdated ) {
-			for ( const [ clientId, collaborator ] of newMap ) {
-				if ( collaborator.isMe || ! collaborator.lastSaveEvent ) {
-					continue;
-				}
-
-				const prevCollab = prevMap.get( clientId );
-
-				/*
-				 * Only notify for save events from collaborators we already
-				 * knew about. A newly appeared collaborator may carry a
-				 * historical save event that predates our session.
-				 */
-				if ( ! prevCollab ) {
-					continue;
-				}
-
-				const prevSavedAt = prevCollab.lastSaveEvent?.savedAt;
-				const { savedAt, status } = collaborator.lastSaveEvent;
-
-				if ( savedAt > ( prevSavedAt ?? 0 ) ) {
-					notify(
-						`${ NOTIFICATION_TYPE.POST_UPDATED }-${ collaborator.collaboratorInfo.id }`,
-						getPostUpdatedMessage(
-							collaborator.collaboratorInfo.name,
-							status
-						)
-					);
-				}
-			}
-		}
 	}, [
 		activeCollaborators,
 		prevCollaborators,
 		isCollaborationEnabled,
 		notificationsConfig,
+		createNotice,
+	] );
+
+	/*
+	 * Detect remote save events via the CRDT state map. The savedByClientId
+	 * is a Y.Doc client ID which maps to a collaborator via clientId.
+	 */
+	useEffect( () => {
+		if (
+			! isCollaborationEnabled ||
+			! notificationsConfig.postUpdated ||
+			! lastPostSave ||
+			! postStatus
+		) {
+			return;
+		}
+
+		if ( prevPostSave && lastPostSave.savedAt === prevPostSave.savedAt ) {
+			return;
+		}
+
+		const saver = activeCollaborators.find(
+			( c ) => c.clientId === lastPostSave.savedByClientId && ! c.isMe
+		);
+
+		if ( ! saver ) {
+			return;
+		}
+
+		const message = getPostUpdatedMessage(
+			saver.collaboratorInfo.name,
+			postStatus
+		);
+
+		void createNotice( 'info', message, {
+			id: `${ NOTIFICATION_TYPE.POST_UPDATED }-${ saver.collaboratorInfo.id }`,
+			type: 'snackbar',
+			isDismissible: false,
+		} );
+	}, [
+		lastPostSave,
+		prevPostSave,
+		activeCollaborators,
+		isCollaborationEnabled,
+		notificationsConfig,
+		postStatus,
 		createNotice,
 	] );
 }

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -3,8 +3,7 @@
  */
 import { usePrevious } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useMemo } from '@wordpress/element';
-import { applyFilters } from '@wordpress/hooks';
+import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import {
@@ -30,13 +29,7 @@ const NOTIFICATION_TYPE = {
 	USER_EXITED: 'collab-user-exited',
 } as const;
 
-interface CollaborationNotificationsConfig {
-	userEntered: boolean;
-	userExited: boolean;
-	postUpdated: boolean;
-}
-
-const DEFAULT_NOTIFICATIONS_CONFIG: CollaborationNotificationsConfig = {
+const NOTIFICATIONS_CONFIG = {
 	userEntered: true,
 	userExited: true,
 	postUpdated: true,
@@ -72,9 +65,6 @@ function getPostUpdatedMessage(
  * Hook that watches for collaborator join/leave events and remote save events,
  * dispatching snackbar notices accordingly.
  *
- * Notification types can be enabled/disabled via the
- * `editor.collaborationNotifications` WordPress filter.
- *
  * @param postId   The ID of the post being edited.
  * @param postType The post type of the post being edited.
  */
@@ -101,15 +91,6 @@ export function useCollaboratorNotifications(
 	}, [] );
 
 	const { createNotice } = useDispatch( noticesStore );
-
-	const notificationsConfig = useMemo(
-		() =>
-			applyFilters(
-				'editor.collaborationNotifications',
-				DEFAULT_NOTIFICATIONS_CONFIG
-			) as CollaborationNotificationsConfig,
-		[]
-	);
 
 	const prevCollaborators = usePrevious( activeCollaborators );
 	const prevPostSave = usePrevious( lastPostSave );
@@ -149,7 +130,7 @@ export function useCollaboratorNotifications(
 		/*
 		 * Detect joins: new clientIds that weren't in the previous state.
 		 */
-		if ( notificationsConfig.userEntered ) {
+		if ( NOTIFICATIONS_CONFIG.userEntered ) {
 			const me = activeCollaborators.find( ( c ) => c.isMe );
 
 			for ( const [ clientId, collaborator ] of newMap ) {
@@ -189,7 +170,7 @@ export function useCollaboratorNotifications(
 		 * Already-disconnected collaborators that are later removed from the
 		 * list (after the 5 s delay) are silently ignored.
 		 */
-		if ( notificationsConfig.userExited ) {
+		if ( NOTIFICATIONS_CONFIG.userExited ) {
 			for ( const [ clientId, prevCollab ] of prevMap ) {
 				if ( prevCollab.isMe || ! prevCollab.isConnected ) {
 					continue;
@@ -214,7 +195,6 @@ export function useCollaboratorNotifications(
 		activeCollaborators,
 		prevCollaborators,
 		isCollaborationEnabled,
-		notificationsConfig,
 		createNotice,
 	] );
 
@@ -225,7 +205,7 @@ export function useCollaboratorNotifications(
 	useEffect( () => {
 		if (
 			! isCollaborationEnabled ||
-			! notificationsConfig.postUpdated ||
+			! NOTIFICATIONS_CONFIG.postUpdated ||
 			! lastPostSave ||
 			! postStatus
 		) {
@@ -272,7 +252,6 @@ export function useCollaboratorNotifications(
 		prevPostSave,
 		activeCollaborators,
 		isCollaborationEnabled,
-		notificationsConfig,
 		postStatus,
 		createNotice,
 	] );

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -42,15 +42,25 @@ const DEFAULT_NOTIFICATIONS_CONFIG: CollaborationNotificationsConfig = {
 	postUpdated: true,
 };
 
+const PUBLISHED_STATUSES = [ 'publish', 'private', 'future' ];
+
 /**
- * Returns the snackbar message for a post updated notification based on post status.
+ * Returns the snackbar message for a post updated notification.
  *
- * @param name   Display name of the collaborator who saved.
- * @param status WordPress post status at the time of save.
+ * @param name           Display name of the collaborator who saved.
+ * @param status         WordPress post status at the time of save.
+ * @param isFirstPublish Whether this save transitioned the post to published.
  */
-function getPostUpdatedMessage( name: string, status: string ): string {
-	const isPublished = [ 'publish', 'private', 'future' ].includes( status );
-	if ( isPublished ) {
+function getPostUpdatedMessage(
+	name: string,
+	status: string,
+	isFirstPublish: boolean
+): string {
+	if ( isFirstPublish ) {
+		/* translators: %s: collaborator display name */
+		return sprintf( __( 'Post published by %s.' ), name );
+	}
+	if ( PUBLISHED_STATUSES.includes( status ) ) {
 		/* translators: %s: collaborator display name */
 		return sprintf( __( 'Post updated by %s.' ), name );
 	}
@@ -234,9 +244,22 @@ export function useCollaboratorNotifications(
 			return;
 		}
 
+		// Prefer the remote status from Y.Doc (accurate at save time) over
+		// the local Redux value, which may not have synced yet.
+		const effectiveStatus =
+			lastPostSave.postStatus ?? postStatus ?? 'draft';
+
+		// prevPostSave is null on the first save this session, so fall back
+		// to the Redux status (still pre-save when the notification fires).
+		const prevStatus = prevPostSave?.postStatus ?? postStatus;
+		const isFirstPublish =
+			! ( prevStatus && PUBLISHED_STATUSES.includes( prevStatus ) ) &&
+			PUBLISHED_STATUSES.includes( effectiveStatus );
+
 		const message = getPostUpdatedMessage(
 			saver.collaboratorInfo.name,
-			postStatus
+			effectiveStatus,
+			isFirstPublish
 		);
 
 		void createNotice( 'info', message, {

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -1,0 +1,278 @@
+/**
+ * WordPress dependencies
+ */
+import { usePrevious } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useMemo } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	privateApis,
+	type PostEditorAwarenessState,
+} from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
+
+const { useActiveCollaborators, useBroadcastSaveEvent } = unlock( privateApis );
+
+/**
+ * Notice IDs for each notification type. Using stable IDs prevents duplicate
+ * notices if the same event is processed more than once.
+ */
+const NOTIFICATION_TYPE = {
+	POST_UPDATED: 'collab-post-updated',
+	USER_ENTERED: 'collab-user-entered',
+	USER_EXITED: 'collab-user-exited',
+} as const;
+
+interface CollaborationNotificationsConfig {
+	userEntered: boolean;
+	userExited: boolean;
+	postUpdated: boolean;
+}
+
+const DEFAULT_NOTIFICATIONS_CONFIG: CollaborationNotificationsConfig = {
+	userEntered: true,
+	userExited: true,
+	postUpdated: true,
+};
+
+/**
+ * Returns the snackbar message for a post updated notification based on post status.
+ *
+ * @param name   Display name of the collaborator who saved.
+ * @param status WordPress post status at the time of save.
+ */
+function getPostUpdatedMessage( name: string, status: string ): string {
+	const isPublished = [ 'publish', 'private', 'future' ].includes( status );
+	if ( isPublished ) {
+		/* translators: %s: collaborator display name */
+		return sprintf( __( 'Post updated by %s.' ), name );
+	}
+	/* translators: %s: collaborator display name */
+	return sprintf( __( 'Draft saved by %s.' ), name );
+}
+
+/**
+ * Hook that watches for collaborator join/leave events and remote save events,
+ * dispatching snackbar notices accordingly.
+ *
+ * Notification types can be enabled/disabled via the
+ * `editor.collaborationNotifications` WordPress filter.
+ *
+ * @param postId   The ID of the post being edited.
+ * @param postType The post type of the post being edited.
+ */
+export function useCollaboratorNotifications(
+	postId: number | null,
+	postType: string | null
+): void {
+	const activeCollaborators = useActiveCollaborators(
+		postId,
+		postType
+	) as PostEditorAwarenessState[];
+
+	const broadcastSaveEvent = useBroadcastSaveEvent( postId, postType );
+
+	const {
+		isSaving,
+		isAutosaving,
+		didSaveSucceed,
+		postStatus,
+		isCollaborationEnabled,
+	} = useSelect( ( select ) => {
+		const editorSel = select( editorStore );
+		return {
+			isSaving: editorSel.isSavingPost(),
+			isAutosaving: editorSel.isAutosavingPost(),
+			didSaveSucceed: editorSel.didPostSaveRequestSucceed(),
+			postStatus: editorSel.getCurrentPostAttribute( 'status' ) as
+				| string
+				| undefined,
+			isCollaborationEnabled:
+				editorSel.isCollaborationEnabledForCurrentPost(),
+		};
+	}, [] );
+
+	const { createNotice } = useDispatch( noticesStore );
+
+	const notificationsConfig = useMemo(
+		() =>
+			applyFilters(
+				'editor.collaborationNotifications',
+				DEFAULT_NOTIFICATIONS_CONFIG
+			) as CollaborationNotificationsConfig,
+		[]
+	);
+
+	const prevCollaborators = usePrevious( activeCollaborators );
+	const prevIsSaving = usePrevious( isSaving );
+	const prevIsAutosaving = usePrevious( isAutosaving );
+
+	// Broadcast our own saves to collaborators via awareness.
+	useEffect( () => {
+		if (
+			prevIsSaving &&
+			! isSaving &&
+			! prevIsAutosaving &&
+			didSaveSucceed &&
+			isCollaborationEnabled &&
+			postStatus
+		) {
+			broadcastSaveEvent( postStatus );
+		}
+	}, [
+		isSaving,
+		prevIsSaving,
+		prevIsAutosaving,
+		didSaveSucceed,
+		postStatus,
+		isCollaborationEnabled,
+		broadcastSaveEvent,
+	] );
+
+	/*
+	 * Detect collaborator joins, leaves, and remote saves.
+	 */
+	useEffect( () => {
+		if ( ! isCollaborationEnabled ) {
+			return;
+		}
+
+		/*
+		 * On first render usePrevious returns undefined. On subsequent renders
+		 * the list may still be empty while the store hydrates. In both cases,
+		 * skip to avoid spurious "X joined" toasts for users already present.
+		 */
+		if ( ! prevCollaborators || prevCollaborators.length === 0 ) {
+			return;
+		}
+
+		/*
+		 * Convenience wrapper to keep notice calls concise.
+		 */
+		function notify( noticeId: string, message: string ) {
+			void createNotice( 'info', message, {
+				id: noticeId,
+				type: 'snackbar',
+				isDismissible: false,
+			} );
+		}
+
+		const prevMap = new Map< number, PostEditorAwarenessState >(
+			prevCollaborators.map( ( c ) => [ c.clientId, c ] )
+		);
+		const newMap = new Map< number, PostEditorAwarenessState >(
+			activeCollaborators.map( ( c ) => [ c.clientId, c ] )
+		);
+
+		/*
+		 * Detect joins: new clientIds that weren't in the previous state.
+		 */
+		if ( notificationsConfig.userEntered ) {
+			const me = activeCollaborators.find( ( c ) => c.isMe );
+
+			for ( const [ clientId, collaborator ] of newMap ) {
+				if ( prevMap.has( clientId ) || collaborator.isMe ) {
+					continue;
+				}
+
+				/*
+				 * Skip collaborators who were present before the current user
+				 * joined. Their enteredAt is earlier than ours, meaning we're
+				 * the newcomer.
+				 */
+				if (
+					me &&
+					collaborator.collaboratorInfo.enteredAt <
+						me.collaboratorInfo.enteredAt
+				) {
+					continue;
+				}
+
+				notify(
+					`${ NOTIFICATION_TYPE.USER_ENTERED }-${ collaborator.collaboratorInfo.id }`,
+					sprintf(
+						/* translators: %s: collaborator display name */
+						__( '%s has joined the post.' ),
+						collaborator.collaboratorInfo.name
+					)
+				);
+			}
+		}
+
+		/*
+		 * Detect leaves by iterating the previous collaborator list. A leave
+		 * notification fires when a previously-connected collaborator either:
+		 *   - transitions to isConnected=false (greyed-out in the UI), or
+		 *   - disappears from the list entirely while still connected.
+		 * Already-disconnected collaborators that are later removed from the
+		 * list (after the 5 s delay) are silently ignored.
+		 */
+		if ( notificationsConfig.userExited ) {
+			for ( const [ clientId, prevCollab ] of prevMap ) {
+				if ( prevCollab.isMe || ! prevCollab.isConnected ) {
+					continue;
+				}
+
+				const newCollab = newMap.get( clientId );
+				if ( newCollab?.isConnected ) {
+					continue;
+				}
+
+				notify(
+					`${ NOTIFICATION_TYPE.USER_EXITED }-${ prevCollab.collaboratorInfo.id }`,
+					sprintf(
+						/* translators: %s: collaborator display name */
+						__( '%s has left the post.' ),
+						prevCollab.collaboratorInfo.name
+					)
+				);
+			}
+		}
+
+		// Detect remote save events from other collaborators.
+		if ( notificationsConfig.postUpdated ) {
+			for ( const [ clientId, collaborator ] of newMap ) {
+				if ( collaborator.isMe || ! collaborator.lastSaveEvent ) {
+					continue;
+				}
+
+				const prevCollab = prevMap.get( clientId );
+
+				/*
+				 * Only notify for save events from collaborators we already
+				 * knew about. A newly appeared collaborator may carry a
+				 * historical save event that predates our session.
+				 */
+				if ( ! prevCollab ) {
+					continue;
+				}
+
+				const prevSavedAt = prevCollab.lastSaveEvent?.savedAt;
+				const { savedAt, status } = collaborator.lastSaveEvent;
+
+				if ( savedAt > ( prevSavedAt ?? 0 ) ) {
+					notify(
+						`${ NOTIFICATION_TYPE.POST_UPDATED }-${ collaborator.collaboratorInfo.id }`,
+						getPostUpdatedMessage(
+							collaborator.collaboratorInfo.name,
+							status
+						)
+					);
+				}
+			}
+		}
+	}, [
+		activeCollaborators,
+		prevCollaborators,
+		isCollaborationEnabled,
+		notificationsConfig,
+		createNotice,
+	] );
+}

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -27,6 +27,7 @@ import InserterSidebar from '../inserter-sidebar';
 import ListViewSidebar from '../list-view-sidebar';
 import { RevisionsHeader, RevisionsCanvas } from '../post-revisions-preview';
 import { CollaboratorsOverlay } from '../collaborators-overlay';
+import { useCollaboratorNotifications } from '../collaborators-presence/use-collaborator-notifications';
 import SavePublishPanels from '../save-publish-panels';
 import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
@@ -122,6 +123,10 @@ export default function EditorInterface( {
 			isRevisionsMode: _isRevisionsMode(),
 		};
 	}, [] );
+	// Runs unconditionally so join/leave/save notifications are dispatched
+	// regardless of viewport width or whether the header centre area is visible.
+	useCollaboratorNotifications( postId, postType );
+
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const secondarySidebarLabel = isListViewOpened
 		? __( 'Document Overview' )

--- a/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-presence.spec.ts
@@ -43,6 +43,10 @@ test.describe( 'Collaboration - Presence', () => {
 		await presenceButton.click();
 
 		// The popover should list the second collaborator by name.
-		await expect( page.getByText( 'Test Collaborator' ) ).toBeVisible();
+		await expect(
+			page.locator( '.editor-collaborators-presence__list-item-name', {
+				hasText: 'Test Collaborator',
+			} )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?

Closes #75323

Depends on #75975

Adds snackbar notifications for real-time collaboration session activity: when a collaborator joins, leaves, or saves the post.

## Why?

Collaborator avatars in the top bar show who's present, but they're easy to miss. There's no active notification when someone joins, leaves, or saves — you'd only notice by watching the avatars constantly.

## How?

- Adds a `useCollaboratorNotifications` hook that compares the current and previous collaborator lists to detect joins, leaves, and remote saves.
- Broadcasts save events to other collaborators via a new `lastSaveEvent` field on the awareness state.
- Detects leaves using the `isConnected` property transition rather than list removal, so the notification fires when the avatar greys out (not after the 5s cleanup delay).
- Skips notifications during initial load to avoid spurious toasts for users already present.
- Notification types can be toggled via the `editor.collaborationNotifications` WordPress filter.

## Testing Instructions

1. Go to Settings > Writing > Enable real-time collaboration.
2. Open a post for editing in two different browser tabs (or two different browsers for different users).
3. Verify a "X has joined the post" snackbar appears in the first tab when the second tab opens the post.
4. Close the second tab. After ~30 seconds, verify a "X has left the post" snackbar appears in the first tab.
5. With both tabs open, save the post from the second tab. Verify a "Draft saved by X" snackbar appears in the first tab.
6. Publish the post from the second tab. Verify a "Post updated by X" snackbar appears in the first tab.
7. Verify no notification appears for your own saves.
8. Verify no duplicate notifications appear on page load for users already present.

### Testing Instructions for Keyboard

No new interactive UI elements are added. Snackbar notifications are announced to screen readers automatically via the existing notice system.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| <img width="707" height="430" alt="Screenshot 2026-02-24 at 7 11 17 PM" src="https://github.com/user-attachments/assets/8db950d3-94c1-40c9-90fc-9a5b82d33548" /> |
| :----: |
| Notification when a collaborator has left |

