### PR TITLE
DataViews Grid and Picker Grid: Add density option for gap between items

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -7,6 +7,10 @@
 - DataViews: Fix last column classname in table layout. [#76133](https://github.com/WordPress/gutenberg/pull/76133)
 - DataForm: Properly handle dates in datetime control. [#76193](https://github.com/WordPress/gutenberg/pull/76193)
 
+### Enhancements
+
+- DataViews: Add density option to Grid and PickerGrid layouts. [#75887](https://github.com/WordPress/gutenberg/pull/75887)
+
 ### Code Quality
 
 - DataForm: Consolidate `date` and `datetime` input placement. [#76136](https://github.com/WordPress/gutenberg/pull/76136)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -240,7 +240,7 @@ Properties:
 
 | Props / Layout | `table` | `pickerTable` | `grid` | `pickerGrid` | `list` | `activity` |
 | -------------- | ------- | ------------- | ------ | ------------ | ------ | ---------- |
-| `density`      | ✓       | ✓             |        |              | ✓      | ✓          |
+| `density`      | ✓       | ✓             | ✓      | ✓            | ✓      | ✓          |
 | `enableMoving` | ✓       | ✓             |        |              |        |            |
 | `styles`       | ✓       | ✓             |        |              |        |            |
 | `badgeFields`  |         |               | ✓      | ✓            |        |            |
@@ -258,6 +258,7 @@ Right-align (`'end'`) whenever the cell value is fundamentally quantitative—nu
 `grid` and `pickerGrid` layout:
 
 -   `badgeFields`: a list of field's `id` to render without label and styled as badges.
+-   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the gap between items in the grid.
 -   `previewSize`: a `number` representing the size of the preview.
 
 `list` layout:

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -372,7 +372,13 @@ export default function CompositeGrid< Item >( {
 	return (
 		<Composite
 			role={ isInfiniteScroll ? 'feed' : 'grid' }
-			className={ clsx( 'dataviews-view-grid', className ) }
+			className={ clsx( 'dataviews-view-grid', className, {
+				[ `has-${ view.layout?.density }-density` ]:
+					view.layout?.density &&
+					[ 'compact', 'comfortable' ].includes(
+						view.layout.density
+					),
+			} ) }
 			focusWrap
 			aria-busy={ isLoading }
 			aria-rowcount={ isInfiniteScroll ? undefined : totalRows }

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -9,7 +9,7 @@
 	padding: 0 $grid-unit-30 $grid-unit-30;
 	display: flex;
 	flex-direction: column;
-	gap: $grid-unit-40;
+	gap: $grid-unit-30;
 	container-type: inline-size;
 	margin-bottom: auto;
 
@@ -26,16 +26,16 @@
 	}
 
 	&.has-comfortable-density {
-		gap: $grid-unit-50;
+		gap: $grid-unit-40;
 
 		.dataviews-view-grid__row {
-			gap: $grid-unit-50;
+			gap: $grid-unit-40;
 		}
 	}
 
 	.dataviews-view-grid__row {
 		display: grid;
-		gap: $grid-unit-40;
+		gap: $grid-unit-30;
 
 		.dataviews-view-grid__row__gridcell {
 			border-radius: $radius-medium;

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -17,6 +17,22 @@
 		transition: padding ease-out 0.1s;
 	}
 
+	&.has-compact-density {
+		gap: $grid-unit-20;
+
+		.dataviews-view-grid__row {
+			gap: $grid-unit-20;
+		}
+	}
+
+	&.has-comfortable-density {
+		gap: $grid-unit-50;
+
+		.dataviews-view-grid__row {
+			gap: $grid-unit-50;
+		}
+	}
+
 	.dataviews-view-grid__row {
 		display: grid;
 		gap: $grid-unit-40;

--- a/packages/dataviews/src/components/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/index.ts
@@ -27,8 +27,8 @@ import {
 	LAYOUT_PICKER_GRID,
 	LAYOUT_PICKER_TABLE,
 } from '../../constants';
-import PreviewSizePicker from './utils/preview-size-picker';
 import DensityPicker from './utils/density-picker';
+import GridConfigOptions from './utils/grid-config-options';
 
 export const VIEW_LAYOUTS = [
 	{
@@ -43,7 +43,7 @@ export const VIEW_LAYOUTS = [
 		label: __( 'Grid' ),
 		component: ViewGrid,
 		icon: category,
-		viewConfigOptions: PreviewSizePicker,
+		viewConfigOptions: GridConfigOptions,
 	},
 	{
 		type: LAYOUT_LIST,
@@ -64,7 +64,7 @@ export const VIEW_LAYOUTS = [
 		label: __( 'Grid' ),
 		component: ViewPickerGrid,
 		icon: category,
-		viewConfigOptions: PreviewSizePicker,
+		viewConfigOptions: GridConfigOptions,
 		isPicker: true,
 	},
 	{

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -336,7 +336,14 @@ function ViewPickerGrid< Item >( {
 						aria-multiselectable={ isMultiselect }
 						className={ clsx(
 							'dataviews-view-picker-grid',
-							className
+							className,
+							{
+								[ `has-${ view.layout?.density }-density` ]:
+									view.layout?.density &&
+									[ 'compact', 'comfortable' ].includes(
+										view.layout.density
+									),
+							}
 						) }
 						aria-label={ itemListLabel }
 						render={ ( { children, ...props } ) => (
@@ -421,7 +428,15 @@ function ViewPickerGrid< Item >( {
 							<GridItems
 								className={ clsx(
 									'dataviews-view-picker-grid',
-									className
+									className,
+									{
+										[ `has-${ view.layout?.density }-density` ]:
+											view.layout?.density &&
+											[
+												'compact',
+												'comfortable',
+											].includes( view.layout.density ),
+									}
 								) }
 								previewSize={ usedPreviewSize }
 								aria-busy={ isLoading }

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	&.has-comfortable-density .dataviews-view-grid-items {
-		gap: $grid-unit-50;
+		gap: $grid-unit-40;
 	}
 
 	.dataviews-view-picker-grid__card {

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
@@ -5,6 +5,16 @@
 @use "../utils/grid-items.scss" as *;
 
 .dataviews-view-picker-grid {
+	// When grouped, the density class is on the parent Composite,
+	// and the gap is on child .dataviews-view-grid-items elements.
+	&.has-compact-density .dataviews-view-grid-items {
+		gap: $grid-unit-20;
+	}
+
+	&.has-comfortable-density .dataviews-view-grid-items {
+		gap: $grid-unit-50;
+	}
+
 	.dataviews-view-picker-grid__card {
 		height: 100%;
 		justify-content: flex-start;

--- a/packages/dataviews/src/components/dataviews-layouts/utils/density-picker.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/density-picker.tsx
@@ -12,11 +12,21 @@ import { useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import DataViewsContext from '../../dataviews-context';
-import type { ViewTable, ViewList, Density } from '../../../types';
+import type {
+	ViewTable,
+	ViewList,
+	ViewGrid,
+	ViewPickerGrid,
+	Density,
+} from '../../../types';
 
 export default function DensityPicker() {
 	const context = useContext( DataViewsContext );
-	const view = context.view as ViewTable | ViewList;
+	const view = context.view as
+		| ViewTable
+		| ViewList
+		| ViewGrid
+		| ViewPickerGrid;
 	return (
 		<ToggleGroupControl
 			size="__unstable-large"

--- a/packages/dataviews/src/components/dataviews-layouts/utils/grid-config-options.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/grid-config-options.tsx
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import DensityPicker from './density-picker';
+import PreviewSizePicker from './preview-size-picker';
+
+export default function GridConfigOptions() {
+	return (
+		<>
+			<DensityPicker />
+			<PreviewSizePicker />
+		</>
+	);
+}

--- a/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.scss
@@ -3,7 +3,7 @@
 .dataviews-view-grid-items {
 	margin-bottom: auto;
 	display: grid;
-	gap: $grid-unit-40;
+	gap: $grid-unit-30;
 	grid-template-rows: max-content;
 	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
 	padding: 0 $grid-unit-30 $grid-unit-30;
@@ -18,6 +18,6 @@
 	}
 
 	&.has-comfortable-density {
-		gap: $grid-unit-50;
+		gap: $grid-unit-40;
 	}
 }

--- a/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.scss
@@ -12,4 +12,12 @@
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;
 	}
+
+	&.has-compact-density {
+		gap: $grid-unit-20;
+	}
+
+	&.has-comfortable-density {
+		gap: $grid-unit-50;
+	}
 }

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -285,6 +285,11 @@ export interface ViewGrid extends ViewBase {
 		 * The preview size of the grid.
 		 */
 		previewSize?: number;
+
+		/**
+		 * The density of the grid layout.
+		 */
+		density?: Density;
 	};
 }
 
@@ -301,6 +306,11 @@ export interface ViewPickerGrid extends ViewBase {
 		 * The preview size of the grid.
 		 */
 		previewSize?: number;
+
+		/**
+		 * The density of the grid layout.
+		 */
+		density?: Density;
 	};
 }
 

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -186,7 +186,7 @@ export function MediaUploadModal( {
 		mediaField: 'media_thumbnail',
 		search: '',
 		page: 1,
-		perPage: 20,
+		perPage: 50,
 		filters: [],
 		layout: {
 			previewSize: 170,

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -190,6 +190,7 @@ export function MediaUploadModal( {
 		filters: [],
 		layout: {
 			previewSize: 170,
+			density: 'compact',
 		},
 	} ) );
 


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73085

Add a `density` option for gap between items in the DataViews Grid and Picker Grid layouts

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in testing feedback in #73085 (media interaction in a modal), the experimental media library modal's gap is currently much bigger than the existing core media library. In order to support folks browsing media with a small preview and lots of items on the page, it'd be good to support a smaller gap between the items.

There are many ways to achieve this, but since we already have a `density` option in other layout types, I thought it'd be worth a try to see how it feels adding this to Grid and Picker Grid, but for it to control the gap between items.

It didn't seem very complex to add it in, and I imagine this is preferable to a separate `gap` concept, but keen to hear what others think.

The overall goal is to support viewing lots of items all at once, with minimal spacing between items, while still supporting large previews and larger gaps.

## How?

* Add the `DensityPicker` to the `viewConfigOptions` for both the Grid and Picker Grid layouts.
* Create a parent `GridConfigOptions` that bundles the `DensityPicker` with the `PreviewSizePicker`
* Output classnames for `compact` and `comfortable` densities, treating `balanced` as the default
* For now I've gone with the following for the pixel sizes of the gaps:

| Density | Gap variable | Pixels |
|---------|-------------|--------|
| Compact | `$grid-unit-20` | 16px |
| Balanced (default) | `$grid-unit-30` | 24px |
| Comfortable | `$grid-unit-40` | 32px |

All of this is up for debate as to whether we think this is a good path of course, keen for feedback on it! It's also fairly low priority in the grand scheme of things, so not urgent to look at.

## Testing Instructions

You can test this out in Storybook (`npm run storybook:dev`) for any of the Layout Grid or Picker Grid stories.

Or, you can try it in the media modal via enabling the experiment:

<img width="957" height="73" alt="image" src="https://github.com/user-attachments/assets/dd5d93bb-0a09-4ec3-8795-3fc18e7405d4" />

Then, go to edit a post or page and add a featured image. Go to the cog / settings dropdown and play around with the toggles.

## Screenshots or screencast <!-- if applicable -->

DataViews Grid

https://github.com/user-attachments/assets/8614be22-e816-47dd-b1bd-2d55eeca03c2

DataViews Picker Grid (in a modal):

https://github.com/user-attachments/assets/2722bba8-7d5f-4e25-a103-3cc66b2d3b24