### PR TITLE
RTC: Fix syncing of emoji / surrogate pairs

### DIFF
--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -39,6 +39,7 @@ jest.mock( '@wordpress/blocks', () => ( {
  */
 import {
 	mergeCrdtBlocks,
+	mergeRichTextUpdate,
 	type Block,
 	type YBlock,
 	type YBlocks,
@@ -1067,6 +1068,352 @@ describe( 'crdt-blocks', () => {
 			const attrs2 = block2.get( 'attributes' ) as YBlockAttributes;
 			expect( attrs2.has( 'content' ) ).toBe( true );
 			expect( attrs2.has( 'caption' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'emoji handling', () => {
+		// Emoji like 😀 (U+1F600) are surrogate pairs in UTF-16 (.length === 2).
+		// The CRDT sync must preserve them without corruption (no U+FFFD / '�').
+
+		it( 'preserves emoji in initial block content', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello 😀 World' },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'Hello 😀 World' );
+		} );
+
+		it( 'handles inserting emoji into existing rich-text', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello World' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello 😀 World' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			// Cursor after 'Hello 😀' = 6 + 2 = 8
+			mergeCrdtBlocks( yblocks, updatedBlocks, 8 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'Hello 😀 World' );
+		} );
+
+		it( 'handles deleting emoji from rich-text', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello 😀 World' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello  World' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			// Cursor at position 6 (after 'Hello ', emoji was deleted)
+			mergeCrdtBlocks( yblocks, updatedBlocks, 6 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'Hello  World' );
+		} );
+
+		it( 'handles typing after emoji in rich-text', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'a😀b' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'a😀xb' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			// Cursor after 'a😀x' = 1 + 2 + 1 = 4
+			mergeCrdtBlocks( yblocks, updatedBlocks, 4 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'a😀xb' );
+		} );
+
+		it( 'handles multiple emoji in rich-text updates', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: '😀🎉🚀' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Insert ' hello ' between first and second emoji
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { content: '😀 hello 🎉🚀' },
+					innerBlocks: [],
+					clientId: 'block-1',
+				},
+			];
+
+			// Cursor after '😀 hello ' = 2 + 7 = 9
+			mergeCrdtBlocks( yblocks, updatedBlocks, 9 );
+
+			const block = yblocks.get( 0 );
+			const content = (
+				block.get( 'attributes' ) as YBlockAttributes
+			 ).get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( '😀 hello 🎉🚀' );
+		} );
+	} );
+
+	describe( 'mergeRichTextUpdate - emoji handling', () => {
+		it( 'preserves emoji when appending text', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '😀' );
+
+			mergeRichTextUpdate( yText, '😀x' );
+
+			expect( yText.toString() ).toBe( '😀x' );
+		} );
+
+		it( 'preserves emoji when inserting before emoji', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '😀' );
+
+			mergeRichTextUpdate( yText, 'x😀' );
+
+			expect( yText.toString() ).toBe( 'x😀' );
+		} );
+
+		it( 'preserves emoji when replacing text around emoji', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'a😀b' );
+
+			mergeRichTextUpdate( yText, 'a😀c', 4 );
+
+			expect( yText.toString() ).toBe( 'a😀c' );
+		} );
+
+		it( 'handles inserting emoji into plain text', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'ab' );
+
+			mergeRichTextUpdate( yText, 'a😀b', 3 );
+
+			expect( yText.toString() ).toBe( 'a😀b' );
+		} );
+
+		it( 'handles deleting emoji', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'a😀b' );
+
+			mergeRichTextUpdate( yText, 'ab', 1 );
+
+			expect( yText.toString() ).toBe( 'ab' );
+		} );
+
+		it( 'handles text with multiple emoji', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'Hello 😀 World 🎉' );
+
+			mergeRichTextUpdate( yText, 'Hello 😀 Beautiful World 🎉', 19 );
+
+			expect( yText.toString() ).toBe( 'Hello 😀 Beautiful World 🎉' );
+		} );
+
+		it( 'handles compound emoji (flag emoji)', () => {
+			// Flag emoji like 🏳️‍🌈 are compound and has .length === 6 in JavaScript
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'a🏳️‍🌈b' );
+
+			mergeRichTextUpdate( yText, 'a🏳️‍🌈xb', 7 );
+
+			expect( yText.toString() ).toBe( 'a🏳️‍🌈xb' );
+		} );
+
+		it( 'handles emoji with skin tone modifier', () => {
+			// 👋🏽 is U+1F44B U+1F3FD (wave + medium skin tone), .length === 4
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'Hi 👋🏽' );
+
+			mergeRichTextUpdate( yText, 'Hi 👋🏽!', 6 );
+
+			expect( yText.toString() ).toBe( 'Hi 👋🏽!' );
+		} );
+	} );
+
+	describe( 'supplementary plane characters (non-emoji)', () => {
+		// Characters above U+FFFF are stored as surrogate pairs in UTF-16,
+		// so .length === 2 per character. The diff library v8 counts them
+		// as 1 grapheme cluster, causing the same mismatch as emoji.
+
+		describe( 'mergeCrdtBlocks', () => {
+			it( 'handles CJK Extension B characters (rare kanji)', () => {
+				// 𠮷 (U+20BB7) is a real character used in Japanese names.
+				// Surrogate pair: .length === 2.
+				const initialBlocks: Block[] = [
+					{
+						name: 'core/paragraph',
+						attributes: { content: '𠮷野家' },
+						innerBlocks: [],
+						clientId: 'block-1',
+					},
+				];
+
+				mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+				const updatedBlocks: Block[] = [
+					{
+						name: 'core/paragraph',
+						attributes: { content: '𠮷野家は美味しい' },
+						innerBlocks: [],
+						clientId: 'block-1',
+					},
+				];
+
+				// Cursor after '𠮷野家は美味しい' = 2+1+1+1+1+1+1+1 = 9
+				mergeCrdtBlocks( yblocks, updatedBlocks, 9 );
+
+				const block = yblocks.get( 0 );
+				const content = (
+					block.get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' ) as Y.Text;
+				expect( content.toString() ).toBe( '𠮷野家は美味しい' );
+			} );
+
+			it( 'handles mathematical symbols from supplementary plane', () => {
+				// 𝐀 (U+1D400) — .length === 2
+				const initialBlocks: Block[] = [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Let 𝐀 be' },
+						innerBlocks: [],
+						clientId: 'block-1',
+					},
+				];
+
+				mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+				const updatedBlocks: Block[] = [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Let 𝐀 be a matrix' },
+						innerBlocks: [],
+						clientId: 'block-1',
+					},
+				];
+
+				mergeCrdtBlocks( yblocks, updatedBlocks, 18 );
+
+				const block = yblocks.get( 0 );
+				const content = (
+					block.get( 'attributes' ) as YBlockAttributes
+				 ).get( 'content' ) as Y.Text;
+				expect( content.toString() ).toBe( 'Let 𝐀 be a matrix' );
+			} );
+		} );
+
+		describe( 'mergeRichTextUpdate', () => {
+			it( 'preserves CJK Extension B characters when appending', () => {
+				const yText = doc.getText( 'test' );
+				yText.insert( 0, '𠮷' );
+
+				mergeRichTextUpdate( yText, '𠮷x' );
+
+				expect( yText.toString() ).toBe( '𠮷x' );
+			} );
+
+			it( 'handles inserting after CJK Extension B character', () => {
+				const yText = doc.getText( 'test' );
+				yText.insert( 0, 'a𠮷b' );
+
+				mergeRichTextUpdate( yText, 'a𠮷xb', 4 );
+
+				expect( yText.toString() ).toBe( 'a𠮷xb' );
+			} );
+
+			it( 'handles mathematical symbols from supplementary plane', () => {
+				// 𝐀 (U+1D400) — .length === 2
+				const yText = doc.getText( 'test' );
+				yText.insert( 0, 'a𝐀b' );
+
+				mergeRichTextUpdate( yText, 'a𝐀xb', 4 );
+
+				expect( yText.toString() ).toBe( 'a𝐀xb' );
+			} );
+
+			it( 'handles mixed surrogate pairs and BMP text', () => {
+				// 𠮷 (CJK Ext B) + 😀 (emoji) — both surrogate pairs
+				const yText = doc.getText( 'test' );
+				yText.insert( 0, '𠮷😀' );
+
+				mergeRichTextUpdate( yText, '𠮷😀!' );
+
+				expect( yText.toString() ).toBe( '𠮷😀!' );
+			} );
+
+			it( 'handles musical symbols (supplementary plane)', () => {
+				// 𝄞 (U+1D11E, Musical Symbol G Clef) — .length === 2
+				const yText = doc.getText( 'test' );
+				yText.insert( 0, 'a𝄞b' );
+
+				mergeRichTextUpdate( yText, 'a𝄞xb', 4 );
+
+				expect( yText.toString() ).toBe( 'a𝄞xb' );
+			} );
 		} );
 	} );
 } );

