### PR TITLE
Fix : BFCache issue in Interactivity Router

### DIFF
--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -453,7 +453,6 @@ export const { state, actions } = store< Store >( 'core/router', {
 			} = options;
 
 			navigatingTo = href;
-			actions.prefetch( pagePath, options );
 
 			// Creates a promise that resolves when the specified timeout ends.
 			// The timeout value is 10 seconds by default.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes https://github.com/WordPress/gutenberg/issues/70500
- Removes prefetch call to prevent in-validated cached page from rendering in query loops
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- When a reload action happens after going through the pagination of a query loop, navigating backwards or forwards renders the same cached page regardless of the URL.
- Expected behaviour is for the correct page in the pagination to render

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removed the `prefetch` call made in the `navigate` action

## Testing Instructions
- Generate many posts, i.e. wp post generate.
- Create/edit a template to display posts with pagination via the core/query block. Ensure Full page reload is off.
- Go to the page that uses said template.
- Click the next page pagination link a couple of times.
- Reload the page.
- Hit the back browser button.
- Notice how the list of blog posts has updated.

### Preview of the fix followed by the actual issue
https://github.com/user-attachments/assets/4cf1c129-0f80-49b0-8952-7b2d96c3599c


