### PR TITLE
[Real-time Collaboration] Fix sync issue on refresh

### DIFF
--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -37,6 +37,7 @@ import { createUndoManager } from './undo-manager';
 import {
 	createYjsDoc,
 	deserializeCrdtDoc,
+	initializeYjsDoc,
 	markEntityAsSaved,
 	serializeCrdtDoc,
 } from './utils';
@@ -284,6 +285,9 @@ export function createSyncManager( debug = false ): SyncManager {
 		recordMap.observeDeep( onRecordUpdate );
 		stateMap.observe( onStateMapUpdate );
 
+		// Initialize the Yjs document with the necessary CRDT state.
+		initializeYjsDoc( ydoc );
+
 		// Get and apply the persisted CRDT document, if it exists.
 		internal.applyPersistedCrdtDoc( objectType, objectId, record );
 	}
@@ -384,6 +388,9 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		// Attach observers.
 		stateMap.observe( onStateMapUpdate );
+
+		// Initialize the Yjs document with the necessary CRDT state.
+		initializeYjsDoc( ydoc );
 	}
 
 	/**

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -462,12 +462,6 @@ function registerRoom( {
 	}
 
 	// Note: Queue is initially paused. Call .resume() to unpause.
-	// Include the current doc state as an UPDATE alongside the SYNC_STEP_1 to
-	// ensure any operations created before the onDocUpdate handler is attached
-	// (e.g. the VERSION_KEY set in createYjsDoc) are sent to peers. Without
-	// this, peers may receive subsequent operations that depend on these
-	// earlier operations but never receive the operations themselves, causing
-	// all updates to be stuck in Yjs's pendingStructs buffer.
 	const updateQueue = createUpdateQueue( [ createSyncStep1Update( doc ) ] );
 
 	function onAwarenessUpdate(): void {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -468,10 +468,7 @@ function registerRoom( {
 	// this, peers may receive subsequent operations that depend on these
 	// earlier operations but never receive the operations themselves, causing
 	// all updates to be stuck in Yjs's pendingStructs buffer.
-	const updateQueue = createUpdateQueue( [
-		createSyncStep1Update( doc ),
-		createSyncUpdate( Y.encodeStateAsUpdate( doc ), SyncUpdateType.UPDATE ),
-	] );
+	const updateQueue = createUpdateQueue( [ createSyncStep1Update( doc ) ] );
 
 	function onAwarenessUpdate(): void {
 		roomState.localAwarenessState = awareness.getLocalState() ?? {};

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -462,7 +462,16 @@ function registerRoom( {
 	}
 
 	// Note: Queue is initially paused. Call .resume() to unpause.
-	const updateQueue = createUpdateQueue( [ createSyncStep1Update( doc ) ] );
+	// Include the current doc state as an UPDATE alongside the SYNC_STEP_1 to
+	// ensure any operations created before the onDocUpdate handler is attached
+	// (e.g. the VERSION_KEY set in createYjsDoc) are sent to peers. Without
+	// this, peers may receive subsequent operations that depend on these
+	// earlier operations but never receive the operations themselves, causing
+	// all updates to be stuck in Yjs's pendingStructs buffer.
+	const updateQueue = createUpdateQueue( [
+		createSyncStep1Update( doc ),
+		createSyncUpdate( Y.encodeStateAsUpdate( doc ), SyncUpdateType.UPDATE ),
+	] );
 
 	function onAwarenessUpdate(): void {
 		roomState.localAwarenessState = awareness.getLocalState() ?? {};

--- a/packages/sync/src/test/utils.ts
+++ b/packages/sync/src/test/utils.ts
@@ -8,11 +8,19 @@ import { describe, expect, it, beforeEach } from '@jest/globals';
 /**
  * Internal dependencies
  */
-import { createYjsDoc, serializeCrdtDoc, deserializeCrdtDoc } from '../utils';
+import {
+	createYjsDoc,
+	initializeYjsDoc,
+	markEntityAsSaved,
+	serializeCrdtDoc,
+	deserializeCrdtDoc,
+} from '../utils';
 import {
 	CRDT_DOC_META_PERSISTENCE_KEY,
 	CRDT_DOC_VERSION,
 	CRDT_STATE_MAP_KEY,
+	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
+	CRDT_STATE_MAP_SAVED_BY_KEY as SAVED_BY_KEY,
 	CRDT_STATE_MAP_VERSION_KEY as VERSION_KEY,
 } from '../config';
 
