### PR TITLE
Custom CSS: Allow defining custom selector for this global styles feature

### DIFF
--- a/backport-changelog/7.1/11000.md
+++ b/backport-changelog/7.1/11000.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11000
+
+* https://github.com/WordPress/gutenberg/pull/75799

--- a/docs/reference-guides/block-api/block-selectors.md
+++ b/docs/reference-guides/block-api/block-selectors.md
@@ -77,6 +77,42 @@ elements to which it should be applied.
 }
 ```
 
+## Custom CSS selector
+
+The `css` selector controls which selector is used when generating a block's
+custom CSS rules set via Global Styles. This maps to the
+`styles.blocks.<block-type>.css` property in theme.json.
+
+If not set, the block's root selector is used.
+
+### Examples
+
+As a string:
+
+```json
+{
+	...
+	"selectors": {
+		"root": ".my-custom-block-selector",
+		"css": ".my-custom-block-selector > .inner-wrapper"
+	}
+}
+```
+
+As an object with a `root` key:
+
+```json
+{
+	...
+	"selectors": {
+		"root": ".my-custom-block-selector",
+		"css": {
+			"root": ".my-custom-block-selector > .inner-wrapper"
+		}
+	}
+}
+```
+
 ## Shorthand
 
 Rather than specify a CSS selector for every subfeature, you can set a single

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3215,7 +3215,12 @@ class WP_Theme_JSON_Gutenberg {
 
 		// 7. Generate and append any custom CSS rules.
 		if ( isset( $node['css'] ) && ! $is_root_selector ) {
-			$block_rules .= $this->process_blocks_custom_css( $node['css'], $selector );
+			$css_feature_selector = $block_metadata['selectors']['css'] ?? null;
+			if ( is_array( $css_feature_selector ) ) {
+				$css_feature_selector = $css_feature_selector['root'] ?? null;
+			}
+			$css_selector = is_string( $css_feature_selector ) ? $css_feature_selector : $selector;
+			$block_rules .= $this->process_blocks_custom_css( $node['css'], $css_selector );
 		}
 
 		return $block_rules;
@@ -4537,9 +4542,9 @@ class WP_Theme_JSON_Gutenberg {
 		$settings = $this->theme_json['settings'] ?? null;
 
 		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
-			// Skip if this is the block's root selector or the block doesn't
-			// have any styles for the feature.
-			if ( 'root' === $feature || empty( $node[ $feature ] ) ) {
+			// Skip if this is the block's root selector, the custom CSS
+			// selector, or the block doesn't have any styles for the feature.
+			if ( 'root' === $feature || 'css' === $feature || empty( $node[ $feature ] ) ) {
 				continue;
 			}
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1782,12 +1782,14 @@ export function generateGlobalStyles(
 				typeof featureSelectors === 'object'
 					? featureSelectors?.css
 					: undefined;
-			const resolvedCssSelector =
-				typeof cssFeatureSelector === 'string'
-					? cssFeatureSelector
-					: typeof cssFeatureSelector === 'object'
-					? ( cssFeatureSelector as Record< string, string > )?.root
-					: undefined;
+			let resolvedCssSelector: string | undefined;
+			if ( typeof cssFeatureSelector === 'string' ) {
+				resolvedCssSelector = cssFeatureSelector;
+			} else if ( typeof cssFeatureSelector === 'object' ) {
+				resolvedCssSelector = (
+					cssFeatureSelector as Record< string, string >
+				 )?.root;
+			}
 			const selector =
 				resolvedCssSelector ??
 				blockSelectors[ blockType.name ].selector;

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1777,7 +1777,20 @@ export function generateGlobalStyles(
 	blocks.forEach( ( blockType: BlockType ) => {
 		const blockStyles = updatedConfig?.styles?.blocks?.[ blockType.name ];
 		if ( blockStyles?.css ) {
-			const selector = blockSelectors[ blockType.name ].selector;
+			const { featureSelectors } = blockSelectors[ blockType.name ];
+			const cssFeatureSelector =
+				typeof featureSelectors === 'object'
+					? featureSelectors?.css
+					: undefined;
+			const resolvedCssSelector =
+				typeof cssFeatureSelector === 'string'
+					? cssFeatureSelector
+					: typeof cssFeatureSelector === 'object'
+					? ( cssFeatureSelector as Record< string, string > )?.root
+					: undefined;
+			const selector =
+				resolvedCssSelector ??
+				blockSelectors[ blockType.name ].selector;
 			styles.push( {
 				css: processCSSNesting( blockStyles.css, selector ),
 				isGlobalStyles: true,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5436,6 +5436,109 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that block custom CSS uses the css feature selector when defined
+	 * in block metadata selectors config.
+	 */
+	public function test_get_styles_for_block_custom_css_uses_css_feature_selector() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'css' => 'color:red;',
+						),
+					),
+				),
+			)
+		);
+
+		$paragraph_node = array(
+			'name'      => 'core/paragraph',
+			'path'      => array( 'styles', 'blocks', 'core/paragraph' ),
+			'selector'  => 'p',
+			'selectors' => array(
+				'root' => 'p',
+				'css'  => '.custom-p',
+			),
+		);
+
+		$this->assertSame(
+			':root :where(.custom-p){color:red;}',
+			$theme_json->get_styles_for_block( $paragraph_node )
+		);
+	}
+
+	/**
+	 * Tests that block custom CSS falls back to the root selector when no
+	 * css feature selector is defined in block metadata selectors config.
+	 */
+	public function test_get_styles_for_block_custom_css_falls_back_to_root_selector() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'css' => 'color:red;',
+						),
+					),
+				),
+			)
+		);
+
+		$paragraph_node = array(
+			'name'      => 'core/paragraph',
+			'path'      => array( 'styles', 'blocks', 'core/paragraph' ),
+			'selector'  => 'p',
+			'selectors' => array(
+				'root' => 'p',
+			),
+		);
+
+		$this->assertSame(
+			':root :where(p){color:red;}',
+			$theme_json->get_styles_for_block( $paragraph_node )
+		);
+	}
+
+	/**
+	 * Tests that block custom CSS uses the css feature selector when defined
+	 * as an object with a root subkey in block metadata selectors config.
+	 */
+	public function test_get_styles_for_block_custom_css_uses_css_feature_selector_object_form() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'css' => 'color:red;',
+						),
+					),
+				),
+			)
+		);
+
+		$paragraph_node = array(
+			'name'      => 'core/paragraph',
+			'path'      => array( 'styles', 'blocks', 'core/paragraph' ),
+			'selector'  => 'p',
+			'selectors' => array(
+				'root' => 'p',
+				'css'  => array(
+					'root' => '.custom-p',
+				),
+			),
+		);
+
+		$this->assertSame(
+			':root :where(.custom-p){color:red;}',
+			$theme_json->get_styles_for_block( $paragraph_node )
+		);
+	}
+
+	/**
 	 * Tests that custom CSS is kept for users with correct capabilities and removed for others.
 	 *
 	 * @dataProvider data_custom_css_for_user_caps

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -790,6 +790,20 @@
 							}
 						}
 					]
+				},
+				"css": {
+					"description": "Custom CSS selector used when generating the block's custom CSS rules set via Global Styles.",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "object",
+							"properties": {
+								"root": { "type": "string" }
+							}
+						}
+					]
 				}
 			}
 		},


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/75786

## What?

When a block type defines a `css` feature selector in its `block.json` `selectors` config, the Global Styles custom CSS output should honor that selector instead of always using the block's root selector.

## Why?

Block types can define granular selectors for different style features via the `selectors` property in `block.json`. For example, a block might define separate selectors for `border`, `color`, `typography`, etc. The Global Styles system already respects these feature-specific selectors when generating CSS for standard style properties.

However, when generating CSS for per-block-type "Additional CSS" (the `css` property in `styles.blocks.<blockName>.css` within theme.json / Global Styles), the system always used the block's root selector, ignoring any `selectors.css` configuration. This meant blocks had no way to control where their custom CSS was scoped.


## How?

### PHP (`lib/class-wp-theme-json-gutenberg.php`)

1. **`get_styles_for_block()`**: When processing custom CSS rules (step 7), check `$block_metadata['selectors']['css']` for a feature-specific selector before falling back to the block's root `$selector`.

2. **`get_feature_declarations_for_node()`**: Skip the `css` key when iterating over feature selectors. Without this, the method would consume `css` as a regular style feature — attempting to generate style declarations from the raw CSS string and then deleting `$node['css']` — which prevented the custom CSS processing in step 7 from ever running.

### JS (`packages/global-styles-engine/src/core/render.tsx`)

3. **`generateGlobalStyles()`**: When looping through blocks to process custom CSS, check `featureSelectors?.css` before falling back to the block's root `.selector`.

All three changes fall back to the root selector when no `css` feature selector is defined, preserving existing behavior for all current blocks.

## Testing Instructions

1. This is an internal API change. No blocks currently define a `selectors.css` property, so there is no user-facing change.
2. Add something like `color: read` into the Additional CSS field of the icon block's Global Styles. Then check the selector of style created for this.
3. Check out https://github.com/WordPress/gutenberg/pull/75786 and confirm the selector remains the same
4. Double check all the new tests are passing