### PR TITLE
Add core/icon block to theme.json schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1026,6 +1026,9 @@
 				"core/html": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
+				"core/icon": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
 				"core/image": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -2094,6 +2097,9 @@
 				"core/html": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
+				"core/icon": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
 				"core/image": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2539,6 +2545,9 @@
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/html": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/icon": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/image": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds a missing Icon block entry to the JSON theme schema.

## Why?

To improve developer experience.

## Testing Instructions

Use `test/emptytheme/theme.json` to confirm that `core/icon` appears in the following three places:

- `settings.blocks`
- `styles.blocks`
- `styles.variations.{variation-name}.blocks`

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"blocks": {
			"core/icon"
		}
	},
	"styles": {
		"blocks": {
			"core/"
		},
		"variations": {
			"my-variation": {
				"blocks": {
					"core/"
				}
			}
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->

<img width="1007" height="585" alt="schema" src="https://github.com/user-attachments/assets/87a67e2a-5a55-4a91-a088-16c7f9286d55" />

