### PR TITLE
Connectors: Dynamically register providers from WP AI Client registry

### DIFF
--- a/backport-changelog/7.0/11080.md
+++ b/backport-changelog/7.0/11080.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11080
+
+* https://github.com/WordPress/gutenberg/pull/76014

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -91,6 +91,7 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *         @type string      $name                  The provider's display name.
  *         @type string      $description           The provider's description.
  *         @type string|null $credentials_url       URL where users can obtain API credentials.
+ *         @type string      $type                  The connector type: 'ai_provider'.
  *         @type string      $authentication_method The authentication method: 'api_key' or 'none'.
  *         @type array       $settings              {
  *             Settings keyed by setting name.
@@ -112,18 +113,21 @@ function _gutenberg_get_provider_settings(): array {
 			'name'                  => 'Gemini',
 			'description'           => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
 			'credentials_url'       => 'https://aistudio.google.com/api-keys',
+			'type'                  => 'ai_provider',
 			'authentication_method' => 'api_key',
 		),
 		'openai'    => array(
 			'name'                  => 'OpenAI',
 			'description'           => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
 			'credentials_url'       => 'https://platform.openai.com/api-keys',
+			'type'                  => 'ai_provider',
 			'authentication_method' => 'api_key',
 		),
 		'anthropic' => array(
 			'name'                  => 'Claude',
 			'description'           => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
 			'credentials_url'       => 'https://platform.claude.com/settings/keys',
+			'type'                  => 'ai_provider',
 			'authentication_method' => 'api_key',
 		),
 	);
@@ -155,6 +159,7 @@ function _gutenberg_get_provider_settings(): array {
 					'name'                  => ucwords( $provider_id ),
 					'description'           => '',
 					'credentials_url'       => null,
+					'type'                  => 'ai_provider',
 					'authentication_method' => 'none',
 				),
 				$registry_data
@@ -195,6 +200,7 @@ function _gutenberg_get_provider_settings(): array {
 			'name'                  => $data['name'],
 			'description'           => $data['description'],
 			'credentials_url'       => $data['credentials_url'],
+			'type'                  => $data['type'],
 			'authentication_method' => $data['authentication_method'],
 			'settings'              => $settings,
 		);
@@ -309,6 +315,9 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 	try {
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 		foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+			if ( 'ai_provider' !== $provider_data['type'] ) {
+				continue;
+			}
 			foreach ( $provider_data['settings'] as $setting_name => $config ) {
 				$api_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
 				if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
@@ -347,6 +356,7 @@ function _gutenberg_get_connector_provider_script_module_data( array $data ): ar
 			'name'                 => $provider_data['name'],
 			'description'          => $provider_data['description'],
 			'credentialsUrl'       => $provider_data['credentials_url'],
+			'type'                 => $provider_data['type'],
 			'authenticationMethod' => $provider_data['authentication_method'],
 			'settings'             => array_keys( $provider_data['settings'] ),
 		);

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -396,4 +396,5 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 	$data['connectors'] = $connectors;
 	return $data;
 }
