### PR TITLE
Fix error when undoing newly added pattern

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -334,7 +334,9 @@ const BlockInspectorSingleBlock = ( {
 			{ hasParentChildBlockCards && (
 				<BlockCard
 					{ ...parentBlockInformation }
-					className={ parentBlockInformation.isSynced && 'is-synced' }
+					className={
+						parentBlockInformation?.isSynced && 'is-synced'
+					}
 					parentClientId={ editedContentOnlySection }
 				/>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Just noticed this bug while testing another PR. Steps to repro:

1. In a template that already contains a pattern, add another pattern.
2. Make sure the block inspector sidebar is open.
3. Click "edit pattern" on the newly added pattern.
4. Press Ctrl or Cmd + Z to undo.
5. Editor explodes:


https://github.com/user-attachments/assets/6b86e993-0071-48fd-8325-04c78a2c35ca



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Repeat steps above and check that error doesn't occur.

