### PR TITLE
DataViews: Fix search input losing characters during debounce when externally synced

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
+- DataViews: Fix search input losing characters during debounce when externally synced. [#75810](https://github.com/WordPress/gutenberg/pull/75810)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataviews-search/index.tsx
+++ b/packages/dataviews/src/components/dataviews-search/index.tsx
@@ -21,7 +21,9 @@ const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
 		view.search
 	);
 	useEffect( () => {
-		setSearch( view.search ?? '' );
+		if ( view.search !== debouncedSearch ) {
+			setSearch( view.search ?? '' );
+		}
 	}, [ view.search, setSearch ] );
 	const onChangeViewRef = useRef( onChangeView );
 	const viewRef = useRef( view );


### PR DESCRIPTION
## What?

The `<DataViewsSearch>` component has a sync effect that overwrites the local search state whenever `view.search` changes:

https://github.com/WordPress/gutenberg/blob/5d217239414e145427a851d3dfbfa283a7ac072d/packages/dataviews/src/components/dataviews-search/index.tsx#L23-L25

 This causes a bug when the consumer updates `view.search` asynchronously in response to `onChangeView` (e.g., syncting to URL query param like `?search=xxx`). Characters typed between the debounce firing and `view.search` updating are lost.

## Why?

Check the following example sequence of events:

1. User types `ab` -> local search = `ab`, debounce pending
2. Debounce fires -> `debouncedSearch` = `ab`, `onChangeView({ search: "ab"})` called
3. User types `c` -> local search = `abc`
4. Consumer's async update completes (e.g. navigate to `?serach=ab`) -> `view.search` becomes "ab"
5. Sync effect fires -> `setSearch("ab")`, overwriting `abc` back to `ab`
6. The `c` keystroke is lost

## How?

```diff
diff --git a/packages/dataviews/src/components/dataviews-search/index.tsx b/packages/dataviews/src/components/dataviews-search/index.tsx
index 09269c7f70d..51305a02030 100644
--- a/packages/dataviews/src/components/dataviews-search/index.tsx
+++ b/packages/dataviews/src/components/dataviews-search/index.tsx
@@ -21,7 +21,9 @@ const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
                view.search
        );
        useEffect( () => {
-               setSearch( view.search ?? '' );
+               if ( view.search !== debouncedSearch ) {
+                       setSearch( view.search ?? '' );
+               }
        }, [ view.search, setSearch ] );
        const onChangeViewRef = useRef( onChangeView );
        const viewRef = useRef( view );
```

When `view.search` changes as a result of the component's own debounce flow, it will equal `debouncedSearch`, so the sync is skipped.

When `view.search` changes externally (e.g., synced with URL), it will differ from `debouncedSearch`, so the sync correctly updates the local search state.

## Testing Instructions

REGRESSION: Verify that you could not reproduce the issue mentioned in [this comment](https://github.com/WordPress/gutenberg/pull/55465#discussion_r1378053538) where this useEffect was initially introduced.