### PR TITLE
RTC: Back off when the window loses focus.

### DIFF
--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -279,6 +279,32 @@ function handlePageHide(): void {
 	postSyncUpdateNonBlocking( { rooms } );
 }
 
+/**
+ * Toggle visibility state of browser tab.
+ *
+ * Used to trigger a slow down of the collaboration syncs when the
+ * browser tab becomes inactive (either the user swtiches tabs or the
+ * screen saveer comes on).
+ *
+ * Fires on the document's visibilitychange event.
+ */
+function toggleVisbilityChange() {
+	const wasActive = isActiveBrowser;
+	isActiveBrowser = document.visibilityState !== 'hidden';
+	if ( isActiveBrowser && ! wasActive ) {
+		// Remove scheduled polling and repoll immediately when reactivated.
+		//
+		// This ensures that any updates by collaborators are immediately reflectecd
+		// in the document once the browser tab becomes active. Otherwise there would
+		// be a delay of 30 seconds before the updates came through.
+		if ( pollingTimeoutId ) {
+			clearTimeout( pollingTimeoutId );
+			pollingTimeoutId = null;
+		}
+		poll();
+	}
+}
+
 function poll(): void {
 	isPolling = true;
 
@@ -413,32 +439,6 @@ function poll(): void {
 
 	// Start polling.
 	void start();
-}
-
-/**
- * Toggle visibility state of browser tab.
- *
- * Used to trigger a slow down of the collaboration syncs when the
- * browser tab becomes inactive (either the user swtiches tabs or the
- * screen saveer comes on).
- *
- * Fires on the document's visibilitychange event.
- */
-function toggleVisbilityChange() {
-	const wasActive = isActiveBrowser;
-	isActiveBrowser = document.visibilityState !== 'hidden';
-	if ( isActiveBrowser && ! wasActive ) {
-		// Remove scheduled polling and repoll immediately when reactivated.
-		//
-		// This ensures that any updates by collaborators are immediately reflectecd
-		// in the document once the browser tab becomes active. Otherwise there would
-		// be a delay of 30 seconds before the updates came through.
-		if ( pollingTimeoutId ) {
-			clearTimeout( pollingTimeoutId );
-			pollingTimeoutId = null;
-		}
-		poll();
-	}
 }
 
 document.addEventListener( 'visibilitychange', toggleVisbilityChange );

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -240,12 +240,11 @@ function processDocUpdate(
 	}
 }
 
+let areListenersRegistered = false;
 let isPolling = false;
 let isUnloadPending = false;
 let isActiveBrowser = document.visibilityState === 'visible';
 let pollInterval = POLLING_INTERVAL_IN_MS;
