### PR TITLE
Add wp_ prefix to real time collaberation option.

### DIFF
--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -2,7 +2,7 @@
 	"$schema": "./schemas/json/wp-env.json",
 	"testsEnvironment": false,
 	"port": 8889,
-	"core": "WordPress/WordPress",
+	"core": "WordPress/WordPress#6.9-branch",
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"config": {

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -2,7 +2,7 @@
 	"$schema": "./schemas/json/wp-env.json",
 	"testsEnvironment": false,
 	"port": 8889,
-	"core": "WordPress/WordPress#6.9-branch",
+	"core": "WordPress/WordPress",
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"config": {

--- a/backport-changelog/7.0/11001.md
+++ b/backport-changelog/7.0/11001.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11001
+
+* https://github.com/WordPress/gutenberg/pull/75837

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
@@ -101,7 +101,7 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 		 * Load the real-time collaboration setting and, when enabled, ensure that an
 		 * an autosave revision is always targeted.
 		 */
-		$is_collaboration_enabled = get_option( 'enable_real_time_collaboration' );
+		$is_collaboration_enabled = get_option( 'wp_enable_real_time_collaboration' );
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -103,7 +103,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 	 * Registers the real-time collaboration setting.
 	 */
 	function gutenberg_register_real_time_collaboration_setting() {
-		$option_name = 'enable_real_time_collaboration';
+		$option_name = 'wp_enable_real_time_collaboration';
 
 		register_setting(
 			'writing',
@@ -124,8 +124,8 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 				$option_value = get_option( $option_name );
 
 				?>
-				<label for="enable_real_time_collaboration">
-					<input name="enable_real_time_collaboration" type="checkbox" id="enable_real_time_collaboration" value="1" <?php checked( '1', $option_value ); ?>/>
+				<label for="wp_enable_real_time_collaboration">
+					<input name="wp_enable_real_time_collaboration" type="checkbox" id="wp_enable_real_time_collaboration" value="1" <?php checked( '1', $option_value ); ?>/>
 					<?php _e( 'Enable real-time collaboration', 'gutenberg' ); ?>
 				</label>
 				<?php
@@ -139,7 +139,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 	 * Injects the real-time collaboration setting into a global variable.
 	 */
 	function gutenberg_inject_real_time_collaboration_setting() {
-		if ( get_option( 'enable_real_time_collaboration' ) ) {
+		if ( get_option( 'wp_enable_real_time_collaboration', '0' ) ) {
 			wp_add_inline_script(
 				'wp-core-data',
 				'window._wpCollaborationEnabled = true;',

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -7,7 +7,7 @@
 
 if ( ! defined( '_GUTENBERG_VERSION_MIGRATION' ) ) {
 	// It's necessary to update this version every time a new migration is needed.
-	define( '_GUTENBERG_VERSION_MIGRATION', '9.8.0' );
+	define( '_GUTENBERG_VERSION_MIGRATION', '22.6.0' );
 }
 
 /**
@@ -23,6 +23,10 @@ function _gutenberg_migrate_database() {
 	if ( _GUTENBERG_VERSION_MIGRATION !== $gutenberg_installed_version ) {
 		if ( version_compare( $gutenberg_installed_version, '9.8.0', '<' ) ) {
 			_gutenberg_migrate_remove_fse_drafts();
+		}
+
+		if ( version_compare( $gutenberg_installed_version, '22.6.0', '<' ) ) {
+			_gutenberg_migrate_enable_real_time_collaboration();
 		}
 
 		update_option( 'gutenberg_version_migration', _GUTENBERG_VERSION_MIGRATION );
@@ -57,6 +61,21 @@ function _gutenberg_migrate_remove_fse_drafts() {
 	// Delete useless options.
 	delete_option( 'gutenberg_last_synchronize_theme_template_checks' );
 	delete_option( 'gutenberg_last_synchronize_theme_template-part_checks' );
+}
+
+/**
+ * Replace unprefixed option enable_real_time_collaboration with prefixed version.
+ *
+ * Adds a `wp_` prefix to the option name to follow the convention for adding new
+ * options to WordPress since WP 5.8.0.
+ *
+ * @since 22.6.0
+ */
+function _gutenberg_migrate_enable_real_time_collaboration() {
+	$current_value = get_option( 'enable_real_time_collaboration', '0' );
+
+	update_option( 'wp_enable_real_time_collaboration', $current_value );
+	delete_option( 'enable_real_time_collaboration' );
 }
 
 // Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_fse_drafts) must happen

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -77,7 +77,7 @@ export default class CollaborationUtils {
 		};
 
 		if ( enabled ) {
-			formData.enable_real_time_collaboration = 1;
+			formData.wp_enable_real_time_collaboration = 1;
 		}
 
 		await this.requestUtils.request.post( '/wp-admin/options.php', {


### PR DESCRIPTION
## What?

Renames RTC option from `enable_real_time_collaboration` to `wp_enable_real_time_collaboration`.

See https://core.trac.wordpress.org/ticket/64622#comment:34

## Why?

Since WordPress 5.8.0 the convention for adding new options to WordPress is to use the `wp_` prefix in order to prevent collisions with code from third party developers.

## How?

* introduces an upgrade routine for the change
* modifies the use of the option to the prefixed version
* updates the E2E test making use of the option

## Testing Instructions

> [!Note]
> ~The E2E tests on this PR are failing as they are running against WordPress trunk so they will fail until~ https://github.com/WordPress/wordpress-develop/pull/11001 is merged.
>
> ~When running the tests against the WordPress 6.9 branch (see [action run](https://github.com/WordPress/gutenberg/actions/runs/22330785117/job/64612420342)) against https://github.com/WordPress/gutenberg/pull/75837/commits/9defb0a583424dce4b3b55d2a09c2d2a112155a8 they are passing as expected.~
>
> ~To avoid breaking the E2E tests in trunk, we should wait until the WP-Dev version is merged before merging this.~

Upgrade routine

1. Checkout Gutenberg trunk, run build
2. Install to run against WordPress 6.9 (this will ensure the GB version of the code runs)
3. Enable real time collaboration on the WP writing options screen
4. View the wp_options table in your tool of choice
5. Ensure the `enable_real_time_collaboration` option exists
6. Checkout this feature branch, run build
7. Reload the writing options page
8. Ensure real time collaboration remains enabled
9. View the wp_options table in your tool of choice
10. Ensure the `enable_real_time_collaboration` option has been removed
11. Ensure the `wp_enable_real_time_collaboration` option exists

Real time collaboration

1. Edit an existing post
2. Open your browser tools network tab
3. Ensure that the RTC requests are been run in the browser
4. Open another browser window
5. Edit the same post
6. Ensure that the RTC feature duplicates edits in both windows

Finally, after testing this feature branch: re-enable collaborative editing on the writing screen once you switch back to trunk. _Testing this PR will disable the feature once you return to trunk._

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A