### PR TITLE
Preserve note selection on browser tab switch

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -79,6 +79,10 @@ export function AddComment( {
 					: undefined
 			}
 			onBlur={ ( event ) => {
+				// Don't deselect notes when the browser window/tab loses focus.
+				if ( ! document.hasFocus() ) {
+					return;
+				}
 				if ( event.currentTarget.contains( event.relatedTarget ) ) {
 					return;
 				}

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -495,6 +495,11 @@ function Thread( {
 	};
 
 	const onBlur = ( event ) => {
+		// Don't deselect notes when the browser window/tab loses focus.
+		if ( ! document.hasFocus() ) {
+			return;
+		}
+
 		const isNoteFocused = event.relatedTarget?.closest(
 			'.editor-collab-sidebar-panel__thread'
 		);


### PR DESCRIPTION


Original code/commit is by @/adamsilverstein 


## What?
Closes https://github.com/WordPress/gutenberg/issues/75640
Prevents notes from collapsing when the browser window or tab loses focus.


## Why?
Currently, switching to another window or tab triggers an onBlur event that deselects the active note. This creates friction for users who need to reference external documents while writing notes.

## How?
Added a check for `document.hasFocus()` within the `onBlur` handlers in add-comment.js and comments.js. 

## Testing Instructions

1. Open the editor and add a note to a block.
2. Keep the note popoveractive.
3. Switch to a different browser tab or a different application window.
4. Return to the editor and verify the note remains open and has not collapsed.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->





## Screencast

### Before


https://github.com/user-attachments/assets/cdfa6527-dd65-4fad-a559-4e102bd6f392




### After

https://github.com/user-attachments/assets/a828f0cf-e420-4001-9ce0-5c84c9752782


### Extra video ref: The popover closes when focus is lost within the same tab, but it stays open when switching to other tabs or apps.


https://github.com/user-attachments/assets/17f45ce5-1139-408b-95a4-fe7c1c19e3ac




