### PR TITLE
NumberControl: merge two state reducers into one

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 -   `ToggleGroupControl`: Make unselected item color consistent across all variants ([#75737](https://github.com/WordPress/gutenberg/pull/75737)).
 
+### Internal
+
+-   `NumberControl`: Improved code and types for state reducer ([#75822](https://github.com/WordPress/gutenberg/pull/75822)).
+
 ## 32.2.0 (2026-02-18)
 
 ### Bug Fixes


### PR DESCRIPTION
Spinoff from React 19 migration in #61521. A little code cleanup that merges two reducers into one. It will help us fix one of type errors where the type of the inline arrow function couldn't be inferred.
