### PR TITLE
DataForm: fix field label for panel (should not be uppercase)

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 - DataViews: Fix search input losing characters during debounce when externally synced. [#75810](https://github.com/WordPress/gutenberg/pull/75810)
 - DataForm: Fix vertical alignment of summary fields in card layout. [#75864](https://github.com/WordPress/gutenberg/pull/75864)
 - DataViews: Remove visual divider between quick and regular actions in the actions menu. [#75893](https://github.com/WordPress/gutenberg/pull/75893)
+- DataForm: field label for panel layout are no longer uppercased. [#75944](https://github.com/WordPress/gutenberg/pull/75944)
 
 ### Enhancements
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -92,6 +92,7 @@
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
 	color: $gray-700;
+	text-transform: capitalize;
 
 	.components-base-control__label {
 		display: inline;

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/get-label-content.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { BaseControl, Icon, Tooltip } from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
 import { error as errorIcon } from '@wordpress/icons';
 
 function getLabelContent(
@@ -13,13 +13,11 @@ function getLabelContent(
 		<Tooltip text={ errorMessage } placement="top">
 			<span className="dataforms-layouts-panel__field-label-error-content">
 				<Icon icon={ errorIcon } size={ 16 } />
-				<BaseControl.VisualLabel>
-					{ fieldLabel }
-				</BaseControl.VisualLabel>
+				{ fieldLabel }
 			</span>
 		</Tooltip>
 	) : (
-		<BaseControl.VisualLabel>{ fieldLabel }</BaseControl.VisualLabel>
+		fieldLabel
 	);
 }
 


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/75730#issuecomment-3959347501

## What?

This PR removes the uppercase styles for the field label in the panel layout.

Before | After
--- | --- 
<img width="487" height="508" alt="Screenshot 2026-02-26 at 09 16 45" src="https://github.com/user-attachments/assets/3f3b2ccc-3f2a-4190-90e7-2dd3d91c3f66" /> | <img width="487" height="508" alt="Screenshot 2026-02-26 at 09 16 25" src="https://github.com/user-attachments/assets/116aef36-2e2a-481b-8949-a5f7af42492b" />

## Why?

As per design specs.

## How?

- Remove the usage of BaseControl.VisualLabel in the summary button component, as we want to offer a distinct look for panel labels.
- Capitalize the field label.

## Testing Instructions

- Visit storybook DataViews > DataForm > Panel Layout and verify labels are no longer uppercased.
- Visit Site Editor > Pages > QuickEdit and verify labels are not uppercased.
