### PR TITLE
fix: A11y issue in play/pause of the audio player in playlist block

### DIFF
--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -127,7 +127,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 			data-wp-on--play="actions.isPlaying"
 			data-wp-on--pause="actions.isPaused"
 			data-wp-bind--src="state.currentTrack.url"
-			data-wp-bind--aria-label="state.currentTrack.ariaLabel"
+			data-wp-bind--aria-label="state.currentTrackAriaLabel"
 			data-wp-watch="callbacks.autoPlay"
 		></audio>
 	';

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -19,6 +19,12 @@ store(
 				}
 				return playlist.tracks[ currentId ] || {};
 			},
+			get currentTrackAriaLabel() {
+				const { isPlaying } = getContext();
+				const baseLabel = this.currentTrack?.ariaLabel || '';
+				const action = isPlaying ? 'Pause ' : 'Play ';
+				return action + baseLabel;
+			},
 			get isCurrentTrack() {
 				const { currentId, uniqueId } = getContext();
 				return currentId === uniqueId;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Prepends the action ("Play"/"Pause") to the audio control aria-label so screen readers hear the intended action plus track info.

Closes https://github.com/WordPress/gutenberg/issues/75583


## Why?
Screen readers only received track metadata and lacked the action context (play vs pause), reducing accessibility.


## How?
Adds a derived state that returns "Play " or "Pause " + the track label, and binds the audio element's aria-label to it.

## Testing Instructions

1. Add a Playlist block with tracks.
2. Start and pause playback.
3. Verify the audio element's reads "Play …" when paused and "Pause …" when playing.


### Testing Instructions for Keyboard
Tab to the play control, press Space/Enter to toggle, and confirm the aria-label updates accordingly.


## Screencast




https://github.com/user-attachments/assets/ab2370d2-a84a-4da8-8703-572eb31c316c


