### PR TITLE
Social Links: Add default block and direct insert

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -111,6 +111,8 @@ export function SocialLinksEdit( props ) {
 
 	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		defaultBlock: { name: 'core/social-link' },
+		directInsert: true,
 		templateLock: false,
 		orientation: attributes.layout?.orientation ?? 'horizontal',
 		__experimentalAppenderTagName: 'li',


### PR DESCRIPTION
## What?

Configure the social links block to directly insert a `core/social-link` block when the appender is clicked, eliminating an extra step and improving the user experience.

## Why?

When adding social links to the block, users previously had to interact with the block inserter to select which type of block to insert. Since this block only accepts social-link children, we can streamline the experience by directly inserting them without requiring an extra selection step.

## How?

Added `defaultBlock: { name: 'core/social-link' }` and `directInsert: true` properties to the `useInnerBlocksProps` configuration in the social links edit component.

## Testing Instructions

1. Create or edit a post/page
2. Insert a "Social Links" block
3. Click the "+" button to add a link
4. Verify that a social-link block is inserted directly without showing the block inserter

### Testing Instructions for Keyboard

1. Insert a "Social Links" block
2. Tab to the "+" button
3. Press Enter to activate the button
4. Verify a social-link block is inserted directly