### PR TITLE
RTC: Add E2E "stress test" with complex interactions

### DIFF
--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -452,7 +452,8 @@ test.describe( 'Collaboration - Stress Test', () => {
 			)
 		);
 
-		// Verify Alpha moved below Beta on all users.
+		// Verify Alpha moved below Beta and Gamma moved above the
+		// "Analysis Team" blockquote on all users.
 		for ( const ed of [ editor, editor2, editor3 ] ) {
 			await expect( async () => {
 				const blocks = await ed.getBlocks();
@@ -468,6 +469,20 @@ test.describe( 'Collaboration - Stress Test', () => {
 				expect( alphaIdx ).toBeGreaterThan( -1 );
 				expect( betaIdx ).toBeGreaterThan( -1 );
 				expect( alphaIdx ).toBeGreaterThan( betaIdx );
+
+				// Gamma was moved up, so it should now be above the
+				// "Analysis Team" blockquote that was previously above it.
+				const gammaIdx = texts.findIndex( ( t ) =>
+					t.includes( 'Gamma section content' )
+				);
+				const quoteIdx = blocks.findIndex( ( b ) =>
+					String( b.attributes.citation ?? '' ).includes(
+						'Analysis Team'
+					)
+				);
+				expect( gammaIdx ).toBeGreaterThan( -1 );
+				expect( quoteIdx ).toBeGreaterThan( -1 );
+				expect( gammaIdx ).toBeLessThan( quoteIdx );
 			} ).toPass( { timeout: 10_000 } );
 		}
 

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -396,16 +396,24 @@ test.describe( 'Collaboration - Stress Test', () => {
 		await collaborationUtils.waitForMutualDiscovery();
 
 		// ── Phase 4 — Two users type in the same paragraph ──────
-		// Typing is sequential to avoid character-level interleaving
-		// from concurrent keyboard.type calls (each sends one key at
-		// a time, which the CRDT merges non-deterministically).
-		await editor.canvas.getByText( 'shared editing target' ).click();
-		await page.keyboard.press( 'End' );
-		await page.keyboard.type( ' — Admin was here.' );
-
-		await editor2.canvas.getByText( 'shared editing target' ).click();
-		await page2.keyboard.press( 'End' );
-		await page2.keyboard.type( ' — Editor was here.' );
+		// Uses insertText (single input event) instead of keyboard.type
+		// (character-by-character) to avoid CRDT character interleaving.
+		await Promise.all( [
+			( async () => {
+				await editor.canvas
+					.getByText( 'shared editing target' )
+					.click();
+				await page.keyboard.press( 'End' );
+				await page.keyboard.insertText( ' — Admin was here.' );
+			} )(),
+			( async () => {
+				await editor2.canvas
+					.getByText( 'shared editing target' )
+					.click();
+				await page2.keyboard.press( 'End' );
+				await page2.keyboard.insertText( ' — Editor was here.' );
+			} )(),
+		] );
 
 		// All three active users should see both additions.
 		for ( const ed of [ editor, editor2, editor3 ] ) {

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -381,7 +381,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 			expect( allContent ).toContain(
 				'Admin typed this paragraph in Phase 2'
 			);
-		} ).toPass( { timeout: 5_000 } );
+		} ).toPass( { timeout: 10_000 } );
 
 		// ── Phase 3 — Save · User 3 joins · Admin refreshes ────
 		await editor.saveDraft();
@@ -396,22 +396,16 @@ test.describe( 'Collaboration - Stress Test', () => {
 		await collaborationUtils.waitForMutualDiscovery();
 
 		// ── Phase 4 — Two users type in the same paragraph ──────
-		await Promise.all( [
-			( async () => {
-				await editor.canvas
-					.getByText( 'shared editing target' )
-					.click();
-				await page.keyboard.press( 'End' );
-				await page.keyboard.type( ' — Admin was here.' );
-			} )(),
-			( async () => {
-				await editor2.canvas
-					.getByText( 'shared editing target' )
-					.click();
-				await page2.keyboard.press( 'End' );
-				await page2.keyboard.type( ' — Editor was here.' );
-			} )(),
-		] );
+		// Typing is sequential to avoid character-level interleaving
+		// from concurrent keyboard.type calls (each sends one key at
+		// a time, which the CRDT merges non-deterministically).
+		await editor.canvas.getByText( 'shared editing target' ).click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( ' — Admin was here.' );
+
+		await editor2.canvas.getByText( 'shared editing target' ).click();
+		await page2.keyboard.press( 'End' );
+		await page2.keyboard.type( ' — Editor was here.' );
 
 		// All three active users should see both additions.
 		for ( const ed of [ editor, editor2, editor3 ] ) {
@@ -420,7 +414,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 				const allContent = JSON.stringify( blocks );
 				expect( allContent ).toContain( 'Admin was here' );
 				expect( allContent ).toContain( 'Editor was here' );
-			} ).toPass( { timeout: 5_000 } );
+			} ).toPass( { timeout: 10_000 } );
 		}
 
 		// ── Phase 5 — Two users move blocks via toolbar ─────────
@@ -474,7 +468,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 				expect( alphaIdx ).toBeGreaterThan( -1 );
 				expect( betaIdx ).toBeGreaterThan( -1 );
 				expect( alphaIdx ).toBeGreaterThan( betaIdx );
-			} ).toPass( { timeout: 5_000 } );
+			} ).toPass( { timeout: 10_000 } );
 		}
 
 		// ── Phase 6 — Second save · User 4 joins ───────────────
@@ -525,7 +519,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 				expect( allContent ).toContain(
 					'Final paragraph from Contributor'
 				);
-			} ).toPass( { timeout: 5_000 } );
+			} ).toPass( { timeout: 10_000 } );
 		}
 
 		// ── Phase 8 — User 3 refreshes (second refresh) ────────
@@ -541,7 +535,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 			expect( allContent ).toContain(
 				'Final paragraph from Contributor'
 			);
-		} ).toPass( { timeout: 5_000 } );
+		} ).toPass( { timeout: 10_000 } );
 
 		// ── Phase 9 — Final save and publish ────────────────────
 		await editor.saveDraft();
@@ -626,7 +620,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 				const deltaIdx = items.indexOf( 'Item Delta' );
 				expect( betaIdx ).toBeGreaterThan( gammaIdx );
 				expect( epsilonIdx ).toBeLessThan( deltaIdx );
