### PR TITLE
Navigation editing: simplify edit/view buttons

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -150,3 +150,21 @@
 .navigation-link-control__error-text {
 	color: $alert-red;
 }
+
+.navigation-link-to__action-button {
+	grid-column: auto;
+	// When this is the last button AND in an odd position among its class
+	// siblings, it's unpaired — span the full grid row.
+	&:nth-last-child(1 of #{&}):nth-child(odd of #{&}) {
+		grid-column: 1 / -1;
+	}
+
+	// Artificially increase specificity to override `justify-content` styles.
+	// Not ideal, but it shouldn't be necessary once switching to the new `Button`
+	// component from `@wordpress/ui`.
+	&#{&}#{&} {
+		justify-content: center;
+	}
+
+}
+

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -5,7 +5,6 @@ import {
 	Button,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalHStack as HStack,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
@@ -150,7 +149,7 @@ export function Controls( {
 
 	// Check if URL is viewable (not hash link or other relative path like ./ or ../)
 	const isViewableUrl =
-		url &&
+		!! url &&
 		( ! isHashLink( url ) ||
 			( isRelativePath( url ) && ! url.startsWith( '/' ) ) );
 
@@ -232,51 +231,38 @@ export function Controls( {
 						/>
 					</ToolsPanelItem>
 
-					{ url && (
-						<HStack
-							className="navigation-link-to__actions"
-							alignment="stretch"
-							style={ { gridColumn: '1 / -1' } }
+					{ !! url &&
+						hasUrlBinding &&
+						isBoundEntityAvailable &&
+						entityRecord?.id &&
+						attributes.kind === 'post-type' &&
+						onNavigateToEntityRecord && (
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									onNavigateToEntityRecord( {
+										postId: entityRecord.id,
+										postType: attributes.type,
+									} );
+								} }
+								__next40pxDefaultSize
+								className="navigation-link-to__action-button"
+							>
+								{ __( 'Edit' ) }
+							</Button>
+						) }
+					{ isViewableUrl && (
+						<Button
+							variant="secondary"
+							href={ viewUrl }
+							target="_blank"
+							icon={ external }
+							iconPosition="right"
+							__next40pxDefaultSize
+							className="navigation-link-to__action-button"
 						>
-							{ hasUrlBinding &&
-								isBoundEntityAvailable &&
-								entityRecord?.id &&
-								attributes.kind === 'post-type' &&
-								onNavigateToEntityRecord && (
-									<Button
-										variant="secondary"
-										onClick={ () => {
-											onNavigateToEntityRecord( {
-												postId: entityRecord.id,
-												postType: attributes.type,
-											} );
-										} }
-										__next40pxDefaultSize
-										style={ {
-											flex: 1,
-											justifyContent: 'center',
-										} }
-									>
-										{ __( 'Edit' ) }
-									</Button>
-								) }
-							{ isViewableUrl && (
-								<Button
-									variant="secondary"
-									href={ viewUrl }
-									target="_blank"
-									icon={ external }
-									iconPosition="right"
-									__next40pxDefaultSize
-									style={ {
-										flex: 1,
-										justifyContent: 'center',
-									} }
-								>
-									{ __( 'View' ) }
-								</Button>
-							) }
-						</HStack>
+							{ __( 'View' ) }
+						</Button>
 					) }
 				</>
 			) }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -158,11 +158,6 @@ export function Controls( {
 	const viewUrl =
 		isViewableUrl && url.startsWith( '/' ) && homeUrl ? homeUrl + url : url;
 
-	const entityTypeName = getEntityTypeName(
-		attributes.type,
-		attributes.kind
-	);
-
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
@@ -262,11 +257,7 @@ export function Controls( {
 											justifyContent: 'center',
 										} }
 									>
-										{ sprintf(
-											/* translators: %s: entity type (e.g., "page", "post", "category") */
-											__( 'Edit %s' ),
-											entityTypeName
-										) }
+										{ __( 'Edit' ) }
 									</Button>
 								) }
 							{ isViewableUrl && (
@@ -282,15 +273,7 @@ export function Controls( {
 										justifyContent: 'center',
 									} }
 								>
-									{ sprintf(
-										/* translators: %s: entity type (e.g., "page", "post", "category") or "link" for external links */
-										__( 'View %s' ),
-										attributes.kind &&
-											attributes.type &&
-											attributes.kind !== 'custom'
-											? entityTypeName
-											: __( 'link' )
-									) }
+									{ __( 'View' ) }
 								</Button>
 							) }
 						</HStack>

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -220,61 +220,6 @@ export function Controls( {
 							help={ helpText ? helpText : undefined }
 						/>
 					</ToolsPanelItem>
-
-					{ url && (
-						<HStack
-							className="navigation-link-to__actions"
-							alignment="left"
-							justify="left"
-							style={ { gridColumn: '1 / -1' } }
-						>
-							{ hasUrlBinding &&
-								isBoundEntityAvailable &&
-								entityRecord?.id &&
-								attributes.kind === 'post-type' &&
-								onNavigateToEntityRecord && (
-									<Button
-										size="compact"
-										variant="secondary"
-										onClick={ () => {
-											onNavigateToEntityRecord( {
-												postId: entityRecord.id,
-												postType: attributes.type,
-											} );
-										} }
-										__next40pxDefaultSize
-									>
-										{ sprintf(
-											/* translators: %s: entity type (e.g., "page", "post", "category") */
-											__( 'Edit %s' ),
-											entityTypeName
-										) }
-									</Button>
-								) }
-							{ isViewableUrl && (
-								<Button
-									size="compact"
-									variant="secondary"
-									href={ viewUrl }
-									target="_blank"
-									icon={ external }
-									iconPosition="right"
-									__next40pxDefaultSize
-								>
-									{ sprintf(
-										/* translators: %s: entity type (e.g., "page", "post", "category") or "link" for external links */
-										__( 'View %s' ),
-										attributes.kind &&
-											attributes.type &&
-											attributes.kind !== 'custom'
-											? entityTypeName
-											: __( 'link' )
-									) }
-								</Button>
-							) }
-						</HStack>
-					) }
-
 					<ToolsPanelItem
 						hasValue={ () => !! opensInNewTab }
 						label={ __( 'Open in new tab' ) }
@@ -291,6 +236,65 @@ export function Controls( {
 							}
 						/>
 					</ToolsPanelItem>
+
+					{ url && (
+						<HStack
+							className="navigation-link-to__actions"
+							alignment="stretch"
+							style={ { gridColumn: '1 / -1' } }
+						>
+							{ hasUrlBinding &&
+								isBoundEntityAvailable &&
+								entityRecord?.id &&
+								attributes.kind === 'post-type' &&
+								onNavigateToEntityRecord && (
+									<Button
+										variant="secondary"
+										onClick={ () => {
+											onNavigateToEntityRecord( {
+												postId: entityRecord.id,
+												postType: attributes.type,
+											} );
+										} }
+										__next40pxDefaultSize
+										style={ {
+											flex: 1,
+											justifyContent: 'center',
+										} }
+									>
+										{ sprintf(
+											/* translators: %s: entity type (e.g., "page", "post", "category") */
+											__( 'Edit %s' ),
+											entityTypeName
+										) }
+									</Button>
+								) }
+							{ isViewableUrl && (
+								<Button
+									variant="secondary"
+									href={ viewUrl }
+									target="_blank"
+									icon={ external }
+									iconPosition="right"
+									__next40pxDefaultSize
+									style={ {
+										flex: 1,
+										justifyContent: 'center',
+									} }
+								>
+									{ sprintf(
+										/* translators: %s: entity type (e.g., "page", "post", "category") or "link" for external links */
+										__( 'View %s' ),
+										attributes.kind &&
+											attributes.type &&
+											attributes.kind !== 'custom'
+											? entityTypeName
+											: __( 'link' )
+									) }
+								</Button>
+							) }
+						</HStack>
+					) }
 				</>
 			) }
 

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -237,7 +237,7 @@ describe( 'Controls', () => {
 
 			render( <Controls { ...propsWithExternalLink } /> );
 
-			expect( screen.getByText( 'View link' ) ).toBeVisible();
+			expect( screen.getByText( 'View' ) ).toBeVisible();
 		} );
 
 		it( 'shows "View page" for page links', () => {
@@ -253,7 +253,7 @@ describe( 'Controls', () => {
 
 			render( <Controls { ...propsWithPageLink } /> );
 
-			expect( screen.getByText( 'View page' ) ).toBeVisible();
+			expect( screen.getByText( 'View' ) ).toBeVisible();
 		} );
 
 		it( 'shows "View post" for post links', () => {
@@ -269,7 +269,7 @@ describe( 'Controls', () => {
 
 			render( <Controls { ...propsWithPostLink } /> );
 
-			expect( screen.getByText( 'View post' ) ).toBeVisible();
+			expect( screen.getByText( 'View' ) ).toBeVisible();
 		} );
 
 		it( 'shows "View category" for category links', () => {
@@ -285,7 +285,7 @@ describe( 'Controls', () => {
 
 			render( <Controls { ...propsWithCategoryLink } /> );
 
-			expect( screen.getByText( 'View category' ) ).toBeVisible();
+			expect( screen.getByText( 'View' ) ).toBeVisible();
 		} );
 
 		it( 'shows "View link" for custom type links', () => {
@@ -301,7 +301,7 @@ describe( 'Controls', () => {
 
 			render( <Controls { ...propsWithCustomLink } /> );
 
-			expect( screen.getByText( 'View link' ) ).toBeVisible();
+			expect( screen.getByText( 'View' ) ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Followup from here: https://github.com/WordPress/gutenberg/pull/75194#issuecomment-3876199365

## Why?

The existing functionality is good, but can be refined slightly to better match existing patterns. Here's what exists:
<img width="586" height="414" alt="Screenshot 2026-02-23 at 10 53 36" src="https://github.com/user-attachments/assets/e6083b5c-2210-4297-9ad4-bd18c1a6d9c5" />

<img width="616" height="451" alt="Screenshot 2026-02-23 at 10 53 40" src="https://github.com/user-attachments/assets/a9eddf53-aa11-40b1-a841-3740a50e0ab2" />

The combination of compact and inline-width buttons is not broadly used, however full-size/full-width buttons are used in a few cases:
<img width="416" height="160" alt="Screenshot 2026-02-23 at 10 54 02" src="https://github.com/user-attachments/assets/42d3ae34-0f4b-418c-ac23-6cc4b01c0939" />

Finally, the "Open in new tab" option, although in the link dialog it's hidden inside an "Advanced" section, it usually follows the URL immediately.

## How?

This PR does a few things:

* Buttons are flex/full-width and centered, same as in the QuickEdit and Pre-publish dialogs.
* Buttons are at the bottom, and default size.

<img width="601" height="437" alt="Screenshot 2026-02-23 at 10 51 41" src="https://github.com/user-attachments/assets/a33030ea-1fa8-4e6b-b040-21ac12f75db7" />

<img width="592" height="457" alt="Screenshot 2026-02-23 at 10 51 35" src="https://github.com/user-attachments/assets/14f9549e-74dc-46be-b883-ffa46d372aa8" />

Additionally, I removed the "type" indicator, so it's now "View" and "Edit" instead of "View page" and "Edit page". This reduces some duplication; if both buttons have a "page" suffix, and there's a "Page" badge right above in the link to, it's arguably redundant.

But the main motivation is in fact to ensure legibility in translated contexts. These labels show "Edit [cpt]", which could be as long as "Edit category". In German, translations usually get longer: "Kategorie anziegen", which in this case breaks the layout:

<img width="589" height="404" alt="Screenshot 2026-02-23 at 10 54 58" src="https://github.com/user-attachments/assets/e8f2fb8a-0b6d-4be3-b91e-3ef6c3905d1c" />

## Testing Instructions

Test using a block theme that has a Header template part, a navigation inside. Ideally this navigation was created recently, so that Pages are _linked_, as opposed to just custom links as they were before a 6.9 improvement. Now click the template part, click Edit navigation, then click the links in the list panel.