### PR TITLE
Build: Clean top-level `build/` directory during `clean:packages`

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"build:profile-types": "rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && node -p \"'\\n\\nDone! Build traces saved to ts-traces/ directory.\\nTrace analysis saved to ts-traces/analysis.txt.'\"",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"clean:package-types": "tsc --build --clean && rimraf --glob \"./packages/*/build-types\"",
-		"clean:packages": "rimraf --glob \"./packages/*/{build,build-module,build-wp,build-style}\"",
+		"clean:packages": "rimraf --glob \"./packages/*/{build,build-module,build-wp,build-style}\" \"./build\"",
 		"component-usage-stats": "node ./node_modules/react-scanner/bin/react-scanner -c ./react-scanner.config.js",
 		"dev": "node ./bin/dev.mjs",
 		"distclean": "git clean --force -d -X",


### PR DESCRIPTION
Closes #75933

## What?

Adds `./build` to the `clean:packages` rimraf targets so the top-level `build/` directory is cleaned alongside the per-package intermediate build directories.

## Why?

The `clean:packages` script only removed `packages/*/build-style/` and similar intermediate directories, but not the top-level `build/` directory where the final bundled artifacts live (e.g. `build/styles/theme/`, `build/scripts/*/`). The bundling step in `wp-build` copies from `packages/*/build-style/` into `build/styles/*/` but never cleans the destination first.

This means when a source file is deleted — like `packages/theme/src/style.scss` in #75879 — the stale output in `build/styles/theme/` persists from the previous build, breaking the build without manual `git clean` intervention.

Since `build/` is gitignored and fully regenerated by the build pipeline (`build-vendors` → `wp-build` → `build-blocks-manifest`), it's safe to clean at the start.

## How?

One-line change to the `clean:packages` script in `package.json` to also rimraf `./build`.

## Testing Instructions

1. Create a stray file in the build directory: `mkdir -p build/fake && echo "stale" > build/fake/stale.css`
2. Run `npm run build`.
3. Verify `build/fake/` no longer exists.
4. Run the app and smoke test that it's not broken.