### PR TITLE
Plugin: Include Icons assets in ZIP

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -79,6 +79,8 @@ zip --recurse-paths --no-dir-entries \
 	gutenberg.php \
 	lib \
 	packages/block-serialization-default-parser/*.php \
+	packages/icons/src/manifest.php \
+	packages/icons/src/library/*.svg \
 	post-content.php \
 	build \
 	build-module \


### PR DESCRIPTION
## What?

Follow-up of #72215, #71878, #74943 

Include in the Gutenberg plugin ZIP file the assets (SVG and manifest.php) of the core library of icons.

## Why?

Without these assets, the new Icon block (#71227) won't show any available icons for users of the Gutenberg plugin.

## How?

Include the assets in the `zip` command invocation.

## Why now?

This has gone unnoticed so far because, in Gutenberg, all testing happens by building the project from scratch and running the tests in that environment. Meanwhile, in Core, there's a dedicated Gutenberg-to-Core copy process that operates similarly, which explains why this was missed in the backport of the Icons API ([Trac](https://core.trac.wordpress.org/ticket/64651)). Luckily, @desrosj is experimenting with https://github.com/WordPress/wordpress-develop/pull/11019 and [noticed](https://github.com/WordPress/wordpress-develop/pull/11019#issuecomment-3948900718) the absence of icons there.

## Testing Instructions

- `npm run build:plugin-zip`
- Install the generated `gutenberg.zip` file in a fresh WordPres site
- Either:
    - In a new post, add a Icon block, then select _Choose icon_ to reveal the icon library in a modal
    - Ensure the icons are there
- Or:
    - Check the REST API: `/wp/v2/icons`