### PR TITLE
Fix: Template revisions infinite spinner

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1099,7 +1099,7 @@ export const getRevisions =
 				// When requesting all fields, the list of results can be used to
 				// resolve the `getRevision` selector in addition to `getRevisions`.
 				if ( ! query?._fields && ! query.context ) {
-					const key = entityConfig.key || DEFAULT_ENTITY_KEY;
+					const key = entityConfig.revisionKey || DEFAULT_ENTITY_KEY;
 					const resolutionsArgs = records
 						.filter( ( record ) => record[ key ] )
 						.map( ( record ) => [

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -20,11 +20,12 @@ import { unlock } from '../../lock-unlock';
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
-	const { revisions, isLoading, currentRevisionId } = useSelect(
+	const { revisions, isLoading, currentRevisionId, revisionKey } = useSelect(
 		( select ) => {
 			const { getCurrentPostId, getCurrentPostType } =
 				select( editorStore );
-			const { getRevisions, isResolving } = select( coreStore );
+			const { getRevisions, isResolving, getEntityConfig } =
+				select( coreStore );
 
 			const postId = getCurrentPostId();
 			const postType = getCurrentPostType();
@@ -33,6 +34,7 @@ function RevisionsSlider() {
 				return {};
 			}
 
+			const entityConfig = getEntityConfig( 'postType', postType );
 			const query = { per_page: -1, context: 'edit' };
 			return {
 				revisions: getRevisions( 'postType', postType, postId, query ),
@@ -45,6 +47,7 @@ function RevisionsSlider() {
 				currentRevisionId: unlock(
 					select( editorStore )
 				).getCurrentRevisionId(),
+				revisionKey: entityConfig?.revisionKey || 'id',
 			};
 		},
 		[]
@@ -62,13 +65,13 @@ function RevisionsSlider() {
 	}, [ revisions ] );
 
 	const selectedIndex = sortedRevisions.findIndex(
-		( r ) => r.id === currentRevisionId
+		( r ) => r[ revisionKey ] === currentRevisionId
 	);
 
 	const handleSliderChange = ( index ) => {
 		const revision = sortedRevisions[ index ];
 		if ( revision ) {
-			setCurrentRevisionId( revision.id );
+			setCurrentRevisionId( revision[ revisionKey ] );
 		}
 	};
 

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -351,7 +351,12 @@ export const getCurrentRevision = createRegistrySelector(
 		if ( ! revisions ) {
 			return null;
 		}
-		return revisions.find( ( r ) => r.id === revisionId ) ?? null;
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
+		const revKey = entityConfig?.revisionKey || 'id';
+		return revisions.find( ( r ) => r[ revKey ] === revisionId ) ?? null;
 	}
 );
 
@@ -408,8 +413,13 @@ export const getPreviousRevision = createRegistrySelector(
 		);
 
 		// Find current revision index.
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
+		const revKey = entityConfig?.revisionKey || 'id';
 		const currentIndex = sortedRevisions.findIndex(
-			( r ) => r.id === currentRevisionId
+			( r ) => r[ revKey ] === currentRevisionId
 		);
 
 		// Return the previous revision (older one) if it exists.


### PR DESCRIPTION
## Summary

Fixes #75642

Template revisions never load (infinite spinner) because the `revisionKey` system isn't used consistently. Templates use `revisionKey: 'wp_id'` instead of `'id'` for revisions. The core-data reducer correctly stores revision records indexed by `wp_id`, but three places assumed revisions are always keyed by `id`:

- The `getRevisions` resolver used `entityConfig.key` instead of `entityConfig.revisionKey` when calling `finishResolutions` for individual `getRevision` lookups
- The `getCurrentRevision` and `getPreviousRevision` selectors compared `r.id` (the template string ID like `"theme//slug"`) against the numeric revision ID (`wp_id`)
- The revisions slider component used `r.id` for finding and setting the current revision

## Changes

- **`packages/core-data/src/resolvers.js`** — Use `entityConfig.revisionKey` instead of `entityConfig.key` in `finishResolutions` call
- **`packages/editor/src/store/private-selectors.js`** — Look up `revisionKey` from entity config in `getCurrentRevision` and `getPreviousRevision` selectors
- **`packages/editor/src/components/post-revisions-preview/revisions-slider.js`** — Get `revisionKey` from `getEntityConfig` and use it in `findIndex` and `setCurrentRevisionId`

## Test plan

- [ ] Open a template in the site editor (e.g. Single Posts)
- [ ] Click Revisions in the sidebar — should load and display revisions instead of infinite spinner
- [ ] Use the slider to navigate between revisions — should update correctly
- [ ] Verify regular post/page revisions still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)