### PR TITLE
Remove `function_exists` checks from PHP template.

### DIFF
--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -6,44 +6,42 @@
  * @package {{PREFIX}}
  */
 
-if ( ! function_exists( '{{PREFIX}}_register_script_modules' ) ) {
-	/**
-	 * Register all script modules.
-	 */
-	function {{PREFIX}}_register_script_modules() {
-		// Load build constants
-		$build_constants = require __DIR__ . '/constants.php';
-		$modules_dir     = __DIR__ . '/modules';
-		$modules_file    = $modules_dir . '/registry.php';
+/**
+ * Register all script modules.
+ */
+function {{PREFIX}}_register_script_modules() {
+	// Load build constants
+	$build_constants = require __DIR__ . '/constants.php';
+	$modules_dir     = __DIR__ . '/modules';
+	$modules_file    = $modules_dir . '/registry.php';
 
-		if ( ! file_exists( $modules_file ) ) {
-			return;
-		}
-
-		$modules = require $modules_file;
-		$base_url = $build_constants['build_url'] . 'modules/';
-		$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
-
-		foreach ( $modules as $module ) {
-			$asset_path = $modules_dir . '/' . $module['asset'];
-			$asset = file_exists( $asset_path ) ? require $asset_path : array();
-
-			// Deregister first to override any previously registered version
-			// (e.g., Core's default modules when running as a plugin).
-			wp_deregister_script_module( $module['id'] );
-
-			wp_register_script_module(
-				$module['id'],
-				$base_url . $module['path'] . $extension,
-				$asset['module_dependencies'] ?? array(),
-				$asset['version'] ?? false,
-				array(
-					'fetchpriority' => 'low',
-					'in_footer'     => true,
-				)
-			);
-		}
+	if ( ! file_exists( $modules_file ) ) {
+		return;
 	}
 
-	add_action( 'wp_default_scripts', '{{PREFIX}}_register_script_modules' );
+	$modules = require $modules_file;
+	$base_url = $build_constants['build_url'] . 'modules/';
+	$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+
+	foreach ( $modules as $module ) {
+		$asset_path = $modules_dir . '/' . $module['asset'];
+		$asset = file_exists( $asset_path ) ? require $asset_path : array();
+
+		// Deregister first to override any previously registered version
+		// (e.g., Core's default modules when running as a plugin).
+		wp_deregister_script_module( $module['id'] );
+
+		wp_register_script_module(
+			$module['id'],
+			$base_url . $module['path'] . $extension,
+			$asset['module_dependencies'] ?? array(),
+			$asset['version'] ?? false,
+			array(
+				'fetchpriority' => 'low',
+				'in_footer'     => true,
+			)
+		);
+	}
 }
+
+add_action( 'wp_default_scripts', '{{PREFIX}}_register_script_modules' );

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -15,277 +15,263 @@ global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes, ${{PREFIX}}_{{PAGE_
 ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes     = array();
 ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items = array();
 
-if ( ! function_exists( '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route' ) ) {
-	/**
-	 * Register a route for the {{PAGE_SLUG}}-wp-admin page.
-	 *
-	 * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
-	 * @param string|null $content_module Script module ID for content (stage/inspector).
-	 * @param string|null $route_module   Script module ID for route lifecycle hooks.
-	 */
-	function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route( $path, $content_module = null, $route_module = null ) {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes;
+/**
+ * Register a route for the {{PAGE_SLUG}}-wp-admin page.
+ *
+ * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
+ * @param string|null $content_module Script module ID for content (stage/inspector).
+ * @param string|null $route_module   Script module ID for route lifecycle hooks.
+ */
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route( $path, $content_module = null, $route_module = null ) {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes;
 
-		$route = array( 'path' => $path );
-		if ( ! empty( $content_module ) ) {
-			$route['content_module'] = $content_module;
-		}
-		if ( ! empty( $route_module ) ) {
-			$route['route_module'] = $route_module;
-		}
-
-		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes[] = $route;
+	$route = array( 'path' => $path );
+	if ( ! empty( $content_module ) ) {
+		$route['content_module'] = $content_module;
 	}
+	if ( ! empty( $route_module ) ) {
+		$route['route_module'] = $route_module;
+	}
+
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes[] = $route;
 }
 
-if ( ! function_exists( '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_item' ) ) {
-	/**
-	 * Register a menu item for the {{PAGE_SLUG}}-wp-admin page.
-	 * Note: Menu items are registered but not displayed in single-page mode.
-	 *
-	 * @param string $id        Menu item ID.
-	 * @param string $label     Display label.
-	 * @param string $to        Route path to navigate to.
-	 * @param string $parent_id Optional. Parent menu item ID.
-	 */
-	function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_item( $id, $label, $to, $parent_id = '' ) {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items;
+/**
+ * Register a menu item for the {{PAGE_SLUG}}-wp-admin page.
+ * Note: Menu items are registered but not displayed in single-page mode.
+ *
+ * @param string $id        Menu item ID.
+ * @param string $label     Display label.
+ * @param string $to        Route path to navigate to.
+ * @param string $parent_id Optional. Parent menu item ID.
+ */
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_item( $id, $label, $to, $parent_id = '' ) {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items;
 
-		$menu_item = array(
-			'id'    => $id,
-			'label' => $label,
-			'to'    => $to,
-		);
+	$menu_item = array(
+		'id'    => $id,
+		'label' => $label,
+		'to'    => $to,
+	);
 
-		if ( ! empty( $parent_id ) ) {
-			$menu_item['parent'] = $parent_id;
-		}
-
-		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items[] = $menu_item;
+	if ( ! empty( $parent_id ) ) {
+		$menu_item['parent'] = $parent_id;
 	}
+
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items[] = $menu_item;
 }
 
-if ( ! function_exists( '{{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes' ) ) {
-	/**
-	 * Get all registered routes for the {{PAGE_SLUG}}-wp-admin page.
-	 *
-	 * @return array Array of route objects.
-	 */
-	function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes() {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes;
-		return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes ?? array();
-	}
+/**
+ * Get all registered routes for the {{PAGE_SLUG}}-wp-admin page.
+ *
+ * @return array Array of route objects.
+ */
+function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes() {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes;
+	return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes ?? array();
 }
 
-if ( ! function_exists( '{{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items' ) ) {
-	/**
-	 * Get all registered menu items for the {{PAGE_SLUG}}-wp-admin page.
-	 *
-	 * @return array Array of menu item objects.
-	 */
-	function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items() {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items;
-		return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items ?? array();
-	}
+/**
+ * Get all registered menu items for the {{PAGE_SLUG}}-wp-admin page.
+ *
+ * @return array Array of menu item objects.
+ */
+function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items() {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items;
+	return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items ?? array();
 }
 
-if ( ! function_exists( '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data' ) ) {
-	/**
-	 * Preload REST API data for the {{PAGE_SLUG}}-wp-admin page.
-	 * Automatically called during page rendering.
-	 */
-	function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
-		// Define paths to preload - same for all pages
-		// Please also change packages/core-data/src/entities.js when changing this.
-		$preload_paths = array(
-			'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,image_output_formats,jpeg_interlaced,png_interlaced,gif_interlaced,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
-			array( '/wp/v2/settings', 'OPTIONS' ),
-		);
+/**
+ * Preload REST API data for the {{PAGE_SLUG}}-wp-admin page.
+ * Automatically called during page rendering.
+ */
+function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
+	// Define paths to preload - same for all pages
+	// Please also change packages/core-data/src/entities.js when changing this.
+	$preload_paths = array(
+		'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,image_output_formats,jpeg_interlaced,png_interlaced,gif_interlaced,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+		array( '/wp/v2/settings', 'OPTIONS' ),
+	);
 
-		// Use rest_preload_api_request to gather the preloaded data
-		$preload_data = array_reduce(
-			$preload_paths,
-			'rest_preload_api_request',
-			array()
-		);
+	// Use rest_preload_api_request to gather the preloaded data
+	$preload_data = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
 
-		// Register the preloading middleware with wp-api-fetch
+	// Register the preloading middleware with wp-api-fetch
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf(
+			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
+			wp_json_encode( $preload_data )
+		),
+		'after'
+	);
+}
+
+/**
+ * Enqueue scripts and styles for the {{PAGE_SLUG}}-wp-admin page.
+ * Hooked to admin_enqueue_scripts.
+ *
+ * @param string $hook_suffix The current admin page.
+ */
+function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
+	// Check all possible ways this page can be accessed:
+	// 1. Menu page via admin.php?page={{PAGE_SLUG}}-wp-admin (plugin)
+	// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
+	$current_screen = get_current_screen();
+	$is_our_page = (
+		( isset( $_GET['page'] ) && '{{PAGE_SLUG}}-wp-admin' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
+	);
+
+	if ( ! $is_our_page ) {
+		return;
+	}
+
+	// Load build constants
+	$build_constants = require __DIR__ . '/../../constants.php';
+
+	// Fire init action for extensions to register routes and menu items
+	do_action( '{{PAGE_SLUG}}-wp-admin_init' );
+
+	// Preload REST API data
+	{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data();
+
+	// Get all registered routes
+	$routes = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes();
+
+	// Get boot module asset file for dependencies
+	$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
+	if ( file_exists( $asset_file ) ) {
+		$asset = require $asset_file;
+
+		// This script serves two purposes:
+		// 1. It ensures all the globals that are made available to the modules are loaded.
+		// 2. It initializes the boot module as an inline script.
+		wp_register_script( '{{PAGE_SLUG}}-wp-admin-prerequisites', '', $asset['dependencies'], $asset['version'], true );
+
+		// Add inline script to initialize the app using initSinglePage (no menuItems)
 		wp_add_inline_script(
-			'wp-api-fetch',
+			'{{PAGE_SLUG}}-wp-admin-prerequisites',
 			sprintf(
-				'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-				wp_json_encode( $preload_data )
+				'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "%s", routes: %s}));',
+				'{{PAGE_SLUG}}-wp-admin-app',
+				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			)
+		);
+
+		// Register prerequisites style by filtering script dependencies to find registered styles
+		$style_dependencies = array_filter(
+			$asset['dependencies'],
+			function ( $handle ) {
+				return wp_style_is( $handle, 'registered' );
+			}
+		);
+		wp_register_style( '{{PAGE_SLUG}}-wp-admin-prerequisites', false, $style_dependencies, $asset['version'] );
+
+		// Build dependencies for {{PAGE_SLUG}}-wp-admin module
+		$boot_dependencies = array(
+			array(
+				'import' => 'static',
+				'id'     => '@wordpress/boot',
 			),
-			'after'
-		);
-	}
-}
-
-if ( ! function_exists( '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' ) ) {
-	/**
-	 * Enqueue scripts and styles for the {{PAGE_SLUG}}-wp-admin page.
-	 * Hooked to admin_enqueue_scripts.
-	 *
-	 * @param string $hook_suffix The current admin page.
-	 */
-	function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
-		// Check all possible ways this page can be accessed:
-		// 1. Menu page via admin.php?page={{PAGE_SLUG}}-wp-admin (plugin)
-		// 2. Direct file via {{PAGE_SLUG}}.php (Core) - screen ID will be '{{PAGE_SLUG}}'
-		$current_screen = get_current_screen();
-		$is_our_page = (
-			( isset( $_GET['page'] ) && '{{PAGE_SLUG}}-wp-admin' === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			( $current_screen && '{{PAGE_SLUG}}' === $current_screen->id )
 		);
 
-		if ( ! $is_our_page ) {
-			return;
-		}
-
-		// Load build constants
-		$build_constants = require __DIR__ . '/../../constants.php';
-
-		// Fire init action for extensions to register routes and menu items
-		do_action( '{{PAGE_SLUG}}-wp-admin_init' );
-
-		// Preload REST API data
-		{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data();
-
-		// Get all registered routes
-		$routes = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes();
-
-		// Get boot module asset file for dependencies
-		$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
-		if ( file_exists( $asset_file ) ) {
-			$asset = require $asset_file;
-
-			// This script serves two purposes:
-			// 1. It ensures all the globals that are made available to the modules are loaded.
-			// 2. It initializes the boot module as an inline script.
-			wp_register_script( '{{PAGE_SLUG}}-wp-admin-prerequisites', '', $asset['dependencies'], $asset['version'], true );
-
-			// Add inline script to initialize the app using initSinglePage (no menuItems)
-			wp_add_inline_script(
-				'{{PAGE_SLUG}}-wp-admin-prerequisites',
-				sprintf(
-					'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "%s", routes: %s}));',
-					'{{PAGE_SLUG}}-wp-admin-app',
-					wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
-				)
-			);
-
-			// Register prerequisites style by filtering script dependencies to find registered styles
-			$style_dependencies = array_filter(
-				$asset['dependencies'],
-				function ( $handle ) {
-					return wp_style_is( $handle, 'registered' );
-				}
-			);
-			wp_register_style( '{{PAGE_SLUG}}-wp-admin-prerequisites', false, $style_dependencies, $asset['version'] );
-
-			// Build dependencies for {{PAGE_SLUG}}-wp-admin module
-			$boot_dependencies = array(
-				array(
+		// Add all registered routes as dependencies
+		foreach ( $routes as $route ) {
+			if ( isset( $route['route_module'] ) ) {
+				$boot_dependencies[] = array(
 					'import' => 'static',
-					'id'     => '@wordpress/boot',
-				),
-			);
-
-			// Add all registered routes as dependencies
-			foreach ( $routes as $route ) {
-				if ( isset( $route['route_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'static',
-						'id'     => $route['route_module'],
-					);
-				}
-				if ( isset( $route['content_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'dynamic',
-						'id'     => $route['content_module'],
-					);
-				}
+					'id'     => $route['route_module'],
+				);
 			}
-
-			// Dummy script module to ensure dependencies are loaded
-			wp_register_script_module(
-				'{{PAGE_SLUG}}-wp-admin',
-				$build_constants['build_url'] . 'pages/{{PAGE_SLUG}}/loader.js',
-				$boot_dependencies
-			);
-
-			// Enqueue the boot scripts and styles
-			wp_enqueue_script( '{{PAGE_SLUG}}-wp-admin-prerequisites' );
-			wp_enqueue_script_module( '{{PAGE_SLUG}}-wp-admin' );
-			wp_enqueue_style( '{{PAGE_SLUG}}-wp-admin-prerequisites' );
+			if ( isset( $route['content_module'] ) ) {
+				$boot_dependencies[] = array(
+					'import' => 'dynamic',
+					'id'     => $route['content_module'],
+				);
+			}
 		}
+
+		// Dummy script module to ensure dependencies are loaded
+		wp_register_script_module(
+			'{{PAGE_SLUG}}-wp-admin',
+			$build_constants['build_url'] . 'pages/{{PAGE_SLUG}}/loader.js',
+			$boot_dependencies
+		);
+
+		// Enqueue the boot scripts and styles
+		wp_enqueue_script( '{{PAGE_SLUG}}-wp-admin-prerequisites' );
+		wp_enqueue_script_module( '{{PAGE_SLUG}}-wp-admin' );
+		wp_enqueue_style( '{{PAGE_SLUG}}-wp-admin-prerequisites' );
 	}
 }
 
-if ( ! function_exists( '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page' ) ) {
-	/**
-	 * Render the {{PAGE_SLUG}}-wp-admin page.
-	 * Call this function from add_menu_page or add_submenu_page.
-	 * This renders within the normal WordPress admin interface.
-	 */
-	function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
-		?>
-		<style>
-			/* Critical styles to prevent layout shifts - inlined for immediate application */
+/**
+ * Render the {{PAGE_SLUG}}-wp-admin page.
+ * Call this function from add_menu_page or add_submenu_page.
+ * This renders within the normal WordPress admin interface.
+ */
+function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
+	?>
+	<style>
+		/* Critical styles to prevent layout shifts - inlined for immediate application */
 
-			/* Background colors */
+		/* Background colors */
+		#wpwrap {
+			background: var(--wpds-color-fg-content-neutral, #1e1e1e);
+			overflow-y: auto;
+		}
+		body {
+			background: #fff;
+		}
+
+		/* Reset wp-admin padding */
+		#wpcontent {
+			padding-left: 0;
+		}
+		#wpbody-content {
+			padding-bottom: 0;
+		}
+
+		/* Hide legacy admin elements */
+		#wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
+			display: none;
+		}
+		#wpfooter {
+			display: none;
+		}
+
+		/* Accessibility regions */
+		.a11y-speak-region {
+			left: -1px;
+			top: -1px;
+		}
+
+		/* Admin menu indicators */
+		ul#adminmenu a.wp-has-current-submenu::after,
+		ul#adminmenu > li.current > a.current::after {
+			border-right-color: #fff;
+		}
+
+		/* Media frame fix */
+		.media-frame select.attachment-filters:last-of-type {
+			width: auto;
+			max-width: 100%;
+		}
+
+		/* Responsive overflow fix for #wpwrap */
+		@media (min-width: 782px) {
 			#wpwrap {
-				background: var(--wpds-color-fg-content-neutral, #1e1e1e);
-				overflow-y: auto;
+				overflow-y: initial;
 			}
-			body {
-				background: #fff;
-			}
-
-			/* Reset wp-admin padding */
-			#wpcontent {
-				padding-left: 0;
-			}
-			#wpbody-content {
-				padding-bottom: 0;
-			}
-
-			/* Hide legacy admin elements */
-			#wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
-				display: none;
-			}
-			#wpfooter {
-				display: none;
-			}
-
-			/* Accessibility regions */
-			.a11y-speak-region {
-				left: -1px;
-				top: -1px;
-			}
-
-			/* Admin menu indicators */
-			ul#adminmenu a.wp-has-current-submenu::after,
-			ul#adminmenu > li.current > a.current::after {
-				border-right-color: #fff;
-			}
-
-			/* Media frame fix */
-			.media-frame select.attachment-filters:last-of-type {
-				width: auto;
-				max-width: 100%;
-			}
-
-			/* Responsive overflow fix for #wpwrap */
-			@media (min-width: 782px) {
-				#wpwrap {
-					overflow-y: initial;
-				}
-			}
-		</style>
-		<div id="{{PAGE_SLUG}}-wp-admin-app" class="boot-layout-container"></div>
-		<?php
-	}
+		}
+	</style>
+	<div id="{{PAGE_SLUG}}-wp-admin-app" class="boot-layout-container"></div>
+	<?php
 }
 
 // Hook the enqueue function to admin_enqueue_scripts

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -12,318 +12,304 @@ global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDE
 ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes     = array();
 ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items = array();
 
-if ( ! function_exists( '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route' ) ) {
-	/**
-	 * Register a route for the {{PAGE_SLUG}} page.
-	 *
-	 * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
-	 * @param string|null $content_module Script module ID for content (stage/inspector).
-	 * @param string|null $route_module   Script module ID for route lifecycle hooks.
-	 */
-	function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route( $path, $content_module = null, $route_module = null ) {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes;
+/**
+ * Register a route for the {{PAGE_SLUG}} page.
+ *
+ * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
+ * @param string|null $content_module Script module ID for content (stage/inspector).
+ * @param string|null $route_module   Script module ID for route lifecycle hooks.
+ */
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route( $path, $content_module = null, $route_module = null ) {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes;
 
-		$route = array( 'path' => $path );
-		if ( ! empty( $content_module ) ) {
-			$route['content_module'] = $content_module;
-		}
-		if ( ! empty( $route_module ) ) {
-			$route['route_module'] = $route_module;
-		}
-
-		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes[] = $route;
+	$route = array( 'path' => $path );
+	if ( ! empty( $content_module ) ) {
+		$route['content_module'] = $content_module;
 	}
+	if ( ! empty( $route_module ) ) {
+		$route['route_module'] = $route_module;
+	}
+
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes[] = $route;
 }
 
-if ( ! function_exists( '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_menu_item' ) ) {
-	/**
-	 * Register a menu item for the {{PAGE_SLUG}} page.
-	 *
-	 * @param string $id          Menu item ID.
-	 * @param string $label       Display label.
-	 * @param string $to          Route path to navigate to.
-	 * @param string $parent_id   Optional. Parent menu item ID.
-	 * @param string $parent_type Optional. Parent type: 'drilldown' or 'dropdown'.
-	 */
-	function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_menu_item( $id, $label, $to, $parent_id = '', $parent_type = '' ) {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items;
+/**
+ * Register a menu item for the {{PAGE_SLUG}} page.
+ *
+ * @param string $id          Menu item ID.
+ * @param string $label       Display label.
+ * @param string $to          Route path to navigate to.
+ * @param string $parent_id   Optional. Parent menu item ID.
+ * @param string $parent_type Optional. Parent type: 'drilldown' or 'dropdown'.
+ */
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_menu_item( $id, $label, $to, $parent_id = '', $parent_type = '' ) {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items;
 
-		$menu_item = array(
-			'id'    => $id,
-			'label' => $label,
-			'to'    => $to,
-		);
+	$menu_item = array(
+		'id'    => $id,
+		'label' => $label,
+		'to'    => $to,
+	);
 
-		if ( ! empty( $parent_id ) ) {
-			$menu_item['parent'] = $parent_id;
-		}
-
-		if ( ! empty( $parent_type ) && in_array( $parent_type, array( 'drilldown', 'dropdown' ), true ) ) {
-			$menu_item['parent_type'] = $parent_type;
-		}
-
-		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items[] = $menu_item;
+	if ( ! empty( $parent_id ) ) {
+		$menu_item['parent'] = $parent_id;
 	}
+
+	if ( ! empty( $parent_type ) && in_array( $parent_type, array( 'drilldown', 'dropdown' ), true ) ) {
+		$menu_item['parent_type'] = $parent_type;
+	}
+
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items[] = $menu_item;
 }
 
-if ( ! function_exists( '{{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes' ) ) {
-	/**
-	 * Get all registered routes for the {{PAGE_SLUG}} page.
-	 *
-	 * @return array Array of route objects.
-	 */
-	function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes() {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes;
-		return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes ?? array();
-	}
+/**
+ * Get all registered routes for the {{PAGE_SLUG}} page.
+ *
+ * @return array Array of route objects.
+ */
+function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes() {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes;
+	return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes ?? array();
 }
 
-if ( ! function_exists( '{{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items' ) ) {
-	/**
-	 * Get all registered menu items for the {{PAGE_SLUG}} page.
-	 *
-	 * @return array Array of menu item objects.
-	 */
-	function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items() {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items;
-		return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items ?? array();
-	}
+/**
+ * Get all registered menu items for the {{PAGE_SLUG}} page.
+ *
+ * @return array Array of menu item objects.
+ */
+function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items() {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items;
+	return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items ?? array();
 }
 
-if ( ! function_exists( '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data' ) ) {
-	/**
-	 * Preload REST API data for the {{PAGE_SLUG}} page.
-	 * Automatically called during page rendering.
-	 */
-	function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data() {
-		// Define paths to preload - same for all pages
-		// Please also change packages/core-data/src/entities.js when changing this.
-		$preload_paths = array(
-			'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,image_output_formats,jpeg_interlaced,png_interlaced,gif_interlaced,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
-			array( '/wp/v2/settings', 'OPTIONS' ),
-		);
+/**
+ * Preload REST API data for the {{PAGE_SLUG}} page.
+ * Automatically called during page rendering.
+ */
+function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data() {
+	// Define paths to preload - same for all pages
+	// Please also change packages/core-data/src/entities.js when changing this.
+	$preload_paths = array(
+		'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,image_output_formats,jpeg_interlaced,png_interlaced,gif_interlaced,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+		array( '/wp/v2/settings', 'OPTIONS' ),
+	);
 
-		// Use rest_preload_api_request to gather the preloaded data
-		$preload_data = array_reduce(
-			$preload_paths,
-			'rest_preload_api_request',
-			array()
-		);
+	// Use rest_preload_api_request to gather the preloaded data
+	$preload_data = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
 
-		// Register the preloading middleware with wp-api-fetch
+	// Register the preloading middleware with wp-api-fetch
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf(
+			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
+			wp_json_encode( $preload_data )
+		),
+		'after'
+	);
+}
+
+/**
+ * Render the {{PAGE_SLUG}} page.
+ * Call this function from add_menu_page or add_submenu_page.
+ */
+function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
+	// Load build constants
+	$build_constants = require __DIR__ . '/../../constants.php';
+
+	// Set current screen
+	set_current_screen();
+
+	// Remove unwanted deprecated handler
+	remove_action( 'admin_head', 'wp_admin_bar_header' );
+
+	// Remove unwanted scripts and styles that were enqueued during `admin_init`
+	foreach ( wp_scripts()->queue as $script ) {
+		wp_dequeue_script( $script );
+	}
+	foreach ( wp_styles()->queue as $style ) {
+		wp_dequeue_style( $style );
+	}
+
+	// Fire init action for extensions to register routes and menu items
+	do_action( '{{PAGE_SLUG}}_init' );
+
+	// Enqueue command palette assets for boot-based pages
+	if ( function_exists( 'wp_enqueue_command_palette_assets' ) ) {
+		wp_enqueue_command_palette_assets();
+	}
+
+	// Preload REST API data
+	{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data();
+
+	// Get all registered routes and menu items
+	$menu_items = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items();
+	$routes = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes();
+
+	// Get boot module asset file for dependencies
+	$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
+	if ( file_exists( $asset_file ) ) {
+		$asset = require $asset_file;
+
+		// This script serves two purposes:
+		// 1. It ensures all the globals that are made available to the modules are loaded.
+		// 2. It initializes the boot module as an inline script.
+		wp_register_script( '{{PAGE_SLUG}}-prerequisites', '', $asset['dependencies'], $asset['version'], true );
+
+		// Add inline script to initialize the app
+		$init_modules = {{INIT_MODULES_JSON}};
 		wp_add_inline_script(
-			'wp-api-fetch',
+			'{{PAGE_SLUG}}-prerequisites',
 			sprintf(
-				'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-				wp_json_encode( $preload_data )
-			),
-			'after'
+				'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"}));',
+				'{{PAGE_SLUG}}-app',
+				wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+				wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+				esc_url( admin_url( '/' ) )
+			)
 		);
-	}
-}
 
-if ( ! function_exists( '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page' ) ) {
-	/**
-	 * Render the {{PAGE_SLUG}} page.
-	 * Call this function from add_menu_page or add_submenu_page.
-	 */
-	function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
-		// Load build constants
-		$build_constants = require __DIR__ . '/../../constants.php';
+		// Register prerequisites style by filtering script dependencies to find registered styles
+		$style_dependencies = array_filter(
+			$asset['dependencies'],
+			function ( $handle ) {
+				return wp_style_is( $handle, 'registered' );
+			}
+		);
+		wp_register_style( '{{PAGE_SLUG}}-prerequisites', false, $style_dependencies, $asset['version'] );
 
-		// Set current screen
-		set_current_screen();
+		// Build dependencies for {{PAGE_SLUG}} module
+		$boot_dependencies = array(
+			array(
+				'import' => 'static',
+				'id'     => '@wordpress/boot',
+			),
+		);
 
-		// Remove unwanted deprecated handler
-		remove_action( 'admin_head', 'wp_admin_bar_header' );
-
-		// Remove unwanted scripts and styles that were enqueued during `admin_init`
-		foreach ( wp_scripts()->queue as $script ) {
-			wp_dequeue_script( $script );
-		}
-		foreach ( wp_styles()->queue as $style ) {
-			wp_dequeue_style( $style );
-		}
-
-		// Fire init action for extensions to register routes and menu items
-		do_action( '{{PAGE_SLUG}}_init' );
-
-		// Enqueue command palette assets for boot-based pages
-		if ( function_exists( 'wp_enqueue_command_palette_assets' ) ) {
-			wp_enqueue_command_palette_assets();
-		}
-
-		// Preload REST API data
-		{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data();
-
-		// Get all registered routes and menu items
-		$menu_items = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items();
-		$routes = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes();
-
-		// Get boot module asset file for dependencies
-		$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
-		if ( file_exists( $asset_file ) ) {
-			$asset = require $asset_file;
-
-			// This script serves two purposes:
-			// 1. It ensures all the globals that are made available to the modules are loaded.
-			// 2. It initializes the boot module as an inline script.
-			wp_register_script( '{{PAGE_SLUG}}-prerequisites', '', $asset['dependencies'], $asset['version'], true );
-
-			// Add inline script to initialize the app
-			$init_modules = {{INIT_MODULES_JSON}};
-			wp_add_inline_script(
-				'{{PAGE_SLUG}}-prerequisites',
-				sprintf(
-					'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"}));',
-					'{{PAGE_SLUG}}-app',
-					wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-					wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-					wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-					esc_url( admin_url( '/' ) )
-				)
-			);
-
-			// Register prerequisites style by filtering script dependencies to find registered styles
-			$style_dependencies = array_filter(
-				$asset['dependencies'],
-				function ( $handle ) {
-					return wp_style_is( $handle, 'registered' );
-				}
-			);
-			wp_register_style( '{{PAGE_SLUG}}-prerequisites', false, $style_dependencies, $asset['version'] );
-
-			// Build dependencies for {{PAGE_SLUG}} module
-			$boot_dependencies = array(
-				array(
-					'import' => 'static',
-					'id'     => '@wordpress/boot',
-				),
-			);
-
-			// Add init modules as static dependencies
+		// Add init modules as static dependencies
 {{INIT_MODULES_PHP_ARRAY}}
 
-			// Add all registered routes as dependencies
-			foreach ( $routes as $route ) {
-				if ( isset( $route['route_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'static',
-						'id'     => $route['route_module'],
-					);
-				}
-				if ( isset( $route['content_module'] ) ) {
-					$boot_dependencies[] = array(
-						'import' => 'dynamic',
-						'id'     => $route['content_module'],
-					);
-				}
+		// Add all registered routes as dependencies
+		foreach ( $routes as $route ) {
+			if ( isset( $route['route_module'] ) ) {
+				$boot_dependencies[] = array(
+					'import' => 'static',
+					'id'     => $route['route_module'],
+				);
 			}
-
-			// Dummy script module to ensure dependencies are loaded
-			wp_register_script_module(
-				'{{PAGE_SLUG}}',
-				$build_constants['build_url'] . 'pages/{{PAGE_SLUG}}/loader.js',
-				$boot_dependencies
-			);
-
-			// Enqueue the boot scripts and styles
-			wp_enqueue_script( '{{PAGE_SLUG}}-prerequisites' );
-			wp_enqueue_script_module( '{{PAGE_SLUG}}' );
-			wp_enqueue_style( '{{PAGE_SLUG}}-prerequisites' );
+			if ( isset( $route['content_module'] ) ) {
+				$boot_dependencies[] = array(
+					'import' => 'dynamic',
+					'id'     => $route['content_module'],
+				);
+			}
 		}
 
-		// Output the HTML
-		?>
-		<!DOCTYPE html>
-		<html <?php language_attributes(); ?>>
-		<head>
-			<meta charset="<?php bloginfo( 'charset' ); ?>">
-			<meta name="viewport" content="width=device-width, initial-scale=1">
-			<title><?php echo esc_html( get_admin_page_title() ); ?></title>
-			<style>
-				html {
-					background: #f1f1f1;
-					color: #444;
-					font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-					font-size: 13px;
-					line-height: 1.4em;
-				}
-				body {
-					margin: 0;
-				}
-				#wpadminbar { display: none; }
-			</style>
-		<?php
-		global $hook_suffix;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$hook_suffix = '{{PAGE_SLUG}}';
+		// Dummy script module to ensure dependencies are loaded
+		wp_register_script_module(
+			'{{PAGE_SLUG}}',
+			$build_constants['build_url'] . 'pages/{{PAGE_SLUG}}/loader.js',
+			$boot_dependencies
+		);
 
-		// BEGIN see wp-admin/admin-header.php
-		print_admin_styles();
-		print_head_scripts();
-
-		/**
-		 * Fires in head section for a specific admin page.
-		 *
-		 * @since 2.1.0
-		 */
-		do_action( "admin_head-{$hook_suffix}" ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-
-		/**
-		 * Fires in head section for all admin pages.
-		 *
-		 * @since 2.1.0
-		 */
-		do_action( 'admin_head' );
-		// END see wp-admin/admin-header.php
-		?>
-		</head>
-		<body class="{{PAGE_SLUG}}">
-			<div id="{{PAGE_SLUG}}-app" style="height: 100vh; box-sizing: border-box;"></div>
-		<?php
-		// BEGIN see wp-admin/admin-footer.php
-
-		/**
-		 * Prints scripts or data before the default footer scripts.
-		 *
-		 * @since 1.2.0
-		 */
-		do_action( 'admin_footer', '' );
-
-		// Print import map first so it's available for inline scripts
-		wp_script_modules()->print_import_map();
-		print_footer_scripts();
-		wp_script_modules()->print_enqueued_script_modules();
-		wp_script_modules()->print_script_module_preloads();
-		wp_script_modules()->print_script_module_data();
-
-		/**
-		 * Prints scripts or data after the default footer scripts.
-		 *
-		 * @since 2.8.0
-		 */
-		do_action( "admin_footer-{$hook_suffix}" ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-		// END see wp-admin/admin-footer.php
-		?>
-		</body>
-		</html>
-		<?php
-		exit;
+		// Enqueue the boot scripts and styles
+		wp_enqueue_script( '{{PAGE_SLUG}}-prerequisites' );
+		wp_enqueue_script_module( '{{PAGE_SLUG}}' );
+		wp_enqueue_style( '{{PAGE_SLUG}}-prerequisites' );
 	}
+
+	// Output the HTML
+	?>
+	<!DOCTYPE html>
+	<html <?php language_attributes(); ?>>
+	<head>
+		<meta charset="<?php bloginfo( 'charset' ); ?>">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title><?php echo esc_html( get_admin_page_title() ); ?></title>
+		<style>
+			html {
+				background: #f1f1f1;
+				color: #444;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				font-size: 13px;
+				line-height: 1.4em;
+			}
+			body {
+				margin: 0;
+			}
+			#wpadminbar { display: none; }
+		</style>
+	<?php
+	global $hook_suffix;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$hook_suffix = '{{PAGE_SLUG}}';
+
+	// BEGIN see wp-admin/admin-header.php
+	print_admin_styles();
+	print_head_scripts();
+
+	/**
+	 * Fires in head section for a specific admin page.
+	 *
+	 * @since 2.1.0
+	 */
+	do_action( "admin_head-{$hook_suffix}" ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+	/**
+	 * Fires in head section for all admin pages.
+	 *
+	 * @since 2.1.0
+	 */
+	do_action( 'admin_head' );
+	// END see wp-admin/admin-header.php
+	?>
+	</head>
+	<body class="{{PAGE_SLUG}}">
+		<div id="{{PAGE_SLUG}}-app" style="height: 100vh; box-sizing: border-box;"></div>
+	<?php
+	// BEGIN see wp-admin/admin-footer.php
+
+	/**
+	 * Prints scripts or data before the default footer scripts.
+	 *
+	 * @since 1.2.0
+	 */
+	do_action( 'admin_footer', '' );
+
+	// Print import map first so it's available for inline scripts
+	wp_script_modules()->print_import_map();
+	print_footer_scripts();
+	wp_script_modules()->print_enqueued_script_modules();
+	wp_script_modules()->print_script_module_preloads();
+	wp_script_modules()->print_script_module_data();
+
+	/**
+	 * Prints scripts or data after the default footer scripts.
+	 *
+	 * @since 2.8.0
+	 */
+	do_action( "admin_footer-{$hook_suffix}" ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	// END see wp-admin/admin-footer.php
+	?>
+	</body>
+	</html>
+	<?php
+	exit;
 }
 
-if ( ! function_exists( '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_intercept_render' ) ) {
-	/**
-	 * Intercept admin_init to render the page early.
-	 * This bypasses the default WordPress admin template.
-	 */
-	function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_intercept_render() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['page'] ) && '{{PAGE_SLUG}}' === $_GET['page'] ) {
-			{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page();
-			exit;
-		}
+/**
+ * Intercept admin_init to render the page early.
+ * This bypasses the default WordPress admin template.
+ */
+function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_intercept_render() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['page'] ) && '{{PAGE_SLUG}}' === $_GET['page'] ) {
+		{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page();
+		exit;
 	}
 }
 

--- a/packages/wp-build/templates/routes-page-functions.php.template
+++ b/packages/wp-build/templates/routes-page-functions.php.template
@@ -1,22 +1,18 @@
 // Page-specific route registration functions for {{PAGE_SLUG}}
-if ( ! function_exists( '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_page_routes' ) ) {
-	/**
-	 * Register routes for {{PAGE_SLUG}} page (full-page mode).
-	 */
-	function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_page_routes() {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data;
-		{{PREFIX}}_register_page_routes( ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data, '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route' );
-	}
+/**
+ * Register routes for {{PAGE_SLUG}} page (full-page mode).
+ */
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_page_routes() {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data;
+	{{PREFIX}}_register_page_routes( ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data, '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route' );
 }
 add_action( '{{PAGE_SLUG}}_init', '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_page_routes' );
 
-if ( ! function_exists( '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_page_routes' ) ) {
-	/**
-	 * Register routes for {{PAGE_SLUG}} page (wp-admin mode).
-	 */
-	function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_page_routes() {
-		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data;
-		{{PREFIX}}_register_page_routes( ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data, '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route' );
-	}
+/**
+ * Register routes for {{PAGE_SLUG}} page (wp-admin mode).
+ */
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_page_routes() {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data;
+	{{PREFIX}}_register_page_routes( ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes_data, '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route' );
 }
 add_action( '{{PAGE_SLUG}}-wp-admin_init', '{{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_page_routes' );

--- a/packages/wp-build/templates/routes-registration.php.template
+++ b/packages/wp-build/templates/routes-registration.php.template
@@ -32,63 +32,61 @@ foreach ( $routes_by_page as $page_slug => $page_routes ) {
 	$GLOBALS[ $global_name ] = $page_routes;
 }
 
-if ( ! function_exists( '{{PREFIX}}_register_page_routes' ) ) {
-	/**
-	 * Generic helper function to register routes for a page.
-	 *
-	 * @param array  $page_routes           Array of route data for the page.
-	 * @param string $register_function_name Name of the function to call for registering each route.
-	 */
-	function {{PREFIX}}_register_page_routes( $page_routes, $register_function_name ) {
-		// Load build constants
-		$build_constants = require __DIR__ . '/constants.php';
+/**
+ * Generic helper function to register routes for a page.
+ *
+ * @param array  $page_routes           Array of route data for the page.
+ * @param string $register_function_name Name of the function to call for registering each route.
+ */
+function {{PREFIX}}_register_page_routes( $page_routes, $register_function_name ) {
+	// Load build constants
+	$build_constants = require __DIR__ . '/constants.php';
 
-		foreach ( $page_routes as $route ) {
-			$content_handle = null;
-			$route_handle = null;
+	foreach ( $page_routes as $route ) {
+		$content_handle = null;
+		$route_handle = null;
 
-			// Register content module if exists
-			if ( $route['has_content'] ) {
-				$content_asset_path = __DIR__ . "/routes/{$route['name']}/content.min.asset.php";
-				if ( file_exists( $content_asset_path ) ) {
-					$content_asset = require $content_asset_path;
-					$content_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
-					$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
-					// Deregister first to override any previously registered version
-					// (e.g., Core's default modules when running as a plugin).
-					wp_deregister_script_module( $content_handle );
-					wp_register_script_module(
-						$content_handle,
-						$build_constants['build_url'] . 'routes/' . $route['name'] . '/content' . $extension,
-						$content_asset['module_dependencies'] ?? array(),
-						$content_asset['version'] ?? false
-					);
-				}
+		// Register content module if exists
+		if ( $route['has_content'] ) {
+			$content_asset_path = __DIR__ . "/routes/{$route['name']}/content.min.asset.php";
+			if ( file_exists( $content_asset_path ) ) {
+				$content_asset = require $content_asset_path;
+				$content_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
+				$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+				// Deregister first to override any previously registered version
+				// (e.g., Core's default modules when running as a plugin).
+				wp_deregister_script_module( $content_handle );
+				wp_register_script_module(
+					$content_handle,
+					$build_constants['build_url'] . 'routes/' . $route['name'] . '/content' . $extension,
+					$content_asset['module_dependencies'] ?? array(),
+					$content_asset['version'] ?? false
+				);
 			}
+		}
 
-			// Register route module if exists
-			if ( $route['has_route'] ) {
-				$route_asset_path = __DIR__ . "/routes/{$route['name']}/route.min.asset.php";
-				if ( file_exists( $route_asset_path ) ) {
-					$route_asset = require $route_asset_path;
-					$route_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/route';
-					$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
-					// Deregister first to override any previously registered version
-					// (e.g., Core's default modules when running as a plugin).
-					wp_deregister_script_module( $route_handle );
-					wp_register_script_module(
-						$route_handle,
-						$build_constants['build_url'] . 'routes/' . $route['name'] . '/route' . $extension,
-						$route_asset['module_dependencies'] ?? array(),
-						$route_asset['version'] ?? false
-					);
-				}
+		// Register route module if exists
+		if ( $route['has_route'] ) {
+			$route_asset_path = __DIR__ . "/routes/{$route['name']}/route.min.asset.php";
+			if ( file_exists( $route_asset_path ) ) {
+				$route_asset = require $route_asset_path;
+				$route_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/route';
+				$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+				// Deregister first to override any previously registered version
+				// (e.g., Core's default modules when running as a plugin).
+				wp_deregister_script_module( $route_handle );
+				wp_register_script_module(
+					$route_handle,
+					$build_constants['build_url'] . 'routes/' . $route['name'] . '/route' . $extension,
+					$route_asset['module_dependencies'] ?? array(),
+					$route_asset['version'] ?? false
+				);
 			}
+		}
 
-			// Register route with page
-			if ( function_exists( $register_function_name ) ) {
-				call_user_func( $register_function_name, $route['path'], $content_handle, $route_handle );
-			}
+		// Register route with page
+		if ( function_exists( $register_function_name ) ) {
+			call_user_func( $register_function_name, $route['path'], $content_handle, $route_handle );
 		}
 	}
 }

--- a/packages/wp-build/templates/script-registration.php.template
+++ b/packages/wp-build/templates/script-registration.php.template
@@ -6,84 +6,80 @@
  * @package {{PREFIX}}
  */
 
-if ( ! function_exists( '{{PREFIX}}_override_script' ) ) {
-	/**
-	 * Registers a script according to `wp_register_script`. Honors this request by
-	 * reassigning internal dependency properties of any script handle already
-	 * registered by that name. It does not deregister the original script, to
-	 * avoid losing inline scripts which may have been attached.
-	 *
-	 * @param WP_Scripts       $scripts   WP_Scripts instance.
-	 * @param string           $handle    Name of the script. Should be unique.
-	 * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
-	 * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
-	 * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
-	 *                                    as a query string for cache busting purposes. If version is set to false, a version
-	 *                                    number is automatically added equal to current installed WordPress version.
-	 *                                    If set to null, no version is added.
-	 * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
-	 *                                    Default 'false'.
-	 */
-	function {{PREFIX}}_override_script( $scripts, $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
-		$script = $scripts->query( $handle, 'registered' );
-		if ( $script ) {
-			/*
-			 * In many ways, this is a reimplementation of `wp_register_script` but
-			 * bypassing consideration of whether a script by the given handle had
-			 * already been registered.
-			 */
+/**
+ * Registers a script according to `wp_register_script`. Honors this request by
+ * reassigning internal dependency properties of any script handle already
+ * registered by that name. It does not deregister the original script, to
+ * avoid losing inline scripts which may have been attached.
+ *
+ * @param WP_Scripts       $scripts   WP_Scripts instance.
+ * @param string           $handle    Name of the script. Should be unique.
+ * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
+ * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                    as a query string for cache busting purposes. If version is set to false, a version
+ *                                    number is automatically added equal to current installed WordPress version.
+ *                                    If set to null, no version is added.
+ * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
+ *                                    Default 'false'.
+ */
+function {{PREFIX}}_override_script( $scripts, $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
+	$script = $scripts->query( $handle, 'registered' );
+	if ( $script ) {
+		/*
+		 * In many ways, this is a reimplementation of `wp_register_script` but
+		 * bypassing consideration of whether a script by the given handle had
+		 * already been registered.
+		 */
 
-			// See: `_WP_Dependency::__construct` .
-			$script->src  = $src;
-			$script->deps = $deps;
-			$script->ver  = $ver;
-			$script->args = $in_footer ? 1 : null;
-		} else {
-			$scripts->add( $handle, $src, $deps, $ver, ( $in_footer ? 1 : null ) );
-		}
+		// See: `_WP_Dependency::__construct` .
+		$script->src  = $src;
+		$script->deps = $deps;
+		$script->ver  = $ver;
+		$script->args = $in_footer ? 1 : null;
+	} else {
+		$scripts->add( $handle, $src, $deps, $ver, ( $in_footer ? 1 : null ) );
+	}
 
-		if ( in_array( 'wp-i18n', $deps, true ) ) {
-			$scripts->set_translations( $handle );
-		}
+	if ( in_array( 'wp-i18n', $deps, true ) ) {
+		$scripts->set_translations( $handle );
 	}
 }
 
-if ( ! function_exists( '{{PREFIX}}_register_package_scripts' ) ) {
-	/**
-	 * Register all package scripts.
-	 */
-	function {{PREFIX}}_register_package_scripts( $scripts ) {
-		// Load build constants
-		$build_constants = require __DIR__ . '/constants.php';
-		$default_version = ! SCRIPT_DEBUG ? $build_constants['version'] : time();
-		$extension       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+/**
+ * Register all package scripts.
+ */
+function {{PREFIX}}_register_package_scripts( $scripts ) {
+	// Load build constants
+	$build_constants = require __DIR__ . '/constants.php';
+	$default_version = ! SCRIPT_DEBUG ? $build_constants['version'] : time();
+	$extension       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 
-		$scripts_dir  = __DIR__ . '/scripts';
-		$scripts_file = $scripts_dir . '/registry.php';
+	$scripts_dir  = __DIR__ . '/scripts';
+	$scripts_file = $scripts_dir . '/registry.php';
 
-		if ( ! file_exists( $scripts_file ) ) {
-			return;
-		}
-
-		$scripts_data = require $scripts_file;
-		$plugin_dir   = dirname( __FILE__ );
-
-		foreach ( $scripts_data as $script_data ) {
-			$asset_file   = $scripts_dir . '/' . $script_data['asset'];
-			$asset        = file_exists( $asset_file ) ? require $asset_file : array();
-			$dependencies = $asset['dependencies'] ?? array();
-			$version      = $asset['version'] ?? $default_version;
-
-			{{PREFIX}}_override_script(
-				$scripts,
-				$script_data['handle'],
-				$build_constants['build_url'] . 'scripts/' . $script_data['path'] . $extension,
-				$dependencies,
-				$version,
-				true
-			);
-		}
+	if ( ! file_exists( $scripts_file ) ) {
+		return;
 	}
 
-	add_action( 'wp_default_scripts', '{{PREFIX}}_register_package_scripts' );
+	$scripts_data = require $scripts_file;
+	$plugin_dir   = dirname( __FILE__ );
+
+	foreach ( $scripts_data as $script_data ) {
+		$asset_file   = $scripts_dir . '/' . $script_data['asset'];
+		$asset        = file_exists( $asset_file ) ? require $asset_file : array();
+		$dependencies = $asset['dependencies'] ?? array();
+		$version      = $asset['version'] ?? $default_version;
+
+		{{PREFIX}}_override_script(
+			$scripts,
+			$script_data['handle'],
+			$build_constants['build_url'] . 'scripts/' . $script_data['path'] . $extension,
+			$dependencies,
+			$version,
+			true
+		);
+	}
 }
+
+add_action( 'wp_default_scripts', '{{PREFIX}}_register_package_scripts' );

--- a/packages/wp-build/templates/style-registration.php.template
+++ b/packages/wp-build/templates/style-registration.php.template
@@ -9,69 +9,65 @@
  * @package {{PREFIX}}
  */
 
-if ( ! function_exists( '{{PREFIX}}_override_style' ) ) {
-	/**
-	 * Registers a style according to `wp_register_style`. Honors this request by
-	 * deregistering any style by the same handler before registration.
-	 *
-	 * @param WP_Styles        $styles WP_Styles instance.
-	 * @param string           $handle Name of the stylesheet. Should be unique.
-	 * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
-	 * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
-	 * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
-	 *                                 as a query string for cache busting purposes. If version is set to false, a version
-	 *                                 number is automatically added equal to current installed WordPress version.
-	 *                                 If set to null, no version is added.
-	 * @param string           $media  Optional. The media for which this stylesheet has been defined.
-	 *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
-	 *                                 '(orientation: portrait)' and '(max-width: 640px)'.
-	 */
-	function {{PREFIX}}_override_style( $styles, $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
-		$style = $styles->query( $handle, 'registered' );
-		if ( $style ) {
-			$styles->remove( $handle );
-		}
-		$styles->add( $handle, $src, $deps, $ver, $media );
+/**
+ * Registers a style according to `wp_register_style`. Honors this request by
+ * deregistering any style by the same handler before registration.
+ *
+ * @param WP_Styles        $styles WP_Styles instance.
+ * @param string           $handle Name of the stylesheet. Should be unique.
+ * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
+ * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
+ * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
+ *                                 as a query string for cache busting purposes. If version is set to false, a version
+ *                                 number is automatically added equal to current installed WordPress version.
+ *                                 If set to null, no version is added.
+ * @param string           $media  Optional. The media for which this stylesheet has been defined.
+ *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
+ *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+ */
+function {{PREFIX}}_override_style( $styles, $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
+	$style = $styles->query( $handle, 'registered' );
+	if ( $style ) {
+		$styles->remove( $handle );
+	}
+	$styles->add( $handle, $src, $deps, $ver, $media );
+}
+
+/**
+ * Register all package styles (simple cases only).
+ * Complex cases should be manually registered in lib/client-assets.php.
+ *
+ * @param WP_Styles $styles WP_Styles instance.
+ */
+function {{PREFIX}}_register_package_styles( $styles ) {
+	// Load build constants
+	$build_constants = require __DIR__ . '/constants.php';
+	$default_version = ! SCRIPT_DEBUG ? $build_constants['version'] : time();
+	$suffix          = SCRIPT_DEBUG ? '' : '.min';
+
+	$styles_dir  = __DIR__ . '/styles';
+	$styles_file = $styles_dir . '/registry.php';
+
+	if ( ! file_exists( $styles_file ) ) {
+		return;
+	}
+
+	$styles_data = require $styles_file;
+	$plugin_dir  = dirname( __FILE__ );
+
+	foreach ( $styles_data as $style_data ) {
+		{{PREFIX}}_override_style(
+			$styles,
+			$style_data['handle'],
+			$build_constants['build_url'] . 'styles/' . $style_data['path'] . $suffix . '.css',
+			$style_data['dependencies'],
+			$default_version
+		);
+
+		// Enable RTL support (WordPress automatically loads -rtl.css variant)
+		$styles->add_data( $style_data['handle'], 'rtl', 'replace' );
+		$styles->add_data( $style_data['handle'], 'suffix', $suffix );
 	}
 }
 
-if ( ! function_exists( '{{PREFIX}}_register_package_styles' ) ) {
-	/**
-	 * Register all package styles (simple cases only).
-	 * Complex cases should be manually registered in lib/client-assets.php.
-	 *
-	 * @param WP_Styles $styles WP_Styles instance.
-	 */
-	function {{PREFIX}}_register_package_styles( $styles ) {
-		// Load build constants
-		$build_constants = require __DIR__ . '/constants.php';
-		$default_version = ! SCRIPT_DEBUG ? $build_constants['version'] : time();
-		$suffix          = SCRIPT_DEBUG ? '' : '.min';
-
-		$styles_dir  = __DIR__ . '/styles';
-		$styles_file = $styles_dir . '/registry.php';
-
-		if ( ! file_exists( $styles_file ) ) {
-			return;
-		}
-
-		$styles_data = require $styles_file;
-		$plugin_dir  = dirname( __FILE__ );
-
-		foreach ( $styles_data as $style_data ) {
-			{{PREFIX}}_override_style(
-				$styles,
-				$style_data['handle'],
-				$build_constants['build_url'] . 'styles/' . $style_data['path'] . $suffix . '.css',
-				$style_data['dependencies'],
-				$default_version
-			);
-
-			// Enable RTL support (WordPress automatically loads -rtl.css variant)
-			$styles->add_data( $style_data['handle'], 'rtl', 'replace' );
-			$styles->add_data( $style_data['handle'], 'suffix', $suffix );
-		}
-	}
-
-	add_action( 'wp_default_styles', '{{PREFIX}}_register_package_styles' );
-}
+add_action( 'wp_default_styles', '{{PREFIX}}_register_package_styles' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the `! function_exists()` checks that wrap the functions within files found in `package/wp-build/templates` used to generate PHP files during build.

Part of #75984.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Functions become what's known as "pluggable" when wrapped in this conditional check. This was a practice that predated the Hooks API (actions/filters) and caused many problems. 

- They are inflexible by nature as multiple people cannot alter the function at the same time. The first one loaded "wins".
"Plugged" versions cannot be trusted to maintain the intended core behavior.
- The quality of a plugged function is unknown and therefor is unreliable.
- It's very difficult to reliably add support for new features within a pluggable feature because there's no guarantee that any plugged function will do the same.
- It creates significant technical debt. Once the function is shipped, it's nearly impossible to change the signature because plugged versions of the function will not be updated reliably. 

When these functions are prefixed with `wp_` within the plugin, there needs to be a `! function_exists()` wrapper to prevent fatal errors. However, with the new build process and these functions being generated with the `wp-build` package through templates, I'm not sure that these are required anymore. There should be no other plugin defining `gutenberg_*` functions, and `wp_*` functions are only built when the script is run to build for `wordpress-develop`.

## How?
This simply removes the wrapping conditionals from the template files.
