### PR TITLE
Custom CSS: Prevent duplicate custom css styles

### DIFF
--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -95,6 +95,18 @@ function gutenberg_render_custom_css_class_name( $block_content, $block ) {
 	return $tags->get_updated_html();
 }
 
+// Remove core filters and action to avoid rendering duplicate custom CSS styles.
+if ( function_exists( 'wp_render_custom_css_class_name' ) ) {
+	remove_filter( 'render_block', 'wp_render_custom_css_class_name' );
+}
+if ( function_exists( 'wp_render_custom_css_support_styles' ) ) {
+	remove_filter( 'render_block_data', 'wp_render_custom_css_support_styles' );
+}
+if ( function_exists( 'wp_enqueue_block_custom_css' ) ) {
+	remove_action( 'wp_enqueue_scripts', 'wp_enqueue_block_custom_css' );
+}
+
+// Add Gutenberg filters and action.
 add_filter( 'render_block', 'gutenberg_render_custom_css_class_name', 10, 2 );
 add_filter( 'render_block_data', 'gutenberg_render_custom_css_support_styles', 10, 1 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_block_custom_css', 1 );


### PR DESCRIPTION
## What?

Removes core WordPress custom CSS block support filters and action before registering Gutenberg's replacements.

## Why?

PR #75799 introduced Gutenberg-prefixed versions of the custom CSS block support functions (`gutenberg_render_custom_css_support_styles`, `gutenberg_render_custom_css_class_name`, `gutenberg_enqueue_block_custom_css`), but did not remove the corresponding core WordPress hooks (`wp_render_custom_css_support_styles`, `wp_render_custom_css_class_name`, `wp_enqueue_block_custom_css`). This results in both the core and Gutenberg versions running, producing duplicate custom CSS styles on the frontend.

## How?

Before registering the Gutenberg filters and action, remove the core equivalents using `remove_filter` / `remove_action`, guarded by `function_exists()` checks for backward compatibility with older WordPress versions where these functions may not exist.

This follows the established pattern used by other block supports in this directory, e.g., `block-style-variations.php`, `elements.php`, `layout.php`, and `duotone.php`.

## Testing Instructions

1. Activate the Gutenberg plugin.
2. Add a block (e.g., a Paragraph block) with custom CSS via the block's "Additional CSS" panel in the editor.
3. View the page on the frontend.
4. Inspect the page source — confirm the custom CSS styles appear only once, not duplicated.

## Screenshots

| Before | After |
|---|---|
| <img width="387" height="82" alt="Screenshot 2026-02-25 at 8 39 46 am" src="https://github.com/user-attachments/assets/7f3bbcaa-0efb-44bb-89be-84dcf07931f5" /> | <img width="385" height="62" alt="Screenshot 2026-02-25 at 8 40 27 am" src="https://github.com/user-attachments/assets/0748ca96-7409-46f1-898e-861755f03926" /> |
