### PR TITLE
Fix: use the same context for font library tabs translations

### DIFF
--- a/routes/font-list/stage.tsx
+++ b/routes/font-list/stage.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
@@ -50,14 +50,14 @@ function FontLibraryPage() {
 	}[] = [
 		{
 			id: 'installed-fonts',
-			title: __( 'Library' ),
+			title: _x( 'Library', 'Font library' ),
 		},
 	];
 
 	if ( canUserCreate ) {
 		tabs.push( {
 			id: 'upload-fonts',
-			title: __( 'Upload' ),
+			title: _x( 'Upload', 'noun' ),
 		} );
 		tabs.push(
 			...( collections || [] ).map( ( { slug, name } ) => ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Update the context of two strings to re-use the existing translations and ensure consistency.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

At the moment the Library / Upload labels are used both in routes/font-list/stage.tsx and packages/global-styles-ui/src/font-library/modal.tsx, once with context and once without. This change ensures that the correct strings are used on the /wp-admin/themes.php?page=font-library-wp-admin&p=%2Ffont-list page.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added context to existing strings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Switch the user locale to a popular non-English one, like German or Turkish.
2. Build the plugin and navigate to /wp-admin/themes.php?page=font-library-wp-admin&p=%2Ffont-list
3. Confirm that the correct translations appear, matching the ones from https://translate.wordpress.org/projects/wp-plugins/gutenberg/

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="590" height="332" alt="Screenshot 2026-02-25 at 20 51 31" src="https://github.com/user-attachments/assets/18d88cd7-e268-4369-b92f-768040421a1f" />|<img width="590" height="332" alt="Screenshot 2026-02-25 at 20 50 08" src="https://github.com/user-attachments/assets/6325a93d-016d-44e7-b35d-3968599b242a" />|

