### PR TITLE
Prevent CSS modules in build from breaking Jest tests

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -173,7 +173,7 @@ function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 			map: false,
 		} );
 
-		let cssModule = `if (typeof document !== 'undefined' && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
+		let cssModule = `if (typeof document !== 'undefined' && !(typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
 	const style = document.createElement("style");
 	style.setAttribute("data-wp-hash", "${ hash }");
 	style.appendChild(document.createTextNode(${ JSON.stringify( css ) }));

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -173,7 +173,7 @@ function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 			map: false,
 		} );
 
-		let cssModule = `if (typeof document !== 'undefined' && !(typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
+		let cssModule = `if (typeof document !== 'undefined' && process.env.NODE_ENV !== 'test' && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
 	const style = document.createElement("style");
 	style.setAttribute("data-wp-hash", "${ hash }");
 	style.appendChild(document.createTextNode(${ JSON.stringify( css ) }));


### PR DESCRIPTION
## What?

Skip runtime CSS style injection during Jest tests to prevent `jsdom` console errors.

## Why?

`wp-build` compiles CSS module imports into JavaScript that injects `<style>` elements into the DOM at runtime. The injected CSS uses `@layer` rules, which `jsdom` doesn't support — causing `Error: Could not parse CSS stylesheet` console errors in any Jest test that transitively imports a package built by `wp-build` (including `@wordpress/ui`).

Consumers shouldn't need to mock `@wordpress/ui` just to avoid CSS parse errors in their test suite. This becomes increasingly impractical as `@wordpress/ui` adoption grows.

## How?

Adds a `NODE_ENV === 'test'` guard to the generated style injection code in `compileInlineStyle()`. When `process.env.NODE_ENV` is `'test'`, style injection is skipped entirely.

Runtime behavior:

- **Browser** — `typeof process` is `'undefined'`, guard short-circuits, styles are injected normally.
- **Jest (`NODE_ENV=test`)** — guard matches, injection is skipped, no console errors.
- **Node non-test (e.g. SSR)** — `NODE_ENV` is not `'test'`, styles are injected normally.

`process.env.NODE_ENV` is not replaced by esbuild's `define` in the built output (at least for normal `build` and `build-module`), so the check is evaluated at runtime as intended.

## Testing Instructions

1. Scaffold a minimal React project with a standard Jest setup.
2. Install `@wordpress/ui` as a dependency. (In the "before" test, it can come straight from npm. In the "after" test, replace it in node_modules with the new built files rebuilt from this PR branch.)
3. Run a minimal Jest test that simply renders a component from `@wordpress/ui`.
4. The test output should not show "Error: Could not parse CSS stylesheet" console errors.