### PR TITLE
DataViews: Right-align `integer` and `number` fields

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- DataViews: Align to end integer and number field types. [#75917](https://github.com/WordPress/gutenberg/pull/75917)
+
 ### Bug Fixes
 
 - DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -16,7 +16,6 @@
 - DataForm: Fix vertical alignment of summary fields in card layout. [#75864](https://github.com/WordPress/gutenberg/pull/75864)
 - DataViews: Remove visual divider between quick and regular actions in the actions menu. [#75893](https://github.com/WordPress/gutenberg/pull/75893)
 - DataForm: field label for panel layout are no longer uppercased. [#75944](https://github.com/WordPress/gutenberg/pull/75944)
-- DataViews: Align to end integer and number field types. [#75917](https://github.com/WordPress/gutenberg/pull/75917)
 
 ### Enhancements
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,7 @@
 - DataForm: Fix vertical alignment of summary fields in card layout. [#75864](https://github.com/WordPress/gutenberg/pull/75864)
 - DataViews: Remove visual divider between quick and regular actions in the actions menu. [#75893](https://github.com/WordPress/gutenberg/pull/75893)
 - DataForm: field label for panel layout are no longer uppercased. [#75944](https://github.com/WordPress/gutenberg/pull/75944)
+- DataViews: Align to end integer and number field types. [#75917](https://github.com/WordPress/gutenberg/pull/75917)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -44,6 +44,19 @@ import getDataByGroup from '../utils/get-data-by-group';
 import { PropertiesSection } from '../../dataviews-view-config/properties-section';
 import { useDelayedLoading } from '../../../hooks/use-delayed-loading';
 
+function getEffectiveAlign(
+	explicitAlign: 'start' | 'center' | 'end' | undefined,
+	fieldType: string | undefined
+): 'start' | 'center' | 'end' | undefined {
+	if ( explicitAlign ) {
+		return explicitAlign;
+	}
+	if ( fieldType === 'integer' || fieldType === 'number' ) {
+		return 'end';
+	}
+	return undefined;
+}
+
 interface TableColumnFieldProps< Item > {
 	fields: NormalizedField< Item >[];
 	column: string;
@@ -226,6 +239,8 @@ function TableRow< Item >( {
 				// Explicit picks the supported styles.
 				const { width, maxWidth, minWidth, align } =
 					view.layout?.styles?.[ column ] ?? {};
+				const field = fields.find( ( f ) => f.id === column );
+				const effectiveAlign = getEffectiveAlign( align, field?.type );
 
 				return (
 					<td
@@ -240,7 +255,7 @@ function TableRow< Item >( {
 							fields={ fields }
 							item={ item }
 							column={ column }
-							align={ align }
+							align={ effectiveAlign }
 						/>
 					</td>
 				);
@@ -501,6 +516,13 @@ function ViewTable< Item >( {
 							// Explicit picks the supported styles.
 							const { width, maxWidth, minWidth, align } =
 								view.layout?.styles?.[ column ] ?? {};
+							const field = fields.find(
+								( f ) => f.id === column
+							);
+							const effectiveAlign = getEffectiveAlign(
+								align,
+								field?.type
+							);
 							const canInsertOrMove =
 								view.layout?.enableMoving ?? true;
 							return (
@@ -510,7 +532,7 @@ function ViewTable< Item >( {
 										width,
 										maxWidth,
 										minWidth,
-										textAlign: align,
+										textAlign: effectiveAlign,
 									} }
 									aria-sort={
 										view.sort?.direction &&

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -177,6 +177,7 @@
 
 			&.dataviews-view-table__cell-align-end {
 				justify-content: flex-end;
+				font-variant-numeric: tabular-nums;
 			}
 
 			&.dataviews-view-table__cell-align-center {

--- a/packages/dataviews/src/dataviews/stories/empty.tsx
+++ b/packages/dataviews/src/dataviews/stories/empty.tsx
@@ -59,13 +59,7 @@ const EmptyComponent = ( {
 		search: '',
 		page: 1,
 		perPage: 10,
-		layout: {
-			styles: {
-				satellites: {
-					align: 'end' as const,
-				},
-			},
-		},
+		layout: {},
 		filters: [],
 		fields: [ 'title', 'description', 'categories' ],
 	} );

--- a/packages/dataviews/src/dataviews/stories/free-composition.tsx
+++ b/packages/dataviews/src/dataviews/stories/free-composition.tsx
@@ -134,11 +134,6 @@ export const FreeCompositionComponent = () => {
 		page: 1,
 		perPage: 10,
 		layout: {
-			styles: {
-				satellites: {
-					align: 'end' as const,
-				},
-			},
 			enableMoving: false,
 		},
 		filters: [],

--- a/packages/dataviews/src/dataviews/stories/layout-table.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-table.tsx
@@ -32,13 +32,7 @@ export const LayoutTableComponent = ( {
 		search: '',
 		page: 1,
 		perPage: 10,
-		layout: {
-			styles: {
-				satellites: {
-					align: 'end' as const,
-				},
-			},
-		},
+		layout: {},
 		filters: [],
 		fields: [ 'categories' ],
 		titleField: 'title',

--- a/packages/dataviews/src/dataviews/stories/minimal-ui.tsx
+++ b/packages/dataviews/src/dataviews/stories/minimal-ui.tsx
@@ -23,11 +23,6 @@ const MinimalUIComponent = ( {
 		page: 1,
 		perPage: 10,
 		layout: {
-			styles: {
-				satellites: {
-					align: 'end' as const,
-				},
-			},
 			enableMoving: false,
 		},
 		filters: [],

--- a/packages/dataviews/src/dataviews/stories/with-card.tsx
+++ b/packages/dataviews/src/dataviews/stories/with-card.tsx
@@ -24,13 +24,7 @@ const WithCardComponent = () => {
 		search: '',
 		page: 1,
 		perPage: 10,
-		layout: {
-			styles: {
-				satellites: {
-					align: 'end' as const,
-				},
-			},
-		},
+		layout: {},
 		filters: [],
 		fields: [ 'categories' ],
 		titleField: 'title',

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -166,11 +166,15 @@ const SLUG_TO_STATUS = {
 };
 
 export function getActiveViewOverridesForTab( activeView ) {
+	const base = {
+		...defaultLayouts.table,
+	};
 	const status = SLUG_TO_STATUS[ activeView ];
 	if ( ! status ) {
-		return {};
+		return base;
 	}
 	return {
+		...base,
 		filters: [
 			{
 				field: 'status',

--- a/packages/edit-site/src/components/post-list/view-utils.js
+++ b/packages/edit-site/src/components/post-list/view-utils.js
@@ -19,7 +19,15 @@ import {
 import { OPERATOR_IS_ANY } from '../../utils/constants';
 
 export const defaultLayouts = {
-	table: {},
+	table: {
+		layout: {
+			styles: {
+				author: {
+					align: 'start',
+				},
+			},
+		},
+	},
 	grid: {},
 	list: {},
 };


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/73365

## What?

Right-align `number` or `integer` field types by default, while respecting explicit alignment.

## Why?

To provide better defaults and improve legibillity.

## How?

Check the field type and set align end, if no align has been provided.

## Testing Instructions

- Verify satellites field in storybook's DataViews table layout.
- Verify notes field in Site Editor's Pages screen.