-let pageHideListenerRegistered = false;
-let pageVisibilityListenerRegistered = false;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
 
 /**
@@ -503,15 +502,11 @@ function registerRoom( {
 	awareness.on( 'change', onAwarenessUpdate );
 	roomStates.set( room, roomState );
 
-	if ( ! pageHideListenerRegistered ) {
+	if ( ! areListenersRegistered ) {
 		window.addEventListener( 'beforeunload', handleBeforeUnload );
 		window.addEventListener( 'pagehide', handlePageHide );
-		pageHideListenerRegistered = true;
-	}
-
-	if ( ! pageVisibilityListenerRegistered ) {
 		document.addEventListener( 'visibilitychange', toggleVisibilityChange );
-		pageVisibilityListenerRegistered = true;
+		areListenersRegistered = true;
 	}
 
 	if ( ! isPolling ) {
@@ -539,18 +534,14 @@ function unregisterRoom( room: string ): void {
 		roomStates.delete( room );
 	}
 
-	if ( roomStates.size === 0 && pageHideListenerRegistered ) {
+	if ( 0 === roomStates.size && areListenersRegistered ) {
 		window.removeEventListener( 'beforeunload', handleBeforeUnload );
 		window.removeEventListener( 'pagehide', handlePageHide );
-		pageHideListenerRegistered = false;
-	}
-
-	if ( roomStates.size === 0 && pageVisibilityListenerRegistered ) {
 		document.removeEventListener(
 			'visibilitychange',
 			toggleVisibilityChange
 		);
-		pageVisibilityListenerRegistered = false;
+		areListenersRegistered = false;
 	}
 }
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -242,7 +242,7 @@ function processDocUpdate(
 
 let isPolling = false;
 let isUnloadPending = false;
-let isActiveBrowser = document.visibilityState !== 'hidden';
+let isActiveBrowser = document.visibilityState === 'visible';
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pageHideListenerRegistered = false;
 let pageVisibilityListenerRegistered = false;
@@ -291,7 +291,7 @@ function handlePageHide(): void {
  */
 function toggleVisbilityChange() {
 	const wasActive = isActiveBrowser;
-	isActiveBrowser = document.visibilityState !== 'hidden';
+	isActiveBrowser = document.visibilityState === 'visible';
 	if ( isActiveBrowser && ! wasActive ) {
 		/*
 		 * Remove scheduled polling and repoll immediately when reactivated.

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -509,15 +509,12 @@ function registerRoom( {
 		pageHideListenerRegistered = true;
 	}
 
-	if ( ! isPolling ) {
-		if ( ! pageVisibilityListenerRegistered ) {
-			document.addEventListener(
-				'visibilitychange',
-				toggleVisbilityChange
-			);
-			pageVisibilityListenerRegistered = true;
-		}
+	if ( ! pageVisibilityListenerRegistered ) {
+		document.addEventListener( 'visibilitychange', toggleVisbilityChange );
+		pageVisibilityListenerRegistered = true;
+	}
 
+	if ( ! isPolling ) {
 		poll();
 	}
 }

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -302,7 +302,10 @@ function toggleVisbilityChange() {
 			clearTimeout( pollingTimeoutId );
 			pollingTimeoutId = null;
 		}
-		poll();
+
+		if ( isPolling ) {
+			poll();
+		}
 	}
 }
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -547,11 +547,14 @@ function unregisterRoom( room: string ): void {
 		window.removeEventListener( 'pagehide', handlePageHide );
 		pageHideListenerRegistered = false;
 	}
-}
 
-if ( roomStates.size === 0 && pageVisibilityListenerRegistered ) {
-	document.removeEventListener( 'visibilitychange', toggleVisbilityChange );
-	pageVisibilityListenerRegistered = false;
+	if ( roomStates.size === 0 && pageVisibilityListenerRegistered ) {
+		document.removeEventListener(
+			'visibilitychange',
+			toggleVisbilityChange
+		);
+		pageVisibilityListenerRegistered = false;
+	}
 }
 
 export const pollingManager: PollingManager = {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -293,11 +293,13 @@ function toggleVisbilityChange() {
 	const wasActive = isActiveBrowser;
 	isActiveBrowser = document.visibilityState !== 'hidden';
 	if ( isActiveBrowser && ! wasActive ) {
-		// Remove scheduled polling and repoll immediately when reactivated.
-		//
-		// This ensures that any updates by collaborators are immediately reflected
-		// in the document once the browser tab becomes active. Otherwise there would
-		// be a delay of 30 seconds before the updates came through.
+		/*
+		 * Remove scheduled polling and repoll immediately when reactivated.
+		 *
+		 * This ensures that any updates by collaborators are immediately reflected
+		 * in the document once the browser tab becomes active. Otherwise there would
+		 * be a delay of 30 seconds before the updates came through.
+		 */
 		if ( pollingTimeoutId ) {
 			clearTimeout( pollingTimeoutId );
 			pollingTimeoutId = null;

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -295,7 +295,7 @@ function toggleVisbilityChange() {
 	if ( isActiveBrowser && ! wasActive ) {
 		// Remove scheduled polling and repoll immediately when reactivated.
 		//
-		// This ensures that any updates by collaborators are immediately reflectecd
+		// This ensures that any updates by collaborators are immediately reflected
 		// in the document once the browser tab becomes active. Otherwise there would
 		// be a delay of 30 seconds before the updates came through.
 		if ( pollingTimeoutId ) {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -30,6 +30,7 @@ import {
 
 const POLLING_INTERVAL_IN_MS = 1000; // 1 second or 1000 milliseconds
 const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = 250; // 250 milliseconds
+const POLLING_INTERVAL_BACKGROUND_TAB_IN_MS = 30 * 1000; // 30 seconds
 const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
 const POLLING_MANAGER_ORIGIN = 'polling-manager';
 
@@ -241,8 +242,10 @@ function processDocUpdate(
 
 let isPolling = false;
 let isUnloadPending = false;
+let isActiveBrowser = document.visibilityState !== 'hidden';
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pageHideListenerRegistered = false;
+let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
 
 /**
  * Mark that a page unload has been requested. This fires on
@@ -315,7 +318,9 @@ function poll(): void {
 			const { rooms } = await postSyncUpdate( payload );
 
 			// Reset poll interval on success.
-			pollInterval = POLLING_INTERVAL_IN_MS;
+			pollInterval = isActiveBrowser
+				? POLLING_INTERVAL_IN_MS
+				: POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
 
 			// Emit 'connected' status.
 			roomStates.forEach( ( state ) => {
@@ -336,7 +341,9 @@ function poll(): void {
 				// If there is another collaborator, resume the queue for the next poll
 				// and increase polling frequency.
 				if ( Object.keys( room.awareness ).length > 1 ) {
-					pollInterval = POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS;
+					pollInterval = isActiveBrowser
+						? POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS
+						: POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
 					roomState.updateQueue.resume();
 				}
 
@@ -401,12 +408,40 @@ function poll(): void {
 			}
 		}
 
-		setTimeout( poll, pollInterval );
+		pollingTimeoutId = setTimeout( poll, pollInterval );
 	}
 
 	// Start polling.
 	void start();
 }
+
+/**
+ * Toggle visibility state of browser tab.
+ *
+ * Used to trigger a slow down of the collaboration syncs when the
+ * browser tab becomes inactive (either the user swtiches tabs or the
+ * screen saveer comes on).
+ *
+ * Fires on the document's visibilitychange event.
+ */
+function toggleVisbilityChange() {
+	const wasActive = isActiveBrowser;
+	isActiveBrowser = document.visibilityState !== 'hidden';
+	if ( isActiveBrowser && ! wasActive ) {
+		// Remove scheduled polling and repoll immediately when reactivated.
+		//
+		// This ensures that any updates by collaborators are immediately reflectecd
+		// in the document once the browser tab becomes active. Otherwise there would
+		// be a delay of 30 seconds before the updates came through.
+		if ( pollingTimeoutId ) {
+			clearTimeout( pollingTimeoutId );
+			pollingTimeoutId = null;
+		}
+		poll();
+	}
+}
+
+document.addEventListener( 'visibilitychange', toggleVisbilityChange );
 
 function registerRoom( {
 	room,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -284,12 +284,12 @@ function handlePageHide(): void {
  * Toggle visibility state of browser tab.
  *
  * Used to trigger a slow down of the collaboration syncs when the
- * browser tab becomes inactive (either the user swtiches tabs or the
- * screen saveer comes on).
+ * browser tab becomes inactive (either the user switches tabs or the
+ * screen saver comes on).
  *
  * Fires on the document's visibilitychange event.
  */
-function toggleVisbilityChange() {
+function toggleVisibilityChange() {
 	const wasActive = isActiveBrowser;
 	isActiveBrowser = document.visibilityState === 'visible';
 	if ( isActiveBrowser && ! wasActive ) {
@@ -510,7 +510,7 @@ function registerRoom( {
 	}
 
 	if ( ! pageVisibilityListenerRegistered ) {
-		document.addEventListener( 'visibilitychange', toggleVisbilityChange );
+		document.addEventListener( 'visibilitychange', toggleVisibilityChange );
 		pageVisibilityListenerRegistered = true;
 	}
 
@@ -548,7 +548,7 @@ function unregisterRoom( room: string ): void {
 	if ( roomStates.size === 0 && pageVisibilityListenerRegistered ) {
 		document.removeEventListener(
 			'visibilitychange',
-			toggleVisbilityChange
+			toggleVisibilityChange
 		);
 		pageVisibilityListenerRegistered = false;
 	}

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -245,6 +245,7 @@ let isUnloadPending = false;
 let isActiveBrowser = document.visibilityState !== 'hidden';
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pageHideListenerRegistered = false;
+let pageVisibilityListenerRegistered = false;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
 
 /**
@@ -440,9 +441,6 @@ function poll(): void {
 	// Start polling.
 	void start();
 }
-
-document.addEventListener( 'visibilitychange', toggleVisbilityChange );
-
 function registerRoom( {
 	room,
 	doc,
@@ -507,6 +505,14 @@ function registerRoom( {
 	}
 
 	if ( ! isPolling ) {
+		if ( ! pageVisibilityListenerRegistered ) {
+			document.addEventListener(
+				'visibilitychange',
+				toggleVisbilityChange
+			);
+			pageVisibilityListenerRegistered = true;
+		}
+
 		poll();
 	}
 }
@@ -536,6 +542,11 @@ function unregisterRoom( room: string ): void {
 		window.removeEventListener( 'pagehide', handlePageHide );
 		pageHideListenerRegistered = false;
 	}
+}
+
+if ( roomStates.size === 0 && pageVisibilityListenerRegistered ) {
+	document.removeEventListener( 'visibilitychange', toggleVisbilityChange );
+	pageVisibilityListenerRegistered = false;
 }
 
 export const pollingManager: PollingManager = {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -241,9 +241,10 @@ function processDocUpdate(
 }
 
 let areListenersRegistered = false;
+let hasCollaborators = false;
+let isActiveBrowser = 'visible' === document.visibilityState;
 let isPolling = false;
 let isUnloadPending = false;
-let isActiveBrowser = document.visibilityState === 'visible';
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
 
@@ -280,7 +281,7 @@ function handlePageHide(): void {
 }
 
 /**
- * Toggle visibility state of browser tab.
+ * Hangle change in visibility state of browser tab.
  *
  * Used to trigger a slow down of the collaboration syncs when the
  * browser tab becomes inactive (either the user switches tabs or the
@@ -288,9 +289,10 @@ function handlePageHide(): void {
  *
  * Fires on the document's visibilitychange event.
  */
-function toggleVisibilityChange() {
+function handleVisibilityChange() {
 	const wasActive = isActiveBrowser;
 	isActiveBrowser = document.visibilityState === 'visible';
+
 	if ( isActiveBrowser && ! wasActive ) {
 		/*
 		 * Remove scheduled polling and repoll immediately when reactivated.
@@ -348,11 +350,6 @@ function poll(): void {
 		try {
 			const { rooms } = await postSyncUpdate( payload );
 
-			// Reset poll interval on success.
-			pollInterval = isActiveBrowser
-				? POLLING_INTERVAL_IN_MS
-				: POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
-
 			// Emit 'connected' status.
 			roomStates.forEach( ( state ) => {
 				state.onStatusChange( { status: 'connected' } );
@@ -372,9 +369,7 @@ function poll(): void {
 				// If there is another collaborator, resume the queue for the next poll
 				// and increase polling frequency.
 				if ( Object.keys( room.awareness ).length > 1 ) {
-					pollInterval = isActiveBrowser
-						? POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS
-						: POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
+					hasCollaborators = true;
 					roomState.updateQueue.resume();
 				}
 
@@ -405,6 +400,15 @@ function poll(): void {
 					);
 				}
 			} );
+
+			// Recalculate polling interval.
+			if ( isActiveBrowser && hasCollaborators ) {
+				pollInterval = POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS;
+			} else if ( isActiveBrowser ) {
+				pollInterval = POLLING_INTERVAL_IN_MS;
+			} else {
+				pollInterval = POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
+			}
 		} catch ( error ) {
 			// Exponential backoff on error: double the backoff time, up to max
 			pollInterval = Math.min(
@@ -505,7 +509,7 @@ function registerRoom( {
 	if ( ! areListenersRegistered ) {
 		window.addEventListener( 'beforeunload', handleBeforeUnload );
 		window.addEventListener( 'pagehide', handlePageHide );
-		document.addEventListener( 'visibilitychange', toggleVisibilityChange );
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
 		areListenersRegistered = true;
 	}
 
@@ -539,7 +543,7 @@ function unregisterRoom( room: string ): void {
 		window.removeEventListener( 'pagehide', handlePageHide );
 		document.removeEventListener(
 			'visibilitychange',
-			toggleVisibilityChange
+			handleVisibilityChange
 		);
 		areListenersRegistered = false;
 	}


### PR DESCRIPTION
## What?
This modifies RTC updates to back right off when the window loses visibility, triggered either by switching tabs or screensavers/lock screens activating.

Closes https://github.com/WordPress/gutenberg/issues/75829

## Why?

* This reduces the load on the web server when the user is not around to receive any updates.
* This prevents the negative side effect on sites with a persistent cache from occurring while browsers are in the background (see [WP#64696](https://core.trac.wordpress.org/ticket/64696))

## How?

* Hidden tabs back off to updating once every 30 seconds.
* After the visibility change the next immediate update is run as scheduled (either 1s or 0.25s) to ensure collaborators receive the changes
* Once a tab becomes active, a poll is run immediately to ensure that updates received while the user was away are promptly displayed

Note: I tried to make this a little better by using `document.hasFocus()` so that the slow down occurred if the editor was in a separate window but this proved to be unfeasible in posts containing embeds as clicking within the embed causes the document to lose focus, even though the browser tab retains it.

## Testing Instructions

1. Run a build on the feature branch
2. Enable real time collaboration, if required
3. Create a new post, write a small amount of content and save.
4. Open the network tools to monitor the number of requests taking place
5. Clear the existing requests
6. Open a new tab
7. Wait a short period of time, say 10 seconds
8. Switch back to the post editing tab
9. Ensure that a slow down in network requests occurred
10. Ensure that the network requests returns to full speed
11. Open the post editor in a second tab
12. Update the content
13. Switch to the original tab
14. Ensure the update made in the second tab is reflected quickly.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
