### PR TITLE
Media Thumbnail Field: Optimise image loading

### DIFF
--- a/packages/media-fields/src/media_thumbnail/style.scss
+++ b/packages/media-fields/src/media_thumbnail/style.scss
@@ -7,6 +7,27 @@
 	align-items: center;
 	position: relative;
 	height: 100%;
+
+	&.is-loading,
+	&.is-loaded {
+		img {
+			@media not (prefers-reduced-motion) {
+				transition: opacity 0.1s linear;
+			}
+		}
+	}
+
+	&.is-loading {
+		img {
+			opacity: 0;
+		}
+	}
+
+	&.is-loaded {
+		img {
+			opacity: 1;
+		}
+	}
 }
 
 .dataviews-media-field__media-thumbnail--image {

--- a/packages/media-fields/src/media_thumbnail/test/get-best-image-url.test.ts
+++ b/packages/media-fields/src/media_thumbnail/test/get-best-image-url.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Internal dependencies
+ */
+import { getBestImageUrl } from '../view';
+
+type Media = Parameters< typeof getBestImageUrl >[ 0 ];
+
+const baseMedia: Media = {
+	id: 1,
+	date: '2024-01-01T00:00:00',
+	date_gmt: '2024-01-01T00:00:00',
+	guid: {
+		raw: 'https://example.com/?attachment_id=1',
+		rendered: 'https://example.com/?attachment_id=1',
+	},
+	modified: '2024-01-01T00:00:00',
+	modified_gmt: '2024-01-01T00:00:00',
+	slug: 'test-image',
+	status: 'publish',
+	type: 'attachment',
+	link: 'https://example.com/test-image/',
+	title: { raw: 'Test Image', rendered: 'Test Image' },
+	author: 1,
+	featured_media: 0,
+	comment_status: 'open',
+	ping_status: 'closed',
+	template: '',
+	permalink_template: '',
+	generated_slug: 'test-image',
+	class_list: [ 'attachment' ],
+	caption: { raw: '', rendered: '' },
+	description: { raw: '', rendered: '' },
+	alt_text: 'A test image',
+	media_type: 'image',
+	mime_type: 'image/jpeg',
+	post: null,
+	source_url: 'https://example.com/original.jpg',
+	missing_image_sizes: [],
+	meta: {},
+	media_details: {
+		sizes: {
+			thumbnail: {
+				file: 'original-150x150.jpg',
+				width: 150,
+				height: 150,
+				mime_type: 'image/jpeg',
+				source_url: 'https://example.com/thumb.jpg',
+			},
+			medium: {
+				file: 'original-300x200.jpg',
+				width: 300,
+				height: 200,
+				mime_type: 'image/jpeg',
+				source_url: 'https://example.com/medium.jpg',
+			},
+			large: {
+				file: 'original-1024x683.jpg',
+				width: 1024,
+				height: 683,
+				mime_type: 'image/jpeg',
+				source_url: 'https://example.com/large.jpg',
+			},
+		},
+	},
+};
+
+describe( 'getBestImageUrl', () => {
+	describe( 'when media_details.sizes is unavailable', () => {
+		it( 'returns source_url when media_details has no sizes', () => {
+			const media = {
+				...baseMedia,
+				media_details: { sizes: {} },
+			};
+			expect( getBestImageUrl( media ) ).toBe( baseMedia.source_url );
+		} );
+	} );
+
+	describe( 'when configSizes is not provided or unparseable', () => {
+		it( 'returns source_url when configSizes is undefined', () => {
+			expect( getBestImageUrl( baseMedia ) ).toBe( baseMedia.source_url );
+		} );
+
+		it( 'returns source_url when configSizes is not a number', () => {
+			expect( getBestImageUrl( baseMedia, 'auto' ) ).toBe(
+				baseMedia.source_url
+			);
+		} );
+	} );
+
+	describe( 'size selection with a valid target width', () => {
+		it( 'picks the smallest size >= target width', () => {
+			expect( getBestImageUrl( baseMedia, '200px' ) ).toBe(
+				'https://example.com/medium.jpg'
+			);
+		} );
+
+		it( 'picks an exact match', () => {
+			expect( getBestImageUrl( baseMedia, '300px' ) ).toBe(
+				'https://example.com/medium.jpg'
+			);
+		} );
+
+		it( 'picks the smallest available size when target is very small', () => {
+			expect( getBestImageUrl( baseMedia, '50px' ) ).toBe(
+				'https://example.com/thumb.jpg'
+			);
+		} );
+
+		it( 'falls back to the largest size when target exceeds all sizes', () => {
+			expect( getBestImageUrl( baseMedia, '2000px' ) ).toBe(
+				'https://example.com/large.jpg'
+			);
+		} );
+	} );
+
+	// These tests deliberately omit required Size fields (width, height, etc.)
+	// to verify runtime defensiveness, so we cast via `unknown` to bypass TS.
+	describe( 'when size entries have missing or invalid widths', () => {
+		it( 'skips entries without a width and selects from valid ones', () => {
+			const media = {
+				...baseMedia,
+				media_details: {
+					sizes: {
+						broken: {
+							source_url: 'https://example.com/broken.jpg',
+						},
+						medium: {
+							file: 'original-300x200.jpg',
+							width: 300,
+							height: 200,
+							mime_type: 'image/jpeg',
+							source_url: 'https://example.com/medium.jpg',
+						},
+					},
+				},
+			} as unknown as Media;
+			expect( getBestImageUrl( media, '200px' ) ).toBe(
+				'https://example.com/medium.jpg'
+			);
+		} );
+
+		it( 'falls back to source_url when all entries lack a valid width', () => {
+			const media = {
+				...baseMedia,
+				media_details: {
+					sizes: {
+						broken: {
+							source_url: 'https://example.com/broken.jpg',
+						},
+						also_broken: {
+							source_url: 'https://example.com/also-broken.jpg',
+						},
+					},
+				},
+			} as unknown as Media;
+			expect( getBestImageUrl( media, '200px' ) ).toBe(
+				baseMedia.source_url
+			);
+		} );
+	} );
+} );

--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -40,10 +40,7 @@ function getBestImageUrl(
 		return featuredMedia.source_url;
 	}
 
-	const sizeEntries = Object.values( sizes ) as Array< {
-		source_url: string;
-		width: number;
-	} >;
+	const sizeEntries = Object.values( sizes );
 
 	if ( ! sizeEntries.length ) {
 		return featuredMedia.source_url;

--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -31,7 +31,7 @@ import type { MediaItem } from '../types';
  * @param featuredMedia The media item with size details.
  * @param configSizes   The target display size string (e.g. '900px').
  */
-function getBestImageUrl(
+export function getBestImageUrl(
 	featuredMedia: Attachment | MediaItem,
 	configSizes?: string
 ): string {
@@ -50,8 +50,19 @@ function getBestImageUrl(
 	const targetWidth = configSizes ? parseInt( configSizes, 10 ) : NaN;
 
 	if ( ! Number.isNaN( targetWidth ) ) {
+		// Filter to entries that have a valid numeric width.
+		const validEntries = sizeEntries.filter(
+			( s ) => typeof s.width === 'number' && ! Number.isNaN( s.width )
+		);
+
+		if ( ! validEntries.length ) {
+			return featuredMedia.source_url;
+		}
+
 		// Sort ascending by width.
-		const sorted = [ ...sizeEntries ].sort( ( a, b ) => a.width - b.width );
+		const sorted = [ ...validEntries ].sort(
+			( a, b ) => a.width - b.width
+		);
 		// Pick the smallest size that is >= target width.
 		const match = sorted.find( ( s ) => s.width >= targetWidth );
 		if ( match ) {

--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -100,32 +100,16 @@ function FallbackView( {
 	);
 }
 
-export default function MediaThumbnailView( {
+function ImageView( {
 	item,
-	config,
-}: DataViewRenderFieldProps< MediaItem > ) {
-	const [ imageError, setImageError ] = useState( false );
-
-	const _featuredMedia = useSelect(
-		( select ) => {
-			// Avoid the network request if it's not needed. `featured_media` is
-			// 0 for images and media without featured media.
-			if ( ! item.featured_media ) {
-				return;
-			}
-			return select( coreStore ).getEntityRecord< Attachment >(
-				'postType',
-				'attachment',
-				item.featured_media
-			);
-		},
-		[ item.featured_media ]
-	);
-	const featuredMedia = item.featured_media ? _featuredMedia : item;
-
-	const imageUrl = featuredMedia
-		? getBestImageUrl( featuredMedia, config?.sizes )
-		: undefined;
+	configSizes,
+	onError,
+}: {
+	item: Attachment | MediaItem;
+	configSizes?: string;
+	onError: () => void;
+} ) {
+	const imageUrl = getBestImageUrl( item, configSizes );
 
 	/*
 	 * Use three states to avoid fade-in animation for cached images:
@@ -154,6 +138,49 @@ export default function MediaThumbnailView( {
 		}
 	};
 
+	return (
+		<div
+			className={ clsx( 'dataviews-media-field__media-thumbnail', {
+				'is-loading': loadingState === 'loading',
+				'is-loaded': loadingState === 'loaded',
+			} ) }
+		>
+			<img
+				ref={ imgRef }
+				className="dataviews-media-field__media-thumbnail--image"
+				src={ imageUrl }
+				alt={ item.alt_text || item.title.raw }
+				onLoad={ handleLoad }
+				onError={ onError }
+				loading="lazy"
+			/>
+		</div>
+	);
+}
+
+export default function MediaThumbnailView( {
+	item,
+	config,
+}: DataViewRenderFieldProps< MediaItem > ) {
+	const [ imageError, setImageError ] = useState( false );
+
+	const _featuredMedia = useSelect(
+		( select ) => {
+			// Avoid the network request if it's not needed. `featured_media` is
+			// 0 for images and media without featured media.
+			if ( ! item.featured_media ) {
+				return;
+			}
+			return select( coreStore ).getEntityRecord< Attachment >(
+				'postType',
+				'attachment',
+				item.featured_media
+			);
+		},
+		[ item.featured_media ]
+	);
+	const featuredMedia = item.featured_media ? _featuredMedia : item;
+
 	// Fetching.
 	if ( ! featuredMedia ) {
 		return null;
@@ -172,21 +199,10 @@ export default function MediaThumbnailView( {
 	}
 
 	return (
-		<div
-			className={ clsx( 'dataviews-media-field__media-thumbnail', {
-				'is-loading': loadingState === 'loading',
-				'is-loaded': loadingState === 'loaded',
-			} ) }
-		>
-			<img
-				ref={ imgRef }
-				className="dataviews-media-field__media-thumbnail--image"
-				src={ imageUrl }
-				alt={ featuredMedia.alt_text || featuredMedia.title.raw }
-				onLoad={ handleLoad }
-				onError={ () => setImageError( true ) }
-				loading="lazy"
-			/>
-		</div>
+		<ImageView
+			item={ featuredMedia }
+			configSizes={ config?.sizes }
+			onError={ () => setImageError( true ) }
+		/>
 	);
 }

--- a/packages/media-fields/src/media_thumbnail/view.tsx
+++ b/packages/media-fields/src/media_thumbnail/view.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -8,7 +13,7 @@ import {
 	__experimentalVStack as VStack,
 	Icon,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useRef, useLayoutEffect } from '@wordpress/element';
 import type { Attachment } from '@wordpress/core-data';
 import { getFilename } from '@wordpress/url';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
@@ -17,6 +22,51 @@ import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
  */
 import { getMediaTypeFromMimeType } from '../utils/get-media-type-from-mime-type';
 import type { MediaItem } from '../types';
+
+/**
+ * Given the available image sizes and a target display width, returns the URL
+ * of the smallest size whose width is >= the target. Falls back to the largest
+ * available size, or the original source_url.
+ *
+ * @param featuredMedia The media item with size details.
+ * @param configSizes   The target display size string (e.g. '900px').
+ */
+function getBestImageUrl(
+	featuredMedia: Attachment | MediaItem,
+	configSizes?: string
+): string {
+	const sizes = featuredMedia?.media_details?.sizes;
+	if ( ! sizes ) {
+		return featuredMedia.source_url;
+	}
+
+	const sizeEntries = Object.values( sizes ) as Array< {
+		source_url: string;
+		width: number;
+	} >;
+
+	if ( ! sizeEntries.length ) {
+		return featuredMedia.source_url;
+	}
+
+	// Parse target width from config.sizes (e.g. '900px' → 900).
+	const targetWidth = configSizes ? parseInt( configSizes, 10 ) : NaN;
+
+	if ( ! Number.isNaN( targetWidth ) ) {
+		// Sort ascending by width.
+		const sorted = [ ...sizeEntries ].sort( ( a, b ) => a.width - b.width );
+		// Pick the smallest size that is >= target width.
+		const match = sorted.find( ( s ) => s.width >= targetWidth );
+		if ( match ) {
+			return match.source_url;
+		}
+		// No size large enough — use the largest available.
+		return sorted[ sorted.length - 1 ].source_url;
+	}
+
+	// If we can't parse the target, fall back to source_url.
+	return featuredMedia.source_url;
+}
 
 function FallbackView( {
 	item,
@@ -73,6 +123,37 @@ export default function MediaThumbnailView( {
 	);
 	const featuredMedia = item.featured_media ? _featuredMedia : item;
 
+	const imageUrl = featuredMedia
+		? getBestImageUrl( featuredMedia, config?.sizes )
+		: undefined;
+
+	/*
+	 * Use three states to avoid fade-in animation for cached images:
+	 * 'instant' = image already cached, 'loading' = waiting, 'loaded' = just finished.
+	 *
+	 * useLayoutEffect runs synchronously after DOM mutations but before paint,
+	 * so we can check img.complete to detect disk-cached images and skip the
+	 * fade-in animation entirely.
+	 */
+	const imgRef = useRef< HTMLImageElement >( null );
+	const [ loadingState, setLoadingState ] = useState<
+		'instant' | 'loading' | 'loaded'
+	>( 'loading' );
+
+	useLayoutEffect( () => {
+		if ( imgRef.current?.complete ) {
+			setLoadingState( 'instant' );
+		} else {
+			setLoadingState( 'loading' );
+		}
+	}, [ imageUrl ] );
+
+	const handleLoad = () => {
+		if ( loadingState === 'loading' ) {
+			setLoadingState( 'loaded' );
+		}
+	};
+
 	// Fetching.
 	if ( ! featuredMedia ) {
 		return null;
@@ -91,30 +172,20 @@ export default function MediaThumbnailView( {
 	}
 
 	return (
-		<div className="dataviews-media-field__media-thumbnail">
+		<div
+			className={ clsx( 'dataviews-media-field__media-thumbnail', {
+				'is-loading': loadingState === 'loading',
+				'is-loaded': loadingState === 'loaded',
+			} ) }
+		>
 			<img
+				ref={ imgRef }
 				className="dataviews-media-field__media-thumbnail--image"
-				src={ featuredMedia.source_url }
-				srcSet={
-					featuredMedia?.media_details?.sizes
-						? (
-								Object.values(
-									featuredMedia.media_details.sizes
-								) as Array< {
-									source_url: string;
-									width: number;
-								} >
-						   )
-								.map(
-									( size ) =>
-										`${ size.source_url } ${ size.width }w`
-								)
-								.join( ', ' )
-						: undefined
-				}
-				sizes={ config?.sizes || '100vw' }
+				src={ imageUrl }
 				alt={ featuredMedia.alt_text || featuredMedia.title.raw }
+				onLoad={ handleLoad }
 				onError={ () => setImageError( true ) }
+				loading="lazy"
 			/>
 		</div>
 	);


### PR DESCRIPTION
## What?

Closes #75406

Note: this is a _slightly_ speculative PR, very happy for feedback if it seems like not the right approach!

Try optimising image loading for the media thumbnail field (e.g. used by the media upload modal), by doing the following:

* Borrow the fade-in approach used by the Author field so that images are only shown after they're loaded (this avoids the clunky pop-in effect seen on trunk when paging through lots of results)
* Try using JS to determine the correct image size to use, and no longer use `srcSet` for this field (I'll explain more below)

## Why?

It turns out that using `srcSet` for large grid images can have an unintended effect on large high-dpi screens. If we assume a grid size of `900px` but the device is of at least a `2x` pixel density, then the browser will attempt to render images that are at least `1800px` across. For a page of 20+ results, this can quickly add up to rendering a lot of large images all at once. I _think_ this is the primary source of the performance issue in #75406.

While not _ideal_, the idea in this PR is to pick a size much closer to the final grid size. The impact is that the images will be slightly less sharp, but we should be loading smaller images overall with better performance. In my local testing, this results in displaying image sizes that are around `1024px` (e.g. large size, instead of full size). Though not `2x` the grid, they're still larger enough than original full-size images that (to my eyes at least) they seem _reasonably_ sharp, while being more performant.

The general idea behind this PR is: performance of loading is a better trade-off than sharpness. But there's still a balance to be had here, so again, happy for feedback / differing opinions 🙂

## How?

* Add the logic (similar to the author field) to fade-in the media thumbnail
* Refactor _slightly_ so that we have a separate `ImageView` that contains the loading logic
* Add a `getBestImageUrl()` function that just grabs the next larger image than the target size — this is what gets us (for example) a `1024px` width image for a `900px` container

## Testing Instructions

Enable the media upload modal experiment in Gutenberg settings:

<img width="942" height="84" alt="image" src="https://github.com/user-attachments/assets/72f22726-0796-405d-9721-1bab2b80999a" />

* Add a File block to a post or page (so that you can test non-image media, too)
* Make sure your media library has a whole bunch of images in it so you can experiment with paging through results
* Open up dev tools and throttle your network
* Try paging through the results, and see how it feels and loads
* Switch to the table view and do the same
* Images should (generally) smoothly load in, and it should be more performant than on `trunk`
* When going "back" to a page that you already loaded, images should (generally) be instantly displayed with no fade (browsers can wind up unloading things, so this isn't _always_ the case, but hopefully it happens most of the time)
* Non-image media should be unaffected and just show their previews like they did previously

## Screenshots or screencast <!-- if applicable -->

Grid view:

https://github.com/user-attachments/assets/642c62be-ce56-42a7-b7a2-a54f533875f2

And here's the table view while throttled (to make the behaviour a bit clearer):

https://github.com/user-attachments/assets/a6cff59c-3eee-4fb1-abc2-c675c9d679a7



