### PR TITLE
BlockListBlock: fix crash when selectedProps are null

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -741,6 +741,31 @@ function BlockListBlockProvider( props ) {
 		[ clientId, rootClientId ]
 	);
 
+	// Use block visibility hook with data from existing useSelect to avoid extra subscription
+	const { isBlockCurrentlyHidden } = useBlockVisibility( {
+		blockVisibility: selectedProps?.blockVisibility,
+		deviceType: selectedProps?.deviceType,
+	} );
+
+	// Users of the editor.BlockListBlock filter used to be able to
+	// access the block prop.
+	// Ideally these blocks would rely on the clientId prop only.
+	// This is kept for backward compatibility reasons.
+	const block = useMemo(
+		() => ( {
+			...selectedProps?.blockWithoutAttributes,
+			attributes: selectedProps?.attributes,
+		} ),
+		[ selectedProps?.blockWithoutAttributes, selectedProps?.attributes ]
+	);
+
+	// Block is sometimes not mounted at the right time, causing it be
+	// undefined see issue for more info
+	// https://github.com/WordPress/gutenberg/issues/17013
+	if ( ! selectedProps ) {
+		return null;
+	}
+
 	const {
 		isPreviewMode,
 		// Fill values that end up as a public API and may not be defined in
@@ -750,7 +775,6 @@ function BlockListBlockProvider( props ) {
 		isLocked = false,
 		canRemove = false,
 		canMove = false,
-		blockWithoutAttributes,
 		name,
 		attributes,
 		isValid,
@@ -785,28 +809,6 @@ function BlockListBlockProvider( props ) {
 		blockVisibility,
 		deviceType,
 	} = selectedProps;
-
-	// Use block visibility hook with data from existing useSelect to avoid extra subscription
-	const { isBlockCurrentlyHidden } = useBlockVisibility( {
-		blockVisibility,
-		deviceType,
-	} );
-
-	// Users of the editor.BlockListBlock filter used to be able to
-	// access the block prop.
-	// Ideally these blocks would rely on the clientId prop only.
-	// This is kept for backward compatibility reasons.
-	const block = useMemo(
-		() => ( { ...blockWithoutAttributes, attributes } ),
-		[ blockWithoutAttributes, attributes ]
-	);
-
-	// Block is sometimes not mounted at the right time, causing it be
-	// undefined see issue for more info
-	// https://github.com/WordPress/gutenberg/issues/17013
-	if ( ! selectedProps ) {
-		return null;
-	}
 
 	const privateContext = {
 		isPreviewMode,


### PR DESCRIPTION
Spinoff from the React 19 migration in #61521. The `BlockListBlockProvider` component selects `selectedProps` from a data store, returns early when `selectedProps === null`, and then uses `selectedProps` by destructuring subfields and using the subfields in hooks. Only the `selectedProps === null` check is only _after_ `selectedProps` has been already used! That's the bug and it causes crashes.

The `useBlockVisibility` and `useMemo` hooks don't mind getting `undefined` arguments. They will use defaults and (cheaply) return a value that won't be used anyway.
