### PR TITLE
Connectors: Redesign connector items as collapsible cards

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -4,7 +4,6 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalItem as Item,
 	__experimentalText as Text,
 	ExternalLink,
 	FlexBlock,
@@ -13,6 +12,7 @@ import {
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -26,6 +26,8 @@ export interface ConnectorItemProps {
 	description: string;
 	actionArea?: ReactNode;
 	children?: ReactNode;
+	isExpanded?: boolean;
+	onToggle?: () => void;
 }
 
 export function ConnectorItem( {
@@ -35,27 +37,51 @@ export function ConnectorItem( {
 	description,
 	actionArea,
 	children,
+	isExpanded = false,
+	onToggle,
 }: ConnectorItemProps ) {
+	const classes = [ 'connector-card', isExpanded && 'is-expanded', className ]
+		.filter( Boolean )
+		.join( ' ' );
+
 	return (
-		<Item className={ className }>
-			<VStack spacing={ 4 }>
-				<HStack alignment="center" spacing={ 4 }>
-					{ icon }
-					<FlexBlock>
-						<VStack spacing={ 0 }>
-							<Text weight={ 600 } size={ 15 }>
-								{ name }
-							</Text>
-							<Text variant="muted" size={ 12 }>
-								{ description }
-							</Text>
-						</VStack>
-					</FlexBlock>
-					{ actionArea }
-				</HStack>
-				{ children }
-			</VStack>
-		</Item>
+		<div className={ classes }>
+			<HStack
+				alignment="center"
+				spacing={ 4 }
+				className="connector-card__header"
+			>
+				{ icon }
+				<FlexBlock>
+					<VStack spacing={ 0 }>
+						<Text weight={ 600 } size={ 15 }>
+							{ name }
+						</Text>
+						<Text variant="muted" size={ 12 }>
+							{ description }
+						</Text>
+					</VStack>
+				</FlexBlock>
+				{ actionArea }
+				{ onToggle && (
+					<Button
+						className="connector-card__toggle"
+						onClick={ onToggle }
+						aria-expanded={ isExpanded }
+						label={
+							isExpanded
+								? __( 'Collapse settings' )
+								: __( 'Expand settings' )
+						}
+						icon={ chevronDown }
+						size="compact"
+					/>
+				) }
+			</HStack>
+			{ isExpanded && children && (
+				<div className="connector-card__body">{ children }</div>
+			) }
+		</div>
 	);
 }
 
@@ -116,7 +142,7 @@ export function DefaultConnectorSettings( {
 			);
 		}
 		if ( saveError ) {
-			return <span style={ { color: '#cc1818' } }>{ saveError }</span>;
+			return <Text style={ { color: '#cc1818' } }>{ saveError }</Text>;
 		}
 		return helpLink;
 	};
@@ -151,38 +177,67 @@ export function DefaultConnectorSettings( {
 					: undefined
 			}
 		>
-			<TextControl
-				__nextHasNoMarginBottom
-				__next40pxDefaultSize
-				label={ __( 'API Key' ) }
-				value={ apiKey }
-				onChange={ ( value ) => {
-					if ( ! readOnly ) {
-						setSaveError( null );
-						setApiKey( value );
-					}
-				} }
-				placeholder="YOUR_API_KEY"
-				disabled={ readOnly || isSaving }
-				help={ getHelp() }
-			/>
 			{ readOnly ? (
-				<Button variant="link" isDestructive onClick={ onRemove }>
-					{ __( 'Remove and replace' ) }
-				</Button>
-			) : (
-				<HStack justify="flex-start">
-					<Button
+				<>
+					<TextControl
+						__nextHasNoMarginBottom
 						__next40pxDefaultSize
-						variant="primary"
-						disabled={ ! apiKey || isSaving }
-						accessibleWhenDisabled
-						isBusy={ isSaving }
-						onClick={ handleSave }
-					>
-						{ __( 'Save' ) }
+						label={ __( 'API Key' ) }
+						value={ apiKey }
+						onChange={ () => {} }
+						placeholder="YOUR_API_KEY"
+						disabled
+						help={ getHelp() }
+					/>
+					<Button variant="link" isDestructive onClick={ onRemove }>
+						{ __( 'Remove and replace' ) }
 					</Button>
-				</HStack>
+				</>
+			) : (
+				<>
+					<HStack
+						alignment="bottom"
+						spacing={ 3 }
+						className="connector-settings__inline"
+					>
+						<FlexBlock>
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'API Key' ) }
+								value={ apiKey }
+								onChange={ ( value ) => {
+									setSaveError( null );
+									setApiKey( value );
+								} }
+								placeholder="YOUR_API_KEY"
+								disabled={ isSaving }
+							/>
+						</FlexBlock>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							disabled={ ! apiKey || isSaving }
+							accessibleWhenDisabled
+							isBusy={ isSaving }
+							onClick={ handleSave }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+					{ ( saveError || helpLink ) && (
+						<Text
+							className="connector-settings__help"
+							variant={ saveError ? undefined : 'muted' }
+							size={ 12 }
+							style={
+								saveError ? { color: '#cc1818' } : undefined
+							}
+						>
+							{ saveError || helpLink }
+						</Text>
+					) }
+				</>
 			) }
 		</VStack>
 	);

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -71,27 +71,30 @@ function ProviderConnector( {
 			icon={ <Logo /> }
 			name={ label }
 			description={ description }
+			isExpanded={ isExpanded }
+			onToggle={
+				pluginStatus === 'active'
+					? () => setIsExpanded( ! isExpanded )
+					: undefined
+			}
 			actionArea={
 				<HStack spacing={ 3 } expanded={ false }>
 					{ isConnected && <ConnectedBadge /> }
-					<Button
-						variant={
-							isExpanded || isConnected ? 'tertiary' : 'secondary'
-						}
-						size={
-							isExpanded || isConnected ? undefined : 'compact'
-						}
-						onClick={ handleButtonClick }
-						disabled={ pluginStatus === 'checking' || isBusy }
-						isBusy={ isBusy }
-						aria-expanded={ isExpanded }
-					>
-						{ getButtonLabel() }
-					</Button>
+					{ getButtonLabel() && (
+						<Button
+							variant={ isConnected ? 'tertiary' : 'secondary' }
+							size={ isConnected ? undefined : 'compact' }
+							onClick={ handleButtonClick }
+							disabled={ pluginStatus === 'checking' || isBusy }
+							isBusy={ isBusy }
+						>
+							{ getButtonLabel() }
+						</Button>
+					) }
 				</HStack>
 			}
 		>
-			{ isExpanded && pluginStatus === 'active' && (
+			{ pluginStatus === 'active' && (
 				<DefaultConnectorSettings
 					key={ isConnected ? 'connected' : 'setup' }
 					initialValue={ currentApiKey }

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -6,7 +6,7 @@
 	margin: 0 auto;
 	padding: 24px;
 
-	.components-item {
+	.connector-card {
 		padding: 20px;
 		border-radius: 8px;
 		border: 1px solid #ddd;
@@ -14,8 +14,50 @@
 		overflow: hidden;
 	}
 
+	.connector-card__header {
+		cursor: default;
+	}
+
+	.connector-card__toggle {
+		flex-shrink: 0;
+
+		svg {
+			transition: transform 0.2s ease;
+		}
+	}
+
+	.connector-card.is-expanded .connector-card__toggle svg {
+		transform: rotate(180deg);
+	}
+
+	.connector-card__body {
+		margin-top: 16px;
+		padding-top: 16px;
+		border-top: 1px solid #ddd;
+	}
+
 	.connector-settings .components-text-control__input {
 		font-family: monospace;
+	}
+
+	.connector-settings__inline {
+		// Align the Save button with the input field, not the label.
+		.components-flex-block {
+			min-width: 0;
+		}
+
+		> .components-button {
+			flex-shrink: 0;
+		}
+	}
+
+	.connector-settings__help {
+		font-size: 12px;
+		color: $gray-700;
+
+		a {
+			font-size: inherit;
+		}
 	}
 
 	> p {

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -124,8 +124,6 @@ export function useConnectorPlugin( {
 			installPlugin();
 		} else if ( pluginStatus === 'inactive' ) {
 			activatePlugin();
-		} else {
-			setIsExpanded( ! isExpanded );
 		}
 	};
 
@@ -135,12 +133,6 @@ export function useConnectorPlugin( {
 				? __( 'Installing…' )
 				: __( 'Activating…' );
 		}
-		if ( isExpanded ) {
-			return __( 'Cancel' );
-		}
-		if ( isConnected ) {
-			return __( 'Edit' );
-		}
 		switch ( pluginStatus ) {
 			case 'checking':
 				return __( 'Checking…' );
@@ -149,7 +141,7 @@ export function useConnectorPlugin( {
 			case 'inactive':
 				return __( 'Activate' );
 			case 'active':
-				return __( 'Set up' );
+				return '';
 		}
 	};
 


### PR DESCRIPTION
## What?
Follow-up to #75833.

Redesign the connector items on the Settings > Connectors page from flat `Item` components to collapsible cards with a chevron toggle.

## Why?
The initial Connectors screen shipped with a flat layout where expanding/collapsing the API key form was handled by a multi-purpose button (Cancel/Set up/Edit). This PR introduces a more standard collapsible card pattern that separates the expand/collapse concern (chevron) from the primary action (Install/Activate), making the UI cleaner and more intuitive.

## How?
- **`connector-item.tsx`**: Replace `<Item>` wrapper with a `<div>`-based card. Add `isExpanded` and `onToggle` props. Render a `Button` with a `chevronDown` icon that rotates when expanded. The toggle only renders when `onToggle` is provided.
- **`connector-item.tsx` (DefaultConnectorSettings)**: In edit mode, place the `TextControl` and Save button inline in an `HStack`. Help/error text rendered below using `Text` component. Read-only mode keeps the vertical layout.
- **`default-connectors.tsx`**: Pass `isExpanded`/`onToggle` to `ConnectorItem`. Only provide `onToggle` when `pluginStatus === 'active'` so the chevron is hidden for not-installed/inactive plugins. Hide the action button when the label is empty.
- **`use-connector-plugin.ts`**: Remove Cancel, Set up, and Edit labels from `getButtonLabel()`. Simplify `handleButtonClick()` to only handle install/activate.
- **`style.scss`**: Replace `.components-item` styles with `.connector-card` card styles. Add chevron rotation, body separator, inline input+save layout, and help text styles.

## Testing Instructions
1. Navigate to **Settings > Connectors** (`/wp-admin/options-general.php?page=connectors-wp-admin`).
2. Verify each connector renders as a card with icon, name, description, and an Install button.
3. Confirm no chevron appears for not-installed connectors.
4. Click **Install** on a connector — the plugin installs, the card auto-expands showing the API key input with an inline Save button.
5. Click the chevron to collapse the form, click again to expand.
6. Enter an API key and click **Save** — the card collapses and a "Connected" badge appears.
7. Click the chevron on a connected card — shows read-only API key with "Remove and replace" link.
8. Click **Remove and replace** — the form switches to editable mode.

### Testing Instructions for Keyboard
1. Tab to the chevron toggle button on each connector card.
2. Press Enter/Space to expand — verify the API key form appears.
3. Press Enter/Space again to collapse.
4. Tab through the expanded form: input field → Save button.
5. Verify the chevron has an accessible label ("Expand settings" / "Collapse settings").

## Screenshots or screencast
<img width="2100" height="882" alt="CleanShot 2026-02-25 at 16 26 52@2x" src="https://github.com/user-attachments/assets/42138f27-2c30-4b14-90a8-977488ed1441" />