### PR TITLE
Cover Block: Add a playlist parameter to loop YouTube background videos.

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -66,6 +66,11 @@ function render_block_core_cover( $attributes, $content ) {
 						$query_params['controls']       = '0';
 						$query_params['modestbranding'] = '1';
 						$query_params['playsinline']    = '1';
+
+						$path                           = $parsed_url['path'] ?? '';
+						$path_segments                  = explode('/', $path);
+						$video_id                       = end($path_segments);
+						$query_params['playlist']       = $video_id;
 					} elseif ( 'vimeo' === $provider ) {
 						$query_params['autoplay']    = '1';
 						$query_params['muted']       = '1';

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -67,10 +67,13 @@ function render_block_core_cover( $attributes, $content ) {
 						$query_params['modestbranding'] = '1';
 						$query_params['playsinline']    = '1';
 
-						$path                     = $parsed_url['path'] ?? '';
-						$path_segments            = explode( '/', $path );
-						$video_id                 = end( $path_segments );
-						$query_params['playlist'] = $video_id;
+						// For loop to work, we need the playlist parameter.
+						$path          = $parsed_url['path'] ?? '';
+						$path_segments = explode( '/', $path );
+						$video_id      = end( $path_segments );
+						if ( $video_id ) {
+								$query_params['playlist'] = $video_id;
+						}
 					} elseif ( 'vimeo' === $provider ) {
 						$query_params['autoplay']    = '1';
 						$query_params['muted']       = '1';

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -67,10 +67,10 @@ function render_block_core_cover( $attributes, $content ) {
 						$query_params['modestbranding'] = '1';
 						$query_params['playsinline']    = '1';
 
-						$path                           = $parsed_url['path'] ?? '';
-						$path_segments                  = explode('/', $path);
-						$video_id                       = end($path_segments);
-						$query_params['playlist']       = $video_id;
+						$path                     = $parsed_url['path'] ?? '';
+						$path_segments            = explode('/', $path);
+						$video_id                 = end($path_segments);
+						$query_params['playlist'] = $video_id;
 					} elseif ( 'vimeo' === $provider ) {
 						$query_params['autoplay']    = '1';
 						$query_params['muted']       = '1';

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -68,8 +68,8 @@ function render_block_core_cover( $attributes, $content ) {
 						$query_params['playsinline']    = '1';
 
 						$path                     = $parsed_url['path'] ?? '';
-						$path_segments            = explode('/', $path);
-						$video_id                 = end($path_segments);
+						$path_segments            = explode( '/', $path );
+						$video_id                 = end( $path_segments );
 						$query_params['playlist'] = $video_id;
 					} elseif ( 'vimeo' === $provider ) {
 						$query_params['autoplay']    = '1';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
When a YouTube video was set as the background for the Cover Block, it did not loop because the playlist parameter was not set on the frontend.

Since `loop=1` is already set, we will now set the `playlist` parameter to the video ID to enable looping.

reference :https://developers.google.com/youtube/player_parameters?#Parameters


The editor already implements this.  
https://github.com/WordPress/gutenberg/blob/41db31e3498e47ea723fac888b53247a6f0158f1/packages/block-library/src/cover/embed-video-utils.js#L159-L164

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Cover block.
3. Set Embed video from URL
4. You will see that it plays on a loop.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/6d10c013-540e-4118-94f2-b69e3c2eaff0


### After

https://github.com/user-attachments/assets/4c0ea143-e9e4-4658-9d77-6387ef632ef9



This screencast is playing the following video:
https://youtu.be/FcTLMTyD2DU?si=7uvSGji8uRPKh1Ur
The video is 1 minute 15 seconds long, so feel free to skip ahead if needed.