### PR TITLE
Media: Use Document-Isolation-Policy for cross-origin isolation on Chromium 137+

### DIFF
--- a/backport-changelog/7.0/11098.md
+++ b/backport-changelog/7.0/11098.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11098
+
+* https://github.com/WordPress/gutenberg/pull/75991

--- a/lib/media/docs/client-side-media-docs.md
+++ b/lib/media/docs/client-side-media-docs.md
@@ -8,17 +8,17 @@ Client-side media processing requires the following browser capabilities:
 |---------|----------|---------|
 | WebAssembly | Yes | Runs the wasm-vips image processing library |
 | SharedArrayBuffer | Yes | Enables multi-threaded WASM execution |
-| Cross-origin isolation | Yes | Required for SharedArrayBuffer in modern browsers |
+| Document-Isolation-Policy | Yes | Required for SharedArrayBuffer in modern browsers |
 | CSP `blob:` workers | Yes | The WASM worker is loaded via a blob URL |
 
 ### Browser Support Matrix
 
 | Browser | Minimum Version | Notes |
 |---------|-----------------|-------|
-| Chrome | 92+ | Full support |
-| Firefox | 79+ | Full support except embed previews |
-| Safari | 15.2+ | Requires `require-corp` instead of `credentialless` |
-| Edge | 92+ | Full support |
+| Chrome | 137+ | Full support via Document-Isolation-Policy |
+| Edge | 137+ | Full support via Document-Isolation-Policy |
+| Firefox | Not supported | Does not support Document-Isolation-Policy |
+| Safari | Not supported | Does not support Document-Isolation-Policy |
 
 ### Automatic Fallback
 
@@ -27,14 +27,16 @@ When client-side media processing is unavailable, the system automatically falls
 The fallback occurs when any of the following conditions are detected:
 - WebAssembly is not supported in the browser
 - SharedArrayBuffer is not available
