### PR TITLE
Connectors: Unhook Core callbacks in Gutenberg coexistence

### DIFF
--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -269,6 +269,7 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 	$response->set_data( $data );
 	return $response;
 }
+remove_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10 );
 add_filter( 'rest_post_dispatch', '_gutenberg_validate_connector_keys_in_rest', 10, 3 );
 
 // --- Registration ---
@@ -299,6 +300,7 @@ function _gutenberg_register_default_connector_settings(): void {
 		add_filter( "option_{$option_name}", $config['mask'] );
 	}
 }
+remove_action( 'init', '_wp_register_default_connector_settings' );
 add_action( 'init', '_gutenberg_register_default_connector_settings' );
 
 /**
@@ -320,4 +322,5 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 		}
 	}
 }
+remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
 add_action( 'init', '_gutenberg_pass_default_connector_keys_to_ai_client' );

--- a/lib/experimental/connectors/load.php
+++ b/lib/experimental/connectors/load.php
@@ -6,6 +6,7 @@
  */
 
 add_action( 'admin_menu', '_gutenberg_connectors_add_settings_menu_item' );
+remove_action( 'admin_menu', '_wp_connectors_add_settings_menu_item' );
 
 /**
  * Registers the Connectors menu item under Settings.
@@ -13,6 +14,8 @@ add_action( 'admin_menu', '_gutenberg_connectors_add_settings_menu_item' );
  * @access private
  */
 function _gutenberg_connectors_add_settings_menu_item(): void {
+	// Remove Core's connectors menu item if it exists.
+	remove_submenu_page( 'options-general.php', 'connectors-wp-admin' );
 	add_submenu_page(
 		'options-general.php',
 		__( 'Connectors', 'gutenberg' ),

--- a/lib/remove-core-enqueue-scripts.php
+++ b/lib/remove-core-enqueue-scripts.php
@@ -10,3 +10,4 @@
 
 remove_action( 'admin_enqueue_scripts', 'wp_font_library_wp_admin_enqueue_scripts' );
 remove_action( 'admin_enqueue_scripts', 'wp_site_editor_v2_wp_admin_enqueue_scripts' );
+remove_action( 'admin_enqueue_scripts', 'wp_connectors_wp_admin_enqueue_scripts' );


### PR DESCRIPTION
## Summary
- unhook Core Connectors admin enqueue callback in Gutenberg, mirroring Font Library coexistence handling
- unhook Core Connectors backend callbacks (REST post-dispatch validation, settings registration, key pass-through) next to Gutenberg equivalent hook registrations
- keep menu override pairing explicit in connectors load bootstrap

## Testing
- enable Core backport with Connectors + enable Gutenberg plugin
- open Settings > Connectors and verify page loads without duplicate route errors
- verify provider setup/save/validation flow still works