### PR TITLE
Components: Fix Tabs selected indicator position when sibling tab resizes

### DIFF
--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -87,10 +87,34 @@ export const TabList = forwardRef<
 		renderedItems && selectedItem
 			? renderedItems.indexOf( selectedItem )
 			: -1;
+
+	// Track when any tab item resizes, so that the selected indicator
+	// position is recalculated even when a sibling tab changes size.
+	const [ tabsResizeCount, setTabsResizeCount ] = useState( 0 );
+	useLayoutEffect( () => {
+		if ( ! renderedItems?.length ) {
+			return;
+		}
+
+		const observer = new ResizeObserver( () => {
+			setTabsResizeCount( ( prev ) => prev + 1 );
+		} );
+
+		for ( const item of renderedItems ) {
+			if ( item.element ) {
+				observer.observe( item.element );
+			}
+		}
+
+		return () => observer.disconnect();
+	}, [ renderedItems ] );
+
 	// Use selectedItemIndex as a dependency to force recalculation when the
 	// selected item index changes (elements are swapped / added / removed).
+	// Use tabsResizeCount to force recalculation when any tab resizes.
 	const selectedRect = useTrackElementOffsetRect( selectedItem?.element, [
 		selectedItemIndex,
+		tabsResizeCount,
 	] );
 
 	// Track overflow to show scroll hints.


### PR DESCRIPTION
## What?
Closes #75716

Fixes the Tabs component's selected tab underline indicator being positioned incorrectly when a sibling tab changes size.

## Why?

The `useTrackElementOffsetRect` hook only observed the selected tab element for resize changes. When a sibling tab changed size (e.g., the label changed from "Template" to "Template Part"), the selected tab's position shifted but
the `ResizeObserver` didn't fire because the selected tab itself didn't resize only its position within the tablist changed.

This bug was visible in the site editor when navigating between a template and a template part, where the inspector tab label changes and the neighboring tab's underline indicator could end up in the wrong position.

## How?

Added a `ResizeObserver` in `TabList` that observes all rendered tab item elements. When any tab item resizes, it triggers a remeasurement of the selected tab's offset rect via the existing `deps` escape hatch in `useTrackElementOffsetRect`. This ensures the underline indicator is repositioned correctly even when the size change comes from a sibling tab.

## Testing Instructions

1. Open the site editor, and navigate to a template like 'Blog home'
2. Click the header template part, and open the block inspector sidebar.
3. Click 'Edit original' to access the template part editor
4. When the template part editor opens, select a block in the template part and ensure the 'Block' tab is selected
5. From the editor topbar, click the back button
6. Verify the selected tab underline is in the correct position


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/0082517d-006a-40cc-9b7c-4f515f715286


After:


https://github.com/user-attachments/assets/cf0f4549-7146-406b-a1fa-141b211e68fd

