### PR TITLE
Post Date: Migrate to textAlign block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -716,8 +716,8 @@ Display a custom date. ([Source](https://github.com/WordPress/gutenberg/tree/tru
 
 -	**Name:** core/post-date
 -	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** datetime, format, isLink, textAlign
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Attributes:** datetime, format, isLink
 
 ## Excerpt
 

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -11,9 +11,6 @@
 			"type": "string",
 			"role": "content"
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"format": {
 			"type": "string"
 		},
@@ -46,6 +43,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
@@ -251,9 +256,10 @@ const v2 = {
 	migrate( { className, displayType, metadata, ...otherAttributes } ) {
 		if ( displayType === 'date' || displayType === 'modified' ) {
 			if ( displayType === 'modified' ) {
-				className = [ className, 'wp-block-post-date__modified-date' ]
-					.filter( Boolean )
-					.join( ' ' );
+				className = clsx(
+					className,
+					'wp-block-post-date__modified-date'
+				);
 			}
 
 			return {
@@ -274,8 +280,11 @@ const v2 = {
 	isEligible( attributes ) {
 		// If there's neither an explicit `datetime` attribute nor a block binding for that attribute,
 		// then we're dealing with an old version of the block.
+		// Exclude blocks with `textAlign`, as those are handled by the v4 deprecation.
 		return (
-			! attributes.datetime && ! attributes?.metadata?.bindings?.datetime
+			! attributes.textAlign &&
+			! attributes.datetime &&
+			! attributes?.metadata?.bindings?.datetime
 		);
 	},
 };

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -1,12 +1,85 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v4 = {
+	attributes: {
+		datetime: {
+			type: 'string',
+			role: 'content',
+		},
+		textAlign: {
+			type: 'string',
+		},
+		format: {
+			type: 'string',
+		},
+		isLink: {
+			type: 'boolean',
+			default: false,
+			role: 'content',
+		},
+	},
+	supports: {
+		anchor: true,
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+};
 
 const v3 = {
 	attributes: {
@@ -178,10 +251,9 @@ const v2 = {
 	migrate( { className, displayType, metadata, ...otherAttributes } ) {
 		if ( displayType === 'date' || displayType === 'modified' ) {
 			if ( displayType === 'modified' ) {
-				className = clsx(
-					className,
-					'wp-block-post-date__modified-date'
-				);
+				className = [ className, 'wp-block-post-date__modified-date' ]
+					.filter( Boolean )
+					.join( ' ' );
 			}
 
 			return {
@@ -254,4 +326,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v3, v2, v1 ];
+export default [ v4, v3, v2, v1 ];

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -165,7 +165,7 @@ const v3 = {
 		...otherAttributes
 	} ) {
 		// Change the block bindings source argument name from "key" to "field".
-		return {
+		return migrateTextAlign( {
 			metadata: {
 				bindings: {
 					datetime: {
@@ -177,7 +177,7 @@ const v3 = {
 				...otherMetadata,
 			},
 			...otherAttributes,
-		};
+		} );
 	},
 	isEligible( attributes ) {
 		return (
@@ -262,7 +262,7 @@ const v2 = {
 				);
 			}
 
-			return {
+			return migrateTextAlign( {
 				...otherAttributes,
 				className,
 				metadata: {
@@ -274,17 +274,14 @@ const v2 = {
 						},
 					},
 				},
-			};
+			} );
 		}
 	},
 	isEligible( attributes ) {
 		// If there's neither an explicit `datetime` attribute nor a block binding for that attribute,
 		// then we're dealing with an old version of the block.
-		// Exclude blocks with `textAlign`, as those are handled by the v4 deprecation.
 		return (
-			! attributes.textAlign &&
-			! attributes.datetime &&
-			! attributes?.metadata?.bindings?.datetime
+			! attributes.datetime && ! attributes?.metadata?.bindings?.datetime
 		);
 	},
 };
@@ -321,7 +318,9 @@ const v1 = {
 	save() {
 		return null;
 	},
-	migrate: migrateFontFamily,
+	migrate( attributes ) {
+		return migrateTextAlign( migrateFontFamily( attributes ) );
+	},
 	isEligible( { style } ) {
 		return style?.typography?.fontFamily;
 	},

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { store as coreStore } from '@wordpress/core-data';
@@ -14,7 +9,6 @@ import {
 	getSettings as getDateSettings,
 } from '@wordpress/date';
 import {
-	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	store as blockEditorStore,
@@ -41,19 +35,18 @@ import { store as blocksStore } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
-export default function PostDateEdit( {
-	attributes,
-	context: { postType: postTypeSlug, queryId },
-	setAttributes,
-	name,
-} ) {
-	const { datetime, textAlign, format, isLink } = attributes;
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+export default function PostDateEdit( props ) {
+	const {
+		attributes,
+		context: { postType: postTypeSlug, queryId },
+		setAttributes,
+		name,
+	} = props;
+	useDeprecatedTextAlign( props );
+	const { datetime, format, isLink } = attributes;
+	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	// Use internal state instead of a ref to make sure that the component
@@ -129,13 +122,6 @@ export default function PostDateEdit( {
 			{ ( blockEditingMode === 'default' ||
 				! isDescendentOfQueryLoop ) && (
 				<BlockControls group="block">
-					<AlignmentControl
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-
 					{ activeBlockVariationName !== 'post-date-modified' &&
 						( ! isDescendentOfQueryLoop ||
 							! activeBlockVariationName ) && (

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -119,64 +119,61 @@ export default function PostDateEdit( props ) {
 	}
 	return (
 		<>
-			{ ( blockEditingMode === 'default' ||
-				! isDescendentOfQueryLoop ) && (
-				<BlockControls group="block">
-					{ activeBlockVariationName !== 'post-date-modified' &&
-						( ! isDescendentOfQueryLoop ||
-							! activeBlockVariationName ) && (
-							<ToolbarGroup>
-								<Dropdown
-									popoverProps={ popoverProps }
-									renderContent={ ( { onClose } ) => (
-										<PublishDateTimePicker
-											title={
-												activeBlockVariationName ===
-												'post-date'
-													? __( 'Publish Date' )
-													: __( 'Date' )
-											}
-											currentDate={ datetime }
-											onChange={ ( newDatetime ) =>
-												setAttributes( {
-													datetime: newDatetime,
-												} )
-											}
-											is12Hour={ is12HourFormat(
-												siteTimeFormat
-											) }
-											onClose={ onClose }
-											dateOrder={
-												/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
-												_x( 'dmy', 'date order' )
-											}
+			{ ( blockEditingMode === 'default' || ! isDescendentOfQueryLoop ) &&
+				activeBlockVariationName !== 'post-date-modified' &&
+				( ! isDescendentOfQueryLoop || ! activeBlockVariationName ) && (
+					<BlockControls group="block">
+						<ToolbarGroup>
+							<Dropdown
+								popoverProps={ popoverProps }
+								renderContent={ ( { onClose } ) => (
+									<PublishDateTimePicker
+										title={
+											activeBlockVariationName ===
+											'post-date'
+												? __( 'Publish Date' )
+												: __( 'Date' )
+										}
+										currentDate={ datetime }
+										onChange={ ( newDatetime ) =>
+											setAttributes( {
+												datetime: newDatetime,
+											} )
+										}
+										is12Hour={ is12HourFormat(
+											siteTimeFormat
+										) }
+										onClose={ onClose }
+										dateOrder={
+											/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
+											_x( 'dmy', 'date order' )
+										}
+									/>
+								) }
+								renderToggle={ ( { isOpen, onToggle } ) => {
+									const openOnArrowDown = ( event ) => {
+										if (
+											! isOpen &&
+											event.keyCode === DOWN
+										) {
+											event.preventDefault();
+											onToggle();
+										}
+									};
+									return (
+										<ToolbarButton
+											aria-expanded={ isOpen }
+											icon={ pencil }
+											title={ __( 'Change Date' ) }
+											onClick={ onToggle }
+											onKeyDown={ openOnArrowDown }
 										/>
-									) }
-									renderToggle={ ( { isOpen, onToggle } ) => {
-										const openOnArrowDown = ( event ) => {
-											if (
-												! isOpen &&
-												event.keyCode === DOWN
-											) {
-												event.preventDefault();
-												onToggle();
-											}
-										};
-										return (
-											<ToolbarButton
-												aria-expanded={ isOpen }
-												icon={ pencil }
-												title={ __( 'Change Date' ) }
-												onClick={ onToggle }
-												onKeyDown={ openOnArrowDown }
-											/>
-										);
-									} }
-								/>
-							</ToolbarGroup>
-						) }
-				</BlockControls>
-			) }
+									);
+								} }
+							/>
+						</ToolbarGroup>
+					</BlockControls>
+				) }
 
 			<InspectorControls>
 				<ToolsPanel

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.html
@@ -1,0 +1,5 @@
+<!-- wp:post-date {"textAlign":"left"} /-->
+
+<!-- wp:post-date {"textAlign":"center"} /-->
+
+<!-- wp:post-date {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.json
@@ -3,16 +3,10 @@
 		"name": "core/post-date",
 		"isValid": true,
 		"attributes": {
-			"textAlign": "left",
 			"isLink": false,
-			"metadata": {
-				"bindings": {
-					"datetime": {
-						"source": "core/post-data",
-						"args": {
-							"field": "date"
-						}
-					}
+			"style": {
+				"typography": {
+					"textAlign": "left"
 				}
 			}
 		},
@@ -22,16 +16,10 @@
 		"name": "core/post-date",
 		"isValid": true,
 		"attributes": {
-			"textAlign": "center",
 			"isLink": false,
-			"metadata": {
-				"bindings": {
-					"datetime": {
-						"source": "core/post-data",
-						"args": {
-							"field": "date"
-						}
-					}
+			"style": {
+				"typography": {
+					"textAlign": "center"
 				}
 			}
 		},
@@ -41,16 +29,10 @@
 		"name": "core/post-date",
 		"isValid": true,
 		"attributes": {
-			"textAlign": "right",
 			"isLink": false,
-			"metadata": {
-				"bindings": {
-					"datetime": {
-						"source": "core/post-data",
-						"args": {
-							"field": "date"
-						}
-					}
+			"style": {
+				"typography": {
+					"textAlign": "right"
 				}
 			}
 		},

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.json
@@ -8,6 +8,16 @@
 				"typography": {
 					"textAlign": "left"
 				}
+			},
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
+				}
 			}
 		},
 		"innerBlocks": []
@@ -21,6 +31,16 @@
 				"typography": {
 					"textAlign": "center"
 				}
+			},
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
+				}
 			}
 		},
 		"innerBlocks": []
@@ -33,6 +53,16 @@
 			"style": {
 				"typography": {
 					"textAlign": "right"
+				}
+			},
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
 				}
 			}
 		},

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.json
@@ -1,0 +1,59 @@
+[
+	{
+		"name": "core/post-date",
+		"isValid": true,
+		"attributes": {
+			"textAlign": "left",
+			"isLink": false,
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-date",
+		"isValid": true,
+		"attributes": {
+			"textAlign": "center",
+			"isLink": false,
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-date",
+		"isValid": true,
+		"attributes": {
+			"textAlign": "right",
+			"isLink": false,
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/post-date",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-date",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-date",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
+<!-- wp:post-date {"style":{"typography":{"textAlign":"left"}}} /-->
 
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
+<!-- wp:post-date {"style":{"typography":{"textAlign":"center"}}} /-->
 
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
+<!-- wp:post-date {"style":{"typography":{"textAlign":"right"}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
+
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
+
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v4.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v4.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:post-date {"style":{"typography":{"textAlign":"left"}}} /-->
+<!-- wp:post-date {"style":{"typography":{"textAlign":"left"}},"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
 
-<!-- wp:post-date {"style":{"typography":{"textAlign":"center"}}} /-->
+<!-- wp:post-date {"style":{"typography":{"textAlign":"center"}},"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
 
-<!-- wp:post-date {"style":{"typography":{"textAlign":"right"}}} /-->
+<!-- wp:post-date {"style":{"typography":{"textAlign":"right"}},"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->


### PR DESCRIPTION
## What?

Part of #60763

Migrates the Post Date block to use the `textAlign` block support instead of a custom `textAlign` attribute. As a consequence, it also enables global styles support for `textAlign` on the Post Date block.

## Why?

The Post Date block currently implements its own text alignment logic with a custom `textAlign` attribute and a manual `AlignmentControl` in the toolbar, duplicating code that should be handled by the centralized `textAlign` block support.

This migration reduces code duplication and consolidates alignment handling across blocks.

## How?

Replaces the custom logic with the block supports, adds deprecation and fixes transforms.


## Testing Instructions

1. Create a new `Post Date` block and test text alignment (left, center, right).
2. Verify alignment works correctly in both the editor and the frontend.
3. Open a post with existing `Post Date` blocks that have alignment set.
4. Verify they migrate correctly (no console errors, no visual changes).
5. Confirm the block is valid after migration by checking there are no block validation warnings in the console.