### PR TITLE
Fix client-side media file naming

### DIFF
--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1110,8 +1110,8 @@ export function generateThumbnails( id: QueueItemId ) {
 			// Use sourceFile for thumbnail generation to preserve quality.
 			// WordPress core generates thumbnails from the original (unscaled) image.
 			// Vips will auto-rotate based on EXIF orientation during thumbnail generation.
-			const file = attachment.media_filename
-				? renameFile( item.sourceFile, attachment.media_filename )
+			const file = attachment.filename
+				? renameFile( item.sourceFile, attachment.filename )
 				: item.sourceFile;
 			const batchId = uuidv4();
 

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -193,7 +193,6 @@ export interface Attachment {
 	mime_type: string;
 	featured_media?: number;
 	missing_image_sizes?: string[];
-	media_filename?: string;
 	poster?: string;
 	/**
 	 * EXIF orientation value from the original image.

--- a/packages/upload-media/src/test/convert-blob-to-file.ts
+++ b/packages/upload-media/src/test/convert-blob-to-file.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import { convertBlobToFile } from '../utils';
+
+describe( 'convertBlobToFile', () => {
+	it( 'should return a File unchanged', () => {
+		const file = new File( [ 'content' ], 'photo.jpg', {
+			type: 'image/jpeg',
+		} );
+		const result = convertBlobToFile( file );
+		expect( result ).toBe( file );
+		expect( result.name ).toBe( 'photo.jpg' );
+	} );
+
+	it( 'should convert a Blob with a default name', () => {
+		const blob = new Blob( [ 'content' ], { type: 'image/png' } );
+		const result = convertBlobToFile( blob );
+		expect( result ).toBeInstanceOf( File );
+		expect( result.name ).toBe( 'image.png' );
+		expect( result.type ).toBe( 'image/png' );
+	} );
+
+	it( 'should use "document" prefix for PDF blobs', () => {
+		const blob = new Blob( [ 'content' ], { type: 'application/pdf' } );
+		const result = convertBlobToFile( blob );
+		expect( result.name ).toBe( 'document.pdf' );
+	} );
+
+	it( 'should preserve the name from cross-realm File objects', () => {
+		// Simulate a cross-realm File object (e.g., from an iframe).
+		// These objects have a `name` property but fail `instanceof File`.
+		const crossRealmFile = new Blob( [ 'content' ], {
+			type: 'image/jpeg',
+		} );
+		Object.defineProperty( crossRealmFile, 'name', {
+			value: 'IMG_7977.jpg',
+			writable: false,
+		} );
+		Object.defineProperty( crossRealmFile, 'lastModified', {
+			value: 1700000000000,
+			writable: false,
+		} );
+
+		const result = convertBlobToFile( crossRealmFile );
+		expect( result ).toBeInstanceOf( File );
+		expect( result.name ).toBe( 'IMG_7977.jpg' );
+		expect( result.type ).toBe( 'image/jpeg' );
+		expect( result.lastModified ).toBe( 1700000000000 );
+	} );
+
+	it( 'should preserve the name for non-image cross-realm File objects', () => {
+		const crossRealmFile = new Blob( [ 'content' ], {
+			type: 'application/pdf',
+		} );
+		Object.defineProperty( crossRealmFile, 'name', {
+			value: 'my-document.pdf',
+			writable: false,
+		} );
+
+		const result = convertBlobToFile( crossRealmFile );
+		expect( result ).toBeInstanceOf( File );
+		expect( result.name ).toBe( 'my-document.pdf' );
+		expect( result.type ).toBe( 'application/pdf' );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes #75302

When the client-side media experiment is active, uploading or drag-and-dropping files causes the original filename to be stripped and replaced with a generic prefix (`image.jpeg`, `document.pdf`). This PR fixes two bugs:

- **Cross-realm `instanceof File` failure**: The block editor canvas renders inside an iframe. File objects from the iframe fail `instanceof File` in the parent window because each browsing context has its own `File` constructor. `convertBlobToFile()` now checks for a `name` property as a fallback, preserving the original filename for cross-realm File objects.
- **Wrong REST field name for thumbnails**: `generateThumbnails()` referenced `attachment.media_filename` which doesn't exist — the REST API field is `filename`. Thumbnails now correctly use the server-provided filename when renaming source files.

Also adds a `convert-blob-to-file.ts` unit test.

## Test plan

- [ ] Enable the Client Side Media experiment (Gutenberg → Experiments → Enable Client Side Media)
- [ ] Upload an image with a distinctive filename (e.g., `IMG_7977.jpg`)
- [ ] Verify the uploaded image retains the original filename prefix (e.g., `IMG_7977-scaled.jpeg`, `IMG_7977-1024x768.jpeg`)
- [ ] Upload a non-image file (e.g., `my-document.pdf`) and verify it retains its original name
- [ ] Drag and drop an image and verify the filename is preserved
- [ ] Verify existing unit tests pass: `npm run test:unit -- --testPathPattern='packages/upload-media/src'`