### PR TITLE
RTC: Ignore HTML when calculating cursor offset

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -532,6 +532,43 @@ function isRichTextAttribute(
 let localDoc: Y.Doc;
 
 /**
+ * Convert a cursor offset in rendered text (visible characters only) to the
+ * corresponding offset in a raw HTML string. HTML tags are skipped so they
+ * don't count toward the rendered position.
+ *
+ * This is needed because Gutenberg's selectionStart.offset is measured in
+ * rendered-text coordinates, but the CRDT diff operates on the serialized
+ * HTML string where tags like `<strong>` occupy additional characters.
+ *
+ * @param html           The serialized HTML string.
+ * @param renderedOffset The cursor offset in rendered text.
+ * @return The corresponding offset in the HTML string.
+ */
+function renderedOffsetToHtmlOffset(
+	html: string,
+	renderedOffset: number
+): number {
+	let rendered = 0;
+	let inTag = false;
+
+	for ( let i = 0; i < html.length; i++ ) {
+		if ( rendered === renderedOffset ) {
+			return i;
+		}
+
+		if ( html[ i ] === '<' ) {
+			inTag = true;
+		} else if ( html[ i ] === '>' ) {
+			inTag = false;
+		} else if ( ! inTag ) {
+			rendered++;
+		}
+	}
+
+	return html.length;
+}
+
+/**
  * Given a Y.Text object and an updated string value, diff the new value and
  * apply the delta to the Y.Text.
  *
@@ -565,9 +602,18 @@ export function mergeRichTextUpdate(
 
 	const currentValueAsDelta = new Delta( blockYText.toDelta() );
 	const updatedValueAsDelta = new Delta( localYText.toDelta() );
+
+	// The cursor position from the editor (selectionStart.offset) is in
+	// rendered-text coordinates (visible characters only). The diff operates on
+	// the raw HTML string, so we must convert to HTML-string coordinates.
+	const htmlCursorPosition =
+		cursorPosition !== null
+			? renderedOffsetToHtmlOffset( updatedValue, cursorPosition )
+			: null;
+
 	const deltaDiff = currentValueAsDelta.diffWithCursor(
 		updatedValueAsDelta,
-		cursorPosition
+		htmlCursorPosition
 	);
 
 	blockYText.applyDelta( deltaDiff.ops );

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -1416,4 +1416,104 @@ describe( 'crdt-blocks', () => {
 			} );
 		} );
 	} );
+
+	describe( 'inline markup cursor position handling', () => {
+		// The cursor position from selectionStart.offset is in rendered-text
+		// coordinates (visible characters only), but the diff operates on the
+		// raw HTML string. Without proper conversion, the cursor hint in
+		// diffWithCursor can match a character inside an HTML tag and produce
+		// garbled output.
+
+		it( 'should not garble HTML when inserting a character that matches a tag character', () => {
+			// Old HTML: "s<strong>x</strong>b" — rendered: "sxb"
+			// User types 's' after the bold text: "sxsb" with cursor at 3
+			// Without fix: cursor=3 lands inside <strong> tag, matches 's',
+			// and splits the tag producing "s<sstrong>x</strong>b"
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 's<strong>x</strong>b' );
+
+			mergeRichTextUpdate( yText, 's<strong>x</strong>sb', 3 );
+
+			expect( yText.toString() ).toBe( 's<strong>x</strong>sb' );
+		} );
+
+		it( 'should handle typing before any HTML tags', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, 'ab<strong>cd</strong>' );
+
+			// Rendered: "abcd" → "axbcd" with cursor at 2
+			mergeRichTextUpdate( yText, 'axb<strong>cd</strong>', 2 );
+
+			expect( yText.toString() ).toBe( 'axb<strong>cd</strong>' );
+		} );
+
+		it( 'should handle typing after closing tag', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '<em>hello</em> world' );
+
+			// Rendered: "hello world" → "hello world!" with cursor at 12
+			mergeRichTextUpdate( yText, '<em>hello</em> world!', 12 );
+
+			expect( yText.toString() ).toBe( '<em>hello</em> world!' );
+		} );
+
+		it( 'should handle deleting a character after inline markup', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '<strong>hello</strong> world' );
+
+			// Rendered: "hello world" → "hello worl" with cursor at 10
+			mergeRichTextUpdate( yText, '<strong>hello</strong> worl', 10 );
+
+			expect( yText.toString() ).toBe( '<strong>hello</strong> worl' );
+		} );
+
+		it( 'should handle emoji combined with inline markup', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '<strong>😀</strong>b' );
+
+			// Rendered: "😀b" → "😀xb" with cursor at 3 (😀=2, x=1)
+			mergeRichTextUpdate( yText, '<strong>😀</strong>xb', 3 );
+
+			expect( yText.toString() ).toBe( '<strong>😀</strong>xb' );
+		} );
+
+		it( 'should handle multiple inline tags', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '<strong>a</strong><em>b</em>c' );
+
+			// Rendered: "abc" → "abxc" with cursor at 3
+			mergeRichTextUpdate( yText, '<strong>a</strong><em>b</em>xc', 3 );
+
+			expect( yText.toString() ).toBe( '<strong>a</strong><em>b</em>xc' );
+		} );
+
+		it( 'should handle nested inline tags', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert( 0, '<strong><em>ab</em></strong>c' );
+
+			// Rendered: "abc" → "abxc" with cursor at 3
+			mergeRichTextUpdate( yText, '<strong><em>ab</em></strong>xc', 3 );
+
+			expect( yText.toString() ).toBe( '<strong><em>ab</em></strong>xc' );
+		} );
+
+		it( 'should handle link tags with attributes', () => {
+			const yText = doc.getText( 'test' );
+			yText.insert(
+				0,
+				'Click <a href="https://example.com">here</a> now'
+			);
+
+			// Rendered: "Click here now" → "Click here now!" with cursor at 15
+			mergeRichTextUpdate(
+				yText,
+				'Click <a href="https://example.com">here</a> now!',
+				15
+			);
+
+			expect( yText.toString() ).toBe(
+				'Click <a href="https://example.com">here</a> now!'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

Fix a coordinate space mismatch in RTC rich-text syncing where the cursor position (in rendered-text coordinates) is compared against offsets in the raw HTML string.

Closes #76057


## Why?

`selectionStart.offset` counts only visible text characters. HTML tags like `<strong>`, `<em>`, and `<a href="...">` are not counted. But `diffWithCursor` compares this cursor position against offsets in the serialized HTML string, where those tags occupy many additional characters.

## How?

Add a `renderedOffsetToHtmlOffset` helper that walks the HTML string, skipping tag characters, to map a rendered-text offset to the corresponding HTML-string offset. This conversion is applied in `mergeRichTextUpdate` before passing the cursor position to `diffWithCursor`.

For plain text (no HTML tags), the conversion is a no-op — existing behavior is unchanged.

## Testing Instructions

1. Settings > Writing > Enable real-time collaboration.
1. Open a post in two browser tabs as two different users.
1. In User A’s tab, type some text.
1. In User B's tab, place the cursor immediately after the inserted text.
1. In User A's tab, bold a few words of the inserted text.
1. Observe User B’s tab. The text should sync correctly and the cursor position should be accurate.
1. Repeat with italic, links, and other inline formatting.

