### PR TITLE
PHP-only Blocks: Reflect bound attribute values in inspector controls

### DIFF
--- a/packages/block-editor/src/hooks/auto-inspector-controls.js
+++ b/packages/block-editor/src/hooks/auto-inspector-controls.js
@@ -1,11 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { useMemo } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,6 +14,8 @@ import { __ } from '@wordpress/i18n';
 import InspectorControls from '../components/inspector-controls';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
+import BlockContext from '../components/block-context';
 import { generateFieldsFromAttributes } from './generate-fields-from-attributes';
 
 /**
@@ -45,9 +47,34 @@ function hasAutoGenerateControl( blockTypeAttributes ) {
 function AutoRegisterControls( { name, clientId, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
 
+	const blockContext = useContext( BlockContext );
+
 	const attributes = useSelect(
-		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
-		[ clientId ]
+		( select ) => {
+			const _attributes =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			if ( ! _attributes?.metadata?.bindings ) {
+				return _attributes;
+			}
+
+			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
+			return Object.entries( _attributes.metadata.bindings ).reduce(
+				( acc, [ attribute, binding ] ) => {
+					const source = getBlockBindingsSource( binding.source );
+					if ( ! source ) {
+						return acc;
+					}
+					const values = source.getValues( {
+						select,
+						context: blockContext,
+						bindings: { [ attribute ]: binding },
+					} );
+					return { ...acc, ...values };
+				},
+				_attributes
+			);
+		},
+		[ blockContext, clientId ]
 	);
 
 	const blockType = getBlockType( name );

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -172,7 +172,7 @@ function gutenberg_test_block_bindings_registration() {
 			'type'         => 'number',
 			'show_in_rest' => true,
 			'single'       => true,
-			'default'      => 5.5,
+			'default'      => 0.5,
 		)
 	);
 	register_meta(
@@ -183,7 +183,7 @@ function gutenberg_test_block_bindings_registration() {
 			'type'         => 'integer',
 			'show_in_rest' => true,
 			'single'       => true,
-			'default'      => 5,
+			'default'      => 3,
 		)
 	);
 	register_meta(

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -87,6 +87,14 @@ add_action(
 			)
 		);
 
+		// Add binding support for the auto-register-with-controls block.
+		add_filter(
+			'block_bindings_supported_attributes_test/auto-register-with-controls',
+			static function () {
+				return array( 'title', 'count', 'spacing', 'showEmojis', 'emoji' );
+			}
+		);
+
 		// PHP-only block with auto-generated controls from various attribute types
 		register_block_type(
 			'test/auto-register-with-controls',

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -91,7 +91,7 @@ add_action(
 		add_filter(
 			'block_bindings_supported_attributes_test/auto-register-with-controls',
 			static function () {
-				return array( 'title', 'count', 'spacing', 'showEmojis', 'emoji' );
+				return array( 'title', 'count', 'spacing', 'showEmojis' );
 			}
 		);
 

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -263,51 +263,45 @@ test.describe( 'PHP-only auto-register blocks', () => {
 			page.getByLabel( 'Emoji', { exact: true } )
 		).toBeVisible();
 	} );
-} );
 
-test.describe( 'PHP-only auto-register blocks with bindings', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activatePlugin(
-			'gutenberg-test-server-side-rendered-block'
-		);
-		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
-	} );
+	test.describe( 'with block bindings', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-block-bindings'
+			);
+		} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-server-side-rendered-block'
-		);
-	} );
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-block-bindings'
+			);
+		} );
 
-	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
-	} );
-
-	test( 'should reflect bound attribute values in auto-generated inspector controls', async ( {
-		editor,
-		page,
-	} ) => {
-		// Insert the block with a binding on the title attribute.
-		await editor.insertBlock( {
-			name: 'test/auto-register-with-controls',
-			attributes: {
-				metadata: {
-					bindings: {
-						title: {
-							source: 'testing/complete-source',
-							args: { key: 'text_field' },
+		test( 'should reflect bound attribute values in auto-generated inspector controls', async ( {
+			editor,
+			page,
+		} ) => {
+			// Insert the block with a binding on the title attribute.
+			await editor.insertBlock( {
+				name: 'test/auto-register-with-controls',
+				attributes: {
+					metadata: {
+						bindings: {
+							title: {
+								source: 'testing/complete-source',
+								args: { key: 'text_field' },
+							},
 						},
 					},
 				},
-			},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Controls should show bound values from the source,
+			// not the block attribute defaults.
+			const titleInput = page.getByLabel( 'Title' );
+			await expect( titleInput ).toHaveValue( 'Text Field Value' );
 		} );
-
-		await editor.openDocumentSettingsSidebar();
-
-		// The Title control should show the bound value from the source,
-		// not the block attribute default ("My Emoji Collection").
-		const titleInput = page.getByLabel( 'Title' );
-		await expect( titleInput ).toHaveValue( 'Text Field Value' );
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -264,3 +264,50 @@ test.describe( 'PHP-only auto-register blocks', () => {
 		).toBeVisible();
 	} );
 } );
+
+test.describe( 'PHP-only auto-register blocks with bindings', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should reflect bound attribute values in auto-generated inspector controls', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert the block with a binding on the title attribute.
+		await editor.insertBlock( {
+			name: 'test/auto-register-with-controls',
+			attributes: {
+				metadata: {
+					bindings: {
+						title: {
+							source: 'testing/complete-source',
+							args: { key: 'text_field' },
+						},
+					},
+				},
+			},
+		} );
+
+		await editor.openDocumentSettingsSidebar();
+
+		// The Title control should show the bound value from the source,
+		// not the block attribute default ("My Emoji Collection").
+		const titleInput = page.getByLabel( 'Title' );
+		await expect( titleInput ).toHaveValue( 'Text Field Value' );
+	} );
+} );

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -277,7 +277,7 @@ test.describe( 'PHP-only auto-register blocks', () => {
 			);
 		} );
 
-		test( 'should reflect bound attribute values in auto-generated inspector controls', async ( {
+		test( 'generated inspector controls should reflect bound attribute values', async ( {
 			editor,
 			page,
 		} ) => {

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -281,15 +281,27 @@ test.describe( 'PHP-only auto-register blocks', () => {
 			editor,
 			page,
 		} ) => {
-			// Insert the block with a binding on the title attribute.
+			// Insert the block with bindings on multiple attributes.
 			await editor.insertBlock( {
 				name: 'test/auto-register-with-controls',
 				attributes: {
 					metadata: {
 						bindings: {
 							title: {
-								source: 'testing/complete-source',
-								args: { key: 'text_field' },
+								source: 'core/post-meta',
+								args: { key: 'text_custom_field' },
+							},
+							count: {
+								source: 'core/post-meta',
+								args: { key: 'integer' },
+							},
+							spacing: {
+								source: 'core/post-meta',
+								args: { key: 'number_custom_field' },
+							},
+							showEmojis: {
+								source: 'core/post-meta',
+								args: { key: 'boolean' },
 							},
 						},
 					},
@@ -300,8 +312,12 @@ test.describe( 'PHP-only auto-register blocks', () => {
 
 			// Controls should show bound values from the source,
 			// not the block attribute defaults.
-			const titleInput = page.getByLabel( 'Title' );
-			await expect( titleInput ).toHaveValue( 'Text Field Value' );
+			await expect( page.getByLabel( 'Title' ) ).toHaveValue(
+				'Value of the text custom field'
+			);
+			await expect( page.getByLabel( 'Count' ) ).toHaveValue( '5' );
+			await expect( page.getByLabel( 'Spacing' ) ).toHaveValue( '5.5' );
+			await expect( page.getByLabel( 'Show Emojis' ) ).toBeChecked();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -315,8 +315,8 @@ test.describe( 'PHP-only auto-register blocks', () => {
 			await expect( page.getByLabel( 'Title' ) ).toHaveValue(
 				'Value of the text custom field'
 			);
-			await expect( page.getByLabel( 'Count' ) ).toHaveValue( '5' );
-			await expect( page.getByLabel( 'Spacing' ) ).toHaveValue( '5.5' );
+			await expect( page.getByLabel( 'Count' ) ).toHaveValue( '3' );
+			await expect( page.getByLabel( 'Spacing' ) ).toHaveValue( '0.5' );
 			await expect( page.getByLabel( 'Show Emojis' ) ).toBeChecked();
 		} );
 	} );


### PR DESCRIPTION
## What?
For PHP-only registered blocks, if an attribute is bound, have the attribute control in the block inspector reflect the bound value.

## Why?
In https://github.com/WordPress/gutenberg/pull/75543#issuecomment-3919063970, it was pointed out that if an attribute was connected to a Block Bindings source, those controls didn't reflect bound attribute values. This PR fixes the issue.

## How?
By essentially applying the same fix as https://github.com/WordPress/gutenberg/pull/72096.

This is the second instance (I'm aware of) of UI controls used to display (and modify) block attribute values that didn't take Block Bindings into account. In an ideal world, we might want to absorb the relevant logic into `getBlockAttributes()`. Unfortunately, Block Bindings require knowledge of a given block's block context, so it's not that straight-forward.

## Testing Instructions

- Use wp-env's test environment (start by running `npm run wp-env-test`).
- At the test instance (found at `localhost:8889`), activate the "Gutenberg Test Block Bindings" and "Gutenberg Test Server-Side Rendered Block" plugins.
- Create a new post. Insert the "Auto Register With Controls" block.
- In the block inspector's Attributes panel, connect:
  - The `title` attribute to the Post Meta source's `text_custom_field` item.
  - The `count` attribute to the Post Meta source's "Integer custom field" item.
  - The `spacing` attribute to the Post Meta source's "Number custom field" item.
  - The `showEmojis` attribute to the Post Meta source's "Boolean custom field" item.
- Verify that the block attribute controls in the sidebar show the correct bound values (rather than the defaults):
  - Title: "Value of the text custom field" (not the default "My Emoji Collection")
  - Count: 3 (not 5).
  - Spacing: 0.5 (not 0.1).
  - Show Emojis: Checked.
- Also verify that these settings are reflected by the block itself (i.e. in the editor canvas).

Additionally:
- Verify that e2e tests pass: `npm run test:e2e -- test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js`.
- Revert the fix (54e664ce69ab7af7fc0626ff7f2d44b00cc04c8c): `git revert 54e664ce69ab7af7fc0626ff7f2d44b00cc04c8c`.
- With the fix reverted, verify that e2e tests fail

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="1039" height="1035" alt="image" src="https://github.com/user-attachments/assets/dba94d29-f525-47eb-bc2a-45c24b59d40e" /> | <img width="1038" height="970" alt="image" src="https://github.com/user-attachments/assets/767f1aab-2228-483a-bea5-02d11cf7063f" /> |

## Follow-up

It was mentioned in https://github.com/WordPress/gutenberg/pull/75543#issuecomment-3932697728 that it is currently possible to bind a block attribute whose values are constrained by an `enum` to an unconstrained block bindings source. I'll follow up with a PR to fix that issue.