### PR TITLE
Add primitive Text component to @wordpress/ui

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens.
+
 ### Bug Fixes
 
 -   `VisuallyHidden`: Add `word-break: normal` to prevent text wrapping issues in screen reader content ([#75539](https://github.com/WordPress/gutenberg/pull/75539)).

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -29,7 +29,6 @@
 ### Enhancements
 
 -   `Field.Label`, `Fieldset.Legend`: Add `hideFromVision` prop to visually hide the label while keeping it accessible to screen readers ([#76052](https://github.com/WordPress/gutenberg/pull/76052)).
--   `Notice`: Use `Text` component for `Title` and `Description` typography.
 -   `Dialog`: Add `--wp-ui-dialog-z-index` CSS custom property for legacy z-index compatibility ([#75874](https://github.com/WordPress/gutenberg/pull/75874)).
 -   `Tooltip`: Change default `side` from `bottom` to `top`. ([#76131](https://github.com/WordPress/gutenberg/pull/76131)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,14 +5,11 @@
 ### New Features
 
 -   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens. ([#75870](https://github.com/WordPress/gutenberg/pull/75870))
+-   Add `Card` and `CollapsibleCard` primitives ([#76252](https://github.com/WordPress/gutenberg/pull/76252)).
 
 ### Bug Fixes
 
 -   `VisuallyHidden`: Add `word-break: normal` to prevent text wrapping issues in screen reader content ([#75539](https://github.com/WordPress/gutenberg/pull/75539)).
-
-### New Features
-
--   Add `Card` and `CollapsibleCard` primitives ([#76252](https://github.com/WordPress/gutenberg/pull/76252)).
 
 ### Enhancements
 
@@ -31,6 +28,7 @@
 ### Enhancements
 
 -   `Field.Label`, `Fieldset.Legend`: Add `hideFromVision` prop to visually hide the label while keeping it accessible to screen readers ([#76052](https://github.com/WordPress/gutenberg/pull/76052)).
+-   `Notice`: Use `Text` component for `Title` and `Description` typography.
 -   `Dialog`: Add `--wp-ui-dialog-z-index` CSS custom property for legacy z-index compatibility ([#75874](https://github.com/WordPress/gutenberg/pull/75874)).
 -   `Tooltip`: Change default `side` from `bottom` to `top`. ([#76131](https://github.com/WordPress/gutenberg/pull/76131)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Enhancements
 
 -   `Notice`: Improve narrow layout by letting description and actions span the icon column when a title is present ([#76202](https://github.com/WordPress/gutenberg/pull/76202)).
+-   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 
 ## 0.8.0 (2026-03-04)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens. ([#75870](https://github.com/WordPress/gutenberg/pull/75870))
+-   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 -   Add `Card` and `CollapsibleCard` primitives ([#76252](https://github.com/WordPress/gutenberg/pull/76252)).
 
 ### Bug Fixes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens.
+-   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens. ([#75870](https://github.com/WordPress/gutenberg/pull/75870))
 
 ### Bug Fixes
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,5 +9,6 @@ export * from './icon-button';
 export * as Notice from './notice';
 export * from './stack';
 export * as Tabs from './tabs';
+export * from './text';
 export * as Tooltip from './tooltip';
 export * from './visually-hidden';

--- a/packages/ui/src/notice/description.tsx
+++ b/packages/ui/src/notice/description.tsx
@@ -7,16 +7,15 @@ import styles from './style.module.css';
 /**
  * The description text for a notice.
  */
-export const Description = forwardRef< HTMLDivElement, DescriptionProps >(
-	function NoticeDescription( { className, children, ...props }, ref ) {
+export const Description = forwardRef< HTMLSpanElement, DescriptionProps >(
+	function NoticeDescription( { className, ...props }, ref ) {
 		return (
 			<Text
+				ref={ ref }
 				variant="body-md"
-				render={ <div ref={ ref } { ...props } /> }
 				className={ clsx( styles.description, className ) }
-			>
-				{ children }
-			</Text>
+				{ ...props }
+			/>
 		);
 	}
 );

--- a/packages/ui/src/notice/description.tsx
+++ b/packages/ui/src/notice/description.tsx
@@ -1,23 +1,22 @@
 import { forwardRef } from '@wordpress/element';
-import { useRender, mergeProps } from '@base-ui/react';
+import clsx from 'clsx';
 import type { DescriptionProps } from './types';
+import { Text } from '../text';
 import styles from './style.module.css';
 
 /**
  * The description text for a notice.
  */
 export const Description = forwardRef< HTMLDivElement, DescriptionProps >(
-	function NoticeDescription( { render, ...props }, ref ) {
-		const element = useRender( {
-			defaultTagName: 'div',
-			render,
-			ref,
-			props: mergeProps< 'div' >(
-				{ className: styles.description },
-				props
-			),
-		} );
-
-		return element;
+	function NoticeDescription( { className, children, ...props }, ref ) {
+		return (
+			<Text
+				variant="body-md"
+				render={ <div ref={ ref } { ...props } /> }
+				className={ clsx( styles.description, className ) }
+			>
+				{ children }
+			</Text>
+		);
 	}
 );

--- a/packages/ui/src/notice/style.module.css
+++ b/packages/ui/src/notice/style.module.css
@@ -32,10 +32,6 @@
 
 		padding-block: var(--text-vertical-padding);
 
-		font-family: var(--wpds-font-family-heading);
-		font-size: var(--wpds-font-size-md);
-		font-weight: var(--wpds-font-weight-medium);
-		line-height: var(--wpds-font-line-height-sm);
 		color: var(--wp-ui-notice-text-color);
 	}
 
@@ -44,10 +40,6 @@
 
 		padding-block: var(--text-vertical-padding);
 
-		font-family: var(--wpds-font-family-body);
-		font-size: var(--wpds-font-size-md);
-		font-weight: var(--wpds-font-weight-regular);
-		line-height: var(--wpds-font-line-height-sm);
 		text-wrap: pretty;
 		color: var(--wp-ui-notice-text-color);
 	}

--- a/packages/ui/src/notice/test/index.test.tsx
+++ b/packages/ui/src/notice/test/index.test.tsx
@@ -8,7 +8,7 @@ describe( 'Notice', () => {
 		it( 'forwards ref', () => {
 			const rootRef = createRef< HTMLDivElement >();
 			const titleRef = createRef< HTMLSpanElement >();
-			const descriptionRef = createRef< HTMLDivElement >();
+			const descriptionRef = createRef< HTMLSpanElement >();
 			const actionsRef = createRef< HTMLDivElement >();
 			const actionButtonRef = createRef< HTMLButtonElement >();
 			const actionLinkRef = createRef< HTMLAnchorElement >();
@@ -36,7 +36,7 @@ describe( 'Notice', () => {
 			);
 			expect( rootRef.current ).toBeInstanceOf( HTMLDivElement );
 			expect( titleRef.current ).toBeInstanceOf( HTMLSpanElement );
-			expect( descriptionRef.current ).toBeInstanceOf( HTMLDivElement );
+			expect( descriptionRef.current ).toBeInstanceOf( HTMLSpanElement );
 			expect( actionsRef.current ).toBeInstanceOf( HTMLDivElement );
 			expect( actionButtonRef.current ).toBeInstanceOf(
 				HTMLButtonElement

--- a/packages/ui/src/notice/title.tsx
+++ b/packages/ui/src/notice/title.tsx
@@ -1,20 +1,21 @@
 import { forwardRef } from '@wordpress/element';
-import { useRender, mergeProps } from '@base-ui/react';
+import clsx from 'clsx';
 import type { TitleProps } from './types';
+import { Text } from '../text';
 import styles from './style.module.css';
 
 /**
  * A short heading that communicates the main message of the notice.
  */
 export const Title = forwardRef< HTMLSpanElement, TitleProps >(
-	function NoticeTitle( { render, ...props }, ref ) {
-		const element = useRender( {
-			defaultTagName: 'span',
-			render,
-			ref,
-			props: mergeProps< 'span' >( { className: styles.title }, props ),
-		} );
-
-		return element;
+	function NoticeTitle( { className, ...props }, ref ) {
+		return (
+			<Text
+				ref={ ref }
+				variant="heading-md"
+				className={ clsx( styles.title, className ) }
+				{ ...props }
+			/>
+		);
 	}
 );

--- a/packages/ui/src/notice/types.ts
+++ b/packages/ui/src/notice/types.ts
@@ -47,7 +47,7 @@ export interface TitleProps extends ComponentProps< 'span' > {
 	children?: ReactNode;
 }
 
-export interface DescriptionProps extends ComponentProps< 'div' > {
+export interface DescriptionProps extends ComponentProps< 'span' > {
 	/**
 	 * The description text of the notice.
 	 */

--- a/packages/ui/src/text/index.ts
+++ b/packages/ui/src/text/index.ts
@@ -1,0 +1,1 @@
+export { Text } from './text';

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/heading-has-content */
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Fragment } from '@wordpress/element';
 import { Text } from '../index';
 import { Stack } from '../../stack';
 
@@ -39,14 +38,12 @@ export const AllVariants: Story = {
 					'body-sm',
 				] as const
 			 ).map( ( variant ) => (
-				<Fragment key={ variant }>
-					<Stack direction="column" gap="xs">
-						<Text variant="heading-sm">{ variant }</Text>
-						<Text variant={ variant }>
-							The quick brown fox jumps over the lazy dog.
-						</Text>
-					</Stack>
-				</Fragment>
+				<Stack key={ variant } direction="column" gap="xs">
+					<Text variant="heading-sm">{ variant }</Text>
+					<Text variant={ variant }>
+						The quick brown fox jumps over the lazy dog.
+					</Text>
+				</Stack>
 			) ) }
 		</Stack>
 	),

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable jsx-a11y/heading-has-content */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Fragment } from '@wordpress/element';
+import { Text } from '../index';
+import { Stack } from '../../stack';
+
+const meta: Meta< typeof Text > = {
+	title: 'Design System/Components/Text',
+	component: Text,
+};
+export default meta;
+
+type Story = StoryObj< typeof Text >;
+
+export const Default: Story = {
+	args: {
+		variant: 'body-md',
+		children: 'The quick brown fox jumps over the lazy dog.',
+	},
+};
+
+export const Heading2xl: Story = {
+	args: {
+		variant: 'heading-2xl',
+		children: 'Heading 2XL',
+	},
+};
+
+export const HeadingXl: Story = {
+	args: {
+		variant: 'heading-xl',
+		children: 'Heading XL',
+	},
+};
+
+export const HeadingLg: Story = {
+	args: {
+		variant: 'heading-lg',
+		children: 'Heading LG',
+	},
+};
+
+export const HeadingMd: Story = {
+	args: {
+		variant: 'heading-md',
+		children: 'Heading MD',
+	},
+};
+
+export const HeadingSm: Story = {
+	args: {
+		variant: 'heading-sm',
+		children: 'Heading SM',
+	},
+};
+
+export const BodyXl: Story = {
+	args: {
+		variant: 'body-xl',
+		children: 'The quick brown fox jumps over the lazy dog.',
+	},
+};
+
+export const BodyLg: Story = {
+	args: {
+		variant: 'body-lg',
+		children: 'The quick brown fox jumps over the lazy dog.',
+	},
+};
+
+export const BodyMd: Story = {
+	args: {
+		variant: 'body-md',
+		children: 'The quick brown fox jumps over the lazy dog.',
+	},
+};
+
+export const BodySm: Story = {
+	args: {
+		variant: 'body-sm',
+		children: 'The quick brown fox jumps over the lazy dog.',
+	},
+};
+
+export const AllVariants: Story = {
+	render: () => (
+		<Stack
+			direction="column"
+			gap="lg"
+			style={ { color: 'var(--wpds-color-fg-content-neutral)' } }
+		>
+			{ (
+				[
+					'heading-2xl',
+					'heading-xl',
+					'heading-lg',
+					'heading-md',
+					'heading-sm',
+					'body-xl',
+					'body-lg',
+					'body-md',
+					'body-sm',
+				] as const
+			 ).map( ( variant ) => (
+				<Fragment key={ variant }>
+					<Stack direction="column" gap="xs">
+						<Text variant="heading-sm">{ variant }</Text>
+						<Text variant={ variant }>
+							The quick brown fox jumps over the lazy dog.
+						</Text>
+					</Stack>
+				</Fragment>
+			) ) }
+		</Stack>
+	),
+};
+
+export const WithRenderProp: Story = {
+	render: () => (
+		<Stack direction="column" gap="md">
+			<Text variant="heading-2xl" render={ <h1 /> }>
+				Page Title
+			</Text>
+			<Text variant="heading-xl" render={ <h2 /> }>
+				Section Heading
+			</Text>
+			<Text variant="body-md" render={ <p /> }>
+				A paragraph of body text rendered as a semantic paragraph
+				element.
+			</Text>
+		</Stack>
+	),
+};
+/* eslint-enable jsx-a11y/heading-has-content */

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -19,69 +19,6 @@ export const Default: Story = {
 	},
 };
 
-export const Heading2xl: Story = {
-	args: {
-		variant: 'heading-2xl',
-		children: 'Heading 2XL',
-	},
-};
-
-export const HeadingXl: Story = {
-	args: {
-		variant: 'heading-xl',
-		children: 'Heading XL',
-	},
-};
-
-export const HeadingLg: Story = {
-	args: {
-		variant: 'heading-lg',
-		children: 'Heading LG',
-	},
-};
-
-export const HeadingMd: Story = {
-	args: {
-		variant: 'heading-md',
-		children: 'Heading MD',
-	},
-};
-
-export const HeadingSm: Story = {
-	args: {
-		variant: 'heading-sm',
-		children: 'Heading SM',
-	},
-};
-
-export const BodyXl: Story = {
-	args: {
-		variant: 'body-xl',
-		children: 'The quick brown fox jumps over the lazy dog.',
-	},
-};
-
-export const BodyLg: Story = {
-	args: {
-		variant: 'body-lg',
-		children: 'The quick brown fox jumps over the lazy dog.',
-	},
-};
-
-export const BodyMd: Story = {
-	args: {
-		variant: 'body-md',
-		children: 'The quick brown fox jumps over the lazy dog.',
-	},
-};
-
-export const BodySm: Story = {
-	args: {
-		variant: 'body-sm',
-		children: 'The quick brown fox jumps over the lazy dog.',
-	},
-};
-
 export const AllVariants: Story = {
 	render: () => (
 		<Stack

--- a/packages/ui/src/text/style.module.css
+++ b/packages/ui/src/text/style.module.css
@@ -1,0 +1,71 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-components {
+	.text {
+		margin: 0;
+	}
+
+	.heading-2xl {
+		font-family: var(--wpds-font-family-heading);
+		font-size: var(--wpds-font-size-2xl);
+		line-height: var(--wpds-font-line-height-2xl);
+		font-weight: var(--wpds-font-weight-medium);
+	}
+
+	.heading-xl {
+		font-family: var(--wpds-font-family-heading);
+		font-size: var(--wpds-font-size-xl);
+		line-height: var(--wpds-font-line-height-md);
+		font-weight: var(--wpds-font-weight-medium);
+	}
+
+	.heading-lg {
+		font-family: var(--wpds-font-family-heading);
+		font-size: var(--wpds-font-size-lg);
+		line-height: var(--wpds-font-line-height-sm);
+		font-weight: var(--wpds-font-weight-medium);
+	}
+
+	.heading-md {
+		font-family: var(--wpds-font-family-heading);
+		font-size: var(--wpds-font-size-md);
+		line-height: var(--wpds-font-line-height-sm);
+		font-weight: var(--wpds-font-weight-medium);
+	}
+
+	.heading-sm {
+		font-family: var(--wpds-font-family-heading);
+		font-size: var(--wpds-font-size-xs);
+		line-height: var(--wpds-font-line-height-xs);
+		font-weight: var(--wpds-font-weight-medium);
+		text-transform: uppercase;
+	}
+
+	.body-xl {
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-xl);
+		line-height: var(--wpds-font-line-height-xl);
+		font-weight: var(--wpds-font-weight-regular);
+	}
+
+	.body-lg {
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-lg);
+		line-height: var(--wpds-font-line-height-md);
+		font-weight: var(--wpds-font-weight-regular);
+	}
+
+	.body-md {
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-md);
+		line-height: var(--wpds-font-line-height-sm);
+		font-weight: var(--wpds-font-weight-regular);
+	}
+
+	.body-sm {
+		font-family: var(--wpds-font-family-body);
+		font-size: var(--wpds-font-size-sm);
+		line-height: var(--wpds-font-line-height-xs);
+		font-weight: var(--wpds-font-weight-regular);
+	}
+}

--- a/packages/ui/src/text/style.module.css
+++ b/packages/ui/src/text/style.module.css
@@ -1,10 +1,6 @@
 @layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
 
 @layer wp-ui-components {
-	.text {
-		margin: 0;
-	}
-
 	.heading-2xl {
 		font-family: var(--wpds-font-family-heading);
 		font-size: var(--wpds-font-size-2xl);

--- a/packages/ui/src/text/test/index.test.tsx
+++ b/packages/ui/src/text/test/index.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from '@wordpress/element';
+import { Text } from '../index';
+
+describe( 'Text', () => {
+	it( 'forwards ref', () => {
+		const ref = createRef< HTMLSpanElement >();
+
+		render( <Text ref={ ref }>Content</Text> );
+
+		expect( ref.current ).toBeInstanceOf( HTMLSpanElement );
+	} );
+
+	it( 'renders children', () => {
+		render( <Text>Hello world</Text> );
+
+		expect( screen.getByText( 'Hello world' ) ).toBeVisible();
+	} );
+
+	it( 'forwards props to the rendered element', () => {
+		render( <Text data-testid="text">Content</Text> );
+
+		expect( screen.getByTestId( 'text' ) ).toBeInTheDocument();
+	} );
+
+	it( 'forwards the className to the rendered element', () => {
+		render(
+			<Text data-testid="text" className="custom-class">
+				Content
+			</Text>
+		);
+
+		expect( screen.getByTestId( 'text' ) ).toHaveClass( 'custom-class' );
+	} );
+
+	it( 'supports the render prop', () => {
+		render(
+			// eslint-disable-next-line jsx-a11y/heading-has-content
+			<Text render={ <h2 /> }>Section title</Text>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { level: 2, name: 'Section title' } )
+		).toBeVisible();
+	} );
+} );

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -9,7 +9,7 @@ import styles from './style.module.css';
  * Built on design tokens for consistent typography across the UI.
  */
 export const Text = forwardRef< HTMLSpanElement, TextProps >( function Text(
-	{ variant, render, className, ...props },
+	{ variant = 'body-md', render, className, ...props },
 	ref
 ) {
 	const element = useRender( {

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -9,7 +9,7 @@ import styles from './style.module.css';
  * Built on design tokens for consistent typography across the UI.
  */
 export const Text = forwardRef< HTMLSpanElement, TextProps >( function Text(
-	{ children, variant, render, className, ...props },
+	{ variant, render, className, ...props },
 	ref
 ) {
 	const element = useRender( {
@@ -18,7 +18,6 @@ export const Text = forwardRef< HTMLSpanElement, TextProps >( function Text(
 		ref,
 		props: mergeProps< 'span' >( props, {
 			className: clsx( styles[ variant ], className ),
-			children,
 		} ),
 	} );
 

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -17,7 +17,7 @@ export const Text = forwardRef< HTMLSpanElement, TextProps >( function Text(
 		defaultTagName: 'span',
 		ref,
 		props: mergeProps< 'span' >( props, {
-			className: clsx( styles.text, styles[ variant ], className ),
+			className: clsx( styles[ variant ], className ),
 			children,
 		} ),
 	} );

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -1,0 +1,26 @@
+import { useRender, mergeProps } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { type TextProps } from './types';
+import styles from './style.module.css';
+
+/**
+ * A text component for rendering content with predefined typographic variants.
+ * Built on design tokens for consistent typography across the UI.
+ */
+export const Text = forwardRef< HTMLSpanElement, TextProps >( function Text(
+	{ children, variant, render, className, ...props },
+	ref
+) {
+	const element = useRender( {
+		render,
+		defaultTagName: 'span',
+		ref,
+		props: mergeProps< 'span' >( props, {
+			className: clsx( styles.text, styles[ variant ], className ),
+			children,
+		} ),
+	} );
+
+	return element;
+} );

--- a/packages/ui/src/text/types.ts
+++ b/packages/ui/src/text/types.ts
@@ -4,8 +4,10 @@ export interface TextProps extends ComponentProps< 'span' > {
 	/**
 	 * The typographic variant to apply, controlling font family, size,
 	 * line height, and weight.
+	 *
+	 * @default "body-md"
 	 */
-	variant:
+	variant?:
 		| 'heading-2xl'
 		| 'heading-xl'
 		| 'heading-lg'

--- a/packages/ui/src/text/types.ts
+++ b/packages/ui/src/text/types.ts
@@ -19,5 +19,5 @@ export interface TextProps extends ComponentProps< 'span' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */
-	children: React.ReactNode;
+	children?: React.ReactNode;
 }

--- a/packages/ui/src/text/types.ts
+++ b/packages/ui/src/text/types.ts
@@ -19,5 +19,5 @@ export interface TextProps extends ComponentProps< 'span' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */
-	children?: React.ReactNode;
+	children: React.ReactNode;
 }

--- a/packages/ui/src/text/types.ts
+++ b/packages/ui/src/text/types.ts
@@ -1,0 +1,23 @@
+import { type ComponentProps } from '../utils/types';
+
+export interface TextProps extends ComponentProps< 'span' > {
+	/**
+	 * The typographic variant to apply, controlling font family, size,
+	 * line height, and weight.
+	 */
+	variant:
+		| 'heading-2xl'
+		| 'heading-xl'
+		| 'heading-lg'
+		| 'heading-md'
+		| 'heading-sm'
+		| 'body-xl'
+		| 'body-lg'
+		| 'body-md'
+		| 'body-sm';
+
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: React.ReactNode;
+}


### PR DESCRIPTION
<img width="1045" height="617" alt="Screenshot 2026-02-24 at 14 05 38" src="https://github.com/user-attachments/assets/99ba7ed8-ddda-44ba-b96f-b48b52986ad4" />

## What

Adds a primitive `Text` component to `@wordpress/ui` with 9 predefined typographic variants:

| Variant | Size | Line height | Weight | Extra |
|---|---|---|---|---|
| `heading-2xl` | 32px | 40px | medium | |
| `heading-xl` | 20px | 24px | medium | |
| `heading-lg` | 15px | 20px | medium | |
| `heading-md` | 13px | 20px | medium | |
| `heading-sm` | 11px | 16px | medium | uppercase |
| `body-xl` | 20px | 32px | regular | |
| `body-lg` | 15px | 24px | regular | |
| `body-md` | 13px | 20px | regular | |
| `body-sm` | 12px | 16px | regular | |

## Why

There's currently no standard way to render text with consistent typographic styles in `@wordpress/ui`. Components like Button and Badge each define their own typography inline, but for standalone text content (headings, paragraphs, captions), consumers have to manually compose the correct combination of font tokens. A dedicated `Text` component gives a single, token-backed API for this.

## How

- Follows the same component patterns established by `Badge` and `Stack`: `forwardRef`, `useRender`/`mergeProps` from `@base-ui/react`, CSS Modules with design tokens, and the `render` prop for element customization.
- Each variant maps to a CSS class that composes `--wpds-font-*` custom properties from `@wordpress/theme`. No inline style computation — all styles are static CSS.
- The API is intentionally minimal: `variant` (required) controls typography, `render` allows changing the HTML element (e.g., `render={<h1 />}`), and standard `className`/`children` props are passed through. No individual typography override props — consumers use CSS custom properties in their own stylesheets when overrides are needed.
- Includes Storybook stories for each variant, an overview of all variants, and a `render` prop example.

## Testing
* `npm run storybook`
* Observe new `Text` component at http://localhost:50240/?path=/docs/design-system-components-text--docs&args=variant:body-sm