### PR TITLE
RTC: Fix undefined array_first() call in sync storage

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -6,3 +6,4 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75708
 * https://github.com/WordPress/gutenberg/pull/75711
 * https://github.com/WordPress/gutenberg/pull/75746
+* https://github.com/WordPress/gutenberg/pull/75869

--- a/lib/compat/wordpress-7.0/class-wp-sync-post-meta-storage.php
+++ b/lib/compat/wordpress-7.0/class-wp-sync-post-meta-storage.php
@@ -213,7 +213,13 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 				)
 			);
 
-			$post_id = array_first( $posts );
+			/*
+			 * array_first() is a PHP 8.5 function. WordPress added
+			 * a polyfill in WP 6.9 (see https://core.trac.wordpress.org/ticket/63853).
+			 * Since Gutenberg must support the two most recent WordPress
+			 * versions (currently 6.8+), we cannot rely on it here.
+			 */
+			$post_id = $posts[0] ?? null;
 			if ( is_int( $post_id ) ) {
 				self::$storage_post_ids[ $room_hash ] = $post_id;
 				return $post_id;


### PR DESCRIPTION
## What?

Fix a fatal error in `WP_Sync_Post_Meta_Storage` caused by calling the undefined `array_first()` function.

## Why?

Opening any post in the editor triggers the RTC sync polling, which calls `get_storage_post_id()`. This method used `array_first()`, a PHP 8.5 function not available in supported PHP versions, causing a fatal error on every `/wp-sync/v1/updates` request. WordPress had a polyfill added in `6.9` (https://core.trac.wordpress.org/ticket/63853) but Gutenberg needs to support 2 latest major WordPress version which means we can't rely on that here.

## How?

Replace `array_first( $posts )` with `$posts[0] ?? null` in `get_storage_post_id()`.

## Testing Instructions

1. Start wp-env with `npm run wp-env start`.
2. Open any post in the editor.
3. Check the browser network tab — `/wp-sync/v1/updates` requests should return 200, not 500.
4. Check `npm run wp-env logs` — no `array_first()` fatal error should appear.
