### PR TITLE
Show transform dropdown previews on focus as well as hover (#75940)

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -176,6 +176,8 @@ function BlockTransformationItem( {
 			disabled={ isDisabled }
 			onMouseLeave={ () => setHoveredTransformItemName( null ) }
 			onMouseEnter={ () => setHoveredTransformItemName( name ) }
+			onFocus={ () => setHoveredTransformItemName( name ) }
+			onBlur={ () => setHoveredTransformItemName( null ) }
 		>
 			<BlockIcon icon={ icon } showColors />
 			{ title }

--- a/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
+++ b/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
@@ -100,6 +100,8 @@ function BlockVariationTransformationItem( {
 			} }
 			onMouseLeave={ () => setHoveredTransformItemName( null ) }
 			onMouseEnter={ () => setHoveredTransformItemName( name ) }
+			onFocus={ () => setHoveredTransformItemName( name ) }
+			onBlur={ () => setHoveredTransformItemName( null ) }
 		>
 			<BlockIcon icon={ icon } showColors />
 			{ title }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Cherry-pick of #75940 onto the release branch.

The conflict was in `packages/block-editor/src/components/block-styles/menu-items.js`, because the release branch doesn't have the previews there that were added in #75889. I just left them out for now, if we later decide to include #75889
 in 7.0 I can add the fix there manually.
