### PR TITLE
useView: ignore `view.layout`

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -70,6 +70,7 @@ export default function PostList( { postType } ) {
 		name: postType,
 		slug: 'default',
 		defaultView,
+		defaultLayouts,
 		activeViewOverrides,
 		queryParams: {
 			page: query.pageNumber,

--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -6,6 +6,7 @@ import type { View, Filter } from '@wordpress/dataviews';
 type ActiveViewOverrides = {
 	filters?: Filter[];
 	sort?: View[ 'sort' ];
+	layout?: Record< string, unknown >;
 };
 
 /**
@@ -61,6 +62,17 @@ export function mergeActiveViewOverrides(
 		}
 	}
 
+	// Merge layout - override keys always win
+	if ( activeViewOverrides.layout ) {
+		result = {
+			...result,
+			layout: {
+				...( result as any ).layout,
+				...activeViewOverrides.layout,
+			},
+		} as View;
+	}
+
 	return result;
 }
 
@@ -111,6 +123,18 @@ export function stripActiveViewOverrides(
 			...result,
 			sort: defaultView?.sort,
 		};
+	}
+
+	// Strip layout keys managed by overrides
+	if ( activeViewOverrides.layout && 'layout' in result && result.layout ) {
+		const layout = { ...result.layout } as Record< string, unknown >;
+		for ( const key of Object.keys( activeViewOverrides.layout ) ) {
+			delete layout[ key ];
+		}
+		result = {
+			...result,
+			layout: Object.keys( layout ).length > 0 ? layout : undefined,
+		} as View;
 	}
 
 	return result;

--- a/packages/views/src/types.ts
+++ b/packages/views/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import type { View, Filter } from '@wordpress/dataviews';
+import type { View, Filter, SupportedLayouts } from '@wordpress/dataviews';
 
 export interface ViewConfig {
 	/**
@@ -34,7 +34,15 @@ export interface ViewConfig {
 	activeViewOverrides?: {
 		filters?: Filter[];
 		sort?: View[ 'sort' ];
+		layout?: Record< string, unknown >;
 	};
+
+	/**
+	 * Per-layout-type default configuration (e.g. table column styles).
+	 * The layout property for the current view type is treated as an
+	 * active view override: merged on read, stripped before persisting.
+	 */
+	defaultLayouts?: SupportedLayouts;
 
 	/**
 	 * Optional query parameters from URL (page, search)

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -8,7 +8,7 @@ import { dequal } from 'dequal';
  */
 import { useCallback, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import type { View } from '@wordpress/dataviews';
+import type { View, SupportedLayouts } from '@wordpress/dataviews';
 // @ts-ignore - Preferences package is not typed
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -53,6 +53,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 		name,
 		slug,
 		defaultView,
+		defaultLayouts,
 		activeViewOverrides,
 		queryParams,
 		onChangeQueryParams,
@@ -71,10 +72,26 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	const { set } = useDispatch( preferencesStore );
 
 	const baseView: View = persistedView ?? defaultView;
+
+	// Derive layout override for current view type
+	const layoutOverride = defaultLayouts?.[
+		baseView.type as keyof SupportedLayouts
+	]?.layout as Record< string, unknown > | undefined;
+
+	// Combine caller's activeViewOverrides with the derived layout override
+	const effectiveOverrides = useMemo( () => {
+		if ( ! layoutOverride && ! activeViewOverrides ) {
+			return undefined;
+		}
+		return {
+			...activeViewOverrides,
+			...( layoutOverride ? { layout: layoutOverride } : {} ),
+		};
+	}, [ activeViewOverrides, layoutOverride ] );
 	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
 	const search = queryParams?.search ?? baseView.search ?? '';
 
-	// Merge URL query parameters (page, search) and activeViewOverrides into the view
+	// Merge URL query parameters (page, search) and effective overrides into the view
 	const view: View = useMemo( () => {
 		return mergeActiveViewOverrides(
 			{
@@ -82,10 +99,10 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				page,
 				search,
 			},
-			activeViewOverrides,
+			effectiveOverrides,
 			defaultView
 		);
-	}, [ baseView, page, search, activeViewOverrides, defaultView ] );
+	}, [ baseView, page, search, effectiveOverrides, defaultView ] );
 
 	const isModified = !! persistedView;
 
@@ -96,11 +113,11 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				page: newView?.page,
 				search: newView?.search,
 			};
-			// Strip activeViewOverrides and URL params before persisting
+			// Strip effective overrides and URL params before persisting
 			// Cast is safe: omitting page/search doesn't change the discriminant (type field)
 			const preferenceView = stripActiveViewOverrides(
 				omit( newView, [ 'page', 'search' ] ) as View,
-				activeViewOverrides,
+				effectiveOverrides,
 				defaultView
 			);
 
@@ -112,15 +129,15 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				onChangeQueryParams( urlParams );
 			}
 
-			// Compare with baseView and defaultView after stripping activeViewOverrides
+			// Compare with baseView and defaultView after stripping effective overrides
 			const comparableBaseView = stripActiveViewOverrides(
 				baseView,
-				activeViewOverrides,
+				effectiveOverrides,
 				defaultView
 			);
 			const comparableDefaultView = stripActiveViewOverrides(
 				defaultView,
-				activeViewOverrides,
+				effectiveOverrides,
 				defaultView
 			);
 
@@ -139,7 +156,7 @@ export function useView( config: ViewConfig ): UseViewReturn {
 			search,
 			baseView,
 			defaultView,
-			activeViewOverrides,
+			effectiveOverrides,
 			set,
 			preferenceKey,
 		]


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/75917

## What?

This PR updates `useView` so that the `view.layout` properties are ignored when loading a persisted view by always merging them on read and stripped them before persisting — using the same pattern already established for activeViewOverrides (filters and sort).

## Why?

The `view.layout` properties are not user config and they are being overriden by the existing mechanism when users have saved views. See https://github.com/WordPress/gutenberg/pull/75917#issuecomment-3965879643

## How?

 Extends the existing activeViewOverrides merge/strip mechanism to also handle layout:

## How to reproduce the bug

- Switch to `trunk`.
- Visit the Site Editor's Pages screen and make sure you have a saved view. For example, switch the layout to table.
- Then, update defaultLayouts to:

```tsx
 const defaultLayouts = {
     table: {
         layout: {
             styles: {
                 author: { align: 'end' },
             },
         },
     },
     grid: {},
     list: {},
 };
```
- Reload. The expected result is that the author field should be right-aligned, but it's not.

With the same steps in this branch, it will.