### PR TITLE
RTC: Bugfix: Fix casing of getPersistedCRDTDoc

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -417,8 +417,12 @@ async function loadPostTypeEntities() {
 			 * @param {import('@wordpress/sync').ObjectData} record
 			 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
 			 */
-			getPersistedCRDTDoc: ( record ) =>
-				record[ POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE ] || null,
+			getPersistedCRDTDoc: ( record ) => {
+				return (
+					record?.meta[ POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE ] ||
+					null
+				);
+			},
 		};
 
 		return entity;

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -408,13 +408,13 @@ export function createSyncManager( debug = false ): SyncManager {
 			syncConfig: {
 				applyChangesToCRDTDoc,
 				getChangesFromCRDTDoc,
-				getPersistedCrdtDoc,
+				getPersistedCRDTDoc,
 			},
 			ydoc: targetDoc,
 		} = entityState;
 
 		// Get the persisted CRDT document, if it exists.
-		const serialized = getPersistedCrdtDoc?.( record );
+		const serialized = getPersistedCRDTDoc?.( record );
 		const tempDoc = serialized ? deserializeCrdtDoc( serialized ) : null;
 
 		if ( ! tempDoc ) {

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -86,7 +86,7 @@ describe( 'SyncManager', () => {
 			createAwareness: jest.fn(
 				( ydoc: Y.Doc ) => new Awareness( ydoc )
 			),
-			getPersistedCrdtDoc: jest.fn( () => null ),
+			getPersistedCRDTDoc: jest.fn( () => null ),
 		};
 
 		mockHandlers = {
@@ -272,7 +272,7 @@ describe( 'SyncManager', () => {
 			it( 'accepts a valid persisted CRDT doc without applying changes', async () => {
 				mockSyncConfig = {
 					...mockSyncConfig,
-					getPersistedCrdtDoc: jest.fn( () =>
+					getPersistedCRDTDoc: jest.fn( () =>
 						createPersistedCRDTDoc( mockRecord )
 					),
 				};
@@ -308,7 +308,7 @@ describe( 'SyncManager', () => {
 			it( 'applies a persisted CRDT doc with invalidated fields, then applies changes', async () => {
 				mockSyncConfig = {
 					...mockSyncConfig,
-					getPersistedCrdtDoc: jest.fn( () =>
+					getPersistedCRDTDoc: jest.fn( () =>
 						createPersistedCRDTDoc( {
 							...mockRecord,
 							title: 'Invalidated title from persisted CRDT doc',

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -140,7 +140,7 @@ export interface SyncConfig {
 		ydoc: Y.Doc,
 		editedRecord: ObjectData
 	) => ObjectData;
-	getPersistedCrdtDoc?: ( record: ObjectData ) => string | null;
+	getPersistedCRDTDoc?: ( record: ObjectData ) => string | null;
 }
 
 export interface SyncManager {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix bug that resulted in `getPersistedCRDTDoc` never being called.

## Why?

There was a case mismatch between `getPersistedCRDTDoc` and `getPersistedCrdtDoc`. It was not caught as a type error because of insufficient type validation in `.js` files. There was coverage in unit tests but only within packages.

Additionally, since this function was never actually called, an accessor bug was not caught. 

## How?

1. Fix casing of function.
2. Fix accessor bug.
3. Add E2E tests to cover code paths.

## Testing Instructions

1. Check out this branch.
2. Settings > Writing > Enable real-time collaboration.
3. Open a post for editing.
4. Confirm that `_crdt_document` post meta is added on save.
5. Confirm that the post is not saved on load.