@@ -40,11 +48,81 @@ describe( 'utils', () => {
 			expect( ydoc.meta?.size ).toBe( 0 );
 		} );
 
+		it( 'does not advance the state vector when creating the doc', () => {
+			const ydoc = createYjsDoc();
+			const sv = Y.decodeStateVector( Y.encodeStateVector( ydoc ) );
+
+			// createYjsDoc does not make any updates to the doc, so the state
+			// vector for the doc's client ID should be undefined.
+			expect( sv.get( ydoc.clientID ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'initializeYjsDoc', () => {
 		it( 'sets the CRDT document version in the state map', () => {
-			const ydoc = createYjsDoc( {} );
+			const ydoc = new Y.Doc( {} );
 			const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
 
+			initializeYjsDoc( ydoc );
+
 			expect( stateMap.get( VERSION_KEY ) ).toBe( CRDT_DOC_VERSION );
+		} );
+
+		it( 'advances the state vector when setting the version key', () => {
+			const ydoc = new Y.Doc();
+
+			initializeYjsDoc( ydoc );
+
+			const sv = Y.decodeStateVector( Y.encodeStateVector( ydoc ) );
+
+			// createYjsDoc sets VERSION_KEY via stateMap.set(), which creates
+			// a Yjs operation. This advances the state vector for the doc's
+			// client ID to clock 1.
+			expect( sv.get( ydoc.clientID ) ).toBe( 1 );
+		} );
+
+		it( 'fires an update event when setting the version key', () => {
+			const updates: Uint8Array[] = [];
+			const ydoc = new Y.Doc();
+
+			ydoc.on( 'update', ( update: Uint8Array ) => {
+				updates.push( update );
+			} );
+
+			initializeYjsDoc( ydoc );
+
+			expect( updates ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'markEntityAsSaved', () => {
+		it( 'sets the saved-at timestamp and saved-by client ID', () => {
+			const ydoc = createYjsDoc();
+			const before = Date.now();
+
+			markEntityAsSaved( ydoc );
+
+			const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
+			const savedAt = stateMap.get( SAVED_AT_KEY ) as number;
+			const savedBy = stateMap.get( SAVED_BY_KEY );
+
+			expect( savedAt ).toBeGreaterThanOrEqual( before );
+			expect( savedAt ).toBeLessThanOrEqual( Date.now() );
+			expect( savedBy ).toBe( ydoc.clientID );
+		} );
+
+		it( 'updates the timestamp on subsequent calls', () => {
+			const ydoc = createYjsDoc();
+
+			markEntityAsSaved( ydoc );
+			const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
+			const firstSavedAt = stateMap.get( SAVED_AT_KEY ) as number;
+
+			// Small delay to ensure timestamp changes.
+			markEntityAsSaved( ydoc );
+			const secondSavedAt = stateMap.get( SAVED_AT_KEY ) as number;
+
+			expect( secondSavedAt ).toBeGreaterThanOrEqual( firstSavedAt );
 		} );
 	} );
 
@@ -75,6 +153,8 @@ describe( 'utils', () => {
 
 		beforeEach( () => {
 			originalDoc = createYjsDoc();
+			initializeYjsDoc( originalDoc );
+
 			const ymap = originalDoc.getMap( 'testMap' );
 			ymap.set( 'title', 'Test Title' );
 			ymap.set( 'count', 42 );

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -21,7 +21,13 @@ import type { CRDTDoc } from './types';
 type DocumentMeta = Record< string, DocumentMetaValue >;
 type DocumentMetaValue = boolean | number | string;
 
-export function createYjsDoc( documentMeta: DocumentMeta = {} ): Y.Doc {
+/**
+ * Creates a new Y.Doc instance with the given document metadata.
+ *
+ * @param {DocumentMeta} documentMeta Optional metadata to associate with the
+ *                                    document. Metadata is not persisted.
+ */
+export function createYjsDoc( documentMeta: DocumentMeta = {} ): CRDTDoc {
 	// Convert the object representation of CRDT document metadata to a map.
 	// Document metadata is passed to the Y.Doc constructor and stored in its
 	// `meta` property. It is not synced to peers or persisted with the document.
@@ -30,12 +36,19 @@ export function createYjsDoc( documentMeta: DocumentMeta = {} ): Y.Doc {
 		Object.entries( documentMeta )
 	);
 
-	const ydoc = new Y.Doc( { meta: metaMap } );
+	// IMPORTANT: Do not add update the document itself to avoid generating updates
+	// before observers are attached. Add initial updates in `initializeYjsDoc`.
+	return new Y.Doc( { meta: metaMap } );
+}
+
+/**
+ * Initializes a Y.Doc instance with the necessary CRDT state for our use case.
+ *
+ * @param {Y.Doc} ydoc Y.Doc instance to initialize.
+ */
+export function initializeYjsDoc( ydoc: CRDTDoc ): void {
 	const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
-
 	stateMap.set( VERSION_KEY, CRDT_DOC_VERSION );
-
-	return ydoc;
 }
 
 /**

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * External dependencies
+ */
+import type { BrowserContext, Page } from '@playwright/test';
+
+/**
+ * WordPress dependencies
+ */
+import { Editor } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+import { SECOND_USER } from './fixtures/collaboration-utils';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+
+test.describe( 'Collaboration - Refresh', () => {
+	let secondContext: BrowserContext;
+	let page2: Page;
+	let editor2: Editor;
+
+	test.afterEach( async () => {
+		await secondContext?.close();
+	} );
+
+	test( 'User A edits are synced to User B after User A refreshes', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+		admin,
+	} ) => {
+		// Destructuring collaborationUtils activates the fixture which
+		// enables the collaboration setting and creates the second user.
+		void collaborationUtils;
+
+		const post = await requestUtils.createPost( {
+			title: 'Refresh Sync Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		// Step 1: User A opens the post, adds content, and saves.
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+		await page.waitForFunction(
+			() =>
+				( window as any )._wpCollaborationEnabled === true &&
+				window?.wp?.data &&
+				window?.wp?.blocks,
+			{ timeout: 15000 }
+		);
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Saved content from User A' },
+		} );
+
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/editor' ).savePost()
+		);
+
+		await page.waitForTimeout( 3000 );
+
+		// Step 2: User B loads the post and adds content.
+		secondContext = await page
+			.context()
+			.browser()!
+			.newContext( { baseURL: BASE_URL } );
+		page2 = await secondContext.newPage();
+
+		await page2.goto( '/wp-login.php' );
+		await page2.locator( '#user_login' ).fill( SECOND_USER.username );
+		await page2.locator( '#user_pass' ).fill( SECOND_USER.password );
+		await page2.getByRole( 'button', { name: 'Log In' } ).click();
+		await page2.waitForURL( '**/wp-admin/**' );
+
+		await page2.goto( `/wp-admin/post.php?post=${ post.id }&action=edit` );
+		await page2.waitForFunction(
+			() => window?.wp?.data && window?.wp?.blocks
+		);
+		await page2.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-post', 'welcomeGuide', false );
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-post', 'fullscreenMode', false );
+		} );
+		await page2.waitForFunction(
+			() =>
+				( window as any )._wpCollaborationEnabled === true &&
+				window?.wp?.data &&
+				window?.wp?.blocks,
+			{ timeout: 15000 }
+		);
+		editor2 = new Editor( { page: page2 } );
+
+		// Wait for both users to discover each other via awareness.
+		await Promise.all( [
+			page
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 15000 } ),
+			page2
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 15000 } ),
+		] );
+
+		await page.waitForTimeout( 3000 );
+
+		// User B adds content.
+		await page2.evaluate( () => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: 'Content from User B',
+			} );
+			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
+		} );
+
+		// User A should see User B's content.
+		await expect
+			.poll(
+				async () => {
+					const blocks = await editor.getBlocks();
+					return blocks.map(
+						( b: { attributes: Record< string, unknown > } ) =>
+							b.attributes.content
+					);
+				},
+				{ timeout: 5000 }
+			)
+			.toContain( 'Content from User B' );
+
+		await page.waitForTimeout( 3000 );
+
+		// Step 3: User A refreshes the page.
+		await page.reload( { waitUntil: 'load' } );
+
+		// Wait for collaboration to re-initialize after refresh.
+		await page.waitForFunction(
+			() =>
+				( window as any )._wpCollaborationEnabled === true &&
+				window?.wp?.data &&
+				window?.wp?.blocks,
+			{ timeout: 15000 }
+		);
+
+		// Wait for both users to re-discover each other via awareness.
+		await Promise.all( [
+			page
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 15000 } ),
+			page2
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 15000 } ),
+		] );
+
+		await page.waitForTimeout( 3000 );
+
+		// Step 4: User A adds new content after refresh.
+		await page.evaluate( () => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: 'After refresh from User A',
+			} );
+			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
+		} );
+
+		// User B should see User A's new content.
+		// The bug in #75976 causes User A's post-refresh edits to be
+		// invisible to User B despite the polling connection appearing active.
+		await expect
+			.poll(
+				async () => {
+					const blocks = await editor2.getBlocks();
+					return blocks.map(
+						( b: { attributes: Record< string, unknown > } ) =>
+							b.attributes.content
+					);
+				},
+				{ timeout: 5000 }
+			)
+			.toContain( 'After refresh from User A' );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -59,16 +59,12 @@ test.describe( 'Collaboration - Refresh', () => {
 			{ timeout: 15000 }
 		);
 
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'Saved content from User A' },
-		} );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'Saved content from User A' );
 
