### PR TITLE
Connectors: Add `_ai_` prefix to connector setting names

### DIFF
--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -91,17 +91,17 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
 	return $value;
 }
 
-// --- Gemini (Google) ---
+// --- Google ---
 
 /**
- * Masks the Gemini API key on read.
+ * Masks the Google API key on read.
  *
  * @access private
  *
  * @param string $value The raw option value.
  * @return string Masked key or empty string.
  */
-function _gutenberg_mask_gemini_api_key( string $value ): string {
+function _gutenberg_mask_google_api_key( string $value ): string {
 	if ( '' === $value ) {
 		return $value;
 	}
@@ -109,14 +109,14 @@ function _gutenberg_mask_gemini_api_key( string $value ): string {
 }
 
 /**
- * Sanitizes and validates the Gemini API key before saving.
+ * Sanitizes and validates the Google API key before saving.
  *
  * @access private
  *
  * @param string $value The new value.
  * @return string The sanitized value, or empty string if the key is not valid.
  */
-function _gutenberg_sanitize_gemini_api_key( string $value ): string {
+function _gutenberg_sanitize_google_api_key( string $value ): string {
 	$value = sanitize_text_field( $value );
 	if ( '' === $value ) {
 		return $value;
@@ -204,17 +204,17 @@ function _gutenberg_sanitize_anthropic_api_key( string $value ): string {
  */
 function _gutenberg_get_connectors(): array {
 	return array(
-		'connectors_gemini_api_key'    => array(
+		'connectors_ai_google_api_key'    => array(
 			'provider' => 'google',
-			'mask'     => '_gutenberg_mask_gemini_api_key',
-			'sanitize' => '_gutenberg_sanitize_gemini_api_key',
+			'mask'     => '_gutenberg_mask_google_api_key',
+			'sanitize' => '_gutenberg_sanitize_google_api_key',
 		),
-		'connectors_openai_api_key'    => array(
+		'connectors_ai_openai_api_key'    => array(
 			'provider' => 'openai',
 			'mask'     => '_gutenberg_mask_openai_api_key',
 			'sanitize' => '_gutenberg_sanitize_openai_api_key',
 		),
-		'connectors_anthropic_api_key' => array(
+		'connectors_ai_anthropic_api_key' => array(
 			'provider' => 'anthropic',
 			'mask'     => '_gutenberg_mask_anthropic_api_key',
 			'sanitize' => '_gutenberg_sanitize_anthropic_api_key',

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -115,7 +115,7 @@ function OpenAIConnector( props: ConnectorRenderProps ) {
 		<ProviderConnector
 			{ ...props }
 			pluginSlug="ai-provider-for-openai"
-			settingName="connectors_openai_api_key"
+			settingName="connectors_ai_openai_api_key"
 			helpUrl="https://platform.openai.com"
 			helpLabel="platform.openai.com"
 			Logo={ OpenAILogo }
@@ -129,7 +129,7 @@ function ClaudeConnector( props: ConnectorRenderProps ) {
 		<ProviderConnector
 			{ ...props }
 			pluginSlug="ai-provider-for-anthropic"
-			settingName="connectors_anthropic_api_key"
+			settingName="connectors_ai_anthropic_api_key"
 			helpUrl="https://console.anthropic.com"
 			helpLabel="console.anthropic.com"
 			Logo={ ClaudeLogo }
@@ -143,7 +143,7 @@ function GeminiConnector( props: ConnectorRenderProps ) {
 		<ProviderConnector
 			{ ...props }
 			pluginSlug="ai-provider-for-google"
-			settingName="connectors_gemini_api_key"
+			settingName="connectors_ai_google_api_key"
 			helpUrl="https://aistudio.google.com"
 			helpLabel="aistudio.google.com"
 			Logo={ GeminiLogo }


### PR DESCRIPTION
## Summary
- Renames all connector setting keys from `connectors_<provider>_api_key` to `connectors_ai_<provider>_api_key` to properly namespace AI-specific settings. Including a prefix for the AI part will allow for example to have other keys from google e.g: google maps, the same company may have other products besides AI.
- Fixes the Google connector to use consistent `google` naming in PHP function names (was `gemini`) the provider name is google so we should also use google in settings.

## Test plan
- [ ] Verify watch build has no errors
- [ ] Confirm connector settings page loads with all three providers (OpenAI, Anthropic, Google)
- [ ] Verify API key save/load works with the new setting names