### PR TITLE
Field.Label, Fieldset.Legend: Add `hideFromVision` prop

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   `Field.Label`, `Fieldset.Legend`: Add `visuallyHidden` prop to visually hide the label while keeping it accessible to screen readers ([#76052](https://github.com/WordPress/gutenberg/pull/76052)).
 -   `Dialog`: Add `--wp-ui-dialog-z-index` CSS custom property for legacy z-index compatibility ([#75874](https://github.com/WordPress/gutenberg/pull/75874)).
 
 ### Bug Fixes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   `Field.Label`, `Fieldset.Legend`: Add `visuallyHidden` prop to visually hide the label while keeping it accessible to screen readers ([#76052](https://github.com/WordPress/gutenberg/pull/76052)).
+-   `Field.Label`, `Fieldset.Legend`: Add `hideFromVision` prop to visually hide the label while keeping it accessible to screen readers ([#76052](https://github.com/WordPress/gutenberg/pull/76052)).
 -   `Dialog`: Add `--wp-ui-dialog-z-index` CSS custom property for legacy z-index compatibility ([#75874](https://github.com/WordPress/gutenberg/pull/75874)).
 
 ### Bug Fixes

--- a/packages/ui/src/form/primitives/field/label.tsx
+++ b/packages/ui/src/form/primitives/field/label.tsx
@@ -7,7 +7,7 @@ import type { FieldLabelProps } from './types';
 
 export const Label = forwardRef< HTMLLabelElement, FieldLabelProps >(
 	function Label(
-		{ className, visuallyHidden, variant, ...restProps },
+		{ className, hideFromVision, variant, ...restProps },
 		ref
 	) {
 		return (
@@ -18,7 +18,7 @@ export const Label = forwardRef< HTMLLabelElement, FieldLabelProps >(
 					variant && fieldStyles[ `is-${ variant }` ],
 					className
 				) }
-				{ ...( visuallyHidden && {
+				{ ...( hideFromVision && {
 					render: <VisuallyHidden />,
 					nativeLabel: false,
 				} ) }

--- a/packages/ui/src/form/primitives/field/label.tsx
+++ b/packages/ui/src/form/primitives/field/label.tsx
@@ -2,10 +2,14 @@ import clsx from 'clsx';
 import { Field as _Field } from '@base-ui/react/field';
 import { forwardRef } from '@wordpress/element';
 import fieldStyles from '../../../utils/css/field.module.css';
+import { VisuallyHidden } from '../../../visually-hidden';
 import type { FieldLabelProps } from './types';
 
 export const Label = forwardRef< HTMLLabelElement, FieldLabelProps >(
-	function Label( { className, variant, ...restProps }, ref ) {
+	function Label(
+		{ className, visuallyHidden, variant, ...restProps },
+		ref
+	) {
 		return (
 			<_Field.Label
 				ref={ ref }
@@ -14,6 +18,10 @@ export const Label = forwardRef< HTMLLabelElement, FieldLabelProps >(
 					variant && fieldStyles[ `is-${ variant }` ],
 					className
 				) }
+				{ ...( visuallyHidden && {
+					render: <VisuallyHidden />,
+					nativeLabel: false,
+				} ) }
 				{ ...restProps }
 			/>
 		);

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -101,14 +101,14 @@ export const UsingAriaLabelledby: StoryObj< typeof Field.Root > = {
 };
 
 /**
- * When `hideLabelFromVision` is set on `Field.Label`, the label is visually
+ * When `hideFromVision` is set on `Field.Label`, the label is visually
  * hidden but remains accessible to screen readers.
  */
 export const HiddenLabel: StoryObj< typeof Field.Root > = {
 	args: {
 		children: (
 			<>
-				<Field.Label visuallyHidden>Label</Field.Label>
+				<Field.Label hideFromVision>Label</Field.Label>
 				<Field.Control
 					render={ <input type="text" placeholder="Placeholder" /> }
 				/>

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -101,6 +101,23 @@ export const UsingAriaLabelledby: StoryObj< typeof Field.Root > = {
 };
 
 /**
+ * When `hideLabelFromVision` is set on `Field.Label`, the label is visually
+ * hidden but remains accessible to screen readers.
+ */
+export const HiddenLabel: StoryObj< typeof Field.Root > = {
+	args: {
+		children: (
+			<>
+				<Field.Label visuallyHidden>Label</Field.Label>
+				<Field.Control
+					render={ <input type="text" placeholder="Placeholder" /> }
+				/>
+			</>
+		),
+	},
+};
+
+/**
  * To add rich content (such as links) to the description, use `Field.Details`.
  *
  * Although this content is not associated with the field using direct semantics,

--- a/packages/ui/src/form/primitives/field/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/field/test/index.test.tsx
@@ -37,7 +37,7 @@ describe( 'Field', () => {
 	it( 'keeps the accessible name when the label is visually hidden', () => {
 		render(
 			<Field.Root>
-				<Field.Label visuallyHidden>Field Label</Field.Label>
+				<Field.Label hideFromVision>Field Label</Field.Label>
 				<Field.Control render={ <input /> } />
 			</Field.Root>
 		);

--- a/packages/ui/src/form/primitives/field/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/field/test/index.test.tsx
@@ -34,6 +34,19 @@ describe( 'Field', () => {
 		expect( detailsRef.current ).toBeInstanceOf( HTMLDivElement );
 	} );
 
+	it( 'keeps the accessible name when the label is visually hidden', () => {
+		render(
+			<Field.Root>
+				<Field.Label visuallyHidden>Field Label</Field.Label>
+				<Field.Control render={ <input /> } />
+			</Field.Root>
+		);
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Field Label' } )
+		).toBeVisible();
+	} );
+
 	it( 'renders details with a semantically associated description for the control', () => {
 		render(
 			<Field.Root>

--- a/packages/ui/src/form/primitives/field/types.ts
+++ b/packages/ui/src/form/primitives/field/types.ts
@@ -39,7 +39,7 @@ export type FieldLabelProps = ComponentProps< typeof Field.Label > & {
 	 *
 	 * @default false
 	 */
-	visuallyHidden?: boolean;
+	hideFromVision?: boolean;
 	/**
 	 * The visual variant of the label.
 	 *

--- a/packages/ui/src/form/primitives/field/types.ts
+++ b/packages/ui/src/form/primitives/field/types.ts
@@ -34,6 +34,13 @@ export type FieldLabelProps = ComponentProps< typeof Field.Label > & {
 	 */
 	children?: Field.Label.Props[ 'children' ];
 	/**
+	 * Whether to visually hide the label while keeping it accessible
+	 * to screen readers.
+	 *
+	 * @default false
+	 */
+	visuallyHidden?: boolean;
+	/**
 	 * The visual variant of the label.
 	 *
 	 * Use 'plain' for controls like checkboxes and radio buttons.

--- a/packages/ui/src/form/primitives/fieldset/legend.tsx
+++ b/packages/ui/src/form/primitives/fieldset/legend.tsx
@@ -2,14 +2,21 @@ import clsx from 'clsx';
 import { Fieldset as _Fieldset } from '@base-ui/react/fieldset';
 import { forwardRef } from '@wordpress/element';
 import fieldStyles from '../../../utils/css/field.module.css';
+import { VisuallyHidden } from '../../../visually-hidden';
 import type { FieldsetLegendProps } from './types';
 
 export const FieldsetLegend = forwardRef< HTMLDivElement, FieldsetLegendProps >(
-	function FieldsetLegend( { className, ...restProps }, ref ) {
+	function FieldsetLegend(
+		{ className, visuallyHidden, ...restProps },
+		ref
+	) {
 		return (
 			<_Fieldset.Legend
 				ref={ ref }
 				className={ clsx( fieldStyles.label, className ) }
+				{ ...( visuallyHidden && {
+					render: <VisuallyHidden />,
+				} ) }
 				{ ...restProps }
 			/>
 		);

--- a/packages/ui/src/form/primitives/fieldset/legend.tsx
+++ b/packages/ui/src/form/primitives/fieldset/legend.tsx
@@ -7,14 +7,14 @@ import type { FieldsetLegendProps } from './types';
 
 export const FieldsetLegend = forwardRef< HTMLDivElement, FieldsetLegendProps >(
 	function FieldsetLegend(
-		{ className, visuallyHidden, ...restProps },
+		{ className, hideFromVision, ...restProps },
 		ref
 	) {
 		return (
 			<_Fieldset.Legend
 				ref={ ref }
 				className={ clsx( fieldStyles.label, className ) }
-				{ ...( visuallyHidden && {
+				{ ...( hideFromVision && {
 					render: <VisuallyHidden />,
 				} ) }
 				{ ...restProps }

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -34,14 +34,14 @@ export const Default: Story = {
 };
 
 /**
- * When `hideLabelFromVision` is set on `Fieldset.Legend`, the legend is visually
+ * When `hideFromVision` is set on `Fieldset.Legend`, the legend is visually
  * hidden but remains accessible to screen readers.
  */
 export const HiddenLegend: Story = {
 	args: {
 		children: (
 			<>
-				<Fieldset.Legend visuallyHidden>Legend</Fieldset.Legend>
+				<Fieldset.Legend hideFromVision>Legend</Fieldset.Legend>
 				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
 					// eslint-disable-next-line jsx-a11y/label-has-associated-control
 					<label key={ fruit }>

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -34,6 +34,26 @@ export const Default: Story = {
 };
 
 /**
+ * When `hideLabelFromVision` is set on `Fieldset.Legend`, the legend is visually
+ * hidden but remains accessible to screen readers.
+ */
+export const HiddenLegend: Story = {
+	args: {
+		children: (
+			<>
+				<Fieldset.Legend visuallyHidden>Legend</Fieldset.Legend>
+				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
+					// eslint-disable-next-line jsx-a11y/label-has-associated-control
+					<label key={ fruit }>
+						<input type="checkbox" /> { fruit }
+					</label>
+				) ) }
+			</>
+		),
+	},
+};
+
+/**
  * To add rich content (such as links) to the description, use `Fieldset.Details`.
  *
  * Although this content is not associated with the fieldset using direct semantics,

--- a/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
@@ -29,6 +29,20 @@ describe( 'Fieldset', () => {
 		expect( detailsRef.current ).toBeInstanceOf( HTMLDivElement );
 	} );
 
+	it( 'keeps the accessible name when the legend is visually hidden', () => {
+		render(
+			<Fieldset.Root>
+				<Fieldset.Legend visuallyHidden>
+					Choose your options
+				</Fieldset.Legend>
+			</Fieldset.Root>
+		);
+
+		expect(
+			screen.getByRole( 'group', { name: 'Choose your options' } )
+		).toBeVisible();
+	} );
+
 	it( 'accessibly associates description when Fieldset.Description is present', () => {
 		render(
 			<Fieldset.Root>

--- a/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
@@ -32,7 +32,7 @@ describe( 'Fieldset', () => {
 	it( 'keeps the accessible name when the legend is visually hidden', () => {
 		render(
 			<Fieldset.Root>
-				<Fieldset.Legend visuallyHidden>
+				<Fieldset.Legend hideFromVision>
 					Choose your options
 				</Fieldset.Legend>
 			</Fieldset.Root>

--- a/packages/ui/src/form/primitives/fieldset/types.ts
+++ b/packages/ui/src/form/primitives/fieldset/types.ts
@@ -7,6 +7,13 @@ export type FieldsetRootProps = ComponentProps< typeof _Fieldset.Root > & {
 
 export type FieldsetLegendProps = ComponentProps< typeof _Fieldset.Legend > & {
 	children?: React.ReactNode;
+	/**
+	 * Whether to visually hide the legend while keeping it accessible
+	 * to screen readers.
+	 *
+	 * @default false
+	 */
+	visuallyHidden?: boolean;
 };
 
 export type FieldsetDescriptionProps = ComponentProps< 'p' > & {

--- a/packages/ui/src/form/primitives/fieldset/types.ts
+++ b/packages/ui/src/form/primitives/fieldset/types.ts
@@ -13,7 +13,7 @@ export type FieldsetLegendProps = ComponentProps< typeof _Fieldset.Legend > & {
 	 *
 	 * @default false
 	 */
-	visuallyHidden?: boolean;
+	hideFromVision?: boolean;
 };
 
 export type FieldsetDescriptionProps = ComponentProps< 'p' > & {


### PR DESCRIPTION
## What?

Adds a `visuallyHidden` prop to `Field.Label` and `Fieldset.Legend`. When set, the label/legend is visually hidden but remains accessible to screen readers via the existing `aria-labelledby` association.

## Why?

Control components like `InputControl` and `SelectControl` in `@wordpress/components` have a `hideLabelFromVision` prop — a common pattern in layout modes like DataForm, where the visual context (e.g. column headers) makes individual visible labels redundant.

The new `@wordpress/ui` control components will need to support this same pattern. While it's technically achievable by composing the primitives directly, in practice consumers often don't realize that's an option and either hack around it or miss the accessibility requirements. A first-class prop on the primitive makes the accessible path the easy path.

The props on these primitives will be used to support the `hideLabelFromVision` prop on the `*Control` components.

## How?

Uses the Base UI `render` composition pattern to render via `<VisuallyHidden />` — the same approach already used by `Field.Details`.

For `Field.Label` specifically, `nativeLabel` is set to `false` when `visuallyHidden` is active, because `VisuallyHidden` renders a `<div>` rather than a `<label>`. Since the label is invisible, native `<label>` click-to-focus behavior is irrelevant. `Fieldset.Legend` doesn't need this because it already renders a `<div>` by default.

## Testing Instructions

See stories in Storybook.