### PR TITLE
Theme: Remove global design tokens stylesheet

### DIFF
--- a/packages/theme/src/style.scss
+++ b/packages/theme/src/style.scss
@@ -1,6 +1,0 @@
-/**
- * WordPress Design System theme styles.
- * This exports the design tokens (CSS custom properties) for use across WordPress packages.
- */
-
-@use "./prebuilt/css/design-tokens.css";


### PR DESCRIPTION
Fix (part 2/2) for https://core.trac.wordpress.org/ticket/64698
⚠️ Merge after #75589

## What?

Removes the `@wordpress/theme` SCSS entry point (`style.scss`) so the package no longer registers a `wp-theme` style handle.

Basically a revert of #74743.

## Why?

With the build-time fallback injection from #75589, design tokens are baked directly into component CSS as `var()` fallback values. This makes the standalone design tokens stylesheet unnecessary as a global — components render correctly with or without it.

Shipping the stylesheet as a registered WP global also implies a public API surface that we're not ready to commit to for this release. Without removing this style handle, the tokens are indeed loaded into many app pages, such as the Site Editor.

## How?

Deletes `packages/theme/src/style.scss`, which previously re-exported `prebuilt/css/design-tokens.css`. Without an SCSS entry point, `compileStyles` produces no output, so no `wp-theme` style handle is registered and no other packages infer it as a style dependency.

Note: a clean build (or removing stale `packages/theme/build-style/` and `build/styles/theme/`) is needed after this change, since the build system doesn't clean previous outputs.

## Testing Instructions

1. Clean stale build artifacts: `rm -rf packages/theme/build-style build/styles/theme`
2. Rebuild: `npm run build`
3. Verify `build/styles/registry.php` has no `wp-theme` entry, and no other style lists `wp-theme` in its dependencies.
4. Open the site editor — styles should load normally. The design tokens stylesheet should not appear in DevTools. An exception is when you have the "Extensible Site Editor" experiment enabled in Gutenberg ▸ Experiments. This loads the tokens through a backdoor, not through the `wp-theme` style handle:

    https://github.com/WordPress/gutenberg/blob/0180c417fc4d2e704f3f8738ed09703ebeeda189/packages/boot/src/style.scss#L1