### PR TITLE
Show transform dropdown previews on focus as well as hover

### DIFF
--- a/packages/block-editor/src/components/block-styles/menu-items.js
+++ b/packages/block-editor/src/components/block-styles/menu-items.js
@@ -24,6 +24,8 @@ export default function BlockStylesMenuItems( {
 						key={ style.name }
 						icon={ activeStyle.name === style.name ? check : null }
 						onClick={ () => onSelect( style ) }
+						onFocus={ () => onHoverStyle( style ) }
+						onBlur={ () => onHoverStyle( null ) }
 						onMouseEnter={ () => onHoverStyle( style ) }
 						onMouseLeave={ () => onHoverStyle( null ) }
 					>

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -176,6 +176,8 @@ function BlockTransformationItem( {
 			disabled={ isDisabled }
 			onMouseLeave={ () => setHoveredTransformItemName( null ) }
 			onMouseEnter={ () => setHoveredTransformItemName( name ) }
+			onFocus={ () => setHoveredTransformItemName( name ) }
+			onBlur={ () => setHoveredTransformItemName( null ) }
 		>
 			<BlockIcon icon={ icon } showColors />
 			{ title }

--- a/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
+++ b/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
@@ -100,6 +100,8 @@ function BlockVariationTransformationItem( {
 			} }
 			onMouseLeave={ () => setHoveredTransformItemName( null ) }
 			onMouseEnter={ () => setHoveredTransformItemName( name ) }
+			onFocus={ () => setHoveredTransformItemName( name ) }
+			onBlur={ () => setHoveredTransformItemName( null ) }
 		>
 			<BlockIcon icon={ icon } showColors />
 			{ title }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up to #75889.

The previews for block transforms from the toolbar weren't showing on focus, only on hover. This PR fixes that:

<img width="861" height="246" alt="Screenshot 2026-02-26 at 3 20 06 pm" src="https://github.com/user-attachments/assets/9b3a5a6c-9964-415c-adb2-dc14045abeb6" />


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a block that can be transformed, such as Paragraph or Heading, to a page.
2. Click the block name/icon in its toolbar to show the dropdown
3. Tab or Arrow down through the options and check that preview appears.
