### PR TITLE
Block Editor: Invalid block selected style

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -191,22 +191,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		}
 	}
 
-	// Scrim overlay.
-	&.has-warning::after {
-		content: "";
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		background-color: rgba($white, 0.4);
-	}
-
-	// Avoid conflict with the multi-selection highlight color.
-	&.has-warning.is-multi-selected::after {
-		background-color: transparent;
-	}
-
 	// Clear floats.
 	&[data-clear="true"] {
 		float: none;
@@ -412,25 +396,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 
 	&:focus {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-	}
-}
-
-
-/**
- * Warnings.
- */
-
-.block-editor-block-list__block .block-editor-warning {
-	z-index: z-index(".block-editor-warning");
-	position: relative;
-
-	&.block-editor-block-list__block-crash-warning {
-		// The block crash warning has no block preview underneath it.
-		// The lack of a preview combined with the negative margin that
-		// the warning normally has results in crashed blocks overlapping
-		// any blocks that come after them. Resetting the margin to `auto`
-		// solves this.
-		margin-bottom: auto;
 	}
 }
 


### PR DESCRIPTION
Fixes #75795

## What? Why? How?

An "invalid" block is one of the following three blocks and the block has the `has-warning` class:

- The block that contains unexpected or invalid content.
- Unsupported block (Missing block)
- The block that has encountered an error and cannot be previewed.

I found that these blocks' outlines and background colors were not displayed correctly when selected.

All of the styles this PR removes were added more than five years ago. They're likely no longer needed in the current block editor.


## Testing Instructions

Insert the following content via the code editor and select a block

```html
<!-- wp:cover {"layout":{"type":"constrained"}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
<!-- /wp:cover -->

<!-- wp:paragraph -->
<div>Hello World</p>
<!-- /wp:paragraph -->

<!-- wp:unsupported-block /-->

<!-- wp:paragraph -->
<p>Hello World</p>
<!-- /wp:paragraph -->
```

The block crashing due to a JS error can be reproduced with the following code: run it from your browser console, insert the block, and click on it.

```javascript
wp.blocks.registerBlockType('my-plugin/invalid-block', {
	apiVersion: 3,
	title: 'Invalid Block',
	edit: function () {
		var useState = wp.element.useState;
		var crashed = useState(false);
		var setCrashed = crashed[1];
		crashed = crashed[0];
		if (crashed) {
			throw new Error('Block crashed on click');
		
}
		return wp.element.createElement(
			'p',
			wp.blockEditor.useBlockProps({
				onClick: function () {
					setCrashed(true);
				},
			}),
			'Hello World (click to trigger BlockCrashBoundary)'
		);
	},
});
```
Select one or more of these blocks to see their outline and background color.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/bcb454ed-44d4-4533-9cf5-19456661ac01

### After

https://github.com/user-attachments/assets/dc3c762a-51af-403b-b850-91750654d34a


