### PR TITLE
DataViews: Remove menu divider again.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
 - DataViews: Fix search input losing characters during debounce when externally synced. [#75810](https://github.com/WordPress/gutenberg/pull/75810)
 - DataForm: Fix vertical alignment of summary fields in card layout. [#75864](https://github.com/WordPress/gutenberg/pull/75864)
+- DataViews: Remove visual divider between quick and regular actions in the actions menu. [#75893](https://github.com/WordPress/gutenberg/pull/75893)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -171,9 +171,6 @@ export function ActionsMenuGroup< Item >( {
 	return (
 		<Menu.Group>
 			{ renderActionGroup( primaryActions ) }
-			{ primaryActions.length > 0 && regularActions.length > 0 && (
-				<Menu.Separator />
-			) }
 			{ renderActionGroup( regularActions ) }
 		</Menu.Group>
 	);


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/issues/72840#issuecomment-3957770838.

Removes the divider that was separating quick actions from the remaining actions that was previously added in #72866, but keeps the change sort order. 

## Why?

The motivation seems valid: there's no clear semantic reason for why the separator is there. Intrinsically I understand why it's there, it separates quick actions from other actions, the hope was to explain why the same actions are available both as quick actions and in the menu. But in practice the separator mostly feels like a source of confusion.

## Testing Instructions

Try dataviews, click the ellipsis menu. Before:

<img width="409" height="533" alt="Screenshot 2026-02-25 at 10 05 11" src="https://github.com/user-attachments/assets/90a4fc35-c7a2-47f0-965d-31ac7279e924" />

After:

<img width="488" height="665" alt="Screenshot 2026-02-25 at 10 04 52" src="https://github.com/user-attachments/assets/e621108e-50b7-4137-bd5c-1413f881c6d9" />
