### PR TITLE
Add documentation for contentRole and listView block supports

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -608,6 +608,21 @@ When the block declares support for `color.text`, the attributes definition is e
     }
     ```
 
+## contentRole
+
+_**Note:** Since WordPress 6.9._
+
+-   Type: `boolean`
+-   Default value: `false`
+
+Marks the block itself as content. It is intended primarily for blocks that do not declare `content` attributes, or whose content is expressed only through their inner blocks. When enabled, content-only editing modes can still edit these blocks and allow inner blocks to be added or removed.
+
+```js
+supports: {
+	contentRole: true
+}
+```
+
 ## customClassName
 
 -   Type: `boolean`
@@ -852,6 +867,25 @@ For the `flex` layout type only, determines display of the "Allow to wrap to mul
 -   Default value: `true`
 
 For the `constrained` layout type only, determines display of the custom content and wide size controls in the block sidebar.
+
+## listView
+
+_**Note:** Since WordPress 7.0._
+
+-   Type: `boolean`
+-   Default value: `false`
+
+Enables a List View panel in the block inspector for the block's inner blocks.
+
+When this support is enabled, the inspector shows a List View tree allowing users to inspect and manage the block's inner blocks from the sidebar instead of only using the global document List View.
+
+```js
+supports: {
+	listView: true
+}
+```
+
+The `listView` support only affects the editor UI and does not add any attributes to the block.
 
 ## lock
 

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -683,6 +683,16 @@
 						}
 					]
 				},
+				"contentRole": {
+					"description": "This property marks the block itself as content. It is intended primarily for blocks that do not declare content attributes, or whose content is expressed only through their inner blocks. When enabled, content-only editing modes can still edit these blocks and allow inner blocks to be added or removed.",
+					"type": "boolean",
+					"default": false
+				},
+				"listView": {
+					"description": "This property enables a dedicated List View panel in the block inspector for the block. When enabled, the inspector shows a List View tree for the block's inner blocks, allowing users to inspect, reorder, and manage the block's items from the sidebar instead of only using the global document List View.",
+					"type": "boolean",
+					"default": false
+				},
 				"splitting": {
 					"description": "This property indicates whether the block can split when the Enter key is pressed or when blocks are pasted.",
 					"type": "boolean",


### PR DESCRIPTION
## What?

Since `contentRole` and `listView` block supports are public APIs, this PR updates the documentation and block.json schema.

The `contentRole` was actually already available in WP 6.9 but was temporarily undocumented due to a small bug, which should now be fixed. #72695

## Testing Instructions

Suggestions for better descriptions are welcome!