### PR TITLE
Cover: Replace strpos() with str_contains() for improved readability

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -39,13 +39,13 @@ function render_block_core_cover( $attributes, $content ) {
 				$lower_src = strtolower( $iframe_src );
 				$provider  = null;
 
-				if ( strpos( $lower_src, 'youtube.com' ) !== false || strpos( $lower_src, 'youtu.be' ) !== false ) {
+				if ( str_contains( $lower_src, 'youtube.com' ) || str_contains( $lower_src, 'youtu.be' ) ) {
 					$provider = 'youtube';
-				} elseif ( strpos( $lower_src, 'vimeo.com' ) !== false ) {
+				} elseif ( str_contains( $lower_src, 'vimeo.com' ) ) {
 					$provider = 'vimeo';
-				} elseif ( strpos( $lower_src, 'videopress.com' ) !== false ) {
+				} elseif ( str_contains( $lower_src, 'videopress.com' ) ) {
 					$provider = 'videopress';
-				} elseif ( strpos( $lower_src, 'wordpress.tv' ) !== false ) {
+				} elseif ( str_contains( $lower_src, 'wordpress.tv' ) ) {
 					$provider = 'wordpress-tv';
 				}
 


### PR DESCRIPTION
## What?
This pull request makes a minor improvement to the `render_block_core_cover` function. The change is a code modernization: it replaces the use of the older `strpos` function with the newer and more readable `str_contains` function for detecting video providers in iframe sources.

We did the same in #43382
This code was introduced in #73023