### PR TITLE
Editor: Decode HTML entities in raw post title input

### DIFF
--- a/packages/editor/src/components/post-title/post-title-raw.js
+++ b/packages/editor/src/components/post-title/post-title-raw.js
@@ -68,7 +68,7 @@ function PostTitleRaw( _, forwardedRef ) {
 	return (
 		<TextareaControl
 			ref={ focusRef }
-			value={ title }
+			value={ decodeEntities( title ) }
 			onChange={ onChange }
 			onFocus={ onSelect }
 			onBlur={ onUnselect }


### PR DESCRIPTION
## What?

Closes #44445

Applies `decodeEntities()` to the title value displayed in the raw (code editor) post title input field.

## Why?

When a post title contains HTML entities (e.g., `&amp;`, `&lt;`, `&#038;`), the raw post title editor (`PostTitleRaw`) displays them literally instead of their decoded characters. For example, a title stored as `Tom &amp; Jerry` shows as `Tom &amp; Jerry` instead of `Tom & Jerry`.

The visual editor already handles this correctly because `useRichText` internally parses the value via `RichTextData.fromHTMLString()`, which decodes entities. The raw editor, however, passes the title string directly to `<TextareaControl>`.

## How?

Wrapped the `title` value with `decodeEntities()` in the `PostTitleRaw` component before passing it to `<TextareaControl>`. The `decodeEntities` import was already present in the file (used for the placeholder).

## Testing Instructions

1. Create a post with a title containing special characters (e.g., `Tom & Jerry` or `A < B`)
2. Save the post
3. Switch to the **Code editor** (Cmd/Ctrl+Shift+Alt+M or via Options menu)
4. Verify the title displays correctly with decoded characters, not raw entities

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1265" height="272" alt="image" src="https://github.com/user-attachments/assets/74520ac5-78e8-4e3c-9842-3b8a65c22ad9" />|<img width="1347" height="266" alt="image" src="https://github.com/user-attachments/assets/8fb9dc95-8e12-4684-98f2-2f97904bea5b" />|
