### PR TITLE
Views: add support for more overrides (all developer-defined config)

### DIFF
--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -90,15 +90,12 @@ export function mergeActiveViewOverrides(
 		} as View;
 	}
 
-	// Merge groupBy — shallow merge, override keys always win
+	// Merge groupBy — full replacement, override always wins
 	if ( activeViewOverrides.groupBy ) {
 		result = {
 			...result,
-			groupBy: {
-				...( result as any ).groupBy,
-				...activeViewOverrides.groupBy,
-			},
-		} as View;
+			groupBy: activeViewOverrides.groupBy,
+		};
 	}
 
 	return result;
@@ -173,20 +170,10 @@ export function stripActiveViewOverrides(
 		} as View;
 	}
 
-	// Strip groupBy keys managed by overrides
-	if (
-		activeViewOverrides.groupBy &&
-		'groupBy' in result &&
-		result.groupBy
-	) {
-		const groupBy = { ...result.groupBy } as Record< string, unknown >;
-		for ( const key of Object.keys( activeViewOverrides.groupBy ) ) {
-			delete groupBy[ key ];
-		}
-		result = {
-			...result,
-			groupBy: Object.keys( groupBy ).length > 0 ? groupBy : undefined,
-		} as View;
+	// Strip groupBy managed by overrides
+	if ( activeViewOverrides.groupBy && 'groupBy' in result ) {
+		const { groupBy: _, ...rest } = result;
+		result = rest as View;
 	}
 
 	return result;

--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -16,7 +16,6 @@ const SCALAR_VALUES = [
 	'showMedia',
 	'showDescription',
 	'showLevels',
-	'groupBy',
 	'infiniteScrollEnabled',
 ] as const;
 

--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -3,10 +3,22 @@
  */
 import type { View, Filter } from '@wordpress/dataviews';
 
-type ActiveViewOverrides = {
-	filters?: Filter[];
-	sort?: View[ 'sort' ];
-};
+/**
+ * Internal dependencies
+ */
+import type { ActiveViewOverrides } from './types';
+
+const SCALAR_VALUES = [
+	'titleField',
+	'mediaField',
+	'descriptionField',
+	'showTitle',
+	'showMedia',
+	'showDescription',
+	'showLevels',
+	'groupBy',
+	'infiniteScrollEnabled',
+] as const;
 
 /**
  * Merges activeViewOverrides into a view.
@@ -28,6 +40,13 @@ export function mergeActiveViewOverrides(
 	}
 
 	let result = view;
+
+	// Merge scalar overrides — always win over persisted values
+	for ( const key of SCALAR_VALUES ) {
+		if ( key in activeViewOverrides ) {
+			result = { ...result, [ key ]: activeViewOverrides[ key ] };
+		}
+	}
 
 	// Merge filters
 	if (
@@ -61,6 +80,28 @@ export function mergeActiveViewOverrides(
 		}
 	}
 
+	// Merge layout — shallow merge, override keys always win
+	if ( activeViewOverrides.layout ) {
+		result = {
+			...result,
+			layout: {
+				...( result as any ).layout,
+				...activeViewOverrides.layout,
+			},
+		} as View;
+	}
+
+	// Merge groupBy — shallow merge, override keys always win
+	if ( activeViewOverrides.groupBy ) {
+		result = {
+			...result,
+			groupBy: {
+				...( result as any ).groupBy,
+				...activeViewOverrides.groupBy,
+			},
+		} as View;
+	}
+
 	return result;
 }
 
@@ -84,6 +125,14 @@ export function stripActiveViewOverrides(
 	}
 
 	let result = view;
+
+	// Strip scalar keys managed by overrides
+	for ( const key of SCALAR_VALUES ) {
+		if ( key in activeViewOverrides ) {
+			const { [ key ]: _, ...rest } = result;
+			result = rest as View;
+		}
+	}
 
 	// Strip managed filters
 	if (
@@ -111,6 +160,34 @@ export function stripActiveViewOverrides(
 			...result,
 			sort: defaultView?.sort,
 		};
+	}
+
+	// Strip layout keys managed by overrides
+	if ( activeViewOverrides.layout && 'layout' in result && result.layout ) {
+		const layout = { ...result.layout } as Record< string, unknown >;
+		for ( const key of Object.keys( activeViewOverrides.layout ) ) {
+			delete layout[ key ];
+		}
+		result = {
+			...result,
+			layout: Object.keys( layout ).length > 0 ? layout : undefined,
+		} as View;
+	}
+
+	// Strip groupBy keys managed by overrides
+	if (
+		activeViewOverrides.groupBy &&
+		'groupBy' in result &&
+		result.groupBy
+	) {
+		const groupBy = { ...result.groupBy } as Record< string, unknown >;
+		for ( const key of Object.keys( activeViewOverrides.groupBy ) ) {
+			delete groupBy[ key ];
+		}
+		result = {
+			...result,
+			groupBy: Object.keys( groupBy ).length > 0 ? groupBy : undefined,
+		} as View;
 	}
 
 	return result;

--- a/packages/views/src/test/filter-utils.ts
+++ b/packages/views/src/test/filter-utils.ts
@@ -240,7 +240,7 @@ describe( 'mergeActiveViewOverrides', () => {
 	} );
 
 	describe( 'groupBy overrides', () => {
-		it( 'should merge groupBy override into existing groupBy', () => {
+		it( 'should replace groupBy with override', () => {
 			const view: View = {
 				...baseView,
 				groupBy: {
@@ -250,12 +250,11 @@ describe( 'mergeActiveViewOverrides', () => {
 				},
 			};
 			const result = mergeActiveViewOverrides( view, {
-				groupBy: { showLabel: true },
+				groupBy: { field: 'category', direction: 'desc' },
 			} );
 			expect( result.groupBy ).toEqual( {
-				field: 'status',
-				direction: 'asc',
-				showLabel: true,
+				field: 'category',
+				direction: 'desc',
 			} );
 		} );
 
@@ -437,7 +436,7 @@ describe( 'stripActiveViewOverrides', () => {
 	} );
 
 	describe( 'groupBy stripping', () => {
-		it( 'should strip groupBy keys managed by overrides', () => {
+		it( 'should remove groupBy when managed by overrides', () => {
 			const view: View = {
 				...baseView,
 				groupBy: {
@@ -447,23 +446,9 @@ describe( 'stripActiveViewOverrides', () => {
 				},
 			};
 			const result = stripActiveViewOverrides( view, {
-				groupBy: { showLabel: true },
+				groupBy: { field: 'category', direction: 'desc' },
 			} );
-			expect( result.groupBy ).toEqual( {
-				field: 'status',
-				direction: 'asc',
-			} );
-		} );
-
-		it( 'should set groupBy to undefined when all keys are stripped', () => {
-			const view: View = {
-				...baseView,
-				groupBy: { field: 'status', direction: 'asc' },
-			};
-			const result = stripActiveViewOverrides( view, {
-				groupBy: { field: 'status', direction: 'asc' },
-			} );
-			expect( result.groupBy ).toBeUndefined();
+			expect( result ).not.toHaveProperty( 'groupBy' );
 		} );
 
 		it( 'should not touch groupBy when view has no groupBy', () => {

--- a/packages/views/src/test/filter-utils.ts
+++ b/packages/views/src/test/filter-utils.ts
@@ -250,7 +250,7 @@ describe( 'mergeActiveViewOverrides', () => {
 				},
 			};
 			const result = mergeActiveViewOverrides( view, {
-				groupBy: { field: 'status', direction: 'asc', showLabel: true },
+				groupBy: { showLabel: true },
 			} );
 			expect( result.groupBy ).toEqual( {
 				field: 'status',
@@ -447,7 +447,7 @@ describe( 'stripActiveViewOverrides', () => {
 				},
 			};
 			const result = stripActiveViewOverrides( view, {
-				groupBy: { field: 'status', direction: 'asc', showLabel: true },
+				groupBy: { showLabel: true },
 			} );
 			expect( result.groupBy ).toEqual( {
 				field: 'status',

--- a/packages/views/src/test/filter-utils.ts
+++ b/packages/views/src/test/filter-utils.ts
@@ -1,0 +1,537 @@
+/**
+ * WordPress dependencies
+ */
+import type { View } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import {
+	mergeActiveViewOverrides,
+	stripActiveViewOverrides,
+} from '../filter-utils';
+
+const baseView: View = {
+	type: 'table',
+	filters: [ { field: 'author', operator: 'isAny', value: [ 'admin' ] } ],
+	sort: { field: 'date', direction: 'desc' },
+	page: 1,
+	perPage: 25,
+};
+
+const defaultView: View = {
+	type: 'table',
+	sort: { field: 'date', direction: 'desc' },
+};
+
+describe( 'mergeActiveViewOverrides', () => {
+	it( 'should return the view unchanged when no overrides are provided', () => {
+		expect( mergeActiveViewOverrides( baseView ) ).toBe( baseView );
+		expect( mergeActiveViewOverrides( baseView, undefined ) ).toBe(
+			baseView
+		);
+	} );
+
+	describe( 'scalar overrides', () => {
+		it( 'should merge titleField override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				titleField: 'name',
+			} );
+			expect( result.titleField ).toBe( 'name' );
+		} );
+
+		it( 'should merge mediaField override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				mediaField: 'thumbnail',
+			} );
+			expect( result.mediaField ).toBe( 'thumbnail' );
+		} );
+
+		it( 'should merge descriptionField override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				descriptionField: 'excerpt',
+			} );
+			expect( result.descriptionField ).toBe( 'excerpt' );
+		} );
+
+		it( 'should merge showTitle override', () => {
+			const result = mergeActiveViewOverrides(
+				{ ...baseView, showTitle: true },
+				{ showTitle: false }
+			);
+			expect( result.showTitle ).toBe( false );
+		} );
+
+		it( 'should merge showMedia override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				showMedia: true,
+			} );
+			expect( result.showMedia ).toBe( true );
+		} );
+
+		it( 'should merge showDescription override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				showDescription: false,
+			} );
+			expect( result.showDescription ).toBe( false );
+		} );
+
+		it( 'should merge showLevels override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				showLevels: true,
+			} );
+			expect( result.showLevels ).toBe( true );
+		} );
+
+		it( 'should merge infiniteScrollEnabled override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				infiniteScrollEnabled: true,
+			} );
+			expect( result.infiniteScrollEnabled ).toBe( true );
+		} );
+
+		it( 'should override existing scalar value on the view', () => {
+			const view: View = { ...baseView, titleField: 'old-title' };
+			const result = mergeActiveViewOverrides( view, {
+				titleField: 'new-title',
+			} );
+			expect( result.titleField ).toBe( 'new-title' );
+		} );
+
+		it( 'should merge multiple scalar overrides at once', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				titleField: 'name',
+				showTitle: true,
+				showMedia: false,
+				infiniteScrollEnabled: true,
+			} );
+			expect( result.titleField ).toBe( 'name' );
+			expect( result.showTitle ).toBe( true );
+			expect( result.showMedia ).toBe( false );
+			expect( result.infiniteScrollEnabled ).toBe( true );
+		} );
+	} );
+
+	describe( 'filter overrides', () => {
+		it( 'should add override filters', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				filters: [
+					{ field: 'status', operator: 'isAny', value: 'publish' },
+				],
+			} );
+			expect( result.filters ).toHaveLength( 2 );
+			expect( result.filters ).toEqual(
+				expect.arrayContaining( [
+					{ field: 'author', operator: 'isAny', value: [ 'admin' ] },
+					{
+						field: 'status',
+						operator: 'isAny',
+						value: 'publish',
+					},
+				] )
+			);
+		} );
+
+		it( 'should replace same-field filters', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				filters: [
+					{
+						field: 'author',
+						operator: 'isAny',
+						value: [ 'editor' ],
+					},
+				],
+			} );
+			expect( result.filters ).toHaveLength( 1 );
+			expect( result.filters![ 0 ] ).toEqual( {
+				field: 'author',
+				operator: 'isAny',
+				value: [ 'editor' ],
+			} );
+		} );
+
+		it( 'should handle empty override filters array', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				filters: [],
+			} );
+			// Empty filters array is treated as no override.
+			expect( result.filters ).toEqual( baseView.filters );
+		} );
+	} );
+
+	describe( 'sort overrides', () => {
+		it( 'should apply sort override when current sort matches default', () => {
+			const result = mergeActiveViewOverrides(
+				baseView,
+				{ sort: { field: 'title', direction: 'asc' } },
+				defaultView
+			);
+			expect( result.sort ).toEqual( {
+				field: 'title',
+				direction: 'asc',
+			} );
+		} );
+
+		it( 'should not apply sort override when user has changed sort', () => {
+			const userView: View = {
+				...baseView,
+				sort: { field: 'title', direction: 'asc' },
+			};
+			const result = mergeActiveViewOverrides(
+				userView,
+				{ sort: { field: 'modified', direction: 'desc' } },
+				defaultView
+			);
+			expect( result.sort ).toEqual( {
+				field: 'title',
+				direction: 'asc',
+			} );
+		} );
+
+		it( 'should not apply sort override when no default view is provided', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				sort: { field: 'title', direction: 'asc' },
+			} );
+			expect( result.sort ).toEqual( baseView.sort );
+		} );
+	} );
+
+	describe( 'layout overrides', () => {
+		it( 'should merge layout override into existing layout', () => {
+			const view: View = {
+				...baseView,
+				layout: { density: 'compact' },
+			};
+			const result = mergeActiveViewOverrides( view, {
+				layout: { styles: { author: { align: 'end' } } },
+			} );
+			expect( result.layout ).toEqual( {
+				density: 'compact',
+				styles: { author: { align: 'end' } },
+			} );
+		} );
+
+		it( 'should set layout when view has no existing layout', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				layout: { styles: { title: { width: '50%' } } },
+			} );
+			expect( result.layout ).toEqual( {
+				styles: { title: { width: '50%' } },
+			} );
+		} );
+
+		it( 'should override matching layout keys', () => {
+			const view: View = {
+				...baseView,
+				layout: {
+					density: 'compact',
+					styles: { old: { width: '10%' } },
+				},
+			};
+			const result = mergeActiveViewOverrides( view, {
+				layout: { styles: { new: { width: '20%' } } },
+			} );
+			// Shallow merge: styles key is replaced entirely.
+			expect( result.layout ).toEqual( {
+				density: 'compact',
+				styles: { new: { width: '20%' } },
+			} );
+		} );
+	} );
+
+	describe( 'groupBy overrides', () => {
+		it( 'should merge groupBy override into existing groupBy', () => {
+			const view: View = {
+				...baseView,
+				groupBy: {
+					field: 'status',
+					direction: 'asc',
+					showLabel: false,
+				},
+			};
+			const result = mergeActiveViewOverrides( view, {
+				groupBy: { field: 'status', direction: 'asc', showLabel: true },
+			} );
+			expect( result.groupBy ).toEqual( {
+				field: 'status',
+				direction: 'asc',
+				showLabel: true,
+			} );
+		} );
+
+		it( 'should set groupBy when view has none', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				groupBy: { field: 'category', direction: 'desc' },
+			} );
+			expect( result.groupBy ).toEqual( {
+				field: 'category',
+				direction: 'desc',
+			} );
+		} );
+	} );
+
+	it( 'should not mutate the original view', () => {
+		const original = { ...baseView };
+		mergeActiveViewOverrides( original, {
+			titleField: 'name',
+			filters: [
+				{ field: 'status', operator: 'isAny', value: 'publish' },
+			],
+			layout: { styles: {} },
+		} );
+		expect( original ).toEqual( baseView );
+	} );
+} );
+
+describe( 'stripActiveViewOverrides', () => {
+	it( 'should return the view unchanged when no overrides are provided', () => {
+		expect( stripActiveViewOverrides( baseView ) ).toBe( baseView );
+		expect( stripActiveViewOverrides( baseView, undefined ) ).toBe(
+			baseView
+		);
+	} );
+
+	describe( 'scalar stripping', () => {
+		it( 'should strip a scalar key managed by overrides', () => {
+			const view: View = { ...baseView, titleField: 'name' };
+			const result = stripActiveViewOverrides( view, {
+				titleField: 'name',
+			} );
+			expect( result ).not.toHaveProperty( 'titleField' );
+		} );
+
+		it( 'should strip multiple scalar keys', () => {
+			const view: View = {
+				...baseView,
+				titleField: 'name',
+				showTitle: true,
+				mediaField: 'thumb',
+			};
+			const result = stripActiveViewOverrides( view, {
+				titleField: 'name',
+				showTitle: true,
+				mediaField: 'thumb',
+			} );
+			expect( result ).not.toHaveProperty( 'titleField' );
+			expect( result ).not.toHaveProperty( 'showTitle' );
+			expect( result ).not.toHaveProperty( 'mediaField' );
+		} );
+
+		it( 'should preserve non-overridden scalar keys', () => {
+			const view: View = {
+				...baseView,
+				titleField: 'name',
+				descriptionField: 'excerpt',
+			};
+			const result = stripActiveViewOverrides( view, {
+				titleField: 'name',
+			} );
+			expect( result ).not.toHaveProperty( 'titleField' );
+			expect( result.descriptionField ).toBe( 'excerpt' );
+		} );
+	} );
+
+	describe( 'filter stripping', () => {
+		it( 'should remove filters on managed fields', () => {
+			const view: View = {
+				...baseView,
+				filters: [
+					{
+						field: 'status',
+						operator: 'isAny',
+						value: 'publish',
+					},
+					{
+						field: 'author',
+						operator: 'isAny',
+						value: [ 'admin' ],
+					},
+				],
+			};
+			const result = stripActiveViewOverrides( view, {
+				filters: [
+					{
+						field: 'status',
+						operator: 'isAny',
+						value: 'publish',
+					},
+				],
+			} );
+			expect( result.filters ).toHaveLength( 1 );
+			expect( result.filters?.[ 0 ].field ).toBe( 'author' );
+		} );
+
+		it( 'should handle empty override filters', () => {
+			const result = stripActiveViewOverrides( baseView, {
+				filters: [],
+			} );
+			expect( result.filters ).toEqual( baseView.filters );
+		} );
+	} );
+
+	describe( 'sort stripping', () => {
+		it( 'should restore default sort when current matches override', () => {
+			const view: View = {
+				...baseView,
+				sort: { field: 'title', direction: 'asc' },
+			};
+			const result = stripActiveViewOverrides(
+				view,
+				{ sort: { field: 'title', direction: 'asc' } },
+				defaultView
+			);
+			expect( result.sort ).toEqual( defaultView.sort );
+		} );
+
+		it( 'should not change sort when it does not match override', () => {
+			const view: View = {
+				...baseView,
+				sort: { field: 'author', direction: 'asc' },
+			};
+			const result = stripActiveViewOverrides(
+				view,
+				{ sort: { field: 'title', direction: 'asc' } },
+				defaultView
+			);
+			expect( result.sort ).toEqual( {
+				field: 'author',
+				direction: 'asc',
+			} );
+		} );
+	} );
+
+	describe( 'layout stripping', () => {
+		it( 'should strip layout keys managed by overrides', () => {
+			const view: View = {
+				...baseView,
+				layout: {
+					density: 'compact',
+					styles: { author: { align: 'end' } },
+				},
+			};
+			const result = stripActiveViewOverrides( view, {
+				layout: { styles: { author: { align: 'end' } } },
+			} );
+			expect( result.layout ).toEqual( { density: 'compact' } );
+		} );
+
+		it( 'should set layout to undefined when all keys are stripped', () => {
+			const view: View = {
+				...baseView,
+				layout: {
+					styles: { author: { align: 'end' } },
+				},
+			};
+			const result = stripActiveViewOverrides( view, {
+				layout: { styles: { author: { align: 'end' } } },
+			} );
+			expect( result.layout ).toBeUndefined();
+		} );
+
+		it( 'should not touch layout when view has no layout', () => {
+			const result = stripActiveViewOverrides( baseView, {
+				layout: { styles: {} },
+			} );
+			expect( result ).not.toHaveProperty( 'layout' );
+		} );
+	} );
+
+	describe( 'groupBy stripping', () => {
+		it( 'should strip groupBy keys managed by overrides', () => {
+			const view: View = {
+				...baseView,
+				groupBy: {
+					field: 'status',
+					direction: 'asc',
+					showLabel: true,
+				},
+			};
+			const result = stripActiveViewOverrides( view, {
+				groupBy: { field: 'status', direction: 'asc', showLabel: true },
+			} );
+			expect( result.groupBy ).toEqual( {
+				field: 'status',
+				direction: 'asc',
+			} );
+		} );
+
+		it( 'should set groupBy to undefined when all keys are stripped', () => {
+			const view: View = {
+				...baseView,
+				groupBy: { field: 'status', direction: 'asc' },
+			};
+			const result = stripActiveViewOverrides( view, {
+				groupBy: { field: 'status', direction: 'asc' },
+			} );
+			expect( result.groupBy ).toBeUndefined();
+		} );
+
+		it( 'should not touch groupBy when view has no groupBy', () => {
+			const result = stripActiveViewOverrides( baseView, {
+				groupBy: { field: 'category', direction: 'asc' },
+			} );
+			expect( result ).not.toHaveProperty( 'groupBy' );
+		} );
+	} );
+
+	it( 'should not mutate the original view', () => {
+		const view: View = {
+			...baseView,
+			titleField: 'name',
+			layout: { density: 'compact', styles: { a: { width: '1px' } } },
+		};
+		const original = { ...view, layout: { ...view.layout } };
+		stripActiveViewOverrides( view, {
+			titleField: 'name',
+			layout: { styles: {} },
+		} );
+		expect( view ).toEqual( original );
+	} );
+} );
+
+describe( 'merge + strip round-trip', () => {
+	it( 'should strip what merge added for scalar overrides', () => {
+		const overrides = {
+			titleField: 'name' as const,
+			showMedia: true as const,
+		};
+		const merged = mergeActiveViewOverrides( baseView, overrides );
+		const stripped = stripActiveViewOverrides( merged, overrides );
+		expect( stripped ).not.toHaveProperty( 'titleField' );
+		expect( stripped ).not.toHaveProperty( 'showMedia' );
+		// Original fields remain.
+		expect( stripped.type ).toBe( 'table' );
+		expect( stripped.sort ).toEqual( baseView.sort );
+	} );
+
+	it( 'should strip what merge added for layout overrides', () => {
+		const overrides = {
+			layout: { styles: { author: { align: 'end' } } },
+		};
+		const view: View = {
+			...baseView,
+			layout: { density: 'compact' },
+		};
+		const merged = mergeActiveViewOverrides( view, overrides );
+		const stripped = stripActiveViewOverrides( merged, overrides );
+		expect( stripped.layout ).toEqual( { density: 'compact' } );
+	} );
+
+	it( 'should strip what merge added for filter overrides', () => {
+		const overrides = {
+			filters: [
+				{
+					field: 'status' as const,
+					operator: 'isAny' as const,
+					value: 'publish',
+				},
+			],
+		};
+		const merged = mergeActiveViewOverrides( baseView, overrides );
+		const stripped = stripActiveViewOverrides( merged, overrides );
+		// Only the original author filter should remain.
+		expect( stripped.filters ).toEqual( [
+			{ field: 'author', operator: 'isAny', value: [ 'admin' ] },
+		] );
+	} );
+} );

