### PR TITLE
Block Supports: Add background gradient support that can combine with background images

### DIFF
--- a/backport-changelog/7.1/11384.md
+++ b/backport-changelog/7.1/11384.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11384
+
+* https://github.com/WordPress/gutenberg/pull/75859

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -398,7 +398,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize, gradient), color (background, button, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName, templateLock
 
 ## Heading

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -61,6 +61,7 @@ Settings related to background.
 | -------- | ----------- | ---- | ------- |
 | backgroundImage | Allow users to set a background image. | `boolean` | `false` |
 | backgroundSize | Allow users to set values related to the size of a background image, including size, position, and repeat controls. | `boolean` | `false` |
+| gradient | Allow users to set a gradient background. | `boolean` | `false` |
 
 ---
 

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -43,27 +43,42 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$block_type                   = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_attributes             = ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) ? $block['attrs'] : array();
 	$has_background_image_support = block_has_support( $block_type, array( 'background', 'backgroundImage' ), false );
+	$has_background_gradient_support = block_has_support( $block_type, array( 'background', 'gradient' ), false );
 
 	if (
-		! $has_background_image_support ||
-		wp_should_skip_block_supports_serialization( $block_type, 'background', 'backgroundImage' ) ||
+		( ! $has_background_image_support && ! $has_background_gradient_support ) ||
 		! isset( $block_attributes['style']['background'] )
 	) {
 		return $block_content;
 	}
 
