### PR TITLE
Post Excerpt: Migrate to textAlign block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -725,8 +725,8 @@ Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk
 
 -	**Name:** core/post-excerpt
 -	**Category:** theme
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textColumns), ~~html~~
--	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign, textColumns), ~~html~~
+-	**Attributes:** excerptLength, moreText, showMoreOnNewLine
 
 ## Featured Image
 

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -7,9 +7,6 @@
 	"description": "Display the excerpt.",
 	"textdomain": "default",
 	"attributes": {
-		"textAlign": {
-			"type": "string"
-		},
 		"moreText": {
 			"type": "string",
 			"role": "content"
@@ -46,6 +43,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"textColumns": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,

--- a/packages/block-library/src/post-excerpt/deprecated.js
+++ b/packages/block-library/src/post-excerpt/deprecated.js
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import migrateTextAlign from '../utils/migrate-text-align';
+
+const v1 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		moreText: {
+			type: 'string',
+			role: 'content',
+		},
+		showMoreOnNewLine: {
+			type: 'boolean',
+			default: true,
+		},
+		excerptLength: {
+			type: 'number',
+			default: 55,
+		},
+	},
+	supports: {
+		anchor: true,
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			textColumns: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate: migrateTextAlign,
+	isEligible( attributes ) {
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
+	},
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -9,13 +9,10 @@ import clsx from 'clsx';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 import {
-	AlignmentToolbar,
-	BlockControls,
 	InspectorControls,
 	RichText,
 	Warning,
 	useBlockProps,
-	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import {
 	ToggleControl,
@@ -33,17 +30,19 @@ import {
 	useCanEditEntity,
 	useToolsPanelDropdownMenuProps,
 } from '../utils/hooks';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
 const ELLIPSIS = '…';
 
-export default function PostExcerptEditor( {
-	attributes: { textAlign, moreText, showMoreOnNewLine, excerptLength },
-	setAttributes,
-	isSelected,
-	context: { postId, postType, queryId },
-} ) {
-	const blockEditingMode = useBlockEditingMode();
-	const showControls = blockEditingMode === 'default';
+export default function PostExcerptEditor( props ) {
+	const {
+		attributes: { moreText, showMoreOnNewLine, excerptLength },
+		setAttributes,
+		isSelected,
+		context: { postId, postType, queryId },
+	} = props;
+	useDeprecatedTextAlign( props );
+
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	const [
@@ -83,11 +82,7 @@ export default function PostExcerptEditor( {
 	const isEditable =
 		userCanEdit && ! isDescendentOfQueryLoop && postTypeSupportsExcerpts;
 
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+	const blockProps = useBlockProps();
 
 	/**
 	 * translators: If your word count is based on single characters (e.g. East Asian characters),
@@ -114,19 +109,9 @@ export default function PostExcerptEditor( {
 
 	if ( ! postType || ! postId ) {
 		return (
-			<>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ textAlign }
-						onChange={ ( newAlign ) =>
-							setAttributes( { textAlign: newAlign } )
-						}
-					/>
-				</BlockControls>
-				<div { ...blockProps }>
-					<p>{ __( 'This block will display the excerpt.' ) }</p>
-				</div>
-			</>
+			<div { ...blockProps }>
+				<p>{ __( 'This block will display the excerpt.' ) }</p>
+			</div>
 		);
 	}
 	if ( isProtected && ! userCanEdit ) {
@@ -225,16 +210,6 @@ export default function PostExcerptEditor( {
 	);
 	return (
 		<>
-			{ showControls && (
-				<BlockControls>
-					<AlignmentToolbar
-						value={ textAlign }
-						onChange={ ( newAlign ) =>
-							setAttributes( { textAlign: newAlign } )
-						}
-					/>
-				</BlockControls>
-			) }
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -18,6 +19,7 @@ export const settings = {
 	icon,
 	transforms,
 	edit,
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.html
@@ -1,0 +1,5 @@
+<!-- wp:post-excerpt {"textAlign":"left"} /-->
+
+<!-- wp:post-excerpt {"textAlign":"center"} /-->
+
+<!-- wp:post-excerpt {"textAlign":"right"} /-->

--- a/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.json
@@ -1,0 +1,44 @@
+[
+	{
+		"name": "core/post-excerpt",
+		"isValid": true,
+		"attributes": {
+			"showMoreOnNewLine": true,
+			"excerptLength": 55,
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-excerpt",
+		"isValid": true,
+		"attributes": {
+			"showMoreOnNewLine": true,
+			"excerptLength": 55,
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/post-excerpt",
+		"isValid": true,
+		"attributes": {
+			"showMoreOnNewLine": true,
+			"excerptLength": 55,
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.parsed.json
@@ -1,0 +1,43 @@
+[
+	{
+		"blockName": "core/post-excerpt",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-excerpt",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/post-excerpt",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-excerpt__deprecated-v1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"left"}}} /-->
+
+<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"center"}}} /-->
+
+<!-- wp:post-excerpt {"style":{"typography":{"textAlign":"right"}}} /-->


### PR DESCRIPTION
## What?

Part of #60763

Migrates the Post Excerpt block to use the `textAlign` block support instead of a custom `textAlign` attribute. As a consequence, it also enables global styles support for `textAlign` on the Post Excerpt block.

## Why?

The Post Excerpt block currently implements its own text alignment logic with a custom `textAlign` attribute and a manual `AlignmentControl` in the toolbar, duplicating code that should be handled by the centralized `textAlign` block support.

This migration reduces code duplication and consolidates alignment handling across blocks.

## How?

- Replaces the custom `textAlign` attribute and manual alignment logic with block supports.
- Adds a deprecation entry to migrate existing blocks using the old `textAlign` attribute.
- Fixes transforms to ensure alignment is preserved when converting between blocks.

## Testing Instructions

1. Create a new `Post Excerpt` block and test text alignment (left, center, right).
2. Verify alignment works correctly in both the editor and the frontend.
3. Open a post with existing `Post Excerpt` blocks that have alignment set.
4. Verify they migrate correctly (no console errors, no visual changes).
5. Confirm the block is valid after migration by checking there are no block validation warnings in the console.