### PR TITLE
RTC: Prevent duplicate poll cycles

### DIFF
--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -297,16 +297,19 @@ function handleVisibilityChange() {
 		/*
 		 * Remove scheduled polling and repoll immediately when reactivated.
 		 *
-		 * This ensures that any updates by collaborators are immediately reflected
-		 * in the document once the browser tab becomes active. Otherwise there would
-		 * be a delay of 30 seconds before the updates came through.
+		 * This ensures that any updates by collaborators are immediately
+		 * reflected in the document once the browser tab becomes active.
+		 * Otherwise there would be a delay of up to 30 seconds before the
+		 * updates came through.
+		 *
+		 * Only repoll if we cleared a pending timeout, meaning the poll loop
+		 * was idle between cycles. If no timeout is pending, a poll request
+		 * is already in-flight and will pick up the updated isActiveBrowser
+		 * value when it schedules the next cycle.
 		 */
 		if ( pollingTimeoutId ) {
 			clearTimeout( pollingTimeoutId );
 			pollingTimeoutId = null;
-		}
-
-		if ( isPolling ) {
 			poll();
 		}
 	}

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -9,6 +9,7 @@ import {
 	it,
 	jest,
 } from '@jest/globals';
+import type { SyncResponse } from '../types';
 
 // Mock all external dependencies before imports.
 jest.mock( 'yjs', () => ( {
@@ -111,7 +112,9 @@ const syncResponse = {
 
 describe( 'polling-manager', () => {
 	let pollingManager: PollingManager;
-	let mockPostSyncUpdate: jest.Mock;
+	let mockPostSyncUpdate: jest.Mock<
+		typeof import('../utils').postSyncUpdate
+	>;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
@@ -137,7 +140,7 @@ describe( 'polling-manager', () => {
 		it( 'does not spawn a duplicate poll when a request is in-flight', () => {
 			// Keep the first postSyncUpdate pending so we can simulate
 			// a visibility change while the request is in-flight.
-			const deferred = createDeferred();
+			const deferred = createDeferred< SyncResponse >();
 			mockPostSyncUpdate.mockReturnValue( deferred.promise );
 
 			pollingManager.registerRoom( {

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1,0 +1,188 @@
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
+
+// Mock all external dependencies before imports.
+jest.mock( 'yjs', () => ( {
+	mergeUpdates: jest.fn( () => new Uint8Array() ),
+	applyUpdate: jest.fn(),
+	encodeStateAsUpdate: jest.fn( () => new Uint8Array() ),
+} ) );
+
+jest.mock( 'lib0/encoding', () => ( {
+	createEncoder: jest.fn( () => ( {} ) ),
+	toUint8Array: jest.fn( () => new Uint8Array( [ 0 ] ) ),
+} ) );
+
+jest.mock( 'lib0/decoding', () => ( {
+	createDecoder: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( 'y-protocols/sync', () => ( {
+	writeSyncStep1: jest.fn(),
+	readSyncMessage: jest.fn(),
+} ) );
+
+jest.mock( 'y-protocols/awareness', () => ( {
+	removeAwarenessStates: jest.fn(),
+} ) );
+
+jest.mock( '../utils', () => ( {
+	base64ToUint8Array: jest.fn( () => new Uint8Array() ),
+	createSyncUpdate: jest.fn( ( _data: unknown, type: string ) => ( {
+		data: '',
+		type,
+	} ) ),
+	createUpdateQueue: jest.fn( () => ( {
+		add: jest.fn(),
+		addBulk: jest.fn(),
+		clear: jest.fn(),
+		get: jest.fn( () => [] ),
+		pause: jest.fn(),
+		restore: jest.fn(),
+		resume: jest.fn(),
+		size: jest.fn( () => 0 ),
+	} ) ),
+	postSyncUpdate: jest.fn(),
+	postSyncUpdateNonBlocking: jest.fn(),
+} ) );
+
+interface PollingManager {
+	registerRoom: ( options: {
+		room: string;
+		doc: unknown;
+		awareness: unknown;
+		log: () => void;
+		onStatusChange: () => void;
+		onSync: () => void;
+	} ) => void;
+	unregisterRoom: ( room: string ) => void;
+}
+
+function createDeferred< T >() {
+	let resolve!: ( value: T ) => void;
+	const promise = new Promise< T >( ( res ) => {
+		resolve = res;
+	} );
+	return { promise, resolve };
+}
+
+function createMockDoc( clientID = 1 ) {
+	return { clientID, on: jest.fn(), off: jest.fn() };
+}
+
+function createMockAwareness() {
+	return {
+		clientID: 1,
+		getLocalState: jest.fn( () => ( {} ) ),
+		getStates: jest.fn( () => new Map() ),
+		on: jest.fn(),
+		off: jest.fn(),
+		emit: jest.fn(),
+	};
+}
+
+function simulateVisibilityChange( state: string ) {
+	Object.defineProperty( document, 'visibilityState', {
+		configurable: true,
+		get: () => state,
+	} );
+	document.dispatchEvent( new Event( 'visibilitychange' ) );
+}
+
+const syncResponse = {
+	rooms: [
+		{
+			room: 'test-room',
+			end_cursor: 1,
+			awareness: {},
+			updates: [],
+		},
+	],
+};
+
+describe( 'polling-manager', () => {
+	let pollingManager: PollingManager;
+	let mockPostSyncUpdate: jest.Mock;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+
+		// Use isolateModules so each test gets fresh module-level state
+		// (isPolling, pollingTimeoutId, roomStates, etc.).
+		jest.isolateModules( () => {
+			pollingManager = require( '../polling-manager' ).pollingManager;
+			mockPostSyncUpdate = require( '../utils' ).postSyncUpdate;
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+		Object.defineProperty( document, 'visibilityState', {
+			configurable: true,
+			get: () => 'visible',
+		} );
+	} );
+
+	describe( 'visibility change', () => {
+		it( 'does not spawn a duplicate poll when a request is in-flight', () => {
+			// Keep the first postSyncUpdate pending so we can simulate
+			// a visibility change while the request is in-flight.
+			const deferred = createDeferred();
+			mockPostSyncUpdate.mockReturnValue( deferred.promise );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			// registerRoom → poll() → start() → postSyncUpdate (pending).
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Simulate tab hidden → visible while the request is in-flight.
+			simulateVisibilityChange( 'hidden' );
+			simulateVisibilityChange( 'visible' );
+
+			// No second poll should have been spawned.
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'repolls immediately when tab becomes visible with a pending timeout', async () => {
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			// Flush so the first poll completes and schedules a timeout.
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Tab hidden → visible while a timeout is pending.
+			simulateVisibilityChange( 'hidden' );
+			simulateVisibilityChange( 'visible' );
+
+			// Should trigger an immediate repoll (not wait for timeout).
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## What?

Fix a race condition in the RTC polling manager that causes multiple concurrent poll cycles.

## Why?

PR #75843 introduced `handleVisibilityChange` to back off polling when the browser tab is inactive. When the tab becomes visible again, it calls `poll()` immediately so collaborator updates appear without delay. However, this can spawn a duplicate poll cycle when an HTTP request is already in-flight, leading to multiple concurrent poll chains that multiply over time.

## How?

The root cause is that `handleVisibilityChange` checked `isPolling` before calling poll(), but `isPolling` is a "has polling ever started" flag. It’s `true` for the entire lifetime of the polling loop, not just while a request is in-flight. So the guard didn’t prevent calling `poll()` during an active `postSyncUpdate` request.


## Testing Instructions

- Check out this PR.
- Enable real-time collaboration (WordPress Admin > Settings > Writing).
- Open a post with two users in separate tabs.
- Open the browser’s Network tab and filter to the sync endpoint.
- With the post editor tab active, observe steady polling (~1 request per second, or ~4/s with collaborators).
- Switch to another tab, wait a few seconds, then switch back. Repeat several times.
- Verify that polling remains steady. No doubling or multiplication of requests after switching back.