### PR TITLE
Search block: double-encodes apostrophes in the input value

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -72,7 +72,7 @@ function render_block_core_search( $attributes ) {
 	if ( $input->next_tag() ) {
 		$input->add_class( implode( ' ', $input_classes ) );
 		$input->set_attribute( 'id', $input_id );
-		$input->set_attribute( 'value', get_search_query() );
+		$input->set_attribute( 'value', get_search_query( false ) );
 		$input->set_attribute( 'placeholder', $attributes['placeholder'] );
 
 		// If it's interactive, enqueue the script module and add the directives.


### PR DESCRIPTION
 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

closes https://github.com/WordPress/gutenberg/issues/76010
## What?

<!-- In a few words, what is the PR actually doing? -->
Fixes the double-encoding of special characters (e.g., apostrophes) in the Search block's input field on the search results page.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When searching for a term containing an apostrophe (e.g., "ada's"), the search input field on the results page displays ada&#039;s instead of ada's. This happens because get_search_query() returns a pre-escaped string (via esc_attr()), and WP_HTML_Tag_Processor::set_attribute() escapes it again, causing double-encoding.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Pass false to get_search_query() in [index.php](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so it returns the raw, unescaped query string. WP_HTML_Tag_Processor::set_attribute() already handles attribute escaping internally, so the single round of escaping is sufficient and correct.

```JS
- $input->set_attribute( 'value', get_search_query() );
+ $input->set_attribute( 'value', get_search_query( false ) );
```

## Testing Instructions

1. Add a Search block to any page or template.
2. On the frontend, search for a term containing an apostrophe, e.g., ada's.
3. On the search results page, verify the search input field displays ada's correctly (not ada&#039;s).
4. Also test with other special characters like "quotes", <angle>, and &ampersand to confirm they render correctly without double-encoding.

### Testing Instructions for Keyboard

1. Use <kbd>Tab</kbd> to navigate to the search input field.
2. Type a search term containing an apostrophe and press <kbd>Enter</kbd>.
3. On the results page, <kbd>Tab</kbd> back to the search input and verify the displayed value is correct.

## Screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/6e814936-5bf7-44aa-b837-90fe22d3d0d8


 