### PR TITLE
Patterns: Hide unnecessary controls in revision mode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -20,20 +20,20 @@ export default function EditSectionButton( { clientId } ) {
 		stopEditingContentOnlySection,
 	} = useContentOnlySectionEdit( clientId );
 
-	const { blockType, isPreviewMode } = useSelect(
+	const { blockName, isPreviewMode } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return { blockType: null, isPreviewMode: false };
+				return { blockName: null, isPreviewMode: false };
 			}
 			const { getBlockName, getSettings } = select( blockEditorStore );
-			const blockName = getBlockName( clientId );
 			return {
-				blockType: blockName ? { name: blockName } : null,
+				blockName: getBlockName( clientId ),
 				isPreviewMode: getSettings().isPreviewMode,
 			};
 		},
 		[ clientId ]
 	);
+	const blockType = blockName ? { name: blockName } : null;
 
 	// Don't show for synced patterns or template parts — they already have
 	// their own toolbar buttons ("Edit original").

--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -20,15 +20,14 @@ export default function EditSectionButton( { clientId } ) {
 		stopEditingContentOnlySection,
 	} = useContentOnlySectionEdit( clientId );
 
-	const { blockName, isPreviewMode } = useSelect(
+	const { blockName } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return { blockName: null, isPreviewMode: false };
+				return { blockName: null };
 			}
-			const { getBlockName, getSettings } = select( blockEditorStore );
+			const { getBlockName } = select( blockEditorStore );
 			return {
 				blockName: getBlockName( clientId ),
-				isPreviewMode: getSettings().isPreviewMode,
 			};
 		},
 		[ clientId ]
@@ -39,13 +38,11 @@ export default function EditSectionButton( { clientId } ) {
 	// their own toolbar buttons ("Edit original").
 	// Note: isSectionBlock returns false while the section is being edited,
 	// so we also check isEditingContentOnlySection to show "Exit pattern".
-	// Also disable in preview mode (e.g. revision mode).
 	if (
 		! clientId ||
 		( ! isSectionBlock && ! isEditingContentOnlySection ) ||
 		isReusableBlock( blockType ) ||
-		isTemplatePart( blockType ) ||
-		isPreviewMode
+		isTemplatePart( blockType )
 	) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-toolbar/edit-section-button.js
+++ b/packages/block-editor/src/components/block-toolbar/edit-section-button.js
@@ -20,14 +20,17 @@ export default function EditSectionButton( { clientId } ) {
 		stopEditingContentOnlySection,
 	} = useContentOnlySectionEdit( clientId );
 
-	const blockType = useSelect(
+	const { blockType, isPreviewMode } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return null;
+				return { blockType: null, isPreviewMode: false };
 			}
-			const { getBlockName } = select( blockEditorStore );
+			const { getBlockName, getSettings } = select( blockEditorStore );
 			const blockName = getBlockName( clientId );
-			return blockName ? { name: blockName } : null;
+			return {
+				blockType: blockName ? { name: blockName } : null,
+				isPreviewMode: getSettings().isPreviewMode,
+			};
 		},
 		[ clientId ]
 	);
