### PR TITLE
Navigation overlay: Prevent duplicate area registration

### DIFF
--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -65,7 +65,7 @@ function gutenberg_register_overlay_template_part_area( $areas ) {
 		'area'        => 'navigation-overlay',
 		'label'       => __( 'Navigation Overlay', 'gutenberg' ),
 		'description' => __(
-			'The Navigation Overlay template defines a full-screen overlay area that typically contains navigation links and can be toggled on and off.'
+			'The Navigation Overlay template defines a overlay area that typically contains navigation links and can be toggled open and closed.'
 		),
 		'icon'        => 'navigation-overlay',
 		'area_tag'    => 'div',

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -65,7 +65,7 @@ function gutenberg_register_overlay_template_part_area( $areas ) {
 		'area'        => 'navigation-overlay',
 		'label'       => __( 'Navigation Overlay', 'gutenberg' ),
 		'description' => __(
-			'The Navigation Overlay template defines a overlay area that typically contains navigation links and can be toggled open and closed.'
+			'The Navigation Overlay template defines an overlay area that typically contains navigation links and can be toggled open and closed.'
 		),
 		'icon'        => 'navigation-overlay',
 		'area_tag'    => 'div',

--- a/lib/compat/wordpress-7.0/rest-api.php
+++ b/lib/compat/wordpress-7.0/rest-api.php
@@ -55,10 +55,18 @@ add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_wp_tem
  * @return array Modified array of template part area definitions.
  */
 function gutenberg_register_overlay_template_part_area( $areas ) {
+	foreach ( $areas as $area ) {
+		if ( isset( $area['area'] ) && 'navigation-overlay' === $area['area'] ) {
+			return $areas;
+		}
+	}
+
 	$areas[] = array(
 		'area'        => 'navigation-overlay',
 		'label'       => __( 'Navigation Overlay', 'gutenberg' ),
-		'description' => __( 'Custom overlay area for navigation overlays.', 'gutenberg' ),
+		'description' => __(
+			'The Navigation Overlay template defines a full-screen overlay area that typically contains navigation links and can be toggled on and off.'
+		),
 		'icon'        => 'navigation-overlay',
 		'area_tag'    => 'div',
 	);


### PR DESCRIPTION
Follow-up on #74968

## What?

| Before | After |
|--------|--------|
| <img width="540" height="665" alt="image" src="https://github.com/user-attachments/assets/2bd03eee-0632-47c2-888f-e09d2f47758e" /> | <img width="535" height="626" alt="image" src="https://github.com/user-attachments/assets/393761dd-2ab7-4134-9962-4d28c44bb422" /> | 

## Why?

If a navigation overlay area has already been registered with the core, we should not register the same area again.

## Testing Instructions

Open the Add Template modal and check the areas.