### PR TITLE
Interactivity Router: fix back and forward navigation after refresh

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
@@ -31,9 +31,10 @@ const { state } = store( 'router-regions', {
 				);
 				yield actions.navigate( e.target.href );
 			} ),
-			back() {
+			back: withSyncEvent( function* ( e ) {
+				e.preventDefault();
 				history.back();
-			},
+			} ),
 		},
 		counter: {
 			increment() {

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -25,6 +25,7 @@ const {
 	routerRegions,
 	h: createElement,
 	navigationSignal,
+	sessionId,
 	warn,
 } = privateApis(
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
@@ -515,7 +516,7 @@ export const { state, actions } = store< Store >( 'core/router', {
 
 				window.history[
 					options.replace ? 'replaceState' : 'pushState'
-				]( {}, '', href );
+				]( { wp_iapi_sessionId: sessionId }, '', href );
 
 				if ( screenReaderAnnouncement ) {
 					a11ySpeak( 'loaded' );

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -516,7 +516,7 @@ export const { state, actions } = store< Store >( 'core/router', {
 
 				window.history[
 					options.replace ? 'replaceState' : 'pushState'
-				]( { wp_iapi_sessionId: sessionId }, '', href );
+				]( { wpInteractivityId: sessionId }, '', href );
 
 				if ( screenReaderAnnouncement ) {
 					a11ySpeak( 'loaded' );

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -116,7 +116,7 @@ onDOMReady( hydrateRegions );
 // Tag the current history entry with the session ID so that, within the same
 // session, all entries share the same ID and back/forward works normally.
 window.history.replaceState(
-	{ ...window.history.state, wp_iapi_sessionId: sessionId },
+	{ ...window.history.state, wpInteractivityId: sessionId },
 	''
 );
 
@@ -126,7 +126,7 @@ window.history.replaceState(
 // the page content would remain stale because the interactivity router — which
 // handles client-side navigations — might not be loaded yet.
 window.addEventListener( 'popstate', ( event ) => {
-	if ( event.state?.wp_iapi_sessionId !== sessionId ) {
+	if ( event.state?.wpInteractivityId !== sessionId ) {
 		window.location.reload();
 	}
 } );

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -125,8 +125,14 @@ window.history.replaceState(
 // server can render the correct content. Without this, the URL would change but
 // the page content would remain stale because the interactivity router — which
 // handles client-side navigations — might not be loaded yet.
-window.addEventListener( 'popstate', ( event ) => {
-	if ( event.state?.wpInteractivityId !== sessionId ) {
-		window.location.reload();
-	}
+//
+// The check runs inside `setTimeout` because `history.state` is not yet updated
+// when the `popstate` callback executes synchronously:
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#:~:text=Note%3A%20When,setTimeout(doSomeThing%2C%200)%3B
+window.addEventListener( 'popstate', () => {
+	setTimeout( () => {
+		if ( window.history.state?.wpInteractivityId !== sessionId ) {
+			window.location.reload();
+		}
+	} );
 } );

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -125,14 +125,8 @@ window.history.replaceState(
 // server can render the correct content. Without this, the URL would change but
 // the page content would remain stale because the interactivity router — which
 // handles client-side navigations — might not be loaded yet.
-//
-// The check runs inside `setTimeout` because `history.state` is not yet updated
-// when the `popstate` callback executes synchronously:
-// https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#:~:text=Note%3A%20When,setTimeout(doSomeThing%2C%200)%3B
-window.addEventListener( 'popstate', () => {
-	setTimeout( () => {
-		if ( window.history.state?.wpInteractivityId !== sessionId ) {
-			window.location.reload();
-		}
-	} );
+window.addEventListener( 'popstate', ( event ) => {
+	if ( event.state?.wpInteractivityId !== sessionId ) {
+		window.location.reload();
+	}
 } );

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -22,7 +22,13 @@ import { directive } from './hooks';
 import { getNamespace } from './namespaces';
 import { parseServerData, populateServerData } from './store';
 import { proxifyState } from './proxies';
-import { deepReadOnly, navigationSignal, onDOMReady, warn } from './utils';
+import {
+	deepReadOnly,
+	navigationSignal,
+	onDOMReady,
+	sessionId,
+	warn,
+} from './utils';
 
 export {
 	store,
@@ -86,6 +92,7 @@ export const privateApis = (
 			routerRegions,
 			deepReadOnly,
 			navigationSignal,
+			sessionId,
 			warn,
 		};
 	}
@@ -105,3 +112,21 @@ registerDirectives();
 // asynchronous modules, or modules importing this module asynchronously, this
 // cannot be guaranteed.
 onDOMReady( hydrateRegions );
+
+// Tag the current history entry with the session ID so that, within the same
+// session, all entries share the same ID and back/forward works normally.
+window.history.replaceState(
+	{ ...window.history.state, wp_iapi_sessionId: sessionId },
+	''
+);
+
+// When the browser fires `popstate` for a history entry that was created in a
+// different session (i.e., before a full page reload), force a reload so the
+// server can render the correct content. Without this, the URL would change but
+// the page content would remain stale because the interactivity router — which
+// handles client-side navigations — might not be loaded yet.
+window.addEventListener( 'popstate', ( event ) => {
+	if ( event.state?.wp_iapi_sessionId !== sessionId ) {
+		window.location.reload();
+	}
+} );

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -508,6 +508,15 @@ export function deepReadOnly< T extends object >(
 export const navigationSignal = signal( 0 );
 
 /**
+ * Unique identifier for the current browser session of the interactivity
+ * runtime. Generated once when the module is first evaluated. Used by the
+ * router to tag history entries so that, after a full page reload, popstate
+ * events for entries created in a previous session trigger a full reload
+ * instead of a client-side navigation that would leave stale content.
+ */
+export const sessionId = crypto.randomUUID();
+
+/**
  * Recursively clones the passed object.
  *
  * @param source Source object.

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -709,4 +709,30 @@ test.describe( 'Router regions', () => {
 			await expect( clientCounter ).toHaveText( '13' );
 		}
 	} );
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/70500.
+	test( 'should update content on back/forward navigation after a page reload', async ( {
+		page,
+	} ) => {
+		const region1Ssr = page.getByTestId( 'region-1-ssr' );
+
+		// Start on page 1.
+		await expect( region1Ssr ).toHaveText( 'content from page 1' );
+
+		// Client-side navigate to page 2.
+		await page.getByTestId( 'next' ).click();
+		await expect( region1Ssr ).toHaveText( 'content from page 2' );
+
+		// Reload the page.
+		await page.reload();
+		await expect( region1Ssr ).toHaveText( 'content from page 2' );
+
+		// Go back: content should update to page 1.
+		await page.goBack();
+		await expect( region1Ssr ).toHaveText( 'content from page 1' );
+
+		// Go forward: content should update back to page 2.
+		await page.goForward();
+		await expect( region1Ssr ).toHaveText( 'content from page 2' );
+	} );
 } );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/70500
Supersedes https://github.com/WordPress/gutenberg/pull/75853

Fixes the Interactivity API client-side router so that browser back/forward navigation correctly updates page content after a full page reload.

## Why?

When a user navigates between pages using the client-side router (e.g., enhanced pagination in `core/query`) and then reloads the page, pressing the browser's back or forward buttons updates the URL but leaves the content stale. This happens because:

1. The router creates history entries via `history.pushState()`, which means the browser expects the app to handle `popstate` events for those entries.
2. After a full page reload, the `@wordpress/interactivity-router` module is not loaded yet (it is dynamically imported on user interaction), so nothing handles the `popstate` event and the content is never updated.

## How?

Introduces a **session ID** mechanism to detect stale history entries after a reload:

1. **`@wordpress/interactivity` runtime** (`packages/interactivity/src/utils.ts`): Generates a unique `sessionId` (`crypto.randomUUID()`) when the module is first evaluated.
2. **`@wordpress/interactivity` runtime** (`packages/interactivity/src/index.ts`):
   - Tags the current history entry with the `sessionId` via `history.replaceState()` so that all entries within the same session share the same ID.
   - Registers a `popstate` event listener that compares `window.history.state.wpInteractivityId` against the current `sessionId`. On a mismatch (i.e., the entry was created before a reload), it forces a full page reload via `window.location.reload()`.
3. **`@wordpress/interactivity-router`** (`packages/interactivity-router/src/index.ts`): Includes the `sessionId` in the state object passed to `history.pushState()` / `history.replaceState()` during client-side navigations.

This ensures:
- **Same session** (no reload in between): All history entries carry the same `sessionId`, the `popstate` handler is a no-op, and the router handles back/forward as before.
- **After a reload**: A new `sessionId` is generated. Old history entries still have the previous session's ID, so navigating to them triggers a full page reload, which lets the server render the correct content.

## Testing Instructions

1. Create several posts (e.g., `wp post generate --count=30`).
2. Add a Query Loop block with enhanced pagination enabled (ensure "Full page reload" is **off**).
3. Visit the page on the front end.
4. Click the next-page pagination link two or three times.
5. Reload the page.
6. Press the browser back button.
7. **Expected:** The page content updates to match the URL (shows the previous page of posts).
8. Press the browser forward button.
9. **Expected:** The page content updates again to match the URL.

