### PR TITLE
Fix DataForm card summary vertical alignment

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -7,6 +7,7 @@
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
 - DataViews: Fix search input losing characters during debounce when externally synced. [#75810](https://github.com/WordPress/gutenberg/pull/75810)
+- DataForm: Fix vertical alignment of summary fields in card layout. [#75864](https://github.com/WordPress/gutenberg/pull/75864)
 
 ### Enhancements
 
@@ -40,6 +41,7 @@
 - DataViews: Consistent rendering of selection checkbox and actions in grid layout. [#75056](https://github.com/WordPress/gutenberg/pull/75056)
 
 ### Code Quality
+
 - DataForm: Style SummaryButton in panel layout with `is-disabled` classname. [#75470](https://github.com/WordPress/gutenberg/pull/75470)
 
 ### Internal

--- a/packages/dataviews/src/components/dataform-layouts/card/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/card/style.scss
@@ -21,4 +21,5 @@
 	display: flex;
 	flex-direction: row;
 	gap: $grid-unit-20;
+	align-items: center;
 }

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -152,7 +152,9 @@ const LayoutCardComponent = ( {
 		isCollapsible: collapsible,
 		isOpened: opened,
 	}: {
-		summary?: string | { id: string; visibility: 'always' }[];
+		summary?:
+			| string
+			| { id: string; visibility?: 'always' | 'when-collapsed' }[];
 		withSummary?: boolean;
 		withHeader?: boolean;
 		isCollapsible?: boolean;
@@ -178,7 +180,13 @@ const LayoutCardComponent = ( {
 				{
 					id: 'customerCard',
 					layout: getCardLayoutFromStoryArgs( {
-						summary: 'plan-summary',
+						summary: [
+							{ id: 'name', visibility: 'when-collapsed' },
+							{
+								id: 'plan-summary',
+								visibility: 'when-collapsed',
+							},
+						],
 						withHeader: withHeader ?? true,
 						withSummary,
 						isCollapsible,

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -152,9 +152,7 @@ const LayoutCardComponent = ( {
 		isCollapsible: collapsible,
 		isOpened: opened,
 	}: {
-		summary?:
-			| string
-			| { id: string; visibility?: 'always' | 'when-collapsed' }[];
+		summary?: string | string[] | { id: string; visibility: 'always' }[];
 		withSummary?: boolean;
 		withHeader?: boolean;
 		isCollapsible?: boolean;
@@ -180,13 +178,7 @@ const LayoutCardComponent = ( {
 				{
 					id: 'customerCard',
 					layout: getCardLayoutFromStoryArgs( {
-						summary: [
-							{ id: 'name', visibility: 'when-collapsed' },
-							{
-								id: 'plan-summary',
-								visibility: 'when-collapsed',
-							},
-						],
+						summary: [ 'name', 'plan-summary' ],
 						withHeader: withHeader ?? true,
 						withSummary,
 						isCollapsible,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes vertical alignment of multiple elements within DataForm card summaries.

## Why?

When there are different height elements e.g. text and a badge, the alignment is not centered.

## How?

Small CSS change and storybook example.

## Testing Instructions
1. Open Storybook
2. Go to DataForms card layout story
3. See alignment on collapsed `customer` card.

<img width="804" height="106" alt="Screenshot 2026-02-24 at 12 25 54" src="https://github.com/user-attachments/assets/428316a6-437c-4f56-92ec-70eed020c27c" />

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="204" height="98" alt="Screenshot 2026-02-24 at 12 07 10" src="https://github.com/user-attachments/assets/7e0a8bd4-4c73-4c12-b449-22eaa21a11bb" />|<img width="230" height="99" alt="Screenshot 2026-02-24 at 12 06 14" src="https://github.com/user-attachments/assets/c5eba78a-2379-4a57-a62a-80f0b9dd1020" />|


