### PR TITLE
Fix: Set quality and strip metadata in client-side image resize

### DIFF
--- a/packages/upload-media/src/store/utils/index.ts
+++ b/packages/upload-media/src/store/utils/index.ts
@@ -135,6 +135,7 @@ export async function vipsHasTransparency( url: string ) {
  * @param addSuffix    Whether to add dimension suffix to filename.
  * @param signal       Optional abort signal to cancel the operation.
  * @param scaledSuffix Whether to add '-scaled' suffix instead of dimensions (for big image threshold).
+ * @param quality      Desired quality (0-1). Defaults to 0.82.
  * @return Resized ImageFile with dimension metadata.
  */
 export async function vipsResizeImage(
@@ -144,7 +145,8 @@ export async function vipsResizeImage(
 	smartCrop: boolean,
 	addSuffix: boolean,
 	signal?: AbortSignal,
-	scaledSuffix?: boolean
+	scaledSuffix?: boolean,
+	quality?: number
 ) {
 	if ( signal?.aborted ) {
 		throw new Error( 'Operation aborted' );
@@ -157,7 +159,8 @@ export async function vipsResizeImage(
 			await file.arrayBuffer(),
 			file.type,
 			resize,
-			smartCrop
+			smartCrop,
+			quality
 		);
 
 	let fileName = file.name;

--- a/packages/vips/README.md
+++ b/packages/vips/README.md
@@ -80,6 +80,7 @@ _Parameters_
 -   _type_ `string`: Mime type.
 -   _resize_ `ImageSizeCrop`: Resize options.
 -   _smartCrop_ Whether to use smart cropping (i.e. saliency-aware).
+-   _quality_ Desired quality (0-1).
 
 _Returns_
 
@@ -168,6 +169,7 @@ _Parameters_
 -   _type_ `string`: Mime type.
 -   _resize_ `ImageSizeCrop`: Resize options.
 -   _smartCrop_ Whether to use smart cropping (i.e. saliency-aware).
+-   _quality_ Desired quality (0-1).
 
 _Returns_
 

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -134,7 +134,11 @@ export async function convertImageFormat(
 			}
 		};
 
-		const saveOptions: SaveOptions< typeof outputType > = {};
+		const saveOptions: SaveOptions< typeof outputType > = {
+			// Strip metadata except ICC color profiles,
+			// matching WordPress core's behavior.
+			keep: 'icc',
+		};
 
 		if ( supportsQuality( outputType ) ) {
 			saveOptions.Q = quality * 100;
@@ -189,6 +193,7 @@ export async function compressImage(
  * @param type      Mime type.
  * @param resize    Resize options.
  * @param smartCrop Whether to use smart cropping (i.e. saliency-aware).
+ * @param quality   Desired quality (0-1).
  * @return Processed file data plus the old and new dimensions.
  */
 export async function resizeImage(
@@ -196,7 +201,8 @@ export async function resizeImage(
 	buffer: ArrayBuffer,
 	type: string,
 	resize: ImageSizeCrop,
-	smartCrop = false
+	smartCrop = false,
+	quality = 0.82
 ): Promise< {
 	buffer: ArrayBuffer | ArrayBufferLike;
 	width: number;
@@ -321,8 +327,16 @@ export async function resizeImage(
 			image.onProgress = onProgress;
 		}
 
-		// TODO: Allow passing quality?
-		const saveOptions: SaveOptions< typeof type > = {};
+		const saveOptions: SaveOptions< typeof type > = {
+			// Strip metadata except ICC color profiles,
+			// matching WordPress core's behavior.
+			keep: 'icc',
+		};
+
+		if ( supportsQuality( type ) ) {
+			saveOptions.Q = quality * 100;
+		}
+
 		const outBuffer = image.writeToBuffer( `.${ ext }`, saveOptions );
 
 		const result = {

--- a/packages/vips/src/vips-worker.ts
+++ b/packages/vips/src/vips-worker.ts
@@ -108,6 +108,7 @@ export async function vipsCompressImage(
  * @param type      Mime type.
  * @param resize    Resize options.
  * @param smartCrop Whether to use smart cropping (i.e. saliency-aware).
+ * @param quality   Desired quality (0-1). Defaults to 0.82.
  * @return Processed file data plus the old and new dimensions.
  */
 export async function vipsResizeImage(
@@ -115,7 +116,8 @@ export async function vipsResizeImage(
 	buffer: ArrayBuffer,
 	type: string,
 	resize: ImageSizeCrop,
-	smartCrop = false
+	smartCrop = false,
+	quality = 0.82
 ): Promise< {
 	buffer: ArrayBuffer | ArrayBufferLike;
 	width: number;
@@ -124,7 +126,7 @@ export async function vipsResizeImage(
 	originalHeight: number;
 } > {
 	const api = getWorkerAPI();
-	return api.resizeImage( id, buffer, type, resize, smartCrop );
+	return api.resizeImage( id, buffer, type, resize, smartCrop, quality );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/WordPress/gutenberg/issues/76030

Match existing core server processing behavior by stripping (most) exif data from image sub sizes.

- Add `quality` parameter (default 0.82) to `resizeImage()` in `@wordpress/vips`, matching WordPress core's Imagick quality for sub-sizes
- Add `keep: 'icc'` to `SaveOptions` in both `resizeImage()` and `convertImageFormat()` to strip non-essential metadata (EXIF, XMP, IPTC) while preserving ICC color profiles, matching WordPress core's behavior
- Pass quality through the `vipsResizeImage` wrapper in `@wordpress/upload-media`

This reduces client-side generated thumbnail file sizes to be comparable with server-side ones (e.g. ~25KB vs previously ~34KB).

## Samples
Stripping the meta data is most important for the smallest images where it represents a disproportionate amount of the data.  Note thumbnail file size.

### Server
<img width="500" height="" alt="server processing" src="https://github.com/user-attachments/assets/19b3eb2e-95be-4bc4-bd4e-a8f7d54362bb" />
erver


### Before PR
<img width="500" height="" alt="on pr" src="https://github.com/user-attachments/assets/6469093e-fc83-4b6c-8a9f-a8fae682e437" />


### After PR
<img width="500" height="" alt="strip-metadata" src="https://github.com/user-attachments/assets/ddc6ba80-f11f-430c-95bd-f1e3380b3b61" />




## Testing instructions

- [ ] Upload a JPEG image with meta data
- [ ] Verify thumbnails retain correct colors (ICC profile preserved)
- [ ] Verify EXIF data is stripped from thumbnails
- [ ] Test format conversion (e.g. JPEG to WebP) still works correctly
- [ ] Compare thumbnail file sizes with server-side generated ones — they should now be comparable or better at all sizes

