### PR TITLE
Connectors: Gate unavailable install actions behind install capability

### DIFF
--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -197,6 +197,32 @@ function _gutenberg_get_connector_settings(): array {
 		}
 	}
 
+	// Add plugin installation and activation status.
+	// Build a slug-to-file map following the same pattern as WP_Plugin_Dependencies::get_plugin_dirnames().
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$plugin_files_by_slug = array();
+	foreach ( array_keys( get_plugins() ) as $plugin_file ) {
+		$slug                         = str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
+		$plugin_files_by_slug[ $slug ] = $plugin_file;
+	}
+
+	foreach ( $connectors as $connector_id => $connector ) {
+		if ( empty( $connector['plugin']['slug'] ) ) {
+			continue;
+		}
+
+		$plugin_slug = $connector['plugin']['slug'];
+		$plugin_file = $plugin_files_by_slug[ $plugin_slug ] ?? null;
+
+		$is_installed = null !== $plugin_file;
+		$is_activated = $is_installed && is_plugin_active( $plugin_file );
+
+		$connectors[ $connector_id ]['plugin']['is_installed'] = $is_installed;
+		$connectors[ $connector_id ]['plugin']['is_activated'] = $is_activated;
+	}
+
 	return $connectors;
 }
 
@@ -388,7 +414,11 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		);
 
 		if ( ! empty( $connector_data['plugin'] ) ) {
-			$connector_out['plugin'] = $connector_data['plugin'];
+			$connector_out['plugin'] = array(
+				'slug'        => $connector_data['plugin']['slug'],
+				'isInstalled' => $connector_data['plugin']['is_installed'] ?? false,
+				'isActivated' => $connector_data['plugin']['is_activated'] ?? false,
+			);
 		}
 
 		$connectors[ $connector_id ] = $connector_out;

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -204,7 +204,7 @@ function _gutenberg_get_connector_settings(): array {
 	}
 	$plugin_files_by_slug = array();
 	foreach ( array_keys( get_plugins() ) as $plugin_file ) {
-		$slug                         = str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
+		$slug                          = str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
 		$plugin_files_by_slug[ $slug ] = $plugin_file;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62963,10 +62963,12 @@
 				"@wordpress/api-fetch": "file:../../packages/api-fetch",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/connectors": "file:../../packages/connectors",
+				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/icons": "file:../../packages/icons"
+				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/ui": "file:../../packages/ui"
 			}
 		},
 		"routes/font-list": {

--- a/packages/e2e-tests/plugins/connectors-capability-restriction.php
+++ b/packages/e2e-tests/plugins/connectors-capability-restriction.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Connectors Capability Restriction
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-connectors-capability-restriction
+ */
+
+add_action(
+	'init',
+	static function () {
+		register_setting(
+			'general',
+			'gutenberg_test_cap_restriction',
+			array(
+				'type'         => 'string',
+				'default'      => '',
+				'show_in_rest' => true,
+			)
+		);
+	}
+);
+
+register_deactivation_hook(
+	__FILE__,
+	static function () {
+		delete_option( 'gutenberg_test_cap_restriction' );
+	}
+);
+
+add_filter(
+	'map_meta_cap',
+	static function ( $caps, $cap ) {
+		$restriction = get_option( 'gutenberg_test_cap_restriction', '' );
+
+		if ( empty( $restriction ) ) {
+			return $caps;
+		}
+
+		$blocked_caps = array();
+
+		switch ( $restriction ) {
+			case 'no_install':
+				$blocked_caps = array( 'install_plugins', 'upload_plugins' );
+				break;
+			case 'no_activate':
+				$blocked_caps = array( 'activate_plugins' );
+				break;
+			case 'no_install_activate':
+				$blocked_caps = array( 'install_plugins', 'upload_plugins', 'activate_plugins' );
+				break;
+			case 'disallow_file_mods':
+				$blocked_caps = array( 'install_plugins', 'upload_plugins', 'delete_plugins', 'update_plugins' );
+				break;
+		}
+
+		if ( in_array( $cap, $blocked_caps, true ) ) {
+			return array( 'do_not_allow' );
+		}
+
+		return $caps;
+	},
+	10,
+	2
+);

--- a/packages/wp-build/templates/routes-registration.php.template
+++ b/packages/wp-build/templates/routes-registration.php.template
@@ -54,6 +54,9 @@ if ( ! function_exists( '{{PREFIX}}_register_page_routes' ) ) {
 					$content_asset = require $content_asset_path;
 					$content_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
 					$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+					// Deregister first to override any previously registered version
+					// (e.g., Core's default modules when running as a plugin).
+					wp_deregister_script_module( $content_handle );
 					wp_register_script_module(
 						$content_handle,
 						$build_constants['build_url'] . 'routes/' . $route['name'] . '/content' . $extension,
@@ -70,6 +73,9 @@ if ( ! function_exists( '{{PREFIX}}_register_page_routes' ) ) {
 					$route_asset = require $route_asset_path;
 					$route_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/route';
 					$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+					// Deregister first to override any previously registered version
+					// (e.g., Core's default modules when running as a plugin).
+					wp_deregister_script_module( $route_handle );
 					wp_register_script_module(
 						$route_handle,
 						$build_constants['build_url'] . 'routes/' . $route['name'] . '/route' . $extension,

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
@@ -15,6 +19,9 @@ import { __ } from '@wordpress/i18n';
  */
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
+import { unlock } from '../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
 
 type ConnectorAuthentication =
 	| { method: 'api_key'; settingName: string; credentialsUrl: string | null }
@@ -66,6 +73,10 @@ const ConnectedBadge = () => (
 	</span>
 );
 
+const UnavailableActionBadge = () => (
+	<Badge intent="default">{ __( 'Not available' ) }</Badge>
+);
+
 interface ApiKeyConnectorConfig {
 	pluginSlug?: string;
 	settingName: string;
@@ -92,6 +103,7 @@ function ApiKeyConnector( {
 
 	const {
 		pluginStatus,
+		canInstallPlugins,
 		isExpanded,
 		setIsExpanded,
 		isBusy,
@@ -105,6 +117,9 @@ function ApiKeyConnector( {
 		pluginSlug,
 		settingName,
 	} );
+	const showUnavailableBadge =
+		pluginStatus === 'not-installed' && canInstallPlugins !== true;
+	const showActionButton = ! showUnavailableBadge;
 
 	return (
 		<ConnectorItem
@@ -117,20 +132,27 @@ function ApiKeyConnector( {
 			actionArea={
 				<HStack spacing={ 3 } expanded={ false }>
 					{ isConnected && <ConnectedBadge /> }
-					<Button
-						variant={
-							isExpanded || isConnected ? 'tertiary' : 'secondary'
-						}
-						size={
-							isExpanded || isConnected ? undefined : 'compact'
-						}
-						onClick={ handleButtonClick }
-						disabled={ pluginStatus === 'checking' || isBusy }
-						isBusy={ isBusy }
-						aria-expanded={ isExpanded }
-					>
-						{ getButtonLabel() }
-					</Button>
+					{ showUnavailableBadge && <UnavailableActionBadge /> }
+					{ showActionButton && (
+						<Button
+							variant={
+								isExpanded || isConnected
+									? 'tertiary'
+									: 'secondary'
+							}
+							size={
+								isExpanded || isConnected
+									? undefined
+									: 'compact'
+							}
+							onClick={ handleButtonClick }
+							disabled={ pluginStatus === 'checking' || isBusy }
+							isBusy={ isBusy }
+							aria-expanded={ isExpanded }
+						>
+							{ getButtonLabel() }
+						</Button>
+					) }
 				</HStack>
 			}
 		>

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -4,7 +4,6 @@
 import {
 	__experimentalHStack as HStack,
 	Button,
-	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
 	__experimentalRegisterConnector as registerConnector,
@@ -13,15 +12,13 @@ import {
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
-import { unlock } from '../lock-unlock';
-
-const { Badge } = unlock( componentsPrivateApis );
 
 type ConnectorAuthentication =
 	| { method: 'api_key'; settingName: string; credentialsUrl: string | null }
@@ -77,9 +74,7 @@ const ConnectedBadge = () => (
 	</span>
 );
 
-const UnavailableActionBadge = () => (
-	<Badge intent="default">{ __( 'Not available' ) }</Badge>
-);
+const UnavailableActionBadge = () => <Badge>{ __( 'Not available' ) }</Badge>;
 
 interface ApiKeyConnectorConfig {
 	pluginSlug?: string;

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	Button,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -86,6 +86,8 @@ interface ApiKeyConnectorConfig {
 	settingName: string;
 	helpUrl?: string;
 	Logo?: React.ComponentType;
+	isInstalled?: boolean;
+	isActivated?: boolean;
 }
 
 function ApiKeyConnector( {
@@ -95,6 +97,8 @@ function ApiKeyConnector( {
 	settingName,
 	helpUrl,
 	Logo,
+	isInstalled,
+	isActivated,
 }: ConnectorRenderProps & ApiKeyConnectorConfig ) {
 	let helpLabel: string | undefined;
 	try {
@@ -120,6 +124,8 @@ function ApiKeyConnector( {
 	} = useConnectorPlugin( {
 		pluginSlug,
 		settingName,
+		isInstalled,
+		isActivated,
 	} );
 	const showUnavailableBadge =
 		pluginStatus === 'not-installed' && canInstallPlugins !== true;
@@ -207,6 +213,8 @@ export function registerDefaultConnectors() {
 					settingName={ authentication.settingName }
 					helpUrl={ authentication.credentialsUrl ?? undefined }
 					Logo={ CONNECTOR_LOGOS[ connectorId ] }
+					isInstalled={ data.plugin?.isInstalled }
+					isActivated={ data.plugin?.isActivated }
 				/>
 			),
 		} );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -112,6 +112,7 @@ function ApiKeyConnector( {
 	const {
 		pluginStatus,
 		canInstallPlugins,
+		canActivatePlugins,
 		isExpanded,
 		setIsExpanded,
 		isBusy,
@@ -128,7 +129,8 @@ function ApiKeyConnector( {
 		isActivated,
 	} );
 	const showUnavailableBadge =
-		pluginStatus === 'not-installed' && canInstallPlugins !== true;
+		( pluginStatus === 'not-installed' && canInstallPlugins === false ) ||
+		( pluginStatus === 'inactive' && canActivatePlugins === false );
 	const showActionButton = ! showUnavailableBadge;
 
 	return (

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -31,7 +31,11 @@ interface ConnectorData {
 	name: string;
 	description: string;
 	type: 'ai_provider';
-	plugin?: { slug: string };
+	plugin?: {
+		slug: string;
+		isInstalled: boolean;
+		isActivated: boolean;
+	};
 	authentication: ConnectorAuthentication;
 }
 

--- a/routes/connectors-home/package.json
+++ b/routes/connectors-home/package.json
@@ -13,6 +13,7 @@
 		"@wordpress/api-fetch": "file:../../packages/api-fetch",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/connectors": "file:../../packages/connectors",
+		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",

--- a/routes/connectors-home/package.json
+++ b/routes/connectors-home/package.json
@@ -17,6 +17,7 @@
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
-		"@wordpress/icons": "file:../../packages/icons"
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/ui": "file:../../packages/ui"
 	}
 }

--- a/routes/connectors-home/route.ts
+++ b/routes/connectors-home/route.ts
@@ -1,8 +1,16 @@
 /**
  * WordPress dependencies
  */
+import { store as coreStore } from '@wordpress/core-data';
+import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 export const route = {
 	title: () => __( 'Connectors' ),
+	loader: async () => {
+		await resolveSelect( coreStore ).canUser( 'create', {
+			kind: 'root',
+			name: 'plugin',
+		} );
+	},
 };

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -10,6 +10,7 @@ import {
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -24,8 +25,14 @@ const { store } = unlock( connectorsPrivateApis );
 registerDefaultConnectors();
 
 function ConnectorsPage() {
-	const connectors = useSelect(
-		( select ) => unlock( select( store ) ).getConnectors(),
+	const { connectors, canInstallPlugins } = useSelect(
+		( select ) => ( {
+			connectors: unlock( select( store ) ).getConnectors(),
+			canInstallPlugins: select( coreStore ).canUser( 'create', {
+				kind: 'root',
+				name: 'plugin',
+			} ),
+		} ),
 		[]
 	);
 
@@ -52,19 +59,21 @@ function ConnectorsPage() {
 						return null;
 					} ) }
 				</VStack>
-				<p>
-					{ createInterpolateElement(
-						__(
-							'Find more connectors in <a>the plugin directory</a>'
-						),
-						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content
-								<a href="plugin-install.php" />
+				{ canInstallPlugins && (
+					<p>
+						{ createInterpolateElement(
+							__(
+								'Find more connectors in <a>the plugin directory</a>'
 							),
-						}
-					) }
-				</p>
+							{
+								a: (
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<a href="plugin-install.php" />
+								),
+							}
+						) }
+					</p>
+				) }
 			</div>
 		</Page>
 	);

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -12,6 +12,8 @@ export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 interface UseConnectorPluginOptions {
 	pluginSlug?: string;
 	settingName: string;
+	isInstalled?: boolean;
+	isActivated?: boolean;
 }
 
 interface UseConnectorPluginReturn {
@@ -31,6 +33,8 @@ interface UseConnectorPluginReturn {
 export function useConnectorPlugin( {
 	pluginSlug,
 	settingName,
+	isInstalled,
+	isActivated,
 }: UseConnectorPluginOptions ): UseConnectorPluginReturn {
 	const [ pluginStatus, setPluginStatus ] =
 		useState< PluginStatus >( 'checking' );
@@ -95,12 +99,20 @@ export function useConnectorPlugin( {
 					setPluginStatus( 'inactive' );
 				}
 			} catch {
-				setPluginStatus( 'not-installed' );
+				// Fallback to server-provided status when API fails (e.g., no permissions).
+				if ( isActivated ) {
+					await fetchApiKey();
+					setPluginStatus( 'active' );
+				} else if ( isInstalled ) {
+					setPluginStatus( 'inactive' );
+				} else {
+					setPluginStatus( 'not-installed' );
+				}
 			}
 		};
 
 		checkPluginStatus();
-	}, [ pluginSlug, fetchApiKey ] );
+	}, [ pluginSlug, fetchApiKey, isInstalled, isActivated ] );
 
 	const installPlugin = async () => {
 		if ( ! pluginSlug ) {

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -19,6 +19,7 @@ interface UseConnectorPluginOptions {
 interface UseConnectorPluginReturn {
 	pluginStatus: PluginStatus;
 	canInstallPlugins: boolean | undefined;
+	canActivatePlugins: boolean | undefined;
 	isExpanded: boolean;
 	setIsExpanded: ( expanded: boolean ) => void;
 	isBusy: boolean;
@@ -41,6 +42,9 @@ export function useConnectorPlugin( {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ currentApiKey, setCurrentApiKey ] = useState( '' );
+	// Track if user can manage plugins based on REST API access.
+	// If the /wp/v2/plugins call succeeds, user has activate_plugins capability.
+	const [ canManagePlugins, setCanManagePlugins ] = useState< boolean >();
 
 	const canInstallPlugins = useSelect(
 		( select ) =>
@@ -50,6 +54,9 @@ export function useConnectorPlugin( {
 			} ),
 		[]
 	);
+
+	// Use canManagePlugins (from REST API result) for activation capability.
+	const canActivatePlugins = canManagePlugins;
 
 	const isConnected =
 		pluginStatus === 'active' &&
@@ -86,6 +93,9 @@ export function useConnectorPlugin( {
 					path: '/wp/v2/plugins',
 				} );
 
+				// API call succeeded, user has activate_plugins capability.
+				setCanManagePlugins( true );
+
 				const plugin = plugins.find(
 					( p ) => p.plugin === `${ pluginSlug }/plugin`
 				);
@@ -99,6 +109,9 @@ export function useConnectorPlugin( {
 					setPluginStatus( 'inactive' );
 				}
 			} catch {
+				// API call failed, user likely lacks activate_plugins capability.
+				setCanManagePlugins( false );
+
 				// Fallback to server-provided status when API fails (e.g., no permissions).
 				if ( isActivated ) {
 					await fetchApiKey();
@@ -163,6 +176,9 @@ export function useConnectorPlugin( {
 			}
 			installPlugin();
 		} else if ( pluginStatus === 'inactive' ) {
+			if ( canActivatePlugins === false ) {
+				return;
+			}
 			activatePlugin();
 		} else {
 			setIsExpanded( ! isExpanded );
@@ -239,6 +255,7 @@ export function useConnectorPlugin( {
 	return {
 		pluginStatus,
 		canInstallPlugins,
+		canActivatePlugins,
 		isExpanded,
 		setIsExpanded,
 		isBusy,

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -48,7 +48,7 @@ export function useConnectorPlugin( {
 
 	const canInstallPlugins = useSelect(
 		( select ) =>
-			select( coreStore ).canUser( 'create', {
+			!! select( coreStore ).canUser( 'create', {
 				kind: 'root',
 				name: 'plugin',
 			} ),

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -14,6 +16,7 @@ interface UseConnectorPluginOptions {
 
 interface UseConnectorPluginReturn {
 	pluginStatus: PluginStatus;
+	canInstallPlugins: boolean | undefined;
 	isExpanded: boolean;
 	setIsExpanded: ( expanded: boolean ) => void;
 	isBusy: boolean;
@@ -34,6 +37,15 @@ export function useConnectorPlugin( {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ currentApiKey, setCurrentApiKey ] = useState( '' );
+
+	const canInstallPlugins = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'root',
+				name: 'plugin',
+			} ),
+		[]
+	);
 
 	const isConnected =
 		pluginStatus === 'active' &&
@@ -134,6 +146,9 @@ export function useConnectorPlugin( {
 
 	const handleButtonClick = () => {
 		if ( pluginStatus === 'not-installed' ) {
+			if ( canInstallPlugins === false ) {
+				return;
+			}
 			installPlugin();
 		} else if ( pluginStatus === 'inactive' ) {
 			activatePlugin();
@@ -211,6 +226,7 @@ export function useConnectorPlugin( {
 
 	return {
 		pluginStatus,
+		canInstallPlugins,
 		isExpanded,
 		setIsExpanded,
 		isBusy,

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -6,6 +6,12 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const SETTINGS_PAGE_PATH = 'options-general.php';
 const CONNECTORS_PAGE_QUERY = 'page=connectors-wp-admin';
 
+const CONNECTOR_SLUGS = [
+	'ai-provider-for-openai',
+	'ai-provider-for-anthropic',
+	'ai-provider-for-google',
+];
+
 test.describe( 'Connectors', () => {
 	test( 'should show a Connectors link in the Settings menu', async ( {
 		page,
@@ -24,77 +30,92 @@ test.describe( 'Connectors', () => {
 		);
 	} );
 
-	test.describe( 'Connectors page', () => {
-		test.beforeEach( async ( { admin } ) => {
-			await admin.visitAdminPage(
-				SETTINGS_PAGE_PATH,
-				CONNECTORS_PAGE_QUERY
-			);
+	test( 'should display default providers with install buttons', async ( {
+		page,
+		admin,
+	} ) => {
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, CONNECTORS_PAGE_QUERY );
+
+		// Verify the page title is visible.
+		await expect(
+			page.getByRole( 'heading', { name: 'Connectors' } )
+		).toBeVisible();
+
+		// Verify each connector card has an Install button.
+		for ( const slug of CONNECTOR_SLUGS ) {
+			const card = page.locator( `.connector-item--${ slug }` );
+			await expect( card ).toBeVisible();
+			await expect(
+				card.getByRole( 'button', { name: 'Install' } )
+			).toBeVisible();
+		}
+
+		// Verify the plugin directory search link is present.
+		await expect(
+			page.getByRole( 'link', {
+				name: 'the plugin directory',
+			} )
+		).toHaveAttribute( 'href', 'plugin-install.php' );
+	} );
+
+	test.describe( 'Connectors page capability checks', () => {
+		const PLUGIN_SLUG = 'gutenberg-test-connectors-capability-restriction';
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin( PLUGIN_SLUG );
 		} );
 
-		test( 'should display default providers with install buttons', async ( {
-			page,
-		} ) => {
-			// Verify the page title is visible.
-			await expect(
-				page.getByRole( 'heading', { name: 'Connectors' } )
-			).toBeVisible();
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin( PLUGIN_SLUG );
+		} );
 
-			// Verify each connector card allows installing the plugin.
-			const openaiCard = page.locator(
-				'.connector-item--ai-provider-for-openai'
-			);
-			await expect( openaiCard ).toBeVisible();
-			await expect(
-				openaiCard.getByText( 'OpenAI', { exact: true } )
-			).toBeVisible();
-			await expect(
-				openaiCard.getByText(
-					'Text, image, and code generation with GPT and DALL-E.'
-				)
-			).toBeVisible();
-			await expect(
-				openaiCard.getByRole( 'button', { name: 'Install' } )
-			).toBeVisible();
+		const capabilities = [
+			[ 'no_install', 'user cannot install plugins' ],
+			[ 'no_activate', 'user cannot activate plugins' ],
+			[
+				'no_install_activate',
+				'user cannot install or activate plugins',
+			],
+			[ 'disallow_file_mods', 'DISALLOW_FILE_MODS is active' ],
+		];
 
-			const claudeCard = page.locator(
-				'.connector-item--ai-provider-for-anthropic'
-			);
-			await expect( claudeCard ).toBeVisible();
-			await expect(
-				claudeCard.getByText( 'Claude', { exact: true } )
-			).toBeVisible();
-			await expect(
-				claudeCard.getByText(
-					'Writing, research, and analysis with Claude.'
-				)
-			).toBeVisible();
-			await expect(
-				claudeCard.getByRole( 'button', { name: 'Install' } )
-			).toBeVisible();
+		capabilities.forEach( ( [ restriction, label ] ) => {
+			test( `should show "Not available" when ${ label }`, async ( {
+				page,
+				admin,
+				requestUtils,
+			} ) => {
+				await requestUtils.rest( {
+					path: '/wp/v2/settings',
+					method: 'POST',
+					data: {
+						gutenberg_test_cap_restriction: restriction,
+					},
+				} );
 
-			const geminiCard = page.locator(
-				'.connector-item--ai-provider-for-google'
-			);
-			await expect( geminiCard ).toBeVisible();
-			await expect(
-				geminiCard.getByText( 'Gemini', { exact: true } )
-			).toBeVisible();
-			await expect(
-				geminiCard.getByText(
-					"Content generation, translation, and vision with Google's Gemini."
-				)
-			).toBeVisible();
-			await expect(
-				geminiCard.getByRole( 'button', { name: 'Install' } )
-			).toBeVisible();
+				await admin.visitAdminPage(
+					SETTINGS_PAGE_PATH,
+					CONNECTORS_PAGE_QUERY
+				);
 
-			// Verify the plugin directory search link is present.
-			await expect(
-				page.getByRole( 'link', {
-					name: 'the plugin directory',
-				} )
-			).toHaveAttribute( 'href', 'plugin-install.php' );
+				for ( const slug of CONNECTOR_SLUGS ) {
+					const card = page.locator( `.connector-item--${ slug }` );
+					await expect( card ).toBeVisible();
+					await expect(
+						card.getByText( 'Not available' )
+					).toBeVisible();
+					await expect(
+						card.getByRole( 'button', { name: 'Install' } )
+					).toBeHidden();
+				}
+
+				// Plugin directory link should be hidden.
+				await expect(
+					page.getByRole( 'link', {
+						name: 'the plugin directory',
+					} )
+				).toBeHidden();
+			} );
 		} );
 	} );
 } );

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -6,10 +6,22 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const SETTINGS_PAGE_PATH = 'options-general.php';
 const CONNECTORS_PAGE_QUERY = 'page=connectors-wp-admin';
 
-const CONNECTOR_SLUGS = [
-	'ai-provider-for-openai',
-	'ai-provider-for-anthropic',
-	'ai-provider-for-google',
+const CONNECTORS = [
+	{
+		slug: 'ai-provider-for-openai',
+		name: 'OpenAI',
+		description: 'Text and image generation with GPT and Dall-E.',
+	},
+	{
+		slug: 'ai-provider-for-anthropic',
+		name: 'Anthropic',
+		description: 'Text generation with Claude.',
+	},
+	{
+		slug: 'ai-provider-for-google',
+		name: 'Google',
+		description: 'Text and image generation with Gemini and Imagen.',
+	},
 ];
 
 test.describe( 'Connectors', () => {
@@ -41,10 +53,14 @@ test.describe( 'Connectors', () => {
 			page.getByRole( 'heading', { name: 'Connectors' } )
 		).toBeVisible();
 
-		// Verify each connector card has an Install button.
-		for ( const slug of CONNECTOR_SLUGS ) {
+		// Verify each connector card shows name, description, and Install button.
+		for ( const { slug, name, description } of CONNECTORS ) {
 			const card = page.locator( `.connector-item--${ slug }` );
 			await expect( card ).toBeVisible();
+			await expect(
+				card.getByText( name, { exact: true } )
+			).toBeVisible();
+			await expect( card.getByText( description ) ).toBeVisible();
 			await expect(
 				card.getByRole( 'button', { name: 'Install' } )
 			).toBeVisible();
@@ -98,7 +114,7 @@ test.describe( 'Connectors', () => {
 					CONNECTORS_PAGE_QUERY
 				);
 
-				for ( const slug of CONNECTOR_SLUGS ) {
+				for ( const { slug } of CONNECTORS ) {
 					const card = page.locator( `.connector-item--${ slug }` );
 					await expect( card ).toBeVisible();
 					await expect(


### PR DESCRIPTION
## What
This PR checks for install and activate permissions before rendering an install button on the connectors screen, if the user can not install/activate plugins we show a not available badge instead of an install button.
Fixes: #75969 

## Screenshot
<img width="1350" height="745" alt="Screenshot 2026-02-26 at 21 51 11" src="https://github.com/user-attachments/assets/12aab608-68cd-4234-8a35-24384ba15db7" />
dling to avoid false blocked states

## Test Scenarios

### Scenario 1: User with Full Permissions (Admin)

**Setup**: Default admin user with all capabilities

| Plugin State | Expected UI | Expected Action |
|--------------|-------------|-----------------|
| Not installed | "Install" button | Clicking installs and activates plugin |
| Installed, inactive | "Activate" button | Clicking activates plugin |
| Installed, active (no API key) | "Set up" button | Clicking expands settings panel |
| Installed, active (with API key) | "Connected" badge + "Edit" button | Clicking expands settings panel |

---

### Scenario 2: User Cannot Install Plugins

**Setup**: Add to theme's `functions.php`:
```php
add_filter( 'map_meta_cap', function( $caps, $cap ) {
    if ( in_array( $cap, array( 'install_plugins', 'upload_plugins' ), true ) ) {
        return array( 'do_not_allow' );
    }
    return $caps;
}, 10, 2 );
```

| Plugin State | Expected UI |
|--------------|-------------|
| Not installed | "Not available" badge (no Install button) |
| Installed, inactive | "Activate" button |
| Installed, active | "Set up" / "Edit" button |

---

### Scenario 3: User Cannot Activate Plugins

**Setup**: Add to theme's `functions.php`:
```php
add_filter( 'map_meta_cap', function( $caps, $cap ) {
    if ( $cap === 'activate_plugins' ) {
        return array( 'do_not_allow' );
    }
    return $caps;
}, 10, 2 );
```

| Plugin State | Expected UI |
|--------------|-------------|
| Not installed | "Not available" badge (no Activate button) |
| Installed, inactive | "Not available" badge (no Activate button) |
| Installed, active | "Set up" / "Edit" button |

---

### Scenario 4: User Cannot Install OR Activate Plugins

**Setup**: Add to theme's `functions.php`:
```php
add_filter( 'map_meta_cap', function( $caps, $cap ) {
    if ( in_array( $cap, array( 'install_plugins', 'upload_plugins', 'activate_plugins' ), true ) ) {
        return array( 'do_not_allow' );
    }
    return $caps;
}, 10, 2 );
```

| Plugin State | Expected UI |
|--------------|-------------|
| Not installed | "Not available" badge |
| Installed, inactive | "Not available" badge |
| Installed, active (no API key) | "Set up" button |
| Installed, active (with API key) | "Connected" badge + "Edit" button |

---

### Scenario 5: DISALLOW_FILE_MODS Constant

**Setup**: Add to `wp-config.php`:
```php
define( 'DISALLOW_FILE_MODS', true );
```

| Plugin State | Expected UI |
|--------------|-------------|
| Not installed | "Not available" badge |
| Installed, inactive | "Activate" button |
| Installed, active | "Set up" / "Edit" button |
