### PR TITLE
DataViews: Improve UI in `list` layout when we render only title and/or media fields

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Enhancements
 
 - Documentation: Update README.md. [#75881](https://github.com/WordPress/gutenberg/pull/75881)
+- DataViews: Improve UI in `list` layout when we render only title and/or media fields. [#76042](https://github.com/WordPress/gutenberg/pull/76042)
 - DataViews: Adjust column spacing in table layout when no titleField is provided. [#75410](https://github.com/WordPress/gutenberg/pull/75410)
 - DataViews: minimize padding for primary actions. [#75721](https://github.com/WordPress/gutenberg/pull/75721)
 

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -217,6 +217,10 @@ function ListItem< Item >( {
 			<titleField.render item={ item } field={ titleField } />
 		) : null;
 
+	const renderDescription = showDescription && descriptionField?.render;
+	// When we have only the media and title fields, we want to center them vertically in the list item.
+	const hasOnlyMediaAndTitle =
+		!! renderedMediaField && ! renderDescription && ! otherFields.length;
 	const usedActions = eligibleActions?.length > 0 && (
 		<Stack
 			direction="row"
@@ -315,7 +319,7 @@ function ListItem< Item >( {
 					direction="row"
 					gap="md"
 					justify="start"
-					align="flex-start"
+					align={ hasOnlyMediaAndTitle ? 'center' : 'flex-start' }
 					style={ { flex: 1, minWidth: 0 } }
 				>
 					{ renderedMediaField }
@@ -333,7 +337,7 @@ function ListItem< Item >( {
 							</div>
 							{ usedActions }
 						</Stack>
-						{ showDescription && descriptionField?.render && (
+						{ renderDescription && (
 							<div className="dataviews-view-list__field">
 								<descriptionField.render
 									item={ item }

--- a/packages/dataviews/src/components/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/list/style.scss
@@ -170,7 +170,6 @@ div.dataviews-view-list {
 	}
 
 	.dataviews-view-list__field-wrapper {
-		min-height: $grid-unit-05 * 13; // Ensures title is centrally aligned when all fields are hidden
 		flex-grow: 1;
 		min-width: 0;
 	}
@@ -225,10 +224,6 @@ div.dataviews-view-list {
 				height: $grid-unit-05 * 8;
 			}
 
-			.dataviews-view-list__field-wrapper {
-				min-height: $grid-unit-05 * 8;
-			}
-
 			.dataviews-view-list__fields {
 				gap: $grid-unit-10;
 				row-gap: $grid-unit-05;
@@ -255,10 +250,6 @@ div.dataviews-view-list {
 			.dataviews-view-list__media-wrapper {
 				width: $grid-unit-05 * 16;
 				height: $grid-unit-05 * 16;
-			}
-
-			.dataviews-view-list__field-wrapper {
-				min-height: $grid-unit-05 * 16;
 			}
 
 			.dataviews-view-list__fields {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/75914

This PR doesn't handle the part of optimizing if the title field is hidden, since it's considered an edge case. Instead it handles the other two [suggested optimizations](https://github.com/WordPress/gutenberg/issues/75914#issuecomment-3984056934):
1. when we show only the `title` field -> removed the `min-height` that seems to not be needed
2. when we show only the `title and media` fields (this also covers the case when we show only the `media` field -> vertically aligned

## Testing Instructions
1. in site editor go to `pages` page in `list` layout
2. from view options set the needed combinations
   a. only show `title`
   b. only show `title and featured image`
   c. show more fields
3. you can test the PR in storybook (`npm run storybook:dev`) as well
4. ensure there are no visual regressions

### Only title and media field

|Before|After|
|-|-|
|<img width="443" height="501" alt="before-only-image-title" src="https://github.com/user-attachments/assets/ca58a992-ea4c-4fb5-a589-a12211aa129e" />|<img width="443" height="501" alt="after-only-image-title" src="https://github.com/user-attachments/assets/fda12026-ba5c-4640-8206-013e0dbb4f87" />|

### Only title 

|Before|After|
|-|-|
|<img width="443" height="501" alt="before" src="https://github.com/user-attachments/assets/9d895c53-3cf7-486b-a0b8-b847ae47b09a" />|<img width="443" height="501" alt="after" src="https://github.com/user-attachments/assets/1d24e9ef-47a4-43d3-8c2f-8006372e8c8c" />|







