### PR TITLE
Fix: Skip scaled image sideload for images below big image threshold

### DIFF
--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1194,49 +1194,60 @@ export function generateThumbnails( id: QueueItemId ) {
 			// Create and sideload the scaled version.
 			const { bigImageSizeThreshold } = settings;
 			if ( bigImageSizeThreshold && attachment.id ) {
-				// Rename sourceFile to match the server attachment filename.
-				const sourceForScaled = attachment.filename
-					? renameFile( item.sourceFile, attachment.filename )
-					: item.sourceFile;
+				// Check if the image actually exceeds the threshold.
+				// Only create a scaled version for images larger than the threshold,
+				// matching WordPress core's wp_create_image_subsizes() behavior.
+				const bitmap = await createImageBitmap( item.sourceFile );
+				const needsScaling =
+					bitmap.width > bigImageSizeThreshold ||
+					bitmap.height > bigImageSizeThreshold;
+				bitmap.close();
 
-				// Add scaling to queue.
-				const scaledOperations: Operation[] = [
-					[
-						OperationType.ResizeCrop,
-						{
-							resize: {
-								width: bigImageSizeThreshold,
-								height: bigImageSizeThreshold,
+				if ( needsScaling ) {
+					// Rename sourceFile to match the server attachment filename.
+					const sourceForScaled = attachment.filename
+						? renameFile( item.sourceFile, attachment.filename )
+						: item.sourceFile;
+
+					// Add scaling to queue.
+					const scaledOperations: Operation[] = [
+						[
+							OperationType.ResizeCrop,
+							{
+								resize: {
+									width: bigImageSizeThreshold,
+									height: bigImageSizeThreshold,
+								},
+								isThresholdResize: true,
 							},
-							isThresholdResize: true,
+						],
+					];
+
+					// Add transcoding if format conversion is configured.
+					if ( thumbnailTranscodeOperation ) {
+						scaledOperations.push( thumbnailTranscodeOperation );
+					}
+
+					scaledOperations.push( OperationType.Upload );
+
+					dispatch.addSideloadItem( {
+						file: sourceForScaled,
+						onChange: ( [ updatedAttachment ] ) => {
+							if ( isBlobURL( updatedAttachment.url ) ) {
+								return;
+							}
+							item.onChange?.( [ updatedAttachment ] );
 						},
-					],
-				];
-
-				// Add transcoding if format conversion is configured.
-				if ( thumbnailTranscodeOperation ) {
-					scaledOperations.push( thumbnailTranscodeOperation );
+						batchId,
+						parentId: item.id,
+						additionalData: {
+							post: attachment.id,
+							image_size: 'scaled',
+							convert_format: false,
+						},
+						operations: scaledOperations,
+					} );
 				}
-
-				scaledOperations.push( OperationType.Upload );
-
-				dispatch.addSideloadItem( {
-					file: sourceForScaled,
-					onChange: ( [ updatedAttachment ] ) => {
-						if ( isBlobURL( updatedAttachment.url ) ) {
-							return;
-						}
-						item.onChange?.( [ updatedAttachment ] );
-					},
-					batchId,
-					parentId: item.id,
-					additionalData: {
-						post: attachment.id,
-						image_size: 'scaled',
-						convert_format: false,
-					},
-					operations: scaledOperations,
-				} );
 			}
 		}
 


### PR DESCRIPTION
## DO NOT MERGE - testing only

## Summary

- Adds a dimension check using `createImageBitmap()` before queuing the scaled image sideload in `generateThumbnails()`
- Only creates the `-scaled` version when the image width or height exceeds `bigImageSizeThreshold`, matching WordPress core's `wp_create_image_subsizes()` behavior
- Fixes the `big-image-size-threshold.spec.js` E2E test failure where small images were incorrectly getting `original_image` metadata set

## Root cause

After #75817, the code unconditionally queued a "scaled" sideload for all images when `bigImageSizeThreshold` was set, regardless of actual image dimensions. The PHP handler then set `metadata['original_image']` for any sideload with `image_size === 'scaled'`, even for images that didn't need scaling.

## Test plan

- [ ] Run `npm run test:e2e -- test/e2e/specs/editor/various/big-image-size-threshold.spec.js`
- [ ] Confirm all 3 tests pass (above threshold scaled, below threshold not scaled, custom naming)
- [ ] Upload a small image (below 2560px) and verify no `original_image` in attachment metadata
- [ ] Upload a large image (above 2560px) and verify `-scaled` version is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)