### PR TITLE
Use homeUrl instead of siteUrl for link badge evaluations

### DIFF
--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -96,6 +96,15 @@ describe( 'computeDisplayUrl', () => {
 			} );
 			expect( result.isExternal ).toBe( false );
 		} );
+
+		it( 'should treat same-origin URLs as internal when homeUrl includes a path', () => {
+			const result = computeDisplayUrl( {
+				linkUrl: 'https://example.com/my-page',
+				homeUrl: 'https://example.com/blog',
+			} );
+			expect( result.isExternal ).toBe( false );
+			expect( result.displayUrl ).toBe( '/my-page' );
+		} );
 	} );
 
 	describe( 'special protocols and edge cases', () => {

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -92,7 +92,7 @@ describe( 'computeDisplayUrl', () => {
 		it( 'should treat same-origin URLs as internal', () => {
 			const result = computeDisplayUrl( {
 				linkUrl: 'https://example.com/my-page',
-				siteUrl: 'https://example.com',
+				homeUrl: 'https://example.com',
 			} );
 			expect( result.isExternal ).toBe( false );
 		} );

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -52,7 +52,10 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 	try {
 		const parsedUrl = new URL( linkUrl );
 		// Use provided homeUrl or fall back to window.location.origin
-		const siteDomain = homeUrl || window.location.origin;
+		const siteDomain = homeUrl
+			? new URL( homeUrl ).origin
+			: window.location.origin;
+
 		if ( parsedUrl.origin === siteDomain ) {
 			// Show only the pathname (and search/hash if present)
 			let path = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -31,10 +31,10 @@ function capitalize( str ) {
  *
  * @param {Object} options         - Parameters object
  * @param {string} options.linkUrl - The URL to process
- * @param {string} options.siteUrl - The WordPress site URL (falls back to window.location.origin)
+ * @param {string} options.homeUrl - The WordPress site URL (falls back to window.location.origin)
  * @return {Object} Object with displayUrl and isExternal flag
  */
-export function computeDisplayUrl( { linkUrl, siteUrl } = {} ) {
+export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 	if ( ! linkUrl ) {
 		return { displayUrl: '', isExternal: false };
 	}
@@ -51,8 +51,8 @@ export function computeDisplayUrl( { linkUrl, siteUrl } = {} ) {
 	// This must happen before trusting the type attribute
 	try {
 		const parsedUrl = new URL( linkUrl );
-		// Use provided siteUrl or fall back to window.location.origin
-		const siteDomain = siteUrl || window.location.origin;
+		// Use provided homeUrl or fall back to window.location.origin
+		const siteDomain = homeUrl || window.location.origin;
 		if ( parsedUrl.origin === siteDomain ) {
 			// Show only the pathname (and search/hash if present)
 			let path = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
@@ -174,13 +174,12 @@ export function useLinkPreview( {
 	hasBinding,
 	isEntityAvailable,
 } ) {
-	// Get the WordPress site URL from settings
-	const siteUrl = useSelect( ( select ) => {
-		const siteEntity = select( coreDataStore ).getEntityRecord(
+	// Get the WordPress homepage URL from settings
+	const homeUrl = useSelect( ( select ) => {
+		return select( coreDataStore ).getEntityRecord(
 			'root',
-			'site'
-		);
-		return siteEntity?.url;
+			'__unstableBase'
+		)?.home;
 	}, [] );
 
 	const title =
@@ -194,7 +193,7 @@ export function useLinkPreview( {
 	// Compute display URL and external flag
 	const { displayUrl, isExternal } = computeDisplayUrl( {
 		linkUrl: url,
-		siteUrl,
+		homeUrl,
 	} );
 
 	const image = useSelect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
This PR would need backporting to 7.0.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Uses the homepage url instead of the site url for determining link badges like "Page," "Internal," "External," etc.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
SiteURL is the site install location and not the root domain that displays the page. If someone installs in a subdirectory (https://my-site.com/wordpress) and outputs their site at the root (https://my-site.com/) then I believe all of the internal/external badges will compute incorrectly. I've updated to using the home url.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Follow the [home url fetching used in the home link block](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/home-link/edit.js#L17-L21):

```
const homeUrl = useSelect( ( select ) => {
	// Site index.
	return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
		?.home;
}, [] );

```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- On a navigation block, add links such as:
- Internal: `#test`
- Relative: `../test`
- External: `https://wordpress.org`
- Bound: Select page from the LinkUI
- Correct site URL but hardcoded: `http://localhost:8888/page`
- Check that each instance's badge reports correctly in the site inspector sidebar for the LinkPicker preview

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