--- a/packages/views/src/types.ts
+++ b/packages/views/src/types.ts
@@ -1,7 +1,24 @@
 /**
  * WordPress dependencies
  */
-import type { View, Filter } from '@wordpress/dataviews';
+import type { View } from '@wordpress/dataviews';
+
+export type ActiveViewOverrides = {
+	// scalar values
+	titleField?: View[ 'titleField' ];
+	showTitle?: View[ 'showTitle' ];
+	mediaField?: View[ 'mediaField' ];
+	showMedia?: View[ 'showMedia' ];
+	descriptionField?: View[ 'descriptionField' ];
+	showDescription?: View[ 'showDescription' ];
+	showLevels?: View[ 'showLevels' ];
+	infiniteScrollEnabled?: View[ 'infiniteScrollEnabled' ];
+	// array & object values
+	filters?: View[ 'filters' ];
+	sort?: View[ 'sort' ];
+	groupBy?: View[ 'groupBy' ];
+	layout?: Record< string, unknown >;
+};
 
 export interface ViewConfig {
 	/**
@@ -28,13 +45,11 @@ export interface ViewConfig {
 
 	/**
 	 * View overrides applied on top of the persisted view but never persisted.
-	 * These represent tab-specific configuration (filters, sort) that should
-	 * override the persisted view settings.
+	 * These represent tab-specific configuration (filters, sort) and
+	 * developer-defined view defaults that should override the persisted
+	 * view settings.
 	 */
-	activeViewOverrides?: {
-		filters?: Filter[];
-		sort?: View[ 'sort' ];
-	};
+	activeViewOverrides?: ActiveViewOverrides;
 
 	/**
 	 * Optional query parameters from URL (page, search)


### PR DESCRIPTION
##  What?                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                
  Extend activeViewOverrides in @wordpress/views to support all developer-defined view properties, not just filters and sort.                                                                                                                                   
                                                                                                                                                                                                                                                                
##  Why?                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                
  When useView persists a view to user preferences, it saves the entire view object. If a developer later changes a property like titleField, showLevels, or layout.styles, users with persisted views keep the stale values because those properties get saved alongside user choices like sort order and page size.                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                
Previously only filters and sort were handled as non-persisted overrides. This extends the mechanism so all developer-controlled properties (titleField, mediaField, descriptionField, showTitle, showMedia, showDescription, showLevels, groupBy, infiniteScrollEnabled, layout) can be declared as overrides — always merged on read and stripped before persisting.

##  How?

Add more values to ActiveViewOverrides, so that consumers can choose whan to override and what not. For now, I've added all that are developer-controlled and users cannot change through the interface.

##  Testing Instructions

- Update `getActiveViewOverridesForTab` in `packages/edit-site/src/components/post-list/view-utils.js` to (overrides `groupBy`):

```tsx
export function getActiveViewOverridesForTab( activeView ) {
	const base = {
		groupBy: {
			field: 'date',
			direction: 'desc',
		},
	};
	const status = SLUG_TO_STATUS[ activeView ];
	if ( ! status ) {
		return base;
	}
	return {
		...base,
		filters: [
			{
				field: 'status',
				operator: OPERATOR_IS_ANY,
				value: status,
				isLocked: true,
			},
		],
	};
}
```
- Save views (e.g., swich layouts or change sort order) and verify the groupBy config remains.
- Update the groupBy config and reload the screen. Verify it's updated.
- In the console, run `wp.data.select('core/preferences').get('core/views', 'dataviews-postType-page-default')` and verify groupBy info is not persisted.