### PR TITLE
Fix: Align DataViews list layout actions when title is hidden

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+* Fix horizontal alignment in list layout when only a single property is visible. ([75932](https://github.com/WordPress/gutenberg/pull/75932))
 
 ### Bug Fixes
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
-* Fix horizontal alignment in list layout when only a single property is visible. ([75932](https://github.com/WordPress/gutenberg/pull/75932))
+* Fix horizontal alignment in list layout when only a single property is visible. ([#75932](https://github.com/WordPress/gutenberg/pull/75932))
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -304,7 +304,9 @@ function ListItem< Item >( {
 					<Composite.Item
 						id={ generateItemWrapperCompositeId( idPrefix ) }
 						aria-pressed={ isSelected }
-						aria-labelledby={ renderedTitleField ? labelId : undefined }
+						aria-labelledby={
+							renderedTitleField ? labelId : undefined
+						}
 						aria-describedby={ descriptionId }
 						className="dataviews-view-list__item"
 						onClick={ () => onSelect( item ) }
@@ -368,7 +370,6 @@ function ListItem< Item >( {
 					</Stack>
 
 					{ usedActions }
-
 				</Stack>
 			</Stack>
 		</Composite.Row>

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -325,16 +325,17 @@ function ListItem< Item >( {
 						gap="xs"
 						className="dataviews-view-list__field-wrapper"
 					>
-						{ renderedTitleField && (
-							<Stack direction="row" align="center">
+						<Stack direction="row" align="center">
+							{ renderedTitleField && (
 								<div
 									className="dataviews-title-field dataviews-view-list__title-field"
 									id={ labelId }
 								>
 									{ renderedTitleField }
 								</div>
-							</Stack>
-						) }
+							) }
+							{ usedActions }
+						</Stack>
 						{ showDescription && descriptionField?.render && (
 							<div className="dataviews-view-list__field">
 								<descriptionField.render
@@ -368,8 +369,6 @@ function ListItem< Item >( {
 							) ) }
 						</div>
 					</Stack>
-
-					{ usedActions }
 				</Stack>
 			</Stack>
 		</Composite.Row>

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -304,7 +304,7 @@ function ListItem< Item >( {
 					<Composite.Item
 						id={ generateItemWrapperCompositeId( idPrefix ) }
 						aria-pressed={ isSelected }
-						aria-labelledby={ labelId }
+						aria-labelledby={ renderedTitleField ? labelId : undefined }
 						aria-describedby={ descriptionId }
 						className="dataviews-view-list__item"
 						onClick={ () => onSelect( item ) }
@@ -323,15 +323,16 @@ function ListItem< Item >( {
 						gap="xs"
 						className="dataviews-view-list__field-wrapper"
 					>
-						<Stack direction="row" align="center">
-							<div
-								className="dataviews-title-field dataviews-view-list__title-field"
-								id={ labelId }
-							>
-								{ renderedTitleField }
-							</div>
-							{ usedActions }
-						</Stack>
+						{ renderedTitleField && (
+							<Stack direction="row" align="center">
+								<div
+									className="dataviews-title-field dataviews-view-list__title-field"
+									id={ labelId }
+								>
+									{ renderedTitleField }
+								</div>
+							</Stack>
+						) }
 						{ showDescription && descriptionField?.render && (
 							<div className="dataviews-view-list__field">
 								<descriptionField.render
@@ -365,6 +366,9 @@ function ListItem< Item >( {
 							) ) }
 						</div>
 					</Stack>
+
+					{ usedActions }
+
 				</Stack>
 			</Stack>
 		</Composite.Row>


### PR DESCRIPTION
Fixes #75914

## Description
This PR fixes the horizontal alignment issue in the DataViews list layout when only a single text-based property is visible and the Title is hidden.

The issue was caused by the `.dataviews-title-field` wrapper forcing an empty vertical space, and the `usedActions` being trapped in the same row as the hidden title.
I have updated the conditionally rendered Title stack and moved the `usedActions` wrapper so it aligns horizontally to the right edge.

## Testing Instructions
1. Go to DataViews, list layout.
2. Open the appearance settings and hide all properties except one that is text-based.
3. Verify that the row height shrinks and the action menu aligns horizontally with the visible property.

## Note
I applied this fix via GitHub Codespaces. Since I couldn't run the full local environment, I would appreciate a maintainer verifying the visual changes.