### PR TITLE
build: Exclude experimental pages from Core builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 				"id": "site-editor-v2",
 				"init": [
 					"@wordpress/edit-site-init"
-				]
+				],
+				"experimental": true
 			},
 			"font-library",
 			"connectors"

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1774,10 +1774,10 @@ async function buildAll( baseUrlExpression ) {
 	} );
 
 	// When building for WordPress Core, exclude experimental pages.
-	const IS_WORDPRESS_CORE = Boolean(
+	const isCoreBuild = Boolean(
 		process.env.npm_package_config_IS_WORDPRESS_CORE
 	);
-	const activePages = IS_WORDPRESS_CORE
+	const activePages = isCoreBuild
 		? normalizedPages.filter( ( page ) => ! page.experimental )
 		: normalizedPages;
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1769,11 +1769,23 @@ async function buildAll( baseUrlExpression ) {
 			id: page.id,
 			init: page.init || [],
 			title: page.title || undefined,
+			experimental: page.experimental || false,
 		};
 	} );
 
-	const pageData = normalizedPages.map( ( page ) => {
-		const pageRoutes = routes.filter( ( r ) => r.page === page.id );
+	// When building for WordPress Core, exclude experimental pages.
+	const IS_WORDPRESS_CORE = Boolean(
+		process.env.npm_package_config_IS_WORDPRESS_CORE
+	);
+	const activePages = IS_WORDPRESS_CORE
+		? normalizedPages.filter( ( page ) => ! page.experimental )
+		: normalizedPages;
+
+	const activePageIds = new Set( activePages.map( ( p ) => p.id ) );
+	const activeRoutes = routes.filter( ( r ) => activePageIds.has( r.page ) );
+
+	const pageData = activePages.map( ( page ) => {
+		const pageRoutes = activeRoutes.filter( ( r ) => r.page === page.id );
 		return {
 			slug: page.id,
 			routes: pageRoutes,
@@ -1838,8 +1850,8 @@ async function buildAll( baseUrlExpression ) {
 		generateScriptRegistrationPhp( scripts, phpReplacements ),
 		generateStyleRegistrationPhp( styles, phpReplacements ),
 		generateConstantsPhp( phpReplacements ),
-		generateRoutesRegistry( routes, phpReplacements ),
-		generateRoutesPhp( routes, phpReplacements ),
+		generateRoutesRegistry( activeRoutes, phpReplacements ),
+		generateRoutesPhp( activeRoutes, phpReplacements ),
 		generatePagesPhp( pageData, phpReplacements ),
 	] );
 	console.log( '   ✔ Generated build/build.php' );


### PR DESCRIPTION
## What?

Allow pages to be marked as `experimental` in `package.json`, and filter them out when building for WordPress Core.

## Why?

The `site-editor-v2` page is experimental and should not be included in WordPress Core builds. This change provides a mechanism to exclude experimental pages by setting the `IS_WORDPRESS_CORE` environment variable during the build process.

## How?

- Add an optional `experimental: true` flag to page entries in `wpPlugin.pages`
- Preserve the flag during page normalization in the build system
- Filter out experimental pages and their associated routes when `IS_WORDPRESS_CORE` is truthy
- Update route registry and route PHP generation to use only active routes

The change is backward-compatible: existing pages without the flag default to non-experimental and are always included.

## Testing Instructions

1. Run a normal build: `npm run build` — site-editor-v2 should be included as usual
2. Run with Core flag: `IS_WORDPRESS_CORE=true npm run build` — site-editor-v2 pages/routes should be excluded from output
3. Verify `build/pages/site-editor-v2/` does not exist when building with `IS_WORDPRESS_CORE=true`
4. Verify routes for site-editor-v2 are excluded from `build/routes/registry.php` in Core builds