### PR TITLE
wordpress/date: Recover WP timezone after third-party reload

### DIFF
--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -184,34 +184,57 @@ export function __experimentalGetSettings() {
 	return getSettings();
 }
 
+// Cached packed zone string, used to re-add the WP zone without requiring
+// moment-timezone-utils (which provides .pack()) after a third-party plugin
+// reloads moment-timezone and destroys both the zone and the utils.
+let wpZonePacked: string | undefined;
+
+/**
+ * Ensures the custom WP timezone zone exists in moment-timezone's registry.
+ *
+ * Third-party plugins (e.g. WooCommerce) may load their own copy of
+ * moment-timezone, which reinitializes the internal zone storage and
+ * destroys the custom 'WP' zone. This function checks for the zone's
+ * existence and re-creates it if necessary.
+ */
+function ensureWPTimezone() {
+	if ( ! momentLib.tz.zone( WP_ZONE ) ) {
+		if ( wpZonePacked ) {
+			momentLib.tz.add( wpZonePacked );
+		} else {
+			setupWPTimezone();
+		}
+	}
+}
+
 function setupWPTimezone() {
 	// Get the current timezone settings from the WP timezone string.
 	const currentTimezone = momentLib.tz.zone( settings.timezone.string );
 
+	let packed;
 	// Check to see if we have a valid TZ data, if so, use it for the custom WP_ZONE timezone, otherwise just use the offset.
 	if ( currentTimezone ) {
 		// Create WP timezone based off settings.timezone.string.  We need to include the additional data so that we
 		// don't lose information about daylight savings time and other items.
 		// See https://github.com/WordPress/gutenberg/pull/48083
-		momentLib.tz.add(
-			momentLib.tz.pack( {
-				name: WP_ZONE,
-				abbrs: currentTimezone.abbrs,
-				untils: currentTimezone.untils,
-				offsets: currentTimezone.offsets,
-			} )
-		);
+		packed = momentLib.tz.pack( {
+			name: WP_ZONE,
+			abbrs: currentTimezone.abbrs,
+			untils: currentTimezone.untils,
+			offsets: currentTimezone.offsets,
+		} );
 	} else {
 		// Create WP timezone based off dateSettings.
-		momentLib.tz.add(
-			momentLib.tz.pack( {
-				name: WP_ZONE,
-				abbrs: [ WP_ZONE ],
-				untils: [ null ],
-				offsets: [ -settings.timezone.offset * 60 || 0 ],
-			} )
-		);
+		packed = momentLib.tz.pack( {
+			name: WP_ZONE,
+			abbrs: [ WP_ZONE ],
+			untils: [ null ],
+			offsets: [ -settings.timezone.offset * 60 || 0 ],
+		} );
 	}
+
+	wpZonePacked = packed;
+	momentLib.tz.add( packed );
 }
 
 // Date constants.
