### PR TITLE
RichText: useAnchor: Enable type checking, fix errors

### DIFF
--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -460,9 +460,9 @@ This hook, to be used in a format type's Edit component, returns the active elem
 
 _Parameters_
 
--   _obj_ `{ editableContentElement: HTMLElement | null; settings?: AnchorSettings; }`: Named parameters.
+-   _obj_ `{ editableContentElement: HTMLElement | null; settings?: WPFormat; }`: Named parameters.
 -   _obj.editableContentElement_ `HTMLElement | null`: The element containing the editable content.
--   _obj.settings_ `AnchorSettings`: The format type's settings.
+-   _obj.settings_ `WPFormat`: The format type's settings.
 
 _Returns_
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -462,7 +462,7 @@ _Parameters_
 
 -   _$1_ `Object`: Named parameters.
 -   _$1.editableContentElement_ `HTMLElement|null`: The element containing the editable content.
--   _$1.settings_ `WPFormat=`: The format type's settings.
+-   _$1.settings_ `AnchorSettings=`: The format type's settings.
 
 _Returns_
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -460,13 +460,13 @@ This hook, to be used in a format type's Edit component, returns the active elem
 
 _Parameters_
 
--   _$1_ `Object`: Named parameters.
--   _$1.editableContentElement_ `HTMLElement|null`: The element containing the editable content.
--   _$1.settings_ `AnchorSettings=`: The format type's settings.
+-   _obj_ `{ editableContentElement: HTMLElement | null; settings?: AnchorSettings; }`: Named parameters.
+-   _obj.editableContentElement_ `HTMLElement | null`: The element containing the editable content.
+-   _obj.settings_ `AnchorSettings`: The format type's settings.
 
 _Returns_
 
--   `Element|VirtualAnchorElement|undefined|null`: The active element or selection range.
+-   `Element | VirtualAnchorElement | undefined | null`: The active element or selection range.
 
 ### useAnchorRef
 

--- a/packages/rich-text/src/hook/use-anchor.js
+++ b/packages/rich-text/src/hook/use-anchor.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * WordPress dependencies
  */
