### PR TITLE
Docs: Correct parameter name `$content` for query title render function.

### DIFF
--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -13,7 +13,7 @@
  * @since 5.8.0
  *
  * @param array  $attributes Block attributes.
- * @param array  $_content   Block content.
+ * @param array  $content   Block content.
  * @param object $block      Block instance.
  *
  * @return string Returns the query title based on the queried object.

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -13,7 +13,7 @@
  * @since 5.8.0
  *
  * @param array  $attributes Block attributes.
- * @param array  $content   Block content.
+ * @param array  $content    Block content.
  * @param object $block      Block instance.
  *
  * @return string Returns the query title based on the queried object.


### PR DESCRIPTION
## What?

This pull request makes a minor update to the PHPDoc comment in the `query-title` block, clarifying the parameter name for block `$content`.

