### PR TITLE
Navigation: Extract NavigationLinkUI and NavigationListViewHeader into separate files

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -6,12 +6,7 @@ import {
 	InspectorControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	Spinner,
-	__experimentalHStack as HStack,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { PanelBody, Spinner } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
@@ -24,120 +19,14 @@ import { unlock } from '../../lock-unlock';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import useNavigationMenu from '../use-navigation-menu';
 import LeafMoreMenu from './leaf-more-menu';
-import {
-	LinkUI,
-	updateAttributes,
-	useEntityBinding,
-} from '../../navigation-link/shared';
+import { NavigationLinkUI } from './navigation-link-ui';
+import NavigationListViewHeader from './navigation-list-view-header';
 
 const actionLabel =
 	/* translators: %s: The name of a menu. */ __( "Switch to '%s'" );
-const BLOCKS_WITH_LINK_UI_SUPPORT = [
-	'core/navigation-link',
-	'core/navigation-submenu',
-];
-const {
-	PrivateListView,
-	useBlockDisplayTitle,
-	PrivateBlockContext,
-	useListViewPanelState,
-} = unlock( blockEditorPrivateApis );
-
-function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
-	const { updateBlockAttributes, removeBlock } =
-		useDispatch( blockEditorStore );
-
-	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT?.includes(
-		insertedBlock?.name
-	);
-	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
-	const showLinkControls = supportsLinkControls && blockWasJustInserted;
-
-	// Get binding utilities for the inserted block
-	const { createBinding, clearBinding } = useEntityBinding( {
-		clientId: insertedBlock?.clientId,
-		attributes: insertedBlock?.attributes || {},
-	} );
-
-	if ( ! showLinkControls ) {
-		return null;
-	}
-
-	/**
-	 * Cleanup function for auto-inserted Navigation Link blocks.
-	 *
-	 * Removes the block if it has no URL and clears the inserted block state.
-	 * This ensures consistent cleanup behavior across different contexts.
-	 */
-	const cleanupInsertedBlock = () => {
-		// Prevent automatic block selection when removing blocks in list view context
-		// This avoids focus stealing that would close the list view and switch to canvas
-		const shouldAutoSelectBlock = false;
-
-		// Follows the exact same pattern as Navigation Link block's onClose handler
-		// If there is no URL then remove the auto-inserted block to avoid empty blocks
-		if ( ! insertedBlock?.attributes?.url && insertedBlock?.clientId ) {
-			// Remove the block entirely to avoid poor UX
-			// This matches the Navigation Link block's behavior
-			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
-		}
-		setInsertedBlock( null );
-	};
-
-	const setInsertedBlockAttributes =
-		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
-			if ( ! _insertedBlockClientId ) {
-				return;
-			}
-			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
-		};
-
-	// Wrapper function to clean up original block when a new block is selected
-	const handleSetInsertedBlock = ( newBlock ) => {
-		// Prevent automatic block selection when removing blocks in list view context
-		// This avoids focus stealing that would close the list view and switch to canvas
-		const shouldAutoSelectBlock = false;
-
-		// If we have an existing inserted block and a new block is being set,
-		// remove the original block to avoid duplicates
-		if ( insertedBlock?.clientId && newBlock ) {
-			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
-		}
-		setInsertedBlock( newBlock );
-	};
-
-	return (
-		<LinkUI
-			clientId={ insertedBlock?.clientId }
-			link={ insertedBlock?.attributes }
-			onBlockInsert={ handleSetInsertedBlock }
-			onClose={ () => {
-				// Use cleanup function
-				cleanupInsertedBlock();
-			} }
-			onChange={ ( updatedValue ) => {
-				// updateAttributes determines the final state and returns metadata
-				const { isEntityLink, attributes: updatedAttributes } =
-					updateAttributes(
-						updatedValue,
-						setInsertedBlockAttributes( insertedBlock?.clientId ),
-						insertedBlock?.attributes
-					);
-
-				// Handle URL binding based on the final computed state
-				// Only create bindings for entity links (posts, pages, taxonomies)
-				// Never create bindings for custom links (manual URLs)
-				if ( isEntityLink ) {
-					createBinding( updatedAttributes );
-				} else {
-					clearBinding();
-				}
-
-				setInsertedBlock( null );
-			} }
-		/>
-	);
-}
+const { PrivateListView, PrivateBlockContext, useListViewPanelState } = unlock(
+	blockEditorPrivateApis
+);
 
 const MainContent = ( {
 	clientId,
@@ -194,7 +83,7 @@ const MainContent = ( {
 				description={ description }
 				showAppender
 				blockSettingsMenu={ LeafMoreMenu }
-				additionalBlockContent={ AdditionalBlockContent }
+				additionalBlockContent={ NavigationLinkUI }
 				onSelect={ openListViewContentPanel }
 			/>
 		</div>
@@ -217,11 +106,6 @@ const MenuInspectorControls = ( props ) => {
 	const { isSelectionWithinCurrentSection } =
 		useContext( PrivateBlockContext );
 
-	const blockTitle = useBlockDisplayTitle( {
-		clientId,
-		context: 'list-view',
-	} );
-
 	// Only make panel collapsible in contentOnly mode
 	const showBlockTitle = isSelectionWithinCurrentSection;
 
@@ -232,34 +116,23 @@ const MenuInspectorControls = ( props ) => {
 		return (
 			<InspectorControls group="list">
 				<PanelBody title={ null }>
-					<HStack className="wp-block-navigation-off-canvas-editor__header">
-						<Heading
-							className="wp-block-navigation-off-canvas-editor__title"
-							level={ 2 }
-						>
-							{ blockTitle }
-						</Heading>
-						{ blockEditingMode === 'default' && (
-							<NavigationMenuSelector
-								currentMenuId={ currentMenuId }
-								onSelectClassicMenu={ onSelectClassicMenu }
-								onSelectNavigationMenu={
-									onSelectNavigationMenu
-								}
-								onCreateNew={ onCreateNew }
-								createNavigationMenuIsSuccess={
-									createNavigationMenuIsSuccess
-								}
-								createNavigationMenuIsError={
-									createNavigationMenuIsError
-								}
-								actionLabel={ actionLabel }
-								isManageMenusButtonDisabled={
-									isManageMenusButtonDisabled
-								}
-							/>
-						) }
-					</HStack>
+					<NavigationListViewHeader
+						clientId={ clientId }
+						blockEditingMode={ blockEditingMode }
+						currentMenuId={ currentMenuId }
+						onSelectClassicMenu={ onSelectClassicMenu }
+						onSelectNavigationMenu={ onSelectNavigationMenu }
+						onCreateNew={ onCreateNew }
+						createNavigationMenuIsSuccess={
+							createNavigationMenuIsSuccess
+						}
+						createNavigationMenuIsError={
+							createNavigationMenuIsError
+						}
+						isManageMenusButtonDisabled={
+							isManageMenusButtonDisabled
+						}
+					/>
 					<MainContent
 						{ ...props }
 						expandRevision={ expandRevision }

--- a/packages/block-library/src/navigation/edit/navigation-link-ui.js
+++ b/packages/block-library/src/navigation/edit/navigation-link-ui.js
@@ -1,0 +1,115 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
+} from '../../navigation-link/shared';
+
+const BLOCKS_WITH_LINK_UI_SUPPORT = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
+export function NavigationLinkUI( { block, insertedBlock, setInsertedBlock } ) {
+	const { updateBlockAttributes, removeBlock } =
+		useDispatch( blockEditorStore );
+
+	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT?.includes(
+		insertedBlock?.name
+	);
+	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
+	const showLinkControls = supportsLinkControls && blockWasJustInserted;
+
+	// Get binding utilities for the inserted block
+	const { createBinding, clearBinding } = useEntityBinding( {
+		clientId: insertedBlock?.clientId,
+		attributes: insertedBlock?.attributes || {},
+	} );
+
+	if ( ! showLinkControls ) {
+		return null;
+	}
+
+	/**
+	 * Cleanup function for auto-inserted Navigation Link blocks.
+	 *
+	 * Removes the block if it has no URL and clears the inserted block state.
+	 * This ensures consistent cleanup behavior across different contexts.
+	 */
+	const cleanupInsertedBlock = () => {
+		// Prevent automatic block selection when removing blocks in list view context
+		// This avoids focus stealing that would close the list view and switch to canvas
+		const shouldAutoSelectBlock = false;
+
+		// Follows the exact same pattern as Navigation Link block's onClose handler
+		// If there is no URL then remove the auto-inserted block to avoid empty blocks
+		if ( ! insertedBlock?.attributes?.url && insertedBlock?.clientId ) {
+			// Remove the block entirely to avoid poor UX
+			// This matches the Navigation Link block's behavior
+			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		}
+		setInsertedBlock( null );
+	};
+
+	const setInsertedBlockAttributes =
+		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
+			if ( ! _insertedBlockClientId ) {
+				return;
+			}
+			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
+		};
+
+	// Wrapper function to clean up original block when a new block is selected
+	const handleSetInsertedBlock = ( newBlock ) => {
+		// Prevent automatic block selection when removing blocks in list view context
+		// This avoids focus stealing that would close the list view and switch to canvas
+		const shouldAutoSelectBlock = false;
+
+		// If we have an existing inserted block and a new block is being set,
+		// remove the original block to avoid duplicates
+		if ( insertedBlock?.clientId && newBlock ) {
+			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		}
+		setInsertedBlock( newBlock );
+	};
+
+	return (
+		<LinkUI
+			clientId={ insertedBlock?.clientId }
+			link={ insertedBlock?.attributes }
+			onBlockInsert={ handleSetInsertedBlock }
+			onClose={ () => {
+				// Use cleanup function
+				cleanupInsertedBlock();
+			} }
+			onChange={ ( updatedValue ) => {
+				// updateAttributes determines the final state and returns metadata
+				const { isEntityLink, attributes: updatedAttributes } =
+					updateAttributes(
+						updatedValue,
+						setInsertedBlockAttributes( insertedBlock?.clientId ),
+						insertedBlock?.attributes
+					);
+
+				// Handle URL binding based on the final computed state
+				// Only create bindings for entity links (posts, pages, taxonomies)
+				// Never create bindings for custom links (manual URLs)
+				if ( isEntityLink ) {
+					createBinding( updatedAttributes );
+				} else {
+					clearBinding();
+				}
+
+				setInsertedBlock( null );
+			} }
+		/>
+	);
+}

--- a/packages/block-library/src/navigation/edit/navigation-list-view-header.js
+++ b/packages/block-library/src/navigation/edit/navigation-list-view-header.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import NavigationMenuSelector from './navigation-menu-selector';
+import { unlock } from '../../lock-unlock';
+
+const { useBlockDisplayTitle } = unlock( blockEditorPrivateApis );
+
+const actionLabel =
+	/* translators: %s: The name of a menu. */ __( "Switch to '%s'" );
+
+export default function NavigationListViewHeader( {
+	clientId,
+	blockEditingMode,
+	currentMenuId,
+	onSelectClassicMenu,
+	onSelectNavigationMenu,
+	onCreateNew,
+	createNavigationMenuIsSuccess,
+	createNavigationMenuIsError,
+	isManageMenusButtonDisabled,
+} ) {
+	const blockTitle = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
+
+	return (
+		<HStack className="wp-block-navigation-off-canvas-editor__header">
+			<Heading
+				className="wp-block-navigation-off-canvas-editor__title"
+				level={ 2 }
+			>
+				{ blockTitle }
+			</Heading>
+			{ blockEditingMode === 'default' && (
+				<NavigationMenuSelector
+					currentMenuId={ currentMenuId }
+					onSelectClassicMenu={ onSelectClassicMenu }
+					onSelectNavigationMenu={ onSelectNavigationMenu }
+					onCreateNew={ onCreateNew }
+					createNavigationMenuIsSuccess={
+						createNavigationMenuIsSuccess
+					}
+					createNavigationMenuIsError={ createNavigationMenuIsError }
+					actionLabel={ actionLabel }
+					isManageMenusButtonDisabled={ isManageMenusButtonDisabled }
+				/>
+			) }
+		</HStack>
+	);
+}


### PR DESCRIPTION
## Summary
- Extracts `AdditionalBlockContent` (renamed to `NavigationLinkUI`) from `menu-inspector-controls.js` into `navigation-link-ui.js`
- Extracts the list view header (HStack with block title + menu selector) into `NavigationListViewHeader` in `navigation-list-view-header.js`
- Updates `menu-inspector-controls.js` to import from the new files

This is a pure refactor with no behavior changes, intended to reduce the diff and simplify review of #75694.

## Test plan
- [ ] Open a page/post with a Navigation block
- [ ] Open the List View sidebar and verify the navigation block appears with the custom header (block title + menu selector dropdown)
- [ ] Verify you can switch between navigation menus
- [ ] Add a new navigation link via the "+" button and verify the inline link editor appears
- [ ] Verify the "Content only" mode still works (collapsible panel with menu selector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)