### PR TITLE
QuickEdit: rename status label and remove extra labels in popup

### DIFF
--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -104,7 +104,13 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 			{
 				id: 'status',
 				label: __( 'Status' ),
-				children: [ 'status', 'password' ],
+				children: [
+					{
+						id: 'status',
+						layout: { type: 'regular', labelPosition: 'none' },
+					},
+					'password',
+				],
 			},
 			'author',
 			'date',

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -119,7 +119,13 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 			{
 				id: 'discussion',
 				label: __( 'Discussion' ),
-				children: [ 'comment_status', 'ping_status' ],
+				children: [
+					{
+						id: 'comment_status',
+						layout: { type: 'regular', labelPosition: 'none' },
+					},
+					'ping_status',
+				],
 			},
 			'template',
 		];

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -103,7 +103,7 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 			},
 			{
 				id: 'status',
-				label: __( 'Status & Visibility' ),
+				label: __( 'Status' ),
 				children: [ 'status', 'password' ],
 			},
 			'author',

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -114,7 +114,7 @@ test.describe( 'Page List', () => {
 			statusVisibility: {
 				performEdit: async ( page ) => {
 					const editButton = page.getByRole( 'button', {
-						name: 'Edit Status & Visibility',
+						name: 'Edit Status',
 					} );
 					await editButton.locator( '..' ).hover();
 					await editButton.click();
@@ -146,7 +146,7 @@ test.describe( 'Page List', () => {
 				assertInitialState: async ( page ) => {
 					const statusAndVisibility = page
 						.getByRole( 'button', {
-							name: 'Edit Status & Visibility',
+							name: 'Edit Status',
 						} )
 						.locator( '..' );
 					await expect( statusAndVisibility ).toContainText(
@@ -156,7 +156,7 @@ test.describe( 'Page List', () => {
 				assertEditedState: async ( page ) => {
 					const statusAndVisibility = page
 						.getByRole( 'button', {
-							name: 'Edit Status & Visibility',
+							name: 'Edit Status',
 						} )
 						.locator( '..' );
 					await expect( statusAndVisibility ).toContainText(


### PR DESCRIPTION
## What?

- Rename `Status & Visibility` to `Status`.
- Remove extra label for status within the popup.
- Remove extra label for comments (discussion field) within the popup.

| Before | After |
| --- | --- |
| <img width="711" height="667" alt="Screenshot 2026-02-23 at 13 29 44" src="https://github.com/user-attachments/assets/9e774f38-7012-48da-93d9-0db658b24bfe" /> | <img width="711" height="667" alt="Screenshot 2026-02-23 at 13 22 28" src="https://github.com/user-attachments/assets/e331a3b7-424a-45fa-bb57-69e3319890c4" /> |
| <img width="684" height="273" alt="Screenshot 2026-02-23 at 13 39 11" src="https://github.com/user-attachments/assets/aad64f44-75d0-48f6-bcfd-b8a04736cd60" /> |<img width="684" height="273" alt="Screenshot 2026-02-23 at 13 39 31" src="https://github.com/user-attachments/assets/5670a82f-2ac1-4ab4-98de-42c3fba903a3" /> | 


| Quick Edit | Editor Inspector |
| --- | --- |
| <img width="711" height="667" alt="Screenshot 2026-02-23 at 13 22 28" src="https://github.com/user-attachments/assets/e331a3b7-424a-45fa-bb57-69e3319890c4" /> | <img width="632" height="675" alt="Screenshot 2026-02-23 at 13 21 07" src="https://github.com/user-attachments/assets/20b2babc-72b3-4203-bd27-50f1c4311e20" /> |
| <img width="684" height="273" alt="Screenshot 2026-02-23 at 13 39 31" src="https://github.com/user-attachments/assets/9fc5ce2a-683c-4666-9dd5-2f5e4a606509" /> | <img width="684" height="273" alt="Screenshot 2026-02-23 at 13 39 20" src="https://github.com/user-attachments/assets/8ae11d13-9ece-4e99-aa53-a5ba477e628b" /> |


## Why?

To align with the existing editor inspector.

## How?

- Rename field label.
- Configure the children field as having no labels.

## Testing Instructions

Visit QuickEdit and verify the changes.