### PR TITLE
Search Block: Corrects style selectors when global styles are set.

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -91,6 +91,15 @@
 		},
 		"html": false
 	},
+	"selectors": {
+		"root": ".wp-block-search",
+		"color": {
+			"root": ".wp-block-search__button"
+		},
+		"border": {
+			"root": ".wp-block-search__input, .wp-block-search__button"
+		}
+	},
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Search Block: Corrects style selectors when global styles are set.
Similar #75724

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Search block renders styles to using `__experimentalSkipSerialization`, so the global style `selectors` will also match.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Changes the global style for site editor Search.
2. You'll see that the default styles are now rendered correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="1920" height="1050" alt="before-search" src="https://github.com/user-attachments/assets/0ca3a93d-37d3-4577-b54f-26d14cc644c6" />


### After
<img width="1920" height="1050" alt="after-search" src="https://github.com/user-attachments/assets/0c1e7583-ae39-4544-9fc6-da9f577c5841" />

