### PR TITLE
RTC: Fix entity save call / initial persistence.

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -229,9 +229,18 @@ export const getEntityRecord =
 								query
 							);
 						},
-						// Save the current entity record's unsaved edits.
+						// Save the current entity record, whether or not it has unsaved
+						// edits. This is used to trigger a persisted CRDT document.
 						saveRecord: () => {
-							dispatch.saveEditedEntityRecord( kind, name, key );
+							resolveSelect
+								.getEditedEntityRecord( kind, name, key )
+								.then( ( editedRecord ) => {
+									dispatch.saveEntityRecord(
+										kind,
+										name,
+										editedRecord
+									);
+								} );
 						},
 						addUndoMeta: ( ydoc, meta ) => {
 							const selectionHistory =

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -98,7 +98,7 @@ describe( 'SyncManager', () => {
 			onStatusChange: jest.fn(),
 			refetchRecord: jest.fn( async () => Promise.resolve() ),
 			restoreUndoMeta: jest.fn(),
-			saveRecord: jest.fn( async () => Promise.resolve() ),
+			saveRecord: jest.fn(),
 		};
 	} );
 

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -135,7 +135,7 @@ export interface RecordHandlers {
 	onStatusChange: OnStatusChangeCallback;
 	refetchRecord: () => Promise< void >;
 	restoreUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
-	saveRecord: () => Promise< void >;
+	saveRecord: () => void;
 }
 
 export interface SyncConfig {

--- a/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
@@ -71,22 +71,6 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 	} ) => {
 		await collaborationUtils.setCollaboration( true );
 
-		page.on( 'request', ( request ) => {
-			if (
-				request.url().includes( '/wp/v2/posts' ) &&
-				[ 'PUT', 'POST' ].includes( request.method() )
-			) {
-				try {
-					const body = request.postDataJSON();
-					if ( body?.meta?._crdt_document ) {
-						savedWithCrdtDoc = true;
-					}
-				} catch {
-					// Ignore parse errors.
-				}
-			}
-		} );
-
 		// Navigate to create a new post (auto-draft).
 		await admin.visitAdminPage( 'post-new.php' );
 		await editor.setPreferences( 'core/edit-post', {

--- a/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - CRDT persistence', () => {
+	test( 'persists CRDT document when loading existing post without one', async ( {
+		admin,
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await collaborationUtils.setCollaboration( true );
+
+		// Create a draft post — it will not have _crdt_document meta.
+		const post = await requestUtils.createPost( {
+			title: 'Persistence Test - Draft',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		// Open the post in the editor.
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Wait for the entity record resolver to finish.
+		await page.waitForFunction(
+			() => {
+				const postId = ( window as any ).wp.data
+					.select( 'core/editor' )
+					.getCurrentPostId();
+				if ( ! postId ) {
+					return false;
+				}
+				return ( window as any ).wp.data
+					.select( 'core' )
+					.hasFinishedResolution( 'getEntityRecord', [
+						'postType',
+						'post',
+						postId,
+					] );
+			},
+			{ timeout: 5000 }
+		);
+
+		const persistedCrdtDoc = await page.evaluate( () => {
+			return window.wp.data
+				.select( 'core' )
+				.getEntityRecord(
+					'postType',
+					'post',
+					window.wp.data.select( 'core/editor' ).getCurrentPostId()
+				).meta._crdt_document;
+		} );
+
+		expect( persistedCrdtDoc ).toBeTruthy();
+	} );
+
+	test( 'does not save CRDT document for auto-draft posts', async ( {
+		admin,
+		collaborationUtils,
+		editor,
+		page,
+	} ) => {
+		await collaborationUtils.setCollaboration( true );
+
+		page.on( 'request', ( request ) => {
+			if (
+				request.url().includes( '/wp/v2/posts' ) &&
+				[ 'PUT', 'POST' ].includes( request.method() )
+			) {
+				try {
+					const body = request.postDataJSON();
+					if ( body?.meta?._crdt_document ) {
+						savedWithCrdtDoc = true;
+					}
+				} catch {
+					// Ignore parse errors.
+				}
+			}
+		} );
+
+		// Navigate to create a new post (auto-draft).
+		await admin.visitAdminPage( 'post-new.php' );
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Wait for collaboration runtime to initialize.
+		await page.waitForFunction(
+			() => ( window as any )._wpCollaborationEnabled === true,
+			{ timeout: 5000 }
+		);
+
+		// Wait for the entity record resolver to finish.
+		await page.waitForFunction(
+			() => {
+				const postId = ( window as any ).wp.data
+					.select( 'core/editor' )
+					.getCurrentPostId();
+				if ( ! postId ) {
+					return false;
+				}
+				return ( window as any ).wp.data
+					.select( 'core' )
+					.hasFinishedResolution( 'getEntityRecord', [
+						'postType',
+						'post',
+						postId,
+					] );
+			},
+			{ timeout: 5000 }
+		);
+
+		const persistedCrdtDoc = await page.evaluate( () => {
+			return window.wp.data
+				.select( 'core' )
+				.getEntityRecord(
+					'postType',
+					'post',
+					window.wp.data.select( 'core/editor' ).getCurrentPostId()
+				).meta._crdt_document;
+		} );
+
+		expect( persistedCrdtDoc ).toBeFalsy();
+	} );
+} );


### PR DESCRIPTION

## What?

Ensure that the initial `handlers.saveRecord` call results in a persisted CRDT document when none exists (auto-drafts excepted).

## Why?

When the sync manager loads a post and there is no persisted CRDT document, it calls `handlers.saveRecord()` in order to (indirectly) create one. This avoids the "initialization problem" that leads to duplicate updates between two users without a shared starting point.

(We skip this action for `auto-draft`s, which cannot be collaborated on.)

However, inside the `saveRecord` handler, we were calling `saveEditedEntityRecord`, which only results in a save when there are unsaved edits (a.k.a., the post is "dirty"). Instead, we want to force a save, so we should instead call `saveEntityRecord`.

An otherwise saved post can be missing a persisted CRDT for a couple reasons:

1. It predates the RTC feature being enabled.
2. It was deleted out-of-band by some unknown process.

## How?

Call `saveEntityRecord` instead of `saveEditedEntityRecord`.

## Testing Instructions

1. Check out this branch.
2. Create and save a post with content.
3. Confirm it has no `_crdt_document` post meta.
4. Settings > Writing > Enable real-time collaboration.
5. Open the post, do not click save.
6. Confirm is has `_crdt_document` post meta.

Also covered by unit and E2E tests.
