### PR TITLE
Unify block settings dropdown menu items across list views

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -74,6 +74,7 @@ export function BlockSettingsDropdown( {
 	clientIds,
 	children,
 	__experimentalSelectBlock,
+	isContentOnlyListView,
 	...props
 } ) {
 	// Get the client id of the current block for this menu, if one is set.
@@ -86,7 +87,6 @@ export function BlockSettingsDropdown( {
 		previousBlockClientId,
 		selectedBlockClientIds,
 		isContentOnly,
-		isParentContentOnly,
 		isZoomOut,
 		canEdit,
 		canMove,
@@ -129,10 +129,6 @@ export function BlockSettingsDropdown( {
 				selectedBlockClientIds: getSelectedBlockClientIds(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
-				isParentContentOnly:
-					!! _firstParentClientId &&
-					getBlockEditingMode( _firstParentClientId ) ===
-						'contentOnly',
 				isZoomOut: _isZoomOut(),
 				canEdit: canEditBlock( firstBlockClientId ),
 				canMove: canMoveBlocks( clientIds ),
@@ -261,7 +257,7 @@ export function BlockSettingsDropdown( {
 											parentBlockType={ parentBlockType }
 										/>
 									) }
-									{ canMove && isParentContentOnly && (
+									{ canMove && isContentOnlyListView && (
 										<>
 											<MenuItem
 												icon={ chevronUp }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/blocks';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { moreVertical } from '@wordpress/icons';
+import { chevronDown, chevronUp, moreVertical } from '@wordpress/icons';
 import { Children, cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -89,6 +89,8 @@ export function BlockSettingsDropdown( {
 		isZoomOut,
 		canEdit,
 		canMove,
+		isFirst,
+		isLast,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -101,6 +103,8 @@ export function BlockSettingsDropdown( {
 				isZoomOut: _isZoomOut,
 				canEditBlock,
 				canMoveBlocks,
+				getBlockIndex,
+				getBlockCount,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -127,6 +131,10 @@ export function BlockSettingsDropdown( {
 				isZoomOut: _isZoomOut(),
 				canEdit: canEditBlock( firstBlockClientId ),
 				canMove: canMoveBlocks( clientIds ),
+				isFirst: getBlockIndex( firstBlockClientId ) === 0,
+				isLast:
+					getBlockIndex( firstBlockClientId ) ===
+					getBlockCount( _firstParentClientId ) - 1,
 			};
 		},
 		[ firstBlockClientId, clientIds ]
@@ -251,6 +259,9 @@ export function BlockSettingsDropdown( {
 									{ canMove && isContentOnly && (
 										<>
 											<MenuItem
+												icon={ chevronUp }
+												disabled={ isFirst }
+												accessibleWhenDisabled
 												onClick={ pipe( onClose, () => {
 													moveBlocksUp(
 														clientIds,
@@ -261,6 +272,9 @@ export function BlockSettingsDropdown( {
 												{ __( 'Move up' ) }
 											</MenuItem>
 											<MenuItem
+												icon={ chevronDown }
+												disabled={ isLast }
+												accessibleWhenDisabled
 												onClick={ pipe( onClose, () => {
 													moveBlocksDown(
 														clientIds,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -86,6 +86,7 @@ export function BlockSettingsDropdown( {
 		previousBlockClientId,
 		selectedBlockClientIds,
 		isContentOnly,
+		isParentContentOnly,
 		isZoomOut,
 		canEdit,
 		canMove,
@@ -128,6 +129,10 @@ export function BlockSettingsDropdown( {
 				selectedBlockClientIds: getSelectedBlockClientIds(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
+				isParentContentOnly:
+					!! _firstParentClientId &&
+					getBlockEditingMode( _firstParentClientId ) ===
+						'contentOnly',
 				isZoomOut: _isZoomOut(),
 				canEdit: canEditBlock( firstBlockClientId ),
 				canMove: canMoveBlocks( clientIds ),
@@ -256,7 +261,7 @@ export function BlockSettingsDropdown( {
 											parentBlockType={ parentBlockType }
 										/>
 									) }
-									{ canMove && isContentOnly && (
+									{ canMove && isParentContentOnly && (
 										<>
 											<MenuItem
 												icon={ chevronUp }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -248,7 +248,7 @@ export function BlockSettingsDropdown( {
 											parentBlockType={ parentBlockType }
 										/>
 									) }
-									{ canMove && (
+									{ canMove && isContentOnly && (
 										<>
 											<MenuItem
 												onClick={ pipe( onClose, () => {

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -88,6 +88,7 @@ export function BlockSettingsDropdown( {
 		isContentOnly,
 		isZoomOut,
 		canEdit,
+		canMove,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -99,6 +100,7 @@ export function BlockSettingsDropdown( {
 				getBlockEditingMode,
 				isZoomOut: _isZoomOut,
 				canEditBlock,
+				canMoveBlocks,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -124,13 +126,16 @@ export function BlockSettingsDropdown( {
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
 				isZoomOut: _isZoomOut(),
 				canEdit: canEditBlock( firstBlockClientId ),
+				canMove: canMoveBlocks( clientIds ),
 			};
 		},
-		[ firstBlockClientId ]
+		[ firstBlockClientId, clientIds ]
 	);
 
 	const { getBlockOrder, getSelectedBlockClientIds } =
 		useSelect( blockEditorStore );
+
+	const { moveBlocksDown, moveBlocksUp } = useDispatch( blockEditorStore );
 
 	const shortcuts = useSelect( ( select ) => {
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
@@ -242,6 +247,30 @@ export function BlockSettingsDropdown( {
 											}
 											parentBlockType={ parentBlockType }
 										/>
+									) }
+									{ canMove && (
+										<>
+											<MenuItem
+												onClick={ pipe( onClose, () => {
+													moveBlocksUp(
+														clientIds,
+														firstParentClientId
+													);
+												} ) }
+											>
+												{ __( 'Move up' ) }
+											</MenuItem>
+											<MenuItem
+												onClick={ pipe( onClose, () => {
+													moveBlocksDown(
+														clientIds,
+														firstParentClientId
+													);
+												} ) }
+											>
+												{ __( 'Move down' ) }
+											</MenuItem>
+										</>
 									) }
 									{ canEdit && count === 1 && (
 										<BlockHTMLConvertButton

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -700,6 +700,11 @@ function ListViewBlock( {
 							__experimentalSelectBlock={
 								updateFocusAndSelection
 							}
+							isContentOnlyListView={
+								!! rootClientId &&
+								getBlockEditingMode( rootClientId ) ===
+									'contentOnly'
+							}
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -124,11 +124,21 @@ export default function LeafMoreMenu( props ) {
 
 	const { rootClientId, canDuplicate, canInsertBlock } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId, canInsertBlockType } =
-				select( blockEditorStore );
+			const {
+				getBlockRootClientId,
+				canInsertBlockType,
+				getDirectInsertBlock,
+			} = select( blockEditorStore );
 			const { getDefaultBlockName } = select( blocksStore );
 
 			const _rootClientId = getBlockRootClientId( clientId );
+			const canInsertDefaultBlock = canInsertBlockType(
+				getDefaultBlockName(),
+				_rootClientId
+			);
+			const directInsertBlock = _rootClientId
+				? getDirectInsertBlock( _rootClientId )
+				: null;
 
 			return {
 				rootClientId: _rootClientId,
@@ -136,10 +146,10 @@ export default function LeafMoreMenu( props ) {
 					!! block &&
 					hasBlockSupport( block.name, 'multiple', true ) &&
 					canInsertBlockType( block.name, _rootClientId ),
-				canInsertBlock: canInsertBlockType(
-					getDefaultBlockName(),
-					_rootClientId
-				),
+				canInsertBlock:
+					( canInsertDefaultBlock || !! directInsertBlock ) &&
+					!! block &&
+					canInsertBlockType( block.name, _rootClientId ),
 			};
 		},
 		[ clientId, block ]

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -122,38 +122,45 @@ export default function LeafMoreMenu( props ) {
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 
-	const { rootClientId, canDuplicate, canInsertBlock } = useSelect(
-		( select ) => {
-			const {
-				getBlockRootClientId,
-				canInsertBlockType,
-				getDirectInsertBlock,
-			} = select( blockEditorStore );
-			const { getDefaultBlockName } = select( blocksStore );
+	const { rootClientId, canDuplicate, canInsertBlock, isFirst, isLast } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockRootClientId,
+					canInsertBlockType,
+					getDirectInsertBlock,
+					getBlockIndex,
+					getBlockCount,
+				} = select( blockEditorStore );
+				const { getDefaultBlockName } = select( blocksStore );
 
-			const _rootClientId = getBlockRootClientId( clientId );
-			const canInsertDefaultBlock = canInsertBlockType(
-				getDefaultBlockName(),
-				_rootClientId
-			);
-			const directInsertBlock = _rootClientId
-				? getDirectInsertBlock( _rootClientId )
-				: null;
+				const _rootClientId = getBlockRootClientId( clientId );
+				const canInsertDefaultBlock = canInsertBlockType(
+					getDefaultBlockName(),
+					_rootClientId
+				);
+				const directInsertBlock = _rootClientId
+					? getDirectInsertBlock( _rootClientId )
+					: null;
 
-			return {
-				rootClientId: _rootClientId,
-				canDuplicate:
-					!! block &&
-					hasBlockSupport( block.name, 'multiple', true ) &&
-					canInsertBlockType( block.name, _rootClientId ),
-				canInsertBlock:
-					( canInsertDefaultBlock || !! directInsertBlock ) &&
-					!! block &&
-					canInsertBlockType( block.name, _rootClientId ),
-			};
-		},
-		[ clientId, block ]
-	);
+				return {
+					rootClientId: _rootClientId,
+					canDuplicate:
+						!! block &&
+						hasBlockSupport( block.name, 'multiple', true ) &&
+						canInsertBlockType( block.name, _rootClientId ),
+					canInsertBlock:
+						( canInsertDefaultBlock || !! directInsertBlock ) &&
+						!! block &&
+						canInsertBlockType( block.name, _rootClientId ),
+					isFirst: getBlockIndex( clientId ) === 0,
+					isLast:
+						getBlockIndex( clientId ) ===
+						getBlockCount( _rootClientId ) - 1,
+				};
+			},
+			[ clientId, block ]
+		);
 
 	return (
 		<DropdownMenu
@@ -169,6 +176,8 @@ export default function LeafMoreMenu( props ) {
 					<MenuGroup>
 						<MenuItem
 							icon={ chevronUp }
+							disabled={ isFirst }
+							accessibleWhenDisabled
 							onClick={ () => {
 								moveBlocksUp( [ clientId ], rootClientId );
 								onClose();
@@ -178,6 +187,8 @@ export default function LeafMoreMenu( props ) {
 						</MenuItem>
 						<MenuItem
 							icon={ chevronDown }
+							disabled={ isLast }
+							accessibleWhenDisabled
 							onClick={ () => {
 								moveBlocksDown( [ clientId ], rootClientId );
 								onClose();

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	hasBlockSupport,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import {
 	addSubmenu,
 	chevronUp,
@@ -103,8 +107,14 @@ export default function LeafMoreMenu( props ) {
 	const { block } = props;
 	const { clientId } = block;
 
-	const { moveBlocksDown, moveBlocksUp, removeBlocks } =
-		useDispatch( blockEditorStore );
+	const {
+		moveBlocksDown,
+		moveBlocksUp,
+		removeBlocks,
+		duplicateBlocks,
+		insertBeforeBlock,
+		insertAfterBlock,
+	} = useDispatch( blockEditorStore );
 
 	const removeLabel = sprintf(
 		/* translators: %s: block name */
@@ -112,13 +122,27 @@ export default function LeafMoreMenu( props ) {
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 
-	const rootClientId = useSelect(
+	const { rootClientId, canDuplicate, canInsertBlock } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
+			const { getBlockRootClientId, canInsertBlockType } =
+				select( blockEditorStore );
+			const { getDefaultBlockName } = select( blocksStore );
 
-			return getBlockRootClientId( clientId );
+			const _rootClientId = getBlockRootClientId( clientId );
+
+			return {
+				rootClientId: _rootClientId,
+				canDuplicate:
+					!! block &&
+					hasBlockSupport( block.name, 'multiple', true ) &&
+					canInsertBlockType( block.name, _rootClientId ),
+				canInsertBlock: canInsertBlockType(
+					getDefaultBlockName(),
+					_rootClientId
+				),
+			};
 		},
-		[ clientId ]
+		[ clientId, block ]
 	);
 
 	return (
@@ -158,6 +182,36 @@ export default function LeafMoreMenu( props ) {
 							expand={ props.expand }
 							setInsertedBlock={ props.setInsertedBlock }
 						/>
+						{ canDuplicate && (
+							<MenuItem
+								onClick={ () => {
+									duplicateBlocks( [ clientId ] );
+									onClose();
+								} }
+							>
+								{ __( 'Duplicate' ) }
+							</MenuItem>
+						) }
+						{ canInsertBlock && (
+							<>
+								<MenuItem
+									onClick={ () => {
+										insertBeforeBlock( clientId );
+										onClose();
+									} }
+								>
+									{ __( 'Add before' ) }
+								</MenuItem>
+								<MenuItem
+									onClick={ () => {
+										insertAfterBlock( clientId );
+										onClose();
+									} }
+								>
+									{ __( 'Add after' ) }
+								</MenuItem>
+							</>
+						) }
 					</MenuGroup>
 					<MenuGroup>
 						<MenuItem

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -263,8 +263,8 @@ test.describe( 'Zoom Out', () => {
 			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem' );
 
-		// we expect 4 items in the options menu: Move up, Move down, Duplicate, and Delete.
-		await expect( optionsMenu ).toHaveCount( 4 );
+		// we expect 2 items in the options menu: Duplicate and Delete.
+		await expect( optionsMenu ).toHaveCount( 2 );
 	} );
 
 	test( 'Zoom Out cannot be activated when the section root is missing', async ( {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -263,8 +263,8 @@ test.describe( 'Zoom Out', () => {
 			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem' );
 
-		// we expect 2 items in the options menu: Duplicate and Delete.
-		await expect( optionsMenu ).toHaveCount( 2 );
+		// we expect 4 items in the options menu: Move up, Move down, Duplicate, and Delete.
+		await expect( optionsMenu ).toHaveCount( 4 );
 	} );
 
 	test( 'Zoom Out cannot be activated when the section root is missing', async ( {


### PR DESCRIPTION
## What?

Add missing menu items to both list view implementations so they have feature parity.

## Why?

The navigation block's contentOnly list view (LeafMoreMenu) and other blocks' contentOnly list views (BlockSettingsDropdown) had different menu items available. This inconsistency confuses users and limits functionality. This change unifies the menus whil keeping block-specific items (like "Add submenu link" for navigation).

This is a prerequisite for the larger refactoring in #75694.

## How?

- **BlockSettingsDropdown** (list, buttons, social icons): Added "Move up" and "Move down" menu items
- **LeafMoreMenu** (navigation): Added "Duplicate", "Add before", and "Add after" menu items

Both menus now share the same core operations while preserving block-specific actions.

## Testing Instructions

1. Insert a pattern that contains a Navigation block
2. Ensure the pattern is in contentOnly mode
3. Open the list view in inspector controls
4. Click the block settings menu (•••) on a navigation link - verify it shows: Move up, Move down, Add submenu link, Duplicate, Add before, Add after, and Remove
5. Insert a **List** block in contentOnly mode
6. Open the list view in inspector controls
7. Click the block settings menu (•••) on a list item - verify it shows: Move up, Move down, Duplicate, Add before, Add after, and Delete
8. Repeat with **Buttons** and **Social Links** blocks

## Sc
<img width="304" height="439" alt="Screenshot 2026-02-26 at 22 12 24" src="https://github.com/user-attachments/assets/1626e902-6aea-4e19-912d-55be9fb7576d" />
<img width="289" height="347" alt="Screenshot 2026-02-26 at 22 12 18" src="https://github.com/user-attachments/assets/e8c2f714-308c-4566-820d-f0e1fd967cac" />
reenshots
