### PR TITLE
ESLint: Add `no-ds-tokens` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -437,6 +437,13 @@ module.exports = {
 			extends: [ 'plugin:ssr-friendly/recommended' ],
 		},
 		{
+			files: [ 'packages/components/src/**' ],
+			excludedFiles: [ 'packages/components/src/**/@(test|stories)/**' ],
+			rules: {
+				'@wordpress/no-ds-tokens': 'error',
+			},
+		},
+		{
 			files: [
 				'packages/block-editor/src/**',
 				'packages/components/src/**',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -440,6 +440,9 @@ module.exports = {
 			files: [ 'packages/components/src/**' ],
 			excludedFiles: [ 'packages/components/src/**/@(test|stories)/**' ],
 			rules: {
+				// Disallow usage of Design System token CSS custom properties (`--wpds-*`)
+				// because the fallback injection in the build process is not compatible with Emotion files.
+				// Can be removed when there are no more Emotion files in the package.
 				'@wordpress/no-ds-tokens': 'error',
 			},
 		},

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added [`no-ds-tokens`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/eslint-plugin/docs/rules/no-ds-tokens.md) rule to disallow usage of Design System token CSS custom properties (`--wpds-*`).
+
 ## 24.2.0 (2026-02-18)
 
 ## 24.1.0 (2026-01-29)

--- a/packages/eslint-plugin/docs/rules/no-ds-tokens.md
+++ b/packages/eslint-plugin/docs/rules/no-ds-tokens.md
@@ -1,0 +1,35 @@
+# Disallow usage of Design System tokens (no-ds-tokens)
+
+Disallows any usage of Design System token CSS custom properties (beginning with `--wpds-`) in string literals and template literals.
+
+This is useful in contexts where Design System tokens should not be referenced directly. It is not included in any preset and must be explicitly enabled.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```js
+const style = 'color: var(--wpds-color-fg-content-neutral)';
+```
+
+```js
+const style = `border: 1px solid var(--wpds-border-color)`;
+```
+
+```jsx
+<div style={ { color: 'var(--wpds-color-fg-content-neutral)' } } />
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const style = 'color: var(--my-custom-prop)';
+```
+
+```js
+const style = `border: 1px solid var(--other-prefix-token)`;
+```
+
+```jsx
+<div style={ { color: 'blue' } } />
+```

--- a/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
+++ b/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
@@ -1,0 +1,62 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-ds-tokens';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+} );
+
+ruleTester.run( 'no-ds-tokens', rule, {
+	valid: [
+		{
+			code: `const style = 'color: var(--my-custom-prop)';`,
+		},
+		{
+			code: `const style = 'color: blue';`,
+		},
+		{
+			code: 'const style = `border: 1px solid var(--other-prefix-token)`;',
+		},
+		{
+			code: `<div style={ { color: 'var(--my-custom-prop)' } } />`,
+		},
+	],
+	invalid: [
+		{
+			code: `const style = 'color: var(--wpds-color-fg-content-neutral)';`,
+			errors: [
+				{
+					messageId: 'disallowed',
+				},
+			],
+		},
+		{
+			code: 'const style = `color: var(--wpds-color-fg-content-neutral)`;',
+			errors: [
+				{
+					messageId: 'disallowed',
+				},
+			],
+		},
+		{
+			code: `<div style={ { color: 'var(--wpds-color-fg-content-neutral)' } } />`,
+			errors: [
+				{
+					messageId: 'disallowed',
+				},
+			],
+		},
+		{
+			code: 'const style = `border: 1px solid var(--wpds-border-color, var(--wpds-border-fallback))`;',
+			errors: [
+				{
+					messageId: 'disallowed',
+				},
+			],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
+++ b/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
@@ -58,5 +58,21 @@ ruleTester.run( 'no-ds-tokens', rule, {
 				},
 			],
 		},
+		{
+			code: `const token = '--wpds-color-fg';`,
+			errors: [
+				{
+					messageId: 'disallowed',
+				},
+			],
+		},
+		{
+			code: 'const style = `--wpds-color-fg: red`;',
+			errors: [
+				{
+					messageId: 'disallowed',
+				},
+			],
+		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
+++ b/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
@@ -22,6 +22,9 @@ ruleTester.run( 'no-ds-tokens', rule, {
 			code: 'const style = `border: 1px solid var(--other-prefix-token)`;',
 		},
 		{
+			code: `const name = 'something--wpds-color';`,
+		},
+		{
 			code: `<div style={ { color: 'var(--my-custom-prop)' } } />`,
 		},
 	],

--- a/packages/eslint-plugin/rules/no-ds-tokens.js
+++ b/packages/eslint-plugin/rules/no-ds-tokens.js
@@ -1,0 +1,29 @@
+const DS_TOKEN_PREFIX = 'wpds-';
+
+const wpdsTokensRegex = new RegExp( `[^\\w]--${ DS_TOKEN_PREFIX }`, 'i' );
+
+module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow any usage of --wpds-* CSS custom properties',
+		},
+		schema: [],
+		messages: {
+			disallowed:
+				'Design System tokens (--wpds-*) should not be used in this context.',
+		},
+	},
+	create( context ) {
+		const selector = `:matches(Literal[value=${ wpdsTokensRegex }], TemplateLiteral TemplateElement[value.raw=${ wpdsTokensRegex }])`;
+		return {
+			/** @param {import('estree').Literal | import('estree').TemplateElement} node */
+			[ selector ]( node ) {
+				context.report( {
+					node,
+					messageId: 'disallowed',
+				} );
+			},
+		};
+	},
+} );

--- a/packages/eslint-plugin/rules/no-ds-tokens.js
+++ b/packages/eslint-plugin/rules/no-ds-tokens.js
@@ -1,6 +1,6 @@
 const DS_TOKEN_PREFIX = 'wpds-';
 
-const wpdsTokensRegex = new RegExp( `[^\\w]--${ DS_TOKEN_PREFIX }`, 'i' );
+const wpdsTokensRegex = new RegExp( `(?:^|[^\\w])--${ DS_TOKEN_PREFIX }`, 'i' );
 
 module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 	meta: {


### PR DESCRIPTION
## What?

Adds a new `@wordpress/no-ds-tokens` ESLint rule that disallows any usage of `--wpds-*` CSS custom properties in string literals and template literals.

Enables it in our repo for `packages/components/src` only.

## Why?

The design token fallback build plugins (#75589) can't inject fallbacks into Emotion files due to a conflict between the esbuild token fallback plugin's `onLoad` hook and the Emotion Babel plugin — only one can handle a given file. This means any `--wpds-*` tokens used in Emotion styles would render without fallback values, breaking in environments where the `@wordpress/theme` stylesheet isn't available.

This lint rule prevents tokens from being introduced into code that the fallback plugins can't reach. Of course, it could also be used when you want to ban design tokens in certain files, for whatever reason.

In terms of the eslint config for our repo, we target all non-story and non-test files in the `@wordpress/components` package. Technically, it's safe to use them in JS files as long as they don't include Emotion, but here we ban them categorically for simplicity.

## How?

- New rule in `@wordpress/eslint-plugin` matching `--wpds-*` patterns in `Literal` and `TemplateElement` AST nodes. Added to the shared package rather than as a repo-local rule since it could be useful for third-party consumers in specific contexts as well.
- Rule doc at `packages/eslint-plugin/docs/rules/no-ds-tokens.md` (not listed in the README yet since DS tokens aren't publicly documented).
- The rule is not included in any preset and must be explicitly enabled. Enabled via an override in `.eslintrc.js` scoped to `packages/components/src/**`, excluding tests and stories.

## Testing Instructions

1. Run `npm run test:unit -- packages/eslint-plugin/rules/__tests__/no-ds-tokens.js --no-coverage` — all tests should pass.
2. Verify the rule is active: add `color: var(--wpds-color-fg-content-neutral)` to a template literal in any file under `packages/components/src/` and confirm that ESLint reports an error.