### PR TITLE
Fix: Skip scaled image sideload for images below big image threshold

### DIFF
--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1194,49 +1194,60 @@ export function generateThumbnails( id: QueueItemId ) {
 			// Create and sideload the scaled version.
 			const { bigImageSizeThreshold } = settings;
 			if ( bigImageSizeThreshold && attachment.id ) {
-				// Rename sourceFile to match the server attachment filename.
-				const sourceForScaled = attachment.filename
-					? renameFile( item.sourceFile, attachment.filename )
-					: item.sourceFile;
+				// Check if the image actually exceeds the threshold.
+				// Only create a scaled version for images larger than the threshold,
+				// matching WordPress core's wp_create_image_subsizes() behavior.
+				const bitmap = await createImageBitmap( item.sourceFile );
+				const needsScaling =
+					bitmap.width > bigImageSizeThreshold ||
+					bitmap.height > bigImageSizeThreshold;
+				bitmap.close();
 
-				// Add scaling to queue.
-				const scaledOperations: Operation[] = [
-					[
-						OperationType.ResizeCrop,
-						{
-							resize: {
-								width: bigImageSizeThreshold,
-								height: bigImageSizeThreshold,
+				if ( needsScaling ) {
+					// Rename sourceFile to match the server attachment filename.
+					const sourceForScaled = attachment.filename
+						? renameFile( item.sourceFile, attachment.filename )
+						: item.sourceFile;
+
+					// Add scaling to queue.
+					const scaledOperations: Operation[] = [
+						[
+							OperationType.ResizeCrop,
+							{
+								resize: {
+									width: bigImageSizeThreshold,
+									height: bigImageSizeThreshold,
+								},
+								isThresholdResize: true,
 							},
-							isThresholdResize: true,
+						],
+					];
+
+					// Add transcoding if format conversion is configured.
+					if ( thumbnailTranscodeOperation ) {
+						scaledOperations.push( thumbnailTranscodeOperation );
+					}
+
+					scaledOperations.push( OperationType.Upload );
+
+					dispatch.addSideloadItem( {
+						file: sourceForScaled,
+						onChange: ( [ updatedAttachment ] ) => {
+							if ( isBlobURL( updatedAttachment.url ) ) {
+								return;
+							}
+							item.onChange?.( [ updatedAttachment ] );
 						},
-					],
-				];
-
-				// Add transcoding if format conversion is configured.
-				if ( thumbnailTranscodeOperation ) {
-					scaledOperations.push( thumbnailTranscodeOperation );
+						batchId,
+						parentId: item.id,
+						additionalData: {
+							post: attachment.id,
+							image_size: 'scaled',
+							convert_format: false,
+						},
+						operations: scaledOperations,
+					} );
 				}
-
-				scaledOperations.push( OperationType.Upload );
-
-				dispatch.addSideloadItem( {
-					file: sourceForScaled,
-					onChange: ( [ updatedAttachment ] ) => {
-						if ( isBlobURL( updatedAttachment.url ) ) {
-							return;
-						}
-						item.onChange?.( [ updatedAttachment ] );
-					},
-					batchId,
-					parentId: item.id,
-					additionalData: {
-						post: attachment.id,
-						image_size: 'scaled',
-						convert_format: false,
-					},
-					operations: scaledOperations,
-				} );
 			}
 		}
 

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -22,6 +22,9 @@ jest.mock( '@wordpress/blob', () => ( {
 jest.mock( '../utils', () => ( {
 	vipsCancelOperations: jest.fn( () => Promise.resolve( true ) ),
 	vipsResizeImage: jest.fn(),
+	vipsRotateImage: jest.fn(),
+	vipsHasTransparency: jest.fn( () => Promise.resolve( false ) ),
+	vipsConvertImageFormat: jest.fn(),
 	terminateVipsWorker: jest.fn(),
 } ) );
 
@@ -409,6 +412,302 @@ describe( 'actions', () => {
 				.cancelItem( item.id, new Error( 'Test error' ), true );
 
 			expect( onError ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'generateThumbnails', () => {
+		const mockBitmapClose = jest.fn();
+
+		function mockCreateImageBitmap( width: number, height: number ) {
+			global.createImageBitmap = jest.fn( () =>
+				Promise.resolve( {
+					width,
+					height,
+					close: mockBitmapClose,
+				} )
+			) as unknown as typeof global.createImageBitmap;
+		}
+
+		/**
+		 * Sets up an item in the queue with an attachment and
+		 * ThumbnailGeneration as the current operation, simulating
+		 * the state after upload completes.
+		 *
+		 * @param overrides            Optional overrides.
+		 * @param overrides.attachment Attachment field overrides.
+		 */
+		async function setupItemForThumbnailGeneration( overrides?: {
+			attachment?: Record< string, unknown >;
+		} ) {
+			// Add an item with ThumbnailGeneration as the only operation.
+			unlock( registry.dispatch( uploadStore ) ).addItem( {
+				file: jpegFile,
+				operations: [ OperationType.ThumbnailGeneration ],
+			} );
+
+			const item = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			// Simulate upload completion by finishing the operation with attachment data.
+			// finishOperation shifts the operations array, so ThumbnailGeneration
+			// becomes the next operation to process.
+			await unlock( registry.dispatch( uploadStore ) ).finishOperation(
+				item.id,
+				{
+					attachment: {
+						id: 123,
+						filename: 'example.jpg',
+						missing_image_sizes: [ 'thumbnail', 'medium' ],
+						...( overrides?.attachment || {} ),
+					},
+				}
+			);
+
+			return unlock( registry.select( uploadStore ) ).getAllItems()[ 0 ];
+		}
+
+		beforeEach( () => {
+			mockBitmapClose.mockClear();
+		} );
+
+		afterEach( () => {
+			// Clean up global mock.
+			// @ts-ignore
+			delete global.createImageBitmap;
+		} );
+
+		it( 'should not sideload a scaled version when image is below the threshold', async () => {
+			// Image is 800x600, threshold is 2560.
+			mockCreateImageBitmap( 800, 600 );
+
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				bigImageSizeThreshold: 2560,
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			const item = await setupItemForThumbnailGeneration();
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			// Should have sideload items for thumbnails, but NOT for 'scaled'.
+			const scaledItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'scaled'
+			);
+			expect( scaledItems ).toHaveLength( 0 );
+			expect( mockBitmapClose ).toHaveBeenCalled();
+		} );
+
+		it( 'should sideload a scaled version when image exceeds the threshold', async () => {
+			// Image is 4000x3000, threshold is 2560.
+			mockCreateImageBitmap( 4000, 3000 );
+
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				bigImageSizeThreshold: 2560,
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			const item = await setupItemForThumbnailGeneration();
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			const scaledItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'scaled'
+			);
+			expect( scaledItems ).toHaveLength( 1 );
+			expect( scaledItems[ 0 ].additionalData.post ).toBe( 123 );
+			expect( mockBitmapClose ).toHaveBeenCalled();
+		} );
+
+		it( 'should sideload a scaled version when only height exceeds the threshold', async () => {
+			// Image is 2000x3000, threshold is 2560 — height exceeds.
+			mockCreateImageBitmap( 2000, 3000 );
+
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				bigImageSizeThreshold: 2560,
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			const item = await setupItemForThumbnailGeneration();
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			const scaledItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'scaled'
+			);
+			expect( scaledItems ).toHaveLength( 1 );
+		} );
+
+		it( 'should not sideload a scaled version when bigImageSizeThreshold is not set', async () => {
+			// No bigImageSizeThreshold in settings — scaling should be skipped entirely.
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			const item = await setupItemForThumbnailGeneration();
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			const scaledItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'scaled'
+			);
+			expect( scaledItems ).toHaveLength( 0 );
+			// createImageBitmap should not have been called since threshold is not set.
+			expect( global.createImageBitmap ).toBeUndefined();
+		} );
+
+		it( 'should not sideload a scaled version when attachment has no id', async () => {
+			mockCreateImageBitmap( 4000, 3000 );
+
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				bigImageSizeThreshold: 2560,
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			// Set up item with attachment that has no id.
+			const item = await setupItemForThumbnailGeneration( {
+				attachment: { id: undefined },
+			} );
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			const scaledItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'scaled'
+			);
+			expect( scaledItems ).toHaveLength( 0 );
+		} );
+
+		it( 'should create sideload items for missing image sizes', async () => {
+			mockCreateImageBitmap( 800, 600 );
+
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				bigImageSizeThreshold: 2560,
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			const item = await setupItemForThumbnailGeneration();
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			// Should have the original item plus 2 sideload items for thumbnail and medium.
+			const thumbnailItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'thumbnail'
+			);
+			const mediumItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'medium'
+			);
+			expect( thumbnailItems ).toHaveLength( 1 );
+			expect( mediumItems ).toHaveLength( 1 );
+		} );
+
+		it( 'should skip thumbnail generation when item has no attachment', async () => {
+			// Add an item without going through the attachment setup.
+			unlock( registry.dispatch( uploadStore ) ).addItem( {
+				file: jpegFile,
+				operations: [ OperationType.ThumbnailGeneration ],
+			} );
+
+			const item = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			// Clear the attachment to simulate no upload response.
+			await unlock( registry.dispatch( uploadStore ) ).finishOperation(
+				item.id,
+				{
+					attachment: undefined,
+				}
+			);
+
+			const updatedItem = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				updatedItem.id
+			);
+
+			// Should only have the original item — no sideloads created.
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+			expect( allItems ).toHaveLength( 1 );
+		} );
+
+		it( 'should not create scaled version when image is exactly at the threshold', async () => {
+			// Image is exactly 2560x2560, threshold is 2560 — should NOT scale.
+			mockCreateImageBitmap( 2560, 2560 );
+
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				bigImageSizeThreshold: 2560,
+				allImageSizes: {
+					thumbnail: { width: 150, height: 150 },
+					medium: { width: 300, height: 300 },
+				},
+			} );
+
+			const item = await setupItemForThumbnailGeneration();
+			await unlock( registry.dispatch( uploadStore ) ).generateThumbnails(
+				item.id
+			);
+
+			const allItems = unlock(
+				registry.select( uploadStore )
+			).getAllItems();
+
+			const scaledItems = allItems.filter(
+				( i ) => i.additionalData?.image_size === 'scaled'
+			);
+			// Exactly at threshold means no scaling (condition is > not >=).
+			expect( scaledItems ).toHaveLength( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Adds a dimension check before queuing the scaled image sideload, so that images below the big image size threshold (default 2560px) are not incorrectly processed as scaled images.

## Problem

After #75817 ("Fix client-side media file naming"), the `generateThumbnails()` function unconditionally queues a "scaled" sideload for **all** images when `bigImageSizeThreshold` is set, regardless of actual image dimensions. This causes the PHP handler to set `metadata['original_image']` even for small images that don't need scaling.

This breaks the `big-image-size-threshold.spec.js` E2E test at line 302, which correctly expects `original_image` to be `undefined` for undersized images.

**Root cause chain:**
1. `packages/upload-media/src/store/private-actions.ts` — `if ( bigImageSizeThreshold && attachment.id )` has no dimension check
2. A sideload with `image_size: 'scaled'` is sent to the server even for small images
3. The PHP handler sees `image_size === 'scaled'` and unconditionally sets `metadata['original_image']`

## Fix

Uses `createImageBitmap()` to check the source file dimensions before queuing the scaled sideload. The sideload is only queued when width or height exceeds `bigImageSizeThreshold`, matching WordPress core's `wp_create_image_subsizes()` behavior.

## Test coverage

Adds 8 unit tests for `generateThumbnails` in `packages/upload-media/src/store/test/actions.ts`, which previously had no test coverage. The tests verify:

- Images **below** the threshold do not get a scaled sideload
- Images **above** the threshold do get a scaled sideload with the correct attachment ID
- Images where only the **height** exceeds the threshold are scaled (width OR height check)
- No scaling when `bigImageSizeThreshold` is **not set** in settings
- No scaling when the attachment has **no ID**
- Sideload items are created for each **missing image size**
- Early return when the item has **no attachment**
- Images **exactly at** the threshold are not scaled (`>` not `>=`, matching WP core)

These tests were verified to **fail against the pre-fix code**, confirming they catch the bug.

## Testing instructions

- [ ] Run `npm run test:unit -- --testPathPattern="packages/upload-media/src/store/test/actions"` — all 21 tests pass
- [ ] Run `npm run test:e2e -- test/e2e/specs/editor/various/big-image-size-threshold.spec.js`
- [ ] Confirm all 3 E2E tests pass (above threshold scaled, below threshold not scaled, custom naming)
- [ ] Upload a small image (below 2560px) and verify no `original_image` in attachment metadata
- [ ] Upload a large image (above 2560px) and verify `-scaled` version is created correctly AND `original_image` in attachment metadata


## Screenshots

### Baseline server processing
<img width="500" height="" alt="server processing" src="https://github.com/user-attachments/assets/a8e3268e-e435-41cd-810c-66fae3645480" />



###  Before fix, note extra file
<img width="500" height="" alt="extra" src="https://github.com/user-attachments/assets/fdff8111-507d-4e7c-a19e-0abb72788780" />

## After fix
<img width="500" height="" alt="on pr" src="https://github.com/user-attachments/assets/b87ad52f-dc61-49c9-ac3f-87e019a23f56" />


## With large image

<img width="500" height="" alt="needs scaling" src="https://github.com/user-attachments/assets/33763b96-d9d2-4bb1-957d-15405609152d" />


## Scaled still working
<img width="500" height="" alt="scaled size" src="https://github.com/user-attachments/assets/5478822f-92cb-45fa-85ef-16c32abcd644" />