--- a/packages/sync/src/quill-delta/Delta.ts
+++ b/packages/sync/src/quill-delta/Delta.ts
@@ -24,6 +24,21 @@ function cloneDeep< T >( value: T ): T {
 
 const NULL_CHARACTER = String.fromCharCode( 0 ); // Placeholder char for embed in diff()
 
+/**
+ * Normalize diff changes so that `count` reflects UTF-16 code-unit length
+ * rather than grapheme-cluster count (which diffChars may return when
+ * Intl.Segmenter is available, e.g. diff v8+).
+ *
+ * @param changes - The array of changes from diffChars.
+ * @return The changes with `count` normalized to UTF-16 code-unit length.
+ */
+function normalizeChangeCounts( changes: Change[] ): Change[] {
+	return changes.map( ( change ) => ( {
+		...change,
+		count: change.value.length,
+	} ) );
+}
+
 interface EmbedHandler< T > {
 	compose: ( a: T, b: T, keepNull: boolean ) => T;
 	invert: ( a: T, b: T ) => T;
@@ -399,7 +414,9 @@ class Delta {
 			return new Delta();
 		}
 		const strings = this.deltasToStrings( other );
-		const diffResult = diffChars( strings[ 0 ], strings[ 1 ] );
+		const diffResult = normalizeChangeCounts(
+			diffChars( strings[ 0 ], strings[ 1 ] )
+		);
 		const thisIter = new OpIterator( this.ops );
 		const otherIter = new OpIterator( other.ops );
 		const retDelta = this.convertChangesToDelta(
@@ -612,7 +629,9 @@ class Delta {
 		}
 
 		const strings = this.deltasToStrings( other );
-		let diffs = diffChars( strings[ 0 ], strings[ 1 ] );
+		let diffs = normalizeChangeCounts(
+			diffChars( strings[ 0 ], strings[ 1 ] )
+		);
 		let lastDiffPosition = 0;
 		const adjustedDiffs: Change[] = [];
 

--- a/packages/sync/src/quill-delta/test/Delta.ts
+++ b/packages/sync/src/quill-delta/test/Delta.ts
@@ -458,4 +458,235 @@ describe( 'Delta.diffWithCursor', () => {
 			expect( diff.ops ).toEqual( [ { retain: 3 }, { insert: 'd' } ] );
 		} );
 	} );
+
+	describe( 'emoji and surrogate pair handling', () => {
+		// Emoji like 😀 (U+1F600) are represented as surrogate pairs in UTF-16,
+		// so '😀'.length === 2 in JavaScript. The diff engine must handle these
+		// correctly without splitting surrogate pairs.
+
+		it( 'should handle diff with emoji in unchanged prefix', () => {
+			// '😀' -> '😀x' — append 'x' after emoji
+			const oldDelta = new Delta().insert( '😀' );
+			const newDelta = new Delta().insert( '😀x' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// 😀 is 2 UTF-16 code units, so retain 2, insert 'x'
+			expect( diff.ops ).toEqual( [ { retain: 2 }, { insert: 'x' } ] );
+		} );
+
+		it( 'should handle diff replacing text after emoji', () => {
+			// 'a😀b' -> 'a😀c'
+			const oldDelta = new Delta().insert( 'a😀b' );
+			const newDelta = new Delta().insert( 'a😀c' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// retain 3 (a + 😀 = 1 + 2), then replace b with c
+			expect( diff.ops ).toEqual( [
+				{ retain: 3 },
+				{ insert: 'c' },
+				{ delete: 1 },
+			] );
+		} );
+
+		it( 'should handle diffWithCursor inserting text after emoji', () => {
+			// 'a😀b' -> 'a😀xb' with cursor at 4 (a=1, 😀=2, x=1)
+			const oldDelta = new Delta().insert( 'a😀b' );
+			const newDelta = new Delta().insert( 'a😀xb' );
+			const cursor = 4;
+
+			const diff = oldDelta.diffWithCursor( newDelta, cursor );
+
+			expect( diff.ops ).toEqual( [
+				{ retain: 3 }, // a(1) + 😀(2)
+				{ insert: 'x' },
+			] );
+		} );
+
+		it( 'should handle diffWithCursor inserting an emoji', () => {
+			// 'ab' -> 'a😀b' with cursor at 3 (a=1, 😀=2)
+			const oldDelta = new Delta().insert( 'ab' );
+			const newDelta = new Delta().insert( 'a😀b' );
+			const cursor = 3;
+
+			const diff = oldDelta.diffWithCursor( newDelta, cursor );
+
+			expect( diff.ops ).toEqual( [ { retain: 1 }, { insert: '😀' } ] );
+		} );
+
+		it( 'should handle diffWithCursor deleting an emoji', () => {
+			// 'a😀b' -> 'ab' with cursor at 1 (after 'a', emoji deleted)
+			const oldDelta = new Delta().insert( 'a😀b' );
+			const newDelta = new Delta().insert( 'ab' );
+			const cursor = 1;
+
+			const diff = oldDelta.diffWithCursor( newDelta, cursor );
+
+			expect( diff.ops ).toEqual( [
+				{ retain: 1 },
+				{ delete: 2 }, // 😀 is 2 UTF-16 code units
+			] );
+		} );
+
+		it( 'should handle inserting between two emoji', () => {
+			// '😀😀' -> '😀x😀' with cursor at 3 (😀=2, x=1)
+			const oldDelta = new Delta().insert( '😀😀' );
+			const newDelta = new Delta().insert( '😀x😀' );
+			const cursor = 3;
+
+			const diff = oldDelta.diffWithCursor( newDelta, cursor );
+
+			expect( diff.ops ).toEqual( [
+				{ retain: 2 }, // first 😀
+				{ insert: 'x' },
+			] );
+		} );
+
+		it( 'should handle diff with emoji-only strings', () => {
+			// '😀🎉' -> '😀🚀🎉' — insert 🚀 between two emoji
+			const oldDelta = new Delta().insert( '😀🎉' );
+			const newDelta = new Delta().insert( '😀🚀🎉' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			expect( diff.ops ).toEqual( [
+				{ retain: 2 }, // 😀
+				{ insert: '🚀' },
+			] );
+		} );
+
+		it( 'should preserve emoji when diffing identical strings', () => {
+			const oldDelta = new Delta().insert( 'Hello 😀 World' );
+			const newDelta = new Delta().insert( 'Hello 😀 World' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			expect( diff.ops ).toEqual( [] );
+		} );
+
+		it( 'should handle diff with mixed emoji and regular text changes', () => {
+			// 'Hello 😀 World' -> 'Hello 😀 Beautiful World'
+			const oldDelta = new Delta().insert( 'Hello 😀 World' );
+			const newDelta = new Delta().insert( 'Hello 😀 Beautiful World' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// 'Hello 😀 ' is 6+2+1 = 9 UTF-16 code units
+			expect( diff.ops ).toEqual( [
+				{ retain: 9 },
+				{ insert: 'Beautiful ' },
+			] );
+		} );
+
+		it( 'should handle compound emoji (flag emoji)', () => {
+			// Flag emoji like 🏳️‍🌈 are compound and has .length === 6 in JavaScript
+			const oldDelta = new Delta().insert( 'a🏳️‍🌈b' );
+			const newDelta = new Delta().insert( 'a🏳️‍🌈xb' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// a(1) + 🏳️‍🌈 (6) = 7 code units to retain
+			expect( diff.ops ).toEqual( [ { retain: 7 }, { insert: 'x' } ] );
+		} );
+
+		it( 'should handle emoji with skin tone modifier', () => {
+			// 👋🏽 is base emoji + skin tone modifier, .length === 4
+			const oldDelta = new Delta().insert( 'Hi 👋🏽' );
+			const newDelta = new Delta().insert( 'Hi 👋🏽!' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// 'Hi '(3) + '👋🏽'(4) = 7 code units to retain
+			expect( diff.ops ).toEqual( [ { retain: 7 }, { insert: '!' } ] );
+		} );
+	} );
+
+	describe( 'supplementary plane characters (non-emoji)', () => {
+		// Characters in the supplementary Unicode planes (U+10000+) are stored
+		// as surrogate pairs in UTF-16, so .length === 2 per character. The
+		// diff library v8 counts them as 1 grapheme cluster via Intl.Segmenter,
+		// causing the same mismatch as emoji.
+
+		it( 'should handle CJK Extension B characters (rare kanji)', () => {
+			// 𠮷 (U+20BB7) is a real kanji used in Japanese names (𠮷野家).
+			// It's in the supplementary plane: .length === 2 (surrogate pair).
+			const oldDelta = new Delta().insert( '𠮷野家' );
+			const newDelta = new Delta().insert( '𠮷野家は美味しい' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// '𠮷'(2) + '野'(1) + '家'(1) = 4 code units to retain
+			expect( diff.ops ).toEqual( [
+				{ retain: 4 },
+				{ insert: 'は美味しい' },
+			] );
+		} );
+
+		it( 'should handle diffWithCursor inserting after CJK Extension B character', () => {
+			// 'a𠮷b' -> 'a𠮷xb'
+			const oldDelta = new Delta().insert( 'a𠮷b' );
+			const newDelta = new Delta().insert( 'a𠮷xb' );
+			const cursor = 4; // a(1) + 𠮷(2) + x(1)
+
+			const diff = oldDelta.diffWithCursor( newDelta, cursor );
+
+			expect( diff.ops ).toEqual( [
+				{ retain: 3 }, // a(1) + 𠮷(2)
+				{ insert: 'x' },
+			] );
+		} );
+
+		it( 'should handle mathematical symbols from supplementary plane', () => {
+			// 𝐀 (U+1D400, Mathematical Bold Capital A) — .length === 2
+			const oldDelta = new Delta().insert( 'Let 𝐀 be a matrix' );
+			const newDelta = new Delta().insert( 'Let 𝐀 be a square matrix' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// 'Let 𝐀 be a ' = L(1)+e(1)+t(1)+' '(1)+𝐀(2)+' '(1)+b(1)+e(1)+' '(1)+a(1)+' '(1) = 12
+			expect( diff.ops ).toEqual( [
+				{ retain: 12 },
+				{ insert: 'square ' },
+			] );
+		} );
+
+		it( 'should handle mixed surrogate pairs and BMP text', () => {
+			// Mix of supplementary plane characters in one string.
+			// '𠮷' (CJK Ext B, surrogate pair) + '😀' (emoji, surrogate pair)
+			const oldDelta = new Delta().insert( '𠮷😀' );
+			const newDelta = new Delta().insert( '𠮷😀!' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// 𠮷(2) + 😀(2) = 4 code units
+			expect( diff.ops ).toEqual( [ { retain: 4 }, { insert: '!' } ] );
+		} );
+
+		it( 'should handle musical symbols', () => {
+			// 𝄞 (U+1D11E, Musical Symbol G Clef) — .length === 2
+			const oldDelta = new Delta().insert( 'Play 𝄞 in C' );
+			const newDelta = new Delta().insert( 'Play 𝄞 in D' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// 'Play 𝄞 in ' = P(1)+l(1)+a(1)+y(1)+' '(1)+𝄞(2)+' '(1)+i(1)+n(1)+' '(1) = 11
+			expect( diff.ops ).toEqual( [
+				{ retain: 11 },
+				{ insert: 'D' },
+				{ delete: 1 },
+			] );
+		} );
+
+		it( 'should handle ancient script characters (Egyptian hieroglyphs)', () => {
+			// 𓀀 (U+13000, Egyptian Hieroglyph A001) — .length === 2
+			const oldDelta = new Delta().insert( 'a𓀀b' );
+			const newDelta = new Delta().insert( 'a𓀀xb' );
+
+			const diff = oldDelta.diff( newDelta );
+
+			// a(1) + 𓀀(2) = 3 code units to retain
+			expect( diff.ops ).toEqual( [ { retain: 3 }, { insert: 'x' } ] );
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-multibyte.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-multibyte.spec.ts
@@ -18,6 +18,7 @@ test.describe( 'Collaboration - Multi-byte character encoding', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Emoji Sync Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 
 		await collaborationUtils.openCollaborativeSession( post.id );
@@ -51,6 +52,7 @@ test.describe( 'Collaboration - Multi-byte character encoding', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Multi-Emoji Sync Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 
 		await collaborationUtils.openCollaborativeSession( post.id );
@@ -82,6 +84,7 @@ test.describe( 'Collaboration - Multi-byte character encoding', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Emoji Insert Sync Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 
 		await collaborationUtils.openCollaborativeSession( post.id );
@@ -90,10 +93,15 @@ test.describe( 'Collaboration - Multi-byte character encoding', () => {
 
 		// User 2: Insert a paragraph with emoji via the data API.
 		await page2.evaluate( () => {
-			const block = window.wp.blocks.createBlock( 'core/paragraph', {
-				content: 'Hello 😀 World',
-			} );
-			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
+			const block = ( window as any ).wp.blocks.createBlock(
+				'core/paragraph',
+				{
+					content: 'Hello 😀 World',
+				}
+			);
+			( window as any ).wp.data
+				.dispatch( 'core/block-editor' )
+				.insertBlock( block );
 		} );
 
 		// User 1: Verify the emoji appears correctly.
@@ -119,6 +127,7 @@ test.describe( 'Collaboration - Multi-byte character encoding', () => {
 		const post = await requestUtils.createPost( {
 			title: 'CJK Extension B Sync Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 
 		await collaborationUtils.openCollaborativeSession( post.id );
@@ -151,6 +160,7 @@ test.describe( 'Collaboration - Multi-byte character encoding', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Math Symbol Sync Test',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 
 		await collaborationUtils.openCollaborativeSession( post.id );

--- a/test/e2e/specs/editor/collaboration/collaboration-multibyte.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-multibyte.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - Multi-byte character encoding', () => {
+	// Characters in the supplementary Unicode planes (U+10000+) are stored as
+	// surrogate pairs in UTF-16, so .length >= 2 per character. The diff
+	// library v8 counts them as 1 grapheme cluster via Intl.Segmenter,
+	// causing a mismatch with the Delta engine's UTF-16 code-unit counting.
+	// This results in split surrogate pairs rendering as U+FFFD (�).
+
+	test( 'syncs emoji between two users without corruption', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Emoji Sync Test',
+			status: 'draft',
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2 } = collaborationUtils;
+
+		// User 1: Insert a paragraph with emoji.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello 😀 World' },
+		} );
+
+		// User 2: Verify the emoji survived the sync.
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			expect( blocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello 😀 World' },
+				},
+			] );
+			expect( blocks[ 0 ].attributes.content ).not.toContain( '\uFFFD' );
+		} ).toPass( { timeout: 5000 } );
+	} );
+
+	test( 'syncs multiple emoji between users', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Multi-Emoji Sync Test',
+			status: 'draft',
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2 } = collaborationUtils;
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '😀 hello 🎉 world 🚀' },
+		} );
+
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			expect( blocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: '😀 hello 🎉 world 🚀' },
+				},
+			] );
+			expect( blocks[ 0 ].attributes.content ).not.toContain( '\uFFFD' );
+		} ).toPass( { timeout: 5000 } );
+	} );
+
+	test( 'syncs emoji inserted by a collaborator', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Emoji Insert Sync Test',
+			status: 'draft',
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2 } = collaborationUtils;
+
+		// User 2: Insert a paragraph with emoji via the data API.
+		await page2.evaluate( () => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: 'Hello 😀 World',
+			} );
+			window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
+		} );
+
+		// User 1: Verify the emoji appears correctly.
+		await expect( async () => {
+			const blocks = await editor.getBlocks();
+			expect( blocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Hello 😀 World' },
+				},
+			] );
+			expect( blocks[ 0 ].attributes.content ).not.toContain( '\uFFFD' );
+		} ).toPass( { timeout: 5000 } );
+	} );
+
+	test( 'syncs CJK Extension B characters (rare kanji) between users', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		// 𠮷 (U+20BB7) is used in Japanese names like 𠮷野家 (Yoshinoya).
+		// It's a supplementary plane character (.length === 2, surrogate pair).
+		const post = await requestUtils.createPost( {
+			title: 'CJK Extension B Sync Test',
+			status: 'draft',
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2 } = collaborationUtils;
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '𠮷野家は美味しい' },
+		} );
+
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			expect( blocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: '𠮷野家は美味しい' },
+				},
+			] );
+			expect( blocks[ 0 ].attributes.content ).not.toContain( '\uFFFD' );
+		} ).toPass( { timeout: 5000 } );
+	} );
+
+	test( 'syncs mathematical symbols from supplementary plane between users', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		// 𝐀 (U+1D400, Mathematical Bold Capital A) — .length === 2
+		const post = await requestUtils.createPost( {
+			title: 'Math Symbol Sync Test',
+			status: 'draft',
+		} );
+
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { editor2 } = collaborationUtils;
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Let 𝐀 be a matrix' },
+		} );
+
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			expect( blocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Let 𝐀 be a matrix' },
+				},
+			] );
+			expect( blocks[ 0 ].attributes.content ).not.toContain( '\uFFFD' );
+		} ).toPass( { timeout: 5000 } );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -25,6 +25,8 @@ export const test = base.extend< Fixtures >( {
 			page,
 		} );
 		await utils.setCollaboration( true );
