### PR TITLE
Add missing `@wordpress/hooks` dependency to `@wordpress/dataviews`

### DIFF
--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
+		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keycodes": "file:../keycodes",


### PR DESCRIPTION
## What?

Adds `@wordpress/hooks` as an explicit dependency in `packages/dataviews/package.json`.

## Why?

`@wordpress/dataviews` declares `@wordpress/deprecated` as a dependency. Internally, `deprecated` calls `doAction()` from `@wordpress/hooks`. However, `@wordpress/hooks` is not declared in `dataviews`'s `package.json`.

This works fine in npm (which hoists everything to the root), but breaks in strict package managers like pnpm, where undeclared dependencies are not resolved. In a local project using pnpm with `@wordpress/dataviews`, the build fails with:

```
[ERROR] Cannot find package '@wordpress/hooks' imported from
node_modules/.pnpm/@wordpress+dataviews@12.1.1-.../node_modules/@wordpress/dataviews/build-wp/
```

The missing dependency was introduced when `@wordpress/deprecated` was added to dataviews (commit `6927f81d2da`).

## How?

Added `"@wordpress/hooks": "file:../hooks"` to `dependencies` in `packages/dataviews/package.json`, following the same pattern as other `@wordpress/*` dependencies in the file.

## Testing

1. Verify `@wordpress/hooks` is listed in `packages/dataviews/package.json` dependencies
2. `npm install` — no errors
3. `npm run build -- --include=dataviews` — builds successfully
