### PR TITLE
Accordion: Remove Down Arrow, Up Arrow, Home, End navigation

### DIFF
--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -40,7 +40,6 @@ function block_core_accordion_item_render( $attributes, $content ) {
 
 		if ( $p->next_tag( array( 'class_name' => 'wp-block-accordion-heading__toggle' ) ) ) {
 			$p->set_attribute( 'data-wp-on--click', 'actions.toggle' );
-			$p->set_attribute( 'data-wp-on--keydown', 'actions.handleKeyDown' );
 			$p->set_attribute( 'id', $unique_id );
 			$p->set_attribute( 'aria-controls', $unique_id . '-panel' );
 			$p->set_attribute( 'data-wp-bind--aria-expanded', 'state.isOpen' );

--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, withSyncEvent } from '@wordpress/interactivity';
+import { store, getContext } from '@wordpress/interactivity';
 
 // Whether the hash has been handled for the current page load.
 // This is used to prevent the hash from being handled multiple times.
@@ -36,49 +36,6 @@ const { actions } = store(
 					accordionItem.isOpen = ! accordionItem.isOpen;
 				}
 			},
-			handleKeyDown: withSyncEvent( ( event ) => {
-				if (
-					event.key !== 'ArrowUp' &&
-					event.key !== 'ArrowDown' &&
-					event.key !== 'Home' &&
-					event.key !== 'End'
-				) {
-					return;
-				}
-
-				event.preventDefault();
-				const context = getContext();
-				const { id, accordionItems } = context;
-				const currentIndex = accordionItems.findIndex(
-					( item ) => item.id === id
-				);
-
-				let nextIndex;
-
-				switch ( event.key ) {
-					case 'ArrowUp':
-						nextIndex = Math.max( 0, currentIndex - 1 );
-						break;
-					case 'ArrowDown':
-						nextIndex = Math.min(
-							currentIndex + 1,
-							accordionItems.length - 1
-						);
-						break;
-					case 'Home':
-						nextIndex = 0;
-						break;
-					case 'End':
-						nextIndex = accordionItems.length - 1;
-						break;
-				}
-
-				const nextId = accordionItems[ nextIndex ].id;
-				const nextButton = document.getElementById( nextId );
-				if ( nextButton ) {
-					nextButton.focus();
-				}
-			} ),
 			openPanelByHash: () => {
 				if ( hashHandled || ! window.location?.hash?.length ) {
 					return;


### PR DESCRIPTION
- Fixes: #75873
- Related to #71786

cc @druxstr

## What?

We've found that the following keyboard navigations can cause accessibility issues in the Accordion block:

  - Down arrow: move focus to the next accordion header
  - Up arrow: Move focus to the previous accordion header
  - Home: Move focus to the first accordion header.
  - End: Move focus to the last accordion header.

We could enable these navigations only when the accordion is collapsed, but this could confuse users. Because these navigations are optional in the WAI pattern, we'll remove them completely.

Note that I've removed not only `Down arrow` and `Up arrow`, but also `Home` and `End`. These are also optional, and some users may want to use these keys to scroll the page.

## Testing Instructions

### Testing Instructions for Keyboard

1. Insert an Accordion block.
2. Open the page.
3. Focus any accordion header and press `Down arrow`, `Up arrow`, `Home`, or `End`.
4. Focus will not move.