@@ -36,11 +39,13 @@ export default function EditSectionButton( { clientId } ) {
 	// their own toolbar buttons ("Edit original").
 	// Note: isSectionBlock returns false while the section is being edited,
 	// so we also check isEditingContentOnlySection to show "Exit pattern".
+	// Also disable in preview mode (e.g. revision mode).
 	if (
 		! clientId ||
 		( ! isSectionBlock && ! isEditingContentOnlySection ) ||
 		isReusableBlock( blockType ) ||
-		isTemplatePart( blockType )
+		isTemplatePart( blockType ) ||
+		isPreviewMode
 	) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -78,6 +78,7 @@ export function PrivateBlockToolbar( {
 		showBlockVisibilityButton,
 		showSwitchSectionStyleButton,
 		areSelectedBlocksHiddenOnViewport,
+		isPreviewMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -124,8 +125,9 @@ export function PrivateBlockToolbar( {
 		const _isSectionBlock = isSectionBlock( selectedBlockClientId );
 		const _showSwitchSectionStyleButton = _isZoomOut || _isSectionBlock;
 
+		const settings = getSettings();
 		const _currentDeviceType =
-			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
+			settings?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
 		const _areSelectedBlocksHiddenOnViewport =
 			selectedBlockClientIds.length > 0 &&
 			selectedBlockClientIds.every( ( id ) =>
@@ -161,6 +163,7 @@ export function PrivateBlockToolbar( {
 			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
 			areSelectedBlocksHiddenOnViewport:
 				_areSelectedBlocksHiddenOnViewport,
+			isPreviewMode: settings?.isPreviewMode,
 		};
 	}, [] );
 
@@ -245,7 +248,7 @@ export function PrivateBlockToolbar( {
 					shouldShowVisualToolbar &&
 					isMultiToolbar &&
 					showGroupButtons && <BlockGroupToolbar /> }
-				{ ! isMultiToolbar && (
+				{ ! isPreviewMode && ! isMultiToolbar && (
 					<EditSectionButton clientId={ blockClientIds[ 0 ] } />
 				) }
 				{ ! areSelectedBlocksHiddenOnViewport && showShuffleButton && (

--- a/packages/block-editor/src/components/block-toolbar/switch-section-style.js
+++ b/packages/block-editor/src/components/block-toolbar/switch-section-style.js
@@ -45,17 +45,20 @@ function SwitchSectionStyle( { clientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	// Get global styles data
-	const { globalSettings, globalStyles, blockName } = useSelect(
-		( select ) => {
-			const settings = select( blockEditorStore ).getSettings();
-			return {
-				globalSettings: settings.__experimentalFeatures,
-				globalStyles: settings[ globalStylesDataKey ],
-				blockName: select( blockEditorStore ).getBlockName( clientId ),
-			};
-		},
-		[ clientId ]
-	);
+	const { globalSettings, globalStyles, blockName, isPreviewMode } =
+		useSelect(
+			( select ) => {
+				const settings = select( blockEditorStore ).getSettings();
+				return {
+					globalSettings: settings.__experimentalFeatures,
+					globalStyles: settings[ globalStylesDataKey ],
+					blockName:
+						select( blockEditorStore ).getBlockName( clientId ),
+					isPreviewMode: settings.isPreviewMode,
+				};
+			},
+			[ clientId ]
+		);
 
 	// Get the background color for the active style
 	const activeStyleBackground = activeStyle?.name
@@ -69,7 +72,7 @@ function SwitchSectionStyle( { clientId } ) {
 		  )?.color?.background
 		: undefined;
 
-	if ( ! stylesToRender || stylesToRender.length === 0 ) {
+	if ( ! stylesToRender || stylesToRender.length === 0 || isPreviewMode ) {
 		return null;
 	}
 

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -25,7 +25,8 @@ function PatternsManageButton( { clientId } ) {
 		isUnsyncedPattern,
 	} = useSelect(
 		( select ) => {
-			const { canRemoveBlock, getBlock } = select( blockEditorStore );
+			const { canRemoveBlock, getBlock, getSettings } =
+				select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const block = getBlock( clientId );
 
@@ -41,6 +42,8 @@ function PatternsManageButton( { clientId } ) {
 					id: block.attributes.ref,
 				} );
 
+			const isPreviewMode = getSettings().isPreviewMode;
+
 			return {
 				attributes: block.attributes,
 				// For unsynced patterns, detaching is simply removing the `patternName` attribute.
@@ -51,7 +54,9 @@ function PatternsManageButton( { clientId } ) {
 					( _isSyncedPattern && canRemoveBlock( clientId ) ),
 				isUnsyncedPattern: _isUnsyncedPattern,
 				isSyncedPattern: _isSyncedPattern,
-				isVisible: _isUnsyncedPattern || _isSyncedPattern,
+				isVisible:
+					( _isUnsyncedPattern || _isSyncedPattern ) &&
+					! isPreviewMode,
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.


### PR DESCRIPTION
Related to #75636

## What? Why?

In revision mode, I think that controls related to editing content should be hidden. This PR hides the following four controls in the Unsynced Pattern block:

- Edit pattern
- Shuffle styles
- Disconnect pattern
- Manage patterns

## Testing Instructions

- Insert a pattern.
- Make changes to your content and save them.
- Press the Revision button.
- Confirm the Pattern Block toolbar.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="720" height="424" alt="before" src="https://github.com/user-attachments/assets/566f886d-bf4c-4b15-8c8e-04d31658a0eb" />

### After

<img width="738" height="436" alt="after" src="https://github.com/user-attachments/assets/5173dedd-1197-4222-af5b-1b2d3e3957c6" />
