### PR TITLE
Link Picker: Use Homepage badge instead of Page if Homepage

### DIFF
--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -138,69 +138,69 @@ describe( 'computeDisplayUrl', () => {
 
 describe( 'isHomepage', () => {
 	const host = 'homepage.com';
-	const siteUrl = 'https://' + host;
+	const homeUrl = 'https://' + host;
 
 	test.each( [
-		[ '/', siteUrl ],
+		[ '/', homeUrl ],
 		[ '/', undefined ],
-	] )( 'should return true for root path "%s"', ( url, siteUrlParam ) => {
-		expect( isHomepage( url, siteUrlParam ) ).toBe( true );
+	] )( 'should return true for root path "%s"', ( url, homeUrlParam ) => {
+		expect( isHomepage( url, homeUrlParam ) ).toBe( true );
 	} );
 
 	// Check combinations of http/s and trailing slash
 	test.each( [
-		[ `http://${ host }`, siteUrl ],
-		[ `https://${ host }`, siteUrl ],
-		[ `http://${ host }/`, siteUrl ],
-		[ `https://${ host }/`, siteUrl ],
+		[ `http://${ host }`, homeUrl ],
+		[ `https://${ host }`, homeUrl ],
+		[ `http://${ host }/`, homeUrl ],
+		[ `https://${ host }/`, homeUrl ],
 	] )( 'should return true for site URL "%s"', ( url ) => {
-		expect( isHomepage( url, siteUrl ) ).toBe( true );
+		expect( isHomepage( url, homeUrl ) ).toBe( true );
 	} );
 
 	test.each( [
-		[ '', siteUrl ],
+		[ '', homeUrl ],
 		[ `https://${ host }`, '' ],
 		[ `https://${ host }`, undefined ],
 	] )(
-		'should return false when url or siteUrl is empty and not a / path',
-		( url, siteUrlParam ) => {
-			expect( isHomepage( url, siteUrlParam ) ).toBe( false );
+		'should return false when url or homeUrl is empty and not a / path',
+		( url, homeUrlParam ) => {
+			expect( isHomepage( url, homeUrlParam ) ).toBe( false );
 		}
 	);
 
 	const subdomain = 'sub.' + host;
 	test.each( [
-		[ false, `http://${ subdomain }/`, siteUrl ],
-		[ false, `https://${ subdomain }`, siteUrl ],
+		[ false, `http://${ subdomain }/`, homeUrl ],
+		[ false, `https://${ subdomain }`, homeUrl ],
 		[ true, `http://${ subdomain }/`, `https://${ subdomain }` ],
 		[ true, `https://${ subdomain }`, `https://${ subdomain }` ],
 	] )(
-		'should return %s for subdomain (url=%s, siteUrl=%s)',
-		( expected, url, siteUrlParam ) => {
-			expect( isHomepage( url, siteUrlParam ) ).toBe( expected );
+		'should return %s for subdomain (url=%s, homeUrl=%s)',
+		( expected, url, homeUrlParam ) => {
+			expect( isHomepage( url, homeUrlParam ) ).toBe( expected );
 		}
 	);
 
 	const path = '/wordpress';
-	const subdirSiteUrl = 'https://' + host + path;
+	const subdirHomeUrl = 'https://' + host + path;
 
 	test.each( [
-		[ `https://${ host }${ path }`, subdirSiteUrl ],
-		[ `https://${ host }${ path }/`, subdirSiteUrl ],
-		[ `http://${ host }${ path }`, subdirSiteUrl ],
-		[ `http://${ host }${ path }/`, subdirSiteUrl ],
+		[ `https://${ host }${ path }`, subdirHomeUrl ],
+		[ `https://${ host }${ path }/`, subdirHomeUrl ],
+		[ `http://${ host }${ path }`, subdirHomeUrl ],
+		[ `http://${ host }${ path }/`, subdirHomeUrl ],
 	] )( 'should return true for subdirectory homepage "%s"', ( url ) => {
-		expect( isHomepage( url, subdirSiteUrl ) ).toBe( true );
+		expect( isHomepage( url, subdirHomeUrl ) ).toBe( true );
 	} );
 
 	test.each( [
-		[ `https://${ host }/page`, siteUrl ],
-		[ '/page', siteUrl ],
-		[ `https://${ host }`, subdirSiteUrl ],
-		[ `https://${ host }/`, subdirSiteUrl ],
-		[ `https://${ host }${ path }/page`, subdirSiteUrl ],
-	] )( 'should return false for non-homepage "%s"', ( url, siteUrlParam ) => {
-		expect( isHomepage( url, siteUrlParam ) ).toBe( false );
+		[ `https://${ host }/page`, homeUrl ],
+		[ '/page', homeUrl ],
+		[ `https://${ host }`, subdirHomeUrl ],
+		[ `https://${ host }/`, subdirHomeUrl ],
+		[ `https://${ host }${ path }/page`, subdirHomeUrl ],
+	] )( 'should return false for non-homepage "%s"', ( url, homeUrlParam ) => {
+		expect( isHomepage( url, homeUrlParam ) ).toBe( false );
 	} );
 } );
 
@@ -263,7 +263,7 @@ describe( 'computeBadges', () => {
 		] )( 'should show "Homepage" badge when url is "%s"', ( url ) => {
 			const badges = computeBadges( {
 				url,
-				siteUrl: 'https://example.com',
+				homeUrl: 'https://example.com',
 				isExternal: false,
 			} );
 			expect( badges ).toContainEqual( {
@@ -273,11 +273,11 @@ describe( 'computeBadges', () => {
 		} );
 
 		test.each( [ [ 'https://sub.example.com/', 'https://example.com' ] ] )(
-			'should not show Homepage badge when subdomain url "%s" does not match siteUrl "%s"',
-			( url, siteUrl ) => {
+			'should not show Homepage badge when subdomain url "%s" does not match homeUrl "%s"',
+			( url, homeUrl ) => {
 				const badges = computeBadges( {
 					url,
-					siteUrl,
+					homeUrl,
 					isExternal: false,
 				} );
 				expect( badges ).not.toContainEqual( {
@@ -290,11 +290,11 @@ describe( 'computeBadges', () => {
 		test.each( [
 			[ 'https://sub.example.com/', 'https://sub.example.com' ],
 		] )(
-			'should show Homepage badge when subdomain url "%s" matches siteUrl "%s"',
-			( url, siteUrl ) => {
+			'should show Homepage badge when subdomain url "%s" matches homeUrl "%s"',
+			( url, homeUrl ) => {
 				const badges = computeBadges( {
 					url,
-					siteUrl,
+					homeUrl,
 					isExternal: false,
 				} );
 				expect( badges ).toContainEqual( {

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -174,6 +174,18 @@ describe( 'computeBadges', () => {
 			} );
 		} );
 
+		it( 'should show "Homepage" badge for root path', () => {
+			const badges = computeBadges( {
+				url: '/',
+				isExternal: false,
+			} );
+
+			expect( badges ).toContainEqual( {
+				label: 'Homepage',
+				intent: 'default',
+			} );
+		} );
+
 		it( 'should show page badge for relative paths', () => {
 			const badges = computeBadges( {
 				url: '/relative-path',
@@ -251,6 +263,25 @@ it( 'should show "Internal link" badge for hash links even when type is present'
 	// Should prioritize hash link detection over type
 	expect( badges ).toContainEqual( {
 		label: 'Internal link',
+		intent: 'default',
+	} );
+	// Should NOT show Page badge
+	expect( badges ).not.toContainEqual( {
+		label: 'Page',
+		intent: 'default',
+	} );
+} );
+
+it( 'should show "Homepage" badge for root path even when type is present', () => {
+	const badges = computeBadges( {
+		url: '/',
+		type: 'page',
+		isExternal: false,
+	} );
+
+	// Should prioritize homepage detection over type
+	expect( badges ).toContainEqual( {
+		label: 'Homepage',
 		intent: 'default',
 	} );
 	// Should NOT show Page badge

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -36,6 +36,7 @@ jest.mock( '../../../lock-unlock', () => ( {
 import {
 	computeDisplayUrl,
 	computeBadges,
+	isHomepage,
 	useLinkPreview,
 } from '../use-link-preview';
 
@@ -135,6 +136,74 @@ describe( 'computeDisplayUrl', () => {
 	} );
 } );
 
+describe( 'isHomepage', () => {
+	const host = 'homepage.com';
+	const siteUrl = 'https://' + host;
+
+	test.each( [
+		[ '/', siteUrl ],
+		[ '/', undefined ],
+	] )( 'should return true for root path "%s"', ( url, siteUrlParam ) => {
+		expect( isHomepage( url, siteUrlParam ) ).toBe( true );
+	} );
+
+	// Check combinations of http/s and trailing slash
+	test.each( [
+		[ `http://${ host }`, siteUrl ],
+		[ `https://${ host }`, siteUrl ],
+		[ `http://${ host }/`, siteUrl ],
+		[ `https://${ host }/`, siteUrl ],
+	] )( 'should return true for site URL "%s"', ( url ) => {
+		expect( isHomepage( url, siteUrl ) ).toBe( true );
+	} );
+
+	test.each( [
+		[ '', siteUrl ],
+		[ `https://${ host }`, '' ],
+		[ `https://${ host }`, undefined ],
+	] )(
+		'should return false when url or siteUrl is empty and not a / path',
+		( url, siteUrlParam ) => {
+			expect( isHomepage( url, siteUrlParam ) ).toBe( false );
+		}
+	);
+
+	const subdomain = 'sub.' + host;
+	test.each( [
+		[ false, `http://${ subdomain }/`, siteUrl ],
+		[ false, `https://${ subdomain }`, siteUrl ],
+		[ true, `http://${ subdomain }/`, `https://${ subdomain }` ],
+		[ true, `https://${ subdomain }`, `https://${ subdomain }` ],
+	] )(
+		'should return %s for subdomain (url=%s, siteUrl=%s)',
+		( expected, url, siteUrlParam ) => {
+			expect( isHomepage( url, siteUrlParam ) ).toBe( expected );
+		}
+	);
+
+	const path = '/wordpress';
+	const subdirSiteUrl = 'https://' + host + path;
+
+	test.each( [
+		[ `https://${ host }${ path }`, subdirSiteUrl ],
+		[ `https://${ host }${ path }/`, subdirSiteUrl ],
+		[ `http://${ host }${ path }`, subdirSiteUrl ],
+		[ `http://${ host }${ path }/`, subdirSiteUrl ],
+	] )( 'should return true for subdirectory homepage "%s"', ( url ) => {
+		expect( isHomepage( url, subdirSiteUrl ) ).toBe( true );
+	} );
+
+	test.each( [
+		[ `https://${ host }/page`, siteUrl ],
+		[ '/page', siteUrl ],
+		[ `https://${ host }`, subdirSiteUrl ],
+		[ `https://${ host }/`, subdirSiteUrl ],
+		[ `https://${ host }${ path }/page`, subdirSiteUrl ],
+	] )( 'should return false for non-homepage "%s"', ( url, siteUrlParam ) => {
+		expect( isHomepage( url, siteUrlParam ) ).toBe( false );
+	} );
+} );
+
 describe( 'computeBadges', () => {
 	describe( 'kind badges', () => {
 		it( 'should show "External link" badge for external links', () => {
@@ -185,6 +254,55 @@ describe( 'computeBadges', () => {
 				intent: 'default',
 			} );
 		} );
+
+		test.each( [
+			[ 'https://example.com' ],
+			[ 'https://example.com/' ],
+			[ 'http://example.com' ],
+			[ 'http://example.com/' ],
+		] )( 'should show "Homepage" badge when url is "%s"', ( url ) => {
+			const badges = computeBadges( {
+				url,
+				siteUrl: 'https://example.com',
+				isExternal: false,
+			} );
+			expect( badges ).toContainEqual( {
+				label: 'Homepage',
+				intent: 'default',
+			} );
+		} );
+
+		test.each( [ [ 'https://sub.example.com/', 'https://example.com' ] ] )(
+			'should not show Homepage badge when subdomain url "%s" does not match siteUrl "%s"',
+			( url, siteUrl ) => {
+				const badges = computeBadges( {
+					url,
+					siteUrl,
+					isExternal: false,
+				} );
+				expect( badges ).not.toContainEqual( {
+					label: 'Homepage',
+					intent: 'default',
+				} );
+			}
+		);
+
+		test.each( [
+			[ 'https://sub.example.com/', 'https://sub.example.com' ],
+		] )(
+			'should show Homepage badge when subdomain url "%s" matches siteUrl "%s"',
+			( url, siteUrl ) => {
+				const badges = computeBadges( {
+					url,
+					siteUrl,
+					isExternal: false,
+				} );
+				expect( badges ).toContainEqual( {
+					label: 'Homepage',
+					intent: 'default',
+				} );
+			}
+		);
 
 		it( 'should show page badge for relative paths', () => {
 			const badges = computeBadges( {

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -44,18 +44,18 @@ export function isHomepage( url, homeUrl ) {
 	}
 	try {
 		const urlParsed = new URL( url, homeUrl );
-		const siteParsed = new URL( homeUrl );
+		const homeParsed = new URL( homeUrl );
 
-		// Same host (sub.homepage.com !== homepage.com unless homeUrl is sub.homepage.com)
-		if ( urlParsed.hostname !== siteParsed.hostname ) {
+		// Same host, i.e. sub.homepage.com or homepage.com
+		if ( urlParsed.hostname !== homeParsed.hostname ) {
 			return false;
 		}
 
 		// Path must match site root (normalize trailing slash)
 		const urlPath = urlParsed.pathname.replace( /\/$/, '' );
-		const sitePath = siteParsed.pathname.replace( /\/$/, '' );
+		const homePath = homeParsed.pathname.replace( /\/$/, '' );
 
-		return urlPath === sitePath;
+		return urlPath === homePath;
 	} catch {
 		return false;
 	}

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -98,7 +98,6 @@ export function computeBadges( {
 	isEntityAvailable,
 } ) {
 	const badges = [];
-
 	// Kind badge
 	if ( url ) {
 		if ( isExternal ) {
@@ -111,6 +110,11 @@ export function computeBadges( {
 			// because they're not entity links even if type is set
 			badges.push( {
 				label: __( 'Internal link' ),
+				intent: 'default',
+			} );
+		} else if ( url === '/' ) {
+			badges.push( {
+				label: __( 'Homepage' ),
 				intent: 'default',
 			} );
 		} else if ( type && type !== 'custom' ) {

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -27,6 +27,41 @@ function capitalize( str ) {
 }
 
 /**
+ * Check if a URL points to the site homepage.
+ * Handles protocol (http/https) and trailing slash variations.
+ * Does not match subdomains unless they are the site URL.
+ *
+ * @param {string} url     - The URL to check
+ * @param {string} siteUrl - The WordPress site URL
+ * @return {boolean} True if url is the homepage
+ */
+export function isHomepage( url, siteUrl ) {
+	if ( url === '/' ) {
+		return true;
+	}
+	if ( ! url || ! siteUrl ) {
+		return false;
+	}
+	try {
+		const urlParsed = new URL( url, siteUrl );
+		const siteParsed = new URL( siteUrl );
+
+		// Same host (sub.homepage.com !== homepage.com unless siteUrl is sub.homepage.com)
+		if ( urlParsed.hostname !== siteParsed.hostname ) {
+			return false;
+		}
+
+		// Path must match site root (normalize trailing slash)
+		const urlPath = urlParsed.pathname.replace( /\/$/, '' );
+		const sitePath = siteParsed.pathname.replace( /\/$/, '' );
+
+		return urlPath === sitePath;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Compute display URL - strips site URL if internal, shows full URL if external.
  *
  * @param {Object} options         - Parameters object
@@ -82,6 +117,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
  *
  * @param {Object}  options                   - Options object
  * @param {string}  options.url               - Link URL
+ * @param {string}  options.siteUrl           - WordPress site URL (for homepage detection)
  * @param {string}  options.type              - Entity type (page, post, etc.)
  * @param {boolean} options.isExternal        - Whether link is external
  * @param {string}  options.entityStatus      - Entity status (publish, draft, etc.)
@@ -91,6 +127,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
  */
 export function computeBadges( {
 	url,
+	siteUrl,
 	type,
 	isExternal,
 	entityStatus,
@@ -112,7 +149,7 @@ export function computeBadges( {
 				label: __( 'Internal link' ),
 				intent: 'default',
 			} );
-		} else if ( url === '/' ) {
+		} else if ( isHomepage( url, siteUrl ) ) {
 			badges.push( {
 				label: __( 'Homepage' ),
 				intent: 'default',
@@ -233,6 +270,7 @@ export function useLinkPreview( {
 	// Compute badges
 	const badges = computeBadges( {
 		url,
+		siteUrl,
 		type,
 		isExternal,
 		entityStatus: entityRecord?.status,

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -32,21 +32,21 @@ function capitalize( str ) {
  * Does not match subdomains unless they are the site URL.
  *
  * @param {string} url     - The URL to check
- * @param {string} siteUrl - The WordPress site URL
+ * @param {string} homeUrl - The WordPress site URL
  * @return {boolean} True if url is the homepage
  */
-export function isHomepage( url, siteUrl ) {
+export function isHomepage( url, homeUrl ) {
 	if ( url === '/' ) {
 		return true;
 	}
-	if ( ! url || ! siteUrl ) {
+	if ( ! url || ! homeUrl ) {
 		return false;
 	}
 	try {
-		const urlParsed = new URL( url, siteUrl );
-		const siteParsed = new URL( siteUrl );
+		const urlParsed = new URL( url, homeUrl );
+		const siteParsed = new URL( homeUrl );
 
-		// Same host (sub.homepage.com !== homepage.com unless siteUrl is sub.homepage.com)
+		// Same host (sub.homepage.com !== homepage.com unless homeUrl is sub.homepage.com)
 		if ( urlParsed.hostname !== siteParsed.hostname ) {
 			return false;
 		}
@@ -117,7 +117,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
  *
  * @param {Object}  options                   - Options object
  * @param {string}  options.url               - Link URL
- * @param {string}  options.siteUrl           - WordPress site URL (for homepage detection)
+ * @param {string}  options.homeUrl           - WordPress site URL (for homepage detection)
  * @param {string}  options.type              - Entity type (page, post, etc.)
  * @param {boolean} options.isExternal        - Whether link is external
  * @param {string}  options.entityStatus      - Entity status (publish, draft, etc.)
@@ -127,7 +127,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
  */
 export function computeBadges( {
 	url,
-	siteUrl,
+	homeUrl,
 	type,
 	isExternal,
 	entityStatus,
@@ -149,7 +149,7 @@ export function computeBadges( {
 				label: __( 'Internal link' ),
 				intent: 'default',
 			} );
-		} else if ( isHomepage( url, siteUrl ) ) {
+		} else if ( isHomepage( url, homeUrl ) ) {
 			badges.push( {
 				label: __( 'Homepage' ),
 				intent: 'default',
@@ -270,7 +270,7 @@ export function useLinkPreview( {
 	// Compute badges
 	const badges = computeBadges( {
 		url,
-		siteUrl,
+		homeUrl,
 		type,
 		isExternal,
 		entityStatus: entityRecord?.status,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Clarifies and improves the link picker's badges to include a "Homepage" for links matching the site url or `/`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Make it clearer where the link is going.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Identify if the link is the homepage by comparing the given link to the siteUrl. I added a new `isHomepage` function with unit tests to verify functionality.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add this content to a navigation block:
```
<!-- wp:navigation-link {"label":"Relative Home","type":"page","url":"/","kind":"post-type"} /-->

<!-- wp:navigation-link {"label":"localhost:8888","type":"page","url":"http://localhost:8888","kind":"post-type"} /-->
```
- You should have Relative Home and localhost:8888 in your navigation
- Open the sidebar inspector
- Select Relative Home
- The link picker should show a "Homepage" badge
- Select localhost:8888
- The link picker should show a "Homepage" badge
- Go to your [Reading settings](http://localhost:8888/wp-admin/options-reading.php) and select a page to be your homepage
- Add this page to your navigation
- The link picker should show a "Homepage" badge for this page

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="695" height="274" alt="Link Picker showing 'Homepage' badge for a / relative link" src="https://github.com/user-attachments/assets/73113cb5-f9b7-47e8-9339-2d2ff5ec3813" />
