### PR TITLE
Fix flaky template-revert e2e tests

### DIFF
--- a/packages/editor/src/components/more-menu/copy-content-menu-item.js
+++ b/packages/editor/src/components/more-menu/copy-content-menu-item.js
@@ -6,8 +6,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
-import { store as coreStore } from '@wordpress/core-data';
-import { __unstableSerializeAndClean } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -16,26 +14,10 @@ import { store as editorStore } from '../../store';
 
 export default function CopyContentMenuItem() {
 	const { createNotice } = useDispatch( noticesStore );
-	const { getCurrentPostId, getCurrentPostType } = useSelect( editorStore );
-	const { getEditedEntityRecord } = useSelect( coreStore );
+	const { getEditedPostContent } = useSelect( editorStore );
 
 	function getText() {
-		const record = getEditedEntityRecord(
-			'postType',
-			getCurrentPostType(),
-			getCurrentPostId()
-		);
-		if ( ! record ) {
-			return '';
-		}
-
-		if ( typeof record.content === 'function' ) {
-			return record.content( record );
-		} else if ( record.blocks ) {
-			return __unstableSerializeAndClean( record.blocks );
-		} else if ( record.content ) {
-			return record.content;
-		}
+		return getEditedPostContent();
 	}
 
 	function onSuccess() {

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -8,8 +8,6 @@ import Textarea from 'react-autosize-textarea';
  */
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
-import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
@@ -26,33 +24,16 @@ import { store as editorStore } from '../../store';
  */
 export default function PostTextEditor() {
 	const instanceId = useInstanceId( PostTextEditor );
-	const { content, blocks, type, id } = useSelect( ( select ) => {
-		const { getEditedEntityRecord } = select( coreStore );
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		const _type = getCurrentPostType();
-		const _id = getCurrentPostId();
-		const editedRecord = getEditedEntityRecord( 'postType', _type, _id );
-
+	const { value, type, id } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId, getEditedPostContent } =
+			select( editorStore );
 		return {
-			content: editedRecord?.content,
-			blocks: editedRecord?.blocks,
-			type: _type,
-			id: _id,
+			value: getEditedPostContent(),
+			type: getCurrentPostType(),
+			id: getCurrentPostId(),
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( coreStore );
-	// Replicates the logic found in getEditedPostContent().
-	const value = useMemo( () => {
-		if ( content instanceof Function ) {
-			return content( { blocks } );
-		} else if ( blocks ) {
-			// If we have parsed blocks already, they should be our source of truth.
-			// Parsing applies block deprecations and legacy block conversions that
-			// unparsed content will not have.
-			return __unstableSerializeAndClean( blocks );
-		}
-		return content;
-	}, [ content, blocks ] );
 
 	return (
 		<>

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -238,28 +238,8 @@ class TemplateRevertUtils {
 	}
 
 	async getCurrentSiteEditorContent() {
-		return this.page.evaluate( () => {
-			const postId = window.wp.data
-				.select( 'core/editor' )
-				.getCurrentPostId();
-			const postType = window.wp.data
-				.select( 'core/editor' )
-				.getCurrentPostType();
-			const record = window.wp.data
-				.select( 'core' )
-				.getEditedEntityRecord( 'postType', postType, postId );
-			if ( record ) {
-				if ( typeof record.content === 'function' ) {
-					return record.content( record );
-				} else if ( record.blocks ) {
-					return window.wp.blocks.__unstableSerializeAndClean(
-						record.blocks
-					);
-				} else if ( record.content ) {
-					return record.content;
-				}
-			}
-			return '';
-		} );
+		return this.page.evaluate( () =>
+			window.wp.data.select( 'core/editor' ).getEditedPostContent()
+		);
 	}
 }

--- a/test/emptytheme/templates/index.html
+++ b/test/emptytheme/templates/index.html
@@ -1,9 +1,9 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","theme":"emptytheme"} /-->
-<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
-<div class="wp-block-query">
-	<!-- wp:post-template -->
-	<!-- wp:post-title {"isLink":true} /-->
-	<!-- wp:post-excerpt /-->
-	<!-- /wp:post-template -->
-</div>
+<!-- wp:template-part {"slug":"header","theme":"emptytheme","tagName":"header"} /-->
+
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title {"isLink":true} /-->
+
+<!-- wp:post-excerpt /-->
+<!-- /wp:post-template --></div>
 <!-- /wp:query -->


### PR DESCRIPTION
As I was working on the React 19 migration in #61521, the `template-revert` e2e tests started permanently failing. When comparing `contentBefore` and `contentAfter`, there were trivial differences: different order of attributes, different whitespace, added default values for some attributes (`query` block's `perPage`).

If you look at the #73252 PR where this test was added, you'll see that the test was failing this way from day one:

<img width="828" height="492" alt="Screenshot 2026-02-25 at 10 44 31" src="https://github.com/user-attachments/assets/d2ac145c-1f22-4d44-9656-5c2a57e6d4f8" />

At that time it was probably just flaky, but now it becomes permanent.

Where does the difference come from? The `getEditedPostContent` logic can calculate the content in three ways:
- if `post.content` is a string, return the string. That's the initial state before any edits.
- if `post.content` is a function, return the result of the function. That's how some kinds of editing update the content in an efficient (lazy-evaluated) way.
- if there is `post.blocks`, serialize the structure and return the serialized string. That's how other kinds of editing work.

Right after the `query` block is rendered, it has a React effect that updates the `perPage` attribute:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/query/edit/query-content.js#L96-L116

This code performs an edit without any user involvement, and switches the post content from the "initial string" mode to the "blocks" mode. And the JS serializer serializes the blocks differently from the original. Different order of attributes (based on `block.json` order). Different whitespace and newlines.

During the `template-revert` test, the Query effect sometimes has time to run, sometimes it doesn't. That's random timing issue that causes the flakiness.

My fix is to update the template source so that it matches the JS serializer syntax, and it provides the default `perPage` value. Then the React effects and content serialization strategies don't matter any more. And the test is more reliable.

The second commit fixes something related: I noticed that we often duplicate logic from the `getEditedPostContent` selector in the `editor` store. I don't know why we ever did that, but it's quite easy to replace the copy/pasted logic with a single selector call.

There is one place where I can't do it: in the "Time to Read" block, we need to the content of the currently edited post, but can't use the `core/editor` store. Maybe the "get content" logic should be at some more universal package, like `block-editor`, where it can be used by any block.