### PR TITLE
Query Title: Migrate to Text-Align Block Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -866,8 +866,8 @@ Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/t
 
 -	**Name:** core/query-title
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** level, levelOptions, showPrefix, showSearchTerm, type
 
 ## Query Total
 

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -10,9 +10,6 @@
 		"type": {
 			"type": "string"
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"level": {
 			"type": "number",
 			"default": 1
@@ -53,6 +50,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,

--- a/packages/block-library/src/query-title/deprecated.js
+++ b/packages/block-library/src/query-title/deprecated.js
@@ -2,6 +2,79 @@
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v2 = {
+	attributes: {
+		type: {
+			type: 'string',
+		},
+		textAlign: {
+			type: 'string',
+		},
+		level: {
+			type: 'number',
+			default: 1,
+		},
+		levelOptions: {
+			type: 'array',
+		},
+	},
+	supports: {
+		anchor: true,
+		align: [ 'wide', 'full' ],
+		html: false,
+		color: {
+			gradients: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			padding: true,
+			margin: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+	save: () => null,
+};
 
 const v1 = {
 	attributes: {
@@ -48,4 +121,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v1 ];
+export default [ v2, v1 ];

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -40,7 +40,9 @@ export default function QueryTitleEdit( props ) {
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: 'wp-block-query-title__placeholder',
+	} );
 
 	if ( ! SUPPORTED_TYPES.includes( type ) ) {
 		return (

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
-	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
@@ -27,32 +21,26 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { useArchiveLabel } from './use-archive-label';
 import { usePostTypeLabel } from './use-post-type-label';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
 const SUPPORTED_TYPES = [ 'archive', 'search', 'post-type' ];
 
-export default function QueryTitleEdit( {
-	attributes: {
-		type,
-		level,
-		levelOptions,
-		textAlign,
-		showPrefix,
-		showSearchTerm,
-	},
-	setAttributes,
-	context: { query },
-} ) {
+export default function QueryTitleEdit( props ) {
+	useDeprecatedTextAlign( props );
+
+	const {
+		attributes: { type, level, levelOptions, showPrefix, showSearchTerm },
+		setAttributes,
+		context: { query },
+	} = props;
+
 	const { archiveTypeLabel, archiveNameLabel } = useArchiveLabel();
 	const { postTypeLabel } = usePostTypeLabel( query?.postType );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 
-	const blockProps = useBlockProps( {
-		className: clsx( 'wp-block-query-title__placeholder', {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 
 	if ( ! SUPPORTED_TYPES.includes( type ) ) {
 		return (
@@ -238,12 +226,6 @@ export default function QueryTitleEdit( {
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}
-				/>
-				<AlignmentControl
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
 				/>
 			</BlockControls>
 			{ titleElement }

--- a/test/integration/fixtures/blocks/core__query-title__deprecated-v2.html
+++ b/test/integration/fixtures/blocks/core__query-title__deprecated-v2.html
@@ -1,0 +1,5 @@
+<!-- wp:query-title {"textAlign":"left"} /-->
+
+<!-- wp:query-title {"textAlign":"center"} /-->
+
+<!-- wp:query-title {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__query-title__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__query-title__deprecated-v2.json
@@ -1,0 +1,41 @@
+[
+	{
+		"name": "core/query-title",
+		"isValid": true,
+		"attributes": {
+			"level": 1,
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/query-title",
+		"isValid": true,
+		"attributes": {
+			"level": 1,
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/query-title",
+		"isValid": true,
+		"attributes": {
+			"level": 1,
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__query-title__deprecated-v2.parsed.json
+++ b/test/integration/fixtures/blocks/core__query-title__deprecated-v2.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/query-title",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/query-title",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/query-title",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__query-title__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__query-title__deprecated-v2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:query-title {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:query-title {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:query-title {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Query Title` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Query Title`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Query Title` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Query Title` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Query Title` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Query Title` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)