### PR TITLE
Pattern editing: Fix block editing modes when switching back and forth from isolated editing.

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -3064,15 +3064,19 @@ export function withDerivedBlockEditingModes( reducer ) {
 				break;
 			}
 			case 'UPDATE_SETTINGS': {
-				// Recompute the entire tree if the section root or
-				// the effective disableContentOnlyForUnsyncedPatterns value changes.
+				// Recompute the entire tree if the section root,
+				// the effective disableContentOnlyForUnsyncedPatterns value,
+				// or the isIsolatedEditor value changes.
+				// These are all values that affect the computation.
 				if (
 					state?.settings?.[ sectionRootClientIdKey ] !==
 						nextState?.settings?.[ sectionRootClientIdKey ] ||
 					!! state?.settings
 						?.disableContentOnlyForUnsyncedPatterns !==
 						!! nextState?.settings
-							?.disableContentOnlyForUnsyncedPatterns
+							?.disableContentOnlyForUnsyncedPatterns ||
+					!! state?.settings?.[ isIsolatedEditorKey ] !==
+						!! nextState?.settings?.[ isIsolatedEditorKey ]
 				) {
 					return {
 						...nextState,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
#73736 introduced changes to how block editing modes are computed based on the `isIsolatedEditorKey` editor setting.

A problem is that though the block editing modes are dependent on the `isIsolatedEditorKey` setting, they are not being recomputed when the value of that setting changes.

This causes a bug in the editor, if a user clicks 'Edit original' on a synced pattern or template part and then navigates back to the original post, incorrect block editing modes may be set due to them not being recomputed. It'll only work correctly if by chance another action like `RESET_BLOCKS` triggers a recompute of block editing modes after the `isIsolatedEditorKey` setting changes.

## How?
The fix is that whenever `UPDATE_SETTINGS` is dispatched and the `isIsolatedEditorKey` has changed, trigger a recompute of the block editing modes.

## Testing Instructions
1. Insert both a synced pattern and an unsynced pattern
2. Click 'Edit original' button on the synced pattern and then click 'back' to return to where you were.
3. Select the inner blocks of the unsynced pattern. 

In trunk: blocks in the unsynced pattern have the full range of block toolbar options as they have the incorrect block editing mode. Blocks like group and columns in an unsynced pattern are also selectable.
In this PR: Only content blocks are selectable and they have reduced toolbar options.

## Screenshots or screencast <!-- if applicable -->
#### Before (it's possible to select a column block in an unsynced pattern)
<img width="1096" height="560" alt="Screenshot 2026-02-23 at 6 06 27 pm" src="https://github.com/user-attachments/assets/f6f0a24b-a8d5-4949-8748-dfe73ec007ae" />

#### After (only content blocks are selectable in an unsynced pattern)
<img width="1107" height="658" alt="Screenshot 2026-02-23 at 6 08 49 pm" src="https://github.com/user-attachments/assets/f7f77c08-3eca-43dc-873d-d04fd2fb36c7" />