-			} ).toPass( { timeout: 5_000 } );
+			} ).toPass( { timeout: 10_000 } );
 		};
 
 		for ( const ed of [ editor, editor2 ] ) {

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -314,7 +314,7 @@ async function typeNewParagraphAfterHeading(
 	await ed.canvas.getByText( headingText, { exact: true } ).click();
 	await pg.keyboard.press( 'End' );
 	await pg.keyboard.press( 'Enter' );
-	await pg.keyboard.type( paragraphText );
+	await pg.keyboard.insertText( paragraphText );
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -364,7 +364,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 		await editor2.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.click( { clickCount: 3 } );
-		await page2.keyboard.type( 'RTC Stress Test — Edited by Editor' );
+		await page2.keyboard.insertText( 'RTC Stress Test — Edited by Editor' );
 
 		// Verify Admin's paragraph synced to Editor.
 		await expect( async () => {

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -1,33 +1,32 @@
 /**
  * External dependencies
  */
-import type { Browser, BrowserContext, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 /**
  * WordPress dependencies
  */
-import { Editor } from '@wordpress/e2e-test-utils-playwright';
+import type { Editor } from '@wordpress/e2e-test-utils-playwright';
 
 /**
  * Internal dependencies
  */
 import { test, expect } from './fixtures';
-
-const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+import type { UserCredentials } from './fixtures/collaboration-utils';
 
 /*
  * All non-admin users need at minimum the 'editor' role so they can
  * edit a post created by the admin.  WordPress author / contributor
  * roles lack the `edit_others_posts` capability.
  */
-const STRESS_USERS = [
+const STRESS_USERS: UserCredentials[] = [
 	{
 		username: 'stress_editor',
 		email: 'stress_editor@example.com',
 		firstName: 'Alice',
 		lastName: 'Editor',
 		password: 'password',
-		roles: [ 'editor' ] as string[],
+		roles: [ 'editor' ],
 	},
 	{
 		username: 'stress_author',
@@ -35,7 +34,7 @@ const STRESS_USERS = [
 		firstName: 'Bob',
 		lastName: 'Author',
 		password: 'password',
-		roles: [ 'editor' ] as string[],
+		roles: [ 'editor' ],
 	},
 	{
 		username: 'stress_contrib',
@@ -43,7 +42,7 @@ const STRESS_USERS = [
 		firstName: 'Carol',
 		lastName: 'Contributor',
 		password: 'password',
-		roles: [ 'editor' ] as string[],
+		roles: [ 'editor' ],
 	},
 ];
 
@@ -302,79 +301,7 @@ function generateStressContent(): string {
 	return blocks.join( '\n\n' );
 }
 
-// ── Session helpers ─────────────────────────────────────────────────
-
-async function loginUser(
-	browser: Browser,
-	user: ( typeof STRESS_USERS )[ number ]
-): Promise< { context: BrowserContext; page: Page } > {
-	const context = await browser.newContext( { baseURL: BASE_URL } );
-	const newPage = await context.newPage();
-	await newPage.goto( '/wp-login.php' );
-	await newPage.locator( '#user_login' ).fill( user.username );
-	await newPage.locator( '#user_pass' ).fill( user.password );
-	await newPage.getByRole( 'button', { name: 'Log In' } ).click();
-	await newPage.waitForURL( '**/wp-admin/**' );
-	return { context, page: newPage };
-}
-
-async function openPostEditor(
-	targetPage: Page,
-	postId: number
-): Promise< Editor > {
-	await targetPage.goto( `/wp-admin/post.php?post=${ postId }&action=edit` );
-	await targetPage.waitForFunction(
-		() => window?.wp?.data && window?.wp?.blocks
-	);
-	await targetPage.evaluate( () => {
-		window.wp.data
-			.dispatch( 'core/preferences' )
-			.set( 'core/edit-post', 'welcomeGuide', false );
-		window.wp.data
-			.dispatch( 'core/preferences' )
-			.set( 'core/edit-post', 'fullscreenMode', false );
-	} );
-	await waitForCollabReady( targetPage );
-	return new Editor( { page: targetPage } );
-}
-
-async function waitForCollabReady( targetPage: Page ) {
-	await targetPage.waitForFunction(
-		() =>
-			( window as any )._wpCollaborationEnabled === true &&
-			window?.wp?.data &&
-			window?.wp?.blocks,
-		{ timeout: 5_000 }
-	);
-}
-
-async function waitForSyncCycle( targetPage: Page, cycles = 3 ) {
-	for ( let i = 0; i < cycles; i++ ) {
-		await targetPage.waitForResponse(
-			( response ) =>
-				response.url().includes( 'wp-sync' ) &&
-				response.status() === 200,
-			{ timeout: 5_000 }
-		);
-	}
-}
-
-/**
- * Wait for all pages to show the Collaborators button (mutual awareness)
- * and then wait for sync cycles to complete.
- *
- * @param pages The Playwright pages to wait on.
- */
-async function waitForMutualDiscovery( pages: Page[] ) {
-	await Promise.all(
-		pages.map( ( pg ) =>
-			pg
-				.getByRole( 'button', { name: /Collaborators list/ } )
-				.waitFor( { timeout: 5_000 } )
-		)
-	);
-	await Promise.all( pages.map( ( pg ) => waitForSyncCycle( pg ) ) );
-}
+// ── Test-specific helpers ───────────────────────────────────────────
 
 /**
  * Type a new paragraph after a heading identified by its visible text.
@@ -401,27 +328,12 @@ async function typeNewParagraphAfterHeading(
 // ── Tests ───────────────────────────────────────────────────────────
 
 test.describe( 'Collaboration - Stress Test', () => {
-	const contexts: BrowserContext[] = [];
-
-	test.afterEach( async () => {
-		for ( const ctx of contexts ) {
-			await ctx.close();
-		}
-		contexts.length = 0;
-	} );
-
 	test( 'four users concurrently edit a large post with diverse blocks', async ( {
 		collaborationUtils,
 		requestUtils,
 		editor,
 		page,
-		admin,
 	} ) => {
-		// The fixture enables collaboration and creates the default
-		// second user; we rely on the fixture for the collaboration
-		// setting toggle and teardown (user cleanup).
-		void collaborationUtils;
-
 		// Create the three additional test users.
 		for ( const user of STRESS_USERS ) {
 			await requestUtils.createUser( user );
@@ -437,29 +349,16 @@ test.describe( 'Collaboration - Stress Test', () => {
 		} );
 
 		// ── Phase 1 — Admin opens the post ──────────────────────
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
-		await waitForCollabReady( page );
+		await collaborationUtils.openPost( post.id );
 
 		// Sanity-check: the large post loaded its blocks.
 		const initialBlocks = await editor.getBlocks();
 		expect( initialBlocks.length ).toBeGreaterThan( 40 );
 
 		// ── Phase 2 — User 2 (Editor) joins ─────────────────────
-		const session2 = await loginUser(
-			page.context().browser()!,
-			STRESS_USERS[ 0 ]
-		);
-		contexts.push( session2.context );
-		const page2 = session2.page;
-		const editor2 = await openPostEditor( page2, post.id );
-		await waitForMutualDiscovery( [ page, page2 ] );
+		const { page: page2, editor: editor2 } =
+			await collaborationUtils.joinUser( post.id, STRESS_USERS[ 0 ] );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// Admin types a new paragraph after the "Conclusion" heading.
 		await typeNewParagraphAfterHeading(
@@ -487,19 +386,14 @@ test.describe( 'Collaboration - Stress Test', () => {
 		// ── Phase 3 — Save · User 3 joins · Admin refreshes ────
 		await editor.saveDraft();
 
-		const session3 = await loginUser(
-			page.context().browser()!,
-			STRESS_USERS[ 1 ]
-		);
-		contexts.push( session3.context );
-		const page3 = session3.page;
-		const editor3 = await openPostEditor( page3, post.id );
+		const { page: page3, editor: editor3 } =
+			await collaborationUtils.joinUser( post.id, STRESS_USERS[ 1 ] );
 
 		// Admin refreshes (first refresh).
 		await page.reload( { waitUntil: 'load' } );
-		await waitForCollabReady( page );
+		await collaborationUtils.waitForCollaborationReady( page );
 
-		await waitForMutualDiscovery( [ page, page2, page3 ] );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// ── Phase 4 — Two users type in the same paragraph ──────
 		await Promise.all( [
@@ -559,7 +453,9 @@ test.describe( 'Collaboration - Stress Test', () => {
 
 		// Wait for block-movement changes to propagate.
 		await Promise.all(
-			[ page, page2, page3 ].map( ( pg ) => waitForSyncCycle( pg ) )
+			collaborationUtils.allPages.map( ( pg ) =>
+				collaborationUtils.waitForSyncCycle( pg )
+			)
 		);
 
 		// Verify Alpha moved below Beta on all users.
@@ -584,14 +480,9 @@ test.describe( 'Collaboration - Stress Test', () => {
 		// ── Phase 6 — Second save · User 4 joins ───────────────
 		await editor.saveDraft();
 
-		const session4 = await loginUser(
-			page.context().browser()!,
-			STRESS_USERS[ 2 ]
-		);
-		contexts.push( session4.context );
-		const page4 = session4.page;
-		const editor4 = await openPostEditor( page4, post.id );
-		await waitForMutualDiscovery( [ page, page2, page3, page4 ] );
+		const { page: page4, editor: editor4 } =
+			await collaborationUtils.joinUser( post.id, STRESS_USERS[ 2 ] );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// ── Phase 7 — All 4 users type new paragraphs concurrently ──
 		// Each user clicks on a different heading, presses Enter to
@@ -624,7 +515,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 		] );
 
 		// All 4 users should see all 4 new paragraphs.
-		for ( const ed of [ editor, editor2, editor3, editor4 ] ) {
+		for ( const ed of collaborationUtils.allEditors ) {
 			await expect( async () => {
 				const blocks = await ed.getBlocks();
 				const allContent = JSON.stringify( blocks );
@@ -639,8 +530,8 @@ test.describe( 'Collaboration - Stress Test', () => {
 
 		// ── Phase 8 — User 3 refreshes (second refresh) ────────
 		await page3.reload( { waitUntil: 'load' } );
-		await waitForCollabReady( page3 );
-		await waitForMutualDiscovery( [ page, page2, page3, page4 ] );
+		await collaborationUtils.waitForCollaborationReady( page3 );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// After refresh, User 3 should still see concurrent edits.
 		await expect( async () => {
@@ -662,10 +553,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 		requestUtils,
 		editor,
 		page,
-		admin,
 	} ) => {
-		void collaborationUtils;
-
 		await requestUtils.createUser( STRESS_USERS[ 0 ] );
 
 		// Create a post with a list of clearly identifiable items.
@@ -685,24 +573,11 @@ test.describe( 'Collaboration - Stress Test', () => {
 		} );
 
 		// ── Phase 1 — Both users open the post ──────────────────
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
-		await waitForCollabReady( page );
+		await collaborationUtils.openPost( post.id );
 
-		const session2 = await loginUser(
-			page.context().browser()!,
-			STRESS_USERS[ 0 ]
-		);
-		contexts.push( session2.context );
-		const page2 = session2.page;
-		const editor2 = await openPostEditor( page2, post.id );
-		await waitForMutualDiscovery( [ page, page2 ] );
+		const { page: page2, editor: editor2 } =
+			await collaborationUtils.joinUser( post.id, STRESS_USERS[ 0 ] );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// ── Phase 2 — Concurrent list-item moves ────────────────
 		// User 1 moves "Item Beta" down; User 2 moves "Item Epsilon" up.
@@ -763,8 +638,8 @@ test.describe( 'Collaboration - Stress Test', () => {
 
 		// ── Phase 4 — User 1 refreshes ──────────────────────────
 		await page.reload( { waitUntil: 'load' } );
-		await waitForCollabReady( page );
-		await waitForMutualDiscovery( [ page, page2 ] );
+		await collaborationUtils.waitForCollaborationReady( page );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// After refresh, User 1 should still see 6 items in the
 		// moved order.
@@ -772,8 +647,8 @@ test.describe( 'Collaboration - Stress Test', () => {
 
 		// ── Phase 5 — User 2 refreshes ──────────────────────────
 		await page2.reload( { waitUntil: 'load' } );
-		await waitForCollabReady( page2 );
-		await waitForMutualDiscovery( [ page, page2 ] );
+		await collaborationUtils.waitForCollaborationReady( page2 );
+		await collaborationUtils.waitForMutualDiscovery();
 
 		// After refresh, User 2 should also see 6 items in the
 		// moved order.

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -1,0 +1,782 @@
+/**
+ * External dependencies
+ */
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+
+/**
+ * WordPress dependencies
+ */
+import { Editor } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+
+/*
+ * All non-admin users need at minimum the 'editor' role so they can
+ * edit a post created by the admin.  WordPress author / contributor
+ * roles lack the `edit_others_posts` capability.
+ */
+const STRESS_USERS = [
+	{
+		username: 'stress_editor',
+		email: 'stress_editor@example.com',
+		firstName: 'Alice',
+		lastName: 'Editor',
+		password: 'password',
+		roles: [ 'editor' ] as string[],
+	},
+	{
+		username: 'stress_author',
+		email: 'stress_author@example.com',
+		firstName: 'Bob',
+		lastName: 'Author',
+		password: 'password',
+		roles: [ 'editor' ] as string[],
+	},
+	{
+		username: 'stress_contrib',
+		email: 'stress_contrib@example.com',
+		firstName: 'Carol',
+		lastName: 'Contributor',
+		password: 'password',
+		roles: [ 'editor' ] as string[],
+	},
+];
+
+// ── Filler text ─────────────────────────────────────────────────────
+
+const SENTENCES = [
+	'The system processes data through multiple layers of abstraction ensuring consistency across all nodes.',
+	'Reliability is maintained by distributed components that handle requests efficiently within the network.',
+	'Each architecture layer guarantees strict ordering for operations that modify shared state.',
+	'Synchronization protocols use vector clocks to track causal dependencies between updates.',
+	'Optimistic replication propagates changes using conflict resolution based on deterministic rules.',
+	'Concurrent modifications are detected and merged by specialized functions in the coordination layer.',
+	'The protocol maintains eventual consistency while minimizing latency for participating clients.',
+	'State transitions are validated against invariants before being committed to the distributed log.',
+	'Recovery mechanisms restore consistency after partial failures using checkpointed snapshots.',
+	'Performance monitoring tracks throughput and latency metrics across all participating services.',
+	'The coordination layer batches updates to reduce network overhead during peak traffic periods.',
+	'Load balancing distributes requests across available replicas based on current capacity estimates.',
+	'Data partitioning strategies ensure that related records are co-located for efficient queries.',
+	'The consensus algorithm tolerates up to one third of nodes failing without losing availability.',
+	'Background compaction processes reclaim storage space from obsolete versions of modified records.',
+	'Event sourcing captures all changes as immutable facts appended to a persistent ordered log.',
+	'Materialized views are rebuilt from the event log to provide optimized read access patterns.',
+	'Schema evolution is managed through compatible transformations that preserve backward compatibility.',
+	'Rate limiting prevents individual clients from consuming disproportionate amounts of shared resources.',
+	'Circuit breakers protect downstream services from cascading failures during periods of degradation.',
+];
+
+function filler( wordCount: number, seed: number = 0 ): string {
+	const words: string[] = [];
+	let idx = seed;
+	while ( words.length < wordCount ) {
+		const sentence = SENTENCES[ idx % SENTENCES.length ];
+		for ( const w of sentence.split( /\s+/ ) ) {
+			if ( words.length >= wordCount ) {
+				break;
+			}
+			words.push( w );
+		}
+		idx++;
+	}
+	return words.join( ' ' );
+}
+
+// ── Block markup helpers ────────────────────────────────────────────
+
+function bp( text: string ): string {
+	return `<!-- wp:paragraph -->\n<p>${ text }</p>\n<!-- /wp:paragraph -->`;
+}
+
+function bh( text: string, level: number = 2 ): string {
+	const attrs = level === 2 ? '' : ` {"level":${ level }}`;
+	return `<!-- wp:heading${ attrs } -->\n<h${ level } class="wp-block-heading">${ text }</h${ level }>\n<!-- /wp:heading -->`;
+}
+
+function bul( items: string[] ): string {
+	const inner = items
+		.map(
+			( item ) =>
+				`<!-- wp:list-item -->\n<li>${ item }</li>\n<!-- /wp:list-item -->`
+		)
+		.join( '\n' );
+	return `<!-- wp:list -->\n<ul class="wp-block-list">${ inner }</ul>\n<!-- /wp:list -->`;
+}
+
+function bol( items: string[] ): string {
+	const inner = items
+		.map(
+			( item ) =>
+				`<!-- wp:list-item -->\n<li>${ item }</li>\n<!-- /wp:list-item -->`
+		)
+		.join( '\n' );
+	return `<!-- wp:list {"ordered":true} -->\n<ol class="wp-block-list">${ inner }</ol>\n<!-- /wp:list -->`;
+}
+
+function bgroup( innerBlocks: string[] ): string {
+	return `<!-- wp:group {"layout":{"type":"constrained"}} -->\n<div class="wp-block-group">${ innerBlocks.join(
+		'\n'
+	) }</div>\n<!-- /wp:group -->`;
+}
+
+function btable( headers: string[], rows: string[][] ): string {
+	const thead = `<thead><tr>${ headers
+		.map( ( hdr ) => `<th>${ hdr }</th>` )
+		.join( '' ) }</tr></thead>`;
+	const tbody = `<tbody>${ rows
+		.map(
+			( row ) =>
+				`<tr>${ row
+					.map( ( cell ) => `<td>${ cell }</td>` )
+					.join( '' ) }</tr>`
+		)
+		.join( '' ) }</tbody>`;
+	return `<!-- wp:table -->\n<figure class="wp-block-table"><table>${ thead }${ tbody }</table></figure>\n<!-- /wp:table -->`;
+}
+
+function bquote( innerBlocks: string[], citation?: string ): string {
+	const cite = citation ? `<cite>${ citation }</cite>` : '';
+	return `<!-- wp:quote -->\n<blockquote class="wp-block-quote">${ innerBlocks.join(
+		'\n'
+	) }${ cite }</blockquote>\n<!-- /wp:quote -->`;
+}
+
+function bcolumns( cols: string[][] ): string {
+	const inner = cols
+		.map(
+			( blocks ) =>
+				`<!-- wp:column -->\n<div class="wp-block-column">${ blocks.join(
+					'\n'
+				) }</div>\n<!-- /wp:column -->`
+		)
+		.join( '\n' );
+	return `<!-- wp:columns -->\n<div class="wp-block-columns">${ inner }</div>\n<!-- /wp:columns -->`;
+}
+
+// ── Content generator (~5 000 words) ────────────────────────────────
+
+function generateStressContent(): string {
+	const blocks: string[] = [];
+	let seed = 0;
+
+	// Introduction
+	blocks.push( bh( 'Introduction' ) );
+	for ( let i = 0; i < 5; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+
+	// Background
+	blocks.push( bh( 'Background' ) );
+	for ( let i = 0; i < 3; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+	blocks.push(
+		bul( Array.from( { length: 8 }, ( _, i ) => filler( 25, seed + i ) ) )
+	);
+	seed += 8;
+
+	// Technical Details
+	blocks.push( bh( 'Technical Details', 3 ) );
+	for ( let i = 0; i < 4; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+	blocks.push(
+		bol( Array.from( { length: 6 }, ( _, i ) => filler( 25, seed + i ) ) )
+	);
+	seed += 6;
+
+	// Analysis
+	blocks.push( bh( 'Analysis' ) );
+	blocks.push(
+		bgroup( [
+			bp( filler( 100, seed++ ) ),
+			bp( filler( 100, seed++ ) ),
+			bp( filler( 100, seed++ ) ),
+		] )
+	);
+	blocks.push(
+		btable(
+			[ 'Metric', 'Baseline', 'Optimized' ],
+			Array.from( { length: 4 }, () => [
+				filler( 8, seed++ ),
+				filler( 8, seed++ ),
+				filler( 8, seed++ ),
+			] )
+		)
+	);
+	for ( let i = 0; i < 4; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+	blocks.push( bquote( [ bp( filler( 80, seed++ ) ) ], 'Research Team' ) );
+
+	// Paragraph targeted for concurrent editing (Phase 4).
+	blocks.push(
+		bp(
+			'This paragraph is the shared editing target for concurrent modification testing.'
+		)
+	);
+
+	// Implementation Notes
+	blocks.push( bh( 'Implementation Notes', 3 ) );
+	blocks.push(
+		bgroup( [
+			bp( filler( 100, seed++ ) ),
+			bp( filler( 100, seed++ ) ),
+			bul(
+				Array.from( { length: 5 }, ( _, i ) => filler( 20, seed + i ) )
+			),
+		] )
+	);
+	seed += 5;
+
+	// Paragraphs targeted for block movement (Phase 5).
+	blocks.push( bp( 'Alpha section content for block movement testing.' ) );
+	blocks.push( bp( 'Beta section content for block movement testing.' ) );
+	for ( let i = 0; i < 3; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+
+	// Results
+	blocks.push( bh( 'Results' ) );
+	blocks.push(
+		bcolumns( [
+			[ bp( filler( 100, seed++ ) ) ],
+			[ bp( filler( 100, seed++ ) ) ],
+		] )
+	);
+	blocks.push(
+		btable(
+			[ 'Test', 'Expected', 'Actual', 'Status' ],
+			Array.from( { length: 3 }, () => [
+				filler( 6, seed++ ),
+				filler( 6, seed++ ),
+				filler( 6, seed++ ),
+				'Passed',
+			] )
+		)
+	);
+	for ( let i = 0; i < 4; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+	blocks.push( bquote( [ bp( filler( 80, seed++ ) ) ], 'Analysis Team' ) );
+
+	// Paragraph targeted for block movement (far from Alpha/Beta).
+	blocks.push( bp( 'Gamma section content for block movement testing.' ) );
+
+	// Discussion
+	blocks.push( bh( 'Discussion' ) );
+	for ( let i = 0; i < 5; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+	blocks.push(
+		bgroup( [
+			bp( filler( 100, seed++ ) ),
+			bp( filler( 100, seed++ ) ),
+			bp( filler( 100, seed++ ) ),
+		] )
+	);
+
+	// Future Work
+	blocks.push( bh( 'Future Work', 3 ) );
+	blocks.push(
+		bul( Array.from( { length: 6 }, ( _, i ) => filler( 25, seed + i ) ) )
+	);
+	seed += 6;
+	for ( let i = 0; i < 3; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+
+	// Conclusion
+	blocks.push( bh( 'Conclusion' ) );
+	for ( let i = 0; i < 3; i++ ) {
+		blocks.push( bp( filler( 100, seed++ ) ) );
+	}
+	blocks.push( bquote( [ bp( filler( 80, seed++ ) ) ], 'Project Lead' ) );
+
+	return blocks.join( '\n\n' );
+}
+
+// ── Session helpers ─────────────────────────────────────────────────
+
+async function loginUser(
+	browser: Browser,
+	user: ( typeof STRESS_USERS )[ number ]
+): Promise< { context: BrowserContext; page: Page } > {
+	const context = await browser.newContext( { baseURL: BASE_URL } );
+	const newPage = await context.newPage();
+	await newPage.goto( '/wp-login.php' );
+	await newPage.locator( '#user_login' ).fill( user.username );
+	await newPage.locator( '#user_pass' ).fill( user.password );
+	await newPage.getByRole( 'button', { name: 'Log In' } ).click();
+	await newPage.waitForURL( '**/wp-admin/**' );
+	return { context, page: newPage };
+}
+
+async function openPostEditor(
+	targetPage: Page,
+	postId: number
+): Promise< Editor > {
+	await targetPage.goto( `/wp-admin/post.php?post=${ postId }&action=edit` );
+	await targetPage.waitForFunction(
+		() => window?.wp?.data && window?.wp?.blocks
+	);
+	await targetPage.evaluate( () => {
+		window.wp.data
+			.dispatch( 'core/preferences' )
+			.set( 'core/edit-post', 'welcomeGuide', false );
+		window.wp.data
+			.dispatch( 'core/preferences' )
+			.set( 'core/edit-post', 'fullscreenMode', false );
+	} );
+	await waitForCollabReady( targetPage );
+	return new Editor( { page: targetPage } );
+}
+
+async function waitForCollabReady( targetPage: Page ) {
+	await targetPage.waitForFunction(
+		() =>
+			( window as any )._wpCollaborationEnabled === true &&
+			window?.wp?.data &&
+			window?.wp?.blocks,
+		{ timeout: 5_000 }
+	);
+}
+
+async function waitForSyncCycle( targetPage: Page, cycles = 3 ) {
+	for ( let i = 0; i < cycles; i++ ) {
+		await targetPage.waitForResponse(
+			( response ) =>
+				response.url().includes( 'wp-sync' ) &&
+				response.status() === 200,
+			{ timeout: 5_000 }
+		);
+	}
+}
+
+/**
+ * Wait for all pages to show the Collaborators button (mutual awareness)
+ * and then wait for sync cycles to complete.
+ *
+ * @param pages The Playwright pages to wait on.
+ */
+async function waitForMutualDiscovery( pages: Page[] ) {
+	await Promise.all(
+		pages.map( ( pg ) =>
+			pg
+				.getByRole( 'button', { name: /Collaborators list/ } )
+				.waitFor( { timeout: 5_000 } )
+		)
+	);
+	await Promise.all( pages.map( ( pg ) => waitForSyncCycle( pg ) ) );
+}
+
+/**
+ * Type a new paragraph after a heading identified by its visible text.
+ * Clicks the heading, presses End then Enter (creating a new paragraph
+ * below it), and types the given content.
+ *
+ * @param ed            Editor instance for the user.
+ * @param pg            Playwright page for the user.
+ * @param headingText   Visible text of the heading to click.
+ * @param paragraphText Text to type into the new paragraph.
+ */
+async function typeNewParagraphAfterHeading(
+	ed: Editor,
+	pg: Page,
+	headingText: string,
+	paragraphText: string
+) {
+	await ed.canvas.getByText( headingText, { exact: true } ).click();
+	await pg.keyboard.press( 'End' );
+	await pg.keyboard.press( 'Enter' );
+	await pg.keyboard.type( paragraphText );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+test.describe( 'Collaboration - Stress Test', () => {
+	const contexts: BrowserContext[] = [];
+
+	test.afterEach( async () => {
+		for ( const ctx of contexts ) {
+			await ctx.close();
+		}
+		contexts.length = 0;
+	} );
+
+	test( 'four users concurrently edit a large post with diverse blocks', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+		admin,
+	} ) => {
+		// The fixture enables collaboration and creates the default
+		// second user; we rely on the fixture for the collaboration
+		// setting toggle and teardown (user cleanup).
+		void collaborationUtils;
+
+		// Create the three additional test users.
+		for ( const user of STRESS_USERS ) {
+			await requestUtils.createUser( user );
+		}
+
+		// Create a large draft post (~5 000 words, diverse block types).
+		const content = generateStressContent();
+		const post = await requestUtils.createPost( {
+			title: 'RTC Stress Test',
+			content,
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		// ── Phase 1 — Admin opens the post ──────────────────────
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+		await waitForCollabReady( page );
+
+		// Sanity-check: the large post loaded its blocks.
+		const initialBlocks = await editor.getBlocks();
+		expect( initialBlocks.length ).toBeGreaterThan( 40 );
+
+		// ── Phase 2 — User 2 (Editor) joins ─────────────────────
+		const session2 = await loginUser(
+			page.context().browser()!,
+			STRESS_USERS[ 0 ]
+		);
+		contexts.push( session2.context );
+		const page2 = session2.page;
+		const editor2 = await openPostEditor( page2, post.id );
+		await waitForMutualDiscovery( [ page, page2 ] );
+
+		// Admin types a new paragraph after the "Conclusion" heading.
+		await typeNewParagraphAfterHeading(
+			editor,
+			page,
+			'Conclusion',
+			'Admin typed this paragraph in Phase 2.'
+		);
+
+		// Editor types a new title.
+		await editor2.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.click( { clickCount: 3 } );
+		await page2.keyboard.type( 'RTC Stress Test — Edited by Editor' );
+
+		// Verify Admin's paragraph synced to Editor.
+		await expect( async () => {
+			const blocks = await editor2.getBlocks();
+			const allContent = JSON.stringify( blocks );
+			expect( allContent ).toContain(
+				'Admin typed this paragraph in Phase 2'
+			);
+		} ).toPass( { timeout: 5_000 } );
+
+		// ── Phase 3 — Save · User 3 joins · Admin refreshes ────
+		await editor.saveDraft();
+
+		const session3 = await loginUser(
+			page.context().browser()!,
+			STRESS_USERS[ 1 ]
+		);
+		contexts.push( session3.context );
+		const page3 = session3.page;
+		const editor3 = await openPostEditor( page3, post.id );
+
+		// Admin refreshes (first refresh).
+		await page.reload( { waitUntil: 'load' } );
+		await waitForCollabReady( page );
+
+		await waitForMutualDiscovery( [ page, page2, page3 ] );
+
+		// ── Phase 4 — Two users type in the same paragraph ──────
+		await Promise.all( [
+			( async () => {
+				await editor.canvas
+					.getByText( 'shared editing target' )
+					.click();
+				await page.keyboard.press( 'End' );
+				await page.keyboard.type( ' — Admin was here.' );
+			} )(),
+			( async () => {
+				await editor2.canvas
+					.getByText( 'shared editing target' )
+					.click();
+				await page2.keyboard.press( 'End' );
+				await page2.keyboard.type( ' — Editor was here.' );
+			} )(),
+		] );
+
+		// All three active users should see both additions.
+		for ( const ed of [ editor, editor2, editor3 ] ) {
+			await expect( async () => {
+				const blocks = await ed.getBlocks();
+				const allContent = JSON.stringify( blocks );
+				expect( allContent ).toContain( 'Admin was here' );
+				expect( allContent ).toContain( 'Editor was here' );
+			} ).toPass( { timeout: 5_000 } );
+		}
+
+		// ── Phase 5 — Two users move blocks via toolbar ─────────
+		// User 2 moves "Alpha" down; User 3 moves "Gamma" up.
+		// The blocks are far apart so the moves don't conflict.
+		await Promise.all( [
+			( async () => {
+				await editor2.canvas
+					.getByText( 'Alpha section content' )
+					.click();
+				await editor2.showBlockToolbar();
+				await page2
+					.locator(
+						'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
+					)
+					.click();
+			} )(),
+			( async () => {
+				await editor3.canvas
+					.getByText( 'Gamma section content' )
+					.click();
+				await editor3.showBlockToolbar();
+				await page3
+					.locator(
+						'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+					)
+					.click();
+			} )(),
+		] );
+
+		// Wait for block-movement changes to propagate.
+		await Promise.all(
+			[ page, page2, page3 ].map( ( pg ) => waitForSyncCycle( pg ) )
+		);
+
+		// Verify Alpha moved below Beta on all users.
+		for ( const ed of [ editor, editor2, editor3 ] ) {
+			await expect( async () => {
+				const blocks = await ed.getBlocks();
+				const texts = blocks.map( ( b ) =>
+					String( b.attributes.content ?? '' )
+				);
+				const alphaIdx = texts.findIndex( ( t ) =>
+					t.includes( 'Alpha section content' )
+				);
+				const betaIdx = texts.findIndex( ( t ) =>
+					t.includes( 'Beta section content' )
+				);
+				expect( alphaIdx ).toBeGreaterThan( -1 );
+				expect( betaIdx ).toBeGreaterThan( -1 );
+				expect( alphaIdx ).toBeGreaterThan( betaIdx );
+			} ).toPass( { timeout: 5_000 } );
+		}
+
+		// ── Phase 6 — Second save · User 4 joins ───────────────
+		await editor.saveDraft();
+
+		const session4 = await loginUser(
+			page.context().browser()!,
+			STRESS_USERS[ 2 ]
+		);
+		contexts.push( session4.context );
+		const page4 = session4.page;
+		const editor4 = await openPostEditor( page4, post.id );
+		await waitForMutualDiscovery( [ page, page2, page3, page4 ] );
+
+		// ── Phase 7 — All 4 users type new paragraphs concurrently ──
+		// Each user clicks on a different heading, presses Enter to
+		// create a new paragraph below it, then types their content.
+		await Promise.all( [
+			typeNewParagraphAfterHeading(
+				editor,
+				page,
+				'Introduction',
+				'Final paragraph from Admin.'
+			),
+			typeNewParagraphAfterHeading(
+				editor2,
+				page2,
+				'Discussion',
+				'Final paragraph from Editor.'
+			),
+			typeNewParagraphAfterHeading(
+				editor3,
+				page3,
+				'Results',
+				'Final paragraph from Author.'
+			),
+			typeNewParagraphAfterHeading(
+				editor4,
+				page4,
+				'Background',
+				'Final paragraph from Contributor.'
+			),
+		] );
+
+		// All 4 users should see all 4 new paragraphs.
+		for ( const ed of [ editor, editor2, editor3, editor4 ] ) {
+			await expect( async () => {
+				const blocks = await ed.getBlocks();
+				const allContent = JSON.stringify( blocks );
+				expect( allContent ).toContain( 'Final paragraph from Admin' );
+				expect( allContent ).toContain( 'Final paragraph from Editor' );
+				expect( allContent ).toContain( 'Final paragraph from Author' );
+				expect( allContent ).toContain(
+					'Final paragraph from Contributor'
+				);
+			} ).toPass( { timeout: 5_000 } );
+		}
+
+		// ── Phase 8 — User 3 refreshes (second refresh) ────────
+		await page3.reload( { waitUntil: 'load' } );
+		await waitForCollabReady( page3 );
+		await waitForMutualDiscovery( [ page, page2, page3, page4 ] );
+
+		// After refresh, User 3 should still see concurrent edits.
+		await expect( async () => {
+			const blocks = await editor3.getBlocks();
+			const allContent = JSON.stringify( blocks );
+			expect( allContent ).toContain( 'Final paragraph from Admin' );
+			expect( allContent ).toContain(
+				'Final paragraph from Contributor'
+			);
+		} ).toPass( { timeout: 5_000 } );
+
+		// ── Phase 9 — Final save and publish ────────────────────
+		await editor.saveDraft();
+		await editor.publishPost();
+	} );
+
+	test( 'two users concurrently move list items', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+		admin,
+	} ) => {
+		void collaborationUtils;
+
+		await requestUtils.createUser( STRESS_USERS[ 0 ] );
+
+		// Create a post with a list of clearly identifiable items.
+		const listContent = bul( [
+			'Item Alpha',
+			'Item Beta',
+			'Item Gamma',
+			'Item Delta',
+			'Item Epsilon',
+			'Item Zeta',
+		] );
+		const post = await requestUtils.createPost( {
+			title: 'List Item Movement Test',
+			content: listContent,
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		// ── Phase 1 — Both users open the post ──────────────────
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+		await waitForCollabReady( page );
+
+		const session2 = await loginUser(
+			page.context().browser()!,
+			STRESS_USERS[ 0 ]
+		);
+		contexts.push( session2.context );
+		const page2 = session2.page;
+		const editor2 = await openPostEditor( page2, post.id );
+		await waitForMutualDiscovery( [ page, page2 ] );
+
+		// ── Phase 2 — Concurrent list-item moves ────────────────
+		// User 1 moves "Item Beta" down; User 2 moves "Item Epsilon" up.
+		// The items are well-separated so the moves don't conflict.
+		await Promise.all( [
+			( async () => {
+				await editor.canvas
+					.getByText( 'Item Beta', { exact: true } )
+					.click();
+				await editor.showBlockToolbar();
+				await page
+					.locator(
+						'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
+					)
+					.click();
+			} )(),
+			( async () => {
+				await editor2.canvas
+					.getByText( 'Item Epsilon', { exact: true } )
+					.click();
+				await editor2.showBlockToolbar();
+				await page2
+					.locator(
+						'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+					)
+					.click();
+			} )(),
+		] );
+
+		// Verify both moves on both users: Beta after Gamma,
+		// Epsilon before Delta.
+		const assertMovedOrder = async ( ed: Editor ) => {
+			await expect( async () => {
+				const blocks = await ed.getBlocks();
+				const listBlock = blocks.find(
+					( b ) => b.name === 'core/list'
+				);
+				expect( listBlock ).toBeDefined();
+				const items = listBlock!.innerBlocks.map( ( item ) =>
+					String( item.attributes.content )
+				);
+				expect( items ).toHaveLength( 6 );
+				const betaIdx = items.indexOf( 'Item Beta' );
+				const gammaIdx = items.indexOf( 'Item Gamma' );
+				const epsilonIdx = items.indexOf( 'Item Epsilon' );
+				const deltaIdx = items.indexOf( 'Item Delta' );
+				expect( betaIdx ).toBeGreaterThan( gammaIdx );
+				expect( epsilonIdx ).toBeLessThan( deltaIdx );
+			} ).toPass( { timeout: 5_000 } );
+		};
+
+		for ( const ed of [ editor, editor2 ] ) {
+			await assertMovedOrder( ed );
+		}
+
+		// ── Phase 3 — Save draft ────────────────────────────────
+		await editor.saveDraft();
+
+		// ── Phase 4 — User 1 refreshes ──────────────────────────
+		await page.reload( { waitUntil: 'load' } );
+		await waitForCollabReady( page );
+		await waitForMutualDiscovery( [ page, page2 ] );
+
+		// After refresh, User 1 should still see 6 items in the
+		// moved order.
+		await assertMovedOrder( editor );
+
+		// ── Phase 5 — User 2 refreshes ──────────────────────────
+		await page2.reload( { waitUntil: 'load' } );
+		await waitForCollabReady( page2 );
+		await waitForMutualDiscovery( [ page, page2 ] );
+
+		// After refresh, User 2 should also see 6 items in the
+		// moved order.
+		await assertMovedOrder( editor2 );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -508,20 +508,7 @@ test.describe( 'Collaboration - Stress Test', () => {
 			} ).toPass( { timeout: 10_000 } );
 		}
 
-		// ── Phase 7 — User 3 refreshes (second refresh) ────────
-		await page3.reload( { waitUntil: 'load' } );
-		await collaborationUtils.waitForCollaborationReady( page3 );
-		await collaborationUtils.waitForMutualDiscovery();
-
-		// After refresh, User 3 should still see concurrent edits.
-		await expect( async () => {
-			const blocks = await editor3.getBlocks();
-			const allContent = JSON.stringify( blocks );
-			expect( allContent ).toContain( 'Final paragraph from Admin' );
-			expect( allContent ).toContain( 'Final paragraph from Author' );
-		} ).toPass( { timeout: 10_000 } );
-
-		// ── Phase 8 — Final save and publish ────────────────────
+		// ── Phase 7 — Final save and publish ────────────────────
 		await editor.saveDraft();
 		await editor.publishPost();
 	} );

--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -36,14 +36,6 @@ const STRESS_USERS: UserCredentials[] = [
 		password: 'password',
 		roles: [ 'editor' ],
 	},
-	{
-		username: 'stress_contrib',
-		email: 'stress_contrib@example.com',
-		firstName: 'Carol',
-		lastName: 'Contributor',
-		password: 'password',
-		roles: [ 'editor' ],
-	},
 ];
 
 // ── Filler text ─────────────────────────────────────────────────────
@@ -328,13 +320,13 @@ async function typeNewParagraphAfterHeading(
 // ── Tests ───────────────────────────────────────────────────────────
 
 test.describe( 'Collaboration - Stress Test', () => {
-	test( 'four users concurrently edit a large post with diverse blocks', async ( {
+	test( 'three users concurrently edit a large post with diverse blocks', async ( {
 		collaborationUtils,
 		requestUtils,
 		editor,
 		page,
 	} ) => {
-		// Create the three additional test users.
+		// Create the two additional test users.
 		for ( const user of STRESS_USERS ) {
 			await requestUtils.createUser( user );
 		}
@@ -479,14 +471,9 @@ test.describe( 'Collaboration - Stress Test', () => {
 			} ).toPass( { timeout: 10_000 } );
 		}
 
-		// ── Phase 6 — Second save · User 4 joins ───────────────
+		// ── Phase 6 — Second save · all 3 users type concurrently ──
 		await editor.saveDraft();
 
-		const { page: page4, editor: editor4 } =
-			await collaborationUtils.joinUser( post.id, STRESS_USERS[ 2 ] );
-		await collaborationUtils.waitForMutualDiscovery();
-
-		// ── Phase 7 — All 4 users type new paragraphs concurrently ──
 		// Each user clicks on a different heading, presses Enter to
 		// create a new paragraph below it, then types their content.
 		await Promise.all( [
@@ -508,15 +495,9 @@ test.describe( 'Collaboration - Stress Test', () => {
 				'Results',
 				'Final paragraph from Author.'
 			),
-			typeNewParagraphAfterHeading(
-				editor4,
-				page4,
-				'Background',
-				'Final paragraph from Contributor.'
-			),
 		] );
 
-		// All 4 users should see all 4 new paragraphs.
+		// All 3 users should see all 3 new paragraphs.
 		for ( const ed of collaborationUtils.allEditors ) {
 			await expect( async () => {
 				const blocks = await ed.getBlocks();
@@ -524,13 +505,10 @@ test.describe( 'Collaboration - Stress Test', () => {
 				expect( allContent ).toContain( 'Final paragraph from Admin' );
 				expect( allContent ).toContain( 'Final paragraph from Editor' );
 				expect( allContent ).toContain( 'Final paragraph from Author' );
-				expect( allContent ).toContain(
-					'Final paragraph from Contributor'
-				);
 			} ).toPass( { timeout: 10_000 } );
 		}
 
-		// ── Phase 8 — User 3 refreshes (second refresh) ────────
+		// ── Phase 7 — User 3 refreshes (second refresh) ────────
 		await page3.reload( { waitUntil: 'load' } );
 		await collaborationUtils.waitForCollaborationReady( page3 );
 		await collaborationUtils.waitForMutualDiscovery();
@@ -540,12 +518,10 @@ test.describe( 'Collaboration - Stress Test', () => {
 			const blocks = await editor3.getBlocks();
 			const allContent = JSON.stringify( blocks );
 			expect( allContent ).toContain( 'Final paragraph from Admin' );
-			expect( allContent ).toContain(
-				'Final paragraph from Contributor'
-			);
+			expect( allContent ).toContain( 'Final paragraph from Author' );
 		} ).toPass( { timeout: 10_000 } );
 
-		// ── Phase 9 — Final save and publish ────────────────────
+		// ── Phase 8 — Final save and publish ────────────────────
 		await editor.saveDraft();
 		await editor.publishPost();
 	} );

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -148,7 +148,7 @@ export default class CollaborationUtils {
 	 */
 	async waitForMutualDiscovery( { timeout }: { timeout?: number } = {} ) {
 		const pages = this.allPages;
-		const resolvedTimeout = timeout ?? 5000 + pages.length * 2500;
+		const resolvedTimeout = timeout ?? 10000 + pages.length * 2500;
 
 		await Promise.all(
 			pages.map( ( pg ) =>

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -12,13 +12,29 @@ import {
 	type RequestUtils,
 } from '@wordpress/e2e-test-utils-playwright';
 
-export const SECOND_USER = {
+export interface UserCredentials {
+	username: string;
+	email: string;
+	firstName: string;
+	lastName: string;
+	password: string;
+	roles: string[];
+}
+
+interface UserSession {
+	user: UserCredentials;
+	context: BrowserContext;
+	page: Page;
+	editor: Editor;
+}
+
+export const SECOND_USER: UserCredentials = {
 	username: 'collaborator',
 	email: 'collaborator@example.com',
 	firstName: 'Test',
 	lastName: 'Collaborator',
 	password: 'password',
-	roles: [ 'editor' ] as string[],
+	roles: [ 'editor' ],
 };
 
 const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
@@ -28,10 +44,7 @@ export default class CollaborationUtils {
 	private editor: Editor;
 	private requestUtils: RequestUtils;
 	private primaryPage: Page;
-
-	private secondContext: BrowserContext | null = null;
-	private secondPage: Page | null = null;
-	private secondEditor: Editor | null = null;
+	private sessions: UserSession[] = [];
 
 	constructor( {
 		admin,
@@ -51,30 +64,12 @@ export default class CollaborationUtils {
 	}
 
 	/**
-	 * Open a collaborative editing session where both the primary user (admin)
-	 * and the second user (collaborator) are editing the same post.
+	 * Navigate the primary user (admin) to a post and wait for
+	 * collaboration to be ready.
 	 *
-	 * @param postId The post ID to collaboratively edit.
+	 * @param postId The post ID to open.
 	 */
-	async openCollaborativeSession( postId: number ) {
-		// Create a second browser context with the same baseURL.
-		this.secondContext = await this.admin.browser.newContext( {
-			baseURL: BASE_URL,
-		} );
-		this.secondPage = await this.secondContext.newPage();
-
-		// Login the second user via the WordPress login form.
-		await this.secondPage.goto( '/wp-login.php' );
-		await this.secondPage
-			.locator( '#user_login' )
-			.fill( SECOND_USER.username );
-		await this.secondPage
-			.locator( '#user_pass' )
-			.fill( SECOND_USER.password );
-		await this.secondPage.getByRole( 'button', { name: 'Log In' } ).click();
-		await this.secondPage.waitForURL( '**/wp-admin/**' );
-
-		// Navigate User 1 (admin) to the post editor.
+	async openPost( postId: number ) {
 		await this.admin.visitAdminPage(
 			'post.php',
 			`post=${ postId }&action=edit`
@@ -83,20 +78,43 @@ export default class CollaborationUtils {
 			welcomeGuide: false,
 			fullscreenMode: false,
 		} );
-
-		// Wait for collaboration to be enabled on User 1's page.
 		await this.waitForCollaborationReady( this.primaryPage );
+	}
 
-		// Navigate User 2 to the same post editor.
-		await this.secondPage.goto(
-			`/wp-admin/post.php?post=${ postId }&action=edit`
-		);
+	/**
+	 * Log in an additional user and open the same post in a new
+	 * browser context. Returns the new user's page and editor.
+	 *
+	 * Can be called multiple times to add N users to a session.
+	 *
+	 * @param postId The post ID to open.
+	 * @param user   Credentials for the user to join.
+	 * @return The joined user's page and editor.
+	 */
+	async joinUser(
+		postId: number,
+		user: UserCredentials
+	): Promise< { page: Page; editor: Editor } > {
+		const context = await this.admin.browser.newContext( {
+			baseURL: BASE_URL,
+		} );
+		const newPage = await context.newPage();
 
-		// Dismiss welcome guide for User 2.
-		await this.secondPage.waitForFunction(
+		// Log in via the WordPress login form.
+		await newPage.goto( '/wp-login.php' );
+		await newPage.locator( '#user_login' ).fill( user.username );
+		await newPage.locator( '#user_pass' ).fill( user.password );
+		await newPage.getByRole( 'button', { name: 'Log In' } ).click();
+		await newPage.waitForURL( '**/wp-admin/**' );
+
+		// Navigate to the post editor.
+		await newPage.goto( `/wp-admin/post.php?post=${ postId }&action=edit` );
+
+		// Dismiss welcome guide.
+		await newPage.waitForFunction(
 			() => window?.wp?.data && window?.wp?.blocks
 		);
-		await this.secondPage.evaluate( () => {
+		await newPage.evaluate( () => {
 			window.wp.data
 				.dispatch( 'core/preferences' )
 				.set( 'core/edit-post', 'welcomeGuide', false );
@@ -105,30 +123,56 @@ export default class CollaborationUtils {
 				.set( 'core/edit-post', 'fullscreenMode', false );
 		} );
 
-		// Create an Editor instance for the second page.
-		this.secondEditor = new Editor( { page: this.secondPage } );
+		const newEditor = new Editor( { page: newPage } );
 
-		// Wait for collaboration to be enabled on User 2's page.
-		await this.waitForCollaborationReady( this.secondPage );
+		await this.waitForCollaborationReady( newPage );
 
-		// Wait for both users to discover each other via awareness.
-		// The collaborator count button appears when another user is
-		// detected through the sync polling.
-		await Promise.all( [
-			this.primaryPage
-				.getByRole( 'button', { name: /Collaborators list/ } )
-				.waitFor( { timeout: 15000 } ),
-			this.secondPage
-				.getByRole( 'button', { name: /Collaborators list/ } )
-				.waitFor( { timeout: 15000 } ),
-		] );
+		this.sessions.push( {
+			user,
+			context,
+			page: newPage,
+			editor: newEditor,
+		} );
 
-		// Allow a full round of polling after awareness is established
-		// so both CRDT docs are synchronized.
-		await Promise.all( [
-			this.waitForSyncCycle( this.primaryPage ),
-			this.waitForSyncCycle( this.secondPage ),
-		] );
+		return { page: newPage, editor: newEditor };
+	}
+
+	/**
+	 * Wait for all current participants (primary + joined users) to
+	 * discover each other via the awareness protocol, then wait for
+	 * sync cycles to complete.
+	 *
+	 * @param [options]         Optional settings.
+	 * @param [options.timeout] Maximum wait time in ms. Defaults to a
+	 *                          value that scales with the number of users.
+	 */
+	async waitForMutualDiscovery( { timeout }: { timeout?: number } = {} ) {
+		const pages = this.allPages;
+		const resolvedTimeout = timeout ?? 5000 + pages.length * 2500;
+
+		await Promise.all(
+			pages.map( ( pg ) =>
+				pg
+					.getByRole( 'button', { name: /Collaborators list/ } )
+					.waitFor( { timeout: resolvedTimeout } )
+			)
+		);
+
+		await Promise.all( pages.map( ( pg ) => this.waitForSyncCycle( pg ) ) );
+	}
+
+	/**
+	 * Convenience method: open a two-user collaborative session.
+	 *
+	 * Equivalent to calling `openPost`, `joinUser` with SECOND_USER,
+	 * and `waitForMutualDiscovery` in sequence.
+	 *
+	 * @param postId The post ID to collaboratively edit.
+	 */
+	async openCollaborativeSession( postId: number ) {
+		await this.openPost( postId );
+		await this.joinUser( postId, SECOND_USER );
+		await this.waitForMutualDiscovery();
 	}
 
 	/**
@@ -243,15 +287,20 @@ export default class CollaborationUtils {
 	 * Wait for the collaboration runtime to be ready on a page.
 	 * Checks that `window._wpCollaborationEnabled` is true and wp.data is loaded.
 	 *
-	 * @param page The Playwright page to wait on.
+	 * @param page              The Playwright page to wait on.
+	 * @param [options]         Optional settings.
+	 * @param [options.timeout] Maximum wait time in ms (default 15000).
 	 */
-	private async waitForCollaborationReady( page: Page ) {
+	async waitForCollaborationReady(
+		page: Page,
+		{ timeout = 15000 }: { timeout?: number } = {}
+	) {
 		await page.waitForFunction(
 			() =>
 				( window as any )._wpCollaborationEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
-			{ timeout: 15000 }
+			{ timeout }
 		);
 	}
 
@@ -262,54 +311,104 @@ export default class CollaborationUtils {
 	 * (rest_route=%2Fwp-sync%2Fv1%2Fupdates), so we match the
 	 * encoded form.
 	 *
-	 * @param page   The Playwright page to wait on.
-	 * @param cycles Number of sync responses to wait for (default 3).
+	 * @param page              The Playwright page to wait on.
+	 * @param cycles            Number of sync responses to wait for (default 3).
+	 * @param [options]         Optional settings.
+	 * @param [options.timeout] Maximum wait time per cycle in ms (default 10000).
 	 */
-	private async waitForSyncCycle( page: Page, cycles = 3 ) {
+	async waitForSyncCycle(
+		page: Page,
+		cycles = 3,
+		{ timeout = 10000 }: { timeout?: number } = {}
+	) {
 		for ( let i = 0; i < cycles; i++ ) {
 			await page.waitForResponse(
 				( response ) =>
 					response.url().includes( 'wp-sync' ) &&
 					response.status() === 200,
-				{ timeout: 10000 }
+				{ timeout }
 			);
 		}
+	}
+
+	/**
+	 * All pages in the session: primary user followed by joined users
+	 * in the order they joined.
+	 */
+	get allPages(): Page[] {
+		return [ this.primaryPage, ...this.sessions.map( ( s ) => s.page ) ];
+	}
+
+	/**
+	 * All editors in the session: primary user followed by joined users
+	 * in the order they joined.
+	 */
+	get allEditors(): Editor[] {
+		return [ this.editor, ...this.sessions.map( ( s ) => s.editor ) ];
+	}
+
+	/**
+	 * Get a joined user's page by index (0-based, in join order).
+	 *
+	 * @param index Index of the joined user.
+	 */
+	getPage( index: number ): Page {
+		if ( index < 0 || index >= this.sessions.length ) {
+			throw new Error(
+				`No session at index ${ index }. ${ this.sessions.length } user(s) have joined.`
+			);
+		}
+		return this.sessions[ index ].page;
+	}
+
+	/**
+	 * Get a joined user's editor by index (0-based, in join order).
+	 *
+	 * @param index Index of the joined user.
+	 */
+	getEditor( index: number ): Editor {
+		if ( index < 0 || index >= this.sessions.length ) {
+			throw new Error(
+				`No session at index ${ index }. ${ this.sessions.length } user(s) have joined.`
+			);
+		}
+		return this.sessions[ index ].editor;
 	}
 
 	/**
 	 * Get the second user's Page instance.
+	 * Backward-compatible accessor for two-user tests.
 	 */
 	get page2(): Page {
-		if ( ! this.secondPage ) {
+		if ( this.sessions.length === 0 ) {
 			throw new Error(
-				'Second page not available. Call openCollaborativeSession() first.'
+				'Second page not available. Call openCollaborativeSession() or joinUser() first.'
 			);
 		}
-		return this.secondPage;
+		return this.sessions[ 0 ].page;
 	}
 
 	/**
 	 * Get the second user's Editor instance.
+	 * Backward-compatible accessor for two-user tests.
 	 */
 	get editor2(): Editor {
-		if ( ! this.secondEditor ) {
+		if ( this.sessions.length === 0 ) {
 			throw new Error(
-				'Second editor not available. Call openCollaborativeSession() first.'
+				'Second editor not available. Call openCollaborativeSession() or joinUser() first.'
 			);
 		}
-		return this.secondEditor;
+		return this.sessions[ 0 ].editor;
 	}
 
 	/**
-	 * Clean up: close second browser context, disable collaboration, delete test users.
+	 * Clean up: close all secondary browser contexts and delete test users.
 	 */
 	async teardown() {
-		if ( this.secondContext ) {
-			await this.secondContext.close();
-			this.secondContext = null;
-			this.secondPage = null;
-			this.secondEditor = null;
+		for ( const session of this.sessions ) {
+			await session.context.close();
 		}
+		this.sessions = [];
 		await this.requestUtils.deleteAllUsers();
 	}
 }


### PR DESCRIPTION

## What?

Add E2E "stress test" with more complex interactions and larger posts.

## Why?

E2E tests that more closely resemble real-world workflows is more likely to present bugs that human users will encounter.

## How?

Add two tests:

### Test 1: Four users concurrently edit a large post with diverse blocks

- Creates a ~5,000-word draft post with 50+ blocks (paragraphs, headings, ordered/unordered lists with list-item inner blocks, groups, tables, quotes, columns), then runs 9 phases:
   - Admin opens the post, verifies 40+ blocks loaded.
   - User 2 (editor) joins. Admin types a new paragraph after the “Conclusion” heading. Editor types a new title. Admin’s paragraph is verified on Editor’s view.
   - Admin saves draft. User 3 (author) joins. Admin refreshes and re-syncs with all 3 users.
   - Admin and Editor concurrently type in the same paragraph (“shared editing target”). Both additions verified on all 3 users.
   - Editor moves the “Alpha” block down via the block toolbar. Author moves the “Gamma” block up. Both moves verified (Alpha after Beta) on all 3 users.
   - Admin saves draft. User 4 (contributor) joins and syncs with all 4 users.
   - All 4 users concurrently type new paragraphs after different headings (Introduction, Discussion, Results, Background). All 4 paragraphs verified on all 4 users.
   - User 3 refreshes, re-syncs, and is verified to still see the paragraphs from phases 7.
   - Admin saves draft, then publishes.

### Test 2: two users concurrently move list items

- Creates a post with a single 6-item unordered list (Alpha through Zeta), then runs 5 phases:
   - Admin and User 2 both open the post and sync.
   - Admin moves “Item Beta” down and User 2 moves “Item Epsilon” up concurrently via the block toolbar. Both moves verified on both users (Beta after Gamma, Epsilon before Delta, 6 items total).
   - Admin saves draft.
   - User 1 refreshes, re-syncs. Same 6 items in moved order verified.
   - User 2 refreshes, re-syncs. Same 6 items in moved order verified.

