### PR TITLE
RTC: Fix stale CRDT document persisted on save

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -771,6 +771,15 @@ export const saveEntityRecord =
 				} else {
 					let edits = record;
 					if ( entityConfig.__unstablePrePersist ) {
+						// When sync (collaboration) is enabled, Y.Doc updates
+						// are deferred via setTimeout(0). Yield to the event
+						// loop so pending updates are flushed before
+						// __unstablePrePersist serializes the CRDT document.
+						if ( entityConfig.syncConfig ) {
+							await new Promise( ( resolve ) =>
+								setTimeout( resolve, 0 )
+							);
+						}
 						edits = {
 							...edits,
 							...entityConfig.__unstablePrePersist(

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -771,21 +771,12 @@ export const saveEntityRecord =
 				} else {
 					let edits = record;
 					if ( entityConfig.__unstablePrePersist ) {
-						// When sync (collaboration) is enabled, Y.Doc updates
-						// are deferred via setTimeout(0). Yield to the event
-						// loop so pending updates are flushed before
-						// __unstablePrePersist serializes the CRDT document.
-						if ( entityConfig.syncConfig ) {
-							await new Promise( ( resolve ) =>
-								setTimeout( resolve, 0 )
-							);
-						}
 						edits = {
 							...edits,
-							...entityConfig.__unstablePrePersist(
+							...( await entityConfig.__unstablePrePersist(
 								persistedRecord,
 								edits
-							),
+							) ),
 						};
 					}
 					updatedRecord = await __unstableFetch( {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -275,9 +275,9 @@ export const additionalEntityConfigLoaders = [
  * @param {Object}  edits           Edits.
  * @param {string}  name            Post type name.
  * @param {boolean} isTemplate      Whether the post type is a template.
- * @return {Object} Updated edits.
+ * @return {Promise< Object >} Updated edits.
  */
-export const prePersistPostType = (
+export const prePersistPostType = async (
 	persistedRecord,
 	edits,
 	name,
@@ -306,7 +306,7 @@ export const prePersistPostType = (
 	if ( persistedRecord ) {
 		const objectType = `postType/${ name }`;
 		const objectId = persistedRecord.id;
-		const serializedDoc = getSyncManager()?.createPersistedCRDTDoc(
+		const serializedDoc = await getSyncManager()?.createPersistedCRDTDoc(
 			objectType,
 			objectId
 		);

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -51,12 +51,14 @@ describe( 'getMethodName', () => {
 } );
 
 describe( 'prePersistPostType', () => {
-	it( 'set the status to draft and empty the title when saving auto-draft posts', () => {
+	it( 'set the status to draft and empty the title when saving auto-draft posts', async () => {
 		let record = {
 			status: 'auto-draft',
 		};
 		const edits = {};
-		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual( {
+		expect(
+			await prePersistPostType( record, edits, 'post', false )
+		).toEqual( {
 			status: 'draft',
 			title: '',
 		} );
@@ -64,15 +66,17 @@ describe( 'prePersistPostType', () => {
 		record = {
 			status: 'publish',
 		};
-		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual(
-			{}
-		);
+		expect(
+			await prePersistPostType( record, edits, 'post', false )
+		).toEqual( {} );
 
 		record = {
 			status: 'auto-draft',
 			title: 'Auto Draft',
 		};
-		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual( {
+		expect(
+			await prePersistPostType( record, edits, 'post', false )
+		).toEqual( {
 			status: 'draft',
 			title: '',
 		} );
@@ -81,23 +85,23 @@ describe( 'prePersistPostType', () => {
 			status: 'publish',
 			title: 'My Title',
 		};
-		expect( prePersistPostType( record, edits, 'post', false ) ).toEqual(
-			{}
-		);
+		expect(
+			await prePersistPostType( record, edits, 'post', false )
+		).toEqual( {} );
 	} );
 
-	it( 'does not set the status to draft and empty the title when saving templates', () => {
+	it( 'does not set the status to draft and empty the title when saving templates', async () => {
 		const record = {
 			status: 'auto-draft',
 			title: 'Auto Draft',
 		};
 		const edits = {};
-		expect( prePersistPostType( record, edits, 'post', true ) ).toEqual(
-			{}
-		);
+		expect(
+			await prePersistPostType( record, edits, 'post', true )
+		).toEqual( {} );
 	} );
 
-	it( 'adds meta with serialized CRDT doc when createPersistedCRDTDoc returns a value', () => {
+	it( 'adds meta with serialized CRDT doc when createPersistedCRDTDoc returns a value', async () => {
 		const mockSerializedDoc = 'serialized-crdt-doc-data';
 		getSyncManager.mockReturnValue( {
 			createPersistedCRDTDoc: jest
@@ -107,7 +111,7 @@ describe( 'prePersistPostType', () => {
 
 		const record = { id: 123, status: 'publish' };
 		const edits = {};
-		const result = prePersistPostType( record, edits, 'post', false );
+		const result = await prePersistPostType( record, edits, 'post', false );
 
 		expect( result.meta ).toEqual( {
 			[ POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE ]: mockSerializedDoc,

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -633,16 +633,21 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * @param {ObjectType} objectType Object type.
 	 * @param {ObjectID}   objectId   Object ID.
 	 */
-	function createPersistedCRDTDoc(
+	async function createPersistedCRDTDoc(
 		objectType: ObjectType,
 		objectId: ObjectID
-	): string | null {
+	): Promise< string | null > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
 
 		if ( ! entityState?.ydoc ) {
 			return null;
 		}
+
+		// Y.Doc updates are deferred via yieldToEventLoop. Await a promise that
+		// resolves on the next tick of the event loop so pending updates are flushed
+		// before we serialize the document.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 		return serializeCrdtDoc( entityState.ydoc );
 	}

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -147,7 +147,7 @@ export interface SyncManager {
 	createPersistedCRDTDoc: (
 		objectType: ObjectType,
 		objectId: ObjectID
-	) => string | null;
+	) => Promise< string | null >;
 	getAwareness: < State extends Awareness >(
 		objectType: ObjectType,
 		objectId: ObjectID

--- a/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
@@ -75,4 +75,61 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 			await collaborationUtils.getCrdtDocument( page );
 		expect( persistedCrdtDoc ).toBeFalsy();
 	} );
+
+	test( 'persisted CRDT document matches content after save and reload', async ( {
+		admin,
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Create a draft post with initial content.
+		const post = await requestUtils.createPost( {
+			title: 'Persistence Test - Save Reload',
+			content:
+				'<!-- wp:paragraph -->\n<p>Initial content</p>\n<!-- /wp:paragraph -->',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		// Open the post in the editor.
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Wait for collaboration runtime and entity record to be ready.
+		await collaborationUtils.waitForEntityReady( page );
+
+		// Edit the paragraph to ensure Y.Doc reflects meaningful changes.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+		await page.keyboard.press( 'Meta+a' );
+		await page.keyboard.type( 'Updated content' );
+
+		// saveDraft() resolves only after the "Draft saved" notice appears,
+		// so isSavingPost() is already false when it returns.
+		await editor.saveDraft();
+
+		const crdtDocAfterSave =
+			await collaborationUtils.getCrdtDocument( page );
+		expect( crdtDocAfterSave ).toBeTruthy();
+
+		// Reload and wait for entity resolution and any in-flight save to
+		// settle before reading store values.
+		await page.reload();
+		await collaborationUtils.waitForEntityReadyAndSaveSettled( page );
+
+		// The CRDT document must be unchanged after reload. A difference means
+		// the _crdt_document persisted during save was stale (e.g. deferred
+		// Y.Doc updates not yet flushed at serialization time).
+		const crdtDocAfterReload =
+			await collaborationUtils.getCrdtDocument( page );
+		expect( crdtDocAfterReload ).toBe( crdtDocAfterSave );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
@@ -11,8 +11,6 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 		page,
 		requestUtils,
 	} ) => {
-		await collaborationUtils.setCollaboration( true );
-
 		// Create a draft post — it will not have _crdt_document meta.
 		const post = await requestUtils.createPost( {
 			title: 'Persistence Test - Draft',
@@ -30,73 +28,23 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 			fullscreenMode: false,
 		} );
 
-		// Wait for the entity record resolver to finish.
-		await page.waitForFunction(
-			() => {
-				const postId = ( window as any ).wp.data
-					.select( 'core/editor' )
-					.getCurrentPostId();
-				if ( ! postId ) {
-					return false;
-				}
-				return ( window as any ).wp.data
-					.select( 'core' )
-					.hasFinishedResolution( 'getEntityRecord', [
-						'postType',
-						'post',
-						postId,
-					] );
-			},
-			{ timeout: 5000 }
-		);
+		// Wait for collaboration runtime and entity record to be ready.
+		await collaborationUtils.waitForEntityReady( page );
 
-		const persistedCrdtDoc = await page.evaluate( () => {
-			return window.wp.data
-				.select( 'core' )
-				.getEntityRecord(
-					'postType',
-					'post',
-					window.wp.data.select( 'core/editor' ).getCurrentPostId()
-				).meta._crdt_document;
-		} );
-
+		const persistedCrdtDoc =
+			await collaborationUtils.getCrdtDocument( page );
 		expect( persistedCrdtDoc ).toBeTruthy();
 
-		// Refresh the page and verify the CRDT document is loaded from the persisted meta.
+		// Refresh the page and verify the CRDT document is loaded from the
+		// persisted meta and no reconciliation save is triggered.
 		await page.reload();
+		await collaborationUtils.waitForEntityReady( page );
 
-		// Wait for the entity record resolver to finish.
-		await page.waitForFunction(
-			() => {
-				const postId = ( window as any ).wp.data
-					.select( 'core/editor' )
-					.getCurrentPostId();
-				if ( ! postId ) {
-					return false;
-				}
-				return ( window as any ).wp.data
-					.select( 'core' )
-					.hasFinishedResolution( 'getEntityRecord', [
-						'postType',
-						'post',
-						postId,
-					] );
-			},
-			{ timeout: 5000 }
-		);
+		const reloadedCrdtDoc =
+			await collaborationUtils.getCrdtDocument( page );
 
-		const reloadedCrdtDoc = await page.evaluate( () => {
-			return window.wp.data
-				.select( 'core' )
-				.getEntityRecord(
-					'postType',
-					'post',
-					window.wp.data.select( 'core/editor' ).getCurrentPostId()
-				).meta._crdt_document;
-		} );
-
-		// No invalidations should occur on reload, so the CRDT document should be
-		// the same as before.
+		// No invalidations should occur on reload, so the CRDT document should
+		// be identical to the one persisted before reload.
 		expect( reloadedCrdtDoc ).toBe( persistedCrdtDoc );
 	} );
 
@@ -106,8 +54,6 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 		editor,
 		page,
 	} ) => {
-		await collaborationUtils.setCollaboration( true );
-
 		// Navigate to create a new post (auto-draft).
 		await admin.visitAdminPage( 'post-new.php' );
 		await editor.setPreferences( 'core/edit-post', {
@@ -115,42 +61,18 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 			fullscreenMode: false,
 		} );
 
-		// Wait for collaboration runtime to initialize.
+		// Wait for collaboration runtime to initialize separately first, then
+		// wait for the entity record resolver to finish.
 		await page.waitForFunction(
 			() => ( window as any )._wpCollaborationEnabled === true,
 			{ timeout: 5000 }
 		);
-
-		// Wait for the entity record resolver to finish.
-		await page.waitForFunction(
-			() => {
-				const postId = ( window as any ).wp.data
-					.select( 'core/editor' )
-					.getCurrentPostId();
-				if ( ! postId ) {
-					return false;
-				}
-				return ( window as any ).wp.data
-					.select( 'core' )
-					.hasFinishedResolution( 'getEntityRecord', [
-						'postType',
-						'post',
-						postId,
-					] );
-			},
-			{ timeout: 5000 }
-		);
-
-		const persistedCrdtDoc = await page.evaluate( () => {
-			return window.wp.data
-				.select( 'core' )
-				.getEntityRecord(
-					'postType',
-					'post',
-					window.wp.data.select( 'core/editor' ).getCurrentPostId()
-				).meta._crdt_document;
+		await collaborationUtils.waitForEntityReady( page, {
+			requireCollaboration: false,
 		} );
 
+		const persistedCrdtDoc =
+			await collaborationUtils.getCrdtDocument( page );
 		expect( persistedCrdtDoc ).toBeFalsy();
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -177,6 +177,114 @@ export default class CollaborationUtils {
 	}
 
 	/**
+	 * Wait for the editor to be fully ready: collaboration runtime enabled and
+	 * the entity record resolver finished. Optionally skips the collaboration
+	 * check (e.g. for the auto-draft test which checks collaboration separately).
+	 *
+	 * @param page                           The Playwright page to wait on.
+	 * @param [options]                      Optional settings.
+	 * @param [options.requireCollaboration] Whether to require _wpCollaborationEnabled (default true).
+	 * @param [options.timeout]              Maximum wait time in ms (default 10000).
+	 */
+	async waitForEntityReady(
+		page: Page,
+		{
+			requireCollaboration = true,
+			timeout = 10000,
+		}: { requireCollaboration?: boolean; timeout?: number } = {}
+	) {
+		await page.waitForFunction(
+			( { requireCollab } ) => {
+				const postId = ( window as any ).wp?.data
+					?.select( 'core/editor' )
+					?.getCurrentPostId();
+				if ( ! postId ) {
+					return false;
+				}
+				if (
+					requireCollab &&
+					( window as any )._wpCollaborationEnabled !== true
+				) {
+					return false;
+				}
+				return ( window as any ).wp.data
+					.select( 'core' )
+					.hasFinishedResolution( 'getEntityRecord', [
+						'postType',
+						'post',
+						postId,
+					] );
+			},
+			{ requireCollab: requireCollaboration },
+			{ timeout }
+		);
+	}
+
+	/**
+	 * Wait for entity resolution AND for any triggered reconciliation save to
+	 * settle. Use this after a page reload when a reconciliation save may be
+	 * initiated synchronously upon entity resolution.
+	 *
+	 * @param page              The Playwright page to wait on.
+	 * @param [options]         Optional settings.
+	 * @param [options.timeout] Maximum wait time in ms (default 15000).
+	 */
+	async waitForEntityReadyAndSaveSettled(
+		page: Page,
+		{ timeout = 15000 }: { timeout?: number } = {}
+	) {
+		await page.waitForFunction(
+			() => {
+				const postId = ( window as any ).wp?.data
+					?.select( 'core/editor' )
+					?.getCurrentPostId();
+				if ( ! postId ) {
+					return false;
+				}
+				if ( ( window as any )._wpCollaborationEnabled !== true ) {
+					return false;
+				}
+				if (
+					! ( window as any ).wp.data
+						.select( 'core' )
+						.hasFinishedResolution( 'getEntityRecord', [
+							'postType',
+							'post',
+							postId,
+						] )
+				) {
+					return false;
+				}
+				// Entity is resolved; wait for any triggered reconciliation
+				// save to settle before we read store values.
+				return ! ( window as any ).wp.data
+					.select( 'core/editor' )
+					.isSavingPost();
+			},
+			{ timeout }
+		);
+	}
+
+	/**
+	 * Read the _crdt_document meta value from the currently loaded entity record.
+	 *
+	 * @param page The Playwright page to evaluate on.
+	 */
+	async getCrdtDocument( page: Page ): Promise< string | null > {
+		return page.evaluate( () => {
+			const postId = ( window as any ).wp.data
+				.select( 'core/editor' )
+				.getCurrentPostId();
+			return (
+				( window as any ).wp.data
+					.select( 'core' )
+					.getEntityRecord( 'postType', 'post', postId )?.meta
+					?._crdt_document ?? null
+			);
+		} );
+	}
+
+	/**
 	 * Wait for the collaboration runtime to be ready on a page.
 	 * Checks that `window._wpCollaborationEnabled` is true and wp.data is loaded.
 	 *


### PR DESCRIPTION
## What?

Fix stale CRDT document being persisted during save when real-time collaboration is enabled.

## Why?

When sync is enabled, Y.Doc updates are deferred via `setTimeout(0)` for performance. `saveEntityRecord` calls `__unstablePrePersist` to serialize the CRDT document, but it was doing so without yielding to the event loop first. This meant the serialized `_crdt_document` was stale — it didn't include the most recent Y.Doc updates. On reload, `_applyPersistedCrdtDoc` detected the mismatch and triggered an unnecessary reconciliation save.

## How?

- Add a `setTimeout(0)` yield inside `saveEntityRecord` before calling `__unstablePrePersist`, only when `syncConfig` is present. This flushes any pending deferred Y.Doc updates before serialization.
- Extract repeated `waitForFunction`/`evaluate` blocks from the collaboration persistence E2E tests into three reusable `CollaborationUtils` helpers: `waitForEntityReady`, `waitForEntityReadyAndSaveSettled`, and `getCrdtDocument`.
- Add a new E2E test (`persisted CRDT document matches content after save and reload`) that verifies the CRDT document is identical before and after a save-reload cycle.

## Testing Instructions

1. Enable real-time collaboration in **Settings → Writing**.
2. Create a new draft post with a paragraph block.
3. Type some content.
4. Open the browser **Network** tab and filter by `posts/:id` to see REST API calls to `wp/v2/posts/:id`.

**On `trunk` (before this PR):**

5. Click **Publish** — observe a `POST` request to `posts/:id`.
6. Reload the page.
7. A second `POST` request to `posts/:id` fires automatically after reload — this is the unnecessary reconciliation save caused by the stale CRDT document.

**On this branch (after this PR):**

5. Click **Publish** — observe a `POST` request to `posts/:id`.
6. Reload the page.
7. No additional `POST` request to `posts/:id` fires — the persisted CRDT document is up-to-date so no reconciliation save is triggered.

### Automated

```bash
npx playwright test --config test/e2e/playwright.config.ts test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
```

All 3 tests should pass. The third test (`persisted CRDT document matches content after save and reload`) fails without the `actions.js` fix.

### Testing Instructions for Keyboard

N/A — no UI changes.
