### PR TITLE
Add Site Logo & Icon screen to Global Styles sidebar

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -7,11 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
-import {
-	createInterpolateElement,
-	useEffect,
-	useState,
-} from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import {
 	RangeControl,
@@ -257,28 +253,8 @@ const SiteLogo = ( {
 		);
 	}
 
-	// Support the previous location for the Site Icon settings. To be removed
-	// when the required WP core version for Gutenberg is >= 6.5.0.
-	const shouldUseNewUrl = ! window?.__experimentalUseCustomizerSiteLogoUrl;
-
-	const siteIconSettingsUrl = shouldUseNewUrl
-		? siteUrl + '/wp-admin/options-general.php'
-		: siteUrl + '/wp-admin/customize.php?autofocus[section]=title_tagline';
-
-	const syncSiteIconHelpText = createInterpolateElement(
-		__(
-			'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. To use a custom icon that is different from your site logo, use the <a>Site Icon settings</a>.'
-		),
-		{
-			a: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				<a
-					href={ siteIconSettingsUrl }
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
-			),
-		}
+	const syncSiteIconHelpText = __(
+		'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps.'
 	);
 
 	return (

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
+		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
@@ -59,7 +60,9 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/url": "file:../url",
 		"change-case": "^4.1.2",
 		"clsx": "^2.1.0",
 		"colord": "^2.7.0"

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -32,6 +32,7 @@ import ScreenColorPalette from './screen-color-palette';
 import ScreenBackground from './screen-background';
 import { ScreenShadows, ScreenShadowsEdit } from './screen-shadows';
 import ScreenLayout from './screen-layout';
+import ScreenSiteLogoAndIcon from './screen-site-logo-and-icon';
 import ScreenStyleVariations from './screen-style-variations';
 import ScreenCSS from './screen-css';
 import ScreenRevisions from './screen-revisions';
@@ -176,6 +177,9 @@ export function GlobalStylesUI( {
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/colors">
 						<ScreenColors />
+					</GlobalStylesNavigationScreen>
+					<GlobalStylesNavigationScreen path="/site-logo-and-icon">
+						<ScreenSiteLogoAndIcon />
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/typography">
 						<ScreenTypography />

--- a/packages/global-styles-ui/src/root-menu.tsx
+++ b/packages/global-styles-ui/src/root-menu.tsx
@@ -8,6 +8,7 @@ import {
 	color,
 	layout,
 	shadow as shadowIcon,
+	siteLogo,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 // @ts-expect-error: Not typed yet.
@@ -60,6 +61,12 @@ function RootMenu() {
 						{ __( 'Colors' ) }
 					</NavigationButtonAsItem>
 				) }
+				<NavigationButtonAsItem
+					icon={ siteLogo }
+					path="/site-logo-and-icon"
+				>
+					{ __( 'Site Logo & Icon' ) }
+				</NavigationButtonAsItem>
 				{ hasBackgroundPanel && (
 					<NavigationButtonAsItem
 						icon={ background }

--- a/packages/global-styles-ui/src/screen-site-logo-and-icon.tsx
+++ b/packages/global-styles-ui/src/screen-site-logo-and-icon.tsx
@@ -1,0 +1,419 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
+	__experimentalTruncate as Truncate,
+	__experimentalItemGroup as ItemGroup,
+	Button,
+	DropZone,
+	FlexItem,
+	MenuItem,
+	Spinner,
+} from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	MediaReplaceFlow as _MediaReplaceFlow,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { getFilename } from '@wordpress/url';
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenHeader } from './screen-header';
+
+const MediaReplaceFlow = _MediaReplaceFlow as React.ComponentType< any >;
+
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+const IMAGE_BACKGROUND_TYPE = 'image';
+
+function SiteLogoSection() {
+	const [ temporaryURL, setTemporaryURL ] = useState< string >();
+
+	const { siteLogoId, mediaItem, isRequestingMediaItem, canUserEdit } =
+		useSelect( ( select: any ) => {
+			const { canUser, getEditedEntityRecord, getEntityRecord } =
+				select( coreStore );
+			const _canUserEdit = canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} );
+			const siteSettings = _canUserEdit
+				? getEditedEntityRecord( 'root', 'site' )
+				: undefined;
+			const _siteLogoId = siteSettings?.site_logo;
+			const _mediaItem =
+				_siteLogoId &&
+				getEntityRecord( 'postType', 'attachment', _siteLogoId, {
+					context: 'view',
+				} );
+			const _isRequestingMediaItem =
+				!! _siteLogoId &&
+				! select( coreStore ).hasFinishedResolution(
+					'getEntityRecord',
+					[
+						'postType',
+						'attachment',
+						_siteLogoId,
+						{ context: 'view' },
+					]
+				);
+			return {
+				siteLogoId: _siteLogoId,
+				mediaItem: _mediaItem,
+				isRequestingMediaItem: _isRequestingMediaItem,
+				canUserEdit: _canUserEdit,
+			};
+		}, [] );
+
+	const { getSettings } = useSelect( blockEditorStore );
+	const { editEntityRecord }: any = useDispatch( coreStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const setLogo = ( newValue: number | null ) => {
+		editEntityRecord( 'root', 'site', undefined, {
+			site_logo: newValue,
+		} );
+	};
+
+	const onSelectMedia = ( media: {
+		id?: number;
+		url?: string;
+		media_type?: string;
+		type?: string;
+		title?: string;
+	} ) => {
+		if ( ! media || ! media.url ) {
+			setLogo( null );
+			setTemporaryURL( undefined );
+			return;
+		}
+
+		if ( isBlobURL( media.url ) ) {
+			setTemporaryURL( media.url );
+			return;
+		}
+
+		if (
+			( media.media_type &&
+				media.media_type !== IMAGE_BACKGROUND_TYPE ) ||
+			( ! media.media_type &&
+				media.type &&
+				media.type !== IMAGE_BACKGROUND_TYPE )
+		) {
+			createErrorNotice(
+				__( 'Only images can be used as a site logo.' ),
+				{ type: 'snackbar' }
+			);
+			return;
+		}
+
+		if ( media.id ) {
+			setLogo( media.id );
+		}
+		setTemporaryURL( media.url );
+	};
+
+	const onRemoveLogo = () => {
+		setLogo( null );
+		setTemporaryURL( undefined );
+	};
+
+	const onUploadError = ( message: string ) => {
+		createErrorNotice( message, { type: 'snackbar' } );
+	};
+
+	const onFilesDrop = ( filesList: File[] ) => {
+		const { mediaUpload } = (
+			getSettings as () => Record< string, any >
+		 )();
+		if ( ! mediaUpload ) {
+			return;
+		}
+		mediaUpload( {
+			allowedTypes: ALLOWED_MEDIA_TYPES,
+			filesList,
+			onFileChange( [ image ]: [ { id?: number; url?: string } ] ) {
+				onSelectMedia( image );
+			},
+			onError: onUploadError,
+			multiple: false,
+		} );
+	};
+
+	// Reset temporary url when the real source url is available.
+	useEffect( () => {
+		if ( mediaItem?.source_url && temporaryURL ) {
+			setTemporaryURL( undefined );
+		}
+	}, [ mediaItem?.source_url, temporaryURL ] );
+
+	const logoUrl = mediaItem?.source_url || temporaryURL;
+	const logoFilename =
+		mediaItem?.media_details?.sizes?.full?.file ||
+		mediaItem?.slug ||
+		getFilename( logoUrl );
+	const isUploading = !! temporaryURL && ! mediaItem?.source_url;
+
+	return (
+		<VStack spacing={ 2 }>
+			<Text className="global-styles-ui-subtitle">
+				{ __( 'Site Logo' ) }
+			</Text>
+			{ isRequestingMediaItem && ! temporaryURL && <Spinner /> }
+			{ ( ! isRequestingMediaItem || temporaryURL ) && canUserEdit && (
+				<div className="global-styles-ui-site-identity__media-control">
+					<MediaReplaceFlow
+						mediaId={ siteLogoId }
+						mediaURL={ logoUrl }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						onSelect={ onSelectMedia }
+						onError={ onUploadError }
+						name={
+							logoUrl ? (
+								<ItemGroup as="span">
+									<HStack justify="flex-start" as="span">
+										<img
+											src={ logoUrl }
+											alt={ mediaItem?.alt_text || '' }
+										/>
+										<FlexItem as="span">
+											<Truncate numberOfLines={ 1 }>
+												{ logoFilename }
+											</Truncate>
+										</FlexItem>
+									</HStack>
+								</ItemGroup>
+							) : (
+								__( 'Choose logo' )
+							)
+						}
+						renderToggle={ ( props: Record< string, any > ) => (
+							<Button { ...props } __next40pxDefaultSize>
+								{ isUploading ? <Spinner /> : props.children }
+							</Button>
+						) }
+						onReset={ onRemoveLogo }
+					>
+						{ !! siteLogoId && (
+							<MenuItem onClick={ onRemoveLogo }>
+								{ __( 'Remove' ) }
+							</MenuItem>
+						) }
+					</MediaReplaceFlow>
+					<DropZone onFilesDrop={ onFilesDrop } />
+				</div>
+			) }
+			<Text variant="muted">
+				{ __( 'Upload a logo to display in the Site Logo block.' ) }
+			</Text>
+		</VStack>
+	);
+}
+
+function SiteIconSection() {
+	const [ temporaryURL, setTemporaryURL ] = useState< string >();
+
+	const { siteIconId, siteIconUrl, mediaItem, canUserEdit } = useSelect(
+		( select: any ) => {
+			const { canUser, getEditedEntityRecord, getEntityRecord } =
+				select( coreStore );
+			const _canUserEdit = canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} );
+			const siteSettings = _canUserEdit
+				? getEditedEntityRecord( 'root', 'site' )
+				: undefined;
+			const siteData = getEntityRecord( 'root', '__unstableBase' );
+			const _siteIconId = siteSettings?.site_icon;
+			const _mediaItem =
+				_siteIconId &&
+				getEntityRecord( 'postType', 'attachment', _siteIconId, {
+					context: 'view',
+				} );
+			return {
+				siteIconId: _siteIconId,
+				siteIconUrl: siteData?.site_icon_url,
+				mediaItem: _mediaItem,
+				canUserEdit: _canUserEdit,
+			};
+		},
+		[]
+	);
+
+	const { getSettings } = useSelect( blockEditorStore );
+	const { editEntityRecord }: any = useDispatch( coreStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const setIcon = ( newValue: number | null ) => {
+		editEntityRecord( 'root', 'site', undefined, {
+			site_icon: newValue ?? null,
+		} );
+	};
+
+	const onSelectMedia = ( media: {
+		id?: number;
+		url?: string;
+		media_type?: string;
+		type?: string;
+		title?: string;
+	} ) => {
+		if ( ! media || ! media.url ) {
+			setIcon( null );
+			setTemporaryURL( undefined );
+			return;
+		}
+
+		if ( isBlobURL( media.url ) ) {
+			setTemporaryURL( media.url );
+			return;
+		}
+
+		if (
+			( media.media_type &&
+				media.media_type !== IMAGE_BACKGROUND_TYPE ) ||
+			( ! media.media_type &&
+				media.type &&
+				media.type !== IMAGE_BACKGROUND_TYPE )
+		) {
+			createErrorNotice(
+				__( 'Only images can be used as a site icon.' ),
+				{ type: 'snackbar' }
+			);
+			return;
+		}
+
+		if ( media.id ) {
+			setIcon( media.id );
+		}
+		setTemporaryURL( media.url );
+	};
+
+	const onRemoveIcon = () => {
+		setIcon( null );
+		setTemporaryURL( undefined );
+	};
+
+	const onUploadError = ( message: string ) => {
+		createErrorNotice( message, { type: 'snackbar' } );
+	};
+
+	const onFilesDrop = ( filesList: File[] ) => {
+		const { mediaUpload } = (
+			getSettings as () => Record< string, any >
+		 )();
+		if ( ! mediaUpload ) {
+			return;
+		}
+		mediaUpload( {
+			allowedTypes: ALLOWED_MEDIA_TYPES,
+			filesList,
+			onFileChange( [ image ]: [ { id?: number; url?: string } ] ) {
+				onSelectMedia( image );
+			},
+			onError: onUploadError,
+			multiple: false,
+		} );
+	};
+
+	// Reset temporary url when the real source url is available.
+	useEffect( () => {
+		if ( mediaItem?.source_url && temporaryURL ) {
+			setTemporaryURL( undefined );
+		}
+	}, [ mediaItem?.source_url, temporaryURL ] );
+
+	const iconUrl = mediaItem?.source_url || siteIconUrl || temporaryURL;
+	const iconFilename =
+		mediaItem?.media_details?.sizes?.full?.file ||
+		mediaItem?.slug ||
+		getFilename( iconUrl );
+	const isUploading = !! temporaryURL && ! mediaItem?.source_url;
+
+	return (
+		<VStack spacing={ 2 }>
+			<Text className="global-styles-ui-subtitle">
+				{ __( 'Site Icon' ) }
+			</Text>
+			{ canUserEdit && (
+				<div className="global-styles-ui-site-identity__media-control">
+					<MediaReplaceFlow
+						mediaId={ siteIconId }
+						mediaURL={ iconUrl }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						onSelect={ onSelectMedia }
+						onError={ onUploadError }
+						name={
+							iconUrl ? (
+								<ItemGroup as="span">
+									<HStack justify="flex-start" as="span">
+										<img
+											src={ iconUrl }
+											alt={ __( 'Site icon' ) }
+										/>
+										<FlexItem as="span">
+											<Truncate numberOfLines={ 1 }>
+												{ iconFilename }
+											</Truncate>
+										</FlexItem>
+									</HStack>
+								</ItemGroup>
+							) : (
+								__( 'Choose icon' )
+							)
+						}
+						renderToggle={ ( props: Record< string, any > ) => (
+							<Button { ...props } __next40pxDefaultSize>
+								{ isUploading ? <Spinner /> : props.children }
+							</Button>
+						) }
+						onReset={ onRemoveIcon }
+					>
+						{ !! siteIconId && (
+							<MenuItem onClick={ onRemoveIcon }>
+								{ __( 'Remove' ) }
+							</MenuItem>
+						) }
+					</MediaReplaceFlow>
+					<DropZone onFilesDrop={ onFilesDrop } />
+				</div>
+			) }
+			<Text variant="muted">
+				{ __(
+					'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. To use a custom icon that is different from your site logo, use the Site Icon settings.'
+				) }
+			</Text>
+		</VStack>
+	);
+}
+
+function ScreenSiteLogoAndIcon() {
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Site Logo & Icon' ) }
+				description={ __(
+					'The logo appears wherever the Site Logo block is used, and the icon shows in browser tabs and bookmarks.'
+				) }
+			/>
+			<Spacer paddingX={ 4 }>
+				<VStack spacing={ 6 }>
+					<SiteLogoSection />
+					<SiteIconSection />
+				</VStack>
+			</Spacer>
+		</>
+	);
+}
+
+export default ScreenSiteLogoAndIcon;

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -270,3 +270,44 @@
 .global-styles-ui-gradient-palette-panel {
 	padding: variables.$grid-unit-20;
 }
+
+// Site Logo & Icon screen
+// Mirrors block-library-utils__media-control styles exactly.
+.global-styles-ui-site-identity__media-control {
+	// Ensure the dropzone is positioned to the size of the item.
+	position: relative;
+
+	// Since there is no option to skip rendering the drag'n'drop icon in drop
+	// zone, we hide it for now.
+	.components-drop-zone__content-icon {
+		display: none;
+	}
+
+	button.components-button {
+		color: colors.$gray-900;
+		box-shadow: inset 0 0 0 1px colors.$gray-400;
+		width: 100%;
+		display: block;
+		height: variables.$grid-unit-50;
+
+		&:hover {
+			color: var(--wp-admin-theme-color);
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
+
+	.components-dropdown {
+		display: block;
+	}
+
+	img {
+		width: 20px;
+		min-width: 20px;
+		aspect-ratio: 1;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		border-radius: 2px;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a new "Site Logo & Icon" item to the Styles sidebar in the Site Editor, positioned after Colors
- Creates a new screen with upload controls for both site logo and site icon, using the same `MediaReplaceFlow` pattern as other sidebar media controls
- Updates the site-logo block's "Use as Site Icon" toggle help text to remove the now-redundant link to Site Icon settings

Closes #66241

## Test plan
- [ ] Open the Site Editor and navigate to Styles
- [ ] Verify "Site Logo & Icon" appears as the 3rd item in the list (after Typography and Colors)
- [ ] Click "Site Logo & Icon" and verify the panel shows with header, description, and two sections (Site Logo and Site Icon)
- [ ] Upload a site logo via the "Choose logo" button and verify the image preview appears immediately
- [ ] Upload a site icon via the "Choose icon" button and verify the image preview appears
- [ ] Verify drag-and-drop upload works for both sections
- [ ] Remove an uploaded logo/icon via the dropdown menu "Remove" option and verify it clears
- [ ] Save changes and verify both logo and icon persist after page reload
- [ ] In a post, add a Site Logo block, check the "Use as Site Icon" toggle, and verify the help text no longer contains a link to Site Icon settings

## Video walkthrough

https://github.com/user-attachments/assets/655a6af9-3fce-4273-aa0a-b9f744d9c30a

🤖 Generated with [Claude Code](https://claude.com/claude-code)