### PR TITLE
DataViews: Fix focus transfer while searching in `list` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)
+- DataViews: Fix focus transfer while searching in `list` layout. [#75999](https://github.com/WordPress/gutenberg/pull/75999)
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Avoid flickering while refreshing. [#74572](https://github.com/WordPress/gutenberg/pull/74572)
 - DataViews: Fix spacing in first column. [#75693](https://github.com/WordPress/gutenberg/pull/75693)

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -427,6 +427,8 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		string | null | undefined
 	>( undefined );
 
+	const compositeRef = useRef< HTMLDivElement >( null );
+
 	// Update the active composite item when the selected item changes.
 	useEffect( () => {
 		if ( selectedItem ) {
@@ -465,7 +467,13 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 			const targetCompositeItemId = generateCompositeId( itemIdPrefix );
 
 			setActiveCompositeId( targetCompositeItemId );
-			document.getElementById( targetCompositeItemId )?.focus();
+			if (
+				compositeRef.current?.contains(
+					compositeRef.current.ownerDocument.activeElement
+				)
+			) {
+				document.getElementById( targetCompositeItemId )?.focus();
+			}
 		},
 		[ data, generateCompositeItemIdPrefix ]
 	);
@@ -536,6 +544,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	if ( hasData && groupField && dataByGroup ) {
 		return (
 			<Composite
+				ref={ compositeRef }
 				id={ `${ baseId }` }
 				render={ <div /> }
 				className="dataviews-view-list__group"
@@ -601,6 +610,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	return (
 		<>
 			<Composite
+				ref={ compositeRef }
 				id={ baseId }
 				render={ <div /> }
 				className={ clsx( 'dataviews-view-list', className, {

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -467,6 +467,10 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 			const targetCompositeItemId = generateCompositeId( itemIdPrefix );
 
 			setActiveCompositeId( targetCompositeItemId );
+			// The active composite item is controlled state that
+			// can update without needing a focus move (e.g., searching
+			// can trigger an active ID update). Only move DOM focus
+			// when it's already within the list.
 			if (
 				compositeRef.current?.contains(
 					compositeRef.current.ownerDocument.activeElement

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -157,6 +157,34 @@ test.describe( 'Dataviews List Layout', () => {
 		await expect( page.getByLabel( 'Privacy Policy' ) ).toBeFocused();
 	} );
 
+	test( 'Search input retains focus while typing', async ( { page } ) => {
+		const searchBox = page.getByRole( 'searchbox', { name: 'Search' } );
+		const grid = page.getByRole( 'grid' );
+
+		// Wait for Ariakit to auto-activate the first composite item.
+		await expect( grid.locator( '[data-active-item]' ) ).toBeVisible();
+
+		// Determine which item is active so we can search for the other one,
+		// forcing the active item to be filtered out of the list.
+		const activeRow = grid.locator(
+			'[role="row"]:has([data-active-item])'
+		);
+		const activeRowText = await activeRow.textContent();
+		const searchTerm = activeRowText.includes( 'Privacy' )
+			? 'Sample'
+			: 'Privacy';
+
+		// Type a query that filters out the auto-activated item.
+		await searchBox.click();
+		await searchBox.fill( searchTerm );
+
+		// Wait for the debounced search to filter the list.
+		await expect( grid.getByRole( 'row' ) ).toHaveCount( 1 );
+
+		// Focus should still be on the search input, not stolen by the list.
+		await expect( searchBox ).toBeFocused();
+	} );
+
 	test( 'Navigates the list via UP/DOWN arrow keys from action buttons', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/67758

Alternative of: https://github.com/WordPress/gutenberg/pull/71810

In `list` layout of DataViews sometimes there is a focus transfer while searching. The issue cannot be reproduced consistently in 'real' usage because of racing conditions between Ariakit's removal/set of active composite item and our own updating of that. I've added an e2e test for that.

The main issue was setting focus to the active list item unconditionally when selecting a new active composite item. That was problematic because while it's fine to keep setting the active item id to a new item if the previous active item was removed from the list, but focus should only update if our above programmatic selection came from within the composite itself (keyboard navigation, etc..).

## Testing Instructions

Results might be inconsistent, but I could reproduce 'reliably' if I typed fast :)
1. In site editor go to `pages` page in list layout
2. wait a bit for Ariakit to set the active item (first of the list)
3. type 'fast' something that would exclude the first item of the list (previous active item)
4. focus should be preserved in search input.


### Before

https://github.com/user-attachments/assets/d0ebc6e4-c7d8-4d50-9356-b963abde8e78




### After


https://github.com/user-attachments/assets/1fd59330-d5d5-4fe9-898f-506323b76aa8




