### PR TITLE
Prototype: Navigation Editing List View Parity in Side Editor Sidebar

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -72,6 +72,7 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
+import { ListViewContentPopover } from './components/inspector-controls/list-view-content-popover';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -137,4 +138,5 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
+	ListViewContentPopover,
 } );

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -76,12 +76,14 @@ function getEntityTypeName( type, kind ) {
  * @param {Function} props.setAttributes  - Function to update block attributes
  * @param {string}   props.clientId       - Block client ID
  * @param {boolean}  props.isLinkEditable - Whether link editing should be allowed
+ * @param {boolean}  props.contentOnly    - Whether to hide non-content fields (description, rel)
  */
 export function Controls( {
 	attributes,
 	setAttributes,
 	clientId,
 	isLinkEditable = true,
+	contentOnly: forceContentOnly = false,
 } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -137,7 +139,8 @@ export function Controls( {
 		[ clientId ]
 	);
 
-	const isContentOnly = blockEditingMode === 'contentOnly';
+	const isContentOnly =
+		forceContentOnly || blockEditingMode === 'contentOnly';
 
 	const preview = useLinkPreview( {
 		url,

--- a/packages/block-library/src/private-apis.js
+++ b/packages/block-library/src/private-apis.js
@@ -3,6 +3,11 @@
  */
 import { default as BlockKeyboardShortcuts } from './block-keyboard-shortcuts';
 import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from './navigation/constants';
+import {
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
+} from './navigation-link/shared';
 import { lock } from './lock-unlock';
 
 /**
@@ -12,4 +17,7 @@ export const privateApis = {};
 lock( privateApis, {
 	BlockKeyboardShortcuts,
 	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
 } );

--- a/packages/block-library/src/private-apis.js
+++ b/packages/block-library/src/private-apis.js
@@ -7,6 +7,7 @@ import {
 	LinkUI,
 	updateAttributes,
 	useEntityBinding,
+	Controls as NavigationLinkControls,
 } from './navigation-link/shared';
 import { lock } from './lock-unlock';
 
@@ -20,4 +21,5 @@ lock( privateApis, {
 	LinkUI,
 	updateAttributes,
 	useEntityBinding,
+	NavigationLinkControls,
 } );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/index.js
@@ -64,9 +64,7 @@ export default function SidebarNavigationScreenNavigationMenu( { backPath } ) {
 	if ( isLoading ) {
 		return (
 			<SidebarNavigationScreenWrapper
-				description={ __(
-					'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
-				) }
+				description={ __( 'Edit this navigation.' ) }
 				backPath={ backPath }
 			>
 				<Spinner className="edit-site-sidebar-navigation-screen-navigation-menus__loading" />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
@@ -48,10 +48,12 @@ export default function NavigationMenuDetail() {
 				'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
 			) }
 		>
-			<NavigationMenuEditor
-				navigationMenuId={ parseInt( postId ) }
-				hasDarkBackground={ false }
-			/>
+			<div style={ { paddingTop: '24px' } }>
+				<NavigationMenuEditor
+					navigationMenuId={ parseInt( postId ) }
+					hasDarkBackground={ false }
+				/>
+			</div>
 		</Page>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
@@ -46,7 +46,7 @@ export default function NavigationMenuDetail() {
 			title={ title || __( 'Navigation Menu' ) }
 			subTitle={ __( 'Edit this navigation.' ) }
 		>
-			<div style={ { paddingTop: '24px' } }>
+			<div style={ { paddingTop: '18px' } }>
 				<NavigationMenuEditor
 					navigationMenuId={ parseInt( postId ) }
 					hasDarkBackground={ false }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
@@ -44,9 +44,7 @@ export default function NavigationMenuDetail() {
 	return (
 		<Page
 			title={ title || __( 'Navigation Menu' ) }
-			subTitle={ __(
-				'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
-			) }
+			subTitle={ __( 'Edit this navigation.' ) }
 		>
 			<div style={ { paddingTop: '24px' } }>
 				<NavigationMenuEditor

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-detail.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { useEntityRecord } from '@wordpress/core-data';
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import NavigationMenuEditor from './navigation-menu-editor';
+import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+export default function NavigationMenuDetail() {
+	const {
+		params: { postId },
+	} = useLocation();
+
+	const { record: navigationMenu, isResolving } = useEntityRecord(
+		'postType',
+		'wp_navigation',
+		postId
+	);
+
+	const title = buildNavigationLabel(
+		navigationMenu?.title,
+		navigationMenu?.id,
+		navigationMenu?.status
+	);
+
+	if ( isResolving ) {
+		return (
+			<Page title={ __( 'Navigation Menu' ) }>
+				<Spinner />
+			</Page>
+		);
+	}
+
+	return (
+		<Page
+			title={ title || __( 'Navigation Menu' ) }
+			subTitle={ __(
+				'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
+			) }
+		>
+			<NavigationMenuEditor
+				navigationMenuId={ parseInt( postId ) }
+				hasDarkBackground={ false }
+			/>
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -5,6 +5,7 @@ import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -24,6 +25,14 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 		};
 	}, [] );
 
+	const settings = useMemo( () => {
+		return {
+			...storedSettings,
+			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
+				fetchLinkSuggestions( search, searchOptions, storedSettings ),
+		};
+	}, [ storedSettings ] );
+
 	const blocks = useMemo( () => {
 		if ( ! navigationMenuId ) {
 			return [];
@@ -38,7 +47,7 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 
 	return (
 		<BlockEditorProvider
-			settings={ storedSettings }
+			settings={ settings }
 			value={ blocks }
 			onChange={ noop }
 			onInput={ noop }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -13,6 +13,7 @@ import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wor
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
 import NavigationMenuContent from '../sidebar-navigation-screen-navigation-menus/navigation-menu-content';
+import useNavigateToEntityRecord from '../block-editor/use-navigate-to-entity-record';
 
 const noop = () => {};
 
@@ -25,13 +26,16 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 		};
 	}, [] );
 
+	const onNavigateToEntityRecord = useNavigateToEntityRecord();
+
 	const settings = useMemo( () => {
 		return {
 			...storedSettings,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, storedSettings ),
+			onNavigateToEntityRecord,
 		};
-	}, [ storedSettings ] );
+	}, [ storedSettings, onNavigateToEntityRecord ] );
 
 	const blocks = useMemo( () => {
 		if ( ! navigationMenuId ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -17,7 +17,10 @@ import useNavigateToEntityRecord from '../block-editor/use-navigate-to-entity-re
 
 const noop = () => {};
 
-export default function NavigationMenuEditor( { navigationMenuId } ) {
+export default function NavigationMenuEditor( {
+	navigationMenuId,
+	hasDarkBackground = true,
+} ) {
 	const { storedSettings } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( editSiteStore ) );
 
@@ -56,7 +59,13 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 			onChange={ noop }
 			onInput={ noop }
 		>
-			<div className="edit-site-sidebar-navigation-screen-navigation-menus__content">
+			<div
+				className={
+					hasDarkBackground
+						? 'edit-site-sidebar-navigation-screen-navigation-menus__content'
+						: undefined
+				}
+			>
 				<NavigationMenuContent rootClientId={ blocks[ 0 ].clientId } />
 			</div>
 		</BlockEditorProvider>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useEntityRecord } from '@wordpress/core-data';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import usePatternSettings from '../page-patterns/use-pattern-settings';
+import { previewField } from '../page-patterns/fields';
+import { LAYOUT_GRID } from '../../utils/constants';
+import useNavigationMenusUsedIn from './use-navigation-menus-used-in';
+
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
+const { patternTitleField } = unlock( editorPrivateApis );
+const { useLocation, useHistory } = unlock( routerPrivateApis );
+
+const EMPTY_ARRAY = [];
+const DEFAULT_VIEW = {
+	type: LAYOUT_GRID,
+	perPage: 20,
+	titleField: 'title',
+	mediaField: 'preview',
+	fields: [],
+	layout: {
+		previewSize: 430,
+	},
+};
+const DEFAULT_LAYOUTS = {
+	[ LAYOUT_GRID ]: {},
+};
+
+export default function NavigationMenuTemplateAreas() {
+	const {
+		params: { postId },
+	} = useLocation();
+	const history = useHistory();
+	const navigationMenuId = parseInt( postId );
+
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+
+	const { record: navigationMenu } = useEntityRecord(
+		'postType',
+		'wp_navigation',
+		postId
+	);
+	const menuTitle = decodeEntities( navigationMenu?.title?.rendered ?? '' );
+
+	const menuIds = useMemo( () => [ navigationMenuId ], [ navigationMenuId ] );
+	const { usageMap, isResolving } = useNavigationMenusUsedIn( menuIds );
+	const matchingParts = usageMap.get( navigationMenuId ) ?? EMPTY_ARRAY;
+
+	const settings = usePatternSettings();
+	const fields = useMemo( () => [ previewField, patternTitleField ], [] );
+
+	const { data, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( matchingParts, view, fields ),
+		[ matchingParts, view, fields ]
+	);
+
+	const title = menuTitle
+		? sprintf(
+				/* translators: %s: navigation menu name */
+				__( 'Template parts using %s' ),
+				menuTitle
+		  )
+		: __( 'Template parts' );
+
+	return (
+		<ExperimentalBlockEditorProvider settings={ settings }>
+			<Page
+				title={ title }
+				subTitle={ __(
+					'A list of all the template parts using this navigation menu'
+				) }
+			>
+				<DataViews
+					paginationInfo={ paginationInfo }
+					fields={ fields }
+					data={ data ?? EMPTY_ARRAY }
+					isLoading={ isResolving }
+					view={ view }
+					onChangeView={ setView }
+					defaultLayouts={ DEFAULT_LAYOUTS }
+					onClickItem={ ( item ) => {
+						history.navigate(
+							`/${ item.type }/${ item.id }?canvas=edit`
+						);
+					} }
+				/>
+			</Page>
+		</ExperimentalBlockEditorProvider>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas.js
@@ -10,6 +10,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -25,6 +26,33 @@ const { patternTitleField } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
+
+/**
+ * Recursively injects a navigation menu ref into unbound core/navigation
+ * blocks so that BlockPreview can load and reflect unsaved navigation edits.
+ *
+ * @param {Array}  blocks - The block tree to search.
+ * @param {number} menuId - The navigation menu ID to inject.
+ * @return {Array} The modified block tree with the navigation menu ref injected.
+ */
+function injectNavigationRef( blocks, menuId ) {
+	return blocks.map( ( block ) => {
+		if ( block.name === 'core/navigation' && ! block.attributes?.ref ) {
+			return {
+				...block,
+				attributes: { ...block.attributes, ref: menuId },
+			};
+		}
+		if ( block.innerBlocks?.length ) {
+			return {
+				...block,
+				innerBlocks: injectNavigationRef( block.innerBlocks, menuId ),
+			};
+		}
+		return block;
+	} );
+}
+
 const DEFAULT_VIEW = {
 	type: LAYOUT_GRID,
 	perPage: 20,
@@ -59,12 +87,31 @@ export default function NavigationMenuTemplateAreas() {
 	const { usageMap, isResolving } = useNavigationMenusUsedIn( menuIds );
 	const matchingParts = usageMap.get( navigationMenuId ) ?? EMPTY_ARRAY;
 
+	// Augment each template part with pre-parsed blocks that have
+	// the navigation ref injected. This ensures BlockPreview loads
+	// the navigation content and reflects unsaved edits in real time
+	// (the navigation block uses getEditedEntityRecord internally).
+	const augmentedParts = useMemo( () => {
+		return matchingParts.map( ( part ) => {
+			if ( ! part?.content?.raw ) {
+				return part;
+			}
+			const parsedBlocks = parse( part.content.raw, {
+				__unstableSkipMigrationLogs: true,
+			} );
+			return {
+				...part,
+				blocks: injectNavigationRef( parsedBlocks, navigationMenuId ),
+			};
+		} );
+	}, [ matchingParts, navigationMenuId ] );
+
 	const settings = usePatternSettings();
 	const fields = useMemo( () => [ previewField, patternTitleField ], [] );
 
 	const { data, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( matchingParts, view, fields ),
-		[ matchingParts, view, fields ]
+		() => filterSortAndPaginate( augmentedParts, view, fields ),
+		[ augmentedParts, view, fields ]
 	);
 
 	const title = menuTitle

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas.js
@@ -130,20 +130,22 @@ export default function NavigationMenuTemplateAreas() {
 					'A list of all the template parts using this navigation menu'
 				) }
 			>
-				<DataViews
-					paginationInfo={ paginationInfo }
-					fields={ fields }
-					data={ data ?? EMPTY_ARRAY }
-					isLoading={ isResolving }
-					view={ view }
-					onChangeView={ setView }
-					defaultLayouts={ DEFAULT_LAYOUTS }
-					onClickItem={ ( item ) => {
-						history.navigate(
-							`/${ item.type }/${ item.id }?canvas=edit`
-						);
-					} }
-				/>
+				<div className="navigation-menu-template-areas">
+					<DataViews
+						paginationInfo={ paginationInfo }
+						fields={ fields }
+						data={ data ?? EMPTY_ARRAY }
+						isLoading={ isResolving }
+						view={ view }
+						onChangeView={ setView }
+						defaultLayouts={ DEFAULT_LAYOUTS }
+						onClickItem={ ( item ) => {
+							history.navigate(
+								`/${ item.type }/${ item.id }?canvas=edit`
+							);
+						} }
+					/>
+				</div>
 			</Page>
 		</ExperimentalBlockEditorProvider>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/single-navigation-menu.js
@@ -39,9 +39,7 @@ export default function SingleNavigationMenu( {
 				navigationMenu?.id,
 				navigationMenu?.status
 			) }
-			description={ __(
-				'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
-			) }
+			description={ __( 'Edit this navigation.' ) }
 		>
 			<NavigationMenuEditor navigationMenuId={ navigationMenu?.id } />
 		</SidebarNavigationScreenWrapper>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss
@@ -1,5 +1,20 @@
 @use "@wordpress/base-styles/colors" as *;
 
+.navigation-menu-template-areas {
+	overflow: scroll;
+
+	.dataviews-view-grid__row {
+		grid-template-columns: 1fr !important;
+	}
+
+	.dataviews-view-grid__media {
+		aspect-ratio: unset;
+		height: auto;
+		max-height: 300px;
+		overflow: hidden;
+	}
+}
+
 .sidebar-navigation__more-menu {
 	.components-button {
 		color: $gray-200;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menus-used-in.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menus-used-in.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
+
+function findNavigationBlocksInBlocks( blocks, menuId ) {
+	const stack = [ ...blocks ];
+	while ( stack.length ) {
+		const { innerBlocks, ...block } = stack.shift();
+		if ( innerBlocks ) {
+			stack.unshift( ...innerBlocks );
+		}
+		if ( block.name === 'core/navigation' ) {
+			// Explicit ref match, or unbound block (no ref = uses the
+			// site's default/fallback navigation menu).
+			if ( block.attributes?.ref === menuId || ! block.attributes?.ref ) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Batch variant: returns Map<menuId, TemplatePart[]> for all given menu IDs.
+ *
+ * @param {number[]} menuIds Navigation menu IDs to search for.
+ *
+ * @return {Object} Object with usageMap (Map of menu IDs to template parts using each menu) and isResolving (whether template parts are loading).
+ */
+export default function useNavigationMenusUsedIn( menuIds ) {
+	const { records: templateParts, isResolving } = useEntityRecords(
+		'postType',
+		TEMPLATE_PART_POST_TYPE,
+		{ per_page: -1 }
+	);
+
+	const usageMap = useMemo( () => {
+		if ( ! templateParts || ! menuIds?.length ) {
+			return new Map();
+		}
+
+		const map = new Map();
+		for ( const menuId of menuIds ) {
+			const usedIn = templateParts.filter( ( templatePart ) => {
+				if ( ! templatePart?.content?.raw ) {
+					return false;
+				}
+				const blocks = parse( templatePart.content.raw );
+				return findNavigationBlocksInBlocks( blocks, menuId );
+			} );
+			map.set( menuId, usedIn );
+		}
+		return map;
+	}, [ templateParts, menuIds ] );
+
+	return {
+		usageMap,
+		isResolving,
+	};
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menus-used-in.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menus-used-in.js
@@ -10,7 +10,23 @@ import { parse } from '@wordpress/blocks';
  */
 import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
-function findNavigationBlocksInBlocks( blocks, menuId ) {
+/**
+ * Searches a block tree for a core/navigation block that matches menuId.
+ *
+ * Matching rules:
+ *  1. Explicit ref: `block.attributes.ref === menuId` — always matches.
+ *  2. Unbound block (no ref) with NO inner blocks AND the current menu is
+ *     the fallback menu — the block has no inline content so WordPress will
+ *     resolve it to the site's fallback navigation at render time.
+ *  3. Unbound block WITH inner blocks — self-contained with hardcoded links,
+ *     does not use any navigation menu, never matches.
+ *
+ * @param {Array}   blocks         Block tree to search.
+ * @param {number}  menuId         Navigation menu ID to match.
+ * @param {boolean} isFallbackMenu Whether menuId is the site's fallback menu.
+ * @return {boolean} True if a matching navigation block was found.
+ */
+function findNavigationBlocksInBlocks( blocks, menuId, isFallbackMenu ) {
 	const stack = [ ...blocks ];
 	while ( stack.length ) {
 		const { innerBlocks, ...block } = stack.shift();
@@ -18,9 +34,22 @@ function findNavigationBlocksInBlocks( blocks, menuId ) {
 			stack.unshift( ...innerBlocks );
 		}
 		if ( block.name === 'core/navigation' ) {
-			// Explicit ref match, or unbound block (no ref = uses the
-			// site's default/fallback navigation menu).
-			if ( block.attributes?.ref === menuId || ! block.attributes?.ref ) {
+			// eslint-disable-next-line no-console
+			console.log(
+				`[useNavigationMenusUsedIn] nav block: ref=${
+					block.attributes?.ref
+				} innerBlocks=${
+					innerBlocks?.length ?? 0
+				} menuId=${ menuId } isFallbackMenu=${ isFallbackMenu }`
+			);
+			if ( block.attributes?.ref === menuId ) {
+				return true;
+			}
+			if (
+				! block.attributes?.ref &&
+				! innerBlocks?.length &&
+				isFallbackMenu
+			) {
 				return true;
 			}
 		}
@@ -32,37 +61,64 @@ function findNavigationBlocksInBlocks( blocks, menuId ) {
  * Batch variant: returns Map<menuId, TemplatePart[]> for all given menu IDs.
  *
  * @param {number[]} menuIds Navigation menu IDs to search for.
- *
- * @return {Object} Object with usageMap (Map of menu IDs to template parts using each menu) and isResolving (whether template parts are loading).
+ * @return {{ usageMap: Map<number, Object[]>, isResolving: boolean }} Map of menu IDs to the template parts that use each menu, and a loading flag.
  */
 export default function useNavigationMenusUsedIn( menuIds ) {
-	const { records: templateParts, isResolving } = useEntityRecords(
-		'postType',
-		TEMPLATE_PART_POST_TYPE,
-		{ per_page: -1 }
-	);
+	const { records: templateParts, isResolving: isResolvingParts } =
+		useEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, {
+			per_page: -1,
+		} );
+
+	// Identify the fallback navigation menu: WordPress resolves unbound
+	// navigation blocks (no ref, no inner items) to the most recently
+	// created published navigation menu at render time.
+	const { records: fallbackMenus, isResolving: isResolvingFallback } =
+		useEntityRecords( 'postType', 'wp_navigation', {
+			per_page: 1,
+			orderby: 'date',
+			order: 'desc',
+			status: 'publish',
+			_fields: 'id',
+		} );
+
+	const fallbackMenuId = fallbackMenus?.[ 0 ]?.id;
 
 	const usageMap = useMemo( () => {
 		if ( ! templateParts || ! menuIds?.length ) {
 			return new Map();
 		}
 
+		// eslint-disable-next-line no-console
+		console.log(
+			`[useNavigationMenusUsedIn] templateParts=${ templateParts.length } fallbackMenuId=${ fallbackMenuId }`
+		);
+
 		const map = new Map();
 		for ( const menuId of menuIds ) {
+			const isFallbackMenu = menuId === fallbackMenuId;
 			const usedIn = templateParts.filter( ( templatePart ) => {
 				if ( ! templatePart?.content?.raw ) {
 					return false;
 				}
 				const blocks = parse( templatePart.content.raw );
-				return findNavigationBlocksInBlocks( blocks, menuId );
+				const matched = findNavigationBlocksInBlocks(
+					blocks,
+					menuId,
+					isFallbackMenu
+				);
+				// eslint-disable-next-line no-console
+				console.log(
+					`[useNavigationMenusUsedIn] part=${ templatePart.slug } menuId=${ menuId } isFallbackMenu=${ isFallbackMenu } matched=${ matched }`
+				);
+				return matched;
 			} );
 			map.set( menuId, usedIn );
 		}
 		return map;
-	}, [ templateParts, menuIds ] );
+	}, [ templateParts, menuIds, fallbackMenuId ] );
 
 	return {
 		usageMap,
-		isResolving,
+		isResolving: isResolvingParts || isResolvingFallback,
 	};
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -143,7 +143,12 @@ export function SidebarNavigationScreenWrapper( {
 		<SidebarNavigationScreen
 			title={ title || __( 'Navigation' ) }
 			actions={ actions }
-			description={ description || __( 'Manage your Navigation Menus.' ) }
+			description={
+				description ||
+				__(
+					'Navigation Menus are a curated collection of blocks that allow visitors to get around your site.'
+				)
+			}
 			backPath={ backPath }
 			content={ children }
 		/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -6,9 +6,9 @@ import {
 	store as blockEditorStore,
 	BlockList,
 } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
-import { useCallback } from '@wordpress/element';
+import { useState, useLayoutEffect, useRef } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as blockLibraryPrivateApis } from '@wordpress/block-library';
 
@@ -19,9 +19,8 @@ import { unlock } from '../../lock-unlock';
 import LeafMoreMenu from './leaf-more-menu';
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
-const { LinkUI, updateAttributes, useEntityBinding } = unlock(
-	blockLibraryPrivateApis
-);
+const { LinkUI, updateAttributes, useEntityBinding, NavigationLinkControls } =
+	unlock( blockLibraryPrivateApis );
 
 const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-link',
@@ -156,38 +155,75 @@ export default function NavigationMenuContent( { rootClientId } ) {
 		},
 		[ rootClientId ]
 	);
-	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
 
-	const offCanvasOnselect = useCallback(
-		( block ) => {
-			if (
-				block.name === 'core/navigation-link' &&
-				! block.attributes.url
-			) {
-				__unstableMarkNextChangeAsNotPersistent();
-				replaceBlock(
-					block.clientId,
-					createBlock( 'core/navigation-link', block.attributes )
-				);
-			}
-		},
-		[ __unstableMarkNextChangeAsNotPersistent, replaceBlock ]
-	);
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	// Track the navigation-link block the user clicked to edit.
+	const [ editingBlock, setEditingBlock ] = useState( null );
+	// DOM element of the clicked list-view row, used to anchor the popover.
+	const [ anchorElement, setAnchorElement ] = useState( null );
+	const listViewRef = useRef();
+
+	// Resolve the anchor DOM element whenever the editing block changes.
+	useLayoutEffect( () => {
+		if ( ! editingBlock?.clientId || ! listViewRef.current ) {
+			setAnchorElement( null );
+			return;
+		}
+		const element = listViewRef.current.querySelector(
+			`[data-block="${ editingBlock.clientId }"]`
+		);
+		setAnchorElement( element ?? null );
+	}, [ editingBlock?.clientId ] );
+
+	const handleSelect = ( block ) => {
+		// Only open the controls panel for blocks that have an existing URL.
+		// Newly inserted empty blocks are handled by AdditionalBlockContent.
+		if (
+			BLOCKS_WITH_LINK_UI_SUPPORT.includes( block?.name ) &&
+			block?.attributes?.url
+		) {
+			setEditingBlock( block );
+		}
+	};
 
 	// The hidden block is needed because it makes block edit side effects trigger.
 	// For example a navigation page list load its items has an effect on edit to load its items.
 	return (
 		<>
 			{ ! isLoading && (
-				<PrivateListView
-					rootClientId={ listViewRootClientId }
-					onSelect={ offCanvasOnselect }
-					blockSettingsMenu={ LeafMoreMenu }
-					showAppender
-					additionalBlockContent={ AdditionalBlockContent }
-					isExpanded
-				/>
+				<div ref={ listViewRef }>
+					<PrivateListView
+						rootClientId={ listViewRootClientId }
+						onSelect={ handleSelect }
+						blockSettingsMenu={ LeafMoreMenu }
+						showAppender
+						additionalBlockContent={ AdditionalBlockContent }
+						isExpanded
+					/>
+				</div>
+			) }
+			{ editingBlock && anchorElement && (
+				<Popover
+					anchor={ anchorElement }
+					placement="right-start"
+					onClose={ () => setEditingBlock( null ) }
+					className="edit-site-sidebar-navigation-screen-navigation-menus__link-editor"
+				>
+					<div style={ { width: '280px' } }>
+						<NavigationLinkControls
+							attributes={ editingBlock.attributes }
+							setAttributes={ ( newAttrs ) => {
+								updateBlockAttributes(
+									editingBlock.clientId,
+									newAttrs
+								);
+							} }
+							clientId={ editingBlock.clientId }
+							contentOnly
+						/>
+					</div>
+				</Popover>
 			) }
 			<div className="edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor">
 				<BlockList />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -10,6 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as blockLibraryPrivateApis } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -18,6 +19,88 @@ import { unlock } from '../../lock-unlock';
 import LeafMoreMenu from './leaf-more-menu';
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
+const { LinkUI, updateAttributes, useEntityBinding } = unlock(
+	blockLibraryPrivateApis
+);
+
+const BLOCKS_WITH_LINK_UI_SUPPORT = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
+function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
+	const {
+		updateBlockAttributes,
+		removeBlock,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
+	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT.includes(
+		insertedBlock?.name
+	);
+	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
+	const showLinkControls = supportsLinkControls && blockWasJustInserted;
+
+	const { createBinding, clearBinding } = useEntityBinding( {
+		clientId: insertedBlock?.clientId,
+		attributes: insertedBlock?.attributes || {},
+	} );
+
+	if ( ! showLinkControls ) {
+		return null;
+	}
+
+	const cleanupInsertedBlock = () => {
+		const shouldAutoSelectBlock = false;
+		if ( ! insertedBlock?.attributes?.url && insertedBlock?.clientId ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		}
+		setInsertedBlock( null );
+	};
+
+	const setInsertedBlockAttributes =
+		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
+			if ( ! _insertedBlockClientId ) {
+				return;
+			}
+			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
+		};
+
+	const handleSetInsertedBlock = ( newBlock ) => {
+		const shouldAutoSelectBlock = false;
+		if ( insertedBlock?.clientId && newBlock ) {
+			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		}
+		setInsertedBlock( newBlock );
+	};
+
+	return (
+		<LinkUI
+			clientId={ insertedBlock?.clientId }
+			link={ insertedBlock?.attributes }
+			onBlockInsert={ handleSetInsertedBlock }
+			onClose={ () => {
+				cleanupInsertedBlock();
+			} }
+			onChange={ ( updatedValue ) => {
+				const { isEntityLink, attributes: updatedAttributes } =
+					updateAttributes(
+						updatedValue,
+						setInsertedBlockAttributes( insertedBlock?.clientId ),
+						insertedBlock?.attributes
+					);
+
+				if ( isEntityLink ) {
+					createBinding( updatedAttributes );
+				} else {
+					clearBinding();
+				}
+
+				setInsertedBlock( null );
+			} }
+		/>
+	);
+}
 
 // Needs to be kept in sync with the query used at packages/block-library/src/page-list/edit.js.
 const MAX_PAGE_COUNT = 100;
@@ -101,7 +184,8 @@ export default function NavigationMenuContent( { rootClientId } ) {
 					rootClientId={ listViewRootClientId }
 					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }
-					showAppender={ false }
+					showAppender
+					additionalBlockContent={ AdditionalBlockContent }
 					isExpanded
 				/>
 			) }

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -61,6 +61,6 @@ export const navigationItemRoute = {
 		},
 	},
 	widths: {
-		content: 380,
+		content: 280,
 	},
 };

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -9,6 +9,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import Editor from '../editor';
 import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
+import NavigationMenuTemplateAreas from '../sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -39,7 +40,7 @@ export const navigationItemRoute = {
 		preview( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? (
-				<Editor />
+				<NavigationMenuTemplateAreas />
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -61,6 +61,6 @@ export const navigationItemRoute = {
 		},
 	},
 	widths: {
-		content: 280,
+		content: 320,
 	},
 };

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -8,8 +8,10 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import Editor from '../editor';
 import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
+import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import NavigationMenuTemplateAreas from '../sidebar-navigation-screen-navigation-menu/navigation-menu-template-areas';
+import NavigationMenuDetail from '../sidebar-navigation-screen-navigation-menu/navigation-menu-detail';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -32,10 +34,14 @@ export const navigationItemRoute = {
 		sidebar( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? (
-				<SidebarNavigationScreenNavigationMenu backPath="/navigation" />
+				<SidebarNavigationScreenNavigationMenus backPath="/" />
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);
+		},
+		content( { siteData } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			return isBlockTheme ? <NavigationMenuDetail /> : null;
 		},
 		preview( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
@@ -53,5 +59,8 @@ export const navigationItemRoute = {
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
+	},
+	widths: {
+		content: 380,
 	},
 };

--- a/packages/edit-site/src/components/site-editor-routes/navigation.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { useEffect } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -10,8 +12,26 @@ import Editor from '../editor';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import { unlock } from '../../lock-unlock';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
-const { useLocation } = unlock( routerPrivateApis );
+const { useLocation, useHistory } = unlock( routerPrivateApis );
+
+function NavigationAutoSelect() {
+	const history = useHistory();
+	const { records, hasResolved } = useEntityRecords(
+		'postType',
+		NAVIGATION_POST_TYPE,
+		{ per_page: 1, order: 'desc', orderby: 'date' }
+	);
+
+	useEffect( () => {
+		if ( hasResolved && records?.length > 0 ) {
+			history.navigate( `/wp_navigation/${ records[ 0 ].id }` );
+		}
+	}, [ hasResolved, records, history ] );
+
+	return null;
+}
 
 function MobileNavigationView() {
 	const { query = {} } = useLocation();
@@ -31,7 +51,10 @@ export const navigationRoute = {
 		sidebar( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? (
-				<SidebarNavigationScreenNavigationMenus backPath="/" />
+				<>
+					<NavigationAutoSelect />
+					<SidebarNavigationScreenNavigationMenus backPath="/" />
+				</>
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);

--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -39,6 +39,56 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 		},
 	} );
 
+	test( 'clicking an existing item opens the link editing popover and Escape returns focus', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Click the existing navigation link in the list view.
+		await listView
+			.getByRole( 'gridcell', { name: 'Existing Item' } )
+			.click();
+
+		// The link editing controls popover should open.
+		const editPopover = page.locator(
+			'.edit-site-sidebar-navigation-screen-navigation-menus__link-editor'
+		);
+		await expect( editPopover ).toBeVisible();
+
+		// Focus should be placed within the popover.
+		const isFocusWithin = await editPopover.evaluate( ( el ) =>
+			el.contains( document.activeElement )
+		);
+		expect( isFocusWithin ).toBe( true );
+
+		// Press Escape to dismiss the popover.
+		await page.keyboard.press( 'Escape' );
+
+		// The popover should close.
+		await expect( editPopover ).toBeHidden();
+
+		// Focus should return to the clicked list item.
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: 'Existing Item' } )
+				.getByRole( 'link' )
+		).toBeFocused();
+	} );
+
 	test( 'can add new menu items from the sidebar list view', async ( {
 		admin,
 		page,

--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -1,0 +1,288 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Navigation sidebar - list view editing', () => {
+	const navMenuFixture = {
+		title: 'Test Navigation Menu',
+		content:
+			'<!-- wp:navigation-link {"label":"Existing Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+	};
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.createPage( {
+			title: 'Test Page 1',
+			status: 'publish',
+		} );
+		await requestUtils.createPage( {
+			title: 'Test Page 2',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPages(),
+			requestUtils.activateTheme( 'twentytwentyone' ),
+		] );
+	} );
+
+	test.use( {
+		linkControl: async ( { page }, use ) => {
+			await use( new LinkControl( { page } ) );
+		},
+	} );
+
+	test( 'can add new menu items from the sidebar list view', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		// Visit the site editor in sidebar-browse mode (without canvas: 'edit')
+		// so that the sidebar shows the navigation menu's list view.
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Verify the existing item is shown in the sidebar list view.
+		await expect(
+			listView.getByRole( 'gridcell', { name: 'Existing Item' } )
+		).toBeVisible();
+
+		// The appender button should be present to allow adding new items.
+		// NOTE: This currently FAILS because NavigationMenuContent passes
+		// showAppender={ false } to PrivateListView. Implementing the feature
+		// requires changing it to showAppender={ true } and wiring up the
+		// AdditionalBlockContent / LinkUI integration.
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await expect( appender ).toBeVisible();
+
+		await appender.click();
+
+		// The LinkUI popover should open and immediately focus the search input.
+		const linkUIInput = linkControl.getSearchInput();
+		await expect( linkUIInput ).toBeFocused();
+		await expect( linkUIInput ).toBeEmpty();
+
+		// Type to trigger search suggestions.
+		await linkControl.searchFor( 'Test Page' );
+
+		// Select the first result to create a new menu item.
+		const firstResult = await linkControl.getNthSearchResult( 0 );
+		const firstResultText =
+			await linkControl.getSearchResultText( firstResult );
+		await firstResult.click();
+
+		// The new item should be appended after the existing item.
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: firstResultText } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+	} );
+
+	test( 'opening the add link UI does not immediately trigger unsaved changes', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Confirm no unsaved changes exist before interacting.
+		await expect(
+			page.getByRole( 'button', { name: /Review \d+ change/ } )
+		).toBeHidden();
+
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+
+		// Wait for the link UI to open so we know the click was processed
+		// and state has settled — then assert no save indicator appeared.
+		await expect( linkControl.getSearchInput() ).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: /Review \d+ change/ } )
+		).toBeHidden();
+
+		// Dismiss without selecting a URL.
+		await page.keyboard.press( 'Escape' );
+
+		// Wait for the link UI to fully close before checking — this ensures
+		// the CSS visibility class has been removed and we are testing the
+		// actual entity dirty state, not just the CSS mask.
+		await expect( linkControl.getSearchInput() ).toBeHidden();
+
+		// Verify the save indicator still does not appear — the empty block
+		// insertion should be fully reverted, leaving the entity clean.
+		await expect(
+			page.getByRole( 'button', { name: /Review \d+ change…/ } )
+		).toBeHidden();
+	} );
+
+	test( 'cancelling a second add does not remove previously added unsaved links', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Add a first new item by selecting a URL.
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+		await linkControl.searchFor( 'Test Page' );
+		const firstResult = await linkControl.getNthSearchResult( 0 );
+		const firstResultText =
+			await linkControl.getSearchResultText( firstResult );
+		await firstResult.click();
+
+		// Verify the first new item was committed (block 2 of 2).
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: firstResultText } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+
+		// Start adding a second item but cancel without selecting a URL.
+		await appender.click();
+		await expect( linkControl.getSearchInput() ).toBeFocused();
+		await page.keyboard.press( 'Escape' );
+
+		// Wait for the link UI to fully close.
+		await expect( linkControl.getSearchInput() ).toBeHidden();
+
+		// The previously committed unsaved link should still be present —
+		// cancelling the second insertion must not remove the first one.
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: 'Existing Item' } )
+				.filter( { hasText: 'Block 1 of 2, Level 1.' } )
+		).toBeVisible();
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: firstResultText } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+	} );
+
+	test( 'focus is managed correctly when dismissing the link UI without selecting a URL', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+
+		// Verify focus goes to the search input immediately (focus management).
+		await expect( linkControl.getSearchInput() ).toBeFocused();
+
+		// Dismiss without selecting a URL.
+		await page.keyboard.press( 'Escape' );
+
+		// The auto-inserted empty block should be cleaned up automatically.
+		// Verify the original item is still there and is the only item
+		// (i.e. no orphaned empty block was left behind).
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: 'Existing Item' } )
+				.filter( { hasText: 'Block 1 of 1, Level 1.' } )
+		).toBeVisible();
+	} );
+} );
+
+class LinkControl {
+	constructor( { page } ) {
+		this.page = page;
+	}
+
+	getSearchInput() {
+		return this.page.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+	}
+
+	async getSearchResults() {
+		const searchInput = this.getSearchInput();
+		const resultsRef = await searchInput.getAttribute( 'aria-owns' );
+		const linkUIResults = this.page.locator( `#${ resultsRef }` );
+		await expect( linkUIResults ).toBeVisible();
+		return linkUIResults.getByRole( 'option' );
+	}
+
+	async getNthSearchResult( index = 0 ) {
+		const results = await this.getSearchResults();
+		return results.nth( index );
+	}
+
+	async searchFor( searchTerm ) {
+		const input = this.getSearchInput();
+		await expect( input ).toBeFocused();
+		await this.page.keyboard.type( searchTerm );
+		await expect( input ).toHaveValue( searchTerm );
+		return input;
+	}
+
+	async getSearchResultText( result ) {
+		await expect( result ).toBeVisible();
+		return result
+			.locator( '.components-menu-item__item' )
+			.last()
+			.innerText();
+	}
+}

