### PR TITLE
RTC: Add debug logging to SyncManager

### DIFF
--- a/packages/sync/src/performance.ts
+++ b/packages/sync/src/performance.ts
@@ -13,7 +13,11 @@ export function logPerformanceTiming<
 		const end = performance.now();
 
 		// eslint-disable-next-line no-console
-		console.log( `${ fn.name } took ${ ( end - start ).toFixed( 2 ) } ms` );
+		console.log(
+			`[SyncManager][performance]: ${ fn.name } took ${ (
+				end - start
+			).toFixed( 2 ) } ms`
+		);
 
 		return result;
 	};

--- a/packages/sync/src/test/performance.test.ts
+++ b/packages/sync/src/test/performance.test.ts
@@ -52,7 +52,7 @@ describe( 'performance utilities', () => {
 
 			expect( consoleSpy ).toHaveBeenCalledTimes( 1 );
 			expect( consoleSpy.mock.calls[ 0 ][ 0 ] ).toMatch(
-				/^myFunction took \d+\.\d{2} ms$/
+				/myFunction took \d+\.\d{2} ms$/
 			);
 		} );
 


### PR DESCRIPTION
## What?

Add debug logging to `SyncManager` (behind a flag).

## Why?

Debugging the SyncManager is not always straightforward, especially for those new to the codebase. Adding debug logging in impactful places helps developers follow the data flow. Even if logging is not enabled, they signal good places to put breakpoints.

## How?

Introduce a `log` function gated behind the existing `debug` flag.

## Testing Instructions

1. Check out this branch.
2. Change `false` to `true` on [this line](https://github.com/WordPress/gutenberg/blob/8084b1d9c8a4b6fb2787046788697d71181c408e/packages/sync/src/manager.ts#L82).
3. Settings > Writing > Enable real-time collaboration.
4. Open a post for editing.
5. Observe debug logging in the console.

https://github.com/user-attachments/assets/32f20e8c-11c8-4cbf-ab58-a48dafb882dd

