### PR TITLE
Fix: Page List block: Editor-only div inside page links causes misalignment in Firefox

### DIFF
--- a/packages/block-library/src/page-list-item/edit.js
+++ b/packages/block-library/src/page-list-item/edit.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { RawHTML } from '@wordpress/element';
 import { safeHTML } from '@wordpress/dom';
 
 /**
@@ -78,9 +77,10 @@ export default function PageListItemEdit( { context, attributes } ) {
 						type="button"
 						className="wp-block-navigation-item__content wp-block-navigation-submenu__toggle"
 						aria-expanded="false"
-					>
-						<RawHTML>{ safeHTML( label ) }</RawHTML>
-					</button>
+						dangerouslySetInnerHTML={ {
+							__html: safeHTML( label ),
+						} }
+					/>
 					<span className="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon">
 						<ItemSubmenuIcon />
 					</span>
@@ -91,9 +91,10 @@ export default function PageListItemEdit( { context, attributes } ) {
 						'wp-block-navigation-item__content': isNavigationChild,
 					} ) }
 					href={ link }
-				>
-					<RawHTML>{ safeHTML( title ) }</RawHTML>
-				</a>
+					dangerouslySetInnerHTML={ {
+						__html: safeHTML( title ),
+					} }
+				/>
 			) }
 			{ hasChildren && (
 				<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75882

Replace `RawHTML` with `dangerouslySetInnerHTML` + `safeHTML` for rendering page titles and labels in the `PageListItemEdit` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
RawHTML wraps content in an extra `<div>`. This causes a layout mismatch between editor and frontend, leading to misalignment issues in Firefox. Using dangerouslySetInnerHTML with safeHTML renders content directly on the element without extra wrappers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaced <RawHTML>{ safeHTML( label ) }</RawHTML> and <RawHTML>{ safeHTML( title ) }</RawHTML> with dangerouslySetInnerHTML={{ __html: safeHTML(...) }} directly on the <button> and <a> elements.

## Testing Instructions
1. Create a few pages with parent-child relationships.
2. Create a post/page with the Page List block and check the layout.

|Before|After|
|-|-|
|<img width="1470" height="878" alt="Screenshot 2026-02-25 at 11 06 59 AM" src="https://github.com/user-attachments/assets/937f73a0-1d91-4b5d-a5e9-c97e3fc12b64" />|<img width="1469" height="876" alt="Screenshot 2026-02-25 at 11 07 31 AM" src="https://github.com/user-attachments/assets/57c59d05-eda8-4e1c-8db4-9accb6dc2d09" />|