--- a/test/e2e/specs/site-editor/navigation-template-areas-debug.spec.js
+++ b/test/e2e/specs/site-editor/navigation-template-areas-debug.spec.js
@@ -145,12 +145,13 @@ test.describe( 'NavigationMenuTemplateAreas', () => {
 		await expect( page.getByText( 'Preview Test Header' ) ).toBeVisible();
 	} );
 
-	test( 'preview area shows template part with unbound nav block when it is the only menu', async ( {
+	test( 'preview area shows unbound nav block (no inner items) when it is the fallback menu', async ( {
 		admin,
 		page,
 		requestUtils,
 	} ) => {
-		// Only one navigation menu exists — unbound nav blocks default to it.
+		// Single menu = it is the fallback. Unbound block with no inner
+		// items will resolve to it at render time.
 		const menu = await requestUtils.createNavigationMenu( {
 			title: 'Only Menu',
 			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
@@ -173,21 +174,55 @@ test.describe( 'NavigationMenuTemplateAreas', () => {
 			} )
 		).toBeVisible();
 
-		// Single menu on the site: unbound nav block defaults to it.
+		// This menu is the fallback → unbound empty nav block matches.
 		await expect( page.getByText( 'Unbound Single Header' ) ).toBeVisible();
 	} );
 
-	test( 'preview area does NOT show template part with unbound nav block when multiple menus exist', async ( {
+	test( 'preview area does NOT show unbound nav block with inline items even for the fallback menu', async ( {
 		admin,
 		page,
 		requestUtils,
 	} ) => {
-		// Two menus exist — can't know which one an unbound block uses.
+		// A nav block with its own navigation-link children is self-contained
+		// and does not resolve to any navigation menu — never shown.
+		const menu = await requestUtils.createNavigationMenu( {
+			title: 'Fallback Menu',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'inline-nav-header',
+			title: 'Inline Nav Header',
+			content: `<!-- wp:navigation --><!-- wp:navigation-link {"label":"Blog","url":"#"} /--><!-- /wp:navigation -->`,
+		} );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menu.id }&postType=wp_navigation`
+		);
+
+		await expect(
+			page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} )
+		).toBeVisible();
+
+		// Nav block has inline items → self-contained, not shown.
+		await expect( page.getByText( 'Inline Nav Header' ) ).toBeHidden();
+	} );
+
+	test( 'with multiple menus: unbound block shown for fallback (newest) menu only', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// menuA is created first, menuB second → menuB is the fallback
+		// (WordPress uses the most recently created published menu).
 		const menuA = await requestUtils.createNavigationMenu( {
 			title: 'Multi Menu A',
 			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
 		} );
-		await requestUtils.createNavigationMenu( {
+		const menuB = await requestUtils.createNavigationMenu( {
 			title: 'Multi Menu B',
 			content:
 				'<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
@@ -199,19 +234,25 @@ test.describe( 'NavigationMenuTemplateAreas', () => {
 			content: `<!-- wp:navigation /-->`,
 		} );
 
+		// Viewing the NON-fallback menu (menuA) → unbound block not shown.
 		await admin.visitAdminPage(
 			'site-editor.php',
 			`postId=${ menuA.id }&postType=wp_navigation`
 		);
-
 		await expect(
-			page.getByRole( 'treegrid', {
-				name: 'Block navigation structure',
-			} )
+			page.getByRole( 'treegrid', { name: 'Block navigation structure' } )
 		).toBeVisible();
-
-		// Multiple menus: unbound nav block is ambiguous, should not appear.
 		await expect( page.getByText( 'Unbound Multi Header' ) ).toBeHidden();
+
+		// Viewing the fallback menu (menuB, most recently created) → shown.
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menuB.id }&postType=wp_navigation`
+		);
+		await expect(
+			page.getByRole( 'treegrid', { name: 'Block navigation structure' } )
+		).toBeVisible();
+		await expect( page.getByText( 'Unbound Multi Header' ) ).toBeVisible();
 	} );
 
 	test( 'preview area does NOT show template part using a different nav menu', async ( {

--- a/test/e2e/specs/site-editor/navigation-template-areas-debug.spec.js
+++ b/test/e2e/specs/site-editor/navigation-template-areas-debug.spec.js
@@ -1,0 +1,252 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Tests for NavigationMenuTemplateAreas preview feature.
+ * Verifies that the preview area shows template PART previews (not full
+ * page templates) for template parts that use the navigation menu.
+ */
+test.describe( 'NavigationMenuTemplateAreas', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllMenus(),
+			requestUtils.deleteAllTemplates( 'wp_template_part' ),
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'navigation block with explicit ref: content.raw contains "ref":ID', async ( {
+		requestUtils,
+	} ) => {
+		const menu = await requestUtils.createNavigationMenu( {
+			title: 'Explicit Ref Menu',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'header-explicit-ref',
+			content: `<!-- wp:navigation {"ref":${ menu.id }} /-->`,
+		} );
+
+		const parts = await requestUtils.rest( {
+			path: '/wp/v2/template-parts',
+		} );
+		const part = parts.find( ( p ) => p.slug === 'header-explicit-ref' );
+
+		// eslint-disable-next-line no-console
+		console.log( 'explicit ref content.raw:', part?.content?.raw );
+
+		// Proves: explicit ref IS searchable with "ref":ID.
+		expect( part?.content?.raw ).toContain( `"ref":${ menu.id }` );
+	} );
+
+	test( 'navigation block without ref: content.raw does NOT contain "ref"', async ( {
+		requestUtils,
+	} ) => {
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'header-no-ref',
+			content: `<!-- wp:navigation /-->`,
+		} );
+
+		const parts = await requestUtils.rest( {
+			path: '/wp/v2/template-parts',
+		} );
+		const part = parts.find( ( p ) => p.slug === 'header-no-ref' );
+
+		// eslint-disable-next-line no-console
+		console.log( 'no ref content.raw:', part?.content?.raw );
+
+		// Proves: no-ref nav block is NOT detectable by "ref":ID string search.
+		expect( part?.content?.raw ).toContain( 'wp:navigation' );
+		expect( part?.content?.raw ).not.toContain( '"ref"' );
+	} );
+
+	test( 'preview area shows template part with deeply nested navigation block', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const menu = await requestUtils.createNavigationMenu( {
+			title: 'Deeply Nested Menu',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+
+		// Mirrors the real TwentyTwentyFive header structure with the nav block
+		// nested four levels deep inside wp:group blocks.
+		const content = `<!-- wp:group {"metadata":{"patternName":"twentytwentyfive/header","name":"Header"},"align":"full","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:site-title {"level":0} /-->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+<div class="wp-block-group"><!-- wp:navigation {"ref":${ menu.id },"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->`;
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'deeply-nested-header',
+			title: 'Deeply Nested Header',
+			content,
+		} );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menu.id }&postType=wp_navigation`
+		);
+
+		await expect(
+			page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} )
+		).toBeVisible();
+
+		await expect( page.getByText( 'Deeply Nested Header' ) ).toBeVisible();
+	} );
+
+	test( 'preview area shows template part with explicit nav menu ref', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const menu = await requestUtils.createNavigationMenu( {
+			title: 'Preview Test Menu',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'preview-test-header',
+			title: 'Preview Test Header',
+			content: `<!-- wp:navigation {"ref":${ menu.id }} /-->`,
+		} );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menu.id }&postType=wp_navigation`
+		);
+
+		await expect(
+			page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} )
+		).toBeVisible();
+
+		// The preview area should show the template PART title.
+		await expect( page.getByText( 'Preview Test Header' ) ).toBeVisible();
+	} );
+
+	test( 'preview area shows template part with unbound nav block when it is the only menu', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Only one navigation menu exists — unbound nav blocks default to it.
+		const menu = await requestUtils.createNavigationMenu( {
+			title: 'Only Menu',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'unbound-single-header',
+			title: 'Unbound Single Header',
+			content: `<!-- wp:navigation /-->`,
+		} );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menu.id }&postType=wp_navigation`
+		);
+
+		await expect(
+			page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} )
+		).toBeVisible();
+
+		// Single menu on the site: unbound nav block defaults to it.
+		await expect( page.getByText( 'Unbound Single Header' ) ).toBeVisible();
+	} );
+
+	test( 'preview area does NOT show template part with unbound nav block when multiple menus exist', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Two menus exist — can't know which one an unbound block uses.
+		const menuA = await requestUtils.createNavigationMenu( {
+			title: 'Multi Menu A',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+		await requestUtils.createNavigationMenu( {
+			title: 'Multi Menu B',
+			content:
+				'<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
+		} );
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'unbound-multi-header',
+			title: 'Unbound Multi Header',
+			content: `<!-- wp:navigation /-->`,
+		} );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menuA.id }&postType=wp_navigation`
+		);
+
+		await expect(
+			page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} )
+		).toBeVisible();
+
+		// Multiple menus: unbound nav block is ambiguous, should not appear.
+		await expect( page.getByText( 'Unbound Multi Header' ) ).toBeHidden();
+	} );
+
+	test( 'preview area does NOT show template part using a different nav menu', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const menuA = await requestUtils.createNavigationMenu( {
+			title: 'Menu A',
+			content: '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+		} );
+		const menuB = await requestUtils.createNavigationMenu( {
+			title: 'Menu B',
+			content:
+				'<!-- wp:navigation-link {"label":"About","url":"/about"} /-->',
+		} );
+
+		await requestUtils.createTemplate( 'wp_template_part', {
+			slug: 'menu-b-header',
+			title: 'Menu B Header',
+			content: `<!-- wp:navigation {"ref":${ menuB.id }} /-->`,
+		} );
+
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`postId=${ menuA.id }&postType=wp_navigation`
+		);
+
+		await expect(
+			page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} )
+		).toBeVisible();
+
+		// Template part for Menu B should NOT appear when viewing Menu A.
+		await expect( page.getByText( 'Menu B Header' ) ).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Bring parity between the contentOnly editable list view for navigation blocks and the site editor navigation sidebar list view.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There's a severe lack of editing capabilities in the site editor admin sidebar. If we can add more capabilities here, I think it would improve UX.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Disregard for now. Prototype by Claude. I haven't considered the implementation in this. 

## NOTE: THIS IS A PROTOTYPE

Many things don't work. Just image it does :) 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to http://localhost:8888/wp-admin/site-editor.php?p=%2Fnavigation
- Interact with the left side navigation to see how it could work

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Iteration 1 Video: Just list view updates**

https://github.com/user-attachments/assets/6bbea4f0-c32e-442b-b8cf-561d1013cfd2

**Iteration 2 Video: DataViews for Navigation Templates used**


https://github.com/user-attachments/assets/00a504e1-26a8-4ab8-8f08-7b5080f1337d



