### PR TITLE
Post Title: Add placeholder attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -780,7 +780,7 @@ Displays the title of a post, page, or any other content-type. ([Source](https:/
 -	**Name:** core/post-title
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
--	**Attributes:** isLink, level, levelOptions, linkTarget, rel
+-	**Attributes:** isLink, level, levelOptions, linkTarget, placeholder, rel
 
 ## Preformatted
 

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -30,6 +30,9 @@
 			"type": "string",
 			"default": "_self",
 			"role": "content"
+		},
+		"placeholder": {
+			"type": "string"
 		}
 	},
 	"example": {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -28,7 +28,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostTitleEdit( {
-	attributes: { level, levelOptions, isLink, rel, linkTarget },
+	attributes: { level, levelOptions, isLink, rel, linkTarget, placeholder },
 	setAttributes,
 	context: { postType, postId, queryId },
 	insertBlocksAfter,
@@ -70,7 +70,9 @@ export default function PostTitleEdit( {
 	const blockEditingMode = useBlockEditingMode();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	let titleElement = <TagName { ...blockProps }>{ __( 'Title' ) }</TagName>;
+	let titleElement = (
+		<TagName { ...blockProps }>{ placeholder || __( 'Title' ) }</TagName>
+	);
 
 	if ( postType && postId ) {
 		titleElement = userCanEdit ? (


### PR DESCRIPTION
## What?
Adds a `placeholder` attribute to the Post Title block so users can customize the placeholder text shown when in template-preview mode.

Closes #75938.

## How?
- Added a `placeholder` string attribute to `block.json`
- Updated the edit component to use the custom placeholder instead of the hardcoded "Title" string; it still falls back to "Title" when the placeholder is empty
- Updated `core-blocks.md` docs to reflect the new attribute

## Screenshot
![placeholder-attr](https://github.com/user-attachments/assets/ad6c1e54-4f63-43cd-b1fe-667c6ebe390e)

## Testing Instructions
1. Open the Site Editor
2. Insert a **Post Title** block
3. In the block's attributes (via Code Editor or block JSON), set e.g., `"placeholder": "Book title"`
4. Switch back to the visual editor
5. Expect the Post Title block to display "Book title" instead of the default "Title" when no post is loaded