### PR TITLE
Backport/update actions with unpadded buttons

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,10 @@
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)
 - DataViews: Remove visual divider between quick and regular actions in the actions menu. [#75893](https://github.com/WordPress/gutenberg/pull/75893)
 
+### Enhancements
+
+- DataViews: minimize padding for primary actions. [#75721](https://github.com/WordPress/gutenberg/pull/75721)
+
 ## 12.0.0 (2026-02-18)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -5,3 +5,10 @@
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }
+
+// TODO: the way forward here would be to use the new unstyle button coming
+// from wordpress/ui package, but we're not ready to use it yet.
+// See https://github.com/WordPress/gutenberg/pull/75721/
+.dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+	padding: 0 $grid-unit-05;
+}


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/75721