### PR TITLE
Try an explicit contentRole for containers where blocks can be added in contentOnly mode

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -389,7 +389,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 -	**Name:** core/gallery
 -	**Category:** media
 -	**Allowed Blocks:** core/image
--	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group
@@ -472,7 +472,7 @@ An organized collection of items displayed in a specific order. ([Source](https:
 -	**Name:** core/list
 -	**Category:** text
 -	**Allowed Blocks:** core/list-item
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), contentRole, interactivity (clientNavigation), listView, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** ordered, placeholder, reversed, start, type, values
 
 ## List Item
@@ -568,7 +568,7 @@ Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/navigation-submenu
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** anchor, contentRole, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -39,7 +39,7 @@ import {
 } from './private-keys';
 import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/constants';
 
-const { isContentBlock } = unlock( blocksPrivateApis );
+const { isContentBlock, isContentRoleBlock } = unlock( blocksPrivateApis );
 
 export { getBlockSettings } from './get-block-settings';
 
@@ -104,12 +104,12 @@ export function isContainerInsertableToInContentOnlyMode(
 ) {
 	const isBlockContentBlock = isContentBlock( blockName );
 	const rootBlockName = getBlockName( state, rootClientId );
-	const isContainerContentBlock = isContentBlock( rootBlockName );
+	const isContainerContentBlock = isContentRoleBlock( rootBlockName );
 	const isRootBlockMain = getSectionRootClientId( state ) === rootClientId;
 
 	// In contentOnly mode, containers shouldn't be inserted into unless:
-	// 1. they are a section root;
-	// 2. they are a content block and the block to be inserted is also content.
+	// 1. they support contentRole.
+	// 2. the block to be inserted supports contentRole or contains content attributes.
 	return (
 		isRootBlockMain || ( isContainerContentBlock && isBlockContentBlock )
 	);

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -163,7 +163,8 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"listView": true
+		"listView": true,
+		"contentRole": true
 	},
 	"editorStyle": "wp-block-gallery-editor",
 	"style": "wp-block-gallery"

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -79,7 +79,8 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"listView": true
+		"listView": true,
+		"contentRole": true
 	},
 	"selectors": {
 		"border": ".wp-block-list:not(.wp-block-list .wp-block-list)"

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -78,7 +78,8 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"contentRole": true
 	},
 	"editorStyle": "wp-block-navigation-submenu-editor",
 	"style": "wp-block-navigation-submenu"

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { lock } from '../lock-unlock';
-import { isContentBlock } from './utils';
+import { isContentBlock, isContentRoleBlock } from './utils';
 
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
@@ -186,6 +186,7 @@ import { parseRawBlock as _parseRawBlock } from './parser';
 export const privateApis = {};
 lock( privateApis, {
 	isContentBlock,
+	isContentRoleBlock,
 	fieldsKey,
 	formKey,
 	parseRawBlock: _parseRawBlock,

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -410,6 +410,17 @@ export const __experimentalGetBlockAttributesNamesByRole = ( ...args ) => {
 };
 
 /**
+ * Checks if a block supports the contentRole feature.
+ *
+ * @param {string} name The name of the block to check.
+ * @return {boolean}    Whether the block supports contentRole.
+ */
+export function isContentRoleBlock( name ) {
+	const blockType = getBlockType( name );
+	return !! blockType?.supports?.contentRole;
+}
+
+/**
  * Checks if a block is a content block by examining its attributes.
  * A block is considered a content block if it has at least one attribute
  * with a role of 'content'.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Trying to solve the problem of blocks which we might want to edit attributes of, but not allow any new blocks to be added inside them, e.g. Query as per [this comment](https://github.com/WordPress/gutenberg/pull/75760#issuecomment-3932124239) or Cover as shown in [this video](https://github.com/WordPress/gutenberg/issues/73775#issuecomment-3913566755).

For some blocks that are containers and also have content attributes (Query doesn't yet have those attributes, but might at some point), we might not want to be able to insert new blocks in them when in contentOnly mode.

This PR prevents that by only allowing insertion into blocks that have `contentRole: true`, and not into blocks that only have content attributes.

In order not to break things for some blocks that relied on their content attributes to be insertable, it adds the `contentRole: true` to those blocks.

I deliberately refrained from adding `contentRole: true` to blocks such as Quote and Details because I'm not sure if we want the ability to insert any type of content to them. Currently it's always possible to insert new paragraphs where a paragraph already exists, which will cover at least some use cases. 

There's also the possibility of combining this with allowing insertion of any content blocks where at least one content block already exists, as proposed by #75655. (If we do want to go with that, we might need further guardrails around which content blocks should be insertable, as mentioned [here](https://github.com/WordPress/gutenberg/pull/75655#issuecomment-3918498321))

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some patterns to a template and check that blocks can be inserted in expected places (Lists, Galleries) but not in Cover blocks (aside from paragraphs)

This TT5 block is a good one to test because it contains an empty Cover block:
<img width="1024" height="564" alt="Screenshot 2026-02-24 at 5 12 25 pm" src="https://github.com/user-attachments/assets/c8fd53ad-1d94-43d8-96a5-05154dc66897" />
The inserter shouldn't be visible with this PR.

