### PR TITLE
Navigation Link: Compare internal links by host instead of origin

### DIFF
--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -105,6 +105,15 @@ describe( 'computeDisplayUrl', () => {
 			expect( result.isExternal ).toBe( false );
 			expect( result.displayUrl ).toBe( '/my-page' );
 		} );
+
+		it( 'should treat http and https to same host as internal (compare by host, not origin)', () => {
+			const result = computeDisplayUrl( {
+				linkUrl: 'http://example.com/my-page',
+				homeUrl: 'https://example.com',
+			} );
+			expect( result.isExternal ).toBe( false );
+			expect( result.displayUrl ).toBe( '/my-page' );
+		} );
 	} );
 
 	describe( 'special protocols and edge cases', () => {

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -63,7 +63,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 			}
 			displayUrl = path;
 		} else {
-			// Different origin - this is an external link
+			// Different host - this is an external link
 			isExternal = true;
 		}
 	} catch ( e ) {

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -51,12 +51,13 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 	// This must happen before trusting the type attribute
 	try {
 		const parsedUrl = new URL( linkUrl );
-		// Use provided homeUrl or fall back to window.location.origin
-		const siteDomain = homeUrl
-			? new URL( homeUrl ).origin
-			: window.location.origin;
+		// Use provided homeUrl or fall back to window.location
+		// Compare by host (not origin) so http/https to same site both count as internal
+		const siteHost = homeUrl
+			? new URL( homeUrl ).host
+			: window.location.host;
 
-		if ( parsedUrl.origin === siteDomain ) {
+		if ( parsedUrl.host === siteHost ) {
 			// Show only the pathname (and search/hash if present)
 			let path = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
 			// Remove trailing slash

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -53,9 +53,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 		const parsedUrl = new URL( linkUrl );
 		// Use provided homeUrl or fall back to window.location
 		// Compare by host (not origin) so http/https to same site both count as internal
-		const siteHost = homeUrl
-			? new URL( homeUrl ).host
-			: window.location.host;
+		const siteHost = new URL( homeUrl ).host;
 
 		if ( parsedUrl.host === siteHost ) {
 			// Show only the pathname (and search/hash if present)

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -31,7 +31,7 @@ function capitalize( str ) {
  *
  * @param {Object} options         - Parameters object
  * @param {string} options.linkUrl - The URL to process
- * @param {string} options.homeUrl - The WordPress site URL (falls back to window.location.origin)
+ * @param {string} options.homeUrl - The WordPress site URL (required for internal/external detection)
  * @return {Object} Object with displayUrl and isExternal flag
  */
 export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
@@ -51,7 +51,6 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 	// This must happen before trusting the type attribute
 	try {
 		const parsedUrl = new URL( linkUrl );
-		// Use provided homeUrl or fall back to window.location
 		// Compare by host (not origin) so http/https to same site both count as internal
 		const siteHost = new URL( homeUrl ).host;
 
@@ -68,8 +67,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 			isExternal = true;
 		}
 	} catch ( e ) {
-		// URL parsing failed - this means it's likely a URL without a protocol (e.g., "www.example.com")
-		// Since we already checked for relative paths and hash links above, treat as external
+		// URL parsing failed - treat as external (e.g. no homeUrl, or URL without protocol)
 		isExternal = true;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Determine internal vs external by `new URL('https://mysite.com').host` instead of `new URL('https://mysite.com').origin`. On trunk, when you use the same URL but change the http:// vs https://, one is considered external.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When determining whether a navigation link is internal or external, the previous implementation compared URLs by their `origin` (scheme + host + port). This caused links using `http://` to be incorrectly classified as external when the site URL used `https://`, even if they pointed to the same domain.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR fixes the comparison to use `host` instead of `origin`, so `http://example.com/page` and `https://example.com/page` are both treated as internal links to an `https://example.com` site.

Additionally, the `window.location.origin` fallback (used when `homeUrl` was not provided) has been removed. The `homeUrl` is now required for internal/external detection; without it, URL parsing fails gracefully and the link is treated as external.

A unit test covering the http/https case is included.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Use the navigation block to add two manual, identical URLs to your navigation:
  - One with http:// - ie: http://localhost:8888
  - One with https:// - ie: https://localhost:8888
- Both should report "Page" and not "External"
- Add an external link, like http://test.com
- Should correctly report external

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
