### PR TITLE
Add `Link` primitive to `@wordpress/ui`

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 -   Add `Card` and `CollapsibleCard` primitives ([#76252](https://github.com/WordPress/gutenberg/pull/76252)).
--   Add `Link` primitive with `brand` and `neutral` tone variants and an `unstyled` variant for custom styling.
+-   Add `Link` primitive ([#76013](https://github.com/WordPress/gutenberg/pull/76013)).
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### New Features
 
 -   Add `Notice` primitive ([#75981](https://github.com/WordPress/gutenberg/pull/75981)).
+-   Add `Link` primitive with `brand` and `neutral` tone variants and an `unstyled` variant for custom styling.
 
 ### Enhancements
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Add `Text` primitive with predefined typographic variants (`heading-2xl` through `heading-sm`, `body-xl` through `body-sm`) built on design tokens ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 -   Add `Card` and `CollapsibleCard` primitives ([#76252](https://github.com/WordPress/gutenberg/pull/76252)).
+-   Add `Link` primitive with `brand` and `neutral` tone variants and an `unstyled` variant for custom styling.
 
 ### Bug Fixes
 
@@ -25,7 +26,6 @@
 ### New Features
 
 -   Add `Notice` primitive ([#75981](https://github.com/WordPress/gutenberg/pull/75981)).
--   Add `Link` primitive with `brand` and `neutral` tone variants and an `unstyled` variant for custom styling.
 
 ### Enhancements
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,6 +6,7 @@ export * as Dialog from './dialog';
 export * from './form/primitives';
 export * from './icon';
 export * from './icon-button';
+export * from './link';
 export * as Notice from './notice';
 export * from './stack';
 export * as Tabs from './tabs';

--- a/packages/ui/src/link/index.ts
+++ b/packages/ui/src/link/index.ts
@@ -1,0 +1,1 @@
+export { Link } from './link';

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -13,7 +13,6 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 		openInNewTab = false,
 		render,
 		className,
-		rel = '',
 		onClick,
 		target,
 		...props
@@ -21,15 +20,6 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 	ref
 ) {
 	const isInternalAnchor = !! props.href?.startsWith( '#' );
-
-	const relParts = [
-		...rel.split( ' ' ),
-		...( openInNewTab ? [ 'noopener' ] : [] ),
-	];
-	const mergedRel =
-		relParts.filter( Boolean ).length > 0
-			? [ ...new Set( relParts.filter( Boolean ) ) ].join( ' ' )
-			: undefined;
 
 	const handleClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 		if ( openInNewTab && isInternalAnchor ) {
@@ -50,7 +40,6 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 				openInNewTab && styles[ 'has-link-icon' ],
 				className
 			),
-			rel: mergedRel,
 			onClick: handleClick,
 			target: openInNewTab ? '_blank' : target,
 			children: openInNewTab ? (

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { type LinkProps } from './types';
+import resetStyles from '../utils/css/resets.module.css';
+import focusStyles from '../utils/css/focus.module.css';
 import styles from './style.module.css';
 
 export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
@@ -33,6 +35,8 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 		ref,
 		props: mergeProps< 'a' >( props, {
 			className: clsx(
+				resetStyles[ 'box-sizing' ],
+				focusStyles[ 'outset-ring--focus' ],
 				variant !== 'unstyled' && styles.link,
 				variant !== 'unstyled' && styles[ `is-${ tone }` ],
 				variant === 'unstyled' && styles[ 'is-unstyled' ],

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -1,6 +1,7 @@
 import { useRender, mergeProps } from '@base-ui/react';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { type LinkProps } from './types';
 import styles from './style.module.css';
 
@@ -12,10 +13,31 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 		openInNewTab = false,
 		render,
 		className,
+		rel = '',
+		onClick,
+		target,
 		...props
 	},
 	ref
 ) {
+	const isInternalAnchor = !! props.href?.startsWith( '#' );
+
+	const relParts = [
+		...rel.split( ' ' ),
+		...( openInNewTab ? [ 'noopener' ] : [] ),
+	];
+	const mergedRel =
+		relParts.filter( Boolean ).length > 0
+			? [ ...new Set( relParts.filter( Boolean ) ) ].join( ' ' )
+			: undefined;
+
+	const handleClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+		if ( openInNewTab && isInternalAnchor ) {
+			event.preventDefault();
+		}
+		onClick?.( event );
+	};
+
 	const element = useRender( {
 		render,
 		defaultTagName: 'a',
@@ -25,13 +47,28 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 				variant !== 'unstyled' && styles.link,
 				variant !== 'unstyled' && styles[ `is-${ tone }` ],
 				variant === 'unstyled' && styles[ 'is-unstyled' ],
+				openInNewTab && styles[ 'has-link-icon' ],
 				className
 			),
-			children,
-			...( openInNewTab && {
-				target: '_blank',
-				rel: 'noopener',
-			} ),
+			rel: mergedRel,
+			onClick: handleClick,
+			target: openInNewTab ? '_blank' : target,
+			children: openInNewTab ? (
+				<>
+					<span className={ styles[ 'link-contents' ] }>
+						{ children }
+					</span>
+					<span
+						className={ styles[ 'link-icon' ] }
+						aria-label={
+							/* translators: accessibility text appended to link text */
+							__( '(opens in a new tab)' )
+						}
+					/>
+				</>
+			) : (
+				children
+			),
 		} ),
 	} );
 

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -7,6 +7,10 @@ import resetStyles from '../utils/css/resets.module.css';
 import focusStyles from '../utils/css/focus.module.css';
 import styles from './style.module.css';
 
+/**
+ * A styled anchor element with support for semantic color tones and an
+ * unstyled escape hatch.
+ */
 export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 	{
 		children,

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -14,7 +14,6 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 		render,
 		className,
 		onClick,
-		target,
 		...props
 	},
 	ref
@@ -41,7 +40,7 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 				className
 			),
 			onClick: handleClick,
-			target: openInNewTab ? '_blank' : target,
+			target: openInNewTab ? '_blank' : undefined,
 			children: openInNewTab ? (
 				<>
 					<span className={ styles[ 'link-contents' ] }>

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -9,6 +9,7 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 		children,
 		variant = 'default',
 		tone = 'brand',
+		openInNewTab = false,
 		render,
 		className,
 		...props
@@ -27,6 +28,10 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 				className
 			),
 			children,
+			...( openInNewTab && {
+				target: '_blank',
+				rel: 'noopener',
+			} ),
 		} ),
 	} );
 

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -1,0 +1,34 @@
+import { useRender, mergeProps } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { type LinkProps } from './types';
+import styles from './style.module.css';
+
+export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
+	{
+		children,
+		variant = 'default',
+		tone = 'brand',
+		render,
+		className,
+		...props
+	},
+	ref
+) {
+	const element = useRender( {
+		render,
+		defaultTagName: 'a',
+		ref,
+		props: mergeProps< 'a' >( props, {
+			className: clsx(
+				variant !== 'unstyled' && styles.link,
+				variant !== 'unstyled' && styles[ `is-${ tone }` ],
+				variant === 'unstyled' && styles[ 'is-unstyled' ],
+				className
+			),
+			children,
+		} ),
+	} );
+
+	return element;
+} );

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -48,6 +48,7 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 					</span>
 					<span
 						className={ styles[ 'link-icon' ] }
+						role="img"
 						aria-label={
 							/* translators: accessibility text appended to link text */
 							__( '(opens in a new tab)' )

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -56,6 +56,11 @@ export const Inline: Story = {
 	),
 };
 
+/**
+ * When composing `Text` and `Link` via the `render` prop, the order matters:
+ * - `<Text render={ <Link /> } />` renders an `<a>` element (Link's default tag wins).
+ * - `<Link render={ <Text /> } />` renders a `<span>` element (Text's default tag wins).
+ */
 export const Standalone: Story = {
 	render: () => (
 		<Stack direction="column" gap="md">

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -46,11 +46,3 @@ export const AllVariants: Story = {
 		</Stack>
 	),
 };
-
-export const WithRenderProp: Story = {
-	render: () => (
-		<Link href="#" render={ <span /> }>
-			A link rendered as a span
-		</Link>
-	),
-};

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -15,8 +15,6 @@ export const Default: Story = {
 	args: {
 		children: 'Learn more',
 		href: '#',
-		tone: 'brand',
-		openInNewTab: false,
 	},
 };
 

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Link } from '../index';
 import { Stack } from '../../stack';
+import { Text } from '../../text';
 
 const meta: Meta< typeof Link > = {
 	title: 'Design System/Components/Link',
@@ -27,23 +28,45 @@ export const AllVariants: Story = {
 			style={ { color: 'var(--wpds-color-fg-content-neutral)' } }
 		>
 			<Stack direction="column" gap="xs">
-				<span>Brand</span>
+				<Text variant="heading-sm">Brand</Text>
 				<Link href="#" tone="brand">
 					Learn more
 				</Link>
 			</Stack>
 			<Stack direction="column" gap="xs">
-				<span>Neutral</span>
+				<Text variant="heading-sm">Neutral</Text>
 				<Link href="#" tone="neutral">
 					Learn more
 				</Link>
 			</Stack>
 			<Stack direction="column" gap="xs">
-				<span>Unstyled</span>
+				<Text variant="heading-sm">Unstyled</Text>
 				<Link href="#" variant="unstyled">
 					Learn more
 				</Link>
 			</Stack>
+		</Stack>
+	),
+};
+
+export const Inline: Story = {
+	render: () => (
+		<Text variant="body-md" render={ <p /> }>
+			This is a paragraph with an <Link href="#">inline link</Link> that
+			inherits its typography from the parent Text component.
+		</Text>
+	),
+};
+
+export const Standalone: Story = {
+	render: () => (
+		<Stack direction="column" gap="md">
+			<Text variant="body-md" render={ <Link href="#" /> }>
+				A standalone link with body-md typography
+			</Text>
+			<Text variant="body-sm" render={ <Link href="#" tone="neutral" /> }>
+				A standalone link with body-sm typography
+			</Text>
 		</Stack>
 	),
 };

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -18,56 +18,65 @@ export const Default: Story = {
 	},
 };
 
-export const AllVariants: Story = {
-	render: () => (
-		<Stack
-			direction="column"
-			gap="lg"
-			style={ { color: 'var(--wpds-color-fg-content-neutral)' } }
-		>
-			<Stack direction="column" gap="xs">
-				<Text variant="heading-sm">Brand</Text>
-				<Link href="#" tone="brand">
-					Learn more
-				</Link>
-			</Stack>
-			<Stack direction="column" gap="xs">
-				<Text variant="heading-sm">Neutral</Text>
-				<Link href="#" tone="neutral">
-					Learn more
-				</Link>
-			</Stack>
-			<Stack direction="column" gap="xs">
-				<Text variant="heading-sm">Unstyled</Text>
-				<Link href="#" variant="unstyled">
-					Learn more
-				</Link>
-			</Stack>
+export const AllTonesAndVariants: Story = {
+	...Default,
+	argTypes: {
+		tone: {
+			control: false,
+		},
+		variant: {
+			control: false,
+		},
+	},
+	render: ( args ) => (
+		<Stack direction="column" gap="lg">
+			{ ( [ 'brand', 'neutral' ] as const ).map( ( tone ) =>
+				( [ 'default', 'unstyled' ] as const ).map( ( variant ) => (
+					<Stack
+						direction="column"
+						gap="xs"
+						key={ `${ tone }-${ variant }` }
+					>
+						<Text variant="heading-sm">
+							{ tone } tone, { variant } variant
+						</Text>
+						<Link { ...args } tone={ tone } variant={ variant } />
+					</Stack>
+				) )
+			) }
 		</Stack>
 	),
 };
 
 export const Inline: Story = {
-	render: () => (
+	...Default,
+	args: {
+		...Default.args,
+		children: 'inline link',
+	},
+	render: ( args ) => (
 		<Text variant="body-md" render={ <p /> }>
-			This is a paragraph with an <Link href="#">inline link</Link> that
-			inherits its typography from the parent Text component.
+			This is a paragraph with an <Link { ...args } /> that inherits its
+			typography from the parent Text component.
 		</Text>
 	),
 };
 
-/**
- * When composing `Text` and `Link` via the `render` prop, the order matters:
- * - `<Text render={ <Link /> } />` renders an `<a>` element (Link's default tag wins).
- * - `<Link render={ <Text /> } />` renders a `<span>` element (Text's default tag wins).
- */
 export const Standalone: Story = {
-	render: () => (
+	args: {
+		href: '#',
+	},
+	argTypes: {
+		children: {
+			control: false,
+		},
+	},
+	render: ( args ) => (
 		<Stack direction="column" gap="md">
-			<Text variant="body-md" render={ <Link href="#" /> }>
+			<Text variant="body-md" render={ <Link { ...args } /> }>
 				A standalone link with body-md typography
 			</Text>
-			<Text variant="body-sm" render={ <Link href="#" tone="neutral" /> }>
+			<Text variant="body-sm" render={ <Link { ...args } /> }>
 				A standalone link with body-sm typography
 			</Text>
 		</Stack>

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Link } from '../index';
+import { Stack } from '../../stack';
+
+const meta: Meta< typeof Link > = {
+	title: 'Design System/Components/Link',
+	component: Link,
+};
+export default meta;
+
+type Story = StoryObj< typeof Link >;
+
+export const Default: Story = {
+	args: {
+		children: 'Learn more',
+		href: '#',
+		tone: 'brand',
+	},
+};
+
+export const AllVariants: Story = {
+	render: () => (
+		<Stack
+			direction="column"
+			gap="lg"
+			style={ { color: 'var(--wpds-color-fg-content-neutral)' } }
+		>
+			<Stack direction="column" gap="xs">
+				<span>Brand</span>
+				<Link href="#" tone="brand">
+					Learn more
+				</Link>
+			</Stack>
+			<Stack direction="column" gap="xs">
+				<span>Neutral</span>
+				<Link href="#" tone="neutral">
+					Learn more
+				</Link>
+			</Stack>
+			<Stack direction="column" gap="xs">
+				<span>Unstyled</span>
+				<Link href="#" variant="unstyled">
+					Learn more
+				</Link>
+			</Stack>
+		</Stack>
+	),
+};
+
+export const WithRenderProp: Story = {
+	render: () => (
+		<Link href="#" render={ <span /> }>
+			A link rendered as a span
+		</Link>
+	),
+};

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -18,6 +18,9 @@ export const Default: Story = {
 	},
 };
 
+/**
+ * Note: `tone` has no effect on `unstyled` variant
+ */
 export const AllTonesAndVariants: Story = {
 	...Default,
 	argTypes: {

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -62,6 +62,11 @@ export const Inline: Story = {
 	),
 };
 
+/**
+ * When composing `Text` and `Link` via the `render` prop, the order matters:
+ * - `<Text render={ <Link /> } />` renders an `<a>` element (Link's default tag wins).
+ * - `<Link render={ <Text /> } />` renders a `<span>` element (Text's default tag wins).
+ */
 export const Standalone: Story = {
 	args: {
 		href: '#',

--- a/packages/ui/src/link/stories/index.story.tsx
+++ b/packages/ui/src/link/stories/index.story.tsx
@@ -15,6 +15,7 @@ export const Default: Story = {
 		children: 'Learn more',
 		href: '#',
 		tone: 'brand',
+		openInNewTab: false,
 	},
 };
 

--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -50,7 +50,6 @@
 	.link-contents {
 		text-decoration: underline;
 		text-decoration-color: inherit;
-		text-underline-offset: 0.2em;
 		text-decoration-thickness: 0.5px;
 	}
 

--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -1,0 +1,37 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+@layer wp-ui-components {
+	.link {
+		text-underline-offset: 0.2em;
+		text-decoration-thickness: 0.5px;
+	}
+
+	/* Brand tone */
+	.is-brand,
+	.is-brand:visited {
+		color: var(--wpds-color-fg-interactive-brand);
+	}
+
+	.is-brand:hover,
+	.is-brand:active {
+		color: var(--wpds-color-fg-interactive-brand-active);
+	}
+
+	/* Neutral tone */
+	.is-neutral,
+	.is-neutral:visited {
+		color: var(--wpds-color-fg-interactive-neutral);
+		text-decoration-color: var(--wpds-color-stroke-interactive-neutral);
+	}
+
+	.is-neutral:hover,
+	.is-neutral:active {
+		color: var(--wpds-color-fg-interactive-neutral-active);
+	}
+
+	/* Unstyled variant */
+	.is-unstyled {
+		color: inherit;
+		text-decoration: none;
+	}
+}

--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -34,4 +34,36 @@
 		color: inherit;
 		text-decoration: none;
 	}
+
+	/* Link icon pattern — arrow rendered via ::after pseudo-element to avoid
+	 * Twemoji replacement and text-selection issues. Root <a> gets
+	 * text-decoration:none; the link-contents span re-applies it.
+	 * text-underline-offset and text-decoration-thickness are inherited
+	 * properties and propagate from .link on the root to .link-contents
+	 * automatically. text-decoration-color is NOT inherited, so
+	 * text-decoration-color:inherit on .link-contents carries the neutral
+	 * tone's custom color token through. */
+	.has-link-icon {
+		text-decoration: none;
+	}
+
+	.link-contents {
+		text-decoration: underline;
+		text-decoration-color: inherit;
+		text-underline-offset: 0.2em;
+		text-decoration-thickness: 0.5px;
+	}
+
+	.link-icon {
+		margin-inline-start: var(--wpds-dimension-padding-xs);
+		font-weight: var(--wpds-font-weight-regular);
+	}
+
+	.link-icon::after {
+		content: "\2197";
+	}
+
+	.link-icon:dir(rtl)::after {
+		content: "\2196";
+	}
 }

--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -38,11 +38,11 @@
 	/* Link icon pattern — arrow rendered via ::after pseudo-element to avoid
 	 * Twemoji replacement and text-selection issues. Root <a> gets
 	 * text-decoration:none; the link-contents span re-applies it.
-	 * text-underline-offset and text-decoration-thickness are inherited
-	 * properties and propagate from .link on the root to .link-contents
-	 * automatically. text-decoration-color is NOT inherited, so
-	 * text-decoration-color:inherit on .link-contents carries the neutral
-	 * tone's custom color token through. */
+	 * text-underline-offset is inherited and propagates from .link
+	 * automatically. text-decoration-thickness and text-decoration-color
+	 * are NOT inherited, so they are explicitly redeclared on
+	 * .link-contents (the latter via `inherit` to carry the neutral
+	 * tone's custom color token through). */
 	.has-link-icon {
 		text-decoration: none;
 	}

--- a/packages/ui/src/link/test/index.test.tsx
+++ b/packages/ui/src/link/test/index.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from '@wordpress/element';
+import { Link } from '../index';
+
+describe( 'Link', () => {
+	it( 'forwards ref', () => {
+		const ref = createRef< HTMLAnchorElement >();
+
+		render(
+			<Link ref={ ref } href="/">
+				Home
+			</Link>
+		);
+
+		expect( ref.current ).toBeInstanceOf( HTMLAnchorElement );
+	} );
+
+	describe( 'openInNewTab', () => {
+		it( 'sets target="_blank" when true', () => {
+			render(
+				<Link href="https://example.com" openInNewTab>
+					External
+				</Link>
+			);
+
+			expect( screen.getByRole( 'link' ) ).toHaveAttribute(
+				'target',
+				'_blank'
+			);
+		} );
+
+		it( 'does not set target="_blank" when false', () => {
+			render( <Link href="https://example.com">External</Link> );
+
+			expect( screen.getByRole( 'link' ) ).not.toHaveAttribute(
+				'target'
+			);
+		} );
+
+		it( 'renders an accessible arrow indicator', () => {
+			render(
+				<Link href="https://example.com" openInNewTab>
+					External
+				</Link>
+			);
+
+			expect(
+				screen.getByLabelText( '(opens in a new tab)' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'prevents default for internal anchor links', async () => {
+			const user = userEvent.setup();
+			const onClick = jest.fn();
+
+			render(
+				<Link href="#section" openInNewTab onClick={ onClick }>
+					Jump
+				</Link>
+			);
+
+			await user.click( screen.getByRole( 'link' ) );
+
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
+			expect( onClick.mock.calls[ 0 ][ 0 ].defaultPrevented ).toBe(
+				true
+			);
+		} );
+
+		it( 'does not prevent default for external links', async () => {
+			const user = userEvent.setup();
+			const onClick = jest.fn();
+
+			render(
+				<Link
+					href="https://example.com"
+					openInNewTab
+					onClick={ onClick }
+				>
+					External
+				</Link>
+			);
+
+			await user.click( screen.getByRole( 'link' ) );
+
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
+			expect( onClick.mock.calls[ 0 ][ 0 ].defaultPrevented ).toBe(
+				false
+			);
+		} );
+	} );
+} );

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -26,6 +26,14 @@ export interface LinkProps extends Omit< ComponentProps< 'a' >, 'href' > {
 	tone?: 'brand' | 'neutral';
 
 	/**
+	 * Whether to open the link in a new browser tab.
+	 * When true, sets `target="_blank"` and `rel="noopener"`.
+	 *
+	 * @default false
+	 */
+	openInNewTab?: boolean;
+
+	/**
 	 * The content to be rendered inside the component.
 	 */
 	children?: ReactNode;

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -1,7 +1,8 @@
 import { type ReactNode } from 'react';
 import { type ComponentProps } from '../utils/types';
 
-export interface LinkProps extends Omit< ComponentProps< 'a' >, 'href' > {
+export interface LinkProps
+	extends Omit< ComponentProps< 'a' >, 'href' | 'target' > {
 	/**
 	 * The URL to navigate to when the link is clicked.
 	 */

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -1,0 +1,32 @@
+import { type ReactNode } from 'react';
+import { type ComponentProps } from '../utils/types';
+
+export interface LinkProps extends Omit< ComponentProps< 'a' >, 'href' > {
+	/**
+	 * The URL to navigate to when the link is clicked.
+	 */
+	href?: string;
+
+	/**
+	 * The visual treatment of the link.
+	 *
+	 * - `default`: Applies tone-based color and underline styles.
+	 * - `unstyled`: Strips all visual styles so consumers can bring their own.
+	 *
+	 * @default "default"
+	 */
+	variant?: 'default' | 'unstyled';
+
+	/**
+	 * The tone of the link. Tone describes a semantic color intent.
+	 * Only applies when `variant` is `default`.
+	 *
+	 * @default "brand"
+	 */
+	tone?: 'brand' | 'neutral';
+
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -2,11 +2,7 @@ import { type ReactNode } from 'react';
 import { type ComponentProps } from '../utils/types';
 
 export interface LinkProps
-	extends Omit< ComponentProps< 'a' >, 'href' | 'target' > {
-	/**
-	 * The URL to navigate to when the link is clicked.
-	 */
-	href?: string;
+	extends Omit< ComponentProps< 'a' >,  'target' > {
 
 	/**
 	 * The visual treatment of the link.

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -27,9 +27,8 @@ export interface LinkProps extends Omit< ComponentProps< 'a' >, 'href' > {
 
 	/**
 	 * Whether to open the link in a new browser tab.
-	 * When true, sets `target="_blank"`, merges `noopener` into the `rel`
-	 * attribute, appends a visual arrow indicator, and prevents navigation
-	 * for internal anchors (`#`-prefixed hrefs).
+	 * When true, sets `target="_blank"`, appends a visual arrow indicator,
+	 * and prevents navigation for internal anchors (`#`-prefixed hrefs).
 	 *
 	 * @default false
 	 */

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -1,9 +1,7 @@
 import { type ReactNode } from 'react';
 import { type ComponentProps } from '../utils/types';
 
-export interface LinkProps
-	extends Omit< ComponentProps< 'a' >,  'target' > {
-
+export interface LinkProps extends Omit< ComponentProps< 'a' >, 'target' > {
 	/**
 	 * The visual treatment of the link.
 	 *

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -27,7 +27,9 @@ export interface LinkProps extends Omit< ComponentProps< 'a' >, 'href' > {
 
 	/**
 	 * Whether to open the link in a new browser tab.
-	 * When true, sets `target="_blank"` and `rel="noopener"`.
+	 * When true, sets `target="_blank"`, merges `noopener` into the `rel`
+	 * attribute, appends a visual arrow indicator, and prevents navigation
+	 * for internal anchors (`#`-prefixed hrefs).
 	 *
 	 * @default false
 	 */

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -1,5 +1,5 @@
-import { forwardRef } from '@wordpress/element';
 import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
 import { Link } from '../link';
 import type { ActionLinkProps } from './types';
 import styles from './style.module.css';

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -12,9 +12,10 @@ export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
 		return (
 			<Link
 				ref={ ref }
-				tone="neutral"
 				className={ clsx( styles[ 'action-link' ], className ) }
 				{ ...props }
+				tone="neutral"
+				variant="default"
 			/>
 		);
 	}

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -14,12 +14,7 @@ export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
 				ref={ ref }
 				tone="neutral"
 				className={ clsx( styles[ 'action-link' ], className ) }
-				ref={ ref }
 				{ ...props }
-				tone="neutral"
-				variant="default"
-				className={ clsx( styles[ 'action-link' ], className ) }
-
 			/>
 		);
 	}

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -14,7 +14,12 @@ export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
 				ref={ ref }
 				tone="neutral"
 				className={ clsx( styles[ 'action-link' ], className ) }
+				ref={ ref }
 				{ ...props }
+				tone="neutral"
+				variant="default"
+				className={ clsx( styles[ 'action-link' ], className ) }
+
 			/>
 		);
 	}

--- a/packages/ui/src/notice/action-link.tsx
+++ b/packages/ui/src/notice/action-link.tsx
@@ -1,28 +1,21 @@
 import { forwardRef } from '@wordpress/element';
-import { useRender, mergeProps } from '@base-ui/react';
 import clsx from 'clsx';
+import { Link } from '../link';
 import type { ActionLinkProps } from './types';
 import styles from './style.module.css';
 
 /**
  * An action link for use within Notice.Actions.
- *
- * TODO: This should use a shared Link component.
  */
 export const ActionLink = forwardRef< HTMLAnchorElement, ActionLinkProps >(
-	function NoticeActionLink( { className, render, ...props }, ref ) {
-		const element = useRender( {
-			defaultTagName: 'a',
-			render,
-			ref,
-			props: mergeProps< 'a' >(
-				{
-					className: clsx( styles[ 'action-link' ], className ),
-				},
-				props
-			),
-		} );
-
-		return element;
+	function NoticeActionLink( { className, ...props }, ref ) {
+		return (
+			<Link
+				ref={ ref }
+				tone="neutral"
+				className={ clsx( styles[ 'action-link' ], className ) }
+				{ ...props }
+			/>
+		);
 	}
 );

--- a/packages/ui/src/notice/style.module.css
+++ b/packages/ui/src/notice/style.module.css
@@ -69,20 +69,6 @@
 		font-weight: var(--wpds-font-weight-regular);
 		line-height: var(--wpds-font-line-height-sm);
 		margin-block: auto;
-		text-underline-offset: 0.2em;
-		text-decoration-thickness: 0.5px;
-		color: var(--wpds-color-fg-interactive-neutral);
-		text-decoration-color: var(--wpds-color-stroke-interactive-neutral);
-
-		&:visited {
-			color: var(--wpds-color-fg-interactive-neutral);
-			text-decoration-color: var(--wpds-color-stroke-interactive-neutral);
-		}
-
-		&:hover,
-		&:active {
-			color: var(--wpds-color-fg-interactive-neutral-active);
-		}
 
 		/* Add more horizontal space when following another action link/button */
 		&:not(:first-child) {

--- a/packages/ui/src/notice/types.ts
+++ b/packages/ui/src/notice/types.ts
@@ -3,6 +3,7 @@ import type { ComponentProps } from '../utils/types';
 import type { IconProps } from '../icon/types';
 import type { ButtonProps } from '../button/types';
 import type { IconButtonProps } from '../icon-button/types';
+import type { LinkProps } from '../link/types';
 
 export type NoticeIntent = 'warning' | 'success' | 'error' | 'info' | 'neutral';
 
@@ -92,7 +93,7 @@ export interface ActionButtonProps
 	children?: ReactNode;
 }
 
-export interface ActionLinkProps extends ComponentProps< 'a' > {
+export interface ActionLinkProps extends Omit< LinkProps, 'variant' | 'tone' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */


### PR DESCRIPTION
## What

Adds a `Link` component to the `@wordpress/ui` package: a styled anchor element with support for semantic color tones and an unstyled escape hatch.

### Props

Here's the updated Props section:

- `variant` (`'default' | 'unstyled'`) -- Controls visual treatment. `unstyled` strips all styles so consumers can bring their own.
- `tone` (`'brand' | 'neutral'`) -- Semantic color intent. Only applies when `variant` is `default`.
- `href` -- URL target.
- `openInNewTab` (`boolean`) -- When true, opens the link in a new tab, merges `noopener` into the `rel` attribute, appends a visual arrow indicator (with RTL support), and prevents navigation for internal anchors.
- Standard anchor element props (`target`, `rel`, etc.).

## Why

Upcoming UI surfaces and components need link elements that are consistent with the design system. A primitive `Link` component provides this foundation, using the same design tokens and patterns as `Button` and other `@wordpress/ui` components.

## How

Follows the established component patterns in `@wordpress/ui`:
- Built with `useRender` / `mergeProps` from `@base-ui/react` and `forwardRef` from `@wordpress/element`.
- CSS modules with cascade layers (`wp-ui-components`) and `--wpds-*` design tokens for colors.
- The `unstyled` variant conditionally excludes the base `.link` class, matching the same pattern used by `Button`.

## Notes for review

- **`render` prop**: The component inherits a `render` prop from the shared `ComponentProps<'a'>` type, which allows rendering as any element. This is arguably too broad for a Link. The main legitimate use case would appear to be framework router links (e.g., React Router, Next.js), which still render `<a>` under the hood. Worth discussing whether to keep, restrict, or remove.
- **Hardcoded style values**: `text-underline-offset: 0.2em` and `text-decoration-thickness: 0.5px` are hardcoded because there are no compatible design tokens for these properties yet. Since spacing tokens are `px` based it will be tricky to tokenify the offset in a way that accounts for different font sizes. The underline isn't technically a stroke, so I'm not sure we need a token for this.

## Testing Instructions

1. `npm start`
2. Open Storybook
3. Navigate to **Design System / Components / Link**
4. Verify the **Default** story renders a brand-toned link
5. Verify the **AllVariants** story shows brand, neutral, and unstyled variants

## Next steps

- [ ] consider a `--wpds-border-width-2xs` DS token ([convo](https://github.com/WordPress/gutenberg/pull/76013#discussion_r2911594279))

