### PR TITLE
Fix: Visual Revisions: Experience seems broken for templates

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1077,6 +1077,17 @@ export const getRevisions =
 				records = Object.values( response );
 			}
 
+			// Normalize: if the entity uses a custom revisionKey (e.g. 'wp_id'
+			// for templates), copy that value into 'id' so all downstream code
+			// can reference revisions consistently via 'id'.
+			const revKey = entityConfig.revisionKey || DEFAULT_ENTITY_KEY;
+			if ( revKey !== DEFAULT_ENTITY_KEY ) {
+				records = records.map( ( record ) => ( {
+					...record,
+					id: record[ revKey ],
+				} ) );
+			}
+
 			// If we request fields but the result doesn't contain the fields,
 			// explicitly set these fields as "undefined"
 			// that way we consider the query "fulfilled".
@@ -1185,6 +1196,12 @@ export const getRevision =
 		}
 
 		if ( record ) {
+			// Normalize: if the entity uses a custom revisionKey (e.g. 'wp_id'
+			// for templates), copy that value into 'id' for consistency.
+			const revKey = entityConfig.revisionKey || DEFAULT_ENTITY_KEY;
+			if ( revKey !== DEFAULT_ENTITY_KEY && record[ revKey ] ) {
+				record = { ...record, id: record[ revKey ] };
+			}
 			dispatch.receiveRevisions( kind, name, recordKey, record, query );
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75642

Fixes the visual revisions panel for the wp_template and wp_template_part post types, where the revision content was not showing and loading infinitely.

## Why?
To fix the issue of visual revisions not showing for the templates and template parts.

## How?
While fetching the revisions, setting the id to the revisionKey instead of having different wp_id and id via normalizing the fetch revisions.

## Testing Instructions
1. Open site editor
2. Go to patterns > Header
3. Open a header template part
4. Click on revision in the sidebar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1920" height="1041" alt="Screenshot 2026-02-23 at 6 41 18 PM" src="https://github.com/user-attachments/assets/1ffafa16-3ee1-4083-a5e3-100497117715" />|<img width="1920" height="1042" alt="Screenshot 2026-02-23 at 6 41 38 PM" src="https://github.com/user-attachments/assets/377316fd-d6ba-4328-ab07-75e1595a864f" />|
