### PR TITLE
Editor: Fix Revisions field/button visibility on first edit in the post editor

### DIFF
--- a/packages/editor/src/components/post-last-revision/check.js
+++ b/packages/editor/src/components/post-last-revision/check.js
@@ -27,7 +27,7 @@ function PostLastRevisionCheck( { children } ) {
 		};
 	}, [] );
 
-	if ( ! lastRevisionId || revisionsCount < 2 ) {
+	if ( ! lastRevisionId || revisionsCount < 1 ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-last-revision/test/check.js
+++ b/packages/editor/src/components/post-last-revision/test/check.js
@@ -39,19 +39,19 @@ describe( 'PostLastRevisionCheck', () => {
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should not render anything if there is only one revision', () => {
-		setupDataMock( 1, 1 );
+	it( 'should not render anything if there are zero revisions', () => {
+		setupDataMock( 1, 0 );
 
 		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
 
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should render if there are two revisions', () => {
-		setupDataMock( 1, 2 );
+	it( 'should render if there is one revision', () => {
+		setupDataMock( 1, 1 );
 
 		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
 
-		expect( screen.getByText( 'Children' ) ).toBeVisible();
+		expect( screen.getByText( 'Children' ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION


## What?
Closes https://github.com/WordPress/gutenberg/issues/75858

This PR makes the Revisions panel visible in the sidebar immediately after the first save.

## Why?

Previously, the Revisions field was hidden until a post had at least two revisions. This was especially confusing when duplicating a page, as the first edit would save a revision but the UI would remain hidden until a second edit was made.

## How?

Modified `PostLastRevisionCheck` to render when `revisionsCount` is at least 1 instead of 2.

## Testing Instructions

1. Go to Appearance > Editor > Pages.
2. Duplicate a page.
3. Make one edit and Save.
4. Verify the Revisions field is now visible in the Page settings panel.
5. Confirm it remains hidden on a brand new post with 0 edits.


## Screenshots or screencast 


https://github.com/user-attachments/assets/43360cc9-1a46-4208-8c40-6a29877432a3