-- Cross-origin isolation is not enabled (missing required headers)
+- Document-Isolation-Policy is not supported by the browser
 - The site's Content Security Policy (CSP) blocks blob URL workers
 
 ## Cross-origin isolation / `SharedArrayBuffer`
 
 WASM-based image optimization requires `SharedArrayBuffer` support, which in turn requires [cross-origin isolation](https://web.dev/articles/cross-origin-isolation-guide).
 
-Once the page is served with these headers, `SharedArrayBuffer` will be available in the browser, and WASM-based image optimization will work as expected. However, all embedded resources (e.g., images, iframes, scripts) must also be served with appropriate CORS headers (or iframe with `iframe-credentialless` for supporting browsers) to ensure cross-origin isolation is maintained. For third party embeds (for example a YouTube video), the plugin uses [iframe `credentialless` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/IFrame_credentialless) to help with this. For browsers that do not support this attribute, embeds will show an information pane instead of a live preview.
+This is achieved using the [`Document-Isolation-Policy`](https://github.com/nicolo-ribaudo/tc39-proposal-structs/blob/main/test262-filtering/isolation-explainer.md) header, which provides per-document cross-origin isolation without affecting other iframes on the page. This avoids the breakage that the older `Cross-Origin-Embedder-Policy` / `Cross-Origin-Opener-Policy` headers caused for third-party plugins and embeds.
+
+Once the page is served with this header, `SharedArrayBuffer` will be available in the browser, and WASM-based image optimization will work as expected. All embedded resources (e.g., images, scripts) are served with `crossorigin="anonymous"` to ensure cross-origin isolation is maintained.
 
 ### Troubleshooting
 
@@ -42,7 +44,6 @@ If client-side media processing is not working, check the browser console for me
 
 1. **"SharedArrayBuffer is not available"**: The server is not sending the required cross-origin isolation headers.
 2. **"Cross-origin isolation is not enabled"**: The headers are present but cross-origin isolation is not active. This can happen if:
-   - Third-party resources are blocking isolation
    - Headers are being stripped by a proxy or CDN
    - The page is being served over HTTP instead of HTTPS
 
@@ -54,4 +55,3 @@ If client-side media processing is not working, check the browser console for me
    - If the CSP header is set at the server level (e.g., in `.htaccess`, Nginx config, or a CDN), update it there
 
 Check out [this tracking issue](https://github.com/WordPress/gutenberg/issues/74464) for more details and further resources.
-

--- a/lib/media/docs/client-side-media-docs.md
+++ b/lib/media/docs/client-side-media-docs.md
@@ -15,7 +15,7 @@ Client-side media processing requires the following browser capabilities:
 
 | Browser | Minimum Version | Notes |
 |---------|-----------------|-------|
-| Chrome | 137+ | Full support via Document-Isolation-Policy |
+| Chromium | 137+ | Full support via Document-Isolation-Policy |
 | Edge | 137+ | Full support via Document-Isolation-Policy |
 | Firefox | Not supported | Does not support Document-Isolation-Policy |
 | Safari | Not supported | Does not support Document-Isolation-Policy |

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -317,11 +317,13 @@ function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 		null !== $chrome_version && $chrome_version >= 137
 	);
 
+	if ( ! $use_dip ) {
+		return;
+	}
+
 	ob_start(
-		function ( string $output ) use ( $use_dip ): string {
-			if ( $use_dip ) {
-				header( 'Document-Isolation-Policy: isolate-and-credentialless' );
-			}
+		function ( string $output ): string {
+			header( 'Document-Isolation-Policy: isolate-and-credentialless' );
 
 			return gutenberg_add_crossorigin_attributes( $output );
 		}

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -273,6 +273,14 @@ function gutenberg_set_up_cross_origin_isolation() {
 		return;
 	}
 
+	// Skip when a third-party page builder (e.g. Elementor) overrides the
+	// block editor. DIP isolates the document into its own agent cluster,
+	// which blocks same-origin iframe access that these editors rely on.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['action'] ) && 'edit' !== $_GET['action'] ) {
+		return;
+	}
+
 	$user_id = get_current_user_id();
 	if ( ! $user_id ) {
 		return;

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -17,6 +17,18 @@ function gutenberg_set_client_side_media_processing_flag() {
 		return;
 	}
 	wp_add_inline_script( 'wp-block-editor', 'window.__clientSideMediaProcessing = true', 'before' );
+
+	$chrome_version = gutenberg_get_chrome_major_version();
+
+	/** This filter is documented in gutenberg/lib/media/load.php */
+	$use_dip = apply_filters(
+		'gutenberg_use_document_isolation_policy',
+		$chrome_version !== null && $chrome_version >= 137
+	);
+
+	if ( $use_dip ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__documentIsolationPolicy = true', 'before' );
+	}
 }
 add_action( 'admin_init', 'gutenberg_set_client_side_media_processing_flag' );
 
@@ -220,6 +232,23 @@ function gutenberg_filter_mod_rewrite_rules( string $rules ): string {
 add_filter( 'mod_rewrite_rules', 'gutenberg_filter_mod_rewrite_rules' );
 
 /**
+ * Returns the major Chrome/Chromium version from the current request's User-Agent.
+ *
+ * Matches all Chromium-based browsers (Chrome, Edge, Opera, Brave).
+ *
+ * @return int|null The major Chrome version, or null if not a Chromium browser.
+ */
+function gutenberg_get_chrome_major_version(): ?int {
+	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		return null;
+	}
+	if ( preg_match( '/Chrome\/(\d+)/', $_SERVER['HTTP_USER_AGENT'], $matches ) ) {
+		return (int) $matches[1];
+	}
+	return null;
+}
+
+/**
  * Enables cross-origin isolation in the block editor.
  *
  * Required for enabling SharedArrayBuffer for WebAssembly-based
@@ -274,12 +303,33 @@ add_action( 'load-widgets.php', 'gutenberg_set_up_cross_origin_isolation' );
 function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	global $is_safari;
 
-	$coep = $is_safari ? 'require-corp' : 'credentialless';
+	$chrome_version = gutenberg_get_chrome_major_version();
+
+	/**
+	 * Filters whether to use Document-Isolation-Policy instead of COEP/COOP.
+	 *
+	 * Document-Isolation-Policy provides per-document cross-origin isolation
+	 * without affecting other iframes on the page, avoiding breakage of plugins
+	 * like Elementor whose iframes lose credentials/DOM access with COEP.
+	 *
+	 * @since 21.8.0
+	 *
+	 * @param bool $use_dip Whether DIP is supported and should be used.
+	 */
+	$use_dip = apply_filters(
+		'gutenberg_use_document_isolation_policy',
+		$chrome_version !== null && $chrome_version >= 137
+	);
 
 	ob_start(
-		function ( string $output ) use ( $coep ): string {
-			header( 'Cross-Origin-Opener-Policy: same-origin' );
-			header( "Cross-Origin-Embedder-Policy: $coep" );
+		function ( string $output ) use ( $is_safari, $use_dip ): string {
+			if ( $use_dip ) {
+				header( 'Document-Isolation-Policy: isolate-and-credentialless' );
+			} else {
+				$coep = $is_safari ? 'require-corp' : 'credentialless';
+				header( 'Cross-Origin-Opener-Policy: same-origin' );
+				header( "Cross-Origin-Embedder-Policy: $coep" );
+			}
 
 			return gutenberg_add_crossorigin_attributes( $output );
 		}

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -23,7 +23,7 @@ function gutenberg_set_client_side_media_processing_flag() {
 	/** This filter is documented in gutenberg/lib/media/load.php */
 	$use_dip = apply_filters(
 		'gutenberg_use_document_isolation_policy',
-		$chrome_version !== null && $chrome_version >= 137
+		null !== $chrome_version && $chrome_version >= 137
 	);
 
 	if ( $use_dip ) {
@@ -297,12 +297,8 @@ add_action( 'load-widgets.php', 'gutenberg_set_up_cross_origin_isolation' );
  * Uses an output buffer to add crossorigin="anonymous" where needed.
  *
  * @link https://web.dev/coop-coep/
- *
- * @global bool $is_safari
  */
 function gutenberg_start_cross_origin_isolation_output_buffer(): void {
-	global $is_safari;
-
 	$chrome_version = gutenberg_get_chrome_major_version();
 
 	/**
@@ -318,17 +314,13 @@ function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	 */
 	$use_dip = apply_filters(
 		'gutenberg_use_document_isolation_policy',
-		$chrome_version !== null && $chrome_version >= 137
+		null !== $chrome_version && $chrome_version >= 137
 	);
 
 	ob_start(
-		function ( string $output ) use ( $is_safari, $use_dip ): string {
+		function ( string $output ) use ( $use_dip ): string {
 			if ( $use_dip ) {
 				header( 'Document-Isolation-Policy: isolate-and-credentialless' );
-			} else {
-				$coep = $is_safari ? 'require-corp' : 'credentialless';
-				header( 'Cross-Origin-Opener-Policy: same-origin' );
-				header( "Cross-Origin-Embedder-Policy: $coep" );
 			}
 
 			return gutenberg_add_crossorigin_attributes( $output );

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -17,18 +17,6 @@ function gutenberg_set_client_side_media_processing_flag() {
 		return;
 	}
 	wp_add_inline_script( 'wp-block-editor', 'window.__clientSideMediaProcessing = true', 'before' );
-
-	$chrome_version = gutenberg_get_chrome_major_version();
-
-	/** This filter is documented in gutenberg/lib/media/load.php */
-	$use_dip = apply_filters(
-		'gutenberg_use_document_isolation_policy',
-		null !== $chrome_version && $chrome_version >= 137
-	);
-
-	if ( $use_dip ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__documentIsolationPolicy = true', 'before' );
-	}
 }
 add_action( 'admin_init', 'gutenberg_set_client_side_media_processing_flag' );
 
@@ -252,9 +240,8 @@ function gutenberg_get_chrome_major_version(): ?int {
  * Enables cross-origin isolation in the block editor.
  *
  * Required for enabling SharedArrayBuffer for WebAssembly-based
- * media processing in the editor.
- *
- * @link https://web.dev/coop-coep/
+ * media processing in the editor. Uses Document-Isolation-Policy
+ * on supported browsers (Chrome 137+).
  */
 function gutenberg_set_up_cross_origin_isolation() {
 	// Re-check the filter at action time, since other plugins (loaded after Gutenberg)
@@ -307,21 +294,19 @@ remove_action( 'load-site-editor.php', 'wp_set_up_cross_origin_isolation' );
 remove_action( 'load-widgets.php', 'wp_set_up_cross_origin_isolation' );
 
 /**
- * Sends headers for cross-origin isolation.
+ * Sends the Document-Isolation-Policy header for cross-origin isolation.
  *
  * Uses an output buffer to add crossorigin="anonymous" where needed.
- *
- * @link https://web.dev/coop-coep/
  */
 function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	$chrome_version = gutenberg_get_chrome_major_version();
 
 	/**
-	 * Filters whether to use Document-Isolation-Policy instead of COEP/COOP.
+	 * Filters whether to use Document-Isolation-Policy for cross-origin isolation.
 	 *
 	 * Document-Isolation-Policy provides per-document cross-origin isolation
 	 * without affecting other iframes on the page, avoiding breakage of plugins
-	 * like Elementor whose iframes lose credentials/DOM access with COEP.
+	 * like Elementor whose iframes lose credentials/DOM access.
 	 *
 	 * @since 21.8.0
 	 *

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -260,8 +260,8 @@ function gutenberg_set_up_cross_origin_isolation() {
 		return;
 	}
 
-	// Skip when a third-party page builder (e.g. Elementor) overrides the
-	// block editor. DIP isolates the document into its own agent cluster,
+	// Skip when a third-party page builder overrides the block editor.
+	// DIP isolates the document into its own agent cluster,
 	// which blocks same-origin iframe access that these editors rely on.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['action'] ) && 'edit' !== $_GET['action'] ) {
@@ -306,7 +306,7 @@ function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	 *
 	 * Document-Isolation-Policy provides per-document cross-origin isolation
 	 * without affecting other iframes on the page, avoiding breakage of plugins
-	 * like Elementor whose iframes lose credentials/DOM access.
+	 * whose iframes lose credentials/DOM access.
 	 *
 	 * @since 21.8.0
 	 *

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -220,13 +220,13 @@ function gutenberg_filter_mod_rewrite_rules( string $rules ): string {
 add_filter( 'mod_rewrite_rules', 'gutenberg_filter_mod_rewrite_rules' );
 
 /**
- * Returns the major Chrome/Chromium version from the current request's User-Agent.
+ * Returns the major Chromium version from the current request's User-Agent.
  *
  * Matches all Chromium-based browsers (Chrome, Edge, Opera, Brave).
  *
- * @return int|null The major Chrome version, or null if not a Chromium browser.
+ * @return int|null The major Chromium version, or null if not a Chromium browser.
  */
-function gutenberg_get_chrome_major_version(): ?int {
+function gutenberg_get_chromium_major_version(): ?int {
 	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
 		return null;
 	}
@@ -241,7 +241,7 @@ function gutenberg_get_chrome_major_version(): ?int {
  *
  * Required for enabling SharedArrayBuffer for WebAssembly-based
  * media processing in the editor. Uses Document-Isolation-Policy
- * on supported browsers (Chrome 137+).
+ * on supported browsers (Chromium 137+).
  */
 function gutenberg_set_up_cross_origin_isolation() {
 	// Re-check the filter at action time, since other plugins (loaded after Gutenberg)
@@ -299,7 +299,7 @@ remove_action( 'load-widgets.php', 'wp_set_up_cross_origin_isolation' );
  * Uses an output buffer to add crossorigin="anonymous" where needed.
  */
 function gutenberg_start_cross_origin_isolation_output_buffer(): void {
-	$chrome_version = gutenberg_get_chrome_major_version();
+	$chromium_version = gutenberg_get_chromium_major_version();
 
 	/**
 	 * Filters whether to use Document-Isolation-Policy for cross-origin isolation.
@@ -314,7 +314,7 @@ function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	 */
 	$use_dip = apply_filters(
 		'gutenberg_use_document_isolation_policy',
-		null !== $chrome_version && $chrome_version >= 137
+		null !== $chromium_version && $chromium_version >= 137
 	);
 
 	if ( ! $use_dip ) {

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -299,6 +299,13 @@ add_action( 'load-post-new.php', 'gutenberg_set_up_cross_origin_isolation' );
 add_action( 'load-site-editor.php', 'gutenberg_set_up_cross_origin_isolation' );
 add_action( 'load-widgets.php', 'gutenberg_set_up_cross_origin_isolation' );
 
+// Remove core's COEP/COOP-based cross-origin isolation in favor of
+// Gutenberg's DIP-based approach, which also skips third-party editors.
+remove_action( 'load-post.php', 'wp_set_up_cross_origin_isolation' );
+remove_action( 'load-post-new.php', 'wp_set_up_cross_origin_isolation' );
+remove_action( 'load-site-editor.php', 'wp_set_up_cross_origin_isolation' );
+remove_action( 'load-widgets.php', 'wp_set_up_cross_origin_isolation' );
+
 /**
  * Sends headers for cross-origin isolation.
  *

--- a/packages/block-editor/src/hooks/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/cross-origin-isolation.js
@@ -15,8 +15,13 @@ function addCrossOriginAttributes( el ) {
 		el.setAttribute( 'crossorigin', 'anonymous' );
 	}
 
-	// For iframes, add the credentialless attribute.
-	if ( el.nodeName === 'IFRAME' && ! el.hasAttribute( 'credentialless' ) ) {
+	// For iframes, add the credentialless attribute — only when NOT using DIP.
+	// With Document-Isolation-Policy, iframes don't need credentialless.
+	if (
+		! window.__documentIsolationPolicy &&
+		el.nodeName === 'IFRAME' &&
+		! el.hasAttribute( 'credentialless' )
+	) {
 		// Do not modify the iframed editor canvas.
 		if ( el.getAttribute( 'src' )?.startsWith( 'blob:' ) ) {
 			return;
@@ -55,7 +60,11 @@ if ( window.crossOriginIsolated ) {
 						addCrossOriginAttributes( v );
 					} );
 
-					if ( el.nodeName === 'IFRAME' ) {
+					// With DIP, iframes are not modified, so no need to observe their content.
+					if (
+						el.nodeName === 'IFRAME' &&
+						! window.__documentIsolationPolicy
+					) {
 						const iframeNode = el;
 
 						/*
@@ -135,8 +144,9 @@ if ( window.crossOriginIsolated ) {
 	startObservingBody();
 }
 
-// Only apply the embed preview filter when cross-origin isolated.
-if ( window.crossOriginIsolated ) {
+// Only apply the embed preview filter when cross-origin isolated via COEP/COOP.
+// With DIP, all embeds preview normally — no filtering needed.
+if ( window.crossOriginIsolated && ! window.__documentIsolationPolicy ) {
 	const supportsCredentialless =
 		'credentialless' in window.HTMLIFrameElement.prototype;
 

--- a/packages/block-editor/src/hooks/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/cross-origin-isolation.js
@@ -1,38 +1,11 @@
 /**
- * WordPress dependencies
- */
-import { addFilter } from '@wordpress/hooks';
-import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
- * Adds crossorigin and credentialless attributes to elements as needed.
+ * Adds crossorigin="anonymous" to an element if missing.
  *
  * @param {Element} el The element to modify.
  */
-function addCrossOriginAttributes( el ) {
-	// Add the crossorigin attribute if missing.
+function addCrossOriginAttribute( el ) {
 	if ( ! el.hasAttribute( 'crossorigin' ) ) {
 		el.setAttribute( 'crossorigin', 'anonymous' );
-	}
-
-	// For iframes, add the credentialless attribute — only when NOT using DIP.
-	// With Document-Isolation-Policy, iframes don't need credentialless.
-	if (
-		! window.__documentIsolationPolicy &&
-		el.nodeName === 'IFRAME' &&
-		! el.hasAttribute( 'credentialless' )
-	) {
-		// Do not modify the iframed editor canvas.
-		if ( el.getAttribute( 'src' )?.startsWith( 'blob:' ) ) {
-			return;
-		}
-
-		el.setAttribute( 'credentialless', '' );
-
-		// Reload the iframe to ensure the new attribute is taken into account.
-		const origSrc = el.getAttribute( 'src' ) || '';
-		el.setAttribute( 'src', '' );
-		el.setAttribute( 'src', origSrc );
 	}
 }
 
@@ -55,62 +28,17 @@ if ( window.crossOriginIsolated ) {
 					}
 
 					el.querySelectorAll(
-						'img,source,script,video,link,iframe'
+						'img,source,script,video,link'
 					).forEach( ( v ) => {
-						addCrossOriginAttributes( v );
+						addCrossOriginAttribute( v );
 					} );
 
-					// With DIP, iframes are not modified, so no need to observe their content.
 					if (
-						el.nodeName === 'IFRAME' &&
-						! window.__documentIsolationPolicy
+						[ 'IMG', 'SOURCE', 'SCRIPT', 'VIDEO', 'LINK' ].includes(
+							el.nodeName
+						)
 					) {
-						const iframeNode = el;
-
-						/*
-						 * Sandboxed iframes should not get modified. For example embedding a tweet served in a sandboxed
-						 * iframe, the tweet itself would not be modified.
-						 */
-						const isEmbedSandboxIframe =
-							iframeNode.classList.contains(
-								'components-sandbox'
-							);
-
-						if ( ! isEmbedSandboxIframe ) {
-							iframeNode.addEventListener( 'load', () => {
-								try {
-									if (
-										iframeNode.contentDocument &&
-										iframeNode.contentDocument.body
-									) {
-										observer.observe(
-											iframeNode.contentDocument,
-											{
-												childList: true,
-												attributes: true,
-												subtree: true,
-											}
-										);
-									}
-								} catch ( e ) {
-									// Iframe may be cross-origin or otherwise inaccessible.
-									// Silently ignore these cases.
-								}
-							} );
-						}
-					}
-
-					if (
-						[
-							'IMG',
-							'SOURCE',
-							'SCRIPT',
-							'VIDEO',
-							'LINK',
-							'IFRAME',
-						].includes( el.nodeName )
-					) {
-						addCrossOriginAttributes( el );
+						addCrossOriginAttribute( el );
 					}
 				} );
 			} );
@@ -142,41 +70,4 @@ if ( window.crossOriginIsolated ) {
 	}
 
 	startObservingBody();
-}
-
-// Only apply the embed preview filter when cross-origin isolated via COEP/COOP.
-// With DIP, all embeds preview normally — no filtering needed.
-if ( window.crossOriginIsolated && ! window.__documentIsolationPolicy ) {
-	const supportsCredentialless =
-		'credentialless' in window.HTMLIFrameElement.prototype;
-
-	const disableEmbedPreviews = createHigherOrderComponent(
-		( BlockEdit ) =>
-			function DisableEmbedPreviews( props ) {
-				if ( 'core/embed' !== props.name ) {
-					return <BlockEdit { ...props } />;
-				}
-
-				// List of embeds that do not support a preview is from packages/block-library/src/embed/variations.js.
-				const previewable =
-					supportsCredentialless &&
-					! [ 'facebook', 'smugmug' ].includes(
-						props.attributes.providerNameSlug
-					);
-
-				return (
-					<BlockEdit
-						{ ...props }
-						attributes={ { ...props.attributes, previewable } }
-					/>
-				);
-			},
-		'withDisabledEmbedPreview'
-	);
-
-	addFilter(
-		'editor.BlockEdit',
-		'media-experiments/disable-embed-previews',
-		disableEmbedPreviews
-	);
 }

--- a/packages/block-editor/src/hooks/test/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/test/cross-origin-isolation.js
@@ -179,6 +179,90 @@ describe( 'cross-origin-isolation', () => {
 		} ).not.toThrow();
 	} );
 
+	describe( 'Document-Isolation-Policy', () => {
+		it( 'should not add credentialless to iframes when __documentIsolationPolicy is true', () => {
+			Object.defineProperty( window, 'crossOriginIsolated', {
+				value: true,
+				writable: true,
+				configurable: true,
+			} );
+
+			window.__documentIsolationPolicy = true;
+
+			// Re-import the module to trigger the side effects
+			jest.isolateModules( () => {
+				require( '../cross-origin-isolation' );
+			} );
+
+			// Create an iframe and add it to the DOM to trigger the MutationObserver
+			const iframe = document.createElement( 'iframe' );
+			iframe.setAttribute( 'src', 'https://example.com' );
+			document.body.appendChild( iframe );
+
+			// The iframe should NOT have the credentialless attribute with DIP
+			expect( iframe ).not.toHaveAttribute( 'credentialless' );
+
+			document.body.removeChild( iframe );
+			delete window.__documentIsolationPolicy;
+		} );
+
+		it( 'should still add crossorigin="anonymous" to images when DIP is active', async () => {
+			Object.defineProperty( window, 'crossOriginIsolated', {
+				value: true,
+				writable: true,
+				configurable: true,
+			} );
+
+			window.__documentIsolationPolicy = true;
+
+			// Re-import the module to trigger the side effects
+			jest.isolateModules( () => {
+				require( '../cross-origin-isolation' );
+			} );
+
+			// Create an image and add it to the DOM
+			const img = document.createElement( 'img' );
+			img.setAttribute( 'src', 'https://example.com/image.jpg' );
+			document.body.appendChild( img );
+
+			// Wait for MutationObserver callback to fire (async microtask).
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+			// The image should still get the crossorigin attribute with DIP
+			expect( img ).toHaveAttribute( 'crossorigin', 'anonymous' );
+
+			document.body.removeChild( img );
+			delete window.__documentIsolationPolicy;
+		} );
+
+		it( 'should not register embed preview filter when DIP is active', () => {
+			Object.defineProperty( window, 'crossOriginIsolated', {
+				value: true,
+				writable: true,
+				configurable: true,
+			} );
+
+			window.__documentIsolationPolicy = true;
+
+			const { hasFilter } = require( '@wordpress/hooks' );
+
+			// Re-import the module to register filters
+			jest.isolateModules( () => {
+				require( '../cross-origin-isolation' );
+			} );
+
+			// The embed preview filter should NOT be registered when DIP is active
+			expect(
+				hasFilter(
+					'editor.BlockEdit',
+					'media-experiments/disable-embed-previews'
+				)
+			).toBeFalsy();
+
+			delete window.__documentIsolationPolicy;
+		} );
+	} );
+
 	it( 'should register embed preview filter when cross-origin isolated', () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: true,

--- a/packages/block-editor/src/hooks/test/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/test/cross-origin-isolation.js
@@ -152,144 +152,29 @@ describe( 'cross-origin-isolation', () => {
 		expect( observeSpy ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should handle iframe contentDocument errors gracefully', () => {
+	it( 'should add crossorigin="anonymous" to images', async () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: true,
 			writable: true,
 			configurable: true,
 		} );
 
-		// Re-import the module
+		// Re-import the module to trigger the side effects
 		jest.isolateModules( () => {
 			require( '../cross-origin-isolation' );
 		} );
 
-		// Create an iframe that throws when accessing contentDocument
-		const iframe = document.createElement( 'iframe' );
-		Object.defineProperty( iframe, 'contentDocument', {
-			get() {
-				throw new Error( 'Cross-origin access denied' );
-			},
-		} );
+		// Create an image and add it to the DOM
+		const img = document.createElement( 'img' );
+		img.setAttribute( 'src', 'https://example.com/image.jpg' );
+		document.body.appendChild( img );
 
-		// This should not throw an error
-		expect( () => {
-			document.body.appendChild( iframe );
-			iframe.dispatchEvent( new Event( 'load' ) );
-		} ).not.toThrow();
-	} );
+		// Wait for MutationObserver callback to fire (async microtask).
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
-	describe( 'Document-Isolation-Policy', () => {
-		it( 'should not add credentialless to iframes when __documentIsolationPolicy is true', () => {
-			Object.defineProperty( window, 'crossOriginIsolated', {
-				value: true,
-				writable: true,
-				configurable: true,
-			} );
+		// The image should get the crossorigin attribute
+		expect( img ).toHaveAttribute( 'crossorigin', 'anonymous' );
 
-			window.__documentIsolationPolicy = true;
-
-			// Re-import the module to trigger the side effects
-			jest.isolateModules( () => {
-				require( '../cross-origin-isolation' );
-			} );
-
-			// Create an iframe and add it to the DOM to trigger the MutationObserver
-			const iframe = document.createElement( 'iframe' );
-			iframe.setAttribute( 'src', 'https://example.com' );
-			document.body.appendChild( iframe );
-
-			// The iframe should NOT have the credentialless attribute with DIP
-			expect( iframe ).not.toHaveAttribute( 'credentialless' );
-
-			document.body.removeChild( iframe );
-			delete window.__documentIsolationPolicy;
-		} );
-
-		it( 'should still add crossorigin="anonymous" to images when DIP is active', async () => {
-			Object.defineProperty( window, 'crossOriginIsolated', {
-				value: true,
-				writable: true,
-				configurable: true,
-			} );
-
-			window.__documentIsolationPolicy = true;
-
-			// Re-import the module to trigger the side effects
-			jest.isolateModules( () => {
-				require( '../cross-origin-isolation' );
-			} );
-
-			// Create an image and add it to the DOM
-			const img = document.createElement( 'img' );
-			img.setAttribute( 'src', 'https://example.com/image.jpg' );
-			document.body.appendChild( img );
-
-			// Wait for MutationObserver callback to fire (async microtask).
-			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
-
-			// The image should still get the crossorigin attribute with DIP
-			expect( img ).toHaveAttribute( 'crossorigin', 'anonymous' );
-
-			document.body.removeChild( img );
-			delete window.__documentIsolationPolicy;
-		} );
-
-		it( 'should not register embed preview filter when DIP is active', () => {
-			Object.defineProperty( window, 'crossOriginIsolated', {
-				value: true,
-				writable: true,
-				configurable: true,
-			} );
-
-			window.__documentIsolationPolicy = true;
-
-			const { hasFilter } = require( '@wordpress/hooks' );
-
-			// Re-import the module to register filters
-			jest.isolateModules( () => {
-				require( '../cross-origin-isolation' );
-			} );
-
-			// The embed preview filter should NOT be registered when DIP is active
-			expect(
-				hasFilter(
-					'editor.BlockEdit',
-					'media-experiments/disable-embed-previews'
-				)
-			).toBeFalsy();
-
-			delete window.__documentIsolationPolicy;
-		} );
-	} );
-
-	it( 'should register embed preview filter when cross-origin isolated', () => {
-		Object.defineProperty( window, 'crossOriginIsolated', {
-			value: true,
-			writable: true,
-			configurable: true,
-		} );
-
-		const hasFilter = jest.spyOn(
-			require( '@wordpress/hooks' ),
-			'hasFilter'
-		);
-
-		// Re-import the module to register filters
-		jest.isolateModules( () => {
-			require( '../cross-origin-isolation' );
-		} );
-
-		// The module should register a filter when cross-origin isolated
-		// We can't easily test the filter itself without a full React environment,
-		// but we can verify the module loads without errors
-		expect( () => {
-			require( '@wordpress/hooks' ).hasFilter(
-				'editor.BlockEdit',
-				'media-experiments/disable-embed-previews'
-			);
-		} ).not.toThrow();
-
-		hasFilter.mockRestore();
+		document.body.removeChild( img );
 	} );
 } );

--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -34,15 +34,10 @@ let cachedResult: FeatureDetectionResult | null = null;
  * 1. WebAssembly support (required for wasm-vips)
  * 2. SharedArrayBuffer support (required for WASM threading)
  * 3. CSP compatibility for blob URL workers (required for inline worker creation)
- * 4. Credentialless iframe support (required so cross-origin isolation does not
- *    break third-party embeds). Browsers that lack `credentialless` iframe support
- *    (currently Firefox and Safari) will have client-side media processing disabled
- *    by default. Developers can re-enable the feature via the server-side
- *    `wp_client_side_media_processing_enabled` filter if it works for their site.
- * 5. Device memory (disables on devices with ≤2 GB RAM)
- * 6. Hardware concurrency (disables on devices with fewer than 4 CPU cores)
- * 7. Network conditions (disables when data saver / reduced data mode is on or connection is 3g/2g/slow-2g)
- * 8. Web Worker support (baseline requirement)
+ * 4. Device memory (disables on devices with ≤2 GB RAM)
+ * 5. Hardware concurrency (disables on devices with fewer than 4 CPU cores)
+ * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 3g/2g/slow-2g)
+ * 7. Web Worker support (baseline requirement)
  *
  * Results are cached after the first call. Use `clearFeatureDetectionCache()` to reset.
  *
@@ -77,21 +72,6 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 		cachedResult = {
 			supported: false,
 			reason: 'Web Workers are not supported in this browser.',
-		};
-		return cachedResult;
-	}
-
-	// Check credentialless iframe support.
-	// Browsers without this (Firefox, Safari) cannot use cross-origin isolation
-	// without breaking third-party embeds.
-	if (
-		typeof window !== 'undefined' &&
-		window.HTMLIFrameElement &&
-		! ( 'credentialless' in window.HTMLIFrameElement.prototype )
-	) {
-		cachedResult = {
-			supported: false,
-			reason: 'Browser does not support credentialless iframes. Cross-origin isolation would break third-party embeds',
 		};
 		return cachedResult;
 	}

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -45,19 +45,6 @@ describe( 'feature-detection', () => {
 		);
 		global.URL.revokeObjectURL = jest.fn();
 
-		// Mock credentialless iframe support so the check passes by default.
-		if ( ! ( 'credentialless' in window.HTMLIFrameElement.prototype ) ) {
-			Object.defineProperty(
-				window.HTMLIFrameElement.prototype,
-				'credentialless',
-				{
-					value: false,
-					writable: true,
-					configurable: true,
-				}
-			);
-		}
-
 		// Remove navigator.deviceMemory and navigator.connection by default
 		// so they don't interfere with unrelated tests.
 		if ( 'deviceMemory' in navigator ) {
@@ -81,11 +68,6 @@ describe( 'feature-detection', () => {
 		global.Worker = originalWorker;
 		global.URL.createObjectURL = originalCreateObjectURL;
 		global.URL.revokeObjectURL = originalRevokeObjectURL;
-
-		// Restore credentialless property.
-		if ( 'credentialless' in window.HTMLIFrameElement.prototype ) {
-			delete ( window.HTMLIFrameElement.prototype as any ).credentialless;
-		}
 
 		// Restore navigator.deviceMemory.
 		if ( originalDeviceMemoryDescriptor ) {
@@ -164,23 +146,6 @@ describe( 'feature-detection', () => {
 			expect( result.reason ).toBe(
 				'Web Workers are not supported in this browser.'
 			);
-		} );
-
-		it( 'returns not supported when credentialless iframes are not supported', () => {
-			// Remove credentialless from the prototype.
-			delete ( window.HTMLIFrameElement.prototype as any ).credentialless;
-
-			const result = detectClientSideMediaSupport();
-
-			expect( result.supported ).toBe( false );
-			expect( result.reason ).toContain( 'credentialless iframes' );
-		} );
-
-		it( 'returns supported when credentialless iframes are supported', () => {
-			// credentialless is already mocked in beforeEach.
-			const result = detectClientSideMediaSupport();
-
-			expect( result.supported ).toBe( true );
 		} );
 
 		it( 'returns not supported when device memory is 2 GB or less', () => {

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -19,7 +19,7 @@ test.use( {
 
 test.describe( 'Classic', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation (COEP) prevents TinyMCE from
+		// Cross-origin isolation prevents TinyMCE from
 		// initializing properly in its iframe.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -18,18 +18,7 @@ test.use( {
 } );
 
 test.describe( 'Classic', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation prevents TinyMCE from
-		// initializing properly in its iframe.
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 		await requestUtils.deleteAllMedia();
 	} );
 

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -395,6 +395,11 @@ test.describe( 'Cover', () => {
 			coverBlock.getByTestId( 'form-file-upload-input' )
 		);
 
+		// Wait for the image upload to complete and the image to appear.
+		await expect(
+			coverBlock.locator( 'img.wp-block-cover__image-background' )
+		).toBeVisible();
+
 		await editor.selectBlocks( coverBlock );
 
 		const focalPointLeft = page.getByRole( 'spinbutton', {

--- a/test/e2e/specs/editor/plugins/block-context.spec.js
+++ b/test/e2e/specs/editor/plugins/block-context.spec.js
@@ -5,9 +5,6 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Block context', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 		await requestUtils.activatePlugin( 'gutenberg-test-block-context' );
 	} );
 
@@ -17,9 +14,6 @@ test.describe( 'Block context', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-context' );
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 	} );
 
 	test( 'Block context propagates to inner blocks', async ( { editor } ) => {

--- a/test/e2e/specs/editor/plugins/iframed-block.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-block.spec.js
@@ -4,18 +4,6 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Iframed block', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.beforeEach( async ( { requestUtils, admin } ) => {
 		await requestUtils.activatePlugin( 'gutenberg-test-iframed-block' );
 		await admin.createNewPost( { postType: 'page' } );

--- a/test/e2e/specs/editor/plugins/iframed-inline-styles.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-inline-styles.spec.js
@@ -6,9 +6,6 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'iframed inline styles', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-		await requestUtils.activatePlugin(
 			'gutenberg-test-iframed-inline-styles'
 		);
 	} );
@@ -16,9 +13,6 @@ test.describe( 'iframed inline styles', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-iframed-inline-styles'
-		);
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
 

--- a/test/e2e/specs/editor/plugins/iframed-masonry-block.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-masonry-block.spec.js
@@ -6,9 +6,6 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'iframed masonry block', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-		await requestUtils.activatePlugin(
 			'gutenberg-test-iframed-masonry-block'
 		);
 	} );
@@ -20,9 +17,6 @@ test.describe( 'iframed masonry block', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-iframed-masonry-block'
-		);
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
 

--- a/test/e2e/specs/editor/plugins/iframed-multiple-block-stylesheets.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-multiple-block-stylesheets.spec.js
@@ -6,9 +6,6 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'iframed multiple block stylesheets', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-		await requestUtils.activatePlugin(
 			'gutenberg-test-iframed-multiple-stylesheets'
 		);
 	} );
@@ -20,9 +17,6 @@ test.describe( 'iframed multiple block stylesheets', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-iframed-multiple-stylesheets'
-		);
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
 

--- a/test/e2e/specs/editor/plugins/meta-attribute-block.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-attribute-block.spec.js
@@ -11,9 +11,6 @@ const VARIATIONS = [
 test.describe( 'Block with a meta attribute', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-		await requestUtils.activatePlugin(
 			'gutenberg-test-meta-attribute-block'
 		);
 	} );
@@ -21,9 +18,6 @@ test.describe( 'Block with a meta attribute', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-meta-attribute-block'
-		);
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
 

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -8,19 +8,11 @@ test.describe( 'WP Editor Meta Boxes', () => {
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-wp-editor-meta-box'
 		);
-		// Cross-origin isolation prevents TinyMCE from
-		// initializing properly in its iframe.
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-plugin-wp-editor-meta-box'
-		);
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
 

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -8,7 +8,7 @@ test.describe( 'WP Editor Meta Boxes', () => {
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-wp-editor-meta-box'
 		);
-		// Cross-origin isolation (COEP) prevents TinyMCE from
+		// Cross-origin isolation prevents TinyMCE from
 		// initializing properly in its iframe.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -49,9 +49,6 @@ const userList = [
 ];
 test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 		await Promise.all(
 			userList.map( ( user ) =>
 				requestUtils.createUser( {
@@ -68,9 +65,6 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		await requestUtils.deleteAllUsers();
 		await requestUtils.deactivatePlugin( 'gutenberg-test-autocompleter' );
 		await requestUtils.activateTheme( 'twentytwentyone' );
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 	} );
 
 	test.beforeEach( async ( { admin } ) => {

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -6,6 +6,19 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 /** @typedef {import('@playwright/test').Page} Page */
 /** @typedef {import('@wordpress/e2e-test-utils-playwright').Editor} Editor */
 
+/**
+ * Returns the major Chrome version from the browser's user agent, or 0 if not Chromium.
+ *
+ * @param {Page} page Playwright page object.
+ * @return {Promise<number>} Major Chrome version.
+ */
+async function getChromeMajorVersion( page ) {
+	return page.evaluate( () => {
+		const match = window.navigator.userAgent.match( /Chrome\/(\d+)/ );
+		return match ? parseInt( match[ 1 ], 10 ) : 0;
+	} );
+}
+
 const EMBED_URLS = [
 	'/oembed/1.0/proxy',
 	`rest_route=${ encodeURIComponent( '/oembed/1.0/proxy' ) }`,
@@ -36,7 +49,13 @@ test.use( {
 } );
 
 test.describe( 'Cross-origin isolation', () => {
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, page } ) => {
+		// These tests only apply when COEP/COOP is used (Chrome < 137).
+		// On Chrome 137+, Document-Isolation-Policy is used instead.
+		test.skip(
+			( await getChromeMajorVersion( page ) ) >= 137,
+			'COEP/COOP not used on Chrome 137+ (uses Document-Isolation-Policy)'
+		);
 		await admin.createNewPost();
 	} );
 
@@ -106,13 +125,8 @@ test.describe( 'Cross-origin isolation', () => {
 test.describe( 'Document-Isolation-Policy', () => {
 	test.beforeEach( async ( { admin, page } ) => {
 		// These tests only apply to Chrome 137+.
-		const chromeVersion = await page.evaluate( () => {
-			const match = window.navigator.userAgent.match( /Chrome\/(\d+)/ );
-			return match ? parseInt( match[ 1 ], 10 ) : 0;
-		} );
-
 		test.skip(
-			chromeVersion < 137,
+			( await getChromeMajorVersion( page ) ) < 137,
 			'Document-Isolation-Policy requires Chrome 137+'
 		);
 

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -7,12 +7,12 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 /** @typedef {import('@wordpress/e2e-test-utils-playwright').Editor} Editor */
 
 /**
- * Returns the major Chrome version from the browser's user agent, or 0 if not Chromium.
+ * Returns the major Chromium version from the browser's user agent, or 0 if not Chromium.
  *
  * @param {Page} page Playwright page object.
- * @return {Promise<number>} Major Chrome version.
+ * @return {Promise<number>} Major Chromium version.
  */
-async function getChromeMajorVersion( page ) {
+async function getChromiumMajorVersion( page ) {
 	return page.evaluate( () => {
 		const match = window.navigator.userAgent.match( /Chrome\/(\d+)/ );
 		return match ? parseInt( match[ 1 ], 10 ) : 0;
@@ -41,10 +41,10 @@ test.use( {
 
 test.describe( 'Document-Isolation-Policy', () => {
 	test.beforeEach( async ( { admin, page } ) => {
-		// These tests only apply to Chrome 137+.
+		// These tests only apply to Chromium 137+.
 		test.skip(
-			( await getChromeMajorVersion( page ) ) < 137,
-			'Document-Isolation-Policy requires Chrome 137+'
+			( await getChromiumMajorVersion( page ) ) < 137,
+			'Document-Isolation-Policy requires Chromium 137+'
 		);
 
 		await admin.createNewPost();

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -40,19 +40,7 @@ test.describe( 'Cross-origin isolation', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should be cross-origin isolated by default', async ( { page } ) => {
-		// Verify that cross-origin isolation IS enabled (default state
-		// now that client-side media processing is graduated).
-		const isCrossOriginIsolated = await page.evaluate(
-			() => window.crossOriginIsolated
-		);
-		expect( isCrossOriginIsolated ).toBe( true );
-	} );
-
-	test( 'should render embed previews when cross-origin isolated', async ( {
-		editor,
-		embedUtils,
-	} ) => {
+	test( 'should render embed previews', async ( { editor, embedUtils } ) => {
 		await embedUtils.interceptRequests( {
 			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
 		} );
@@ -64,13 +52,13 @@ test.describe( 'Cross-origin isolation', () => {
 			.getByRole( 'document', { name: 'Block' } )
 			.last();
 		const iframe = embedBlock.locator( 'iframe' );
-		await expect(
-			iframe,
-			'Embed should render iframe when cross-origin isolated'
-		).toHaveAttribute( 'title', 'Embedded content from twitter.com' );
+		await expect( iframe, 'Embed should render iframe' ).toHaveAttribute(
+			'title',
+			'Embedded content from twitter.com'
+		);
 	} );
 
-	test( 'should render video embeds with aspect ratio when cross-origin isolated', async ( {
+	test( 'should render video embeds with aspect ratio', async ( {
 		editor,
 		embedUtils,
 	} ) => {
@@ -112,70 +100,6 @@ test.describe( 'Cross-origin isolation', () => {
 			iframe,
 			'Embed iframe should have crossorigin attribute'
 		).toHaveAttribute( 'crossorigin', 'anonymous' );
-	} );
-
-	test( 'should add credentialless attribute to embed iframes when supported', async ( {
-		page,
-		editor,
-		embedUtils,
-	} ) => {
-		// Check if browser supports credentialless iframes.
-		const supportsCredentialless = await page.evaluate(
-			() => 'credentialless' in window.HTMLIFrameElement.prototype
-		);
-
-		test.skip(
-			! supportsCredentialless,
-			'Browser does not support credentialless iframes'
-		);
-
-		await embedUtils.interceptRequests( {
-			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
-		} );
-
-		await embedUtils.insertEmbed( 'https://twitter.com/notnownikki' );
-
-		const embedBlock = editor.canvas
-			.getByRole( 'document', { name: 'Block' } )
-			.last();
-		const iframe = embedBlock.locator( 'iframe.components-sandbox' );
-
-		await expect(
-			iframe,
-			'Embed iframe should have credentialless attribute'
-		).toHaveAttribute( 'credentialless', '' );
-	} );
-
-	test( 'should show placeholder for denylisted providers when credentialless not supported', async ( {
-		page,
-		editor,
-		embedUtils,
-	} ) => {
-		// This test only applies when credentialless is NOT supported.
-		const supportsCredentialless = await page.evaluate(
-			() => 'credentialless' in window.HTMLIFrameElement.prototype
-		);
-
-		test.skip(
-			supportsCredentialless,
-			'Browser supports credentialless iframes'
-		);
-
-		await embedUtils.interceptRequests( {
-			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
-		} );
-
-		await embedUtils.insertEmbed( 'https://twitter.com/notnownikki' );
-
-		const embedBlock = editor.canvas
-			.getByRole( 'document', { name: 'Block' } )
-			.last();
-
-		// When credentialless is not supported, embeds should show a placeholder.
-		await expect(
-			embedBlock.locator( '.components-placeholder__error' ),
-			'Should show placeholder when credentialless not supported'
-		).toContainText( "can't be previewed" );
 	} );
 } );
 

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -33,93 +33,10 @@ const MOCK_EMBED_RICH_SUCCESS_RESPONSE = {
 	version: '1.0',
 };
 
-const MOCK_EMBED_VIDEO_SUCCESS_RESPONSE = {
-	url: 'https://www.youtube.com/watch?v=lXMskKTw3Bc',
-	html: '<iframe width="16" height="9" src="https://www.youtube.com/embed/lXMskKTw3Bc"></iframe>',
-	type: 'video',
-	provider_name: 'YouTube',
-	provider_url: 'https://youtube.com',
-	version: '1.0',
-};
-
 test.use( {
 	embedUtils: async ( { page, editor }, use ) => {
 		await use( new EmbedUtils( { page, editor } ) );
 	},
-} );
-
-test.describe( 'Cross-origin isolation', () => {
-	test.beforeEach( async ( { admin, page } ) => {
-		// These tests only apply when COEP/COOP is used (Chrome < 137).
-		// On Chrome 137+, Document-Isolation-Policy is used instead.
-		test.skip(
-			( await getChromeMajorVersion( page ) ) >= 137,
-			'COEP/COOP not used on Chrome 137+ (uses Document-Isolation-Policy)'
-		);
-		await admin.createNewPost();
-	} );
-
-	test( 'should render embed previews', async ( { editor, embedUtils } ) => {
-		await embedUtils.interceptRequests( {
-			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
-		} );
-
-		await embedUtils.insertEmbed( 'https://twitter.com/notnownikki' );
-
-		// Verify the embed iframe is visible.
-		const embedBlock = editor.canvas
-			.getByRole( 'document', { name: 'Block' } )
-			.last();
-		const iframe = embedBlock.locator( 'iframe' );
-		await expect( iframe, 'Embed should render iframe' ).toHaveAttribute(
-			'title',
-			'Embedded content from twitter.com'
-		);
-	} );
-
-	test( 'should render video embeds with aspect ratio', async ( {
-		editor,
-		embedUtils,
-	} ) => {
-		await embedUtils.interceptRequests( {
-			'https://www.youtube.com/watch?v=lXMskKTw3Bc':
-				MOCK_EMBED_VIDEO_SUCCESS_RESPONSE,
-		} );
-
-		await embedUtils.insertEmbed(
-			'https://www.youtube.com/watch?v=lXMskKTw3Bc'
-		);
-
-		// Verify the embed renders with aspect ratio class.
-		const embedBlock = editor.canvas
-			.getByRole( 'document', { name: 'Block' } )
-			.last();
-		await expect(
-			embedBlock,
-			'Video embed should have aspect ratio class'
-		).toHaveClass( /wp-embed-aspect-16-9/ );
-	} );
-
-	test( 'should add crossorigin attribute to embed iframes', async ( {
-		editor,
-		embedUtils,
-	} ) => {
-		await embedUtils.interceptRequests( {
-			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
-		} );
-
-		await embedUtils.insertEmbed( 'https://twitter.com/notnownikki' );
-
-		const embedBlock = editor.canvas
-			.getByRole( 'document', { name: 'Block' } )
-			.last();
-		const iframe = embedBlock.locator( 'iframe.components-sandbox' );
-
-		await expect(
-			iframe,
-			'Embed iframe should have crossorigin attribute'
-		).toHaveAttribute( 'crossorigin', 'anonymous' );
-	} );
 } );
 
 test.describe( 'Document-Isolation-Policy', () => {
@@ -133,7 +50,7 @@ test.describe( 'Document-Isolation-Policy', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should send Document-Isolation-Policy header instead of COEP/COOP', async ( {
+	test( 'should send Document-Isolation-Policy header', async ( {
 		page,
 	} ) => {
 		// Navigate and capture response headers.
@@ -143,27 +60,6 @@ test.describe( 'Document-Isolation-Policy', () => {
 		expect( headers[ 'document-isolation-policy' ] ).toBe(
 			'isolate-and-credentialless'
 		);
-		expect( headers[ 'cross-origin-embedder-policy' ] ).toBeUndefined();
-		expect( headers[ 'cross-origin-opener-policy' ] ).toBeUndefined();
-	} );
-
-	test( 'should not add credentialless to plugin iframes', async ( {
-		page,
-	} ) => {
-		// Inject a test iframe (simulating a plugin iframe).
-		await page.evaluate( () => {
-			const iframe = document.createElement( 'iframe' );
-			iframe.setAttribute( 'src', 'about:blank' );
-			iframe.setAttribute( 'data-testid', 'plugin-iframe' );
-			document.body.appendChild( iframe );
-		} );
-
-		// Wait for the iframe to be present in DOM.
-		const pluginIframe = page.locator( '[data-testid="plugin-iframe"]' );
-		await pluginIframe.waitFor();
-
-		// The iframe should NOT have the credentialless attribute with DIP.
-		await expect( pluginIframe ).not.toHaveAttribute( 'credentialless' );
 	} );
 
 	test( 'should render all embed previews normally with DIP', async ( {

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -179,6 +179,77 @@ test.describe( 'Cross-origin isolation', () => {
 	} );
 } );
 
+test.describe( 'Document-Isolation-Policy', () => {
+	test.beforeEach( async ( { admin, page } ) => {
+		// These tests only apply to Chrome 137+.
+		const chromeVersion = await page.evaluate( () => {
+			const match = window.navigator.userAgent.match( /Chrome\/(\d+)/ );
+			return match ? parseInt( match[ 1 ], 10 ) : 0;
+		} );
+
+		test.skip(
+			chromeVersion < 137,
+			'Document-Isolation-Policy requires Chrome 137+'
+		);
+
+		await admin.createNewPost();
+	} );
+
+	test( 'should send Document-Isolation-Policy header instead of COEP/COOP', async ( {
+		page,
+	} ) => {
+		// Navigate and capture response headers.
+		const response = await page.goto( page.url() );
+		const headers = response.headers();
+
+		expect( headers[ 'document-isolation-policy' ] ).toBe(
+			'isolate-and-credentialless'
+		);
+		expect( headers[ 'cross-origin-embedder-policy' ] ).toBeUndefined();
+		expect( headers[ 'cross-origin-opener-policy' ] ).toBeUndefined();
+	} );
+
+	test( 'should not add credentialless to plugin iframes', async ( {
+		page,
+	} ) => {
+		// Inject a test iframe (simulating a plugin iframe).
+		await page.evaluate( () => {
+			const iframe = document.createElement( 'iframe' );
+			iframe.setAttribute( 'src', 'about:blank' );
+			iframe.setAttribute( 'data-testid', 'plugin-iframe' );
+			document.body.appendChild( iframe );
+		} );
+
+		// Wait for the iframe to be present in DOM.
+		const pluginIframe = page.locator( '[data-testid="plugin-iframe"]' );
+		await pluginIframe.waitFor();
+
+		// The iframe should NOT have the credentialless attribute with DIP.
+		await expect( pluginIframe ).not.toHaveAttribute( 'credentialless' );
+	} );
+
+	test( 'should render all embed previews normally with DIP', async ( {
+		editor,
+		embedUtils,
+	} ) => {
+		await embedUtils.interceptRequests( {
+			'https://twitter.com/notnownikki': MOCK_EMBED_RICH_SUCCESS_RESPONSE,
+		} );
+
+		await embedUtils.insertEmbed( 'https://twitter.com/notnownikki' );
+
+		// With DIP, the embed should render its preview iframe normally.
+		const embedBlock = editor.canvas
+			.getByRole( 'document', { name: 'Block' } )
+			.last();
+		const iframe = embedBlock.locator( 'iframe' );
+		await expect(
+			iframe,
+			'Embed should render iframe preview with DIP active'
+		).toHaveAttribute( 'title', 'Embedded content from twitter.com' );
+	} );
+} );
+
 class EmbedUtils {
 	/** @type {Page} */
 	#page;

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -5,7 +5,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Unsynced pattern', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation (COEP) prevents page navigations
+		// Cross-origin isolation prevents page navigations
 		// from working properly during pattern editing.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
@@ -600,7 +600,7 @@ test.describe( 'Unsynced pattern', () => {
 
 test.describe( 'Synced pattern', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation (COEP) prevents page navigations
+		// Cross-origin isolation prevents page navigations
 		// from working properly during pattern editing.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -5,8 +5,10 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Unsynced pattern', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation prevents page navigations
-		// from working properly during pattern editing.
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Pattern editing involves page reloads and entity navigation to pages
+		// without the DIP header, creating an agent cluster mismatch that breaks
+		// cross-window communication.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
@@ -600,8 +602,10 @@ test.describe( 'Unsynced pattern', () => {
 
 test.describe( 'Synced pattern', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation prevents page navigations
-		// from working properly during pattern editing.
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Pattern editing involves page reloads and entity navigation to pages
+		// without the DIP header, creating an agent cluster mismatch that breaks
+		// cross-window communication.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -23,6 +23,11 @@ test.use( {
 test.describe( 'Post Editor Template mode', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-templates' );
+		// Cross-origin isolation prevents page navigations
+		// from working properly during template creation.
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
@@ -35,6 +40,9 @@ test.describe( 'Post Editor Template mode', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-templates' );
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
 	} );
 
 	test( 'Allow to switch to template mode, edit the template and check the result', async ( {

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -23,8 +23,10 @@ test.use( {
 test.describe( 'Post Editor Template mode', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-templates' );
-		// Cross-origin isolation prevents page navigations
-		// from working properly during template creation.
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Template creation involves page reload and preview opens frontend
+		// pages without the DIP header, creating an agent cluster mismatch
+		// that breaks cross-window communication.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -23,11 +23,6 @@ test.use( {
 test.describe( 'Post Editor Template mode', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-templates' );
-		// Cross-origin isolation prevents page navigations
-		// from working properly during template creation.
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
@@ -40,9 +35,6 @@ test.describe( 'Post Editor Template mode', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-templates' );
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 	} );
 
 	test( 'Allow to switch to template mode, edit the template and check the result', async ( {

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -23,7 +23,7 @@ test.use( {
 test.describe( 'Post Editor Template mode', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-templates' );
-		// Cross-origin isolation (COEP) prevents page navigations
+		// Cross-origin isolation prevents page navigations
 		// from working properly during template creation.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -11,7 +11,7 @@ test.use( {
 
 test.describe( 'Preview', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation (COOP: same-origin) prevents the editor
+		// Cross-origin isolation prevents the editor
 		// from reusing the preview popup window, breaking preview navigation.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -10,20 +10,6 @@ test.use( {
 } );
 
 test.describe( 'Preview', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		// Cross-origin isolation prevents the editor
-		// from reusing the preview popup window, breaking preview navigation.
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -216,6 +216,10 @@ test.describe( 'Preview', () => {
 
 test.describe( 'Preview with Custom Fields enabled', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Preview opens frontend pages without the DIP header, creating an
+		// agent cluster mismatch that breaks popup reuse and cross-window
+		// communication.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -6,7 +6,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Site editor url navigation', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
-		// Cross-origin isolation (COEP) prevents page navigations
+		// Cross-origin isolation prevents page navigations
 		// from working properly during template creation.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -6,8 +6,10 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Site editor url navigation', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
-		// Cross-origin isolation prevents page navigations
-		// from working properly during template creation.
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Template creation triggers URL/page navigation to pages without the
+		// DIP header, creating an agent cluster mismatch that breaks
+		// cross-window communication.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -14,8 +14,10 @@ test.describe( 'Template Revert', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-		// Cross-origin isolation prevents page navigations
-		// from working properly during template creation.
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Template revert involves visitSiteEditor() page navigations to pages
+		// without the DIP header, creating an agent cluster mismatch that breaks
+		// cross-window communication.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -14,7 +14,7 @@ test.describe( 'Template Revert', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-		// Cross-origin isolation (COEP) prevents page navigations
+		// Cross-origin isolation prevents page navigations
 		// from working properly during template creation.
 		await requestUtils.activatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'


### PR DESCRIPTION
## Summary

Replaces `Cross-Origin-Embedder-Policy` / `Cross-Origin-Opener-Policy` (COEP/COOP) headers with `Document-Isolation-Policy: isolate-and-credentialless` for cross-origin isolation in the block editor.

DIP is a per-document isolation mechanism available in Chromium 137+ that avoids the breakage COEP/COOP caused for third-party plugins whose iframes lost credentials and DOM access.

Note that we have already decided to disable client-side media for non chromium browsers for now. Those users can re-enable (plus add back coep/coop headers) [using a plugin](https://github.com/adamsilverstein/client-side-media-experiments).

### What changed

- **DIP-only isolation**: Cross-origin isolation is now exclusively provided via Document-Isolation-Policy. COEP/COOP headers are no longer sent.
- **Removed credentialless iframe logic**: The `credentialless` attribute on iframes, iframe content observation, and embed preview filtering are all removed — DIP doesn't need them.
- **Removed `__documentIsolationPolicy` JS flag**: No longer needed since there's only one code path.
- **Removed core COEP/COOP hooks**: Gutenberg's `wp_set_up_cross_origin_isolation` hooks are replaced with DIP equivalents.
- **Skips third-party editors**: Cross-origin isolation is skipped when the current screen's editor is not the core block editor.
- **`crossorigin="anonymous"` still added** to subresources via mutation observer.
- **`gutenberg_use_document_isolation_policy` filter** available for customization.

### Browser support

- **Chromium 137+**: Full client-side media processing with DIP
- **Other browsers**: No cross-origin isolation headers sent; client-side media processing disabled. Support for non-DIP browsers will be handled separately in a plugin.

### Key files

- `lib/media/load.php` — Chromium version detection, DIP header, filter
- `packages/block-editor/src/hooks/cross-origin-isolation.js` — Simplified mutation observer (no iframe/credentialless logic)
- `packages/upload-media/src/feature-detection.ts` — Removed credentialless iframe check
- `lib/media/docs/client-side-media-docs.md` — Updated browser matrix

## Test plan

- [ ] Open the block editor in Chromium 137+ — verify `Document-Isolation-Policy: isolate-and-credentialless` response header (no COEP/COOP)
- [ ] Verify `window.crossOriginIsolated === true` in console
- [ ] Upload an image — verify client-side processing works (wasm-vips loads)
- [ ] Add a YouTube embed — verify preview renders without restrictions
- [ ] Open editor in Firefox/Safari — verify no cross-origin isolation headers are sent and client-side media processing is disabled
- [ ] Run unit tests: `npm run test:unit -- --testPathPattern="cross-origin-isolation|feature-detection"`
- [ ] Run E2E tests: `npm run test:e2e -- test/e2e/specs/editor/various/cross-origin-isolation.spec.js`

Trac ticket: https://core.trac.wordpress.org/ticket/64766
Backport PR: https://github.com/WordPress/wordpress-develop/pull/11098