### PR TITLE
Block editor: Force LTR direction in block HTML editing mode

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -390,6 +390,10 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
 	line-height: 1.5;
+	// HTML input is always LTR regardless of language.
+	/*rtl:ignore*/
+	direction: ltr;
+
 	@media not ( prefers-reduced-motion ) {
 		transition: padding 0.2s linear;
 	}


### PR DESCRIPTION
Similar PRs:

- https://github.com/WordPress/gutenberg/pull/72901
- https://github.com/WordPress/gutenberg/pull/65891
- https://github.com/WordPress/gutenberg/pull/62083

## What?

| Before | After |
|--------|--------|
| <img width="675" height="172" alt="image" src="https://github.com/user-attachments/assets/3f6a4c78-4375-4438-b668-6256a8c8cb19" /> | <img width="687" height="157" alt="image" src="https://github.com/user-attachments/assets/ef979775-d233-444f-a730-1b002567a8a9" /> | 

## Why?

The HTML input direction is always LTR.

## Testing Instructions

1. Change the site language to RTL (e.g. `مُثبت`)
2. Create a post and insert any block that support HTML editing
3. Click the `تحرير كـ HTML` from the block toolbar dropdown menu
4. Confirm the direction