@@ -547,6 +570,7 @@ export function gmdateI18n(
  * @return Is in the future.
  */
 export function isInTheFuture( dateValue: Date | string | number ) {
+	ensureWPTimezone();
 	const now = momentLib.tz( WP_ZONE );
 	const momentObject = momentLib.tz( dateValue, WP_ZONE );
 
@@ -561,6 +585,7 @@ export function isInTheFuture( dateValue: Date | string | number ) {
  * @return  Date
  */
 export function getDate( dateString?: string | null ) {
+	ensureWPTimezone();
 	if ( ! dateString ) {
 		return momentLib.tz( WP_ZONE ).toDate();
 	}
@@ -580,6 +605,7 @@ export function humanTimeDiff(
 	from: Moment | Date | string | number,
 	to?: Moment | Date | string | number
 ) {
+	ensureWPTimezone();
 	const fromMoment = momentLib.tz( from, WP_ZONE );
 	const toMoment = to ? momentLib.tz( to, WP_ZONE ) : momentLib.tz( WP_ZONE );
 	return fromMoment.from( toMoment );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import momentLib from 'moment';
+
+/**
  * Internal dependencies
  */
 import {
@@ -681,5 +686,68 @@ describe( 'Moment.js Localization', () => {
 
 			expect( humanTimeDiff( twoDaysLater ) ).toBe( 'in 2 days' );
 		} );
+	} );
+} );
+
+describe( 'WP timezone zone recovery', () => {
+	// Simulate what happens when a third-party plugin (e.g. WooCommerce)
+	// loads its own copy of moment-timezone, which reinitializes the
+	// internal zone storage and destroys the custom 'WP' zone.
+	function destroyWPZone() {
+		// moment-timezone stores zones in an internal object.
+		// Removing 'wp' simulates a third-party moment-timezone reload.
+		const zones = momentLib.tz._zones;
+		delete zones.wp;
+	}
+
+	it( 'getDate should recover after WP zone is lost', () => {
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { offset: 4, string: '' },
+		} );
+
+		destroyWPZone();
+
+		// Should not throw and should return a valid date.
+		const result = getDate( '2024-01-15T10:00:00' );
+		expect( result ).toBeInstanceOf( Date );
+		expect( result.getTime() ).not.toBeNaN();
+
+		setSettings( settings );
+	} );
+
+	it( 'isInTheFuture should recover after WP zone is lost', () => {
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { offset: 4, string: '' },
+		} );
+
+		destroyWPZone();
+
+		// Create a date far in the future.
+		const futureDate = new Date( Date.now() + 1000 * 60 * 60 * 24 * 365 );
+		expect( isInTheFuture( futureDate ) ).toBe( true );
+
+		setSettings( settings );
+	} );
+
+	it( 'humanTimeDiff should recover after WP zone is lost', () => {
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { offset: 4, string: '' },
+		} );
+
+		destroyWPZone();
+
+		const result = humanTimeDiff(
+			'2023-04-28T11:00:00.000Z',
+			'2023-04-28T12:00:00.000Z'
+		);
+		expect( result ).toBe( 'an hour ago' );
+
+		setSettings( settings );
 	} );
 } );


### PR DESCRIPTION
## What?

Makes the `@wordpress/date` package resilient to third-party plugins that reload moment-timezone and destroy the custom 'WP' timezone zone.

## Why?

On sites with non-UTC timezones, post times in the block editor can be offset by 2x the site's UTC difference (e.g., a post published at 10 AM on a UTC+4 site shows as 2 AM). This occurs because plugins like WooCommerce load their own copy of moment-timezone, which reinitializes the internal zone storage and destroys Gutenberg's custom 'WP' timezone zone. When the zone is lost, `moment.tz(date, 'WP')` falls back incorrectly, causing the UTC offset to be applied twice.

## How?

The fix adds resilience to moment-timezone reloads by:

1. Caching the packed WP timezone zone string after first creation
2. Adding an `ensureWPTimezone()` guard that checks if the 'WP' zone still exists before using it
3. Re-adding the zone from cache when needed (which only requires `momentLib.tz.add()`, not the utils that get destroyed)
4. Calling the guard in `isInTheFuture()`, `getDate()`, and `humanTimeDiff()` before accessing `WP_ZONE`

The cached approach avoids calling `pack()` on recovery since the utils are also destroyed by third-party reloads.

## Testing Instructions

1. Install a plugin that loads moment-timezone after `wp-date` (e.g., enqueue `moment-timezone-with-data-10-year-range.min.js` from cdnjs with `wp-date` as a dependency), for example, the following testing plugin 
[telex-timezone-converter.zip](https://github.com/user-attachments/files/25495931/telex-timezone-converter.zip)
2. Set the site timezone to something other than UTC (e.g., UTC+4)
3. Create/edit a post in the block editor
4. If you installed the `timezone-converter` plugin, add the `Timezone Date Converter` block to the pot
5. Publish the post and observe the publish time is correct (not offset by 2x the UTC difference)

### Testing Instructions for Keyboard

N/A — no UI changes.