### PR TITLE
Fixes keyboard focus escaping the lightbox overlay when navigating a gallery with Tab/Shift+Tab.

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -310,10 +310,7 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 
-	$overlay_callback = function () {
-		block_core_image_print_lightbox_overlay();
-	};
-	add_action( 'wp_footer', $overlay_callback );
+	add_action( 'wp_footer', 'block_core_image_print_lightbox_overlay' );
 
 	return $body_content;
 }

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -271,11 +271,17 @@ const { state, actions, callbacks } = store(
 						// Traps focus within the overlay.
 						const focusableElements = Array.from(
 							document.querySelectorAll( focusableSelectors )
-						);
+						).filter( ( element ) => ! element.hidden );
 						const firstFocusableElement = focusableElements[ 0 ];
 						const lastFocusableElement =
 							focusableElements[ focusableElements.length - 1 ];
-						if (
+						// If focus is not on any of the known focusable
+						// elements (e.g. on the overlay div itself),
+						// move it to the first focusable element.
+						if ( ! focusableElements.includes( event.target ) ) {
+							event.preventDefault();
+							firstFocusableElement.focus();
+						} else if (
 							event.shiftKey &&
 							event.target === firstFocusableElement
 						) {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -271,17 +271,11 @@ const { state, actions, callbacks } = store(
 						// Traps focus within the overlay.
 						const focusableElements = Array.from(
 							document.querySelectorAll( focusableSelectors )
-						).filter( ( element ) => ! element.hidden );
+						);
 						const firstFocusableElement = focusableElements[ 0 ];
 						const lastFocusableElement =
 							focusableElements[ focusableElements.length - 1 ];
-						// If focus is not on any of the known focusable
-						// elements (e.g. on the overlay div itself),
-						// move it to the first focusable element.
-						if ( ! focusableElements.includes( event.target ) ) {
-							event.preventDefault();
-							firstFocusableElement.focus();
-						} else if (
+						if (
 							event.shiftKey &&
 							event.target === firstFocusableElement
 						) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? 
Closes #75801

Fixes keyboard focus escaping the lightbox overlay when navigating a gallery with Tab/Shift+Tab.

## Why?
When a Gallery block has the lightbox option enabled and a user opens the lightbox on the frontend, pressing Tab repeatedly causes focus to escape outside the lightbox. The focus indicator disappears entirely, leaving no visual feedback on where the user is on the page.

- Duplicate overlay elements in the DOM. Each lightbox-enabled image registers a separate `wp_footer` callback using an anonymous closure. WordPress treats each closure as a unique callback, so the overlay HTML is printed once per image instead of once per page. This was introduced in #62906 ([676fabe8cd](https://github.com/WordPress/gutenberg/pull/62906/changes#diff-1e4aa29ea183efda9c795271dc1acf6e8049355db104d0dca5b0ea5caf7f619cR313-R316)), which inadvertently changed the original named function reference to a closure. With duplicate overlays, `document.querySelectorAll('.wp-lightbox-navigation-button')` returns buttons from all overlays, breaking the focus trap boundary logic. 

## How?
The lightbox overlay is rendered once per lightbox-enabled image instead of once per page. Each call to `block_core_image_render_lightbox()` registers a new wp_footer callback using an anonymous closure. WordPress treats each closure as a unique callback, so the overlay HTML is printed multiple times.

## Testing Instructions

- Add a Gallery block to a page/post.
- Enable the lightbox option for the gallery.
- Open the published page and open the lightbox by clicking on an image.
- Navigate using the `Tab` key repeatedly.
 
## Screenshots or screencast  

https://github.com/user-attachments/assets/26584701-b0a4-4e4f-b2d0-b91a9d070d27

|Before|After|
|-|-| 
|<img width="1917" height="878" alt="Core Issue" src="https://github.com/user-attachments/assets/3ba8ab13-c32f-41ca-9279-f62d080b8b5e" />|<img width="1917" height="874" alt="Core Issue Fix" src="https://github.com/user-attachments/assets/60d7f0b7-b1f2-4ef2-a8aa-ee9d6300ecb9" />|