-	$background_styles                         = array();
-	$background_styles['backgroundImage']      = $block_attributes['style']['background']['backgroundImage'] ?? null;
-	$background_styles['backgroundSize']       = $block_attributes['style']['background']['backgroundSize'] ?? null;
-	$background_styles['backgroundPosition']   = $block_attributes['style']['background']['backgroundPosition'] ?? null;
-	$background_styles['backgroundRepeat']     = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
-	$background_styles['backgroundAttachment'] = $block_attributes['style']['background']['backgroundAttachment'] ?? null;
-	if ( ! empty( $background_styles['backgroundImage'] ) ) {
-		$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
-		// If the background size is set to `contain` and no position is set, set the position to `center`.
-		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {
-			$background_styles['backgroundPosition'] = '50% 50%';
+	// Check serialization skip for each feature individually.
+	$skip_background_image    = ! $has_background_image_support || wp_should_skip_block_supports_serialization( $block_type, 'background', 'backgroundImage' );
+	$skip_background_gradient = ! $has_background_gradient_support || wp_should_skip_block_supports_serialization( $block_type, 'background', 'gradient' );
+
+	if ( $skip_background_image && $skip_background_gradient ) {
+		return $block_content;
+	}
+
+	$background_styles = array();
+
+	if ( ! $skip_background_image ) {
+		$background_styles['backgroundImage']      = $block_attributes['style']['background']['backgroundImage'] ?? null;
+		$background_styles['backgroundSize']       = $block_attributes['style']['background']['backgroundSize'] ?? null;
+		$background_styles['backgroundPosition']   = $block_attributes['style']['background']['backgroundPosition'] ?? null;
+		$background_styles['backgroundRepeat']     = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
+		$background_styles['backgroundAttachment'] = $block_attributes['style']['background']['backgroundAttachment'] ?? null;
+		if ( ! empty( $background_styles['backgroundImage'] ) ) {
+			$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
+			// If the background size is set to `contain` and no position is set, set the position to `center`.
+			if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {
+				$background_styles['backgroundPosition'] = '50% 50%';
+			}
 		}
+	}
+
+	if ( ! $skip_background_gradient ) {
+		$background_styles['gradient'] = $block_attributes['style']['background']['gradient'] ?? null;
 	}
 
 	$styles = gutenberg_style_engine_get_styles( array( 'background' => $background_styles ) );

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -40,9 +40,9 @@ function gutenberg_register_background_support( $block_type ) {
  * @return string                Filtered block content.
  */
 function gutenberg_render_background_support( $block_content, $block ) {
-	$block_type                   = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$block_attributes             = ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) ? $block['attrs'] : array();
-	$has_background_image_support = block_has_support( $block_type, array( 'background', 'backgroundImage' ), false );
+	$block_type                      = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$block_attributes                = ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) ? $block['attrs'] : array();
+	$has_background_image_support    = block_has_support( $block_type, array( 'background', 'backgroundImage' ), false );
 	$has_background_gradient_support = block_has_support( $block_type, array( 'background', 'gradient' ), false );
 
 	if (

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -106,8 +106,17 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Gradients.
+	// Suppress color.gradient CSS when background.gradient is supported and
+	// explicitly set. background.php owns CSS generation in that case, and
+	// emitting the background shorthand here would conflict with it.
+	$has_background_gradient_support = block_has_support( $block_type, array( 'background', 'gradient' ), false );
+	$has_background_gradient_value   = ! empty( $block_attributes['style']['background']['gradient'] );
 
-	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
+	if (
+		$has_gradients_support &&
+		! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) &&
+		! ( $has_background_gradient_support && $has_background_gradient_value )
+	) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
 		$custom_gradient_color          = $block_attributes['style']['color']['gradient'] ?? null;
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2560,12 +2560,21 @@ class WP_Theme_JSON_Gutenberg {
 			 * For an uploaded image (images with a database ID), apply size and position
 			 * defaults equal to those applied in block supports in lib/background.php.
 			 */
-			if ( 'background-image' === $css_property && ! empty( $value ) ) {
-				$background_styles = gutenberg_style_engine_get_styles(
-					array( 'background' => array( 'backgroundImage' => $value ) )
-				);
-
-				$value = $background_styles['declarations'][ $css_property ];
+			if ( 'background-image' === $css_property ) {
+				$background_image_input = array();
+				if ( ! empty( $value ) ) {
+					$background_image_input['backgroundImage'] = $value;
+				}
+				$gradient_value = $styles['background']['gradient'] ?? null;
+				if ( ! empty( $gradient_value ) ) {
+					$background_image_input['gradient'] = $gradient_value;
+				}
+				if ( ! empty( $background_image_input ) ) {
+					$background_styles = gutenberg_style_engine_get_styles(
+						array( 'background' => $background_image_input )
+					);
+					$value = $background_styles['declarations'][ $css_property ] ?? null;
+				}
 			}
 			if ( empty( $value ) && static::ROOT_BLOCK_SELECTOR !== $selector && ! empty( $styles['background']['backgroundImage']['id'] ) ) {
 				if ( 'background-size' === $css_property ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2573,7 +2573,7 @@ class WP_Theme_JSON_Gutenberg {
 					$background_styles = gutenberg_style_engine_get_styles(
 						array( 'background' => $background_image_input )
 					);
-					$value = $background_styles['declarations'][ $css_property ] ?? null;
+					$value             = $background_styles['declarations'][ $css_property ] ?? null;
 				}
 			}
 			if ( empty( $value ) && static::ROOT_BLOCK_SELECTOR !== $selector && ! empty( $styles['background']['backgroundImage']['id'] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -345,6 +345,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'background-image' => array(
 			array( 'background', 'backgroundImage', 'url' ),
+			array( 'background', 'gradient' ),
 		),
 	);
 
@@ -397,6 +398,7 @@ class WP_Theme_JSON_Gutenberg {
 		'background'                    => array(
 			'backgroundImage' => null,
 			'backgroundSize'  => null,
+			'gradient'        => null,
 		),
 		'border'                        => array(
 			'color'       => null,
@@ -529,6 +531,7 @@ class WP_Theme_JSON_Gutenberg {
 			'backgroundPosition'   => null,
 			'backgroundRepeat'     => null,
 			'backgroundSize'       => null,
+			'gradient'             => null,
 		),
 		'border'     => array(
 			'color'  => null,
@@ -782,6 +785,7 @@ class WP_Theme_JSON_Gutenberg {
 	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'background', 'backgroundImage' ),
 		array( 'background', 'backgroundSize' ),
+		array( 'background', 'gradient' ),
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),
 		array( 'border', 'style' ),

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -96,6 +96,59 @@ if ( ! function_exists( 'allow_filter_in_styles' ) ) {
 add_filter( 'safecss_filter_attr_allow_css', 'allow_filter_in_styles', 10, 2 );
 
 /**
+ * Allow combined gradient and url() background-image values in inline styles.
+ *
+ * WordPress's safecss_filter_attr() handles gradient and url() values
+ * separately for background-image, but fails when both appear in a single
+ * comma-separated declaration. The url() portion is stripped from the test
+ * string before the filter runs, but the gradient regex in core expects the
+ * gradient to be the only value and doesn't match when a trailing comma and
+ * whitespace remain. This leaves parentheses in the test string, which
+ * triggers the unsafe-character check.
+ *
+ * This filter catches that case: the test string still contains a valid
+ * gradient function with only commas and whitespace remaining after the
+ * url() was removed.
+ *
+ * @param bool   $allow_css       Whether the CSS is allowed.
+ * @param string $css_test_string The CSS declaration to test.
+ * @return bool Whether the CSS is allowed.
+ */
+function gutenberg_allow_background_image_combined( $allow_css, $css_test_string ) {
+	if ( $allow_css ) {
+		return $allow_css;
+	}
+
+	/*
+	 * The test string at this point has url() values already removed by
+	 * safecss_filter_attr. What remains is a gradient with comma/whitespace
+	 * residue where the url() was stripped. Two possible forms:
+	 *
+	 * Gradient first: "background-image:<gradient>(...), "
+	 * URL first:      "background-image:, <gradient>(...)"
+	 *
+	 * A trailing or leading comma (with optional whitespace) must be present
+	 * to confirm a url() was actually removed. Without that residue, the
+	 * gradient alone would already pass core's own check.
+	 */
+	$gradient_pattern = '(?:linear|radial|conic|repeating-linear|repeating-radial|repeating-conic)-gradient\((?:[^()]|(?:rgba?\([^()]*\)))*\)';
+	$var_pattern      = 'var\(--[a-zA-Z0-9_-]+(?:--[a-zA-Z0-9_-]+)*\)';
+	$value_pattern    = "(?:$gradient_pattern|$var_pattern)";
+
+	// Gradient/var first, then comma+whitespace residue from stripped url().
+	$pattern_gradient_first = '/^background-image\s*:\s*' . $value_pattern . '\s*,[\s,]*$/';
+	// Stripped url() first (comma+whitespace residue), then gradient/var.
+	$pattern_url_first = '/^background-image\s*:[\s,]*,\s*' . $value_pattern . '\s*$/';
+
+	if ( preg_match( $pattern_gradient_first, $css_test_string ) || preg_match( $pattern_url_first, $css_test_string ) ) {
+		return true;
+	}
+
+	return $allow_css;
+}
+add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_allow_background_image_combined', 10, 2 );
+
+/**
  * Update allowed inline style attributes list.
  *
  * @param string[] $attrs Array of allowed CSS attributes.

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -118,7 +118,6 @@ function gutenberg_allow_background_image_combined( $allow_css, $css_test_string
 	if ( $allow_css ) {
 		return $allow_css;
 	}
-
 	/*
 	 * The test string at this point has url() values already removed by
 	 * safecss_filter_attr. What remains is a gradient with comma/whitespace
@@ -131,7 +130,7 @@ function gutenberg_allow_background_image_combined( $allow_css, $css_test_string
 	 * to confirm a url() was actually removed. Without that residue, the
 	 * gradient alone would already pass core's own check.
 	 */
-	$gradient_pattern = '(?:linear|radial|conic|repeating-linear|repeating-radial|repeating-conic)-gradient\((?:[^()]|(?:rgba?\([^()]*\)))*\)';
+	$gradient_pattern = '(?:linear|radial|conic|repeating-linear|repeating-radial|repeating-conic)-gradient\((?:[^()]|\([^()]*\))*\)';
 	$var_pattern      = 'var\(--[a-zA-Z0-9_-]+(?:--[a-zA-Z0-9_-]+)*\)';
 	$value_pattern    = "(?:$gradient_pattern|$var_pattern)";
 

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -10,6 +10,7 @@
 			"style": false,
 			"width": false
 		},
+		"background": { "gradient": true },
 		"color": {
 			"background": true,
 			"button": true,

--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -3,10 +3,6 @@
 @use "@wordpress/base-styles/z-index" as *;
 
 .block-editor-global-styles-background-panel__inspector-media-replace-container {
-	border: $border-width solid $gray-300;
-	border-radius: $radius-small;
-	// Full width. ToolsPanel lays out children in a grid.
-	grid-column: 1 / -1;
 	position: relative;
 
 	&.is-open {

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -54,6 +54,7 @@ function StyleInspectorSlots( {
 			<InspectorControls.Slot
 				group="background"
 				label={ __( 'Background image' ) }
+				className="background-block-support-panel__inner-wrapper"
 			/>
 			<InspectorControls.Slot
 				group="typography"

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -154,6 +154,10 @@ export default function BackgroundImagePanel( {
 		return {
 			...previousValue,
 			background: {},
+			color: {
+				...previousValue?.color,
+				gradient: undefined,
+			},
 		};
 	}, [] );
 
@@ -184,26 +188,38 @@ export default function BackgroundImagePanel( {
 			)
 		);
 
-	const resetGradient = () =>
-		onChange(
-			setImmutably( value, [ 'background', 'gradient' ], undefined )
+	const resetGradient = () => {
+		let newValue = setImmutably(
+			value,
+			[ 'background', 'gradient' ],
+			undefined
 		);
+		newValue = setImmutably( newValue, [ 'color', 'gradient' ], undefined );
+		onChange( newValue );
+	};
 
 	// Get current gradient value, decoding preset slug references.
-	const currentGradient = decodeValue( value?.background?.gradient );
+	// Fall back to color.gradient for legacy blocks that haven't migrated
+	// to background.gradient yet (mirrors block inspector fallback in
+	// packages/block-editor/src/hooks/background.js).
+	const currentGradient = decodeValue(
+		value?.background?.gradient ?? value?.color?.gradient
+	);
 	const inheritedGradient = decodeValue(
-		inheritedValue?.background?.gradient
+		inheritedValue?.background?.gradient ?? inheritedValue?.color?.gradient
 	);
 
 	// Set gradient value, encoding preset matches as slug references.
+	// Also clear color.gradient to migrate from the legacy location,
+	// matching the block inspector behavior in hooks/background.js.
 	const setGradient = ( newGradient ) => {
-		onChange(
-			setImmutably(
-				value,
-				[ 'background', 'gradient' ],
-				encodeGradientValue( newGradient )
-			)
+		let newValue = setImmutably(
+			value,
+			[ 'background', 'gradient' ],
+			encodeGradientValue( newGradient )
 		);
+		newValue = setImmutably( newValue, [ 'color', 'gradient' ], undefined );
+		onChange( newValue );
 	};
 
 	return (

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -30,10 +30,7 @@ const DEFAULT_CONTROLS = {
  * @param {string} feature  Background feature to check.
  * @return {boolean}        Whether site settings has activated background panel.
  */
-export function useHasBackgroundControl(
-	settings,
-	feature = 'backgroundImage'
-) {
+export function useHasBackgroundControl( settings, feature ) {
 	return Platform.OS === 'web' && settings?.background?.[ feature ];
 }
 
@@ -148,18 +145,26 @@ export default function BackgroundImagePanel( {
 	);
 	const showBackgroundGradientControl =
 		hasGradientColors && hasBackgroundGradientControl;
-	const showBackgroundImageControl = useHasBackgroundControl( settings );
+	const showBackgroundImageControl = useHasBackgroundControl(
+		settings,
+		'backgroundImage'
+	);
 
-	const resetAllFilter = useCallback( ( previousValue ) => {
-		return {
-			...previousValue,
-			background: {},
-			color: {
-				...previousValue?.color,
-				gradient: undefined,
-			},
-		};
-	}, [] );
+	const resetAllFilter = useCallback(
+		( previousValue ) => {
+			return {
+				...previousValue,
+				background: {},
+				color: hasBackgroundGradientControl
+					? {
+							...previousValue?.color,
+							gradient: undefined,
+					  }
+					: previousValue?.color,
+			};
+		},
+		[ hasBackgroundGradientControl ]
+	);
 
 	if ( ! showBackgroundGradientControl && ! showBackgroundImageControl ) {
 		return null;

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -218,6 +218,7 @@ export default function BackgroundImagePanel( {
 		>
 			{ showBackgroundImageControl && (
 				<ToolsPanelItem
+					className="block-editor-background-panel__item"
 					hasValue={ () => hasBackgroundImageValue( value ) }
 					label={ __( 'Image' ) }
 					onDeselect={ resetBackground }
@@ -236,6 +237,7 @@ export default function BackgroundImagePanel( {
 			) }
 			{ showBackgroundGradientControl && (
 				<ColorPanelDropdown
+					className="block-editor-background-panel__item"
 					label={ __( 'Gradient' ) }
 					hasValue={ () => hasBackgroundGradientValue( value ) }
 					resetValue={ resetGradient }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -7,16 +7,35 @@ import {
 } from '@wordpress/components';
 import { useCallback, Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getValueFromVariable } from '@wordpress/global-styles-engine';
+
 /**
  * Internal dependencies
  */
 import BackgroundImageControl from '../background-image-control';
+import { ColorPanelDropdown } from './color-panel';
+import { useColorsPerOrigin, useGradientsPerOrigin } from './hooks';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
+	gradient: true,
 };
+
+/**
+ * Checks site settings to see if the requested feature's control may be used.
+ *
+ * @param {Object} settings Site settings.
+ * @param {string} feature  Background feature to check.
+ * @return {boolean}        Whether site settings has activated background panel.
+ */
+export function useHasBackgroundControl(
+	settings,
+	feature = 'backgroundImage'
+) {
+	return Platform.OS === 'web' && settings?.background?.[ feature ];
+}
 
 /**
  * Checks site settings to see if the background panel may be used.
@@ -27,7 +46,8 @@ const DEFAULT_CONTROLS = {
  * @return {boolean}        Whether site settings has activated background panel.
  */
 export function useHasBackgroundPanel( settings ) {
-	return Platform.OS === 'web' && settings?.background?.backgroundImage;
+	const { backgroundImage, gradient } = settings?.background || {};
+	return Platform.OS === 'web' && ( backgroundImage || gradient );
 }
 
 /**
@@ -61,6 +81,20 @@ export function hasBackgroundImageValue( style ) {
 	);
 }
 
+/**
+ * Checks if there is a current value in the background gradient block support
+ * attributes.
+ *
+ * @param {Object} style Style attribute.
+ * @return {boolean}     Whether the block has a background gradient value set.
+ */
+export function hasBackgroundGradientValue( style ) {
+	return (
+		'string' === typeof style?.background?.gradient &&
+		style?.background?.gradient !== ''
+	);
+}
+
 function BackgroundToolsPanel( {
 	resetAllFilter,
 	onChange,
@@ -80,9 +114,15 @@ function BackgroundToolsPanel( {
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
+			hasInnerWrapper
+			className="background-block-support-panel"
+			__experimentalFirstVisibleItemClass="first"
+			__experimentalLastVisibleItemClass="last"
 			dropdownMenuProps={ dropdownMenuProps }
 		>
-			{ children }
+			<div className="background-block-support-panel__inner-wrapper">
+				{ children }
+			</div>
 		</ToolsPanel>
 	);
 }
@@ -98,15 +138,75 @@ export default function BackgroundImagePanel( {
 	defaultValues = {},
 	headerLabel = __( 'Background' ),
 } ) {
-	const showBackgroundImageControl = useHasBackgroundPanel( settings );
-	const resetBackground = () =>
-		onChange( setImmutably( value, [ 'background' ], {} ) );
+	const colors = useColorsPerOrigin( settings );
+	const gradients = useGradientsPerOrigin( settings );
+	const areCustomSolidsEnabled = settings?.color?.custom;
+	const areCustomGradientsEnabled = settings?.color?.customGradient;
+	const hasGradientColors = gradients.length > 0 || areCustomGradientsEnabled;
+
+	const hasBackgroundGradientControl = useHasBackgroundControl(
+		settings,
+		'gradient'
+	);
+	const showBackgroundGradientControl =
+		hasGradientColors && hasBackgroundGradientControl;
+	const showBackgroundImageControl = useHasBackgroundControl( settings );
+
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
 			...previousValue,
 			background: {},
 		};
 	}, [] );
+
+	if ( ! showBackgroundGradientControl && ! showBackgroundImageControl ) {
+		return null;
+	}
+
+	const decodeValue = ( rawValue ) =>
+		getValueFromVariable( { settings }, '', rawValue );
+	const encodeGradientValue = ( gradientValue ) => {
+		const allGradients = gradients.flatMap(
+			( { gradients: originGradients } ) => originGradients
+		);
+		const gradientObject = allGradients.find(
+			( { gradient } ) => gradient === gradientValue
+		);
+		return gradientObject
+			? 'var:preset|gradient|' + gradientObject.slug
+			: gradientValue;
+	};
+
+	const resetBackground = () =>
+		onChange(
+			setImmutably(
+				value,
+				[ 'background', 'backgroundImage' ],
+				undefined
+			)
+		);
+
+	const resetGradient = () =>
+		onChange(
+			setImmutably( value, [ 'background', 'gradient' ], undefined )
+		);
+
+	// Get current gradient value, decoding preset slug references.
+	const currentGradient = decodeValue( value?.background?.gradient );
+	const inheritedGradient = decodeValue(
+		inheritedValue?.background?.gradient
+	);
+
+	// Set gradient value, encoding preset matches as slug references.
+	const setGradient = ( newGradient ) => {
+		onChange(
+			setImmutably(
+				value,
+				[ 'background', 'gradient' ],
+				encodeGradientValue( newGradient )
+			)
+		);
+	};
 
 	return (
 		<Wrapper
@@ -118,7 +218,7 @@ export default function BackgroundImagePanel( {
 		>
 			{ showBackgroundImageControl && (
 				<ToolsPanelItem
-					hasValue={ () => !! value?.background }
+					hasValue={ () => hasBackgroundImageValue( value ) }
 					label={ __( 'Image' ) }
 					onDeselect={ resetBackground }
 					isShownByDefault={ defaultControls.backgroundImage }
@@ -133,6 +233,33 @@ export default function BackgroundImagePanel( {
 						defaultValues={ defaultValues }
 					/>
 				</ToolsPanelItem>
+			) }
+			{ showBackgroundGradientControl && (
+				<ColorPanelDropdown
+					label={ __( 'Gradient' ) }
+					hasValue={ () => hasBackgroundGradientValue( value ) }
+					resetValue={ resetGradient }
+					isShownByDefault={ defaultControls.gradient }
+					indicators={ [ currentGradient ] }
+					tabs={ [
+						{
+							key: 'gradient',
+							label: __( 'Gradient' ),
+							inheritedValue:
+								currentGradient ?? inheritedGradient,
+							setValue: setGradient,
+							userValue: currentGradient,
+							isGradient: true,
+						},
+					] }
+					colorGradientControlSettings={ {
+						colors,
+						disableCustomColors: ! areCustomSolidsEnabled,
+						gradients,
+						disableCustomGradients: ! areCustomGradientsEnabled,
+					} }
+					panelId={ panelId }
+				/>
 			) }
 		</Wrapper>
 	);

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -14,7 +14,7 @@ import { getValueFromVariable } from '@wordpress/global-styles-engine';
  */
 import BackgroundImageControl from '../background-image-control';
 import { ColorPanelDropdown } from './color-panel';
-import { useColorsPerOrigin, useGradientsPerOrigin } from './hooks';
+import { useGradientsPerOrigin } from './hooks';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 
@@ -138,9 +138,7 @@ export default function BackgroundImagePanel( {
 	defaultValues = {},
 	headerLabel = __( 'Background' ),
 } ) {
-	const colors = useColorsPerOrigin( settings );
 	const gradients = useGradientsPerOrigin( settings );
-	const areCustomSolidsEnabled = settings?.color?.custom;
 	const areCustomGradientsEnabled = settings?.color?.customGradient;
 	const hasGradientColors = gradients.length > 0 || areCustomGradientsEnabled;
 
@@ -255,8 +253,6 @@ export default function BackgroundImagePanel( {
 						},
 					] }
 					colorGradientControlSettings={ {
-						colors,
-						disableCustomColors: ! areCustomSolidsEnabled,
 						gradients,
 						disableCustomGradients: ! areCustomGradientsEnabled,
 					} }

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -374,14 +374,18 @@ export default function ColorPanel( {
 	const userBackgroundColor = decodeValue( value?.color?.background );
 	const gradient = decodeValue( inheritedValue?.color?.gradient );
 	const userGradient = decodeValue( value?.color?.gradient );
-	const hasBackground = () => !! userBackgroundColor || !! userGradient;
+	const hasBackground = () =>
+		!! userBackgroundColor ||
+		( ! hasBackgroundGradientSupport && !! userGradient );
 	const setBackgroundColor = ( newColor ) => {
 		const newValue = setImmutably(
 			value,
 			[ 'color', 'background' ],
 			encodeColorValue( newColor )
 		);
-		newValue.color.gradient = undefined;
+		if ( ! hasBackgroundGradientSupport ) {
+			newValue.color.gradient = undefined;
+		}
 		onChange( newValue );
 	};
 	const setGradient = ( newGradient ) => {
@@ -399,7 +403,9 @@ export default function ColorPanel( {
 			[ 'color', 'background' ],
 			undefined
 		);
-		newValue.color.gradient = undefined;
+		if ( ! hasBackgroundGradientSupport ) {
+			newValue.color.gradient = undefined;
+		}
 		onChange( newValue );
 	};
 

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -573,7 +573,10 @@ export default function ColorPanel( {
 			hasValue: hasBackground,
 			resetValue: resetBackground,
 			isShownByDefault: defaultControls.background,
-			indicators: [ gradient ?? backgroundColor ],
+			indicators: [
+				( showGradientColors ? gradient : undefined ) ??
+					backgroundColor,
+			],
 			tabs: [
 				hasSolidColors && {
 					key: 'background',

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -210,13 +210,14 @@ export function ColorPanelDropdown( {
 	tabs,
 	colorGradientControlSettings,
 	panelId,
+	className = 'block-editor-tools-panel-color-gradient-settings__item',
 } ) {
 	const currentTab = tabs.find( ( tab ) => tab.userValue !== undefined );
 	const { key: firstTabKey, ...firstTab } = tabs[ 0 ] ?? {};
 	const colorGradientDropdownButtonRef = useRef( undefined );
 	return (
 		<ToolsPanelItem
-			className="block-editor-tools-panel-color-gradient-settings__item"
+			className={ className }
 			hasValue={ hasValue }
 			label={ label }
 			onDeselect={ resetValue }

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -201,7 +201,7 @@ function ColorPanelTab( {
 	);
 }
 
-function ColorPanelDropdown( {
+export function ColorPanelDropdown( {
 	label,
 	hasValue,
 	resetValue,
@@ -336,6 +336,12 @@ export default function ColorPanel( {
 	const areCustomGradientsEnabled = settings?.color?.customGradient;
 	const hasSolidColors = colors.length > 0 || areCustomSolidsEnabled;
 	const hasGradientColors = gradients.length > 0 || areCustomGradientsEnabled;
+	// When a block opts into background.gradient support, the gradient
+	// picker moves to the Background panel. Hide it here to avoid
+	// showing duplicate gradient controls.
+	const hasBackgroundGradientSupport = !! settings?.background?.gradient;
+	const showGradientColors =
+		hasGradientColors && ! hasBackgroundGradientSupport;
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );
 	const encodeColorValue = ( colorValue ) => {
@@ -575,7 +581,7 @@ export default function ColorPanel( {
 					setValue: setBackgroundColor,
 					userValue: userBackgroundColor,
 				},
-				hasGradientColors && {
+				showGradientColors && {
 					key: 'gradient',
 					label: __( 'Gradient' ),
 					inheritedValue: gradient,

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -81,7 +81,11 @@ export function useSettingsForBlockElement(
 		};
 
 		// Some blocks can enable background colors but disable gradients.
-		if ( ! supportedStyles.includes( 'background' ) ) {
+		// Preserve gradient settings when background.gradient is supported.
+		if (
+			! supportedStyles.includes( 'background' ) &&
+			! supportedStyles.includes( 'backgroundGradient' )
+		) {
 			updatedSettings.color.gradients = [];
 			updatedSettings.color.customGradient = false;
 		}
@@ -184,11 +188,15 @@ export function useSettingsForBlockElement(
 			}
 		} );
 
-		[ 'backgroundImage', 'backgroundSize' ].forEach( ( key ) => {
-			if ( ! supportedStyles.includes( key ) ) {
+		[
+			[ 'backgroundImage', 'backgroundImage' ],
+			[ 'backgroundSize', 'backgroundSize' ],
+			[ 'backgroundGradient', 'gradient' ],
+		].forEach( ( [ styleKey, settingKey ] ) => {
+			if ( ! supportedStyles.includes( styleKey ) ) {
 				updatedSettings.background = {
 					...updatedSettings.background,
-					[ key ]: false,
+					[ settingKey ]: false,
 				};
 			}
 		} );

--- a/packages/block-editor/src/components/global-styles/test/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/background-panel.js
@@ -2,7 +2,10 @@
  * Internal dependencies
  */
 
-import { hasBackgroundImageValue } from '../background-panel';
+import {
+	hasBackgroundImageValue,
+	hasBackgroundGradientValue,
+} from '../background-panel';
 
 describe( 'hasBackgroundImageValue', () => {
 	it( 'should return `true` when id and url exist', () => {
@@ -35,5 +38,45 @@ describe( 'hasBackgroundImageValue', () => {
 				background: { backgroundImage: {} },
 			} )
 		).toBe( false );
+	} );
+} );
+
+describe( 'hasBackgroundGradientValue', () => {
+	it( 'should return `true` when a gradient string is set', () => {
+		expect(
+			hasBackgroundGradientValue( {
+				background: {
+					gradient: 'linear-gradient(135deg, red 0%, blue 100%)',
+				},
+			} )
+		).toBe( true );
+	} );
+
+	it( 'should return `true` for a preset slug reference', () => {
+		expect(
+			hasBackgroundGradientValue( {
+				background: { gradient: 'var:preset|gradient|vivid-cyan-blue' },
+			} )
+		).toBe( true );
+	} );
+
+	it( 'should return `false` when gradient is undefined', () => {
+		expect( hasBackgroundGradientValue( { background: {} } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'should return `false` when gradient is an empty string', () => {
+		expect(
+			hasBackgroundGradientValue( { background: { gradient: '' } } )
+		).toBe( false );
+	} );
+
+	it( 'should return `false` when background is undefined', () => {
+		expect( hasBackgroundGradientValue( {} ) ).toBe( false );
+	} );
+
+	it( 'should return `false` when style is undefined', () => {
+		expect( hasBackgroundGradientValue( undefined ) ).toBe( false );
 	} );
 } );

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -88,6 +88,7 @@ const StylesTab = ( {
 					<InspectorControls.Slot
 						group="background"
 						label={ __( 'Background image' ) }
+						className="background-block-support-panel__inner-wrapper"
 					/>
 					<InspectorControls.Slot group="filter" />
 					<InspectorControls.Slot

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -126,8 +126,17 @@ function BackgroundInspectorControl( {
 } ) {
 	const resetAllFilter = useCallback(
 		( attributes ) => {
+			const updatedClassName = attributes.className?.includes(
+				'has-background'
+			)
+				? attributes.className
+						.split( ' ' )
+						.filter( ( c ) => c !== 'has-background' )
+						.join( ' ' ) || undefined
+				: attributes.className;
 			return {
 				...attributes,
+				className: updatedClassName,
 				style: cleanEmptyObject( {
 					...attributes.style,
 					background: undefined,
@@ -225,8 +234,19 @@ export function BackgroundImagePanel( {
 		// the has-background class so existing styles relying on it (e.g.
 		// theme padding) are not silently broken. Only add the class when a
 		// gradient value is being set — not when it is being cleared/reset.
+		// Conversely, if the gradient is cleared and has-background was added
+		// during a previous migration, remove it so it does not linger.
 		if ( isMigrating && !! newStyle?.background?.gradient ) {
 			newAttributes.className = clsx( className, 'has-background' );
+		} else if (
+			! newStyle?.background?.gradient &&
+			className?.includes( 'has-background' )
+		) {
+			newAttributes.className =
+				className
+					.split( ' ' )
+					.filter( ( c ) => c !== 'has-background' )
+					.join( ' ' ) || undefined;
 		}
 
 		setAttributes( newAttributes );

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
@@ -115,16 +120,28 @@ export function getBackgroundImageClasses( style ) {
 		: '';
 }
 
-function BackgroundInspectorControl( { children } ) {
-	const resetAllFilter = useCallback( ( attributes ) => {
-		return {
-			...attributes,
-			style: {
-				...attributes.style,
-				background: undefined,
-			},
-		};
-	}, [] );
+function BackgroundInspectorControl( {
+	children,
+	backgroundGradientSupported = false,
+} ) {
+	const resetAllFilter = useCallback(
+		( attributes ) => {
+			return {
+				...attributes,
+				style: cleanEmptyObject( {
+					...attributes.style,
+					background: undefined,
+					color: backgroundGradientSupported
+						? {
+								...attributes.style?.color,
+								gradient: undefined,
+						  }
+						: attributes.style?.color,
+				} ),
+			};
+		},
+		[ backgroundGradientSupported ]
+	);
 	return (
 		<InspectorControls group="background" resetAllFilter={ resetAllFilter }>
 			{ children }
@@ -138,13 +155,15 @@ export function BackgroundImagePanel( {
 	setAttributes,
 	settings,
 } ) {
-	const { style, inheritedValue } = useSelect(
+	const { style, className, inheritedValue } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
 				select( blockEditorStore );
 			const _settings = getSettings();
+			const blockAttributes = getBlockAttributes( clientId );
 			return {
-				style: getBlockAttributes( clientId )?.style,
+				style: blockAttributes?.style,
+				className: blockAttributes?.className,
 				/*
 				 * To ensure we pass down the right inherited values:
 				 * @TODO 1. Pass inherited value down to all block style controls,
@@ -159,6 +178,25 @@ export function BackgroundImagePanel( {
 		[ clientId, name ]
 	);
 
+	const backgroundGradientSupported = hasBackgroundSupport(
+		name,
+		'gradient'
+	);
+
+	// Must be declared before the early return to follow Rules of Hooks.
+	// Passes backgroundGradientSupported so that "Reset All" also clears
+	// the legacy color.gradient value when background.gradient is supported.
+	const as = useCallback(
+		( { children } ) => (
+			<BackgroundInspectorControl
+				backgroundGradientSupported={ backgroundGradientSupported }
+			>
+				{ children }
+			</BackgroundInspectorControl>
+		),
+		[ backgroundGradientSupported ]
+	);
+
 	if (
 		! useHasBackgroundPanel( settings ) ||
 		! hasBackgroundSupport( name )
@@ -167,10 +205,48 @@ export function BackgroundImagePanel( {
 	}
 
 	const onChange = ( newStyle ) => {
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
+		const isMigrating =
+			backgroundGradientSupported && !! style?.color?.gradient;
+		const newAttributes = {
+			style: cleanEmptyObject(
+				backgroundGradientSupported
+					? {
+							...newStyle,
+							color: {
+								...newStyle?.color,
+								gradient: undefined,
+							},
+					  }
+					: newStyle
+			),
+		};
+
+		// When migrating from color.gradient to background.gradient, preserve
+		// the has-background class so existing styles relying on it (e.g.
+		// theme padding) are not silently broken. Only add the class when a
+		// gradient value is being set — not when it is being cleared/reset.
+		if ( isMigrating && !! newStyle?.background?.gradient ) {
+			newAttributes.className = clsx( className, 'has-background' );
+		}
+
+		setAttributes( newAttributes );
 	};
+
+	// When background.gradient is supported but not yet explicitly set, fall
+	// back to color.gradient for display. Any write from this panel migrates
+	// the value to background.gradient and clears color.gradient atomically.
+	const styleValue =
+		backgroundGradientSupported &&
+		! style?.background?.gradient &&
+		style?.color?.gradient
+			? {
+					...style,
+					background: {
+						...style?.background,
+						gradient: style?.color?.gradient,
+					},
+			  }
+			: style;
 
 	const updatedSettings = {
 		...settings,
@@ -190,13 +266,13 @@ export function BackgroundImagePanel( {
 	return (
 		<StylesBackgroundPanel
 			inheritedValue={ inheritedValue }
-			as={ BackgroundInspectorControl }
+			as={ as }
 			panelId={ clientId }
 			defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ style }
+			value={ styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -15,6 +15,7 @@ import {
 	default as StylesBackgroundPanel,
 	useHasBackgroundPanel,
 	hasBackgroundImageValue,
+	hasBackgroundGradientValue,
 } from '../components/global-styles/background-panel';
 import { globalStylesDataKey } from '../store/private-keys';
 
@@ -45,7 +46,8 @@ export function hasBackgroundSupport( blockName, feature = 'any' ) {
 		return (
 			!! support?.backgroundImage ||
 			!! support?.backgroundSize ||
-			!! support?.backgroundRepeat
+			!! support?.backgroundRepeat ||
+			!! support?.gradient
 		);
 	}
 
@@ -107,7 +109,10 @@ function useBlockProps( { name, style } ) {
  * @return {string} CSS class name.
  */
 export function getBackgroundImageClasses( style ) {
-	return hasBackgroundImageValue( style ) ? 'has-background' : '';
+	return hasBackgroundImageValue( style ) ||
+		hasBackgroundGradientValue( style )
+		? 'has-background'
+		: '';
 }
 
 function BackgroundInspectorControl( { children } ) {
@@ -156,7 +161,7 @@ export function BackgroundImagePanel( {
 
 	if (
 		! useHasBackgroundPanel( settings ) ||
-		! hasBackgroundSupport( name, 'backgroundImage' )
+		! hasBackgroundSupport( name )
 	) {
 		return null;
 	}
@@ -179,7 +184,7 @@ export function BackgroundImagePanel( {
 
 	const defaultControls = getBlockSupport( name, [
 		BACKGROUND_SUPPORT_KEY,
-		'defaultControls',
+		'__experimentalDefaultControls',
 	] );
 
 	return (

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -1,0 +1,21 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.background-block-support-panel {
+	/* Increased specificity required to remove the slot wrapper's row gap */
+	&#{&} {
+		.background-block-support-panel__inner-wrapper {
+			row-gap: 0;
+		}
+	}
+
+	/**
+	 * In the color panel, the first color-gradient-settings item gets a
+	 * margin-top and border-top to separate it from the panel header. In the
+	 * background panel, the gradient control sits below the image control
+	 * and should not have this extra spacing or double border.
+	 */
+	.block-editor-tools-panel-color-gradient-settings__item:nth-child(1 of .block-editor-tools-panel-color-gradient-settings__item) {
+		margin-top: 0;
+		border-top: none;
+	}
+}

--- a/packages/block-editor/src/hooks/background.scss
+++ b/packages/block-editor/src/hooks/background.scss
@@ -1,4 +1,39 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
+/**
+ * ItemGroup-like border styles for the background panel's ToolsPanelItems.
+ * Replicates the separated border of the `ItemGroup` component while
+ * allowing for hidden placeholder items (same approach as the color panel).
+ */
+.block-editor-background-panel__item {
+	padding: 0;
+	max-width: 100%;
+	position: relative;
+
+	// Border styles.
+	border-left: 1px solid $gray-300;
+	border-right: 1px solid $gray-300;
+	border-bottom: 1px solid $gray-300;
+
+	// Identify the first visible instance as placeholder items will not have this class.
+	&:nth-child(1 of &) {
+		border-top-left-radius: $radius-small;
+		border-top-right-radius: $radius-small;
+		border-top: 1px solid $gray-300;
+	}
+
+	// Identify the last visible instance as placeholder items will not have this class.
+	&:nth-last-child(1 of &) {
+		border-bottom-left-radius: $radius-small;
+		border-bottom-right-radius: $radius-small;
+	}
+
+	> div,
+	> div > button {
+		border-radius: inherit;
+	}
+}
 
 .background-block-support-panel {
 	/* Increased specificity required to remove the slot wrapper's row gap */
@@ -6,16 +41,5 @@
 		.background-block-support-panel__inner-wrapper {
 			row-gap: 0;
 		}
-	}
-
-	/**
-	 * In the color panel, the first color-gradient-settings item gets a
-	 * margin-top and border-top to separate it from the panel header. In the
-	 * background panel, the gradient control sits below the image control
-	 * and should not have this extra spacing or double border.
-	 */
-	.block-editor-tools-panel-color-gradient-settings__item:nth-child(1 of .block-editor-tools-panel-color-gradient-settings__item) {
-		margin-top: 0;
-		border-top: none;
 	}
 }

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -238,6 +238,7 @@ export function useBlockSettings( name, parentLayout ) {
 	const [
 		backgroundImage,
 		backgroundSize,
+		gradient,
 		customFontFamilies,
 		defaultFontFamilies,
 		themeFontFamilies,
@@ -300,6 +301,7 @@ export function useBlockSettings( name, parentLayout ) {
 	] = useSettings(
 		'background.backgroundImage',
 		'background.backgroundSize',
+		'background.gradient',
 		'typography.fontFamilies.custom',
 		'typography.fontFamilies.default',
 		'typography.fontFamilies.theme',
@@ -366,6 +368,7 @@ export function useBlockSettings( name, parentLayout ) {
 			background: {
 				backgroundImage,
 				backgroundSize,
+				gradient,
 			},
 			color: {
 				palette: {
@@ -453,6 +456,7 @@ export function useBlockSettings( name, parentLayout ) {
 	}, [
 		backgroundImage,
 		backgroundSize,
+		gradient,
 		customFontFamilies,
 		defaultFontFamilies,
 		themeFontFamilies,

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -55,6 +55,7 @@
 @use "./components/tabbed-sidebar/style.scss" as *;
 @use "./components/url-input/style.scss" as *;
 @use "./components/url-popover/style.scss" as *;
+@use "./hooks/background.scss" as *;
 @use "./hooks/block-fields/styles.scss" as *;
 @use "./hooks/block-hooks.scss" as *;
 @use "./hooks/block-bindings.scss" as *;

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -28,8 +28,10 @@
 		"background": {
 			"backgroundImage": true,
 			"backgroundSize": true,
+			"gradient": true,
 			"__experimentalDefaultControls": {
-				"backgroundImage": true
+				"backgroundImage": true,
+				"gradient": true
 			}
 		},
 		"color": {

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -56,6 +56,11 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		support: [ 'background', 'backgroundPosition' ],
 		useEngine: true,
 	},
+	backgroundGradient: {
+		value: [ 'background', 'gradient' ],
+		support: [ 'background', 'gradient' ],
+		useEngine: true,
+	},
 	borderColor: {
 		value: [ 'border', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],

--- a/packages/global-styles-engine/src/settings/get-setting.ts
+++ b/packages/global-styles-engine/src/settings/get-setting.ts
@@ -11,6 +11,7 @@ const VALID_SETTINGS = [
 	'background.backgroundRepeat',
 	'background.backgroundSize',
 	'background.backgroundPosition',
+	'background.gradient',
 	'border.color',
 	'border.radius',
 	'border.radiusSizes',

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -73,6 +73,18 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 					),
 					'path'          => array( 'background', 'backgroundAttachment' ),
 				),
+				'gradient'             => array(
+					'property_keys' => array(
+						'default' => 'background-image',
+					),
+					'css_vars'      => array(
+						'gradient' => '--wp--preset--gradient--$slug',
+					),
+					'path'          => array( 'background', 'gradient' ),
+					'classnames'    => array(
+						'has-background' => true,
+					),
+				),
 			),
 			'color'      => array(
 				'text'       => array(
@@ -455,6 +467,13 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 
 					$css_declarations = static::get_css_declarations( $style_value, $style_definition, $options );
 					if ( ! empty( $css_declarations ) ) {
+						/*
+						 * Combine background gradient and background image into a single
+						 * comma-separated background-image value, matching the JS style engine.
+						 */
+						if ( isset( $css_declarations['background-image'] ) && isset( $parsed_styles['declarations']['background-image'] ) ) {
+							$css_declarations['background-image'] = $css_declarations['background-image'] . ', ' . $parsed_styles['declarations']['background-image'];
+						}
 						$parsed_styles['declarations'] = array_merge( $parsed_styles['declarations'], $css_declarations );
 					}
 				}

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -2,37 +2,38 @@
  * Internal dependencies
  */
 import type { Style, StyleOptions } from '../../types';
-import { generateRule, safeDecodeURI } from '../utils';
+import { generateRule, getCSSValueFromRawStyle, safeDecodeURI } from '../utils';
 
 const backgroundImage = {
 	name: 'backgroundImage',
 	generate: ( style: Style, options: StyleOptions ) => {
 		const _backgroundImage = style?.background?.backgroundImage;
+		const gradient =
+			getCSSValueFromRawStyle( style?.background?.gradient ) || '';
 
-		/*
-		 * The background image can be a string or an object.
-		 * If the background image is a string, it could already contain a url() function,
-		 * or have a linear-gradient value.
-		 */
-		if ( typeof _backgroundImage === 'object' && _backgroundImage?.url ) {
-			return [
-				{
-					selector: options.selector,
-					key: 'backgroundImage',
-					// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-					value: `url( '${ encodeURI(
-						safeDecodeURI( _backgroundImage.url )
-					) }' )`,
-				},
-			];
+		if ( ! _backgroundImage && ! gradient ) {
+			return [];
 		}
 
-		return generateRule(
-			style,
-			options,
-			[ 'background', 'backgroundImage' ],
-			'backgroundImage'
-		);
+		const backgroundImageValue =
+			typeof _backgroundImage === 'object' && _backgroundImage?.url
+				? `url( '${ encodeURI(
+						safeDecodeURI( _backgroundImage.url )
+				  ) }' )`
+				: getCSSValueFromRawStyle( _backgroundImage );
+		const cssValue = [ gradient, backgroundImageValue ]
+			.filter( Boolean )
+			.join( ', ' );
+
+		return !! cssValue
+			? [
+					{
+						selector: options.selector,
+						key: 'backgroundImage',
+						value: cssValue,
+					},
+			  ]
+			: [];
 	},
 };
 

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -456,4 +456,72 @@ describe( 'getCSSRules', () => {
 			},
 		] );
 	} );
+
+	it( 'should comma-separate background gradient and background image into a single background-image value', () => {
+		expect(
+			getCSSRules(
+				{
+					background: {
+						backgroundImage: {
+							url: 'https://example.com/image.jpg',
+						},
+						gradient:
+							'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%)',
+					},
+				},
+				{
+					selector: '.some-selector',
+				}
+			)
+		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'backgroundImage',
+				value: "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%), url( 'https://example.com/image.jpg' )",
+			},
+		] );
+	} );
+
+	it( 'should output only gradient as background-image when no background image is set', () => {
+		expect(
+			getCSSRules(
+				{
+					background: {
+						gradient:
+							'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%)',
+					},
+				},
+				{
+					selector: '.some-selector',
+				}
+			)
+		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'backgroundImage',
+				value: 'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%)',
+			},
+		] );
+	} );
+
+	it( 'should resolve background gradient preset slug to CSS custom property', () => {
+		expect(
+			getCSSRules(
+				{
+					background: {
+						gradient: 'var:preset|gradient|vivid-cyan-blue',
+					},
+				},
+				{
+					selector: '.some-selector',
+				}
+			)
+		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'backgroundImage',
+				value: 'var(--wp--preset--gradient--vivid-cyan-blue)',
+			},
+		] );
+	} );
 } );

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -28,6 +28,7 @@ export interface Style {
 		backgroundPosition?: CSSProperties[ 'backgroundPosition' ];
 		backgroundRepeat?: CSSProperties[ 'backgroundRepeat' ];
 		backgroundSize?: CSSProperties[ 'backgroundSize' ];
+		gradient?: CSSProperties[ 'backgroundImage' ];
 	};
 	border?: {
 		color?: CSSProperties[ 'borderColor' ];

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -132,7 +132,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 		$apos = $this->get_apostrophe_entity();
 
 		return array(
-			'background image style is applied' => array(
+			'background image style is applied'      => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',
 				'background_settings' => array(
@@ -203,7 +203,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
-			'background gradient style is applied'             => array(
+			'background gradient style is applied'   => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-gradient-rules-are-output',
 				'background_settings' => array(
@@ -239,7 +239,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div class="has-background" style="background-image:var(--wp--preset--gradient--vivid-cyan-blue);">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
-			'background gradient and image combined'       => array(
+			'background gradient and image combined' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-gradient-and-image-combined',
 				'background_settings' => array(

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -203,6 +203,58 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
+			'background gradient style is applied'             => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-gradient-rules-are-output',
+				'background_settings' => array(
+					'gradient' => true,
+				),
+				'background_style'    => array(
+					'gradient' => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+				),
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%);">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+			'background gradient style is not applied if the block does not support it' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-gradient-rules-are-not-output',
+				'background_settings' => array(
+					'gradient' => false,
+				),
+				'background_style'    => array(
+					'gradient' => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+				),
+				'expected_wrapper'    => '<div>Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+			'background gradient style with preset slug is applied' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-gradient-preset-slug',
+				'background_settings' => array(
+					'gradient' => true,
+				),
+				'background_style'    => array(
+					'gradient' => 'var:preset|gradient|vivid-cyan-blue',
+				),
+				'expected_wrapper'    => '<div class="has-background" style="background-image:var(--wp--preset--gradient--vivid-cyan-blue);">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+			'background gradient and image combined'       => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-gradient-and-image-combined',
+				'background_settings' => array(
+					'backgroundImage' => true,
+					'gradient'        => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+					'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+				),
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
 			'background image style is not applied if the block does not support background image' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-not-output',

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -255,6 +255,22 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
+			'background gradient with hsl colors and image combined' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-gradient-hsl-and-image',
+				'background_settings' => array(
+					'backgroundImage' => true,
+					'gradient'        => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+					'gradient'        => 'linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%)',
+				),
+				'expected_wrapper'    => '<div class="has-background" style="background-image:linear-gradient(135deg,hsl(0,100%,50%) 0%,hsl(240,100%,50%) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
 			'background image style is not applied if the block does not support background image' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-not-output',
@@ -268,6 +284,75 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				),
 				'expected_wrapper'    => '<div>Content</div>',
 				'wrapper'             => '<div>Content</div>',
+			),
+		);
+	}
+
+	/**
+	 * Tests that combined background gradient and image CSS values pass KSES.
+	 *
+	 * WordPress's safecss_filter_attr() handles gradient and url() values
+	 * separately but strips the declaration when both appear in a single
+	 * comma-separated background-image. The gutenberg_allow_background_image_combined
+	 * filter should ensure these combined values survive sanitization.
+	 *
+	 * @covers ::gutenberg_allow_background_image_combined
+	 *
+	 * @dataProvider data_background_combined_values_pass_kses
+	 *
+	 * @param string $css The CSS declaration to test.
+	 */
+	public function test_background_combined_values_pass_kses( $css ) {
+		$result = safecss_filter_attr( $css );
+		$this->assertNotEmpty( $result, "Expected CSS to be allowed: $css" );
+		$this->assertStringContainsString( 'background-image', $result );
+	}
+
+	/**
+	 * Data provider for combined background-image KSES tests.
+	 *
+	 * @return array[]
+	 */
+	public function data_background_combined_values_pass_kses() {
+		return array(
+			'gradient first with rgb colors'     => array(
+				'background-image: linear-gradient(135deg, rgb(255,0,0) 0%, rgb(0,0,255) 100%), url(https://example.com/image.jpg)',
+			),
+			'url first with rgb colors'          => array(
+				'background-image: url(https://example.com/image.jpg), linear-gradient(135deg, rgb(255,0,0) 0%, rgb(0,0,255) 100%)',
+			),
+			'gradient first with rgba colors'    => array(
+				'background-image: linear-gradient(135deg, rgba(0,0,0,0.8) 0%, rgba(255,255,255,0.2) 100%), url(https://example.com/image.jpg)',
+			),
+			'gradient first with hsl colors'     => array(
+				'background-image: linear-gradient(135deg, hsl(0, 100%, 50%) 0%, hsl(240, 100%, 50%) 100%), url(https://example.com/image.jpg)',
+			),
+			'gradient first with hsla colors'    => array(
+				'background-image: linear-gradient(135deg, hsla(0, 100%, 50%, 0.8) 0%, hsla(240, 100%, 50%, 0.5) 100%), url(https://example.com/image.jpg)',
+			),
+			'gradient first with oklch colors'   => array(
+				'background-image: linear-gradient(135deg, oklch(0.7 0.15 30) 0%, oklch(0.5 0.2 260) 100%), url(https://example.com/image.jpg)',
+			),
+			'gradient first with lab colors'     => array(
+				'background-image: linear-gradient(135deg, lab(50% 40 59.5) 0%, lab(70% -45 0) 100%), url(https://example.com/image.jpg)',
+			),
+			'radial gradient with url'           => array(
+				'background-image: radial-gradient(circle, rgb(255,0,0) 0%, rgb(0,0,255) 100%), url(https://example.com/image.jpg)',
+			),
+			'conic gradient with url'            => array(
+				'background-image: conic-gradient(rgb(255,0,0), rgb(0,0,255)), url(https://example.com/image.jpg)',
+			),
+			'repeating-linear gradient with url' => array(
+				'background-image: repeating-linear-gradient(45deg, rgb(255,0,0) 0px, rgb(0,0,255) 40px), url(https://example.com/image.jpg)',
+			),
+			'var preset gradient first with url' => array(
+				'background-image: var(--wp--preset--gradient--vivid-cyan-blue), url(https://example.com/image.jpg)',
+			),
+			'url first with var preset gradient' => array(
+				'background-image: url(https://example.com/image.jpg), var(--wp--preset--gradient--vivid-cyan-blue)',
+			),
+			'gradient with hex colors'           => array(
+				'background-image: linear-gradient(135deg, #ff0000 0%, #0000ff 100%), url(https://example.com/image.jpg)',
 			),
 		);
 	}

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -141,4 +141,131 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 	}
+
+	public function test_color_gradient_suppressed_when_background_gradient_is_supported_and_set() {
+		$this->test_block_name = 'test/color-gradient-suppressed-by-background-gradient';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color'      => array(
+						'gradients' => true,
+					),
+					'background' => array(
+						'gradient' => true,
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $this->test_block_name );
+
+		// Both color.gradient and background.gradient are set — background.php
+		// owns CSS generation, so color.gradient CSS must be suppressed.
+		$block_atts = array(
+			'style' => array(
+				'color'      => array(
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%)',
+				),
+				'background' => array(
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%)',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_color_gradient_emitted_when_background_gradient_is_supported_but_not_set() {
+		$this->test_block_name = 'test/color-gradient-not-suppressed-without-background-gradient-value';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color'      => array(
+						'gradients' => true,
+					),
+					'background' => array(
+						'gradient' => true,
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $this->test_block_name );
+
+		// background.gradient is supported but not yet set — legacy color.gradient
+		// CSS must still be emitted to preserve existing content rendering.
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%)',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-background',
+			'style' => 'background:linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%);',
+		);
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_color_gradient_emitted_when_background_gradient_is_not_supported() {
+		$this->test_block_name = 'test/color-gradient-no-background-gradient-support';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'gradients' => true,
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $this->test_block_name );
+
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%)',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-background',
+			'style' => 'background:linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%);',
+		);
+
+		$this->assertSame( $expected, $actual );
+	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -316,6 +316,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'background' => array(
 				'backgroundImage' => true,
 				'backgroundSize'  => true,
+				'gradient'        => true,
 			),
 			'border'     => array(
 				'width'  => true,
@@ -358,6 +359,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'background' => array(
 						'backgroundImage' => true,
 						'backgroundSize'  => true,
+						'gradient'        => true,
 					),
 					'border'     => array(
 						'width'  => true,
@@ -3012,6 +3014,66 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
 	 */
+	public function test_remove_insecure_properties_allows_combined_background_gradient_and_image() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'background' => array(
+						'backgroundImage' => array(
+							'url' => 'https://example.com/image.jpg',
+						),
+						'gradient'        => 'linear-gradient(135deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0) 100%)',
+					),
+				),
+			),
+			true
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'background' => array(
+					'backgroundImage' => array(
+						'url' => 'https://example.com/image.jpg',
+					),
+					'gradient'        => 'linear-gradient(135deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0) 100%)',
+				),
+			),
+		);
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
+	public function test_remove_insecure_properties_allows_background_gradient_only() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'background' => array(
+						'gradient' => 'linear-gradient(135deg, #fff 0%, #000 100%)',
+					),
+				),
+			),
+			true
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'background' => array(
+					'gradient' => 'linear-gradient(135deg, #fff 0%, #000 100%)',
+				),
+			),
+		);
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
 	public function test_remove_insecure_properties_should_allow_indirect_properties() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
@@ -5650,6 +5712,89 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$expected = "html{min-height: calc(100% - var(--wp-admin--admin-bar--height, 0px));}body{background-image: url('http://example.org/top.png');background-position: 10% 20%;background-repeat: repeat;background-size: contain;background-attachment: scroll;}:root :where(.wp-block-group){background-image: url('http://example.org/group.png');background-size: cover;}:root :where(.wp-block-post-content){background-image: url('http://example.org/top.png');background-position: 10% 20%;background-repeat: repeat;background-size: contain;background-attachment: scroll;}";
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+	}
+
+	/**
+	 * Tests that background gradient styles are output correctly in theme.json.
+	 */
+	public function test_get_background_gradient_styles() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'background' => array(
+						'gradient' => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+					),
+				),
+			)
+		);
+
+		$body_node = array(
+			'path'     => array( 'styles' ),
+			'selector' => 'body',
+		);
+
+		$expected_styles = 'html{min-height: calc(100% - var(--wp-admin--admin-bar--height, 0px));}body{background-image: linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%);}';
+		$this->assertSameCSS( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_styles_for_block()" with top-level background gradient do not match expectations' );
+	}
+
+	/**
+	 * Tests that background gradient preset slug styles are resolved correctly in theme.json.
+	 */
+	public function test_get_background_gradient_preset_slug_styles() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'   => array(
+					'background' => array(
+						'gradient' => 'var:preset|gradient|vivid-cyan-blue',
+					),
+				),
+			)
+		);
+
+		$body_node = array(
+			'path'     => array( 'styles' ),
+			'selector' => 'body',
+		);
+
+		$expected_styles = 'html{min-height: calc(100% - var(--wp-admin--admin-bar--height, 0px));}body{background-image: var(--wp--preset--gradient--vivid-cyan-blue);}';
+		$this->assertSameCSS( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_styles_for_block()" with background gradient preset slug do not match expectations' );
+	}
+
+	/**
+	 * Tests that background gradient and image are combined correctly in theme.json.
+	 */
+	public function test_get_background_gradient_and_image_combined_styles() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'background' => array(
+								'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+								'backgroundImage' => array(
+									'url' => 'http://example.org/image.png',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$group_node = array(
+			'name'      => 'core/group',
+			'path'      => array( 'styles', 'blocks', 'core/group' ),
+			'selector'  => '.wp-block-group',
+			'selectors' => array(
+				'root' => '.wp-block-group',
+			),
+		);
+
+		$expected_styles = ":root :where(.wp-block-group){background-image: linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url('http://example.org/image.png');}";
+		$this->assertSameCSS( $expected_styles, $theme_json->get_styles_for_block( $group_node ), 'Styles returned from "::get_styles_for_block()" with combined background gradient and image do not match expectations' );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5744,8 +5744,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_get_background_gradient_preset_slug_styles() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'styles'   => array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
 					'background' => array(
 						'gradient' => 'var:preset|gradient|vivid-cyan-blue',
 					),

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -503,6 +503,57 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
+			'inline_background_gradient_only'                   => array(
+				'block_styles'    => array(
+					'background' => array(
+						'gradient' => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%);',
+					'declarations' => array(
+						'background-image' => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+					),
+					'classnames'   => 'has-background',
+				),
+			),
+
+			'inline_background_gradient_with_preset_slug'  => array(
+				'block_styles'    => array(
+					'background' => array(
+						'gradient' => 'var:preset|gradient|vivid-cyan-blue',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'background-image:var(--wp--preset--gradient--vivid-cyan-blue);',
+					'declarations' => array(
+						'background-image' => 'var(--wp--preset--gradient--vivid-cyan-blue)',
+					),
+					'classnames'   => 'has-background',
+				),
+			),
+
+			'inline_background_gradient_and_image_combined' => array(
+				'block_styles'    => array(
+					'background' => array(
+						'backgroundImage' => array(
+							'url' => 'https://example.com/image.jpg',
+						),
+						'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => "background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url('https://example.com/image.jpg');",
+					'declarations' => array(
+						'background-image' => "linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url('https://example.com/image.jpg')",
+					),
+					'classnames'   => 'has-background',
+				),
+			),
+
 			'inline_background_image_url_with_background_size' => array(
 				'block_styles'    => array(
 					'background' => array(

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -503,7 +503,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'inline_background_gradient_only'                   => array(
+			'inline_background_gradient_only'              => array(
 				'block_styles'    => array(
 					'background' => array(
 						'gradient' => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -376,6 +376,11 @@
 							"description": "Allow blocks to define values related to the size of a background image, including size, position, and repeat controls",
 							"type": "boolean",
 							"default": false
+						},
+						"gradient": {
+							"description": "Allow blocks to define gradient values.",
+							"type": "boolean",
+							"default": false
 						}
 					}
 				},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -43,6 +43,11 @@
 							"description": "Allow users to set values related to the size of a background image, including size, position, and repeat controls.",
 							"type": "boolean",
 							"default": false
+						},
+						"gradient": {
+							"description": "Allow users to set a gradient background.",
+							"type": "boolean",
+							"default": false
 						}
 					},
 					"additionalProperties": false

--- a/test/e2e/specs/editor/various/background-gradient.spec.js
+++ b/test/e2e/specs/editor/various/background-gradient.spec.js
@@ -204,6 +204,9 @@ test.describe( 'Background gradient block support', () => {
 			);
 
 			// Now clear the gradient — has-background must be removed.
+			// Dismiss any open popover first so the next click reliably
+			// *opens* the dropdown rather than toggling it closed.
+			await page.keyboard.press( 'Escape' );
 			await page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'button', { name: 'Gradient' } )

--- a/test/e2e/specs/editor/various/background-gradient.spec.js
+++ b/test/e2e/specs/editor/various/background-gradient.spec.js
@@ -170,6 +170,56 @@ test.describe( 'Background gradient block support', () => {
 			);
 		} );
 
+		test( 'removes has-background class when gradient is reset after migration', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					style: {
+						color: {
+							gradient: LEGACY_GRADIENT,
+						},
+					},
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+			await page.getByRole( 'tab', { name: 'Styles' } ).click();
+
+			// First, trigger migration by selecting a preset gradient.
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Gradient' } )
+				.click();
+			await page
+				.getByRole( 'option', { name: /Gradient: Vivid cyan blue/i } )
+				.click();
+
+			// Verify has-background was added during migration.
+			const [ blockAfterMigration ] = await editor.getBlocks();
+			expect( blockAfterMigration.attributes.className ).toContain(
+				'has-background'
+			);
+
+			// Now clear the gradient — has-background must be removed.
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Gradient' } )
+				.click();
+			await page.getByRole( 'button', { name: 'Clear' } ).click();
+
+			const [ block ] = await editor.getBlocks();
+
+			expect(
+				block.attributes.style?.background?.gradient
+			).toBeUndefined();
+			expect( block.attributes.className ?? '' ).not.toContain(
+				'has-background'
+			);
+		} );
+
 		test( 'block remains valid after migration and re-save', async ( {
 			editor,
 			page,

--- a/test/e2e/specs/editor/various/background-gradient.spec.js
+++ b/test/e2e/specs/editor/various/background-gradient.spec.js
@@ -1,0 +1,209 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Background gradient block support', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// Switch to emptytheme so WordPress default gradient presets are
+		// available (TwentyTwentyFive sets defaultGradients:false).
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.describe( 'color.gradient read-through and migration', () => {
+		// A custom gradient that does NOT match any WordPress preset so that
+		// clicking a preset in the picker always performs a fresh selection
+		// rather than a deselect of the already-active value.
+		const LEGACY_GRADIENT =
+			'linear-gradient(135deg,rgb(100,100,200) 0%,rgb(200,100,100) 100%)';
+
+		test( 'block with legacy color.gradient loads without a deprecation warning', async ( {
+			editor,
+			page,
+		} ) => {
+			// Insert a group block with legacy style.color.gradient — simulating
+			// content saved before background.gradient support was added.
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					style: {
+						color: {
+							gradient: LEGACY_GRADIENT,
+						},
+					},
+				},
+			} );
+
+			// Block should be valid — no "Attempt Block Recovery" notice.
+			await expect(
+				page.getByRole( 'button', { name: 'Attempt Block Recovery' } )
+			).toBeHidden();
+		} );
+
+		test( 'legacy color.gradient is shown in the background panel via read-through fallback', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					style: {
+						color: {
+							gradient: LEGACY_GRADIENT,
+						},
+					},
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+			await page.getByRole( 'tab', { name: 'Styles' } ).click();
+
+			// The gradient indicator in the Background panel should be visible,
+			// meaning the color.gradient value surfaced via the read-through fallback.
+			const backgroundGradientButton = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', { name: 'Gradient' } );
+
+			await expect( backgroundGradientButton ).toBeVisible();
+
+			// Gradient indicator should have a non-transparent background,
+			// confirming the fallback value is being displayed.
+			const indicator = backgroundGradientButton.locator(
+				'.component-color-indicator'
+			);
+			await expect( indicator ).toBeVisible();
+		} );
+
+		test( 'migrates color.gradient to background.gradient and adds has-background when gradient is set', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					style: {
+						color: {
+							gradient: LEGACY_GRADIENT,
+						},
+					},
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+			await page.getByRole( 'tab', { name: 'Styles' } ).click();
+
+			// Open the gradient picker in the Background panel and select a
+			// preset, which triggers the migration.
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Gradient' } )
+				.click();
+			await page
+				.getByRole( 'option', { name: /Gradient: Vivid cyan blue/i } )
+				.click();
+
+			const [ block ] = await editor.getBlocks();
+
+			// color.gradient must be cleared.
+			expect( block.attributes.style?.color?.gradient ).toBeUndefined();
+
+			// Gradient value must now live in background.gradient.
+			expect( block.attributes.style?.background?.gradient ).toBeTruthy();
+
+			// has-background must be added to className to preserve theme
+			// styles that were relying on it from the old color.gradient support.
+			expect( block.attributes.className ).toContain( 'has-background' );
+		} );
+
+		test( 'clears color.gradient without adding has-background when gradient is reset', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					style: {
+						color: {
+							gradient: LEGACY_GRADIENT,
+						},
+					},
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+			await page.getByRole( 'tab', { name: 'Styles' } ).click();
+
+			// Open the gradient picker and clear it. The inline reset icon
+			// button (aria-label="Reset") is hidden until hover; using the
+			// "Clear" button inside the picker is more reliable across pointer
+			// environments.
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Gradient' } )
+				.click();
+			await page.getByRole( 'button', { name: 'Clear' } ).click();
+
+			const [ block ] = await editor.getBlocks();
+
+			// Both gradient paths must be cleared.
+			expect( block.attributes.style?.color?.gradient ).toBeUndefined();
+			expect(
+				block.attributes.style?.background?.gradient
+			).toBeUndefined();
+
+			// has-background must NOT be added — no gradient is set, so the
+			// class would add padding with no visual justification.
+			// className may be undefined if never set; either way has-background
+			// must not be present.
+			expect( block.attributes.className ?? '' ).not.toContain(
+				'has-background'
+			);
+		} );
+
+		test( 'block remains valid after migration and re-save', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					style: {
+						color: {
+							gradient: LEGACY_GRADIENT,
+						},
+					},
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+			await page.getByRole( 'tab', { name: 'Styles' } ).click();
+
+			// Trigger migration by clearing the gradient via the picker.
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Gradient' } )
+				.click();
+			await page.getByRole( 'button', { name: 'Clear' } ).click();
+
+			// Save the post.
+			await editor.publishPost();
+
+			// Reload and verify the block is still valid — no deprecation
+			// recovery dialog should appear, proving no deprecation is needed.
+			await page.reload();
+			await expect(
+				page.getByRole( 'button', { name: 'Attempt Block Recovery' } )
+			).toBeHidden();
+		} );
+	} );
+} );


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/32787

## What?

Adds `background.gradient` as a new block support, enabling blocks to have a gradient picker in the Background panel. This is separate from the existing `color.gradient` in the Color panel and allows blocks to combine a background gradient with a background image via comma-separated `background-image` CSS values.

## Why?

Currently, the only way to apply a gradient to a block is through the Color panel's `color.gradient` support. This stores the gradient at `style.color.gradient` and renders it as a `background` CSS shorthand, which conflicts with and overrides background image properties.

By introducing `background.gradient` (stored at `style.background.gradient`), gradients become part of the background style group. The style engine can then combine gradient and image values into a single `background-image` declaration (e.g., `background-image: linear-gradient(...), url(...)`), enabling layered backgrounds without conflict.

This also lays the groundwork for eventually migrating `color.gradient` to `background.gradient` across all blocks, providing a more consistent and capable background styling system.

## How?

The implementation is organized into commits representing distinct layers of the system, which may help when reviewing:

**1. Schema & constants** (`e5aebaf`)
Adds `background.gradient` to `block.json` and `theme.json` schemas, `STYLE_PROPERTY` constants, and the theme JSON class (`VALID_SETTINGS`, `VALID_STYLES`, `PROPERTIES_METADATA`, `INDIRECT_PROPERTIES_METADATA`, `APPEARANCE_TOOLS_OPT_INS`).

**2. Style engine & global styles output** (`9259102`)
Updates the JS style engine to combine gradient and `backgroundImage` into a comma-separated `background-image` CSS value, adds the gradient definition to the PHP style engine, and updates `compute_style_properties` to pass both values to the engine.

**3. Block support rendering & safe CSS** (`63faf64`)
Updates `background.php` to handle gradient values on the frontend (including combined gradient + image), and adds a `safecss_filter_attr_allow_css` filter in `kses.php` to allow combined `gradient+url()` values that core's `safecss_filter_attr()` strips.

**4. Editor UI** (`522b740`)
Adds the gradient picker to the Background panel using `ColorPanelDropdown`, suppresses the Color panel's gradient tab when `background.gradient` is enabled, gates gradient settings per block in `useSettingsForBlockElement`, and adds panel styles.

**5. Block opt-in** (`45fd7b2`)
Opts the Group block into `background.gradient` as the first adopter, with documentation updates.

**6. Tests** (`0c13dba`)
PHP tests for block support rendering, theme JSON (`compute_style_properties`, `remove_insecure_properties`, appearance tools), and style engine. JS tests for gradient and combined gradient+image output.

## Testing Instructions

1. Open a new post
2. Insert a **Group** block (add some inner content so it has height)
3. Open **Block Settings → Styles** tab
4. The **Background** panel should show both an Image control and a Gradient control
5. Click the Gradient control and set a custom gradient (e.g., `linear-gradient(135deg, #000 0%, #fff 100%)`)
6. Verify the gradient renders in the editor
7. Save and view the post on the frontend — the gradient should render via inline styles
8. Go back to the editor and also set a **background image** on the same Group block
9. Verify both gradient and image render together (gradient overlays the image)
10. Clear the gradient — the image should remain unaffected
11. Verify the **Color panel** does NOT show a Gradient tab (it's suppressed to avoid duplicate UI)

### Global styles

12. Open **Site Editor → Styles → Edit styles**
13. Set a background gradient at the root level
14. Verify it renders in the frontend stylesheet

### Testing Instructions for Keyboard

1. Tab to the Gradient control in the Background panel
2. Press Enter/Space to open the dropdown
3. Navigate gradient presets with arrow keys (if available) or Tab to the custom gradient picker
4. Interact with the gradient bar to add/modify color stops using keyboard
5. Press Escape to close the dropdown

## Screenshots or screencast

<!-- Screenshots of the gradient picker in the Background panel, and frontend rendering of gradient-only and combined gradient+image would be helpful here -->