### PR TITLE
DataViews: Fix filter toggle flickering when there are locked or primary filters

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,6 +13,7 @@
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Avoid flickering while refreshing. [#74572](https://github.com/WordPress/gutenberg/pull/74572)
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
+- DataViews: Fix filter toggle flickering when there are locked or primary filters. [#75913](https://github.com/WordPress/gutenberg/pull/75913)
 - DataViews: Fix search input losing characters during debounce when externally synced. [#75810](https://github.com/WordPress/gutenberg/pull/75810)
 - DataForm: Fix vertical alignment of summary fields in card layout. [#75864](https://github.com/WordPress/gutenberg/pull/75864)
 - DataViews: Remove visual divider between quick and regular actions in the actions menu. [#75893](https://github.com/WordPress/gutenberg/pull/75893)

--- a/packages/dataviews/src/components/dataviews-filters/toggle.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/toggle.tsx
@@ -31,12 +31,17 @@ function FiltersToggle() {
 		},
 		[ onChangeView, setIsShowingFilter ]
 	);
-	const visibleFilters = filters.filter( ( filter ) => filter.isVisible );
+	const hasPrimaryOrLockedFilters = filters.some(
+		( filter ) => filter.isPrimary || filter.isLocked
+	);
 
-	const hasVisibleFilters = !! visibleFilters.length;
-	if ( filters.length === 0 ) {
+	// When there are primary or locked filters, the filter bar is always
+	// visible and cannot be hidden, so the toggle button serves no purpose.
+	if ( filters.length === 0 || hasPrimaryOrLockedFilters ) {
 		return null;
 	}
+
+	const hasVisibleFilters = filters.some( ( filter ) => filter.isVisible );
 
 	const addFilterButtonProps = {
 		label: __( 'Add filter' ),

--- a/packages/dataviews/src/components/dataviews-filters/toggle.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/toggle.tsx
@@ -31,13 +31,8 @@ function FiltersToggle() {
 		},
 		[ onChangeView, setIsShowingFilter ]
 	);
-	const hasPrimaryOrLockedFilters = filters.some(
-		( filter ) => filter.isPrimary || filter.isLocked
-	);
 
-	// When there are primary or locked filters, the filter bar is always
-	// visible and cannot be hidden, so the toggle button serves no purpose.
-	if ( filters.length === 0 || hasPrimaryOrLockedFilters ) {
+	if ( filters.length === 0 ) {
 		return null;
 	}
 
@@ -59,12 +54,19 @@ function FiltersToggle() {
 			setIsShowingFilter( ! isShowingFilter );
 		},
 	};
+	// When there are primary or locked filters, the filter bar is always
+	// visible and cannot be hidden, so the toggle button should be disabled.
+	const hasPrimaryOrLockedFilters = filters.some(
+		( filter ) => filter.isPrimary || filter.isLocked
+	);
 	const buttonComponent = (
 		<Button
 			ref={ buttonRef }
 			className="dataviews-filters__visibility-toggle"
 			size="compact"
 			icon={ funnel }
+			disabled={ hasPrimaryOrLockedFilters }
+			accessibleWhenDisabled
 			{ ...( hasVisibleFilters
 				? toggleFiltersButtonProps
 				: addFilterButtonProps ) }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
First step of: https://github.com/WordPress/gutenberg/issues/71672

Alternative of: https://github.com/WordPress/gutenberg/pull/71674, which I had [pinged](https://github.com/WordPress/gutenberg/pull/71674#issuecomment-3522482170) months ago to move forward.


Currently if there are any primary or locked filters the filter bar is [always visible](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/src/dataviews/index.tsx#L192) and cannot be hidden. This PR **disables** the toggle in that case.

## Testing Instructions
1. In site editor visit pages that have locked/primary filters like in the published pages(`wp-admin/site-editor.php?p=%2Fpage&activeView=published`) or patterns page.
2. In the cases we have locked or primary filters the button should be disabled.
3. Everything else should work as before
