### PR TITLE
Disable client-side media processing in Playground

### DIFF
--- a/lib/compat/wordpress-7.0/media.php
+++ b/lib/compat/wordpress-7.0/media.php
@@ -16,6 +16,13 @@
  * @return bool Whether client-side media processing is enabled.
  */
 function gutenberg_is_client_side_media_processing_enabled() {
+	// Disable in php-wasm environments (e.g. WordPress Playground) where
+	// cross-origin isolation headers conflict with the iframe architecture.
+	// See https://github.com/WordPress/gutenberg/issues/75941
+	if ( 'wasm' === PHP_SAPI ) {
+		return false;
+	}
+
 	/**
 	 * Filters whether client-side media processing is enabled.
 	 *

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -211,6 +211,24 @@ HTML;
 	}
 
 	/**
+	 * Tests that client-side media processing is disabled in php-wasm environments.
+	 *
+	 * Note: PHP_SAPI is a runtime constant that cannot be changed in tests.
+	 * This test verifies the check exists in the function source code.
+	 * When PHP_SAPI === 'wasm' (WordPress Playground), the function returns
+	 * false before the filter is ever applied, preventing cross-origin
+	 * isolation headers from conflicting with Playground's iframe architecture.
+	 *
+	 * @covers ::gutenberg_is_client_side_media_processing_enabled
+	 */
+	public function test_client_side_media_processing_disabled_in_wasm_environments() {
+		// Verify the function contains the wasm SAPI check.
+		$function = new ReflectionFunction( 'gutenberg_is_client_side_media_processing_enabled' );
+		$source   = file_get_contents( $function->getFileName() );
+		$this->assertStringContainsString( "'wasm' === PHP_SAPI", $source );
+	}
+
+	/**
 	 * Tests that client-side media processing can be disabled via filter.
 	 *
 	 * @covers ::gutenberg_is_client_side_media_processing_enabled


### PR DESCRIPTION
## Summary

- Adds a `PHP_SAPI === 'wasm'` check to `gutenberg_is_client_side_media_processing_enabled()` that returns `false` early in WordPress Playground environments
- Prevents COOP/COEP cross-origin isolation headers from being sent, which conflict with Playground's iframe architecture and crash the editor
- Media uploads fall back to server-side processing automatically in Playground

## How it works

WordPress Playground runs PHP via WebAssembly (php-wasm), which registers its SAPI as `"wasm"`. By checking `PHP_SAPI` before applying the filter, all CSM infrastructure is disabled: no `window.__clientSideMediaProcessing = true` flag, no COOP/COEP headers, and `lib/media/load.php` early-returns.

Closes #75941

## Test plan

- [ ] Verify CSM still works normally in standard WordPress environments
- [ ] Verify Playground no longer crashes when editing posts with media
- [ ] Run PHP unit tests: `vendor/bin/phpunit phpunit/media/media-processing-test.php`

🤖 Generated with [Claude Code](https://claude.ai/code)