+remove_filter( 'script_module_data_connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
 add_filter( 'script_module_data_connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -105,7 +105,7 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
 function _gutenberg_get_connector_settings(): array {
 	$connectors = array(
 		'google'    => array(
-			'name'           => 'Gemini',
+			'name'           => 'Google',
 			'description'    => __( 'Text and image generation with Gemini and Imagen.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'authentication' => array(

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -83,26 +83,27 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  * @access private
  *
  * @return array {
- *     Provider settings keyed by provider ID.
+ *     Connector settings keyed by connector ID.
  *
  *     @type array ...$0 {
- *         Data for a single provider.
+ *         Data for a single connector.
  *
- *         @type string $name           The provider's display name.
- *         @type string $description    The provider's description.
+ *         @type string $name           The connector's display name.
+ *         @type string $description    The connector's description.
  *         @type string $type           The connector type: 'ai_provider'.
  *         @type array  $authentication {
- *             Authentication configuration.
+ *             Authentication configuration. When method is 'api_key', includes
+ *             credentials_url and setting_name. When 'none', only method is present.
  *
  *             @type string      $method          The authentication method: 'api_key' or 'none'.
- *             @type string|null $credentials_url URL where users can obtain API credentials (api_key only).
- *             @type string      $setting_name    The setting name for the API key (api_key only).
+ *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+ *             @type string      $setting_name    Optional. The setting name for the API key.
  *         }
  *     }
  * }
  */
 function _gutenberg_get_connector_settings(): array {
-	$providers = array(
+	$connectors = array(
 		'google'    => array(
 			'name'           => 'Gemini',
 			'description'    => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
@@ -134,65 +135,57 @@ function _gutenberg_get_connector_settings(): array {
 
 	$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 
-	foreach ( $registry->getRegisteredProviderIds() as $provider_id ) {
-		$provider_class_name = $registry->getProviderClassName( $provider_id );
-		$provider_metadata   = $provider_class_name::metadata();
+	foreach ( $registry->getRegisteredProviderIds() as $connector_id ) {
+		$provider_class = $registry->getProviderClassName( $connector_id );
+		$metadata       = $provider_class::metadata();
 
-		$auth_method     = $provider_metadata->getAuthenticationMethod();
-		$is_api_key      = null !== $auth_method && $auth_method->isApiKey();
-		$credentials_url = $provider_metadata->getCredentialsUrl();
+		$auth_method = $metadata->getAuthenticationMethod();
+		$is_api_key  = null !== $auth_method && $auth_method->isApiKey();
 
-		$authentication = $is_api_key
-			? array(
+		if ( $is_api_key ) {
+			$credentials_url = $metadata->getCredentialsUrl();
+			$authentication  = array(
 				'method'          => 'api_key',
 				'credentials_url' => $credentials_url ? $credentials_url : null,
-			)
-			: array( 'method' => 'none' );
-
-		$registry_data = array_filter(
-			array(
-				'name'        => $provider_metadata->getName(),
-				'description' => method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null,
-			)
-		);
-
-		if ( isset( $providers[ $provider_id ] ) ) {
-			// Merge non-empty registry data over hardcoded fallbacks.
-			$providers[ $provider_id ] = array_merge( $providers[ $provider_id ], $registry_data );
-			// Update authentication from the registry.
-			$providers[ $provider_id ]['authentication'] = array_merge(
-				$providers[ $provider_id ]['authentication'],
-				array_filter( $authentication )
 			);
 		} else {
-			$providers[ $provider_id ] = array_merge(
-				array(
-					'name'           => ucwords( $provider_id ),
-					'description'    => '',
-					'type'           => 'ai_provider',
-					'authentication' => $authentication,
-				),
-				$registry_data
+			$authentication = array( 'method' => 'none' );
+		}
+
+		$name        = $metadata->getName();
+		$description = method_exists( $metadata, 'getDescription' ) ? $metadata->getDescription() : null;
+
+		if ( isset( $connectors[ $connector_id ] ) ) {
+			// Override fields with non-empty registry values.
+			if ( $name ) {
+				$connectors[ $connector_id ]['name'] = $name;
+			}
+			if ( $description ) {
+				$connectors[ $connector_id ]['description'] = $description;
+			}
+			// Always update auth method; keep existing credentials_url as fallback.
+			$connectors[ $connector_id ]['authentication']['method'] = $authentication['method'];
+			if ( ! empty( $authentication['credentials_url'] ) ) {
+				$connectors[ $connector_id ]['authentication']['credentials_url'] = $authentication['credentials_url'];
+			}
+		} else {
+			$connectors[ $connector_id ] = array(
+				'name'           => $name ? $name : ucwords( $connector_id ),
+				'description'    => $description ? $description : '',
+				'type'           => 'ai_provider',
+				'authentication' => $authentication,
 			);
 		}
 	}
 
-	$provider_settings = array();
-	foreach ( $providers as $provider => $data ) {
-		$auth = $data['authentication'];
-
-		if ( 'api_key' === $auth['method'] ) {
-			$auth['setting_name'] = "connectors_ai_{$provider}_api_key";
+	// Add setting_name for connectors that use API key authentication.
+	foreach ( $connectors as $connector_id => $connector ) {
+		if ( 'api_key' === $connector['authentication']['method'] ) {
+			$connectors[ $connector_id ]['authentication']['setting_name'] = "connectors_ai_{$connector_id}_api_key";
 		}
-
-		$provider_settings[ $provider ] = array(
-			'name'           => $data['name'],
-			'description'    => $data['description'],
-			'type'           => $data['type'],
-			'authentication' => $auth,
-		);
 	}
-	return $provider_settings;
+
+	return $connectors;
 }
 
 /**
@@ -235,8 +228,8 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 		return $response;
 	}
 
-	foreach ( _gutenberg_get_connector_settings() as $provider => $provider_data ) {
-		$auth = $provider_data['authentication'];
+	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+		$auth = $connector_data['authentication'];
 		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
@@ -251,7 +244,7 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 			continue;
 		}
 
-		if ( true !== _gutenberg_is_api_key_valid( $real_key, $provider ) ) {
+		if ( true !== _gutenberg_is_api_key_valid( $real_key, $connector_id ) ) {
 			$data[ $setting_name ] = 'invalid_key';
 		}
 	}
@@ -272,8 +265,8 @@ function _gutenberg_register_default_connector_settings(): void {
 		return;
 	}
 
-	foreach ( _gutenberg_get_connector_settings() as $provider => $provider_data ) {
-		$auth = $provider_data['authentication'];
+	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+		$auth = $connector_data['authentication'];
 		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
@@ -287,22 +280,22 @@ function _gutenberg_register_default_connector_settings(): void {
 				'label'             => sprintf(
 					/* translators: %s: AI provider name. */
 					__( '%s API Key', 'gutenberg' ),
-					$provider_data['name']
+					$connector_data['name']
 				),
 				'description'       => sprintf(
 					/* translators: %s: AI provider name. */
 					__( 'API key for the %s AI provider.', 'gutenberg' ),
-					$provider_data['name']
+					$connector_data['name']
 				),
 				'default'           => '',
 				'show_in_rest'      => true,
-				'sanitize_callback' => static function ( string $value ) use ( $provider ): string {
+				'sanitize_callback' => static function ( string $value ) use ( $connector_id ): string {
 					$value = sanitize_text_field( $value );
 					if ( '' === $value ) {
 						return $value;
 					}
 
-					$valid = _gutenberg_is_api_key_valid( $value, $provider );
+					$valid = _gutenberg_is_api_key_valid( $value, $connector_id );
 					return true === $valid ? $value : '';
 				},
 			)
@@ -325,23 +318,23 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 
 	try {
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		foreach ( _gutenberg_get_connector_settings() as $provider => $provider_data ) {
-			if ( 'ai_provider' !== $provider_data['type'] ) {
+		foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+			if ( 'ai_provider' !== $connector_data['type'] ) {
 				continue;
 			}
 
-			$auth = $provider_data['authentication'];
+			$auth = $connector_data['authentication'];
 			if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 				continue;
 			}
 
 			$api_key = _gutenberg_get_real_api_key( $auth['setting_name'], '_gutenberg_mask_api_key' );
-			if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
+			if ( '' === $api_key || ! $registry->hasProvider( $connector_id ) ) {
 				continue;
 			}
 
 			$registry->setProviderRequestAuthentication(
-				$provider,
+				$connector_id,
 				new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( $api_key )
 			);
 		}
@@ -353,21 +346,21 @@ remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
 add_action( 'init', '_gutenberg_pass_default_connector_keys_to_ai_client' );
 
 /**
- * Exposes connector provider settings to the connectors-wp-admin script module.
+ * Exposes connector settings to the connectors-wp-admin script module.
  *
  * @access private
  *
  * @param array $data Existing script module data.
- * @return array Script module data with providers added.
+ * @return array Script module data with connectors added.
  */
-function _gutenberg_get_connector_provider_script_module_data( array $data ): array {
+function _gutenberg_get_connector_script_module_data( array $data ): array {
 	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
 		return $data;
 	}
 
-	$providers = array();
-	foreach ( _gutenberg_get_connector_settings() as $provider_id => $provider_data ) {
-		$auth     = $provider_data['authentication'];
+	$connectors = array();
+	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+		$auth     = $connector_data['authentication'];
 		$auth_out = array( 'method' => $auth['method'] );
 
 		if ( 'api_key' === $auth['method'] ) {
@@ -375,14 +368,14 @@ function _gutenberg_get_connector_provider_script_module_data( array $data ): ar
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
 		}
 
-		$providers[ $provider_id ] = array(
-			'name'           => $provider_data['name'],
-			'description'    => $provider_data['description'],
-			'type'           => $provider_data['type'],
+		$connectors[ $connector_id ] = array(
+			'name'           => $connector_data['name'],
+			'description'    => $connector_data['description'],
+			'type'           => $connector_data['type'],
 			'authentication' => $auth_out,
 		);
 	}
-	$data['providers'] = $providers;
+	$data['connectors'] = $connectors;
 	return $data;
 }
-add_filter( 'script_module_data_connectors-wp-admin', '_gutenberg_get_connector_provider_script_module_data' );
+add_filter( 'script_module_data_connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -115,7 +115,7 @@ function _gutenberg_get_provider_settings(): array {
 		'openai'    => array(
 			'name'            => 'OpenAI',
 			'description'     => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
-			'credentials_url' => 'https://platform.openai.com/',
+			'credentials_url' => 'https://platform.openai.com/api-keys',
 		),
 		'anthropic' => array(
 			'name'            => 'Claude',

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -149,7 +149,7 @@ function _gutenberg_get_provider_settings(): array {
 		} else {
 			$providers[ $provider_id ] = array_merge(
 				array(
-					'name'            => '',
+					'name'            => ucwords( $provider_id ),
 					'description'     => '',
 					'credentials_url' => null,
 				),

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -230,7 +230,7 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 
 	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -88,10 +88,11 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *     @type array ...$0 {
  *         Data for a single provider.
  *
- *         @type string      $name            The provider's display name.
- *         @type string      $description     The provider's description.
- *         @type string|null $credentials_url URL where users can obtain API credentials.
- *         @type array       $settings        {
+ *         @type string      $name                  The provider's display name.
+ *         @type string      $description           The provider's description.
+ *         @type string|null $credentials_url       URL where users can obtain API credentials.
+ *         @type string      $authentication_method The authentication method: 'api_key' or 'none'.
+ *         @type array       $settings              {
  *             Settings keyed by setting name.
  *
  *             @type array ...$0 {
@@ -108,19 +109,22 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
 function _gutenberg_get_provider_settings(): array {
 	$providers = array(
 		'google'    => array(
-			'name'            => 'Gemini',
-			'description'     => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
-			'credentials_url' => 'https://aistudio.google.com/api-keys',
+			'name'                  => 'Gemini',
+			'description'           => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
+			'credentials_url'       => 'https://aistudio.google.com/api-keys',
+			'authentication_method' => 'api_key',
 		),
 		'openai'    => array(
-			'name'            => 'OpenAI',
-			'description'     => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
-			'credentials_url' => 'https://platform.openai.com/api-keys',
+			'name'                  => 'OpenAI',
+			'description'           => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
+			'credentials_url'       => 'https://platform.openai.com/api-keys',
+			'authentication_method' => 'api_key',
 		),
 		'anthropic' => array(
-			'name'            => 'Claude',
-			'description'     => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
-			'credentials_url' => 'https://platform.claude.com/settings/keys',
+			'name'                  => 'Claude',
+			'description'           => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
+			'credentials_url'       => 'https://platform.claude.com/settings/keys',
+			'authentication_method' => 'api_key',
 		),
 	);
 
@@ -131,15 +135,14 @@ function _gutenberg_get_provider_settings(): array {
 		$provider_metadata   = $provider_class_name::metadata();
 
 		$auth_method = $provider_metadata->getAuthenticationMethod();
-		if ( null === $auth_method || ! $auth_method->isApiKey() ) {
-			continue;
-		}
+		$auth_type   = ( null !== $auth_method && $auth_method->isApiKey() ) ? 'api_key' : 'none';
 
 		$registry_data = array_filter(
 			array(
-				'name'            => $provider_metadata->getName(),
-				'description'     => method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null,
-				'credentials_url' => $provider_metadata->getCredentialsUrl(),
+				'name'                  => $provider_metadata->getName(),
+				'description'           => method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null,
+				'credentials_url'       => $provider_metadata->getCredentialsUrl(),
+				'authentication_method' => $auth_type,
 			)
 		);
 
@@ -149,9 +152,10 @@ function _gutenberg_get_provider_settings(): array {
 		} else {
 			$providers[ $provider_id ] = array_merge(
 				array(
-					'name'            => ucwords( $provider_id ),
-					'description'     => '',
-					'credentials_url' => null,
+					'name'                  => ucwords( $provider_id ),
+					'description'           => '',
+					'credentials_url'       => null,
+					'authentication_method' => 'none',
 				),
 				$registry_data
 			);
@@ -160,35 +164,39 @@ function _gutenberg_get_provider_settings(): array {
 
 	$provider_settings = array();
 	foreach ( $providers as $provider => $data ) {
-		$setting_name = "connectors_ai_{$provider}_api_key";
+		$settings = array();
+
+		if ( 'api_key' === $data['authentication_method'] ) {
+			$setting_name              = "connectors_ai_{$provider}_api_key";
+			$settings[ $setting_name ] = array(
+				'label'       => sprintf(
+					/* translators: %s: AI provider name. */
+					__( '%s API Key', 'gutenberg' ),
+					$data['name']
+				),
+				'description' => sprintf(
+					/* translators: %s: AI provider name. */
+					__( 'API key for the %s AI provider.', 'gutenberg' ),
+					$data['name']
+				),
+				'sanitize'    => static function ( string $value ) use ( $provider ): string {
+					$value = sanitize_text_field( $value );
+					if ( '' === $value ) {
+						return $value;
+					}
+
+					$valid = _gutenberg_is_api_key_valid( $value, $provider );
+					return true === $valid ? $value : '';
+				},
+			);
+		}
 
 		$provider_settings[ $provider ] = array(
-			'name'            => $data['name'],
-			'description'     => $data['description'],
-			'credentials_url' => $data['credentials_url'],
-			'settings'        => array(
-				$setting_name => array(
-					'label'       => sprintf(
-						/* translators: %s: AI provider name. */
-						__( '%s API Key', 'gutenberg' ),
-						$data['name']
-					),
-					'description' => sprintf(
-						/* translators: %s: AI provider name. */
-						__( 'API key for the %s AI provider.', 'gutenberg' ),
-						$data['name']
-					),
-					'sanitize'    => static function ( string $value ) use ( $provider ): string {
-						$value = sanitize_text_field( $value );
-						if ( '' === $value ) {
-							return $value;
-						}
-
-						$valid = _gutenberg_is_api_key_valid( $value, $provider );
-						return true === $valid ? $value : '';
-					},
-				),
-			),
+			'name'                  => $data['name'],
+			'description'           => $data['description'],
+			'credentials_url'       => $data['credentials_url'],
+			'authentication_method' => $data['authentication_method'],
+			'settings'              => $settings,
 		);
 	}
 	return $provider_settings;
@@ -336,10 +344,11 @@ function _gutenberg_get_connector_provider_script_module_data( array $data ): ar
 	$providers = array();
 	foreach ( _gutenberg_get_provider_settings() as $provider_id => $provider_data ) {
 		$providers[ $provider_id ] = array(
-			'name'           => $provider_data['name'],
-			'description'    => $provider_data['description'],
-			'credentialsUrl' => $provider_data['credentials_url'],
-			'settings'       => array_keys( $provider_data['settings'] ),
+			'name'                 => $provider_data['name'],
+			'description'          => $provider_data['description'],
+			'credentialsUrl'       => $provider_data['credentials_url'],
+			'authenticationMethod' => $provider_data['authentication_method'],
+			'settings'             => array_keys( $provider_data['settings'] ),
 		);
 	}
 	$data['providers'] = $providers;

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -82,50 +82,114 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *
  * @access private
  *
- * @return array<string, array{provider: string, label: string, description: string, mask: callable, sanitize: callable}> Provider settings keyed by setting name.
+ * @return array {
+ *     Provider settings keyed by provider ID.
+ *
+ *     @type array ...$0 {
+ *         Data for a single provider.
+ *
+ *         @type string      $name            The provider's display name.
+ *         @type string      $description     The provider's description.
+ *         @type string|null $credentials_url URL where users can obtain API credentials.
+ *         @type array       $settings        {
+ *             Settings keyed by setting name.
+ *
+ *             @type array ...$0 {
+ *                 Data for a single setting.
+ *
+ *                 @type string   $label       The setting label.
+ *                 @type string   $description The setting description.
+ *                 @type callable $sanitize    Callback to sanitize the input value.
+ *             }
+ *         }
+ *     }
+ * }
  */
 function _gutenberg_get_provider_settings(): array {
 	$providers = array(
 		'google'    => array(
-			'name' => 'Google',
+			'name'            => 'Gemini',
+			'description'     => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
+			'credentials_url' => 'https://aistudio.google.com/',
 		),
 		'openai'    => array(
-			'name' => 'OpenAI',
+			'name'            => 'OpenAI',
+			'description'     => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
+			'credentials_url' => 'https://platform.openai.com/',
 		),
 		'anthropic' => array(
-			'name' => 'Anthropic',
+			'name'            => 'Claude',
+			'description'     => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
+			'credentials_url' => 'https://console.anthropic.com/',
 		),
 	);
+
+	$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+
+	foreach ( $registry->getRegisteredProviderIds() as $provider_id ) {
+		$provider_class_name = $registry->getProviderClassName( $provider_id );
+		$provider_metadata   = $provider_class_name::metadata();
+
+		$auth_method = $provider_metadata->getAuthenticationMethod();
+		if ( null === $auth_method || ! $auth_method->isApiKey() ) {
+			continue;
+		}
+
+		$registry_data = array_filter(
+			array(
+				'name'            => $provider_metadata->getName(),
+				'credentials_url' => $provider_metadata->getCredentialsUrl(),
+			)
+		);
+
+		if ( isset( $providers[ $provider_id ] ) ) {
+			// Merge non-empty registry data over hardcoded fallbacks.
+			$providers[ $provider_id ] = array_merge( $providers[ $provider_id ], $registry_data );
+		} else {
+			$providers[ $provider_id ] = array_merge(
+				array(
+					'name'            => '',
+					'description'     => '',
+					'credentials_url' => null,
+				),
+				$registry_data
+			);
+		}
+	}
 
 	$provider_settings = array();
 	foreach ( $providers as $provider => $data ) {
 		$setting_name = "connectors_ai_{$provider}_api_key";
 
-		$provider_settings[ $setting_name ] = array(
-			'provider'    => $provider,
-			'label'       => sprintf(
-				/* translators: %s: AI provider name. */
-				__( '%s API Key', 'gutenberg' ),
-				$data['name']
-			),
-			'description' => sprintf(
-				/* translators: %s: AI provider name. */
-				__( 'API key for the %s AI provider.', 'gutenberg' ),
-				$data['name']
-			),
-			'mask'        => '_gutenberg_mask_api_key',
-			'sanitize'    => static function ( string $value ) use ( $provider ): string {
-				$value = sanitize_text_field( $value );
-				if ( '' === $value ) {
-					return $value;
-				}
+		$provider_settings[ $provider ] = array(
+			'name'            => $data['name'],
+			'description'     => $data['description'],
+			'credentials_url' => $data['credentials_url'],
+			'settings'        => array(
+				$setting_name => array(
+					'label'       => sprintf(
+						/* translators: %s: AI provider name. */
+						__( '%s API Key', 'gutenberg' ),
+						$data['name']
+					),
+					'description' => sprintf(
+						/* translators: %s: AI provider name. */
+						__( 'API key for the %s AI provider.', 'gutenberg' ),
+						$data['name']
+					),
+					'sanitize'    => static function ( string $value ) use ( $provider ): string {
+						$value = sanitize_text_field( $value );
+						if ( '' === $value ) {
+							return $value;
+						}
 
-				$valid = _gutenberg_is_api_key_valid( $value, $provider );
-				return true === $valid ? $value : '';
-			},
+						$valid = _gutenberg_is_api_key_valid( $value, $provider );
+						return true === $valid ? $value : '';
+					},
+				),
+			),
 		);
 	}
-
 	return $provider_settings;
 }
 
@@ -169,18 +233,20 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 		return $response;
 	}
 
-	foreach ( _gutenberg_get_provider_settings() as $setting_name => $config ) {
-		if ( ! in_array( $setting_name, $requested, true ) ) {
-			continue;
-		}
+	foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+		foreach ( $provider_data['settings'] as $setting_name => $config ) {
+			if ( ! in_array( $setting_name, $requested, true ) ) {
+				continue;
+			}
 
-		$real_key = _gutenberg_get_real_api_key( $setting_name, $config['mask'] );
-		if ( '' === $real_key ) {
-			continue;
-		}
+			$real_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
+			if ( '' === $real_key ) {
+				continue;
+			}
 
-		if ( true !== _gutenberg_is_api_key_valid( $real_key, $config['provider'] ) ) {
-			$data[ $setting_name ] = 'invalid_key';
+			if ( true !== _gutenberg_is_api_key_valid( $real_key, $provider ) ) {
+				$data[ $setting_name ] = 'invalid_key';
+			}
 		}
 	}
 
@@ -200,20 +266,22 @@ function _gutenberg_register_default_connector_settings(): void {
 		return;
 	}
 
-	foreach ( _gutenberg_get_provider_settings() as $setting_name => $config ) {
-		register_setting(
-			'connectors',
-			$setting_name,
-			array(
-				'type'              => 'string',
-				'label'             => $config['label'],
-				'description'       => $config['description'],
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => $config['sanitize'],
-			)
-		);
-		add_filter( "option_{$setting_name}", $config['mask'] );
+	foreach ( _gutenberg_get_provider_settings() as $provider_data ) {
+		foreach ( $provider_data['settings'] as $setting_name => $config ) {
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					'type'              => 'string',
+					'label'             => $config['label'],
+					'description'       => $config['description'],
+					'default'           => '',
+					'show_in_rest'      => true,
+					'sanitize_callback' => $config['sanitize'],
+				)
+			);
+			add_filter( "option_{$setting_name}", '_gutenberg_mask_api_key' );
+		}
 	}
 }
 remove_action( 'init', '_wp_register_default_connector_settings' );
@@ -231,16 +299,18 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 
 	try {
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		foreach ( _gutenberg_get_provider_settings() as $setting_name => $config ) {
-			$api_key = _gutenberg_get_real_api_key( $setting_name, $config['mask'] );
-			if ( '' === $api_key || ! $registry->hasProvider( $config['provider'] ) ) {
-				continue;
-			}
+		foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+			foreach ( $provider_data['settings'] as $setting_name => $config ) {
+				$api_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
+				if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
+					continue;
+				}
 
-			$registry->setProviderRequestAuthentication(
-				$config['provider'],
-				new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( $api_key )
-			);
+				$registry->setProviderRequestAuthentication(
+					$provider,
+					new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( $api_key )
+				);
+			}
 		}
 	} catch ( Exception $e ) {
 		wp_trigger_error( __FUNCTION__, $e->getMessage() );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -120,7 +120,7 @@ function _gutenberg_get_provider_settings(): array {
 		'anthropic' => array(
 			'name'            => 'Claude',
 			'description'     => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
-			'credentials_url' => 'https://console.anthropic.com/',
+			'credentials_url' => 'https://platform.claude.com/settings/keys',
 		),
 	);
 

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -106,7 +106,7 @@ function _gutenberg_get_connector_settings(): array {
 	$connectors = array(
 		'google'    => array(
 			'name'           => 'Gemini',
-			'description'    => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
+			'description'    => __( 'Text and image generation with Gemini and Imagen.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'authentication' => array(
 				'method'          => 'api_key',

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -123,7 +123,7 @@ function _gutenberg_get_connector_settings(): array {
 			),
 		),
 		'anthropic' => array(
-			'name'           => 'Claude',
+			'name'           => 'Anthropic',
 			'description'    => __( 'Text generation with Claude.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'authentication' => array(

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -115,7 +115,7 @@ function _gutenberg_get_connector_settings(): array {
 		),
 		'openai'    => array(
 			'name'           => 'OpenAI',
-			'description'    => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
+			'description'    => __( 'Text and image generation with GPT and Dall-E.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'authentication' => array(
 				'method'          => 'api_key',

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -88,21 +88,15 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *     @type array ...$0 {
  *         Data for a single provider.
  *
- *         @type string      $name                  The provider's display name.
- *         @type string      $description           The provider's description.
- *         @type string|null $credentials_url       URL where users can obtain API credentials.
- *         @type string      $type                  The connector type: 'ai_provider'.
- *         @type string      $authentication_method The authentication method: 'api_key' or 'none'.
- *         @type array       $settings              {
- *             Settings keyed by setting name.
+ *         @type string $name           The provider's display name.
+ *         @type string $description    The provider's description.
+ *         @type string $type           The connector type: 'ai_provider'.
+ *         @type array  $authentication {
+ *             Authentication configuration.
  *
- *             @type array ...$0 {
- *                 Data for a single setting.
- *
- *                 @type string   $label       The setting label.
- *                 @type string   $description The setting description.
- *                 @type callable $sanitize    Callback to sanitize the input value.
- *             }
+ *             @type string      $method          The authentication method: 'api_key' or 'none'.
+ *             @type string|null $credentials_url URL where users can obtain API credentials (api_key only).
+ *             @type string      $setting_name    The setting name for the API key (api_key only).
  *         }
  *     }
  * }
@@ -110,25 +104,31 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
 function _gutenberg_get_provider_settings(): array {
 	$providers = array(
 		'google'    => array(
-			'name'                  => 'Gemini',
-			'description'           => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
-			'credentials_url'       => 'https://aistudio.google.com/api-keys',
-			'type'                  => 'ai_provider',
-			'authentication_method' => 'api_key',
+			'name'           => 'Gemini',
+			'description'    => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://aistudio.google.com/api-keys',
+			),
 		),
 		'openai'    => array(
-			'name'                  => 'OpenAI',
-			'description'           => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
-			'credentials_url'       => 'https://platform.openai.com/api-keys',
-			'type'                  => 'ai_provider',
-			'authentication_method' => 'api_key',
+			'name'           => 'OpenAI',
+			'description'    => __( 'Text, image, and code generation with GPT and DALL-E.', 'gutenberg' ),
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.openai.com/api-keys',
+			),
 		),
 		'anthropic' => array(
-			'name'                  => 'Claude',
-			'description'           => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
-			'credentials_url'       => 'https://platform.claude.com/settings/keys',
-			'type'                  => 'ai_provider',
-			'authentication_method' => 'api_key',
+			'name'           => 'Claude',
+			'description'    => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.claude.com/settings/keys',
+			),
 		),
 	);
 
@@ -138,29 +138,39 @@ function _gutenberg_get_provider_settings(): array {
 		$provider_class_name = $registry->getProviderClassName( $provider_id );
 		$provider_metadata   = $provider_class_name::metadata();
 
-		$auth_method = $provider_metadata->getAuthenticationMethod();
-		$auth_type   = ( null !== $auth_method && $auth_method->isApiKey() ) ? 'api_key' : 'none';
+		$auth_method     = $provider_metadata->getAuthenticationMethod();
+		$is_api_key      = null !== $auth_method && $auth_method->isApiKey();
+		$credentials_url = $provider_metadata->getCredentialsUrl();
+
+		$authentication = $is_api_key
+			? array(
+				'method'          => 'api_key',
+				'credentials_url' => $credentials_url ? $credentials_url : null,
+			)
+			: array( 'method' => 'none' );
 
 		$registry_data = array_filter(
 			array(
-				'name'                  => $provider_metadata->getName(),
-				'description'           => method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null,
-				'credentials_url'       => $provider_metadata->getCredentialsUrl(),
-				'authentication_method' => $auth_type,
+				'name'        => $provider_metadata->getName(),
+				'description' => method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null,
 			)
 		);
 
 		if ( isset( $providers[ $provider_id ] ) ) {
 			// Merge non-empty registry data over hardcoded fallbacks.
 			$providers[ $provider_id ] = array_merge( $providers[ $provider_id ], $registry_data );
+			// Update authentication from the registry.
+			$providers[ $provider_id ]['authentication'] = array_merge(
+				$providers[ $provider_id ]['authentication'],
+				array_filter( $authentication )
+			);
 		} else {
 			$providers[ $provider_id ] = array_merge(
 				array(
-					'name'                  => ucwords( $provider_id ),
-					'description'           => '',
-					'credentials_url'       => null,
-					'type'                  => 'ai_provider',
-					'authentication_method' => 'none',
+					'name'           => ucwords( $provider_id ),
+					'description'    => '',
+					'type'           => 'ai_provider',
+					'authentication' => $authentication,
 				),
 				$registry_data
 			);
@@ -169,40 +179,17 @@ function _gutenberg_get_provider_settings(): array {
 
 	$provider_settings = array();
 	foreach ( $providers as $provider => $data ) {
-		$settings = array();
+		$auth = $data['authentication'];
 
-		if ( 'api_key' === $data['authentication_method'] ) {
-			$setting_name              = "connectors_ai_{$provider}_api_key";
-			$settings[ $setting_name ] = array(
-				'label'       => sprintf(
-					/* translators: %s: AI provider name. */
-					__( '%s API Key', 'gutenberg' ),
-					$data['name']
-				),
-				'description' => sprintf(
-					/* translators: %s: AI provider name. */
-					__( 'API key for the %s AI provider.', 'gutenberg' ),
-					$data['name']
-				),
-				'sanitize'    => static function ( string $value ) use ( $provider ): string {
-					$value = sanitize_text_field( $value );
-					if ( '' === $value ) {
-						return $value;
-					}
-
-					$valid = _gutenberg_is_api_key_valid( $value, $provider );
-					return true === $valid ? $value : '';
-				},
-			);
+		if ( 'api_key' === $auth['method'] ) {
+			$auth['setting_name'] = "connectors_ai_{$provider}_api_key";
 		}
 
 		$provider_settings[ $provider ] = array(
-			'name'                  => $data['name'],
-			'description'           => $data['description'],
-			'credentials_url'       => $data['credentials_url'],
-			'type'                  => $data['type'],
-			'authentication_method' => $data['authentication_method'],
-			'settings'              => $settings,
+			'name'           => $data['name'],
+			'description'    => $data['description'],
+			'type'           => $data['type'],
+			'authentication' => $auth,
 		);
 	}
 	return $provider_settings;
@@ -249,19 +236,23 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 	}
 
 	foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
-		foreach ( $provider_data['settings'] as $setting_name => $config ) {
-			if ( ! in_array( $setting_name, $requested, true ) ) {
-				continue;
-			}
+		$auth = $provider_data['authentication'];
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+			continue;
+		}
 
-			$real_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
-			if ( '' === $real_key ) {
-				continue;
-			}
+		$setting_name = $auth['setting_name'];
+		if ( ! in_array( $setting_name, $requested, true ) ) {
+			continue;
+		}
 
-			if ( true !== _gutenberg_is_api_key_valid( $real_key, $provider ) ) {
-				$data[ $setting_name ] = 'invalid_key';
-			}
+		$real_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
+		if ( '' === $real_key ) {
+			continue;
+		}
+
+		if ( true !== _gutenberg_is_api_key_valid( $real_key, $provider ) ) {
+			$data[ $setting_name ] = 'invalid_key';
 		}
 	}
 
@@ -281,22 +272,42 @@ function _gutenberg_register_default_connector_settings(): void {
 		return;
 	}
 
-	foreach ( _gutenberg_get_provider_settings() as $provider_data ) {
-		foreach ( $provider_data['settings'] as $setting_name => $config ) {
-			register_setting(
-				'connectors',
-				$setting_name,
-				array(
-					'type'              => 'string',
-					'label'             => $config['label'],
-					'description'       => $config['description'],
-					'default'           => '',
-					'show_in_rest'      => true,
-					'sanitize_callback' => $config['sanitize'],
-				)
-			);
-			add_filter( "option_{$setting_name}", '_gutenberg_mask_api_key' );
+	foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+		$auth = $provider_data['authentication'];
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+			continue;
 		}
+
+		$setting_name = $auth['setting_name'];
+		register_setting(
+			'connectors',
+			$setting_name,
+			array(
+				'type'              => 'string',
+				'label'             => sprintf(
+					/* translators: %s: AI provider name. */
+					__( '%s API Key', 'gutenberg' ),
+					$provider_data['name']
+				),
+				'description'       => sprintf(
+					/* translators: %s: AI provider name. */
+					__( 'API key for the %s AI provider.', 'gutenberg' ),
+					$provider_data['name']
+				),
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => static function ( string $value ) use ( $provider ): string {
+					$value = sanitize_text_field( $value );
+					if ( '' === $value ) {
+						return $value;
+					}
+
+					$valid = _gutenberg_is_api_key_valid( $value, $provider );
+					return true === $valid ? $value : '';
+				},
+			)
+		);
+		add_filter( "option_{$setting_name}", '_gutenberg_mask_api_key' );
 	}
 }
 remove_action( 'init', '_wp_register_default_connector_settings' );
@@ -318,17 +329,21 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 			if ( 'ai_provider' !== $provider_data['type'] ) {
 				continue;
 			}
-			foreach ( $provider_data['settings'] as $setting_name => $config ) {
-				$api_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
-				if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
-					continue;
-				}
 
-				$registry->setProviderRequestAuthentication(
-					$provider,
-					new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( $api_key )
-				);
+			$auth = $provider_data['authentication'];
+			if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+				continue;
 			}
+
+			$api_key = _gutenberg_get_real_api_key( $auth['setting_name'], '_gutenberg_mask_api_key' );
+			if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
+				continue;
+			}
+
+			$registry->setProviderRequestAuthentication(
+				$provider,
+				new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( $api_key )
+			);
 		}
 	} catch ( Exception $e ) {
 		wp_trigger_error( __FUNCTION__, $e->getMessage() );
@@ -352,13 +367,19 @@ function _gutenberg_get_connector_provider_script_module_data( array $data ): ar
 
 	$providers = array();
 	foreach ( _gutenberg_get_provider_settings() as $provider_id => $provider_data ) {
+		$auth     = $provider_data['authentication'];
+		$auth_out = array( 'method' => $auth['method'] );
+
+		if ( 'api_key' === $auth['method'] ) {
+			$auth_out['settingName']    = $auth['setting_name'] ?? '';
+			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
+		}
+
 		$providers[ $provider_id ] = array(
-			'name'                 => $provider_data['name'],
-			'description'          => $provider_data['description'],
-			'credentialsUrl'       => $provider_data['credentials_url'],
-			'type'                 => $provider_data['type'],
-			'authenticationMethod' => $provider_data['authentication_method'],
-			'settings'             => array_keys( $provider_data['settings'] ),
+			'name'           => $provider_data['name'],
+			'description'    => $provider_data['description'],
+			'type'           => $provider_data['type'],
+			'authentication' => $auth_out,
 		);
 	}
 	$data['providers'] = $providers;

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -78,7 +78,7 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
 }
 
 /**
- * Gets the registered connector provider settings.
+ * Gets the registered connector settings.
  *
  * @access private
  *
@@ -101,7 +101,7 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *     }
  * }
  */
-function _gutenberg_get_provider_settings(): array {
+function _gutenberg_get_connector_settings(): array {
 	$providers = array(
 		'google'    => array(
 			'name'           => 'Gemini',
@@ -235,7 +235,7 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 		return $response;
 	}
 
-	foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+	foreach ( _gutenberg_get_connector_settings() as $provider => $provider_data ) {
 		$auth = $provider_data['authentication'];
 		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
@@ -272,7 +272,7 @@ function _gutenberg_register_default_connector_settings(): void {
 		return;
 	}
 
-	foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+	foreach ( _gutenberg_get_connector_settings() as $provider => $provider_data ) {
 		$auth = $provider_data['authentication'];
 		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
@@ -325,7 +325,7 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 
 	try {
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		foreach ( _gutenberg_get_provider_settings() as $provider => $provider_data ) {
+		foreach ( _gutenberg_get_connector_settings() as $provider => $provider_data ) {
 			if ( 'ai_provider' !== $provider_data['type'] ) {
 				continue;
 			}
@@ -366,7 +366,7 @@ function _gutenberg_get_connector_provider_script_module_data( array $data ): ar
 	}
 
 	$providers = array();
-	foreach ( _gutenberg_get_provider_settings() as $provider_id => $provider_data ) {
+	foreach ( _gutenberg_get_connector_settings() as $provider_id => $provider_data ) {
 		$auth     = $provider_data['authentication'];
 		$auth_out = array( 'method' => $auth['method'] );
 

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -90,7 +90,7 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *
  *         @type string $name           The connector's display name.
  *         @type string $description    The connector's description.
- *         @type string $type           The connector type: 'ai_provider'.
+ *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
  *         @type array  $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -138,6 +138,7 @@ function _gutenberg_get_provider_settings(): array {
 		$registry_data = array_filter(
 			array(
 				'name'            => $provider_metadata->getName(),
+				'description'     => method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null,
 				'credentials_url' => $provider_metadata->getCredentialsUrl(),
 			)
 		);

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -91,6 +91,9 @@ function _gutenberg_get_real_api_key( string $option_name, callable $mask_callba
  *         @type string $name           The connector's display name.
  *         @type string $description    The connector's description.
  *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+ *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+ *             @type string $slug       The WordPress.org plugin slug.
+ *         }
  *         @type array  $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.
@@ -108,6 +111,9 @@ function _gutenberg_get_connector_settings(): array {
 			'name'           => 'Google',
 			'description'    => __( 'Text and image generation with Gemini and Imagen.', 'gutenberg' ),
 			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-google',
+			),
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://aistudio.google.com/api-keys',
@@ -117,6 +123,9 @@ function _gutenberg_get_connector_settings(): array {
 			'name'           => 'OpenAI',
 			'description'    => __( 'Text and image generation with GPT and Dall-E.', 'gutenberg' ),
 			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-openai',
+			),
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.openai.com/api-keys',
@@ -126,6 +135,9 @@ function _gutenberg_get_connector_settings(): array {
 			'name'           => 'Anthropic',
 			'description'    => __( 'Text generation with Claude.', 'gutenberg' ),
 			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-anthropic',
+			),
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.claude.com/settings/keys',
@@ -368,12 +380,18 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
 		}
 
-		$connectors[ $connector_id ] = array(
+		$connector_out = array(
 			'name'           => $connector_data['name'],
 			'description'    => $connector_data['description'],
 			'type'           => $connector_data['type'],
 			'authentication' => $auth_out,
 		);
+
+		if ( ! empty( $connector_data['plugin'] ) ) {
+			$connector_out['plugin'] = $connector_data['plugin'];
+		}
+
+		$connectors[ $connector_id ] = $connector_out;
 	}
 	$data['connectors'] = $connectors;
 	return $data;

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -110,7 +110,7 @@ function _gutenberg_get_provider_settings(): array {
 		'google'    => array(
 			'name'            => 'Gemini',
 			'description'     => __( 'Content generation, translation, and vision with Google\'s Gemini.', 'gutenberg' ),
-			'credentials_url' => 'https://aistudio.google.com/',
+			'credentials_url' => 'https://aistudio.google.com/api-keys',
 		),
 		'openai'    => array(
 			'name'            => 'OpenAI',

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -30,7 +30,7 @@ function _gutenberg_mask_api_key( string $key ): string {
  * @param string $provider_id The WP AI client provider ID.
  * @return bool|null True if valid, false if invalid, null if unable to determine.
  */
-function _gutenberg_is_api_key_valid( string $key, string $provider_id ): ?bool {
+function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bool {
 	try {
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 
@@ -244,7 +244,7 @@ function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response,
 			continue;
 		}
 
-		if ( true !== _gutenberg_is_api_key_valid( $real_key, $connector_id ) ) {
+		if ( true !== _gutenberg_is_ai_api_key_valid( $real_key, $connector_id ) ) {
 			$data[ $setting_name ] = 'invalid_key';
 		}
 	}
@@ -295,7 +295,7 @@ function _gutenberg_register_default_connector_settings(): void {
 						return $value;
 					}
 
-					$valid = _gutenberg_is_api_key_valid( $value, $connector_id );
+					$valid = _gutenberg_is_ai_api_key_valid( $value, $connector_id );
 					return true === $valid ? $value : '';
 				},
 			)

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -124,7 +124,7 @@ function _gutenberg_get_connector_settings(): array {
 		),
 		'anthropic' => array(
 			'name'           => 'Claude',
-			'description'    => __( 'Writing, research, and analysis with Claude.', 'gutenberg' ),
+			'description'    => __( 'Text generation with Claude.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'authentication' => array(
 				'method'          => 'api_key',

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -318,3 +318,30 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 }
 remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
 add_action( 'init', '_gutenberg_pass_default_connector_keys_to_ai_client' );
+
+/**
+ * Exposes connector provider settings to the connectors-wp-admin script module.
+ *
+ * @access private
+ *
+ * @param array $data Existing script module data.
+ * @return array Script module data with providers added.
+ */
+function _gutenberg_get_connector_provider_script_module_data( array $data ): array {
+	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+		return $data;
+	}
+
+	$providers = array();
+	foreach ( _gutenberg_get_provider_settings() as $provider_id => $provider_data ) {
+		$providers[ $provider_id ] = array(
+			'name'           => $provider_data['name'],
+			'description'    => $provider_data['description'],
+			'credentialsUrl' => $provider_data['credentials_url'],
+			'settings'       => array_keys( $provider_data['settings'] ),
+		);
+	}
+	$data['providers'] = $providers;
+	return $data;
+}
+add_filter( 'script_module_data_connectors-wp-admin', '_gutenberg_get_connector_provider_script_module_data' );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -165,7 +165,11 @@ export function registerDefaultConnectors() {
 			// Invalid URL — leave helpLabel undefined.
 		}
 
-		registerConnector( `core/${ connectorId }`, {
+		const sanitize = ( s: string ) => s.replace( /[^a-z0-9-]/gi, '-' );
+		const connectorName = `${ sanitize( data.type ) }/${ sanitize(
+			connectorId
+		) }`;
+		registerConnector( connectorName, {
 			label: data.name,
 			description: data.description,
 			render: ( props: ConnectorRenderProps ) => (

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -20,6 +20,7 @@ interface ProviderData {
 	name: string;
 	description: string;
 	credentialsUrl: string | null;
+	authenticationMethod: 'api_key' | 'none';
 	settings: string[];
 }
 
@@ -61,7 +62,7 @@ const ConnectedBadge = () => (
 	</span>
 );
 
-interface ConnectorConfig {
+interface ApiKeyConnectorConfig {
 	pluginSlug: string;
 	settingName: string;
 	helpUrl?: string;
@@ -69,7 +70,7 @@ interface ConnectorConfig {
 	Logo?: React.ComponentType;
 }
 
-function ProviderConnector( {
+function ApiKeyProviderConnector( {
 	label,
 	description,
 	pluginSlug,
@@ -77,7 +78,7 @@ function ProviderConnector( {
 	helpUrl,
 	helpLabel,
 	Logo,
-}: ConnectorRenderProps & ConnectorConfig ) {
+}: ConnectorRenderProps & ApiKeyConnectorConfig ) {
 	const {
 		pluginStatus,
 		isExpanded,
@@ -143,6 +144,10 @@ export function registerDefaultConnectors() {
 	const providers = getProviderData();
 
 	for ( const [ providerId, data ] of Object.entries( providers ) ) {
+		if ( data.authenticationMethod !== 'api_key' ) {
+			continue;
+		}
+
 		const settingName = data.settings[ 0 ];
 		if ( ! settingName ) {
 			continue;
@@ -156,7 +161,7 @@ export function registerDefaultConnectors() {
 			label: data.name,
 			description: data.description,
 			render: ( props: ConnectorRenderProps ) => (
-				<ProviderConnector
+				<ApiKeyProviderConnector
 					{ ...props }
 					pluginSlug={ `ai-provider-for-${ providerId }` }
 					settingName={ settingName }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -153,6 +153,8 @@ function ApiKeyConnector( {
 export function registerDefaultConnectors() {
 	const connectors = getConnectorData();
 
+	const sanitize = ( s: string ) => s.replace( /[^a-z0-9-]/gi, '-' );
+
 	for ( const [ connectorId, data ] of Object.entries( connectors ) ) {
 		const { authentication } = data;
 
@@ -163,7 +165,6 @@ export function registerDefaultConnectors() {
 			continue;
 		}
 
-		const sanitize = ( s: string ) => s.replace( /[^a-z0-9-]/gi, '-' );
 		const connectorName = `${ sanitize( data.type ) }/${ sanitize(
 			connectorId
 		) }`;

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -16,13 +16,15 @@ import { __ } from '@wordpress/i18n';
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
 
+type ProviderAuthentication =
+	| { method: 'api_key'; settingName: string; credentialsUrl: string | null }
+	| { method: 'none' };
+
 interface ProviderData {
 	name: string;
 	description: string;
-	credentialsUrl: string | null;
 	type: 'ai_provider';
-	authenticationMethod: 'api_key' | 'none';
-	settings: string[];
+	authentication: ProviderAuthentication;
 }
 
 /**
@@ -145,19 +147,16 @@ export function registerDefaultConnectors() {
 	const providers = getProviderData();
 
 	for ( const [ providerId, data ] of Object.entries( providers ) ) {
+		const { authentication } = data;
+
 		if (
 			data.type !== 'ai_provider' ||
-			data.authenticationMethod !== 'api_key'
+			authentication.method !== 'api_key'
 		) {
 			continue;
 		}
 
-		const settingName = data.settings[ 0 ];
-		if ( ! settingName ) {
-			continue;
-		}
-
-		const helpLabel = data.credentialsUrl
+		const helpLabel = authentication.credentialsUrl
 			?.replace( /^https?:\/\//, '' )
 			.replace( /\/$/, '' );
 
@@ -168,8 +167,8 @@ export function registerDefaultConnectors() {
 				<ApiKeyProviderConnector
 					{ ...props }
 					pluginSlug={ `ai-provider-for-${ providerId }` }
-					settingName={ settingName }
-					helpUrl={ data.credentialsUrl ?? undefined }
+					settingName={ authentication.settingName }
+					helpUrl={ authentication.credentialsUrl ?? undefined }
 					helpLabel={ helpLabel }
 					Logo={ PROVIDER_LOGOS[ providerId ] }
 				/>

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -20,6 +20,7 @@ interface ProviderData {
 	name: string;
 	description: string;
 	credentialsUrl: string | null;
+	type: 'ai_provider';
 	authenticationMethod: 'api_key' | 'none';
 	settings: string[];
 }
@@ -144,7 +145,10 @@ export function registerDefaultConnectors() {
 	const providers = getProviderData();
 
 	for ( const [ providerId, data ] of Object.entries( providers ) ) {
-		if ( data.authenticationMethod !== 'api_key' ) {
+		if (
+			data.type !== 'ai_provider' ||
+			data.authenticationMethod !== 'api_key'
+		) {
 			continue;
 		}
 

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -156,9 +156,14 @@ export function registerDefaultConnectors() {
 			continue;
 		}
 
-		const helpLabel = authentication.credentialsUrl
-			?.replace( /^https?:\/\//, '' )
-			.replace( /\/$/, '' );
+		let helpLabel: string | undefined;
+		try {
+			if ( authentication.credentialsUrl ) {
+				helpLabel = new URL( authentication.credentialsUrl ).hostname;
+			}
+		} catch {
+			// Invalid URL — leave helpLabel undefined.
+		}
 
 		registerConnector( `core/${ connectorId }`, {
 			label: data.name,

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -16,34 +16,34 @@ import { __ } from '@wordpress/i18n';
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
 
-type ProviderAuthentication =
+type ConnectorAuthentication =
 	| { method: 'api_key'; settingName: string; credentialsUrl: string | null }
 	| { method: 'none' };
 
-interface ProviderData {
+interface ConnectorData {
 	name: string;
 	description: string;
 	type: 'ai_provider';
-	authentication: ProviderAuthentication;
+	authentication: ConnectorAuthentication;
 }
 
 /**
- * Reads provider data passed from PHP via the script module data mechanism.
+ * Reads connector data passed from PHP via the script module data mechanism.
  */
-function getProviderData(): Record< string, ProviderData > {
+function getConnectorData(): Record< string, ConnectorData > {
 	try {
 		const parsed = JSON.parse(
 			document.getElementById(
 				'wp-script-module-data-connectors-wp-admin'
 			)?.textContent ?? ''
 		);
-		return parsed?.providers ?? {};
+		return parsed?.connectors ?? {};
 	} catch {
 		return {};
 	}
 }
 
-const PROVIDER_LOGOS: Record< string, React.ComponentType > = {
+const CONNECTOR_LOGOS: Record< string, React.ComponentType > = {
 	google: GeminiLogo,
 	openai: OpenAILogo,
 	anthropic: ClaudeLogo,
@@ -142,11 +142,11 @@ function ApiKeyProviderConnector( {
 	);
 }
 
-// Register connectors from server-provided provider data.
+// Register connectors from server-provided connector data.
 export function registerDefaultConnectors() {
-	const providers = getProviderData();
+	const connectors = getConnectorData();
 
-	for ( const [ providerId, data ] of Object.entries( providers ) ) {
+	for ( const [ connectorId, data ] of Object.entries( connectors ) ) {
 		const { authentication } = data;
 
 		if (
@@ -160,17 +160,17 @@ export function registerDefaultConnectors() {
 			?.replace( /^https?:\/\//, '' )
 			.replace( /\/$/, '' );
 
-		registerConnector( `core/${ providerId }`, {
+		registerConnector( `core/${ connectorId }`, {
 			label: data.name,
 			description: data.description,
 			render: ( props: ConnectorRenderProps ) => (
 				<ApiKeyProviderConnector
 					{ ...props }
-					pluginSlug={ `ai-provider-for-${ providerId }` }
+					pluginSlug={ `ai-provider-for-${ connectorId }` }
 					settingName={ authentication.settingName }
 					helpUrl={ authentication.credentialsUrl ?? undefined }
 					helpLabel={ helpLabel }
-					Logo={ PROVIDER_LOGOS[ providerId ] }
+					Logo={ CONNECTOR_LOGOS[ connectorId ] }
 				/>
 			),
 		} );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -16,6 +16,35 @@ import { __ } from '@wordpress/i18n';
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
 
+interface ProviderData {
+	name: string;
+	description: string;
+	credentialsUrl: string | null;
+	settings: string[];
+}
+
+/**
+ * Reads provider data passed from PHP via the script module data mechanism.
+ */
+function getProviderData(): Record< string, ProviderData > {
+	try {
+		const parsed = JSON.parse(
+			document.getElementById(
+				'wp-script-module-data-connectors-wp-admin'
+			)?.textContent ?? ''
+		);
+		return parsed?.providers ?? {};
+	} catch {
+		return {};
+	}
+}
+
+const PROVIDER_LOGOS: Record< string, React.ComponentType > = {
+	google: GeminiLogo,
+	openai: OpenAILogo,
+	anthropic: ClaudeLogo,
+};
+
 const ConnectedBadge = () => (
 	<span
 		style={ {
@@ -35,9 +64,9 @@ const ConnectedBadge = () => (
 interface ConnectorConfig {
 	pluginSlug: string;
 	settingName: string;
-	helpUrl: string;
-	helpLabel: string;
-	Logo: React.ComponentType;
+	helpUrl?: string;
+	helpLabel?: string;
+	Logo?: React.ComponentType;
 }
 
 function ProviderConnector( {
@@ -68,7 +97,7 @@ function ProviderConnector( {
 	return (
 		<ConnectorItem
 			className={ `connector-item--${ pluginSlug }` }
-			icon={ <Logo /> }
+			icon={ Logo ? <Logo /> : undefined }
 			name={ label }
 			description={ description }
 			actionArea={
@@ -109,69 +138,33 @@ function ProviderConnector( {
 	);
 }
 
-// OpenAI connector render component
-function OpenAIConnector( props: ConnectorRenderProps ) {
-	return (
-		<ProviderConnector
-			{ ...props }
-			pluginSlug="ai-provider-for-openai"
-			settingName="connectors_ai_openai_api_key"
-			helpUrl="https://platform.openai.com"
-			helpLabel="platform.openai.com"
-			Logo={ OpenAILogo }
-		/>
-	);
-}
-
-// Claude connector render component
-function ClaudeConnector( props: ConnectorRenderProps ) {
-	return (
-		<ProviderConnector
-			{ ...props }
-			pluginSlug="ai-provider-for-anthropic"
-			settingName="connectors_ai_anthropic_api_key"
-			helpUrl="https://console.anthropic.com"
-			helpLabel="console.anthropic.com"
-			Logo={ ClaudeLogo }
-		/>
-	);
-}
-
-// Gemini connector render component
-function GeminiConnector( props: ConnectorRenderProps ) {
-	return (
-		<ProviderConnector
-			{ ...props }
-			pluginSlug="ai-provider-for-google"
-			settingName="connectors_ai_google_api_key"
-			helpUrl="https://aistudio.google.com"
-			helpLabel="aistudio.google.com"
-			Logo={ GeminiLogo }
-		/>
-	);
-}
-
-// Register built-in connectors
+// Register connectors from server-provided provider data.
 export function registerDefaultConnectors() {
-	registerConnector( 'core/openai', {
-		label: __( 'OpenAI' ),
-		description: __(
-			'Text, image, and code generation with GPT and DALL-E.'
-		),
-		render: OpenAIConnector,
-	} );
+	const providers = getProviderData();
 
-	registerConnector( 'core/claude', {
-		label: __( 'Claude' ),
-		description: __( 'Writing, research, and analysis with Claude.' ),
-		render: ClaudeConnector,
-	} );
+	for ( const [ providerId, data ] of Object.entries( providers ) ) {
+		const settingName = data.settings[ 0 ];
+		if ( ! settingName ) {
+			continue;
+		}
 
-	registerConnector( 'core/gemini', {
-		label: __( 'Gemini' ),
-		description: __(
-			"Content generation, translation, and vision with Google's Gemini."
-		),
-		render: GeminiConnector,
-	} );
+		const helpLabel = data.credentialsUrl
+			?.replace( /^https?:\/\//, '' )
+			.replace( /\/$/, '' );
+
+		registerConnector( `core/${ providerId }`, {
+			label: data.name,
+			description: data.description,
+			render: ( props: ConnectorRenderProps ) => (
+				<ProviderConnector
+					{ ...props }
+					pluginSlug={ `ai-provider-for-${ providerId }` }
+					settingName={ settingName }
+					helpUrl={ data.credentialsUrl ?? undefined }
+					helpLabel={ helpLabel }
+					Logo={ PROVIDER_LOGOS[ providerId ] }
+				/>
+			),
+		} );
+	}
 }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -24,6 +24,7 @@ interface ConnectorData {
 	name: string;
 	description: string;
 	type: 'ai_provider';
+	plugin?: { slug: string };
 	authentication: ConnectorAuthentication;
 }
 
@@ -66,7 +67,7 @@ const ConnectedBadge = () => (
 );
 
 interface ApiKeyConnectorConfig {
-	pluginSlug: string;
+	pluginSlug?: string;
 	settingName: string;
 	helpUrl?: string;
 	Logo?: React.ComponentType;
@@ -107,7 +108,9 @@ function ApiKeyConnector( {
 
 	return (
 		<ConnectorItem
-			className={ `connector-item--${ pluginSlug }` }
+			className={
+				pluginSlug ? `connector-item--${ pluginSlug }` : undefined
+			}
 			icon={ Logo ? <Logo /> : undefined }
 			name={ label }
 			description={ description }
@@ -174,7 +177,7 @@ export function registerDefaultConnectors() {
 			render: ( props ) => (
 				<ApiKeyConnector
 					{ ...props }
-					pluginSlug={ `ai-provider-for-${ connectorId }` }
+					pluginSlug={ data.plugin?.slug }
 					settingName={ authentication.settingName }
 					helpUrl={ authentication.credentialsUrl ?? undefined }
 					Logo={ CONNECTOR_LOGOS[ connectorId ] }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -69,19 +69,26 @@ interface ApiKeyConnectorConfig {
 	pluginSlug: string;
 	settingName: string;
 	helpUrl?: string;
-	helpLabel?: string;
 	Logo?: React.ComponentType;
 }
 
-function ApiKeyProviderConnector( {
+function ApiKeyConnector( {
 	label,
 	description,
 	pluginSlug,
 	settingName,
 	helpUrl,
-	helpLabel,
 	Logo,
 }: ConnectorRenderProps & ApiKeyConnectorConfig ) {
+	let helpLabel: string | undefined;
+	try {
+		if ( helpUrl ) {
+			helpLabel = new URL( helpUrl ).hostname;
+		}
+	} catch {
+		// Invalid URL — leave helpLabel undefined.
+	}
+
 	const {
 		pluginStatus,
 		isExpanded,
@@ -156,15 +163,6 @@ export function registerDefaultConnectors() {
 			continue;
 		}
 
-		let helpLabel: string | undefined;
-		try {
-			if ( authentication.credentialsUrl ) {
-				helpLabel = new URL( authentication.credentialsUrl ).hostname;
-			}
-		} catch {
-			// Invalid URL — leave helpLabel undefined.
-		}
-
 		const sanitize = ( s: string ) => s.replace( /[^a-z0-9-]/gi, '-' );
 		const connectorName = `${ sanitize( data.type ) }/${ sanitize(
 			connectorId
@@ -172,13 +170,12 @@ export function registerDefaultConnectors() {
 		registerConnector( connectorName, {
 			label: data.name,
 			description: data.description,
-			render: ( props: ConnectorRenderProps ) => (
-				<ApiKeyProviderConnector
+			render: ( props ) => (
+				<ApiKeyConnector
 					{ ...props }
 					pluginSlug={ `ai-provider-for-${ connectorId }` }
 					settingName={ authentication.settingName }
 					helpUrl={ authentication.credentialsUrl ?? undefined }
-					helpLabel={ helpLabel }
 					Logo={ CONNECTOR_LOGOS[ connectorId ] }
 				/>
 			),

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 
 interface UseConnectorPluginOptions {
-	pluginSlug: string;
+	pluginSlug?: string;
 	settingName: string;
 }
 
@@ -56,6 +56,13 @@ export function useConnectorPlugin( {
 	// Check plugin status on mount
 	useEffect( () => {
 		const checkPluginStatus = async () => {
+			if ( ! pluginSlug ) {
+				// No plugin slug — assume active, just fetch the API key.
+				await fetchApiKey();
+				setPluginStatus( 'active' );
+				return;
+			}
+
 			try {
 				const plugins = await apiFetch<
 					Array< { plugin: string; status: string } >
@@ -84,6 +91,9 @@ export function useConnectorPlugin( {
 	}, [ pluginSlug, fetchApiKey ] );
 
 	const installPlugin = async () => {
+		if ( ! pluginSlug ) {
+			return;
+		}
 		setIsBusy( true );
 		try {
 			await apiFetch( {
@@ -102,6 +112,9 @@ export function useConnectorPlugin( {
 	};
 
 	const activatePlugin = async () => {
+		if ( ! pluginSlug ) {
+			return;
+		}
 		setIsBusy( true );
 		try {
 			await apiFetch( {


### PR DESCRIPTION
## Summary

Polyfills WordPress/wordpress-develop#11080 for the Gutenberg plugin and wires up the frontend to consume provider data dynamically.

- Expand `_gutenberg_get_provider_settings()` to dynamically fetch registered providers from the AI Client registry, in addition to the three hardcoded featured providers (Gemini, OpenAI, Claude).
- Restructure the return value to be keyed by provider ID with `name`, `description`, `credentials_url` at the top level and `settings` as a nested array.
- Filter out providers whose authentication method is not `api_key`.
- Update all consumer functions (`_gutenberg_validate_connector_keys_in_rest`, `_gutenberg_register_default_connector_settings`, `_gutenberg_pass_default_connector_keys_to_ai_client`) to use the new structure.
- Expose provider settings to the `connectors-wp-admin` script module via the `script_module_data` filter.
- Update the frontend to read provider data from the script module data JSON and register connectors dynamically instead of hardcoding them.

## Test plan

- [ ] Verify the three featured providers (Google/Gemini, OpenAI, Claude) still appear with correct names, descriptions, and credentials URLs on the Connectors settings page.
- [ ] Confirm a third-party provider plugin registered via `AiClient::defaultRegistry()->registerProvider()` with API key auth appears in the settings.
- [ ] Confirm providers without API key authentication are excluded from the settings.
- [ ] Verify API key save/remove/validation flow still works for each provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)