### PR TITLE
Docs: Fix incorrect echo of wp_interactivity_state() in getServerState() example

### DIFF
--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -750,10 +750,13 @@ The `getServerState()` function returns a read-only reactive object. This means 
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
-<div <?php echo wp_interactivity_state( 'myPlugin', array(
+<?php
+wp_interactivity_state( 'myPlugin', array(
 	'question' => get_question_for_page( get_the_ID() ),
 	'timeLeft' => 5 * 60, // Time to answer all the questions.
-) ); ?>>
+) );
+?>
+<div data-wp-interactive="myPlugin">
 ```
 
 ```javascript


### PR DESCRIPTION

## What?
Closes #75827
Fixes incorrect PHP code example in the `getServerState()` section of the "Understanding global state, local context and derived state" documentation.

## Why?
`wp_interactivity_state()` sets global state server-side (serialized as a `<script>` tag) and **does not return HTML attributes**. The example was incorrectly calling `echo wp_interactivity_state()` inside an HTML tag's attribute position — mimicking `wp_interactivity_data_wp_context()`, which _does_ output HTML attributes.

## How?
- Call `wp_interactivity_state()` without `echo`, outside the `<div>` tag
- Add `data-wp-interactive="myPlugin"` to the `<div>` element



