### PR TITLE
Real-time collaboration: Remove ghost awareness state explicitly when refreshing

### DIFF
--- a/backport-changelog/7.0/11049.md
+++ b/backport-changelog/7.0/11049.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11049
+
+* https://github.com/WordPress/gutenberg/pull/75883

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				),
 				'awareness' => array(
 					'required' => true,
-					'type'     => 'object',
+					'type'     => array( 'object', 'null' ),
 				),
 				'client_id' => array(
 					'minimum'  => 1,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -25,6 +25,7 @@ import {
 	createSyncUpdate,
 	createUpdateQueue,
 	postSyncUpdate,
+	sendDisconnect,
 } from './utils';
 
 const POLLING_INTERVAL_IN_MS = 1000; // 1 second or 1000 milliseconds
@@ -240,6 +241,22 @@ function processDocUpdate(
 
 let isPolling = false;
 let pollInterval = POLLING_INTERVAL_IN_MS;
+let pageHideListenerRegistered = false;
+
+/**
+ * Send a disconnect signal for all registered rooms when the page is
+ * being unloaded. Uses `sendBeacon` so the request survives navigation.
+ */
+function handlePageHide(): void {
+	const rooms = Array.from( roomStates.entries() ).map(
+		( [ room, state ] ) => ( {
+			room,
+			clientId: state.clientId,
+		} )
+	);
+
+	sendDisconnect( rooms );
+}
 
 function poll(): void {
 	isPolling = true;
@@ -394,7 +411,6 @@ function registerRoom( {
 	function unregister(): void {
 		doc.off( 'update', onDocUpdate );
 		awareness.off( 'change', onAwarenessUpdate );
-		// TODO: poll will null awareness state to trigger removal
 		updateQueue.clear();
 	}
 
@@ -421,14 +437,30 @@ function registerRoom( {
 	awareness.on( 'change', onAwarenessUpdate );
 	roomStates.set( room, roomState );
 
+	if ( ! pageHideListenerRegistered ) {
+		window.addEventListener( 'pagehide', handlePageHide );
+		pageHideListenerRegistered = true;
+	}
+
 	if ( ! isPolling ) {
 		poll();
 	}
 }
 
 function unregisterRoom( room: string ): void {
-	roomStates.get( room )?.unregister();
-	roomStates.delete( room );
+	const state = roomStates.get( room );
+	if ( state ) {
+		// Send a disconnect signal so the server removes this client's
+		// awareness entry immediately instead of waiting for the timeout.
+		sendDisconnect( [ { room, clientId: state.clientId } ] );
+		state.unregister();
+		roomStates.delete( room );
+	}
+
+	if ( roomStates.size === 0 && pageHideListenerRegistered ) {
+		window.removeEventListener( 'pagehide', handlePageHide );
+		pageHideListenerRegistered = false;
+	}
 }
 
 export const pollingManager: PollingManager = {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -25,7 +25,7 @@ import {
 	createSyncUpdate,
 	createUpdateQueue,
 	postSyncUpdate,
-	sendDisconnect,
+	postSyncUpdateNonBlocking,
 } from './utils';
 
 const POLLING_INTERVAL_IN_MS = 1000; // 1 second or 1000 milliseconds
@@ -250,12 +250,15 @@ let pageHideListenerRegistered = false;
 function handlePageHide(): void {
 	const rooms = Array.from( roomStates.entries() ).map(
 		( [ room, state ] ) => ( {
+			after: 0,
+			awareness: null,
+			client_id: state.clientId,
 			room,
-			clientId: state.clientId,
+			updates: [],
 		} )
 	);
 
-	sendDisconnect( rooms );
+	postSyncUpdateNonBlocking( { rooms } );
 }
 
 function poll(): void {
@@ -452,7 +455,17 @@ function unregisterRoom( room: string ): void {
 	if ( state ) {
 		// Send a disconnect signal so the server removes this client's
 		// awareness entry immediately instead of waiting for the timeout.
-		sendDisconnect( [ { room, clientId: state.clientId } ] );
+		const rooms = [
+			{
+				after: 0,
+				awareness: null,
+				client_id: state.clientId,
+				room,
+				updates: [],
+			},
+		];
+
+		postSyncUpdateNonBlocking( { rooms } );
 		state.unregister();
 		roomStates.delete( room );
 	}

--- a/packages/sync/src/providers/http-polling/utils.ts
+++ b/packages/sync/src/providers/http-polling/utils.ts
@@ -127,38 +127,17 @@ export async function postSyncUpdate(
 	return await response.json();
 }
 
-interface DisconnectRoom {
-	room: string;
-	clientId: number;
-}
-
 /**
- * Send a fire-and-forget disconnect signal for the given rooms so the
- * server can immediately remove the client's awareness entries.
+ * Fire-and-forget variant of postSyncUpdate. Uses `keepalive` so the
+ * request survives page unload, and errors are silently ignored.
  *
- * @param rooms Rooms to disconnect from, with their client IDs.
+ * @param payload The sync payload to send.
  */
-export function sendDisconnect( rooms: DisconnectRoom[] ): void {
-	if ( rooms.length === 0 ) {
+export function postSyncUpdateNonBlocking( payload: SyncPayload ): void {
+	if ( payload.rooms.length === 0 ) {
 		return;
 	}
 
-	const payload: SyncPayload = {
-		rooms: rooms.map( ( { room, clientId } ) => ( {
-			after: 0,
-			awareness: null,
-			client_id: clientId,
-			room,
-			updates: [],
-		} ) ),
-	};
-
-	// Fire-and-forget: keepalive: true ensures the request completes even
-	// during pagehide. We intentionally ignore the response and any
-	// errors (e.g. expired nonce on a stale tab).
-	//
-	// In the worst case, the server will clean up the awareness entries after
-	// a timeout anyway.
 	apiFetch( {
 		body: JSON.stringify( payload ),
 		headers: { 'Content-Type': 'application/json' },

--- a/packages/sync/src/providers/http-polling/utils.ts
+++ b/packages/sync/src/providers/http-polling/utils.ts
@@ -126,3 +126,45 @@ export async function postSyncUpdate(
 
 	return await response.json();
 }
+
+interface DisconnectRoom {
+	room: string;
+	clientId: number;
+}
+
+/**
+ * Send a fire-and-forget disconnect signal for the given rooms so the
+ * server can immediately remove the client's awareness entries.
+ *
+ * @param rooms Rooms to disconnect from, with their client IDs.
+ */
+export function sendDisconnect( rooms: DisconnectRoom[] ): void {
+	if ( rooms.length === 0 ) {
+		return;
+	}
+
+	const payload: SyncPayload = {
+		rooms: rooms.map( ( { room, clientId } ) => ( {
+			after: 0,
+			awareness: null,
+			client_id: clientId,
+			room,
+			updates: [],
+		} ) ),
+	};
+
+	// Fire-and-forget: keepalive: true ensures the request completes even
+	// during pagehide. We intentionally ignore the response and any
+	// errors (e.g. expired nonce on a stale tab).
+	//
+	// In the worst case, the server will clean up the awareness entries after
+	// a timeout anyway.
+	apiFetch( {
+		body: JSON.stringify( payload ),
+		headers: { 'Content-Type': 'application/json' },
+		keepalive: true,
+		method: 'POST',
+		parse: false,
+		path: SYNC_API_PATH,
+	} ).catch( () => {} );
+}


### PR DESCRIPTION
## What?

This PR explicitly disconnects users from awareness when the page is refreshed or otherwise navigated using the browser `pagehide` event.

## Why?

When refreshing the page in real-time collaboration, the previous session's cursor stays around for a while. This can lead to confusion from ghost collaborators from the same user and have a negative visual impact:

https://github.com/user-attachments/assets/1fa5b497-b907-4ade-8929-8bdc21368043

*Clicking into a post and refreshing quickly creates several ghost users and cursors in `trunk`*

## How?

This PR explicitly sends a disconnect signal (`null` awareness update) on `pagehide`. [From MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event):

> If you're specifically trying to detect page unload events, the `pagehide` event is the best option.

The documentation above notes that this behavior works differently on mobile, but only in the way that it will NOT be explicitly fired if a user force-closes a browser in the background. This is fine, since awareness state will automatically be cleared out [after a 30-second interval](https://github.com/Automattic/gutenberg/blob/fbdf761b6cefccaaa867dc05f459f8137b1f4072/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php#L25-L32) anyway.

---

We also `apiFetch()` with the `keepalive: true` option, which [according to documentation](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive):

> This enables a [fetch()](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) request to, for example, send analytics at the end of a session even if the user navigates away from or closes the page.

The naming is a bit confusing but `keepalive: true` means the disconnect request can finish independent of the current page, so it's non-blocking to a refresh or navigation.

## Testing Instructions

1. Check out this PR.
2. Ensure real-time collaboration is enabled via: WordPress Admin -> Settings -> Writing, and check the "Enable real-time collaboration" checkbox. Click the "Save Changes" button.
3. Open a post with two separate users in two tabs.
4. As user A, rapidly click into post content and refresh a few times.
5. You should observe that as user A you do not see ghost cursors persist from previous sessions. It's possible that if a disconnect signal takes a while you may see a prior cursor for up to 5 seconds, but much less than before.
6. As user B, you should see ghost cursors disappear after 5 seconds.

## Screenshots

Here is the same demo as above but performed within this PR:

https://github.com/user-attachments/assets/4615b0e6-00f8-4c98-a365-f4784d6202c0

I've also included a second user to see what this looks like to a third-party observer watching the same post.

Above we can see that user A (the left-hand side) never sees their cursor reappear, as their awareness data is removed during the refresh and no longer present after loading. User B has a [short grace period](https://github.com/Automattic/gutenberg/blob/fbdf761b6cefccaaa867dc05f459f8137b1f4072/packages/core-data/src/awareness/awareness-state.ts#L177-L184) for ghost cursors (5 seconds) before duplicate cursors are removed. This could be further improved but is relatively minor.