### PR TITLE
Connectors: Avoid manual string concatenation

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -11,8 +11,8 @@ import {
 	Button,
 	TextControl,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -93,27 +93,43 @@ export function DefaultConnectorSettings( {
 
 	const helpLinkLabel = helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
 
-	const helpLink = helpUrl ? (
-		<>
-			{ __( 'Get your API key at' ) }{ ' ' }
-			<ExternalLink href={ helpUrl }>{ helpLinkLabel }</ExternalLink>
-		</>
-	) : undefined;
-
-	const getHelp = () => {
-		if ( readOnly ) {
-			return (
-				<>
-					{ __(
-						'Your API key is stored securely. You can reset it at'
-					) }{ ' ' }
-					{ helpUrl ? (
+	const helpLink = helpUrl
+		? createInterpolateElement(
+				sprintf(
+					/* translators: %s: Link to provider settings. */
+					__( 'Get your API key at %s' ),
+					'<a></a>'
+				),
+				{
+					a: (
 						<ExternalLink href={ helpUrl }>
 							{ helpLinkLabel }
 						</ExternalLink>
-					) : undefined }
-				</>
-			);
+					),
+				}
+		  )
+		: undefined;
+
+	const getHelp = () => {
+		if ( readOnly ) {
+			return helpUrl
+				? createInterpolateElement(
+						sprintf(
+							/* translators: %s: Link to provider settings. */
+							__(
+								'Your API key is stored securely. You can reset it at %s'
+							),
+							'<a></a>'
+						),
+						{
+							a: (
+								<ExternalLink href={ helpUrl }>
+									{ helpLinkLabel }
+								</ExternalLink>
+							),
+						}
+				  )
+				: __( 'Your API key is stored securely.' );
 		}
 		if ( saveError ) {
 			return <span style={ { color: '#cc1818' } }>{ saveError }</span>;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Joining strings with spaces is not recommended from an a18n perspective, because the order of nouns, verbs, objects, etc., changes depending on the locale. This PR uses createInterpolateElement to ensure the text is localized correctly.

## Testing Instructions

There are no visual changes.

## Screenshots or screencast <!-- if applicable -->

<img width="848" height="559" alt="connector" src="https://github.com/user-attachments/assets/328e4c4d-fce3-4b48-8a16-9c5d59f6a9a4" />
