### PR TITLE
Client Side Media: Add device/browser capability detection

### DIFF
--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -61,10 +61,70 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 		return cachedResult;
 	}
 
+	// Check Web Worker support.
+	if ( typeof Worker === 'undefined' ) {
+		cachedResult = {
+			supported: false,
+			reason: 'Web Workers are not supported in this browser.',
+		};
+		return cachedResult;
+	}
+
+	// Check credentialless iframe support.
+	// Browsers without this (Firefox, Safari) cannot use cross-origin isolation
+	// without breaking third-party embeds.
+	if (
+		typeof window !== 'undefined' &&
+		! ( 'credentialless' in window.HTMLIFrameElement.prototype )
+	) {
+		cachedResult = {
+			supported: false,
+			reason: 'Browser does not support credentialless iframes. Cross-origin isolation would break third-party embeds. Developers can re-enable via the wp_client_side_media_processing_enabled filter.',
+		};
+		return cachedResult;
+	}
+
+	// Check device memory.
+	if (
+		typeof navigator !== 'undefined' &&
+		'deviceMemory' in navigator &&
+		( navigator as any ).deviceMemory <= 2
+	) {
+		cachedResult = {
+			supported: false,
+			reason: 'Device has insufficient memory for client-side media processing.',
+		};
+		return cachedResult;
+	}
+
+	// Check network conditions.
+	if ( typeof navigator !== 'undefined' ) {
+		const connection = ( navigator as any ).connection;
+		if ( connection ) {
+			if ( connection.saveData ) {
+				cachedResult = {
+					supported: false,
+					reason: 'Data saver mode is enabled.',
+				};
+				return cachedResult;
+			}
+			if (
+				connection.effectiveType === '2g' ||
+				connection.effectiveType === 'slow-2g'
+			) {
+				cachedResult = {
+					supported: false,
+					reason: 'Network connection is too slow for client-side media processing.',
+				};
+				return cachedResult;
+			}
+		}
+	}
+
 	// Check that blob URL workers are allowed by CSP.
 	// Security plugins often set a strict worker-src directive that blocks blob: URLs,
 	// which would prevent creating the WASM processing worker at runtime.
-	if ( typeof window !== 'undefined' && typeof Worker !== 'undefined' ) {
+	if ( typeof window !== 'undefined' ) {
 		try {
 			const testBlob = new Blob( [ '' ], {
 				type: 'application/javascript',

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -28,7 +28,7 @@ let cachedResult: FeatureDetectionResult | null = null;
  *    break third-party embeds). Browsers that lack `credentialless` iframe support
  *    (currently Firefox and Safari) will have client-side media processing disabled
  *    by default. Developers can re-enable the feature via the server-side
- *    `client_side_media_processing_enabled` filter if it works for their site.
+ *    `wp_client_side_media_processing_enabled` filter if it works for their site.
  * 5. Device memory (disables on devices with ≤2 GB RAM)
  * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 2g/slow-2g)
  * 7. Web Worker support (baseline requirement)
@@ -75,6 +75,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 	// without breaking third-party embeds.
 	if (
 		typeof window !== 'undefined' &&
+		window.HTMLIFrameElement &&
 		! ( 'credentialless' in window.HTMLIFrameElement.prototype )
 	) {
 		cachedResult = {

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -30,8 +30,9 @@ let cachedResult: FeatureDetectionResult | null = null;
  *    by default. Developers can re-enable the feature via the server-side
  *    `wp_client_side_media_processing_enabled` filter if it works for their site.
  * 5. Device memory (disables on devices with ≤2 GB RAM)
- * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 3g/2g/slow-2g)
- * 7. Web Worker support (baseline requirement)
+ * 6. Hardware concurrency (disables on devices with fewer than 4 CPU cores)
+ * 7. Network conditions (disables when data saver / reduced data mode is on or connection is 3g/2g/slow-2g)
+ * 8. Web Worker support (baseline requirement)
  *
  * Results are cached after the first call. Use `clearFeatureDetectionCache()` to reset.
  *
@@ -94,6 +95,19 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 		cachedResult = {
 			supported: false,
 			reason: 'Device has insufficient memory for client-side media processing.',
+		};
+		return cachedResult;
+	}
+
+	// Check hardware concurrency (number of CPU cores).
+	if (
+		typeof navigator !== 'undefined' &&
+		'hardwareConcurrency' in navigator &&
+		navigator.hardwareConcurrency < 4
+	) {
+		cachedResult = {
+			supported: false,
+			reason: 'Device has insufficient CPU cores for client-side media processing.',
 		};
 		return cachedResult;
 	}

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -80,7 +80,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 	) {
 		cachedResult = {
 			supported: false,
-			reason: 'Browser does not support credentialless iframes. Cross-origin isolation would break third-party embeds. Developers can re-enable via the wp_client_side_media_processing_enabled filter.',
+			reason: 'Browser does not support credentialless iframes. Cross-origin isolation would break third-party embeds',
 		};
 		return cachedResult;
 	}

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -48,7 +48,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 	if ( typeof WebAssembly === 'undefined' ) {
 		cachedResult = {
 			supported: false,
-			reason: 'WebAssembly is not supported in this browser',
+			reason: 'WebAssembly is not supported in this browser.',
 		};
 		return cachedResult;
 	}

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -30,7 +30,7 @@ let cachedResult: FeatureDetectionResult | null = null;
  *    by default. Developers can re-enable the feature via the server-side
  *    `client_side_media_processing_enabled` filter if it works for their site.
  * 5. Device memory (disables on devices with ≤2 GB RAM)
- * 6. Network conditions (disables when data saver is on or connection is 2g/slow-2g)
+ * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 2g/slow-2g)
  * 7. Web Worker support (baseline requirement)
  *
  * Results are cached after the first call. Use `clearFeatureDetectionCache()` to reset.

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -30,7 +30,7 @@ let cachedResult: FeatureDetectionResult | null = null;
  *    by default. Developers can re-enable the feature via the server-side
  *    `wp_client_side_media_processing_enabled` filter if it works for their site.
  * 5. Device memory (disables on devices with ≤2 GB RAM)
- * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 2g/slow-2g)
+ * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 3g/2g/slow-2g)
  * 7. Web Worker support (baseline requirement)
  *
  * Results are cached after the first call. Use `clearFeatureDetectionCache()` to reset.
