### PR TITLE
Docs: Fix broken link to `autoRegister` block-supports

### DIFF
--- a/docs/getting-started/fundamentals/registration-of-a-block.md
+++ b/docs/getting-started/fundamentals/registration-of-a-block.md
@@ -46,7 +46,7 @@ _See the [full block example](https://github.com/WordPress/block-development-exa
 
 ### PHP-only blocks with auto-registration
 
-For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`autoRegister`](/docs/reference-guides/block-api/block-supports.md#autoRegister) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](/docs/getting-started/fundamentals/static-dynamic-rendering.md).
+For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`autoRegister`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#autoRegister) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/).
 
 ```php
 register_block_type( 'my-plugin/server-block', array(

--- a/docs/getting-started/fundamentals/registration-of-a-block.md
+++ b/docs/getting-started/fundamentals/registration-of-a-block.md
@@ -46,7 +46,7 @@ _See the [full block example](https://github.com/WordPress/block-development-exa
 
 ### PHP-only blocks with auto-registration
 
-For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`autoRegister`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#autoRegister) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/).
+For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`autoRegister`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#autoregister) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/).
 
 ```php
 register_block_type( 'my-plugin/server-block', array(

--- a/docs/getting-started/fundamentals/registration-of-a-block.md
+++ b/docs/getting-started/fundamentals/registration-of-a-block.md
@@ -46,7 +46,7 @@ _See the [full block example](https://github.com/WordPress/block-development-exa
 
 ### PHP-only blocks with auto-registration
 
-For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`autoRegister`](/docs/reference-guides/block-api/block-supports.md#auto_register) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](/docs/getting-started/fundamentals/static-dynamic-rendering.md).
+For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`autoRegister`](/docs/reference-guides/block-api/block-supports.md#autoRegister) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](/docs/getting-started/fundamentals/static-dynamic-rendering.md).
 
 ```php
 register_block_type( 'my-plugin/server-block', array(


### PR DESCRIPTION
Follow-up of #75543 

In the process of promoting the PHP-only block registration feature to stable, the flag was renamed from `auto_register` to `autoRegister`, but a single link in the documentation was missed. This pull request fixes it.