@@ -28,6 +29,7 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 	// So at a given selection index, start with the deepest format DOM element.
 	if (
 		element.nodeType === element.TEXT_NODE &&
+		element instanceof window.Text &&
 		range.startOffset === element.length &&
 		element.nextSibling
 	) {
@@ -39,10 +41,14 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 	}
 
 	if ( element.nodeType !== element.ELEMENT_NODE ) {
+		if ( ! element.parentElement ) {
+			return;
+		}
 		element = element.parentElement;
 	}
 
 	if ( ! element ) {
+		// FIXME: Should no longer be needed
 		return;
 	}
 	if ( element === editableContentElement ) {
@@ -54,19 +60,30 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 
 	const selector = tagName + ( className ? '.' + className : '' );
 
+	if ( ! ( element instanceof window.HTMLElement ) ) {
+		return;
+	}
+
+	/**
+	 * @type {HTMLElement|null}
+	 */
+	let closestElement = element;
+
 	// .closest( selector ), but with a boundary. Check if the element matches
 	// the selector. If it doesn't match, try the parent element if it's not the
 	// editable wrapper. We don't want to try to match ancestors of the editable
 	// wrapper, which is what .closest( selector ) would do. When the element is
 	// the editable wrapper (which is most likely the case because most text is
 	// unformatted), this never runs.
-	while ( element !== editableContentElement ) {
-		if ( element.matches( selector ) ) {
-			return element;
+	while ( closestElement && closestElement !== editableContentElement ) {
+		if ( closestElement.matches( selector ) ) {
+			return closestElement;
 		}
 
-		element = element.parentElement;
+		closestElement = closestElement.parentElement;
 	}
+
+	return undefined;
 }
 
 /**
@@ -103,11 +120,11 @@ function createVirtualAnchorElement( range, editableContentElement ) {
  * Get the anchor: a format element if there is a matching one based on the
  * tagName and className or a range otherwise.
  *
- * @param {HTMLElement} editableContentElement The editable wrapper.
- * @param {string}      tagName                The tag name of the format
- *                                             element.
- * @param {string}      className              The class name of the format
- *                                             element.
+ * @param {HTMLElement|null} editableContentElement The editable wrapper.
+ * @param {string}           tagName                The tag name of the format
+ *                                                  element.
+ * @param {string}           className              The class name of the format
+ *                                                  element.
  *
  * @return {HTMLElement|VirtualAnchorElement|undefined} The anchor.
  */
@@ -118,7 +135,7 @@ function getAnchor( editableContentElement, tagName, className ) {
 
 	const { ownerDocument } = editableContentElement;
 	const { defaultView } = ownerDocument;
-	const selection = defaultView.getSelection();
+	const selection = defaultView?.getSelection();
 
 	if ( ! selection ) {
 		return;
@@ -148,6 +165,18 @@ function getAnchor( editableContentElement, tagName, className ) {
 }
 
 /**
+ * @typedef {Pick<WPFormat, 'tagName' | 'className'> & {isActive?: boolean}} AnchorSettings
+ */
+
+/**
+ * @type {AnchorSettings}
+ */
+const DEFAULT_SETTINGS = {
+	tagName: '',
+	className: '',
+};
+
+/**
  * This hook, to be used in a format type's Edit component, returns the active
  * element that is formatted, or a virtual element for the selection range if
  * no format is active. The returned value is meant to be used for positioning
@@ -156,13 +185,16 @@ function getAnchor( editableContentElement, tagName, className ) {
  * @param {Object}           $1                        Named parameters.
  * @param {HTMLElement|null} $1.editableContentElement The element containing
  *                                                     the editable content.
- * @param {WPFormat=}        $1.settings               The format type's settings.
+ * @param {AnchorSettings=}  $1.settings               The format type's settings.
  * @return {Element|VirtualAnchorElement|undefined|null} The active element or selection range.
  */
-export function useAnchor( { editableContentElement, settings = {} } ) {
+export function useAnchor( {
+	editableContentElement,
+	settings = DEFAULT_SETTINGS,
+} ) {
 	const { tagName, className, isActive } = settings;
 	const [ anchor, setAnchor ] = useState( () =>
-		getAnchor( editableContentElement, tagName, className )
+		getAnchor( editableContentElement, tagName, className ?? '' )
 	);
 	const wasActive = usePrevious( isActive );
 
@@ -173,7 +205,7 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 
 		function callback() {
 			setAnchor(
-				getAnchor( editableContentElement, tagName, className )
+				getAnchor( editableContentElement, tagName, className ?? '' )
 			);
 		}
 
@@ -197,7 +229,7 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 			( wasActive && ! isActive )
 		) {
 			setAnchor(
-				getAnchor( editableContentElement, tagName, className )
+				getAnchor( editableContentElement, tagName, className ?? '' )
 			);
 			attach();
 		}

--- a/packages/rich-text/src/hook/use-anchor.ts
+++ b/packages/rich-text/src/hook/use-anchor.ts
@@ -168,11 +168,7 @@ function getAnchor(
 	return createVirtualAnchorElement( range, editableContentElement );
 }
 
-type AnchorSettings = Pick< WPFormat, 'tagName' | 'className' > & {
-	isActive?: boolean;
-};
-
-const DEFAULT_SETTINGS: AnchorSettings = {
+const DEFAULT_SETTINGS = {
 	tagName: '',
 	className: '',
 };
@@ -190,12 +186,23 @@ const DEFAULT_SETTINGS: AnchorSettings = {
  */
 export function useAnchor( {
 	editableContentElement,
-	settings = DEFAULT_SETTINGS,
+	settings,
 }: {
 	editableContentElement: HTMLElement | null;
-	settings?: AnchorSettings;
+	settings?: WPFormat;
 } ): Element | VirtualAnchorElement | undefined | null {
-	const { tagName, className, isActive } = settings;
+	const { tagName, className } = settings ?? DEFAULT_SETTINGS;
+
+	// `isActive` is not a property of `WPFormat`, but it has made its way into
+	// `settings` in certain cases (see `core/link` format). Avoid making this
+	// exception "public" in the function signature: tell TS how to look for it
+	// dynamically.
+	const isActive = !! (
+		settings &&
+		'isActive' in settings &&
+		settings.isActive
+	);
+
 	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className ?? '' )
 	);

--- a/packages/rich-text/src/hook/use-anchor.ts
+++ b/packages/rich-text/src/hook/use-anchor.ts
@@ -1,4 +1,3 @@
-// @ts-check
 /**
  * WordPress dependencies
  */
@@ -6,21 +5,27 @@ import { usePrevious } from '@wordpress/compose';
 import { useState, useLayoutEffect } from '@wordpress/element';
 import { getRectangleFromRange } from '@wordpress/dom';
 
-/** @typedef {import('../register-format-type').WPFormat} WPFormat */
-/** @typedef {import('../types').RichTextValue} RichTextValue */
+/**
+ * Internal dependencies
+ */
+import type { WPFormat } from '../register-format-type';
 
 /**
  * Given a range and a format tag name and class name, returns the closest
  * format element.
  *
- * @param {Range}       range                  The Range to check.
- * @param {HTMLElement} editableContentElement The editable wrapper.
- * @param {string}      tagName                The tag name of the format element.
- * @param {string}      className              The class name of the format element.
- *
- * @return {HTMLElement|undefined} The format element, if found.
+ * @param range                  The Range to check.
+ * @param editableContentElement The editable wrapper.
+ * @param tagName                The tag name of the format element.
+ * @param className              The class name of the format element.
+ * @return                       The format element, if found.
  */
-function getFormatElement( range, editableContentElement, tagName, className ) {
+function getFormatElement(
+	range: Range,
+	editableContentElement: HTMLElement,
+	tagName: string,
+	className: string
+): HTMLElement | undefined {
 	let element = range.startContainer;
 
 	// Even if the active format is defined, the actually DOM range's start
@@ -64,10 +69,7 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 		return;
 	}
 
-	/**
-	 * @type {HTMLElement|null}
-	 */
-	let closestElement = element;
+	let closestElement: HTMLElement | null = element;
 
 	// .closest( selector ), but with a boundary. Check if the element matches
 	// the selector. If it doesn't match, try the parent element if it's not the
@@ -86,21 +88,22 @@ function getFormatElement( range, editableContentElement, tagName, className ) {
 	return undefined;
 }
 
-/**
- * @typedef {Object} VirtualAnchorElement
- * @property {() => DOMRect} getBoundingClientRect A function returning a DOMRect
- * @property {HTMLElement}   contextElement        The actual DOM element
- */
+interface VirtualAnchorElement {
+	getBoundingClientRect: () => DOMRect;
+	contextElement: HTMLElement;
+}
 
 /**
  * Creates a virtual anchor element for a range.
  *
- * @param {Range}       range                  The range to create a virtual anchor element for.
- * @param {HTMLElement} editableContentElement The editable wrapper.
- *
- * @return {VirtualAnchorElement} The virtual anchor element.
+ * @param range                  The range to create a virtual anchor element for.
+ * @param editableContentElement The editable wrapper.
+ * @return                       The virtual anchor element.
  */
-function createVirtualAnchorElement( range, editableContentElement ) {
+function createVirtualAnchorElement(
+	range: Range,
+	editableContentElement: HTMLElement
+): VirtualAnchorElement {
 	return {
 		contextElement: editableContentElement,
 		getBoundingClientRect() {
@@ -120,15 +123,16 @@ function createVirtualAnchorElement( range, editableContentElement ) {
  * Get the anchor: a format element if there is a matching one based on the
  * tagName and className or a range otherwise.
  *
- * @param {HTMLElement|null} editableContentElement The editable wrapper.
- * @param {string}           tagName                The tag name of the format
- *                                                  element.
- * @param {string}           className              The class name of the format
- *                                                  element.
- *
- * @return {HTMLElement|VirtualAnchorElement|undefined} The anchor.
+ * @param editableContentElement The editable wrapper.
+ * @param tagName                The tag name of the format element.
+ * @param className              The class name of the format element.
+ * @return                       The anchor.
  */
-function getAnchor( editableContentElement, tagName, className ) {
+function getAnchor(
+	editableContentElement: HTMLElement | null,
+	tagName: string,
+	className: string
+): HTMLElement | VirtualAnchorElement | undefined {
 	if ( ! editableContentElement ) {
 		return;
 	}
@@ -164,14 +168,11 @@ function getAnchor( editableContentElement, tagName, className ) {
 	return createVirtualAnchorElement( range, editableContentElement );
 }
 
-/**
- * @typedef {Pick<WPFormat, 'tagName' | 'className'> & {isActive?: boolean}} AnchorSettings
- */
+type AnchorSettings = Pick< WPFormat, 'tagName' | 'className' > & {
+	isActive?: boolean;
+};
 
-/**
- * @type {AnchorSettings}
- */
-const DEFAULT_SETTINGS = {
+const DEFAULT_SETTINGS: AnchorSettings = {
 	tagName: '',
 	className: '',
 };
@@ -182,16 +183,18 @@ const DEFAULT_SETTINGS = {
  * no format is active. The returned value is meant to be used for positioning
  * UI, e.g. by passing it to the `Popover` component via the `anchor` prop.
  *
- * @param {Object}           $1                        Named parameters.
- * @param {HTMLElement|null} $1.editableContentElement The element containing
- *                                                     the editable content.
- * @param {AnchorSettings=}  $1.settings               The format type's settings.
- * @return {Element|VirtualAnchorElement|undefined|null} The active element or selection range.
+ * @param obj                        Named parameters.
+ * @param obj.editableContentElement The element containing the editable content.
+ * @param obj.settings               The format type's settings.
+ * @return                           The active element or selection range.
  */
 export function useAnchor( {
 	editableContentElement,
 	settings = DEFAULT_SETTINGS,
-} ) {
+}: {
+	editableContentElement: HTMLElement | null;
+	settings?: AnchorSettings;
+} ): Element | VirtualAnchorElement | undefined | null {
 	const { tagName, className, isActive } = settings;
 	const [ anchor, setAnchor ] = useState( () =>
 		getAnchor( editableContentElement, tagName, className ?? '' )

--- a/packages/rich-text/src/hook/use-anchor.ts
+++ b/packages/rich-text/src/hook/use-anchor.ts
@@ -52,13 +52,10 @@ function getFormatElement(
 		element = element.parentElement;
 	}
 
-	if ( ! element ) {
-		// FIXME: Should no longer be needed
-		return;
-	}
 	if ( element === editableContentElement ) {
 		return;
 	}
+
 	if ( ! editableContentElement.contains( element ) ) {
 		return;
 	}


### PR DESCRIPTION
## What?

Follow-up of #75900

To do:
- [x] Actually convert to `.ts`
- [x] Rebase once #75900 is merged

## Why?

#75900 fixed a bug (#75897) that would have been caught by standard type checking, were it enabled. We should in general strive to have a lot more type checking going on.

## How?

Check commit history for easier reviewing

## Testing Instructions

- No changes in behaviour expected.
- Play around with popovers (e.g. autocompleters, per #75900), ensure everything looks good.