### PR TITLE
RTC: Fix fallthrough for sync update switch statement

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -7,3 +7,4 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75711
 * https://github.com/WordPress/gutenberg/pull/75746
 * https://github.com/WordPress/gutenberg/pull/75869
+* https://github.com/WordPress/gutenberg/pull/76060

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -409,7 +409,10 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 
 						return $this->add_update( $room, $client_id, $type, $data );
 					}
-					break;
+
+					// Reaching this point means there's a newer compaction, so we can
+					// silently ignore this one.
+					return true;
 
 				case self::UPDATE_TYPE_SYNC_STEP1:
 				case self::UPDATE_TYPE_SYNC_STEP2:


### PR DESCRIPTION

## What?

Fix a bug where the `UPDATE_TYPE_COMPACTION` case in the sync server's switch statement would fall through to the default case (`WP_Error`) when a newer compaction already existed.

Backport PR: https://github.com/WordPress/wordpress-develop/pull/11118

## Why?

When the sync server receives a compaction update but a newer compaction already exists, the code correctly skips it. But then it falls through to the default case via `break`, which returns a `WP_Error` for invalid sync update type.

In practice this is fairly harmless, but results in failed requests that could cause concern.

## How?

Replace the `break` after the `$has_newer_compaction` check with `return true`, so the stale compaction is silently discarded instead of falling through.

## Testing Instructions

This can be difficult to replicate, but:

1. Settings > Writing > Enable real-time collaboration.
1. Open a post in two browser tabs.
1. Make edits in both tabs to generate sync traffic.
1. Wait for compaction updates. Meanwhile, refresh the page periodically to increase the likelihood of stale compaction updates.
1. Verify that no sync update request returns 400.