+		// Clean up any leftover users from previous runs before creating.
+		await requestUtils.deleteAllUsers();
 		await requestUtils.createUser( SECOND_USER );
 		await use( utils );
 		await utils.teardown();


### PR DESCRIPTION
## What?

When two users are collaboratively editing a post via RTC, correctly sync emoji characters and other multi-code-unit Unicode characters.

Closes https://github.com/WordPress/gutenberg/issues/76044

## Why?

The Quill Delta diff engine in `@wordpress/sync` uses `diffChars` from the `diff` library (v8.0.3). In `diff` v7+, `diffChars` uses `Intl.Segmenter` (when available) to tokenize by grapheme cluster, so an emoji like 😀 counts as `1` token. However, the `Delta Op.length()` and `OpIterator` use JavaScript’s `.length`, which counts UTF-16 code units — where the same emoji counts as `2`.

This mismatch occurs in `convertChangesToDelta()` (`packages/sync/src/quill-delta/Delta.ts`), where `component.count` from `diffChars` is used to advance the `OpIterator`. Since the iterator measures in UTF-16 code units but count is in grapheme clusters, `.substr()` calls in `OpIterator.next()` split surrogate pairs, producing lone surrogates that render as � or result in data corruption.

The same mismatch affects cursor position arithmetic in `diffWithCursor()`, where `lastDiffPosition` is tracked in grapheme clusters but `cursorAfterChange` is in UTF-16 code units.

## How?

Add a single normalization step after each call to `diffChars` that replaces `count` (grapheme clusters) with `value.length` (UTF-16 code units).

## Testing Instructions

1. Settings > Writing > Enable real-time collaboration
1. Open a post in two browser tabs as two different users.
1. In User A’s tab, type an emoji (e.g. 😀) into a paragraph block.
1. Observe User B’s tab and ensure it syncs correctly.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/ca306c8d-f36a-4e51-a5a0-92f99dda57b5

### After

https://github.com/user-attachments/assets/e10cf146-b372-48a3-943e-86592bb7738c