@@ -110,8 +110,9 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 				return cachedResult;
 			}
 			if (
+				connection.effectiveType === 'slow-2g' ||
 				connection.effectiveType === '2g' ||
-				connection.effectiveType === 'slow-2g'
+				connection.effectiveType === '3g'
 			) {
 				cachedResult = {
 					supported: false,

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -24,6 +24,16 @@ let cachedResult: FeatureDetectionResult | null = null;
  * 1. WebAssembly support (required for wasm-vips)
  * 2. SharedArrayBuffer support (required for WASM threading)
  * 3. CSP compatibility for blob URL workers (required for inline worker creation)
+ * 4. Credentialless iframe support (required so cross-origin isolation does not
+ *    break third-party embeds). Browsers that lack `credentialless` iframe support
+ *    (currently Firefox and Safari) will have client-side media processing disabled
+ *    by default. Developers can re-enable the feature via the server-side
+ *    `client_side_media_processing_enabled` filter if it works for their site.
+ * 5. Device memory (disables on devices with ≤2 GB RAM)
+ * 6. Network conditions (disables when data saver is on or connection is 2g/slow-2g)
+ * 7. Web Worker support (baseline requirement)
+ *
+ * Results are cached after the first call. Use `clearFeatureDetectionCache()` to reset.
  *
  * @return Feature detection result with supported status and reason if not supported.
  */

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -1,3 +1,13 @@
+interface NavigatorNetworkInformation {
+	saveData: boolean;
+	effectiveType: 'slow-2g' | '2g' | '3g' | '4g';
+}
+
+interface NavigatorExtended extends Navigator {
+	deviceMemory?: number;
+	connection?: NavigatorNetworkInformation;
+}
+
 /**
  * Result of client-side media processing support detection.
  */
@@ -90,7 +100,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 	if (
 		typeof navigator !== 'undefined' &&
 		'deviceMemory' in navigator &&
-		( navigator as any ).deviceMemory <= 2
+		( navigator as NavigatorExtended ).deviceMemory! <= 2
 	) {
 		cachedResult = {
 			supported: false,
@@ -114,7 +124,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 
 	// Check network conditions.
 	if ( typeof navigator !== 'undefined' ) {
-		const connection = ( navigator as any ).connection;
+		const connection = ( navigator as NavigatorExtended ).connection;
 		if ( connection ) {
 			if ( connection.saveData ) {
 				cachedResult = {

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -14,6 +14,16 @@ describe( 'feature-detection', () => {
 	const originalCreateObjectURL = global.URL.createObjectURL;
 	const originalRevokeObjectURL = global.URL.revokeObjectURL;
 
+	// Store original property descriptors for navigator properties.
+	const originalDeviceMemoryDescriptor = Object.getOwnPropertyDescriptor(
+		navigator,
+		'deviceMemory'
+	);
+	const originalConnectionDescriptor = Object.getOwnPropertyDescriptor(
+		navigator,
+		'connection'
+	);
+
 	beforeEach( () => {
 		// Clear the cache before each test.
 		clearFeatureDetectionCache();
@@ -28,6 +38,30 @@ describe( 'feature-detection', () => {
 			() => 'blob:http://localhost/test'
 		);
 		global.URL.revokeObjectURL = jest.fn();
+
+		// Mock credentialless iframe support so the check passes by default.
+		if ( ! ( 'credentialless' in window.HTMLIFrameElement.prototype ) ) {
+			Object.defineProperty(
+				window.HTMLIFrameElement.prototype,
+				'credentialless',
+				{
+					value: false,
+					writable: true,
+					configurable: true,
+				}
+			);
+		}
+
+		// Remove navigator.deviceMemory and navigator.connection by default
+		// so they don't interfere with unrelated tests.
+		if ( 'deviceMemory' in navigator ) {
+			// @ts-ignore
+			delete navigator.deviceMemory;
+		}
+		if ( 'connection' in navigator ) {
+			// @ts-ignore
+			delete navigator.connection;
+		}
 	} );
 
 	afterEach( () => {
@@ -37,6 +71,35 @@ describe( 'feature-detection', () => {
 		global.Worker = originalWorker;
 		global.URL.createObjectURL = originalCreateObjectURL;
 		global.URL.revokeObjectURL = originalRevokeObjectURL;
+
+		// Restore credentialless property.
+		if ( 'credentialless' in window.HTMLIFrameElement.prototype ) {
+			delete ( window.HTMLIFrameElement.prototype as any ).credentialless;
+		}
+
+		// Restore navigator.deviceMemory.
+		if ( originalDeviceMemoryDescriptor ) {
+			Object.defineProperty(
+				navigator,
+				'deviceMemory',
+				originalDeviceMemoryDescriptor
+			);
+		} else if ( 'deviceMemory' in navigator ) {
+			// @ts-ignore
+			delete navigator.deviceMemory;
+		}
+
+		// Restore navigator.connection.
+		if ( originalConnectionDescriptor ) {
+			Object.defineProperty(
+				navigator,
+				'connection',
+				originalConnectionDescriptor
+			);
+		} else if ( 'connection' in navigator ) {
+			// @ts-ignore
+			delete navigator.connection;
+		}
 	} );
 
 	describe( 'detectClientSideMediaSupport', () => {
@@ -72,6 +135,120 @@ describe( 'feature-detection', () => {
 
 			expect( result.supported ).toBe( false );
 			expect( result.reason ).toContain( 'SharedArrayBuffer' );
+		} );
+
+		it( 'returns not supported when Worker is unavailable', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+			// @ts-ignore - Intentionally setting Worker to undefined for testing.
+			global.Worker = undefined;
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toBe(
+				'Web Workers are not supported in this browser.'
+			);
+		} );
+
+		it( 'returns not supported when credentialless iframes are not supported', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			// Remove credentialless from the prototype.
+			delete ( window.HTMLIFrameElement.prototype as any ).credentialless;
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toContain( 'credentialless iframes' );
+		} );
+
+		it( 'returns supported when credentialless iframes are supported', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			// credentialless is already mocked in beforeEach.
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( true );
+		} );
+
+		it( 'returns not supported when device memory is 2 GB or less', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'deviceMemory', {
+				value: 2,
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toContain( 'insufficient memory' );
+		} );
+
+		it( 'returns supported when device memory is greater than 2 GB', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'deviceMemory', {
+				value: 4,
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( true );
+		} );
+
+		it( 'returns not supported when data saver is enabled', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'connection', {
+				value: { saveData: true, effectiveType: '4g' },
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toBe( 'Data saver mode is enabled.' );
+		} );
+
+		it( 'returns not supported when connection is 2g', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'connection', {
+				value: { saveData: false, effectiveType: '2g' },
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toContain( 'too slow' );
+		} );
+
+		it( 'returns not supported when connection is slow-2g', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'connection', {
+				value: {
+					saveData: false,
+					effectiveType: 'slow-2g',
+				},
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toContain( 'too slow' );
 		} );
 
 		it( 'returns not supported when CSP blocks blob workers', () => {

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -233,6 +233,21 @@ describe( 'feature-detection', () => {
 			expect( result.reason ).toContain( 'too slow' );
 		} );
 
+		it( 'returns not supported when connection is 3g', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'connection', {
+				value: { saveData: false, effectiveType: '3g' },
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toContain( 'too slow' );
+		} );
+
 		it( 'returns not supported when connection is slow-2g', () => {
 			global.WebAssembly = originalWebAssembly;
 			global.SharedArrayBuffer = originalSharedArrayBuffer;

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -30,6 +30,10 @@ describe( 'feature-detection', () => {
 		// Clear the cache before each test.
 		clearFeatureDetectionCache();
 
+		// Restore WebAssembly and SharedArrayBuffer before each test.
+		global.WebAssembly = originalWebAssembly;
+		global.SharedArrayBuffer = originalSharedArrayBuffer;
+
 		// By default, provide a mock Worker that does not throw (CSP allows blob workers).
 		global.Worker = class MockWorker {
 			terminate() {}
@@ -122,10 +126,6 @@ describe( 'feature-detection', () => {
 
 	describe( 'detectClientSideMediaSupport', () => {
 		it( 'returns supported when all features are available', () => {
-			// Ensure all features are available.
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			const result = detectClientSideMediaSupport();
 
 			expect( result.supported ).toBe( true );
@@ -145,7 +145,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when SharedArrayBuffer is unavailable', () => {
-			global.WebAssembly = originalWebAssembly;
 			// @ts-ignore - Intentionally setting SharedArrayBuffer to undefined for testing.
 			global.SharedArrayBuffer = undefined;
 
@@ -156,8 +155,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when Worker is unavailable', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
 			// @ts-ignore - Intentionally setting Worker to undefined for testing.
 			global.Worker = undefined;
 
@@ -170,9 +167,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when credentialless iframes are not supported', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			// Remove credentialless from the prototype.
 			delete ( window.HTMLIFrameElement.prototype as any ).credentialless;
 
@@ -183,9 +177,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns supported when credentialless iframes are supported', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			// credentialless is already mocked in beforeEach.
 			const result = detectClientSideMediaSupport();
 
@@ -193,9 +184,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when device memory is 2 GB or less', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'deviceMemory', {
 				value: 2,
 				configurable: true,
@@ -208,9 +196,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns supported when device memory is greater than 2 GB', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'deviceMemory', {
 				value: 4,
 				configurable: true,
@@ -222,9 +207,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when hardware concurrency is less than 4', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'hardwareConcurrency', {
 				value: 2,
 				configurable: true,
@@ -237,9 +219,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns supported when hardware concurrency is 4 or more', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'hardwareConcurrency', {
 				value: 4,
 				configurable: true,
@@ -251,9 +230,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when data saver is enabled', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'connection', {
 				value: { saveData: true, effectiveType: '4g' },
 				configurable: true,
@@ -266,9 +242,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when connection is 2g', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'connection', {
 				value: { saveData: false, effectiveType: '2g' },
 				configurable: true,
@@ -281,9 +254,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when connection is 3g', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'connection', {
 				value: { saveData: false, effectiveType: '3g' },
 				configurable: true,
@@ -296,9 +266,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when connection is slow-2g', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			Object.defineProperty( navigator, 'connection', {
 				value: {
 					saveData: false,
@@ -314,9 +281,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when CSP blocks blob workers', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			// Simulate CSP blocking blob URL workers by throwing a SecurityError.
 			global.Worker = class ThrowingWorker {
 				constructor() {
@@ -335,9 +299,6 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'caches the result', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			const result1 = detectClientSideMediaSupport();
 			expect( result1.supported ).toBe( true );
 
@@ -353,9 +314,6 @@ describe( 'feature-detection', () => {
 
 	describe( 'isClientSideMediaSupported', () => {
 		it( 'returns true when all features are available', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			expect( isClientSideMediaSupported() ).toBe( true );
 		} );
 
@@ -369,9 +327,6 @@ describe( 'feature-detection', () => {
 
 	describe( 'clearFeatureDetectionCache', () => {
 		it( 'clears the cached result', () => {
-			global.WebAssembly = originalWebAssembly;
-			global.SharedArrayBuffer = originalSharedArrayBuffer;
-
 			const result1 = detectClientSideMediaSupport();
 			expect( result1.supported ).toBe( true );
 

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -23,6 +23,8 @@ describe( 'feature-detection', () => {
 		navigator,
 		'connection'
 	);
+	const originalHardwareConcurrencyDescriptor =
+		Object.getOwnPropertyDescriptor( navigator, 'hardwareConcurrency' );
 
 	beforeEach( () => {
 		// Clear the cache before each test.
@@ -62,6 +64,10 @@ describe( 'feature-detection', () => {
 			// @ts-ignore
 			delete navigator.connection;
 		}
+		if ( 'hardwareConcurrency' in navigator ) {
+			// @ts-ignore
+			delete navigator.hardwareConcurrency;
+		}
 	} );
 
 	afterEach( () => {
@@ -99,6 +105,18 @@ describe( 'feature-detection', () => {
 		} else if ( 'connection' in navigator ) {
 			// @ts-ignore
 			delete navigator.connection;
+		}
+
+		// Restore navigator.hardwareConcurrency.
+		if ( originalHardwareConcurrencyDescriptor ) {
+			Object.defineProperty(
+				navigator,
+				'hardwareConcurrency',
+				originalHardwareConcurrencyDescriptor
+			);
+		} else if ( 'hardwareConcurrency' in navigator ) {
+			// @ts-ignore
+			delete navigator.hardwareConcurrency;
 		}
 	} );
 
@@ -194,6 +212,35 @@ describe( 'feature-detection', () => {
 			global.SharedArrayBuffer = originalSharedArrayBuffer;
 
 			Object.defineProperty( navigator, 'deviceMemory', {
+				value: 4,
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( true );
+		} );
+
+		it( 'returns not supported when hardware concurrency is less than 4', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'hardwareConcurrency', {
+				value: 2,
+				configurable: true,
+			} );
+
+			const result = detectClientSideMediaSupport();
+
+			expect( result.supported ).toBe( false );
+			expect( result.reason ).toContain( 'insufficient CPU cores' );
+		} );
+
+		it( 'returns supported when hardware concurrency is 4 or more', () => {
+			global.WebAssembly = originalWebAssembly;
+			global.SharedArrayBuffer = originalSharedArrayBuffer;
+
+			Object.defineProperty( navigator, 'hardwareConcurrency', {
 				value: 4,
 				configurable: true,
 			} );

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -140,7 +140,7 @@ describe( 'feature-detection', () => {
 
 			expect( result.supported ).toBe( false );
 			expect( result.reason ).toBe(
-				'WebAssembly is not supported in this browser'
+				'WebAssembly is not supported in this browser.'
 			);
 		} );
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/WordPress/gutenberg/issues/75849

Implements the four new capability detection checks from #75849 in `detectClientSideMediaSupport()`:

- **Web Worker support** — early exit when `Worker` is undefined
- **Credentialless iframe support** — disables by default in browsers (Firefox/Safari) that lack `credentialless` iframes, since cross-origin isolation breaks third-party embeds
- **Device memory** — disables on devices with ≤2 GB RAM via `navigator.deviceMemory`
- **Network conditions** — disables when data saver / reduced data mode is enabled or connection is `2g`/`slow-2g`

All new checks are ordered before the existing blob worker CSP test (the most expensive check). Check ordering:
1. WebAssembly (existing)
2. SharedArrayBuffer (existing)
3. Web Worker support (new)
4. Credentialless iframe support (new)
5. Device memory (new)
6. Network conditions (new)
7. Blob worker CSP (existing)

## Context

Part of #74333 (Client Side Media iteration for WordPress 7.0). Tracked in #75849.

## Test plan

- [x] 16 unit tests pass (8 new + 8 existing)
- [ ] Verify `detectClientSideMediaSupport()` returns `supported: false` with correct reason in Chrome DevTools when simulating: slow network (2g), low memory, data saver
- [ ] Verify feature is disabled by default in Firefox/Safari (no credentialless iframe support)
- [ ] Verify feature works in Chrome with good conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)