-		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).savePost()
-		);
-
-		await page.waitForTimeout( 3000 );
+		await editor.saveDraft();
 
 		// Step 2: User B loads the post and adds content.
 		secondContext = await page
@@ -114,15 +110,14 @@ test.describe( 'Collaboration - Refresh', () => {
 				.waitFor( { timeout: 15000 } ),
 		] );
 
-		await page.waitForTimeout( 3000 );
-
-		// User B adds content.
-		await page2.evaluate( () => {
-			const block = window.wp.blocks.createBlock( 'core/paragraph', {
-				content: 'Content from User B',
-			} );
-			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
-		} );
+		// User B adds content below the existing paragraph.
+		await editor2.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.last()
+			.click();
+		await page2.keyboard.press( 'End' );
+		await page2.keyboard.press( 'Enter' );
+		await page2.keyboard.type( 'Content from User B' );
 
 		// User A should see User B's content.
 		await expect
@@ -137,8 +132,6 @@ test.describe( 'Collaboration - Refresh', () => {
 				{ timeout: 5000 }
 			)
 			.toContain( 'Content from User B' );
-
-		await page.waitForTimeout( 3000 );
 
 		// Step 3: User A refreshes the page.
 		await page.reload( { waitUntil: 'load' } );
@@ -162,15 +155,14 @@ test.describe( 'Collaboration - Refresh', () => {
 				.waitFor( { timeout: 15000 } ),
 		] );
 
-		await page.waitForTimeout( 3000 );
-
 		// Step 4: User A adds new content after refresh.
-		await page.evaluate( () => {
-			const block = window.wp.blocks.createBlock( 'core/paragraph', {
-				content: 'After refresh from User A',
-			} );
-			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
-		} );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.last()
+			.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'After refresh from User A' );
 
 		// User B should see User A's new content.
 		// The bug in #75976 causes User A's post-refresh edits to be

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -165,8 +165,6 @@ test.describe( 'Collaboration - Refresh', () => {
 		await page.keyboard.type( 'After refresh from User A' );
 
 		// User B should see User A's new content.
-		// The bug in #75976 causes User A's post-refresh edits to be
-		// invisible to User B despite the polling connection appearing active.
 		await expect
 			.poll(
 				async () => {

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -66,6 +66,15 @@ export default class CollaborationUtils {
 		const html = await response.text();
 		const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
 
+		// WordPress core (7.0+) uses 'enable_real_time_collaboration',
+		// while the Gutenberg plugin uses 'wp_enable_real_time_collaboration'.
+		// Detect which field name is present on the page.
+		const optionName = html.includes(
+			'name="enable_real_time_collaboration"'
+		)
+			? 'enable_real_time_collaboration'
+			: 'wp_enable_real_time_collaboration';
+
 		const formData: Record< string, string | number > = {
 			option_page: 'writing',
 			action: 'update',
@@ -77,7 +86,7 @@ export default class CollaborationUtils {
 		};
 
 		if ( enabled ) {
-			formData.wp_enable_real_time_collaboration = 1;
+			formData[ optionName ] = 1;
 		}
 
 		await this.requestUtils.request.post( '/wp-admin/options.php', {


### PR DESCRIPTION
## What?

Fixes #75976

Improves Yjs initialization to prevent issues when a collaborator refreshes their page

## Why?

When a collaborator refreshed, they could get into a state where their changes weren't being properly synced.

## How?
Instead of adding updates in `createYjsDoc`, delay those updates instead until `initializeYjsDoc` when observers have already been attached.

## Testing Instructions
1. Enable real-time collaboration via WordPress Admin -> Settings -> Writing, and check the "Enable real-time collaboration" checkbox. Click the "Save Changes" button.
2. Open a post in tab A, then add a title and content and click "Save Draft".
3. In tab B, also open the post and add content. Both users should see the content synced.
4. Go back to tab A and refresh the page.
5. After refreshing, add more content in tab A. Verify the new content in tab A is synced to other peers.
