### PR TITLE
Pattern Editing: Fix sibling blocks to edited pattern not being disabled

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2636,7 +2636,7 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 		}
 
 		if ( syncedPatternClientIds.length ) {
-			// Check whether this block is a synced pattern block (core/block).
+			// Synced pattern blocks (core/block).
 			if ( syncedPatternClientIds.includes( clientId ) ) {
 				// This is a synced pattern nested in another synced pattern,
 				// disable the core/block itself.
@@ -2662,6 +2662,8 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 				syncedPatternClientIds
 			);
 			if ( parentSyncedPatternClientId ) {
+				// This is an inner block of a synced pattern that's nested in another synced pattern,
+				// disable its contents.
 				if (
 					findParentInClientIdsList(
 						state,
@@ -2669,8 +2671,6 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 						syncedPatternClientIds
 					)
 				) {
-					// This is an inner block of a synced pattern that's nested in another synced pattern,
-					// disable its contents.
 					derivedBlockEditingModes.set( clientId, 'disabled' );
 					return;
 				}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2559,6 +2559,25 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
 
+		const hasEditedContentOnlySection = !! state.editedContentOnlySection;
+		let isWithinEditedContentOnlySection = false;
+		if ( hasEditedContentOnlySection ) {
+			isWithinEditedContentOnlySection =
+				clientId === state.editedContentOnlySection ||
+				!! findParentInClientIdsList( state, clientId, [
+					state.editedContentOnlySection,
+				] );
+
+			// When a contentOnly section is being edited, all blocks outside
+			// the section are disabled. This should never be overridable by any
+			// other block editing modes, it helps to constrain keyboard navigation
+			// to within the edited section.
+			if ( ! isWithinEditedContentOnlySection ) {
+				derivedBlockEditingModes.set( clientId, 'disabled' );
+				return;
+			}
+		}
+
 		// If the block already has an explicit block editing mode set,
 		// don't override it.
 		if ( state.blockEditingModes.has( clientId ) ) {
@@ -2617,7 +2636,7 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 		}
 
 		if ( syncedPatternClientIds.length ) {
-			// Synced pattern blocks (core/block).
+			// Check whether this block is a synced pattern block (core/block).
 			if ( syncedPatternClientIds.includes( clientId ) ) {
 				// This is a synced pattern nested in another synced pattern,
 				// disable the core/block itself.
@@ -2643,8 +2662,6 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 				syncedPatternClientIds
 			);
 			if ( parentSyncedPatternClientId ) {
-				// This is an inner block of a synced pattern that's nested in another synced pattern,
-				// disable its contents.
 				if (
 					findParentInClientIdsList(
 						state,
@@ -2652,6 +2669,8 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 						syncedPatternClientIds
 					)
 				) {
+					// This is an inner block of a synced pattern that's nested in another synced pattern,
+					// disable its contents.
 					derivedBlockEditingModes.set( clientId, 'disabled' );
 					return;
 				}
@@ -2670,26 +2689,10 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 		}
 
 		// Set the edited section and all blocks within it to 'default', so that all changes can be made.
-		if ( state.editedContentOnlySection ) {
-			// If this is the edited section, use the default mode.
-			if ( state.editedContentOnlySection === clientId ) {
-				derivedBlockEditingModes.set( clientId, 'default' );
-				return;
-			}
-
-			// If the block is within the edited section also use the default mode.
-			const parentTempEditedClientId = findParentInClientIdsList(
-				state,
-				clientId,
-				[ state.editedContentOnlySection ]
-			);
-			if ( parentTempEditedClientId ) {
-				derivedBlockEditingModes.set( clientId, 'default' );
-				return;
-			}
-
-			// Disable blocks that are outside of the edited section.
-			derivedBlockEditingModes.set( clientId, 'disabled' );
+		if ( hasEditedContentOnlySection && isWithinEditedContentOnlySection ) {
+			derivedBlockEditingModes.set( clientId, 'default' );
+			// When there's an editedContentOnlySection, it overrides any modes that are usually
+			// set for `contentOnlyParents`, return early to prevent continuing to code below.
 			return;
 		}
 


### PR DESCRIPTION
## What?
I've noticed a bug I introduced in #75818. If a user inserts a synced pattern and an unsynced one as siblings, then proceeds to click 'Edit pattern' on the unsynced pattern, the Synced Pattern is still visible in List View and navigable to using the keyboard.

This is an inconsistency as all other blocks are usually hidden and disabled.

## Why?
In #75818 I lowered the precedence of the block editing modes for `editedContentOnlySection` so that synced patterns can override it, but I've quickly realized this is the wrong move.

## How?
The right balance is instead to keep the code that disables blocks outside the `editedContentOnlySection` at a very high precedence (it overrides all other block editing modes).

The code that sets the `default` mode for blocks inside `editedContentOnlySection` should still have the lowered precedence from #75818 to ensure synced patterns nested in an unsynced pattern have the right block editing modes.

## Testing Instructions
1. Create a new post
2. Insert an unsynced pattern and then a synced pattern after it
3. Open the main List View sidebar
4. With the unsynced pattern selected, click 'Edit pattern' from the toolbar

Expected: keyboard block navigation is constrained to the unsynced pattern, the synced pattern is not present in List View
In trunk: keyboard block navigation can escape the unsynced pattern, the synced pattern is present in List View

## Screenshots or screencast <!-- if applicable -->

#### Before

https://github.com/user-attachments/assets/8f1641ff-6f61-42bb-a418-63e5a200dd0c

#### After

https://github.com/user-attachments/assets/ab9eb49f-2fec-4e6d-aa22-031695f58869

