### PR TITLE
DataForm: Fix `card` layout's toggle button screen reader text

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)
+- DataForm: Fix `card` layout's toggle button screen reader text. [#76039](https://github.com/WordPress/gutenberg/pull/76039)
 - DataViews: Fix focus transfer while searching in `list` layout. [#75999](https://github.com/WordPress/gutenberg/pull/75999)
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)
 - DataViews: Avoid flickering while refreshing. [#74572](https://github.com/WordPress/gutenberg/pull/74572)

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -98,14 +98,9 @@ export default function FormCardField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedCardLayout;
 	const cardBodyRef = useRef< HTMLDivElement >( null );
-	const bodyId = useInstanceId(
-		FormCardField,
-		'dataforms-layouts-card-card-body'
-	);
-	const titleId = useInstanceId(
-		FormCardField,
-		'dataforms-layouts-card-card-title'
-	);
+	const instanceId = useInstanceId( FormCardField );
+	const bodyId = `dataforms-layouts-card-card-body-${ instanceId }`;
+	const titleId = `dataforms-layouts-card-card-title-${ instanceId }`;
 
 	const form: NormalizedForm = useMemo(
 		() => ( {

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -16,7 +16,6 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
@@ -102,6 +101,10 @@ export default function FormCardField< Item >( {
 	const bodyId = useInstanceId(
 		FormCardField,
 		'dataforms-layouts-card-card-body'
+	);
+	const titleId = useInstanceId(
+		FormCardField,
+		'dataforms-layouts-card-card-title'
 	);
 
 	const form: NormalizedForm = useMemo(
@@ -240,7 +243,10 @@ export default function FormCardField< Item >( {
 							alignItems: 'center',
 						} }
 					>
-						<span className="dataforms-layouts-card__field-header-label">
+						<span
+							id={ titleId }
+							className="dataforms-layouts-card__field-header-label"
+						>
 							{ label }
 						</span>
 						{ validationBadge }
@@ -266,9 +272,7 @@ export default function FormCardField< Item >( {
 							icon={ isOpen ? chevronUp : chevronDown }
 							aria-expanded={ isOpen }
 							aria-controls={ bodyId }
-							aria-label={
-								isOpen ? __( 'Collapse' ) : __( 'Expand' )
-							}
+							aria-labelledby={ titleId }
 						/>
 					) }
 				</OriginalCardHeader>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73638

Currently in `card` layout of DataForm the toggle button to collapse and expand content simply announces "Expand" or "Collapse", lacking any context of what's being expanded/collapsed.

This PR improves that by using the [disclosure pattern
](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-card/) and now the card's label/title is announced in screen readers. Since we use `aria-labelledby` we don't need the previous `aria-label` and the existing `aria-expanded` attribute is enough to provide the necessary info to screen readers about the collapsed/expanded state.


## Testing Instructions
1. In storybook (`npm run storybook:dev`) go to the card story (`?path=/story/dataviews-dataform--layout-card`) and use a screen reader.


### Before

https://github.com/user-attachments/assets/5587bf5a-8cda-4941-8148-34ebf309c22d




### After



https://github.com/user-attachments/assets/88f28397-40d6-4679-9ac5-c8128b0c0ad5


