### PR TITLE
RTC: Verify client ID to avoid awareness mutation

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -7,5 +7,4 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75711
 * https://github.com/WordPress/gutenberg/pull/75746
 * https://github.com/WordPress/gutenberg/pull/75869
-* https://github.com/WordPress/gutenberg/pull/76056
 * https://github.com/WordPress/gutenberg/pull/76060

--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -7,4 +7,5 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75711
 * https://github.com/WordPress/gutenberg/pull/75746
 * https://github.com/WordPress/gutenberg/pull/75869
+* https://github.com/WordPress/gutenberg/pull/76056
 * https://github.com/WordPress/gutenberg/pull/76060

--- a/backport-changelog/7.0/11120.md
+++ b/backport-changelog/7.0/11120.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11120
+
+* https://github.com/WordPress/gutenberg/pull/76056

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -183,10 +183,25 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				);
 			}
 
-			$rooms = $request['rooms'];
+			$rooms      = $request['rooms'];
+			$wp_user_id = get_current_user_id();
 
 			foreach ( $rooms as $room ) {
-				$room         = $room['room'];
+				$client_id = $room['client_id'];
+				$room      = $room['room'];
+
+				// Check that the client_id is not already owned by another user.
+				$existing_awareness = $this->storage->get_awareness_state( $room );
+				foreach ( $existing_awareness as $entry ) {
+					if ( $client_id === $entry['client_id'] && $wp_user_id !== $entry['wp_user_id'] ) {
+						return new WP_Error(
+							'forbidden',
+							__( 'Client ID is already in use by another user.', 'gutenberg' ),
+							array( 'status' => 403 )
+						);
+					}
+				}
+
 				$type_parts   = explode( '/', $room, 2 );
 				$object_parts = explode( ':', $type_parts[1] ?? '', 2 );
 
@@ -348,6 +363,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 					'client_id'  => $client_id,
 					'state'      => $awareness_update,
 					'updated_at' => $current_time,
+					'wp_user_id' => get_current_user_id(),
 				);
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Verify client ID before allowing awareness mutation.

## Why?

Awareness data is not particularly sensitive, but nothing currently stops a user from sending a request to overwrite another user's awareness state.


## How?

If awareness state is being updated, first check that the WP user ID matches the user who initially created it.

