### PR TITLE
Navigation: Allow creating new links in site editor sidebar List View

### DIFF
--- a/packages/block-library/src/private-apis.js
+++ b/packages/block-library/src/private-apis.js
@@ -3,6 +3,11 @@
  */
 import { default as BlockKeyboardShortcuts } from './block-keyboard-shortcuts';
 import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from './navigation/constants';
+import {
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
+} from './navigation-link/shared';
 import { lock } from './lock-unlock';
 
 /**
@@ -12,4 +17,7 @@ export const privateApis = {};
 lock( privateApis, {
 	BlockKeyboardShortcuts,
 	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
 } );

--- a/packages/block-library/src/private-apis.js
+++ b/packages/block-library/src/private-apis.js
@@ -3,11 +3,7 @@
  */
 import { default as BlockKeyboardShortcuts } from './block-keyboard-shortcuts';
 import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from './navigation/constants';
-import {
-	LinkUI,
-	updateAttributes,
-	useEntityBinding,
-} from './navigation-link/shared';
+import { NavigationLinkUI } from './navigation/edit/navigation-link-ui';
 import { lock } from './lock-unlock';
 
 /**
@@ -17,7 +13,5 @@ export const privateApis = {};
 lock( privateApis, {
 	BlockKeyboardShortcuts,
 	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
-	LinkUI,
-	updateAttributes,
-	useEntityBinding,
+	NavigationLinkUI,
 } );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -5,6 +5,7 @@ import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -24,6 +25,14 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 		};
 	}, [] );
 
+	const settings = useMemo( () => {
+		return {
+			...storedSettings,
+			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
+				fetchLinkSuggestions( search, searchOptions, storedSettings ),
+		};
+	}, [ storedSettings ] );
+
 	const blocks = useMemo( () => {
 		if ( ! navigationMenuId ) {
 			return [];
@@ -38,7 +47,7 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 
 	return (
 		<BlockEditorProvider
-			settings={ storedSettings }
+			settings={ settings }
 			value={ blocks }
 			onChange={ noop }
 			onInput={ noop }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -19,88 +19,7 @@ import { unlock } from '../../lock-unlock';
 import LeafMoreMenu from './leaf-more-menu';
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
-const { LinkUI, updateAttributes, useEntityBinding } = unlock(
-	blockLibraryPrivateApis
-);
-
-const BLOCKS_WITH_LINK_UI_SUPPORT = [
-	'core/navigation-link',
-	'core/navigation-submenu',
-];
-
-function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
-	const {
-		updateBlockAttributes,
-		removeBlock,
-		__unstableMarkNextChangeAsNotPersistent,
-	} = useDispatch( blockEditorStore );
-	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT.includes(
-		insertedBlock?.name
-	);
-	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
-	const showLinkControls = supportsLinkControls && blockWasJustInserted;
-
-	const { createBinding, clearBinding } = useEntityBinding( {
-		clientId: insertedBlock?.clientId,
-		attributes: insertedBlock?.attributes || {},
-	} );
-
-	if ( ! showLinkControls ) {
-		return null;
-	}
-
-	const cleanupInsertedBlock = () => {
-		const shouldAutoSelectBlock = false;
-		if ( ! insertedBlock?.attributes?.url && insertedBlock?.clientId ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
-		}
-		setInsertedBlock( null );
-	};
-
-	const setInsertedBlockAttributes =
-		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
-			if ( ! _insertedBlockClientId ) {
-				return;
-			}
-			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
-		};
-
-	const handleSetInsertedBlock = ( newBlock ) => {
-		const shouldAutoSelectBlock = false;
-		if ( insertedBlock?.clientId && newBlock ) {
-			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
-		}
-		setInsertedBlock( newBlock );
-	};
-
-	return (
-		<LinkUI
-			clientId={ insertedBlock?.clientId }
-			link={ insertedBlock?.attributes }
-			onBlockInsert={ handleSetInsertedBlock }
-			onClose={ () => {
-				cleanupInsertedBlock();
-			} }
-			onChange={ ( updatedValue ) => {
-				const { isEntityLink, attributes: updatedAttributes } =
-					updateAttributes(
-						updatedValue,
-						setInsertedBlockAttributes( insertedBlock?.clientId ),
-						insertedBlock?.attributes
-					);
-
-				if ( isEntityLink ) {
-					createBinding( updatedAttributes );
-				} else {
-					clearBinding();
-				}
-
-				setInsertedBlock( null );
-			} }
-		/>
-	);
-}
+const { NavigationLinkUI } = unlock( blockLibraryPrivateApis );
 
 // Needs to be kept in sync with the query used at packages/block-library/src/page-list/edit.js.
 const MAX_PAGE_COUNT = 100;
@@ -185,7 +104,7 @@ export default function NavigationMenuContent( { rootClientId } ) {
 					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }
 					showAppender
-					additionalBlockContent={ AdditionalBlockContent }
+					additionalBlockContent={ NavigationLinkUI }
 					isExpanded
 				/>
 			) }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -10,6 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as blockLibraryPrivateApis } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -18,6 +19,88 @@ import { unlock } from '../../lock-unlock';
 import LeafMoreMenu from './leaf-more-menu';
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
+const { LinkUI, updateAttributes, useEntityBinding } = unlock(
+	blockLibraryPrivateApis
+);
+
+const BLOCKS_WITH_LINK_UI_SUPPORT = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
+function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
+	const {
+		updateBlockAttributes,
+		removeBlock,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
+	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT.includes(
+		insertedBlock?.name
+	);
+	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
+	const showLinkControls = supportsLinkControls && blockWasJustInserted;
+
+	const { createBinding, clearBinding } = useEntityBinding( {
+		clientId: insertedBlock?.clientId,
+		attributes: insertedBlock?.attributes || {},
+	} );
+
+	if ( ! showLinkControls ) {
+		return null;
+	}
+
+	const cleanupInsertedBlock = () => {
+		const shouldAutoSelectBlock = false;
+		if ( ! insertedBlock?.attributes?.url && insertedBlock?.clientId ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		}
+		setInsertedBlock( null );
+	};
+
+	const setInsertedBlockAttributes =
+		( _insertedBlockClientId ) => ( _updatedAttributes ) => {
+			if ( ! _insertedBlockClientId ) {
+				return;
+			}
+			updateBlockAttributes( _insertedBlockClientId, _updatedAttributes );
+		};
+
+	const handleSetInsertedBlock = ( newBlock ) => {
+		const shouldAutoSelectBlock = false;
+		if ( insertedBlock?.clientId && newBlock ) {
+			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		}
+		setInsertedBlock( newBlock );
+	};
+
+	return (
+		<LinkUI
+			clientId={ insertedBlock?.clientId }
+			link={ insertedBlock?.attributes }
+			onBlockInsert={ handleSetInsertedBlock }
+			onClose={ () => {
+				cleanupInsertedBlock();
+			} }
+			onChange={ ( updatedValue ) => {
+				const { isEntityLink, attributes: updatedAttributes } =
+					updateAttributes(
+						updatedValue,
+						setInsertedBlockAttributes( insertedBlock?.clientId ),
+						insertedBlock?.attributes
+					);
+
+				if ( isEntityLink ) {
+					createBinding( updatedAttributes );
+				} else {
+					clearBinding();
+				}
+
+				setInsertedBlock( null );
+			} }
+		/>
+	);
+}
 
 // Needs to be kept in sync with the query used at packages/block-library/src/page-list/edit.js.
 const MAX_PAGE_COUNT = 100;
@@ -101,7 +184,8 @@ export default function NavigationMenuContent( { rootClientId } ) {
 					rootClientId={ listViewRootClientId }
 					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }
-					showAppender={ false }
+					showAppender
+					additionalBlockContent={ AdditionalBlockContent }
 					isExpanded
 				/>
 			) }

--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -39,7 +39,7 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 		},
 	} );
 
-	test( 'can add new menu items from the sidebar list view', async ( {
+	test( 'can use appender in site editor sidebar list view', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -63,217 +63,92 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 
 		// Verify the existing item is shown in the sidebar list view.
 		await expect(
-			listView.getByRole( 'gridcell', { name: 'Existing Item' } )
+			listView.getByRole( 'link', { name: 'Existing Item' } )
 		).toBeVisible();
 
 		// The appender button should be present to allow adding new items.
 		const appender = listView.getByRole( 'button', { name: 'Add page' } );
 		await expect( appender ).toBeVisible();
 
-		await appender.click();
+		const linkControlSearch = linkControl.getLinkControlSearch();
 
-		// The LinkUI popover should open and immediately focus the search input.
-		await expect( linkControl.getLinkControlSearch() ).toBeFocused();
+		await test.step( 'can add new menu items', async () => {
+			await appender.click();
 
-		// Search for and select the page.
-		await linkControl.useLinkControlSearch( 'Test Page 2' );
+			// The LinkUI popover should open and immediately focus the search input.
+			await expect( linkControlSearch ).toBeFocused();
 
-		// The new item should be appended after the existing item.
-		await expect(
-			listView
-				.getByRole( 'gridcell', { name: 'Test Page 2' } )
-				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
-		).toBeVisible();
-	} );
+			// Search for and select the page.
+			await linkControl.useLinkControlSearch( 'Test Page 2' );
 
-	test( 'can open and close the add link UI', async ( {
-		admin,
-		page,
-		requestUtils,
-		linkControl,
-	} ) => {
-		const createdMenu =
-			await requestUtils.createNavigationMenu( navMenuFixture );
-
-		await admin.visitSiteEditor( {
-			postId: createdMenu?.id,
-			postType: 'wp_navigation',
+			// The new item should be appended after the existing item.
+			await expect(
+				listView.getByRole( 'link', { name: 'Test Page 2' } )
+			).toBeVisible();
 		} );
 
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
+		await test.step( 'can open and close the Link UI without losing focus', async () => {
+			await page.keyboard.press( 'ArrowDown' );
+			await expect( appender ).toBeFocused();
+			await page.keyboard.press( 'Enter' );
+			await expect( linkControlSearch ).toBeFocused();
+			await page.keyboard.press( 'Escape' );
+			await expect( linkControlSearch ).toBeHidden();
 		} );
 
-		await expect( listView ).toBeVisible();
+		await test.step( 'can create a new page', async () => {
+			await appender.click();
 
-		const appender = listView.getByRole( 'button', { name: 'Add page' } );
-		await appender.click();
+			// The search input should be focused immediately.
+			await expect( linkControl.getLinkControlSearch() ).toBeFocused();
 
-		await linkControl.addLinkClose();
-	} );
+			// Type a new page title that doesn't exist yet.
+			await page.keyboard.type( 'Brand New Page', { delay: 50 } );
 
-	test( 'cancelling a second add does not remove previously added unsaved links', async ( {
-		admin,
-		page,
-		requestUtils,
-		linkControl,
-	} ) => {
-		const createdMenu =
-			await requestUtils.createNavigationMenu( navMenuFixture );
+			// Tab twice to reach the "Create page" button.
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
 
-		await admin.visitSiteEditor( {
-			postId: createdMenu?.id,
-			postType: 'wp_navigation',
+			const createPageButton = page.getByRole( 'button', {
+				name: 'Create page',
+			} );
+			await expect( createPageButton ).toBeVisible();
+			await expect( createPageButton ).toBeFocused();
+
+			// Open the page creation form.
+			await page.keyboard.press( 'Enter' );
+
+			// The title field should be pre-populated with the typed text.
+			const titleField = page.getByRole( 'textbox', { name: 'Title' } );
+			await expect( titleField ).toHaveValue( 'Brand New Page' );
+
+			// The Back button should be focused after entering the creation form.
+			const backButton = page.locator( '.link-ui-page-creator__back' );
+			await expect( backButton ).toBeFocused();
+
+			// Tab to the title field.
+			await page.keyboard.press( 'Tab' );
+			await expect( titleField ).toBeFocused();
+
+			// Tab to the Publish checkbox (on by default).
+			await page.keyboard.press( 'Tab' );
+			const publishCheckbox = page.getByRole( 'checkbox', {
+				name: 'Publish',
+			} );
+			await expect( publishCheckbox ).toBeFocused();
+			await expect( publishCheckbox ).toBeChecked();
+
+			// Tab twice more to reach the Create page button.
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+			await expect( createPageButton ).toBeFocused();
+			await page.keyboard.press( 'Enter' );
+
+			// The newly created page should appear as a new item in the list view.
+			await expect(
+				listView.getByRole( 'link', { name: 'Brand New Page' } )
+			).toBeVisible();
 		} );
-
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-		} );
-
-		await expect( listView ).toBeVisible();
-
-		// Add a first new item by selecting a page.
-		const appender = listView.getByRole( 'button', { name: 'Add page' } );
-		await appender.click();
-		await linkControl.useLinkControlSearch( 'Test Page 2' );
-
-		// Verify the first new item was committed (block 2 of 2).
-		await expect(
-			listView
-				.getByRole( 'gridcell', { name: 'Test Page 2' } )
-				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
-		).toBeVisible();
-
-		// Start adding a second item but cancel without selecting a URL.
-		await appender.click();
-		await linkControl.addLinkClose();
-
-		// The previously committed unsaved link should still be present —
-		// cancelling the second insertion must not remove the first one.
-		await expect(
-			listView
-				.getByRole( 'gridcell', { name: 'Existing Item' } )
-				.filter( { hasText: 'Block 1 of 2, Level 1.' } )
-		).toBeVisible();
-		await expect(
-			listView
-				.getByRole( 'gridcell', { name: 'Test Page 2' } )
-				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
-		).toBeVisible();
-	} );
-
-	test( 'can create a new page from the sidebar list view appender', async ( {
-		admin,
-		page,
-		requestUtils,
-		linkControl,
-	} ) => {
-		const createdMenu =
-			await requestUtils.createNavigationMenu( navMenuFixture );
-
-		await admin.visitSiteEditor( {
-			postId: createdMenu?.id,
-			postType: 'wp_navigation',
-		} );
-
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-		} );
-
-		await expect( listView ).toBeVisible();
-
-		const appender = listView.getByRole( 'button', { name: 'Add page' } );
-		await appender.click();
-
-		// The search input should be focused immediately.
-		await expect( linkControl.getLinkControlSearch() ).toBeFocused();
-
-		// Type a new page title that doesn't exist yet.
-		await page.keyboard.type( 'Brand New Page', { delay: 50 } );
-
-		// Tab twice to reach the "Create page" button.
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-
-		const createPageButton = page.getByRole( 'button', {
-			name: 'Create page',
-		} );
-		await expect( createPageButton ).toBeVisible();
-		await expect( createPageButton ).toBeFocused();
-
-		// Open the page creation form.
-		await page.keyboard.press( 'Enter' );
-
-		// The title field should be pre-populated with the typed text.
-		const titleField = page.getByRole( 'textbox', { name: 'Title' } );
-		await expect( titleField ).toHaveValue( 'Brand New Page' );
-
-		// The Back button should be focused after entering the creation form.
-		const backButton = page.locator( '.link-ui-page-creator__back' );
-		await expect( backButton ).toBeFocused();
-
-		// Tab to the title field.
-		await page.keyboard.press( 'Tab' );
-		await expect( titleField ).toBeFocused();
-
-		// Tab to the Publish checkbox (on by default).
-		await page.keyboard.press( 'Tab' );
-		const publishCheckbox = page.getByRole( 'checkbox', {
-			name: 'Publish',
-		} );
-		await expect( publishCheckbox ).toBeFocused();
-		await expect( publishCheckbox ).toBeChecked();
-
-		// Tab twice more to reach the Create page button.
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await expect( createPageButton ).toBeFocused();
-		await page.keyboard.press( 'Enter' );
-
-		// The newly created page should appear as a new item in the list view.
-		await expect(
-			listView
-				.getByRole( 'gridcell', { name: 'Brand New Page' } )
-				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
-		).toBeVisible();
-	} );
-
-	test( 'focus is managed correctly when dismissing the link UI without selecting a URL', async ( {
-		admin,
-		page,
-		requestUtils,
-		linkControl,
-	} ) => {
-		const createdMenu =
-			await requestUtils.createNavigationMenu( navMenuFixture );
-
-		await admin.visitSiteEditor( {
-			postId: createdMenu?.id,
-			postType: 'wp_navigation',
-		} );
-
-		const listView = page.getByRole( 'treegrid', {
-			name: 'Block navigation structure',
-		} );
-
-		await expect( listView ).toBeVisible();
-
-		const appender = listView.getByRole( 'button', { name: 'Add page' } );
-		await appender.click();
-
-		// Verify focus goes to the search input immediately (focus management).
-		await expect( linkControl.getLinkControlSearch() ).toBeFocused();
-
-		await linkControl.addLinkClose();
-
-		// The auto-inserted empty block should be cleaned up automatically.
-		// Verify the original item is still there and is the only item
-		// (i.e. no orphaned empty block was left behind).
-		await expect(
-			listView
-				.getByRole( 'gridcell', { name: 'Existing Item' } )
-				.filter( { hasText: 'Block 1 of 1, Level 1.' } )
-		).toBeVisible();
 	} );
 } );
 
@@ -299,11 +174,5 @@ class LinkControl {
 
 		await this.page.keyboard.press( 'ArrowDown' );
 		await this.page.keyboard.press( 'Enter' );
-	}
-
-	async addLinkClose() {
-		await expect( this.getLinkControlSearch() ).toBeFocused();
-		await this.page.keyboard.press( 'Escape' );
-		await expect( this.getLinkControlSearch() ).toBeHidden();
 	}
 }

--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -162,6 +162,82 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 		).toBeVisible();
 	} );
 
+	test( 'can create a new page from the sidebar list view appender', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+
+		// The search input should be focused immediately.
+		await expect( linkControl.getLinkControlSearch() ).toBeFocused();
+
+		// Type a new page title that doesn't exist yet.
+		await page.keyboard.type( 'Brand New Page', { delay: 50 } );
+
+		// Tab twice to reach the "Create page" button.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+
+		const createPageButton = page.getByRole( 'button', {
+			name: 'Create page',
+		} );
+		await expect( createPageButton ).toBeVisible();
+		await expect( createPageButton ).toBeFocused();
+
+		// Open the page creation form.
+		await page.keyboard.press( 'Enter' );
+
+		// The title field should be pre-populated with the typed text.
+		const titleField = page.getByRole( 'textbox', { name: 'Title' } );
+		await expect( titleField ).toHaveValue( 'Brand New Page' );
+
+		// The Back button should be focused after entering the creation form.
+		const backButton = page.locator( '.link-ui-page-creator__back' );
+		await expect( backButton ).toBeFocused();
+
+		// Tab to the title field.
+		await page.keyboard.press( 'Tab' );
+		await expect( titleField ).toBeFocused();
+
+		// Tab to the Publish checkbox (on by default).
+		await page.keyboard.press( 'Tab' );
+		const publishCheckbox = page.getByRole( 'checkbox', {
+			name: 'Publish',
+		} );
+		await expect( publishCheckbox ).toBeFocused();
+		await expect( publishCheckbox ).toBeChecked();
+
+		// Tab twice more to reach the Create page button.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await expect( createPageButton ).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+
+		// The newly created page should appear as a new item in the list view.
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: 'Brand New Page' } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+	} );
+
 	test( 'focus is managed correctly when dismissing the link UI without selecting a URL', async ( {
 		admin,
 		page,

--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -67,38 +67,26 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 		).toBeVisible();
 
 		// The appender button should be present to allow adding new items.
-		// NOTE: This currently FAILS because NavigationMenuContent passes
-		// showAppender={ false } to PrivateListView. Implementing the feature
-		// requires changing it to showAppender={ true } and wiring up the
-		// AdditionalBlockContent / LinkUI integration.
 		const appender = listView.getByRole( 'button', { name: 'Add page' } );
 		await expect( appender ).toBeVisible();
 
 		await appender.click();
 
 		// The LinkUI popover should open and immediately focus the search input.
-		const linkUIInput = linkControl.getSearchInput();
-		await expect( linkUIInput ).toBeFocused();
-		await expect( linkUIInput ).toBeEmpty();
+		await expect( linkControl.getLinkControlSearch() ).toBeFocused();
 
-		// Type to trigger search suggestions.
-		await linkControl.searchFor( 'Test Page' );
-
-		// Select the first result to create a new menu item.
-		const firstResult = await linkControl.getNthSearchResult( 0 );
-		const firstResultText =
-			await linkControl.getSearchResultText( firstResult );
-		await firstResult.click();
+		// Search for and select the page.
+		await linkControl.useLinkControlSearch( 'Test Page 2' );
 
 		// The new item should be appended after the existing item.
 		await expect(
 			listView
-				.getByRole( 'gridcell', { name: firstResultText } )
+				.getByRole( 'gridcell', { name: 'Test Page 2' } )
 				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
 		).toBeVisible();
 	} );
 
-	test( 'opening the add link UI does not immediately trigger unsaved changes', async ( {
+	test( 'can open and close the add link UI', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -118,34 +106,10 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 
 		await expect( listView ).toBeVisible();
 
-		// Confirm no unsaved changes exist before interacting.
-		await expect(
-			page.getByRole( 'button', { name: /Review \d+ change/ } )
-		).toBeHidden();
-
 		const appender = listView.getByRole( 'button', { name: 'Add page' } );
 		await appender.click();
 
-		// Wait for the link UI to open so we know the click was processed
-		// and state has settled — then assert no save indicator appeared.
-		await expect( linkControl.getSearchInput() ).toBeVisible();
-		await expect(
-			page.getByRole( 'button', { name: /Review \d+ change/ } )
-		).toBeHidden();
-
-		// Dismiss without selecting a URL.
-		await page.keyboard.press( 'Escape' );
-
-		// Wait for the link UI to fully close before checking — this ensures
-		// the CSS visibility class has been removed and we are testing the
-		// actual entity dirty state, not just the CSS mask.
-		await expect( linkControl.getSearchInput() ).toBeHidden();
-
-		// Verify the save indicator still does not appear — the empty block
-		// insertion should be fully reverted, leaving the entity clean.
-		await expect(
-			page.getByRole( 'button', { name: /Review \d+ change…/ } )
-		).toBeHidden();
+		await linkControl.addLinkClose();
 	} );
 
 	test( 'cancelling a second add does not remove previously added unsaved links', async ( {
@@ -168,29 +132,21 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 
 		await expect( listView ).toBeVisible();
 
-		// Add a first new item by selecting a URL.
+		// Add a first new item by selecting a page.
 		const appender = listView.getByRole( 'button', { name: 'Add page' } );
 		await appender.click();
-		await linkControl.searchFor( 'Test Page' );
-		const firstResult = await linkControl.getNthSearchResult( 0 );
-		const firstResultText =
-			await linkControl.getSearchResultText( firstResult );
-		await firstResult.click();
+		await linkControl.useLinkControlSearch( 'Test Page 2' );
 
 		// Verify the first new item was committed (block 2 of 2).
 		await expect(
 			listView
-				.getByRole( 'gridcell', { name: firstResultText } )
+				.getByRole( 'gridcell', { name: 'Test Page 2' } )
 				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
 		).toBeVisible();
 
 		// Start adding a second item but cancel without selecting a URL.
 		await appender.click();
-		await expect( linkControl.getSearchInput() ).toBeFocused();
-		await page.keyboard.press( 'Escape' );
-
-		// Wait for the link UI to fully close.
-		await expect( linkControl.getSearchInput() ).toBeHidden();
+		await linkControl.addLinkClose();
 
 		// The previously committed unsaved link should still be present —
 		// cancelling the second insertion must not remove the first one.
@@ -201,7 +157,7 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 		).toBeVisible();
 		await expect(
 			listView
-				.getByRole( 'gridcell', { name: firstResultText } )
+				.getByRole( 'gridcell', { name: 'Test Page 2' } )
 				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
 		).toBeVisible();
 	} );
@@ -230,10 +186,9 @@ test.describe( 'Navigation sidebar - list view editing', () => {
 		await appender.click();
 
 		// Verify focus goes to the search input immediately (focus management).
-		await expect( linkControl.getSearchInput() ).toBeFocused();
+		await expect( linkControl.getLinkControlSearch() ).toBeFocused();
 
-		// Dismiss without selecting a URL.
-		await page.keyboard.press( 'Escape' );
+		await linkControl.addLinkClose();
 
 		// The auto-inserted empty block should be cleaned up automatically.
 		// Verify the original item is still there and is the only item
@@ -251,38 +206,28 @@ class LinkControl {
 		this.page = page;
 	}
 
-	getSearchInput() {
+	getLinkControlSearch() {
 		return this.page.getByRole( 'combobox', {
 			name: 'Search or type URL',
 		} );
 	}
 
-	async getSearchResults() {
-		const searchInput = this.getSearchInput();
-		const resultsRef = await searchInput.getAttribute( 'aria-owns' );
-		const linkUIResults = this.page.locator( `#${ resultsRef }` );
-		await expect( linkUIResults ).toBeVisible();
-		return linkUIResults.getByRole( 'option' );
+	async useLinkControlSearch( searchTerm ) {
+		await expect( this.getLinkControlSearch() ).toBeFocused();
+
+		await this.page.keyboard.type( searchTerm, { delay: 50 } );
+
+		await expect(
+			this.page.getByRole( 'listbox', { name: 'Search results' } )
+		).toBeVisible();
+
+		await this.page.keyboard.press( 'ArrowDown' );
+		await this.page.keyboard.press( 'Enter' );
 	}
 
-	async getNthSearchResult( index = 0 ) {
-		const results = await this.getSearchResults();
-		return results.nth( index );
-	}
-
-	async searchFor( searchTerm ) {
-		const input = this.getSearchInput();
-		await expect( input ).toBeFocused();
-		await this.page.keyboard.type( searchTerm );
-		await expect( input ).toHaveValue( searchTerm );
-		return input;
-	}
-
-	async getSearchResultText( result ) {
-		await expect( result ).toBeVisible();
-		return result
-			.locator( '.components-menu-item__item' )
-			.last()
-			.innerText();
+	async addLinkClose() {
+		await expect( this.getLinkControlSearch() ).toBeFocused();
+		await this.page.keyboard.press( 'Escape' );
+		await expect( this.getLinkControlSearch() ).toBeHidden();
 	}
 }

--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -1,0 +1,288 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Navigation sidebar - list view editing', () => {
+	const navMenuFixture = {
+		title: 'Test Navigation Menu',
+		content:
+			'<!-- wp:navigation-link {"label":"Existing Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+	};
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.createPage( {
+			title: 'Test Page 1',
+			status: 'publish',
+		} );
+		await requestUtils.createPage( {
+			title: 'Test Page 2',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPages(),
+			requestUtils.activateTheme( 'twentytwentyone' ),
+		] );
+	} );
+
+	test.use( {
+		linkControl: async ( { page }, use ) => {
+			await use( new LinkControl( { page } ) );
+		},
+	} );
+
+	test( 'can add new menu items from the sidebar list view', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		// Visit the site editor in sidebar-browse mode (without canvas: 'edit')
+		// so that the sidebar shows the navigation menu's list view.
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Verify the existing item is shown in the sidebar list view.
+		await expect(
+			listView.getByRole( 'gridcell', { name: 'Existing Item' } )
+		).toBeVisible();
+
+		// The appender button should be present to allow adding new items.
+		// NOTE: This currently FAILS because NavigationMenuContent passes
+		// showAppender={ false } to PrivateListView. Implementing the feature
+		// requires changing it to showAppender={ true } and wiring up the
+		// AdditionalBlockContent / LinkUI integration.
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await expect( appender ).toBeVisible();
+
+		await appender.click();
+
+		// The LinkUI popover should open and immediately focus the search input.
+		const linkUIInput = linkControl.getSearchInput();
+		await expect( linkUIInput ).toBeFocused();
+		await expect( linkUIInput ).toBeEmpty();
+
+		// Type to trigger search suggestions.
+		await linkControl.searchFor( 'Test Page' );
+
+		// Select the first result to create a new menu item.
+		const firstResult = await linkControl.getNthSearchResult( 0 );
+		const firstResultText =
+			await linkControl.getSearchResultText( firstResult );
+		await firstResult.click();
+
+		// The new item should be appended after the existing item.
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: firstResultText } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+	} );
+
+	test( 'opening the add link UI does not immediately trigger unsaved changes', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Confirm no unsaved changes exist before interacting.
+		await expect(
+			page.getByRole( 'button', { name: /Review \d+ change/ } )
+		).toBeHidden();
+
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+
+		// Wait for the link UI to open so we know the click was processed
+		// and state has settled — then assert no save indicator appeared.
+		await expect( linkControl.getSearchInput() ).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: /Review \d+ change/ } )
+		).toBeHidden();
+
+		// Dismiss without selecting a URL.
+		await page.keyboard.press( 'Escape' );
+
+		// Wait for the link UI to fully close before checking — this ensures
+		// the CSS visibility class has been removed and we are testing the
+		// actual entity dirty state, not just the CSS mask.
+		await expect( linkControl.getSearchInput() ).toBeHidden();
+
+		// Verify the save indicator still does not appear — the empty block
+		// insertion should be fully reverted, leaving the entity clean.
+		await expect(
+			page.getByRole( 'button', { name: /Review \d+ change…/ } )
+		).toBeHidden();
+	} );
+
+	test( 'cancelling a second add does not remove previously added unsaved links', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Add a first new item by selecting a URL.
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+		await linkControl.searchFor( 'Test Page' );
+		const firstResult = await linkControl.getNthSearchResult( 0 );
+		const firstResultText =
+			await linkControl.getSearchResultText( firstResult );
+		await firstResult.click();
+
+		// Verify the first new item was committed (block 2 of 2).
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: firstResultText } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+
+		// Start adding a second item but cancel without selecting a URL.
+		await appender.click();
+		await expect( linkControl.getSearchInput() ).toBeFocused();
+		await page.keyboard.press( 'Escape' );
+
+		// Wait for the link UI to fully close.
+		await expect( linkControl.getSearchInput() ).toBeHidden();
+
+		// The previously committed unsaved link should still be present —
+		// cancelling the second insertion must not remove the first one.
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: 'Existing Item' } )
+				.filter( { hasText: 'Block 1 of 2, Level 1.' } )
+		).toBeVisible();
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: firstResultText } )
+				.filter( { hasText: 'Block 2 of 2, Level 1.' } )
+		).toBeVisible();
+	} );
+
+	test( 'focus is managed correctly when dismissing the link UI without selecting a URL', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitSiteEditor( {
+			postId: createdMenu?.id,
+			postType: 'wp_navigation',
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await appender.click();
+
+		// Verify focus goes to the search input immediately (focus management).
+		await expect( linkControl.getSearchInput() ).toBeFocused();
+
+		// Dismiss without selecting a URL.
+		await page.keyboard.press( 'Escape' );
+
+		// The auto-inserted empty block should be cleaned up automatically.
+		// Verify the original item is still there and is the only item
+		// (i.e. no orphaned empty block was left behind).
+		await expect(
+			listView
+				.getByRole( 'gridcell', { name: 'Existing Item' } )
+				.filter( { hasText: 'Block 1 of 1, Level 1.' } )
+		).toBeVisible();
+	} );
+} );
+
+class LinkControl {
+	constructor( { page } ) {
+		this.page = page;
+	}
+
+	getSearchInput() {
+		return this.page.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+	}
+
+	async getSearchResults() {
+		const searchInput = this.getSearchInput();
+		const resultsRef = await searchInput.getAttribute( 'aria-owns' );
+		const linkUIResults = this.page.locator( `#${ resultsRef }` );
+		await expect( linkUIResults ).toBeVisible();
+		return linkUIResults.getByRole( 'option' );
+	}
+
+	async getNthSearchResult( index = 0 ) {
+		const results = await this.getSearchResults();
+		return results.nth( index );
+	}
+
+	async searchFor( searchTerm ) {
+		const input = this.getSearchInput();
+		await expect( input ).toBeFocused();
+		await this.page.keyboard.type( searchTerm );
+		await expect( input ).toHaveValue( searchTerm );
+		return input;
+	}
+
+	async getSearchResultText( result ) {
+		await expect( result ).toBeVisible();
+		return result
+			.locator( '.components-menu-item__item' )
+			.last()
+			.innerText();
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/66367
Part of https://github.com/WordPress/gutenberg/issues/75920

Allows adding links from the Site Editor Navigation List View. This functionality already exists in the Sidebar Inspector for the Navigation Block in canvas.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The site editor navigation experience is quite lacking. Only allowing reordering and deleting items. We should allow adding links here as well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Export NavigationLinkUI as a private API and utilize it within the site editor sidebar. I also added e2e tests for the flow.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

`npm run test:e2e test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js`

First, Navigate to the Site Editor for a navigation menu   
                                                            
  **Add an existing page/URL:**
  2. Click the "Add page" appender button at the bottom of the list.
  3. Confirm the link search input opens and is immediately focused.
  4. Type a partial page title — confirm search results appear.
  5. Select a result — confirm the new item appears in the list view.

  **Dismiss without saving:**
  1. Click the appender again to open the link UI.
  2. Press Escape — confirm the popover closes, no empty item is left in the list, and focus
  returns correctly to the appender

  **Create a new page:**
  1. Click the appender and type a title that doesn't exist yet.
  2. Click "Create page" button
  3. Confirm the page creation form opens with the title pre-filled.
  4. Submit the form — confirm the new page appears as a list item.

  **Regression — existing behavior unchanged:**
  - Confirm the existing items in the list still show their labels and links.
  - Confirm the LeafMoreMenu (the ... context menu on each item) still works.
  - Confirm navigating to the canvas edit mode still works from the sidebar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/3129400e-2440-40f5-bcce-882b251519e0

