### PR TITLE
Prototype: Navigation DataViews drill-down with discovery surface

### DIFF
--- a/packages/edit-site/src/components/block-editor/focus-navigation-block.js
+++ b/packages/edit-site/src/components/block-editor/focus-navigation-block.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import useFocusNavigationBlock from './use-focus-navigation-block';
+
+/**
+ * Component that applies focus to a navigation block when navigating from the
+ * Navigation sidebar with focusNavigationBlock in the URL. Renders nothing.
+ */
+export default function FocusNavigationBlock() {
+	useFocusNavigationBlock();
+	return null;
+}

--- a/packages/edit-site/src/components/block-editor/use-focus-navigation-block.js
+++ b/packages/edit-site/src/components/block-editor/use-focus-navigation-block.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+/**
+ * When navigating from the Navigation sidebar with focusNavigationBlock in the URL,
+ * finds the navigation block with matching ref and selects it once the blocks have loaded.
+ * Syncs the selection to the entity record via editEntityRecord so it integrates with
+ * the existing selectedBlock flow (use-resolve-edited-entity, use-navigate-to-entity-record).
+ */
+export default function useFocusNavigationBlock() {
+	const { query } = useLocation();
+	const focusMenuId = query?.focusNavigationBlock;
+	const appliedRef = useRef( null );
+
+	const { navigationBlockClientId, postType, postId } = useSelect(
+		( select ) => {
+			const result = {
+				navigationBlockClientId: null,
+				postType: null,
+				postId: null,
+			};
+			if ( ! focusMenuId ) {
+				return result;
+			}
+			const { getBlocksByName, getBlockAttributes } =
+				select( blockEditorStore );
+			const navBlockIds = getBlocksByName( 'core/navigation' );
+			const matchingId = navBlockIds.find( ( clientId ) => {
+				const attrs = getBlockAttributes( clientId );
+				return String( attrs?.ref ) === String( focusMenuId );
+			} );
+			result.navigationBlockClientId = matchingId || null;
+			result.postType = select( editorStore ).getCurrentPostType();
+			result.postId = select( editorStore ).getCurrentPostId();
+			return result;
+		},
+		[ focusMenuId ]
+	);
+
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const { editEntityRecord } = useDispatch( coreDataStore );
+
+	useEffect( () => {
+		if (
+			! focusMenuId ||
+			! navigationBlockClientId ||
+			appliedRef.current === focusMenuId
+		) {
+			return;
+		}
+		selectBlock( navigationBlockClientId );
+		// Sync selection to entity record so it integrates with selectedBlock flow.
+		if ( postType && postId ) {
+			editEntityRecord(
+				'postType',
+				postType,
+				postId,
+				{
+					selection: {
+						selectionStart: { clientId: navigationBlockClientId },
+						selectionEnd: { clientId: navigationBlockClientId },
+					},
+				},
+				{ undoIgnore: true }
+			);
+		}
+		appliedRef.current = focusMenuId;
+	}, [
+		focusMenuId,
+		navigationBlockClientId,
+		postType,
+		postId,
+		selectBlock,
+		editEntityRecord,
+	] );
+}

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -27,13 +27,20 @@ function useNavigateToPreviousEntityRecord() {
 	const previousCanvas = usePrevious( location.query.canvas );
 	const history = useHistory();
 	const goBack = useMemo( () => {
+		const { parentPath } = location.query;
 		const isFocusMode =
 			location.query.focusMode ||
 			( location?.params?.postId &&
 				FOCUSABLE_ENTITIES.includes( location?.params?.postType ) );
 		const didComeFromEditorCanvas = previousCanvas === 'edit';
-		const showBackButton = isFocusMode && didComeFromEditorCanvas;
-		return showBackButton ? () => history.back() : undefined;
+		const showBackButton =
+			isFocusMode && ( didComeFromEditorCanvas || parentPath );
+		if ( ! showBackButton ) {
+			return undefined;
+		}
+		return parentPath
+			? () => history.navigate( parentPath )
+			: () => history.back();
 	}, [ location, history, previousCanvas ] );
 	return goBack;
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -48,6 +48,7 @@ import {
 	useSyncDeprecatedEntityIntoState,
 } from './use-resolve-edited-entity';
 import SitePreview from './site-preview';
+import useAutoSelectNavigationBlock from '../../hooks/use-auto-select-navigation-block';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -119,6 +120,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	const { canvas = 'view' } = location.query;
 	const isLoading = useIsSiteEditorLoading();
 	useAdaptEditorToCanvas( canvas );
+	useAutoSelectNavigationBlock();
 	const entity = useResolveEditedEntity();
 	// deprecated sync state with url
 	useSyncDeprecatedEntityIntoState( entity );

--- a/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
+++ b/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
@@ -33,7 +33,7 @@ const authorizedPostTypes = [ 'page', 'post' ];
 
 function getPostType( name ) {
 	let postType;
-	if ( name === 'navigation-item' ) {
+	if ( name === 'navigation' || name === 'navigation-item' ) {
 		postType = NAVIGATION_POST_TYPE;
 	} else if ( name === 'pattern-item' ) {
 		postType = PATTERN_TYPES.user;

--- a/packages/edit-site/src/components/navigation-menu-detail/index.js
+++ b/packages/edit-site/src/components/navigation-menu-detail/index.js
@@ -11,22 +11,21 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_PART_POST_TYPE, LAYOUT_LIST } from '../../utils/constants';
+import { TEMPLATE_PART_POST_TYPE, LAYOUT_GRID } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import useMenuUsedInTemplateParts from '../../hooks/use-menu-used-in-template-parts';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 const EMPTY_ARRAY = [];
 
-const defaultLayouts = { list: {} };
+const defaultLayouts = { grid: {} };
 
 const DEFAULT_VIEW = {
-	type: LAYOUT_LIST,
+	type: LAYOUT_GRID,
 	sort: { field: 'title', direction: 'asc' },
 	titleField: 'title',
 };
 
-// Minimal fields for template part display
 const TEMPLATE_PART_FIELDS = [
 	{
 		id: 'title',
@@ -48,9 +47,25 @@ function getItemId( item ) {
 	return String( item.id );
 }
 
-export default function NavigationMenuDetail( { menuId } ) {
+function useNavigateToTemplatePart( menuId ) {
 	const history = useHistory();
+	const { path } = useLocation();
+
+	return ( templatePartId ) => {
+		history.navigate(
+			addQueryArgs( `/${ TEMPLATE_PART_POST_TYPE }/${ templatePartId }`, {
+				canvas: 'edit',
+				focusMode: true,
+				navigationRef: menuId,
+				parentPath: path,
+			} )
+		);
+	};
+}
+
+export default function NavigationMenuDetail( { menuId } ) {
 	const { templateParts, isResolving } = useMenuUsedInTemplateParts( menuId );
+	const navigateToTemplatePart = useNavigateToTemplatePart( menuId );
 
 	const view = useMemo( () => DEFAULT_VIEW, [] );
 
@@ -60,21 +75,16 @@ export default function NavigationMenuDetail( { menuId } ) {
 			label: __( 'Edit in context' ),
 			isPrimary: true,
 			callback( items ) {
-				const tp = items[ 0 ];
-				history.navigate(
-					addQueryArgs( `/${ TEMPLATE_PART_POST_TYPE }/${ tp.id }`, {
-						canvas: 'edit',
-					} )
-				);
+				navigateToTemplatePart( items[ 0 ].id );
 			},
 		} ),
-		[ history ]
+		[ navigateToTemplatePart ]
 	);
 
 	const data = templateParts ?? EMPTY_ARRAY;
 
 	return (
-		<Page title={ __( 'Used in' ) }>
+		<Page title={ __( 'Active Menu locations' ) }>
 			<DataViews
 				data={ data }
 				fields={ TEMPLATE_PART_FIELDS }
@@ -87,12 +97,7 @@ export default function NavigationMenuDetail( { menuId } ) {
 				defaultLayouts={ defaultLayouts }
 				isItemClickable={ () => true }
 				onClickItem={ ( item ) => {
-					history.navigate(
-						addQueryArgs(
-							`/${ TEMPLATE_PART_POST_TYPE }/${ item.id }`,
-							{ canvas: 'edit' }
-						)
-					);
+					navigateToTemplatePart( item.id );
 				} }
 			/>
 		</Page>

--- a/packages/edit-site/src/components/navigation-menu-detail/index.js
+++ b/packages/edit-site/src/components/navigation-menu-detail/index.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { DataViews } from '@wordpress/dataviews';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE, LAYOUT_LIST } from '../../utils/constants';
+import { unlock } from '../../lock-unlock';
+import useMenuUsedInTemplateParts from '../../hooks/use-menu-used-in-template-parts';
+
+const { useHistory } = unlock( routerPrivateApis );
+const EMPTY_ARRAY = [];
+
+const defaultLayouts = { list: {} };
+
+const DEFAULT_VIEW = {
+	type: LAYOUT_LIST,
+	sort: { field: 'title', direction: 'asc' },
+	titleField: 'title',
+};
+
+// Minimal fields for template part display
+const TEMPLATE_PART_FIELDS = [
+	{
+		id: 'title',
+		header: __( 'Title' ),
+		getValue: ( { item } ) =>
+			item.title?.rendered || item.slug || __( '(no title)' ),
+		enableSorting: true,
+		filterBy: false,
+	},
+	{
+		id: 'area',
+		header: __( 'Area' ),
+		getValue: ( { item } ) => item.area || '—',
+		filterBy: false,
+	},
+];
+
+function getItemId( item ) {
+	return String( item.id );
+}
+
+export default function NavigationMenuDetail( { menuId } ) {
+	const history = useHistory();
+	const { templateParts, isResolving } = useMenuUsedInTemplateParts( menuId );
+
+	const view = useMemo( () => DEFAULT_VIEW, [] );
+
+	const editInContextAction = useMemo(
+		() => ( {
+			id: 'edit-in-context',
+			label: __( 'Edit in context' ),
+			isPrimary: true,
+			callback( items ) {
+				const tp = items[ 0 ];
+				history.navigate(
+					addQueryArgs( `/${ TEMPLATE_PART_POST_TYPE }/${ tp.id }`, {
+						canvas: 'edit',
+					} )
+				);
+			},
+		} ),
+		[ history ]
+	);
+
+	const data = templateParts ?? EMPTY_ARRAY;
+
+	return (
+		<Page title={ __( 'Used in' ) }>
+			<DataViews
+				data={ data }
+				fields={ TEMPLATE_PART_FIELDS }
+				view={ view }
+				onChangeView={ () => {} }
+				actions={ [ editInContextAction ] }
+				isLoading={ isResolving }
+				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+				isItemClickable={ () => true }
+				onClickItem={ ( item ) => {
+					history.navigate(
+						addQueryArgs(
+							`/${ TEMPLATE_PART_POST_TYPE }/${ item.id }`,
+							{ canvas: 'edit' }
+						)
+					);
+				} }
+			/>
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/navigation-menu-detail/index.js
+++ b/packages/edit-site/src/components/navigation-menu-detail/index.js
@@ -92,7 +92,12 @@ export default function NavigationMenuDetail( { menuId } ) {
 
 	return (
 		<ExperimentalBlockEditorProvider settings={ settings }>
-			<Page title={ __( 'Active Menu locations' ) }>
+			<Page
+				title={ __( 'Active Menu locations' ) }
+				subTitle={ __(
+					'Template parts where this menu is displayed on your site.'
+				) }
+			>
 				<DataViews
 					data={ data }
 					fields={ TEMPLATE_PART_FIELDS }

--- a/packages/edit-site/src/components/navigation-menu-detail/index.js
+++ b/packages/edit-site/src/components/navigation-menu-detail/index.js
@@ -5,6 +5,7 @@ import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { DataViews } from '@wordpress/dataviews';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -14,8 +15,11 @@ import { addQueryArgs } from '@wordpress/url';
 import { TEMPLATE_PART_POST_TYPE, LAYOUT_GRID } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import useMenuUsedInTemplateParts from '../../hooks/use-menu-used-in-template-parts';
+import usePatternSettings from '../page-patterns/use-pattern-settings';
+import { previewField } from '../page-patterns/fields';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const EMPTY_ARRAY = [];
 
 const defaultLayouts = { grid: {} };
@@ -24,9 +28,11 @@ const DEFAULT_VIEW = {
 	type: LAYOUT_GRID,
 	sort: { field: 'title', direction: 'asc' },
 	titleField: 'title',
+	mediaField: 'preview',
 };
 
 const TEMPLATE_PART_FIELDS = [
+	previewField,
 	{
 		id: 'title',
 		header: __( 'Title' ),
@@ -66,6 +72,7 @@ function useNavigateToTemplatePart( menuId ) {
 export default function NavigationMenuDetail( { menuId } ) {
 	const { templateParts, isResolving } = useMenuUsedInTemplateParts( menuId );
 	const navigateToTemplatePart = useNavigateToTemplatePart( menuId );
+	const settings = usePatternSettings();
 
 	const view = useMemo( () => DEFAULT_VIEW, [] );
 
@@ -84,22 +91,27 @@ export default function NavigationMenuDetail( { menuId } ) {
 	const data = templateParts ?? EMPTY_ARRAY;
 
 	return (
-		<Page title={ __( 'Active Menu locations' ) }>
-			<DataViews
-				data={ data }
-				fields={ TEMPLATE_PART_FIELDS }
-				view={ view }
-				onChangeView={ () => {} }
-				actions={ [ editInContextAction ] }
-				isLoading={ isResolving }
-				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
-				getItemId={ getItemId }
-				defaultLayouts={ defaultLayouts }
-				isItemClickable={ () => true }
-				onClickItem={ ( item ) => {
-					navigateToTemplatePart( item.id );
-				} }
-			/>
-		</Page>
+		<ExperimentalBlockEditorProvider settings={ settings }>
+			<Page title={ __( 'Active Menu locations' ) }>
+				<DataViews
+					data={ data }
+					fields={ TEMPLATE_PART_FIELDS }
+					view={ view }
+					onChangeView={ () => {} }
+					actions={ [ editInContextAction ] }
+					isLoading={ isResolving }
+					paginationInfo={ {
+						totalItems: data.length,
+						totalPages: 1,
+					} }
+					getItemId={ getItemId }
+					defaultLayouts={ defaultLayouts }
+					isItemClickable={ () => true }
+					onClickItem={ ( item ) => {
+						navigateToTemplatePart( item.id );
+					} }
+				/>
+			</Page>
+		</ExperimentalBlockEditorProvider>
 	);
 }

--- a/packages/edit-site/src/components/navigation-menu-list/index.js
+++ b/packages/edit-site/src/components/navigation-menu-list/index.js
@@ -22,13 +22,32 @@ import { useEvent } from '@wordpress/compose';
  */
 import {
 	OPERATOR_IS_ANY,
+	OPERATOR_IS,
 	LAYOUT_LIST,
 	NAVIGATION_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import AddNewPostModal from '../add-new-post';
+import useMenuIdsWithActiveLocations from '../../hooks/use-menu-ids-with-active-locations';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
+
+const ACTIVE_FILTER_ELEMENTS = [
+	{ value: 'active', label: __( 'Active' ) },
+	{ value: 'inactive', label: __( 'Inactive' ) },
+];
+
+const activeField = {
+	id: 'active',
+	label: __( 'Active' ),
+	getValue: () => '',
+	filterBy: {
+		operators: [ OPERATOR_IS ],
+		isPrimary: true,
+	},
+	elements: ACTIVE_FILTER_ELEMENTS,
+	enableSorting: false,
+};
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const EMPTY_ARRAY = [];
@@ -52,21 +71,39 @@ const SLUG_TO_STATUS = {
 	trash: 'trash',
 };
 
+const SLUG_TO_ACTIVE_FILTER = {
+	active: 'active',
+	inactive: 'inactive',
+};
+
 function getActiveViewOverridesForTab( activeView ) {
 	const status = SLUG_TO_STATUS[ activeView ];
-	if ( ! status ) {
-		return {};
+	if ( status ) {
+		return {
+			filters: [
+				{
+					field: 'status',
+					operator: OPERATOR_IS_ANY,
+					value: status,
+					isLocked: true,
+				},
+			],
+		};
 	}
-	return {
-		filters: [
-			{
-				field: 'status',
-				operator: OPERATOR_IS_ANY,
-				value: status,
-				isLocked: true,
-			},
-		],
-	};
+	const activeValue = SLUG_TO_ACTIVE_FILTER[ activeView ];
+	if ( activeValue ) {
+		return {
+			filters: [
+				{
+					field: 'active',
+					operator: OPERATOR_IS,
+					value: activeValue,
+					isLocked: true,
+				},
+			],
+		};
+	}
+	return {};
 }
 
 function getItemId( item ) {
@@ -128,7 +165,19 @@ export default function NavigationMenuList() {
 		setSelection( postId ? [ postId ] : [] );
 	}, [ postId ] );
 
-	const fields = usePostFields( { postType: NAVIGATION_POST_TYPE } );
+	const baseFields = usePostFields( { postType: NAVIGATION_POST_TYPE } );
+	const fields = useMemo(
+		() => ( baseFields ? [ activeField, ...baseFields ] : null ),
+		[ baseFields ]
+	);
+
+	const { activeMenuIds, isResolving: isLoadingActiveIds } =
+		useMenuIdsWithActiveLocations();
+
+	const activeFilter = view.filters?.find(
+		( f ) => f.field === 'active' && f.operator === OPERATOR_IS
+	);
+	const hasActiveFilter = !! activeFilter?.value;
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -146,31 +195,71 @@ export default function NavigationMenuList() {
 		}
 
 		return {
-			per_page: view.perPage,
-			page: view.page,
+			per_page: hasActiveFilter ? -1 : view.perPage,
+			page: hasActiveFilter ? 1 : view.page,
 			order: view.sort?.direction,
 			orderby: view.sort?.field,
 			search: view.search,
 			...filters,
 		};
-	}, [ view ] );
+	}, [ view, hasActiveFilter ] );
 
 	const {
 		records,
 		isResolving: isLoadingData,
-		totalItems,
-		totalPages,
+		totalItems: apiTotalItems,
+		totalPages: apiTotalPages,
 	} = useEntityRecordsWithPermissions(
 		'postType',
 		NAVIGATION_POST_TYPE,
 		queryArgs
 	);
 
-	const data = records ?? EMPTY_ARRAY;
-	const paginationInfo = useMemo(
-		() => ( { totalItems: totalItems ?? 0, totalPages: totalPages ?? 0 } ),
-		[ totalItems, totalPages ]
-	);
+	const { data, paginationInfo } = useMemo( () => {
+		let filtered = records ?? EMPTY_ARRAY;
+
+		if ( hasActiveFilter ) {
+			const isActive = activeFilter.value === 'active';
+			filtered = filtered.filter( ( menu ) =>
+				isActive
+					? activeMenuIds.has( menu.id )
+					: ! activeMenuIds.has( menu.id )
+			);
+		}
+
+		if ( ! hasActiveFilter ) {
+			return {
+				data: filtered,
+				paginationInfo: {
+					totalItems: apiTotalItems ?? 0,
+					totalPages: apiTotalPages ?? 0,
+				},
+			};
+		}
+
+		const totalItems = filtered.length;
+		const totalPages = Math.max(
+			1,
+			Math.ceil( totalItems / view.perPage )
+		);
+		const page = Math.min( view.page, totalPages );
+		const start = ( page - 1 ) * view.perPage;
+		const paginatedData = filtered.slice( start, start + view.perPage );
+
+		return {
+			data: paginatedData,
+			paginationInfo: { totalItems, totalPages },
+		};
+	}, [
+		records,
+		hasActiveFilter,
+		activeFilter?.value,
+		activeMenuIds,
+		apiTotalItems,
+		apiTotalPages,
+		view.perPage,
+		view.page,
+	] );
 
 	const { labels, canCreateRecord } = useSelect( ( select ) => {
 		const { getPostType, canUser } = select( coreStore );
@@ -247,7 +336,11 @@ export default function NavigationMenuList() {
 				fields={ fields }
 				actions={ actions }
 				data={ data }
-				isLoading={ isLoadingData || ! fields }
+				isLoading={
+					isLoadingData ||
+					( hasActiveFilter && isLoadingActiveIds ) ||
+					! fields
+				}
 				view={ view }
 				onChangeView={ onChangeView }
 				selection={ selection }

--- a/packages/edit-site/src/components/navigation-menu-list/index.js
+++ b/packages/edit-site/src/components/navigation-menu-list/index.js
@@ -7,7 +7,7 @@ import {
 	store as coreStore,
 	privateApis as coreDataPrivateApis,
 } from '@wordpress/core-data';
-import { useState, useMemo, useCallback } from '@wordpress/element';
+import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
@@ -75,9 +75,9 @@ function getItemId( item ) {
 
 export default function NavigationMenuList() {
 	const { path, query } = useLocation();
-	const { activeView = 'all' } = query;
+	const { activeView = 'all', postId } = query;
 	const history = useHistory();
-	const [ selection, setSelection ] = useState( [] );
+	const [ selection, setSelection ] = useState( postId ? [ postId ] : [] );
 
 	const activeViewOverrides = useMemo(
 		() => getActiveViewOverridesForTab( activeView ),
@@ -112,9 +112,21 @@ export default function NavigationMenuList() {
 		}
 	} );
 
-	const onChangeSelection = useCallback( ( items ) => {
-		setSelection( items );
-	}, [] );
+	const onChangeSelection = useCallback(
+		( items ) => {
+			setSelection( items );
+			history.navigate(
+				addQueryArgs( path, {
+					postId: items[ 0 ] || undefined,
+				} )
+			);
+		},
+		[ path, history ]
+	);
+
+	useEffect( () => {
+		setSelection( postId ? [ postId ] : [] );
+	}, [ postId ] );
 
 	const fields = usePostFields( { postType: NAVIGATION_POST_TYPE } );
 
@@ -190,10 +202,10 @@ export default function NavigationMenuList() {
 		} ),
 		[ historyForActions ]
 	);
-
-	const actions = useMemo( () => {
-		return [ editAction, ...postTypeActions ];
-	}, [ editAction, postTypeActions ] );
+	const actions = useMemo(
+		() => [ editAction, ...postTypeActions ],
+		[ editAction, postTypeActions ]
+	);
 
 	const [ showAddModal, setShowAddModal ] = useState( false );
 	const openModal = () => setShowAddModal( true );
@@ -242,7 +254,7 @@ export default function NavigationMenuList() {
 				onChangeSelection={ onChangeSelection }
 				isItemClickable={ ( item ) => item.status !== 'trash' }
 				onClickItem={ ( { id } ) => {
-					history.navigate( `/navigation/${ id }` );
+					onChangeSelection( [ id.toString() ] );
 				} }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }

--- a/packages/edit-site/src/components/navigation-menu-list/index.js
+++ b/packages/edit-site/src/components/navigation-menu-list/index.js
@@ -1,0 +1,203 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { Button } from '@wordpress/components';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
+import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useSelect } from '@wordpress/data';
+import { DataViews } from '@wordpress/dataviews';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { addQueryArgs } from '@wordpress/url';
+import { useView } from '@wordpress/views';
+
+/**
+ * Internal dependencies
+ */
+import { LAYOUT_LIST, NAVIGATION_POST_TYPE } from '../../utils/constants';
+import { unlock } from '../../lock-unlock';
+import { PRELOADED_NAVIGATION_MENUS_QUERY } from '../sidebar-navigation-screen-navigation-menus/constants';
+import AddNewPostModal from '../add-new-post';
+
+const { usePostFields } = unlock( editorPrivateApis );
+const { useLocation, useHistory } = unlock( routerPrivateApis );
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+const EMPTY_ARRAY = [];
+
+const DEFAULT_VIEW = {
+	type: LAYOUT_LIST,
+	sort: { field: 'date', direction: 'desc' },
+	titleField: 'title',
+	perPage: 100,
+};
+
+const defaultLayouts = { list: {} };
+
+function getItemId( item ) {
+	return item.id.toString();
+}
+
+export default function NavigationMenuList() {
+	const { path, query } = useLocation();
+	const postId = query?.postId;
+	const history = useHistory();
+	const [ selection, setSelection ] = useState( postId ? [ postId ] : [] );
+
+	const { view, updateView } = useView( {
+		kind: 'postType',
+		name: NAVIGATION_POST_TYPE,
+		slug: 'navigation-menus',
+		defaultView: DEFAULT_VIEW,
+		queryParams: {
+			page: query?.pageNumber,
+			search: query?.search,
+		},
+		onChangeQueryParams: ( newQueryParams ) => {
+			history.navigate(
+				addQueryArgs( path, {
+					...query,
+					pageNumber: newQueryParams.page,
+					search: newQueryParams.search || undefined,
+				} )
+			);
+		},
+	} );
+
+	const onChangeSelection = useCallback(
+		( items ) => {
+			setSelection( items );
+			history.navigate(
+				addQueryArgs( path, {
+					...query,
+					postId: items[ 0 ] || undefined,
+				} )
+			);
+		},
+		[ path, query, history ]
+	);
+
+	useEffect( () => {
+		setSelection( postId ? [ postId ] : [] );
+	}, [ postId ] );
+
+	const fields = usePostFields( { postType: NAVIGATION_POST_TYPE } );
+
+	const {
+		records,
+		isResolving: isLoadingData,
+		totalItems,
+		totalPages,
+	} = useEntityRecordsWithPermissions(
+		'postType',
+		NAVIGATION_POST_TYPE,
+		useMemo(
+			() => ( {
+				...PRELOADED_NAVIGATION_MENUS_QUERY,
+				per_page: view.perPage,
+				page: view.page,
+				search: view.search,
+				order: view.sort?.direction,
+				orderby: view.sort?.field,
+			} ),
+			[ view.perPage, view.page, view.search, view.sort ]
+		)
+	);
+
+	const data = records ?? EMPTY_ARRAY;
+	const paginationInfo = useMemo(
+		() => ( { totalItems: totalItems ?? 0, totalPages: totalPages ?? 0 } ),
+		[ totalItems, totalPages ]
+	);
+
+	const { labels, canCreateRecord } = useSelect( ( select ) => {
+		const { getPostType, canUser } = select( coreStore );
+		return {
+			labels: getPostType( NAVIGATION_POST_TYPE )?.labels,
+			canCreateRecord: canUser( 'create', {
+				kind: 'postType',
+				name: NAVIGATION_POST_TYPE,
+			} ),
+		};
+	}, [] );
+
+	const historyForActions = useHistory();
+	const editAction = useMemo(
+		() => ( {
+			id: 'edit-post',
+			label: __( 'Edit' ),
+			isPrimary: true,
+			callback( items ) {
+				historyForActions.navigate( `/navigation/${ items[ 0 ].id }` );
+			},
+		} ),
+		[ historyForActions ]
+	);
+	const [ showAddModal, setShowAddModal ] = useState( false );
+	const openModal = () => setShowAddModal( true );
+	const closeModal = () => setShowAddModal( false );
+	const handleNewMenu = ( newMenu ) => {
+		history.navigate( `/navigation/${ newMenu.id }` );
+		closeModal();
+	};
+
+	// Default selection to first menu when none selected and we have data.
+	const firstItemId = data[ 0 ]?.id;
+	useEffect( () => {
+		if ( selection.length === 0 && firstItemId && ! postId ) {
+			history.navigate(
+				addQueryArgs( path, { ...query, postId: firstItemId } )
+			);
+		}
+	}, [ firstItemId, postId, selection.length, history, path, query ] );
+
+	return (
+		<Page
+			title={ labels?.name }
+			actions={
+				<>
+					{ labels?.add_new_item && canCreateRecord && (
+						<>
+							<Button
+								variant="primary"
+								onClick={ openModal }
+								__next40pxDefaultSize
+							>
+								{ labels.add_new_item }
+							</Button>
+							{ showAddModal && (
+								<AddNewPostModal
+									postType={ NAVIGATION_POST_TYPE }
+									onSave={ handleNewMenu }
+									onClose={ closeModal }
+								/>
+							) }
+						</>
+					) }
+				</>
+			}
+		>
+			<DataViews
+				paginationInfo={ paginationInfo }
+				fields={ fields }
+				actions={ [ { ...editAction, isPrimary: true } ] }
+				data={ data }
+				isLoading={ isLoadingData || ! fields }
+				view={ view }
+				onChangeView={ updateView }
+				selection={ selection }
+				onChangeSelection={ onChangeSelection }
+				isItemClickable={ () => true }
+				onClickItem={ ( { id } ) => {
+					history.navigate( `/navigation/${ id }` );
+				} }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+			/>
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/navigation-menu-list/index.js
+++ b/packages/edit-site/src/components/navigation-menu-list/index.js
@@ -7,7 +7,7 @@ import {
 	store as coreStore,
 	privateApis as coreDataPrivateApis,
 } from '@wordpress/core-data';
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import { useState, useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
@@ -15,28 +15,59 @@ import { DataViews } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { addQueryArgs } from '@wordpress/url';
 import { useView } from '@wordpress/views';
+import { useEvent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { LAYOUT_LIST, NAVIGATION_POST_TYPE } from '../../utils/constants';
+import {
+	OPERATOR_IS_ANY,
+	LAYOUT_LIST,
+	NAVIGATION_POST_TYPE,
+} from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
-import { PRELOADED_NAVIGATION_MENUS_QUERY } from '../sidebar-navigation-screen-navigation-menus/constants';
 import AddNewPostModal from '../add-new-post';
 
-const { usePostFields } = unlock( editorPrivateApis );
+const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const EMPTY_ARRAY = [];
 
+const DEFAULT_STATUSES = 'draft,future,pending,private,publish';
+
 const DEFAULT_VIEW = {
 	type: LAYOUT_LIST,
+	filters: [],
 	sort: { field: 'date', direction: 'desc' },
 	titleField: 'title',
 	perPage: 100,
+	fields: [ 'status' ],
 };
 
 const defaultLayouts = { list: {} };
+
+const SLUG_TO_STATUS = {
+	published: 'publish',
+	drafts: 'draft',
+	trash: 'trash',
+};
+
+function getActiveViewOverridesForTab( activeView ) {
+	const status = SLUG_TO_STATUS[ activeView ];
+	if ( ! status ) {
+		return {};
+	}
+	return {
+		filters: [
+			{
+				field: 'status',
+				operator: OPERATOR_IS_ANY,
+				value: status,
+				isLocked: true,
+			},
+		],
+	};
+}
 
 function getItemId( item ) {
 	return item.id.toString();
@@ -44,15 +75,21 @@ function getItemId( item ) {
 
 export default function NavigationMenuList() {
 	const { path, query } = useLocation();
-	const postId = query?.postId;
+	const { activeView = 'all' } = query;
 	const history = useHistory();
-	const [ selection, setSelection ] = useState( postId ? [ postId ] : [] );
+	const [ selection, setSelection ] = useState( [] );
+
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( activeView ),
+		[ activeView ]
+	);
 
 	const { view, updateView } = useView( {
 		kind: 'postType',
 		name: NAVIGATION_POST_TYPE,
 		slug: 'navigation-menus',
 		defaultView: DEFAULT_VIEW,
+		activeViewOverrides,
 		queryParams: {
 			page: query?.pageNumber,
 			search: query?.search,
@@ -68,24 +105,43 @@ export default function NavigationMenuList() {
 		},
 	} );
 
-	const onChangeSelection = useCallback(
-		( items ) => {
-			setSelection( items );
-			history.navigate(
-				addQueryArgs( path, {
-					...query,
-					postId: items[ 0 ] || undefined,
-				} )
-			);
-		},
-		[ path, query, history ]
-	);
+	const onChangeView = useEvent( ( newView ) => {
+		updateView( newView );
+		if ( newView.type !== view.type ) {
+			history.invalidate();
+		}
+	} );
 
-	useEffect( () => {
-		setSelection( postId ? [ postId ] : [] );
-	}, [ postId ] );
+	const onChangeSelection = useCallback( ( items ) => {
+		setSelection( items );
+	}, [] );
 
 	const fields = usePostFields( { postType: NAVIGATION_POST_TYPE } );
+
+	const queryArgs = useMemo( () => {
+		const filters = {};
+		view.filters?.forEach( ( filter ) => {
+			if (
+				filter.field === 'status' &&
+				filter.operator === OPERATOR_IS_ANY
+			) {
+				filters.status = filter.value;
+			}
+		} );
+
+		if ( ! filters.status || filters.status === '' ) {
+			filters.status = DEFAULT_STATUSES;
+		}
+
+		return {
+			per_page: view.perPage,
+			page: view.page,
+			order: view.sort?.direction,
+			orderby: view.sort?.field,
+			search: view.search,
+			...filters,
+		};
+	}, [ view ] );
 
 	const {
 		records,
@@ -95,17 +151,7 @@ export default function NavigationMenuList() {
 	} = useEntityRecordsWithPermissions(
 		'postType',
 		NAVIGATION_POST_TYPE,
-		useMemo(
-			() => ( {
-				...PRELOADED_NAVIGATION_MENUS_QUERY,
-				per_page: view.perPage,
-				page: view.page,
-				search: view.search,
-				order: view.sort?.direction,
-				orderby: view.sort?.field,
-			} ),
-			[ view.perPage, view.page, view.search, view.sort ]
-		)
+		queryArgs
 	);
 
 	const data = records ?? EMPTY_ARRAY;
@@ -125,18 +171,30 @@ export default function NavigationMenuList() {
 		};
 	}, [] );
 
+	const postTypeActions = usePostActions( {
+		postType: NAVIGATION_POST_TYPE,
+		context: 'list',
+	} );
 	const historyForActions = useHistory();
 	const editAction = useMemo(
 		() => ( {
 			id: 'edit-post',
 			label: __( 'Edit' ),
 			isPrimary: true,
+			isEligible( post ) {
+				return post.status !== 'trash';
+			},
 			callback( items ) {
 				historyForActions.navigate( `/navigation/${ items[ 0 ].id }` );
 			},
 		} ),
 		[ historyForActions ]
 	);
+
+	const actions = useMemo( () => {
+		return [ editAction, ...postTypeActions ];
+	}, [ editAction, postTypeActions ] );
+
 	const [ showAddModal, setShowAddModal ] = useState( false );
 	const openModal = () => setShowAddModal( true );
 	const closeModal = () => setShowAddModal( false );
@@ -144,16 +202,6 @@ export default function NavigationMenuList() {
 		history.navigate( `/navigation/${ newMenu.id }` );
 		closeModal();
 	};
-
-	// Default selection to first menu when none selected and we have data.
-	const firstItemId = data[ 0 ]?.id;
-	useEffect( () => {
-		if ( selection.length === 0 && firstItemId && ! postId ) {
-			history.navigate(
-				addQueryArgs( path, { ...query, postId: firstItemId } )
-			);
-		}
-	}, [ firstItemId, postId, selection.length, history, path, query ] );
 
 	return (
 		<Page
@@ -182,16 +230,17 @@ export default function NavigationMenuList() {
 			}
 		>
 			<DataViews
+				key={ activeView }
 				paginationInfo={ paginationInfo }
 				fields={ fields }
-				actions={ [ { ...editAction, isPrimary: true } ] }
+				actions={ actions }
 				data={ data }
 				isLoading={ isLoadingData || ! fields }
 				view={ view }
-				onChangeView={ updateView }
+				onChangeView={ onChangeView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
-				isItemClickable={ () => true }
+				isItemClickable={ ( item ) => item.status !== 'trash' }
 				onClickItem={ ( { id } ) => {
 					history.navigate( `/navigation/${ id }` );
 				} }

--- a/packages/edit-site/src/components/navigation-menu-list/index.js
+++ b/packages/edit-site/src/components/navigation-menu-list/index.js
@@ -2,13 +2,16 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import {
 	store as coreStore,
 	privateApis as coreDataPrivateApis,
 } from '@wordpress/core-data';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
@@ -31,23 +34,38 @@ import AddNewPostModal from '../add-new-post';
 import useMenuIdsWithActiveLocations from '../../hooks/use-menu-ids-with-active-locations';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
+const { Badge } = unlock( componentsPrivateApis );
 
 const ACTIVE_FILTER_ELEMENTS = [
 	{ value: 'active', label: __( 'Active' ) },
 	{ value: 'inactive', label: __( 'Inactive' ) },
 ];
 
-const activeField = {
-	id: 'active',
-	label: __( 'Active' ),
-	getValue: () => '',
-	filterBy: {
-		operators: [ OPERATOR_IS ],
-		isPrimary: true,
-	},
-	elements: ACTIVE_FILTER_ELEMENTS,
-	enableSorting: false,
-};
+function createActiveField( menuLocationCounts ) {
+	return {
+		id: 'active',
+		label: __( 'Active' ),
+		getValue: () => '',
+		filterBy: {
+			operators: [ OPERATOR_IS ],
+			isPrimary: true,
+		},
+		elements: ACTIVE_FILTER_ELEMENTS,
+		enableSorting: false,
+		render: ( { item } ) => {
+			const count = menuLocationCounts.get( item.id ) ?? 0;
+			const label =
+				count > 0
+					? sprintf(
+							/* translators: %d: number of locations where the menu is used */
+							__( 'Active - %d locations' ),
+							count
+					  )
+					: __( 'Inactive - unused' );
+			return <Badge>{ label }</Badge>;
+		},
+	};
+}
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const EMPTY_ARRAY = [];
@@ -60,7 +78,7 @@ const DEFAULT_VIEW = {
 	sort: { field: 'date', direction: 'desc' },
 	titleField: 'title',
 	perPage: 100,
-	fields: [ 'status' ],
+	fields: [ 'active', 'status' ],
 };
 
 const defaultLayouts = { list: {} };
@@ -142,6 +160,15 @@ export default function NavigationMenuList() {
 		},
 	} );
 
+	// Ensure the Active field is always shown (e.g. in case of persisted view without it).
+	const viewWithActiveField = useMemo( () => {
+		const fields = view.fields ?? [];
+		if ( ! fields.includes( 'active' ) ) {
+			return { ...view, fields: [ 'active', ...fields ] };
+		}
+		return view;
+	}, [ view ] );
+
 	const onChangeView = useEvent( ( newView ) => {
 		updateView( newView );
 		if ( newView.type !== view.type ) {
@@ -165,14 +192,20 @@ export default function NavigationMenuList() {
 		setSelection( postId ? [ postId ] : [] );
 	}, [ postId ] );
 
+	const {
+		activeMenuIds,
+		menuLocationCounts,
+		isResolving: isLoadingActiveIds,
+	} = useMenuIdsWithActiveLocations();
+
 	const baseFields = usePostFields( { postType: NAVIGATION_POST_TYPE } );
 	const fields = useMemo(
-		() => ( baseFields ? [ activeField, ...baseFields ] : null ),
-		[ baseFields ]
+		() =>
+			baseFields
+				? [ createActiveField( menuLocationCounts ), ...baseFields ]
+				: null,
+		[ baseFields, menuLocationCounts ]
 	);
-
-	const { activeMenuIds, isResolving: isLoadingActiveIds } =
-		useMenuIdsWithActiveLocations();
 
 	const activeFilter = view.filters?.find(
 		( f ) => f.field === 'active' && f.operator === OPERATOR_IS
@@ -307,6 +340,9 @@ export default function NavigationMenuList() {
 	return (
 		<Page
 			title={ labels?.name }
+			subTitle={ __(
+				'Navigation menus are used to create the menus for your site.'
+			) }
 			actions={
 				<>
 					{ labels?.add_new_item && canCreateRecord && (
@@ -341,7 +377,7 @@ export default function NavigationMenuList() {
 					( hasActiveFilter && isLoadingActiveIds ) ||
 					! fields
 				}
-				view={ view }
+				view={ viewWithActiveField }
 				onChangeView={ onChangeView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -11,12 +11,18 @@ import {
 	scheduled,
 	pending,
 	notAllowed,
+	pin,
+	archive,
 } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { OPERATOR_IS_ANY } from '../../utils/constants';
+import {
+	OPERATOR_IS_ANY,
+	OPERATOR_IS,
+	NAVIGATION_POST_TYPE,
+} from '../../utils/constants';
 
 export const defaultLayouts = {
 	table: {},
@@ -40,6 +46,44 @@ export const DEFAULT_VIEW = {
 };
 
 export function getDefaultViews( postType ) {
+	const isNavigation = postType?.name === NAVIGATION_POST_TYPE;
+	const navigationActiveViews = isNavigation
+		? [
+				{
+					title: __( 'Active' ),
+					slug: 'active',
+					icon: pin,
+					view: {
+						...DEFAULT_VIEW,
+						filters: [
+							{
+								field: 'active',
+								operator: OPERATOR_IS,
+								value: 'active',
+								isLocked: true,
+							},
+						],
+					},
+				},
+				{
+					title: __( 'Inactive' ),
+					slug: 'inactive',
+					icon: archive,
+					view: {
+						...DEFAULT_VIEW,
+						filters: [
+							{
+								field: 'active',
+								operator: OPERATOR_IS,
+								value: 'inactive',
+								isLocked: true,
+							},
+						],
+					},
+				},
+		  ]
+		: [];
+
 	return [
 		{
 			title: postType?.labels?.all_items || __( 'All items' ),
@@ -47,6 +91,7 @@ export function getDefaultViews( postType ) {
 			icon: pages,
 			view: DEFAULT_VIEW,
 		},
+		...navigationActiveViews,
 		{
 			title: __( 'Published' ),
 			slug: 'published',

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu-detail/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu-detail/index.js
@@ -17,6 +17,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
+import useMenuUsedInTemplateParts from '../../hooks/use-menu-used-in-template-parts';
 
 const POST_TYPE = 'wp_navigation';
 
@@ -30,7 +31,7 @@ function countMenuItems( rawContent ) {
 	return matches ? matches.length : 0;
 }
 
-function MenuDetails( { navigationMenu } ) {
+function MenuDetails( { navigationMenu, locationCount } ) {
 	const status = navigationMenu?.status;
 	const modified = navigationMenu?.modified;
 	const rawContent = navigationMenu?.content?.raw;
@@ -48,8 +49,31 @@ function MenuDetails( { navigationMenu } ) {
 	const statusLabel =
 		status === 'publish' ? __( 'Published' ) : __( 'Draft' );
 
+	const activeLabel =
+		locationCount > 0
+			? sprintf(
+					/* translators: %d: number of locations where the menu is used */
+					__( 'Active (%d locations)' ),
+					locationCount
+			  )
+			: __( 'Inactive - unused' );
+
 	return (
 		<VStack spacing={ 3 }>
+			<HStack alignment="left" spacing={ 2 }>
+				<Text
+					as="span"
+					color="#a7aaad"
+					size="12px"
+					upperCase
+					weight={ 500 }
+				>
+					{ __( 'Active' ) }
+				</Text>
+				<Text as="span" size="12px" weight={ 600 }>
+					{ activeLabel }
+				</Text>
+			</HStack>
 			<HStack alignment="left" spacing={ 2 }>
 				<Text
 					as="span"
@@ -109,6 +133,7 @@ export default function SidebarNavigationScreenNavigationMenuDetail( {
 		POST_TYPE,
 		postId
 	);
+	const { templateParts } = useMenuUsedInTemplateParts( postId );
 
 	if ( isResolving && ! navigationMenu ) {
 		return (
@@ -130,10 +155,12 @@ export default function SidebarNavigationScreenNavigationMenuDetail( {
 		<SidebarNavigationScreen
 			title={ title || __( 'Navigation' ) }
 			backPath={ backPath }
-			description={ __(
-				'Template parts where this menu is used. Click to edit in context.'
-			) }
-			content={ <MenuDetails navigationMenu={ navigationMenu } /> }
+			content={
+				<MenuDetails
+					navigationMenu={ navigationMenu }
+					locationCount={ templateParts.length }
+				/>
+			}
 		/>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu-detail/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu-detail/index.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityRecord } from '@wordpress/core-data';
+import {
+	Spinner,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import buildNavigationLabel from '../sidebar-navigation-screen-navigation-menus/build-navigation-label';
+
+const POST_TYPE = 'wp_navigation';
+
+function countMenuItems( rawContent ) {
+	if ( ! rawContent ) {
+		return 0;
+	}
+	const matches = rawContent.match(
+		/<!-- wp:navigation-link|<!-- wp:navigation-submenu/g
+	);
+	return matches ? matches.length : 0;
+}
+
+function MenuDetails( { navigationMenu } ) {
+	const status = navigationMenu?.status;
+	const modified = navigationMenu?.modified;
+	const rawContent = navigationMenu?.content?.raw;
+
+	const itemCount = useMemo(
+		() => countMenuItems( rawContent ),
+		[ rawContent ]
+	);
+
+	const dateSettings = getDateSettings();
+	const formattedDate = modified
+		? dateI18n( dateSettings.formats.date, modified )
+		: '—';
+
+	const statusLabel =
+		status === 'publish' ? __( 'Published' ) : __( 'Draft' );
+
+	return (
+		<VStack spacing={ 3 }>
+			<HStack alignment="left" spacing={ 2 }>
+				<Text
+					as="span"
+					color="#a7aaad"
+					size="12px"
+					upperCase
+					weight={ 500 }
+				>
+					{ __( 'Status' ) }
+				</Text>
+				<Text as="span" size="12px" weight={ 600 }>
+					{ statusLabel }
+				</Text>
+			</HStack>
+			<HStack alignment="left" spacing={ 2 }>
+				<Text
+					as="span"
+					color="#a7aaad"
+					size="12px"
+					upperCase
+					weight={ 500 }
+				>
+					{ __( 'Last modified' ) }
+				</Text>
+				<Text as="span" size="12px">
+					{ formattedDate }
+				</Text>
+			</HStack>
+			<HStack alignment="left" spacing={ 2 }>
+				<Text
+					as="span"
+					color="#a7aaad"
+					size="12px"
+					upperCase
+					weight={ 500 }
+				>
+					{ __( 'Menu items' ) }
+				</Text>
+				<Text as="span" size="12px">
+					{ sprintf(
+						/* translators: %d: number of menu items */
+						__( '%d items' ),
+						itemCount
+					) }
+				</Text>
+			</HStack>
+		</VStack>
+	);
+}
+
+export default function SidebarNavigationScreenNavigationMenuDetail( {
+	postId,
+	backPath = '/navigation',
+} ) {
+	const { record: navigationMenu, isResolving } = useEntityRecord(
+		'postType',
+		POST_TYPE,
+		postId
+	);
+
+	if ( isResolving && ! navigationMenu ) {
+		return (
+			<SidebarNavigationScreen
+				title={ __( 'Navigation' ) }
+				backPath={ backPath }
+				content={ <Spinner /> }
+			/>
+		);
+	}
+
+	const title = buildNavigationLabel(
+		navigationMenu?.title,
+		navigationMenu?.id,
+		navigationMenu?.status
+	);
+
+	return (
+		<SidebarNavigationScreen
+			title={ title || __( 'Navigation' ) }
+			backPath={ backPath }
+			description={ __(
+				'Template parts where this menu is used. Click to edit in context.'
+			) }
+			content={ <MenuDetails navigationMenu={ navigationMenu } /> }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -58,7 +58,7 @@ export default function ScreenNavigationMoreMenu( props ) {
 						<MenuItem
 							onClick={ () => {
 								history.navigate(
-									`/wp_navigation/${ menuId }?canvas=edit`
+									`/navigation/${ menuId }?canvas=edit`
 								);
 							} }
 						>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-used-in.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-used-in.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	__experimentalItemGroup as ItemGroup,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Spinner,
+} from '@wordpress/components';
+import { getTemplatePartIcon } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import useNavigationMenuUsedIn from './use-navigation-menu-used-in';
+import SidebarNavigationItem from '../sidebar-navigation-item';
+
+function AreaLabel( { area, templatePartAreas } ) {
+	const match = templatePartAreas.find( ( item ) => item.area === area );
+	return match?.label || area;
+}
+
+export default function NavigationMenuUsedIn( { navigationMenuId } ) {
+	const { templateParts, isResolving } =
+		useNavigationMenuUsedIn( navigationMenuId );
+
+	const templatePartAreas = useSelect(
+		( select ) =>
+			select( coreStore ).getCurrentTheme()
+				?.default_template_part_areas || [],
+		[]
+	);
+
+	if ( isResolving ) {
+		return <Spinner />;
+	}
+
+	if ( ! templateParts.length ) {
+		return (
+			<VStack spacing={ 3 }>
+				<Heading level={ 5 }>
+					{ sprintf(
+						/* translators: %d: number of template parts */
+						__( 'Used in %d template part(s)' ),
+						0
+					) }
+				</Heading>
+			</VStack>
+		);
+	}
+
+	return (
+		<VStack spacing={ 3 }>
+			<Heading level={ 5 }>
+				{ sprintf(
+					/* translators: %d: number of template parts */
+					__( 'Used in %d template part(s)' ),
+					templateParts.length
+				) }
+			</Heading>
+			<ItemGroup>
+				{ templateParts.map( ( templatePart ) => (
+					<SidebarNavigationItem
+						key={ templatePart.id }
+						uid={ `template-part-${ String(
+							templatePart.id
+						).replace( /\//g, '-' ) }` }
+						icon={ getTemplatePartIcon(
+							templatePart.area || 'uncategorized'
+						) }
+						to={ addQueryArgs(
+							`/wp_template_part/${ templatePart.id }`,
+							{
+								canvas: 'edit',
+								focusNavigationBlock: navigationMenuId,
+							}
+						) }
+					>
+						{ templatePart.title?.rendered ||
+							templatePart.slug ||
+							templatePart.id }
+						<Text variant="muted" size="body" as="span">
+							{ ' — ' }
+							<AreaLabel
+								area={ templatePart.area }
+								templatePartAreas={ templatePartAreas }
+							/>
+						</Text>
+					</SidebarNavigationItem>
+				) ) }
+			</ItemGroup>
+		</VStack>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -165,7 +165,7 @@ function useDuplicateNavigationMenu() {
 				createSuccessNotice( __( 'Duplicated Navigation Menu' ), {
 					type: 'snackbar',
 				} );
-				history.navigate( `/wp_navigation/${ savedRecord.id }` );
+				history.navigate( `/navigation/${ savedRecord.id }` );
 			}
 		} catch ( error ) {
 			createErrorNotice(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-used-in.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-used-in.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import useMenuUsedInTemplateParts from '../../hooks/use-menu-used-in-template-parts';
+
+export default function useNavigationMenuUsedIn( menuId ) {
+	return useMenuUsedInTemplateParts( menuId );
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -152,9 +152,6 @@ export function SidebarNavigationScreenWrapper( {
 
 const NavMenuItem = ( { postId, ...props } ) => {
 	return (
-		<SidebarNavigationItem
-			to={ `/wp_navigation/${ postId }` }
-			{ ...props }
-		/>
+		<SidebarNavigationItem to={ `/navigation/${ postId }` } { ...props } />
 	);
 };

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -7,34 +7,51 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import Editor from '../editor';
-import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
+import SidebarNavigationScreenNavigationMenuDetail from '../sidebar-navigation-screen-navigation-menu-detail';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
+import NavigationMenuDetail from '../navigation-menu-detail';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
 
 function MobileNavigationItemView() {
-	const { query = {} } = useLocation();
+	const { query = {}, params = {} } = useLocation();
 	const { canvas = 'view' } = query;
+	const { postId } = params;
 
 	return canvas === 'edit' ? (
 		<Editor />
 	) : (
-		<SidebarNavigationScreenNavigationMenu backPath="/navigation" />
+		<>
+			<SidebarNavigationScreenNavigationMenuDetail
+				postId={ postId }
+				backPath="/navigation"
+			/>
+			<NavigationMenuDetail menuId={ postId } />
+		</>
 	);
 }
 
 export const navigationItemRoute = {
 	name: 'navigation-item',
-	path: '/wp_navigation/:postId',
+	path: '/navigation/:postId',
 	areas: {
-		sidebar( { siteData } ) {
+		sidebar( { siteData, params } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? (
-				<SidebarNavigationScreenNavigationMenu backPath="/navigation" />
+				<SidebarNavigationScreenNavigationMenuDetail
+					postId={ params?.postId }
+					backPath="/navigation"
+				/>
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);
+		},
+		content( { siteData, params } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			return isBlockTheme ? (
+				<NavigationMenuDetail menuId={ params?.postId } />
+			) : undefined;
 		},
 		preview( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
@@ -52,5 +69,8 @@ export const navigationItemRoute = {
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
+	},
+	widths: {
+		content: () => 380,
 	},
 };

--- a/packages/edit-site/src/components/site-editor-routes/navigation.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation.js
@@ -2,14 +2,18 @@
  * WordPress dependencies
  */
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Editor from '../editor';
-import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import NavigationMenuList from '../navigation-menu-list';
 import { unlock } from '../../lock-unlock';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -17,11 +21,7 @@ function MobileNavigationView() {
 	const { query = {} } = useLocation();
 	const { canvas = 'view' } = query;
 
-	return canvas === 'edit' ? (
-		<Editor />
-	) : (
-		<SidebarNavigationScreenNavigationMenus backPath="/" />
-	);
+	return canvas === 'edit' ? <Editor /> : <NavigationMenuList />;
 }
 
 export const navigationRoute = {
@@ -31,10 +31,22 @@ export const navigationRoute = {
 		sidebar( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? (
-				<SidebarNavigationScreenNavigationMenus backPath="/" />
+				<SidebarNavigationScreen
+					title={ __( 'Navigation' ) }
+					backPath="/"
+					content={
+						<DataViewsSidebarContent
+							postType={ NAVIGATION_POST_TYPE }
+						/>
+					}
+				/>
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);
+		},
+		content( { siteData } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			return isBlockTheme ? <NavigationMenuList /> : undefined;
 		},
 		preview( { siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
@@ -48,5 +60,8 @@ export const navigationRoute = {
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
+	},
+	widths: {
+		content: () => 380,
 	},
 };

--- a/packages/edit-site/src/hooks/use-auto-select-navigation-block.js
+++ b/packages/edit-site/src/hooks/use-auto-select-navigation-block.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function findNavigationBlock( blocks, refId ) {
+	for ( const block of blocks ) {
+		if (
+			block.name === 'core/navigation' &&
+			block.attributes.ref === refId
+		) {
+			return block;
+		}
+		if ( block.innerBlocks?.length ) {
+			const found = findNavigationBlock( block.innerBlocks, refId );
+			if ( found ) {
+				return found;
+			}
+		}
+	}
+	return null;
+}
+
+export default function useAutoSelectNavigationBlock() {
+	const { navigationRef } = useLocation().query;
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const blocks = useSelect(
+		( select ) => select( blockEditorStore ).getBlocks(),
+		[]
+	);
+
+	useEffect( () => {
+		if ( ! navigationRef || ! blocks.length ) {
+			return;
+		}
+		const refId = Number( navigationRef );
+		const navBlock = findNavigationBlock( blocks, refId );
+		if ( navBlock ) {
+			selectBlock( navBlock.clientId );
+		}
+	}, [ navigationRef, blocks, selectBlock ] );
+}

--- a/packages/edit-site/src/hooks/use-menu-ids-with-active-locations.js
+++ b/packages/edit-site/src/hooks/use-menu-ids-with-active-locations.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE } from '../utils/constants';
+
+/**
+ * Extracts navigation menu ref IDs from template part content.
+ *
+ * @param {string} content - Raw content of the template part.
+ * @return {number[]} Array of menu IDs referenced in the content.
+ */
+function extractNavigationRefs( content ) {
+	if ( ! content ) {
+		return [];
+	}
+	const refPattern = /<!-- wp:navigation[^>]*"ref"[^:]*:\s*["']?(\d+)["']?/gi;
+	const refs = [];
+	let match;
+	while ( ( match = refPattern.exec( content ) ) !== null ) {
+		refs.push( parseInt( match[ 1 ], 10 ) );
+	}
+	return refs;
+}
+
+/**
+ * Hook that returns the set of navigation menu IDs that are used in at least one template part.
+ *
+ * @return {Object} { activeMenuIds: Set<number>, isResolving: boolean }
+ */
+export default function useMenuIdsWithActiveLocations() {
+	const { records } = useEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, {
+		per_page: -1,
+		status: [ 'publish', 'draft' ],
+	} );
+
+	const activeMenuIds = useMemo( () => {
+		const set = new Set();
+		if ( ! records ) {
+			return set;
+		}
+		for ( const tp of records ) {
+			const refs = extractNavigationRefs( tp.content?.raw );
+			refs.forEach( ( id ) => set.add( id ) );
+		}
+		return set;
+	}, [ records ] );
+
+	return {
+		activeMenuIds,
+		isResolving: ! records,
+	};
+}

--- a/packages/edit-site/src/hooks/use-menu-ids-with-active-locations.js
+++ b/packages/edit-site/src/hooks/use-menu-ids-with-active-locations.js
@@ -29,9 +29,10 @@ function extractNavigationRefs( content ) {
 }
 
 /**
- * Hook that returns the set of navigation menu IDs that are used in at least one template part.
+ * Hook that returns the set of navigation menu IDs that are used in at least one template part,
+ * and a map of menu ID to location count.
  *
- * @return {Object} { activeMenuIds: Set<number>, isResolving: boolean }
+ * @return {Object} { activeMenuIds: Set<number>, menuLocationCounts: Map<number, number>, isResolving: boolean }
  */
 export default function useMenuIdsWithActiveLocations() {
 	const { records } = useEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, {
@@ -39,20 +40,26 @@ export default function useMenuIdsWithActiveLocations() {
 		status: [ 'publish', 'draft' ],
 	} );
 
-	const activeMenuIds = useMemo( () => {
+	const { activeMenuIds, menuLocationCounts } = useMemo( () => {
 		const set = new Set();
+		const counts = new Map();
 		if ( ! records ) {
-			return set;
+			return { activeMenuIds: set, menuLocationCounts: counts };
 		}
 		for ( const tp of records ) {
 			const refs = extractNavigationRefs( tp.content?.raw );
-			refs.forEach( ( id ) => set.add( id ) );
+			const uniqueRefs = [ ...new Set( refs ) ];
+			uniqueRefs.forEach( ( id ) => {
+				set.add( id );
+				counts.set( id, ( counts.get( id ) ?? 0 ) + 1 );
+			} );
 		}
-		return set;
+		return { activeMenuIds: set, menuLocationCounts: counts };
 	}, [ records ] );
 
 	return {
 		activeMenuIds,
+		menuLocationCounts,
 		isResolving: ! records,
 	};
 }

--- a/packages/edit-site/src/hooks/use-menu-used-in-template-parts.js
+++ b/packages/edit-site/src/hooks/use-menu-used-in-template-parts.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE } from '../utils/constants';
+
+/**
+ * Checks if a template part's content references a navigation menu by ID.
+ *
+ * @param {string}        content - Raw content of the template part.
+ * @param {string|number} menuId  - Navigation menu ID to search for.
+ * @return {boolean} True if the template part contains a navigation block referencing the menu.
+ */
+function templatePartReferencesMenu( content, menuId ) {
+	if ( ! content || menuId === null || menuId === undefined ) {
+		return false;
+	}
+	// Match <!-- wp:navigation {"ref":ID or <!-- wp:navigation {"ref": "ID"
+	const refPattern = new RegExp(
+		`<!-- wp:navigation[^>]*"ref"[^:]*:\\s*["']?${ menuId }["']?`,
+		'i'
+	);
+	return refPattern.test( content );
+}
+
+/**
+ * Hook that returns template parts that reference a given navigation menu.
+ *
+ * Uses client-side parsing of template part content for the "used in" relationship.
+ * Acceptable for prototype; production would want a server-side index.
+ *
+ * @param {string|number} menuId - The navigation menu ID to find usages for.
+ * @return {Object} { templateParts: Array, isResolving: boolean, hasResolved: boolean }
+ */
+export default function useMenuUsedInTemplateParts( menuId ) {
+	const { records } = useEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, {
+		per_page: -1,
+		status: [ 'publish', 'draft' ],
+	} );
+
+	const templateParts = useMemo( () => {
+		if ( ! records || ! menuId ) {
+			return [];
+		}
+		return records.filter( ( tp ) =>
+			templatePartReferencesMenu( tp.content?.raw, menuId )
+		);
+	}, [ records, menuId ] );
+
+	return {
+		templateParts,
+		isResolving: ! records,
+		hasResolved: !! records,
+	};
+}


### PR DESCRIPTION
## What?

Alternative approach to [#75791](https://github.com/WordPress/gutenberg/pull/75791): a prototype that explores reframing the Navigation sidebar as a **discovery surface** rather than an isolated editing view.

The current Navigation section shows menus divorced from context—with no indication of where they live on the site or how to get to the right place to edit them. This prototype explores a different model: the sidebar as a place to **discover** menus and **navigate** to the right editing context, rather than as a third editor.

It aims to answer three questions the current UI leaves unanswered:

1. **What is this menu?** — Name, status, and whether it's used anywhere
2. **Where does it live?** — Which template parts reference it
3. **How do I edit it in context?** — A direct path to the template part with the Navigation block selected

## Why?

The Navigation sidebar currently confuses users: menus are shown in isolation, divorced from theme context and placement. Users struggle to find where to edit menus, and what they see can differ from the frontend. Feedback (including from CIAB) suggests this is blocking for some users. This prototype explores the discovery-surface approach before committing to implementation.

## NOTE: THIS IS A PROTOTYPE

This is an exploratory prototype. Not all flows may be complete or production-ready.

## How?

- Pages-like navigation list with DataViews (status, actions menu, sidebar filters)
- Active/Inactive filters based on menu usage in template parts
- Drill-down flow: list → menu detail (Active Menu locations) → template part edit
- "Active - X locations" badge per menu in the list
- "Edit in context" opens the canvas with the template part and Navigation block selected
- Back button and auto-select of the navigation block when navigating from menu detail

## Testing Instructions

1. Go to Site Editor → Navigation (`/wp-admin/site-editor.php?p=%2Fnavigation`)
2. Use the sidebar filters (All, Active, Inactive, Published, Drafts, Trash)
3. Select a menu to view its detail and Active Menu locations
4. Click a template part to edit in context; use Back to return
5. Confirm the Active badge shows "Active - N locations" or "Inactive - unused" per menu

## Screenshots


https://github.com/user-attachments/assets/db7fca11-9966-491a-95eb-cb14ad7be45a


