### PR TITLE
Unsynced patterns: Rename 'Disconnect pattern' to 'Detach pattern' in context menu

### DIFF
--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -102,7 +102,9 @@ function PatternsManageButton( { clientId } ) {
 						}
 					} }
 				>
-					{ __( 'Disconnect pattern' ) }
+					{ isSyncedPattern
+						? __( 'Disconnect pattern' )
+						: __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
 			<MenuItem href={ managePatternsUrl }>

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -461,6 +461,35 @@ test.describe( 'Unsynced pattern', () => {
 		).toBeVisible();
 	} );
 
+	test( 'detaches an unsynced pattern via the block options menu', async ( {
+		editor,
+	} ) => {
+		// Insert a paragraph block with unsynced pattern metadata.
+		await editor.setContent(
+			`<!-- wp:paragraph {"metadata":{"patternName":"my-pattern","name":"My unsynced pattern"}} -->
+<p>Pattern content</p>
+<!-- /wp:paragraph -->`
+		);
+
+		// Select the paragraph block (the unsynced pattern).
+		await editor.selectBlocks(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		);
+
+		// Open the block options menu and click "Detach pattern".
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+
+		// Verify block content is preserved but patternName is removed from metadata.
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].name ).toBe( 'core/paragraph' );
+		expect( blocks[ 0 ].attributes.content ).toBe( 'Pattern content' );
+		expect( blocks[ 0 ].attributes.metadata?.patternName ).toBeUndefined();
+		expect( blocks[ 0 ].attributes.metadata?.name ).toBe(
+			'My unsynced pattern'
+		);
+	} );
+
 	test( 'supports editing pattern via Edit pattern toolbar button', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -800,7 +800,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -835,7 +835,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -936,7 +936,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -800,7 +800,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -835,7 +835,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -936,7 +936,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Pattern' } )
 		);
-		await editor.clickBlockOptionsMenuItem( 'Disconnect pattern' );
+		await editor.clickBlockOptionsMenuItem( 'Detach pattern' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{


### PR DESCRIPTION

## What?

Renames the "Disconnect pattern" menu item to "Detach pattern" for unsynced patterns 

See https://github.com/WordPress/gutenberg/pull/73105#issuecomment-3549452891

Split out from:

- https://github.com/WordPress/gutenberg/pull/75713



## Why?

The previous "Disconnect pattern" label (introduced in https://github.com/WordPress/gutenberg/pull/73105) was originally intended for synced patterns only but unintentionally also applied to unsynced patterns.

"Detach" is better suited to unsynced patterns as, unlike synced patterns, there's no source from which to "Disconnect".

We're "detaching" the unsynced pattern from pattern editing mode and restricted editing.

## How?

Find, replace.

## Testing Instructions

Insert an unsynced pattern and a synced pattern. 

Check the block and list view context menus. 

Unsynced patterns can be detached.

Synced patterns can be disconnected.

Run the E2E tests

```
npm run test:e2e -- test/e2e/specs/editor/various/patterns.spec.js
```

## Screenshots or screencast <!-- if applicable -->


### Unsynced patterns

<img width="785" height="784" alt="Screenshot 2026-02-23 at 2 38 58 pm" src="https://github.com/user-attachments/assets/9428cd93-3dda-4e40-863a-14d0a3d0473e" />

### Synced patterns (no change)

<img width="608" height="579" alt="Screenshot 2026-02-23 at 2 38 52 pm" src="https://github.com/user-attachments/assets/cabc5463-e834-4d02-8260-70cb5158b302" />
