### PR TITLE
wp-build: Deregister script modules before re-registering

### DIFF
--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -28,6 +28,10 @@ if ( ! function_exists( '{{PREFIX}}_register_script_modules' ) ) {
 			$asset_path = $modules_dir . '/' . $module['asset'];
 			$asset = file_exists( $asset_path ) ? require $asset_path : array();
 
+			// Deregister first to override any previously registered version
+			// (e.g., Core's default modules when running as a plugin).
+			wp_deregister_script_module( $module['id'] );
+
 			wp_register_script_module(
 				$module['id'],
 				$base_url . $module['path'] . $extension,


### PR DESCRIPTION
## What?

Follow-up to #75705. Adds `wp_deregister_script_module()` before `wp_register_script_module()` in the auto-generated module registration template.

## Why?

#75705 removed the `remove_action( 'wp_default_scripts', 'wp_default_script_modules' )` line to fix issues with third-party plugins using wp-build without Gutenberg activated. However, this caused a regression: `wp_register_script_module()` does not override existing registrations, so Gutenberg's bundled module versions are silently ignored in favor of Core's.

This is a problem for any module where Gutenberg's version differs from Core's. For example, the playlist block's view script module bundles additional dependencies (waveform player) that aren't in Core's version. With Core's version being served instead, the relative import to the waveform utilities fails silently and the player doesn't render on the frontend.

## How?

Calls `wp_deregister_script_module()` before each `wp_register_script_module()` call. This is more targeted than the previous approach of removing Core's entire `wp_default_script_modules` action:

- Core's modules are registered normally
- The plugin explicitly overrides only the modules it ships
- Third-party plugins using wp-build without Gutenberg still work correctly

## Testing Instructions

1. Activate Gutenberg
2. Create a post with a block that uses a `viewScriptModule` (e.g., the playlist block if available, or any block with interactivity)
3. View the post on the frontend
4. Open browser DevTools → Network tab
5. Verify the script module loads from the Gutenberg plugin's `build/modules/` path, not from `wp-includes/js/dist/script-modules/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)