### PR TITLE
ToolsPanel: Remove unnecessary label prop from dropdownMenuProps type

### DIFF
--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -20,7 +20,10 @@ export type ToolsPanelProps = {
 	/**
 	 * The dropdown menu props to configure the panel's `DropdownMenu`.
 	 */
-	dropdownMenuProps?: React.ComponentProps< typeof DropdownMenu >;
+	dropdownMenuProps?: Omit<
+		React.ComponentProps< typeof DropdownMenu >,
+		'label'
+	>;
 	/**
 	 * Flags that the items in this ToolsPanel will be contained within an inner
 	 * wrapper element allowing the panel to lay them out accordingly.


### PR DESCRIPTION
Follow-up on #70951

## What?

We omitted the unnecessary `label` property from the type of `dropdownMenuProps` in #70951. However, we should have changed not only `ToolsPanelHeaderProps` but also `ToolsPanelProps`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Add the following code somewhere and make sure it doesn't cause any errors:

```typescript
import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';

function Component() {
	return (
		<ToolsPanel label="Test" resetAll={ () => {} } dropdownMenuProps={ {} }>
			Children
		</ToolsPanel>
	);
}
export default Component;
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

<img width="1034" height="510" alt="image" src="https://github.com/user-attachments/assets/fdaae6d9-f454-4f73-985c-d0069cbc4823" />

After:

<img width="1047" height="287" alt="image" src="https://github.com/user-attachments/assets/a543e3a9-9af9-43d3-a63a-39c91296e79d" />

