### PR TITLE
Editor: Remove View dropdown and pinned items from revisions header

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-header.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-header.js
@@ -15,14 +15,8 @@ import { seen } from '@wordpress/icons';
 import HeaderSkeleton from '../header/header-skeleton';
 import MoreMenu from '../more-menu';
 import PostPreviewButton from '../post-preview-button';
-import PreviewDropdown from '../preview-dropdown';
 import RevisionsSlider from './revisions-slider';
 import { store as editorStore } from '../../store';
-import {
-	TEMPLATE_PART_POST_TYPE,
-	PATTERN_POST_TYPE,
-	NAVIGATION_POST_TYPE,
-} from '../../store/constants';
 import { unlock } from '../../lock-unlock';
 
 /**
@@ -35,31 +29,20 @@ import { unlock } from '../../lock-unlock';
  */
 function RevisionsHeader( { showDiff, onToggleDiff } ) {
 	const isWideViewport = useViewportMatch( 'large' );
-	const { postType, showIconLabels, currentRevisionId } = useSelect(
-		( select ) => {
-			const { get: getPreference } = select( preferencesStore );
-			const { getCurrentPostType } = select( editorStore );
+	const { showIconLabels, currentRevisionId } = useSelect( ( select ) => {
+		const { get: getPreference } = select( preferencesStore );
 
-			return {
-				postType: getCurrentPostType(),
-				showIconLabels: getPreference( 'core', 'showIconLabels' ),
-				currentRevisionId: unlock(
-					select( editorStore )
-				).getCurrentRevisionId(),
-			};
-		},
-		[]
-	);
+		return {
+			showIconLabels: getPreference( 'core', 'showIconLabels' ),
+			currentRevisionId: unlock(
+				select( editorStore )
+			).getCurrentRevisionId(),
+		};
+	}, [] );
 
 	const { setCurrentRevisionId, restoreRevision } = unlock(
 		useDispatch( editorStore )
 	);
-
-	const disablePreviewOption = [
-		NAVIGATION_POST_TYPE,
-		TEMPLATE_PART_POST_TYPE,
-		PATTERN_POST_TYPE,
-	].includes( postType );
 
 	const canRestore = !! currentRevisionId;
 
@@ -85,8 +68,6 @@ function RevisionsHeader( { showDiff, onToggleDiff } ) {
 			center={ <RevisionsSlider /> }
 			settings={
 				<>
-					<PreviewDropdown disabled={ disablePreviewOption } />
-
 					<PostPreviewButton className="editor-header__post-preview-button" />
 
 					{ ( isWideViewport || ! showIconLabels ) && (

--- a/packages/editor/src/components/post-revisions-preview/revisions-header.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-header.js
@@ -2,12 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
-import { store as preferencesStore } from '@wordpress/preferences';
-import { PinnedItems } from '@wordpress/interface';
-import { __, _x } from '@wordpress/i18n';
-import { seen } from '@wordpress/icons';
+import { store as interfaceStore } from '@wordpress/interface';
+import { __, _x, isRTL } from '@wordpress/i18n';
+import { drawerLeft, drawerRight, seen } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -17,6 +15,7 @@ import MoreMenu from '../more-menu';
 import PostPreviewButton from '../post-preview-button';
 import RevisionsSlider from './revisions-slider';
 import { store as editorStore } from '../../store';
+import { sidebars } from '../sidebar/constants';
 import { unlock } from '../../lock-unlock';
 
 /**
@@ -28,21 +27,24 @@ import { unlock } from '../../lock-unlock';
  * @return {React.JSX.Element} The revisions header component.
  */
 function RevisionsHeader( { showDiff, onToggleDiff } ) {
-	const isWideViewport = useViewportMatch( 'large' );
-	const { showIconLabels, currentRevisionId } = useSelect( ( select ) => {
-		const { get: getPreference } = select( preferencesStore );
-
+	const { currentRevisionId, sidebarIsOpened } = useSelect( ( select ) => {
 		return {
-			showIconLabels: getPreference( 'core', 'showIconLabels' ),
 			currentRevisionId: unlock(
 				select( editorStore )
 			).getCurrentRevisionId(),
+			sidebarIsOpened:
+				!! select( interfaceStore ).getActiveComplementaryArea(
+					'core'
+				),
 		};
 	}, [] );
 
 	const { setCurrentRevisionId, restoreRevision } = unlock(
 		useDispatch( editorStore )
 	);
+
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
 
 	const canRestore = !! currentRevisionId;
 
@@ -70,9 +72,24 @@ function RevisionsHeader( { showDiff, onToggleDiff } ) {
 				<>
 					<PostPreviewButton className="editor-header__post-preview-button" />
 
-					{ ( isWideViewport || ! showIconLabels ) && (
-						<PinnedItems.Slot scope="core" />
-					) }
+					<Button
+						__next40pxDefaultSize
+						icon={ isRTL() ? drawerLeft : drawerRight }
+						label={ _x( 'Settings', 'panel button label' ) }
+						isPressed={ sidebarIsOpened }
+						aria-expanded={ sidebarIsOpened }
+						onClick={ () => {
+							if ( sidebarIsOpened ) {
+								disableComplementaryArea( 'core' );
+							} else {
+								enableComplementaryArea(
+									'core',
+									sidebars.document
+								);
+							}
+						} }
+						size="compact"
+					/>
 
 					<Button
 						__next40pxDefaultSize


### PR DESCRIPTION
## Summary

- Removes the View (preview) dropdown from the revisions screen header, which exposed the "Show Template" option and a pathway to opening Styles — neither of which should be available when viewing post revisions.
- Replaces the generic `PinnedItems.Slot` with an explicit Settings sidebar toggle button, giving the revisions screen direct control over which toolbar buttons appear.

Fixes #75636

## Test plan

- [ ] Open a post that has revisions
- [ ] Enter the revisions screen
- [ ] Verify the "View" dropdown is no longer present in the header
- [ ] Verify the Settings sidebar toggle (drawer icon) is still present and functional
- [ ] Verify the "Show Template" option is no longer accessible from revisions
- [ ] Verify the Styles panel cannot be reached from the revisions screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)