### PR TITLE
Docs: Update first parameter in `block_core_page_list_render_nested_page_list()`

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -166,7 +166,7 @@ function block_core_page_list_build_css_font_sizes( $context ) {
  *
  * @since 5.8.0
  *
- * @param boolean $open_submenus_on_click Whether to open submenus on click instead of hover.
+ * @param string  $submenu_visibility The submenu visibility mode: 'hover', 'click', or 'always'.
  * @param boolean $show_submenu_icons Whether to show submenu indicator icons.
  * @param boolean $is_navigation_child If block is a child of Navigation block.
  * @param array   $nested_pages The array of nested pages.


### PR DESCRIPTION
## What?
In #75531, the first parameter of `block_core_page_list_render_nested_page_list()`was changed form `$open_submenus_on_click` to `$submenu_visibility`.

This PR updates the doc block.