### PR TITLE
Sync: Fix awareness state JSON serialization format

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -7,3 +7,4 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75711
 * https://github.com/WordPress/gutenberg/pull/75746
 * https://github.com/WordPress/gutenberg/pull/75869
+* https://github.com/WordPress/gutenberg/pull/75919

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -226,7 +226,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			);
 
 			foreach ( $rooms as $room_request ) {
-				$awareness = $room_request['awareness'];
+				$awareness = (object) $room_request['awareness'];
 				$client_id = $room_request['client_id'];
 				$cursor    = $room_request['after'];
 				$room      = $room_request['room'];
@@ -250,7 +250,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 
 				// Get updates for this client.
 				$room_response              = $this->get_updates( $room, $client_id, $cursor, $is_compactor );
-				$room_response['awareness'] = $merged_awareness;
+				$room_response['awareness'] = (object) $merged_awareness;
 
 				$response['rooms'][] = $room_response;
 			}
@@ -320,15 +320,20 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		 *
 		 * @param string                    $room             Room identifier.
 		 * @param int                       $client_id        Client identifier.
-		 * @param array<string, mixed>|null $awareness_update Awareness state sent by the client.
+		 * @param object|null               $awareness_update Awareness state sent by the client.
 		 * @return array<int, array<string, mixed>> Map of client ID to awareness state.
 		 */
-		private function process_awareness_update( string $room, int $client_id, ?array $awareness_update ): array {
+		private function process_awareness_update( string $room, int $client_id, ?object $awareness_update ): array {
 			$existing_awareness = $this->storage->get_awareness_state( $room );
 			$updated_awareness  = array();
 			$current_time       = time();
 
 			foreach ( $existing_awareness as $entry ) {
+				// Skip entries with unexpected structure.
+				if ( ! is_array( $entry ) || ! isset( $entry['client_id'], $entry['state'], $entry['updated_at'] ) ) {
+					continue;
+				}
+
 				// Remove this client's entry (it will be updated below).
 				if ( $client_id === $entry['client_id'] ) {
 					continue;
@@ -357,7 +362,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			// Convert to client_id => state map for response.
 			$response = array();
 			foreach ( $updated_awareness as $entry ) {
-				$response[ $entry['client_id'] ] = $entry['state'];
+				$response[ $entry['client_id'] ] = (object) $entry['state'];
 			}
 
 			return $response;

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -90,14 +90,6 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		}
 
 		/**
-		 * Schema for a stored awareness entry.
-		 *
-		 * @since 7.0.0
-		 * @var array<string, mixed>
-		 */
-		private array $awareness_entry_schema;
-
-		/**
 		 * Registers REST API routes.
 		 *
 		 * @since 7.0.0
@@ -175,8 +167,6 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 					'type'     => 'array',
 				),
 			);
-
-			$this->awareness_entry_schema = $room_args['awareness'];
 
 			register_rest_route(
 				self::REST_NAMESPACE,

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -90,6 +90,14 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		}
 
 		/**
+		 * Schema for a stored awareness entry.
+		 *
+		 * @since 7.0.0
+		 * @var array<string, mixed>
+		 */
+		private array $awareness_entry_schema;
+
+		/**
 		 * Registers REST API routes.
 		 *
 		 * @since 7.0.0
@@ -123,8 +131,32 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 					'type'     => 'integer',
 				),
 				'awareness' => array(
-					'required' => true,
-					'type'     => array( 'object', 'null' ),
+					'required'             => true,
+					'type'                 => array( 'object', 'null' ),
+					'sanitize_callback'    => static function ( $value ) {
+						if ( null === $value ) {
+							return null;
+						}
+						return (object) $value;
+					},
+					'properties'           => array(
+						'client_id'        => array(
+							'type' => 'integer',
+						),
+						'collaboratorInfo' => array(
+							'type' => 'object',
+						),
+						'editorState'      => array(
+							'type' => 'object',
+						),
+						'state'            => array(
+							'type' => 'object',
+						),
+						'updated_at'       => array(
+							'type' => 'integer',
+						),
+					),
+					'additionalProperties' => false,
 				),
 				'client_id' => array(
 					'minimum'  => 1,
@@ -143,6 +175,8 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 					'type'     => 'array',
 				),
 			);
+
+			$this->awareness_entry_schema = $room_args['awareness'];
 
 			register_rest_route(
 				self::REST_NAMESPACE,
@@ -226,7 +260,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			);
 
 			foreach ( $rooms as $room_request ) {
-				$awareness = (object) $room_request['awareness'];
+				$awareness = $room_request['awareness'];
 				$client_id = $room_request['client_id'];
 				$cursor    = $room_request['after'];
 				$room      = $room_request['room'];
@@ -320,17 +354,17 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		 *
 		 * @param string                    $room             Room identifier.
 		 * @param int                       $client_id        Client identifier.
-		 * @param object|null               $awareness_update Awareness state sent by the client.
+		 * @param array<string, mixed>|null $awareness_update Awareness state sent by the client.
 		 * @return array<int, array<string, mixed>> Map of client ID to awareness state.
 		 */
-		private function process_awareness_update( string $room, int $client_id, ?object $awareness_update ): array {
+		private function process_awareness_update( string $room, int $client_id, ?array $awareness_update ): array {
 			$existing_awareness = $this->storage->get_awareness_state( $room );
 			$updated_awareness  = array();
 			$current_time       = time();
 
 			foreach ( $existing_awareness as $entry ) {
-				// Skip entries with unexpected structure.
-				if ( ! is_array( $entry ) || ! isset( $entry['client_id'], $entry['state'], $entry['updated_at'] ) ) {
+				// Skip entries that don't match the expected schema.
+				if ( is_wp_error( rest_validate_value_from_schema( $entry, $this->awareness_entry_schema ) ) ) {
 					continue;
 				}
 

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -363,11 +363,6 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			$current_time       = time();
 
 			foreach ( $existing_awareness as $entry ) {
-				// Skip entries that don't match the expected schema.
-				if ( is_wp_error( rest_validate_value_from_schema( $entry, $this->awareness_entry_schema ) ) ) {
-					continue;
-				}
-
 				// Remove this client's entry (it will be updated below).
 				if ( $client_id === $entry['client_id'] ) {
 					continue;
@@ -396,7 +391,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 			// Convert to client_id => state map for response.
 			$response = array();
 			foreach ( $updated_awareness as $entry ) {
-				$response[ $entry['client_id'] ] = (object) $entry['state'];
+				$response[ $entry['client_id'] ] = $entry['state'];
 			}
 
 			return $response;


### PR DESCRIPTION
## What?
Ensures awareness state values are cast to `stdClass` objects before storage and in response maps, preventing JSON serialization issues.

## Why?
When clients send empty awareness objects `{}`, PHP's `json_decode($body, true)` converts them to empty arrays `[]`. Without casting, these empty arrays serialize back as `[]` instead of `{}`, breaking the TypeScript type contract (`LocalAwarenessState = object | null`). This fix ensures proper round-tripping through PHP for both empty and non-empty awareness states.

## How?
Cast awareness state values to `(object)` at three points: when storing new entries, when building the response map, and when assigning the awareness map to the response. Also added defensive validation to skip entries from storage with missing required keys.

## Testing
Collaborative editing with multiple users should properly sync awareness state (cursor positions, presence) without type errors. The fix handles both empty and populated awareness states correctly during JSON serialization/deserialization.