### PR TITLE
Block Support: Fix custom CSS not saved when style schema is not defined

### DIFF
--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { addFilter } from '@wordpress/hooks';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
@@ -23,6 +24,36 @@ const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 
 // Stable empty object reference for useSelect.
 const EMPTY_STYLE = {};
+
+/**
+ * Filters registered block settings, extending attributes to include `style`
+ * when the block has customCSS support.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+function addAttribute( settings ) {
+	if ( ! hasBlockSupport( settings, 'customCSS', true ) ) {
+		return settings;
+	}
+
+	if ( ! settings.attributes?.style ) {
+		Object.assign( settings.attributes, {
+			style: {
+				type: 'object',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/customCSS/addAttribute',
+	addAttribute
+);
 
 /**
  * Inspector control for custom CSS.

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { addFilter } from '@wordpress/hooks';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
@@ -24,36 +23,6 @@ const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 
 // Stable empty object reference for useSelect.
 const EMPTY_STYLE = {};
-
-/**
- * Filters registered block settings, extending attributes to include `style`
- * when the block has customCSS support.
- *
- * @param {Object} settings Original block settings.
- *
- * @return {Object} Filtered block settings.
- */
-function addAttribute( settings ) {
-	if ( ! hasBlockSupport( settings, 'customCSS', true ) ) {
-		return settings;
-	}
-
-	if ( ! settings.attributes?.style ) {
-		Object.assign( settings.attributes, {
-			style: {
-				type: 'object',
-			},
-		} );
-	}
-
-	return settings;
-}
-
-addFilter(
-	'blocks.registerBlockType',
-	'core/customCSS/addAttribute',
-	addAttribute
-);
 
 /**
  * Inspector control for custom CSS.

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -74,7 +74,10 @@ export function getInlineStyles( styles = {} ) {
  * @return {Object} Filtered block settings.
  */
 function addAttribute( settings ) {
-	if ( ! hasStyleSupport( settings ) ) {
+	if (
+		! hasStyleSupport( settings ) &&
+		! hasBlockSupport( settings, 'customCSS', true )
+	) {
 		return settings;
 	}
 

--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -297,8 +297,8 @@ const v4 = {
 			backgroundColor: isSolidColorStyle ? mainColor : undefined,
 			borderColor: isSolidColorStyle ? undefined : mainColor,
 			textAlign: isSolidColorStyle ? 'left' : undefined,
-			style,
 			...attributes,
+			style,
 		};
 	},
 };
@@ -454,8 +454,8 @@ const v3 = {
 			backgroundColor: isSolidColorStyle ? mainColor : undefined,
 			borderColor: isSolidColorStyle ? undefined : mainColor,
 			textAlign: isSolidColorStyle ? 'left' : undefined,
-			style,
 			...attributes,
+			style,
 		};
 	},
 };
@@ -572,8 +572,8 @@ const v2 = {
 			backgroundColor: isSolidColorStyle ? mainColor : undefined,
 			borderColor: isSolidColorStyle ? undefined : mainColor,
 			textAlign: isSolidColorStyle ? 'left' : undefined,
-			style,
 			...attributes,
+			style,
 		};
 	},
 };

--- a/test/integration/fixtures/blocks/core__pullquote__custom-colors__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__pullquote__custom-colors__deprecated-4.json
@@ -5,13 +5,13 @@
 		"attributes": {
 			"value": "Pullquote custom color",
 			"className": "has-background is-style-default",
+			"citation": "my citation",
+			"textColor": "subtle-background",
 			"style": {
 				"border": {
 					"color": "#2207d0"
 				}
-			},
-			"citation": "my citation",
-			"textColor": "subtle-background"
+			}
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-main-color.json
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-main-color.json
@@ -5,13 +5,13 @@
 		"attributes": {
 			"value": "Pullquote custom color",
 			"className": "is-style-default",
+			"citation": "my citation",
+			"textColor": "subtle-background",
 			"style": {
 				"border": {
 					"color": "#2207d0"
 				}
-			},
-			"citation": "my citation",
-			"textColor": "subtle-background"
+			}
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator__deprecated-custom-color-v1.json
+++ b/test/integration/fixtures/blocks/core__separator__deprecated-custom-color-v1.json
@@ -3,12 +3,12 @@
 		"name": "core/separator",
 		"isValid": true,
 		"attributes": {
-			"opacity": "css",
 			"style": {
 				"color": {
 					"background": "#cc1d1d"
 				}
 			},
+			"opacity": "css",
 			"tagName": "hr"
 		},
 		"innerBlocks": []


### PR DESCRIPTION
Fixes #75766

## What? Why?

Block serialization only considers attributes that exist in the block type's schema. If the block has any block support, the style property is added to the attribute definition [here](https://github.com/WordPress/gutenberg/blob/7b24fa8b5977d579caf072ffa017035333f3c9cb/packages/block-editor/src/hooks/style.js#L81-L88), so custom CSS support will work correctly in most cases.

However, for blocks that don't have any block support, `attributes.style` doesn't exist, so custom CSS serialization will fail.

## How?

When a block supports custom CSS, explicitly adds `attributes.style` definition via the `blocks.registerBlockType` hook.

At first, I thought simply adding `customCSS` [here](https://github.com/WordPress/gutenberg/blob/7b24fa8b5977d579caf072ffa017035333f3c9cb/packages/block-editor/src/hooks/style.js#L38-L46) would work, but it doesn't. This is because [the `hasStyleSupport` check checks whether the block support is explicitly set to true](https://github.com/WordPress/gutenberg/blob/7b24fa8b5977d579caf072ffa017035333f3c9cb/packages/block-editor/src/hooks/style.js#L48-L49). Since `customCSS` is `true` by default and the blocks don't have it explicitly set to `true`, the `hasStyleSupport` check fails.

## Testing Instructions

Register a minimal block that doesn't define any block supports. Insert a block, add custom CSS from the block sidebar, and switch to the code editor. The CSS should now be serialized.

```javascript
wp.blocks.registerBlockType( 'test/custom-css-block', {
	apiVersion: 3,
	title: 'Custom CSS Test',
	edit() {
		return wp.element.createElement(
			'p',
			wp.blockEditor.useBlockProps(),
			'Hello World'
		);
	},
} );
```

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/b7ac00d6-5c93-48f3-9c66-ac2332880f10

