### PR TITLE
Media Notices: Bump global snackbar z-index, re-use global notices for media modal

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -112,8 +112,8 @@ $z-layers: (
 	// Below the block toolbar.
 	".block-editor-grid-visualizer": 30,
 
-	// Show snackbars above everything (similar to popovers)
-	".components-snackbar-list": 100000,
+	// Show snackbars above modals so transient notifications remain visible.
+	".components-snackbar-list": 200000,
 
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -26,7 +26,7 @@ import {
 	mediaThumbnailField,
 	mimeTypeField,
 } from '@wordpress/media-fields';
-import { store as noticesStore, SnackbarNotices } from '@wordpress/notices';
+import { store as noticesStore } from '@wordpress/notices';
 import { isBlobURL } from '@wordpress/blob';
 
 /**
@@ -42,9 +42,6 @@ const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 // Layout constants - matching the picker layout types
 const LAYOUT_PICKER_GRID = 'pickerGrid';
 const LAYOUT_PICKER_TABLE = 'pickerTable';
-
-// Custom notices context for the media modal
-const NOTICES_CONTEXT = 'media-modal';
 
 // Notice ID - reused for all upload-related notices to prevent flooding
 const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
@@ -352,7 +349,7 @@ export function MediaUploadModal( {
 					),
 					{
 						type: 'snackbar',
-						context: NOTICES_CONTEXT,
+
 						id: NOTICE_ID_UPLOAD_PROGRESS,
 					}
 				);
@@ -387,7 +384,6 @@ export function MediaUploadModal( {
 			// Show error notice (replaces progress notice via ID)
 			createErrorNotice( error.message, {
 				type: 'snackbar',
-				context: NOTICES_CONTEXT,
 				id: NOTICE_ID_UPLOAD_PROGRESS,
 			} );
 		},
@@ -413,7 +409,7 @@ export function MediaUploadModal( {
 					),
 					{
 						type: 'snackbar',
-						context: NOTICES_CONTEXT,
+
 						id: NOTICE_ID_UPLOAD_PROGRESS,
 						explicitDismiss: true,
 					}
@@ -533,7 +529,7 @@ export function MediaUploadModal( {
 							),
 							{
 								type: 'snackbar',
-								context: NOTICES_CONTEXT,
+
 								id: NOTICE_ID_UPLOAD_PROGRESS,
 								explicitDismiss: true,
 							}
@@ -564,10 +560,6 @@ export function MediaUploadModal( {
 				search={ search }
 				searchLabel={ searchLabel }
 				itemListLabel={ __( 'Media items' ) }
-			/>
-			<SnackbarNotices
-				className="media-upload-modal__snackbar"
-				context={ NOTICES_CONTEXT }
 			/>
 		</Modal>
 	);

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -1,5 +1,4 @@
 @use "@wordpress/base-styles/variables" as *;
-@use "@wordpress/base-styles/mixins" as *;
 
 .media-upload-modal {
 	.components-modal__header {
@@ -22,7 +21,4 @@
 		padding-bottom: $grid-unit-10;
 	}
 
-	.media-upload-modal__snackbar {
-		@include snackbar-container();
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/73085

This PR proposes:

* Bump the z-index of the snackbar component globally, so that it sits above modals.
* For the experimental media modal, no longer use the custom snackbar context, and instead re-use the global snackbars

## Why?

While testing the media modal upload flow, @tellthemachines noticed that there was an odd fly-in animation with the snackbar notices that only occurred sometimes. It turns out it was due to a conflict between the image replace flow's dropdowns (e.g. the floating ui) and the motion div used by Framer Motion for the snackbars. Rather than wrestle with this, the solution proposed here is to abandon using a custom snackbar context for the media modal, and instead simply reuse the global snackbars that are already in place.

This simplifies how the snackbars for the media modal work, and involves a more global fix. Which is that we now set all snackbars to have a higher z-index, that sits it above modals.

While this is a global change, I think in principle snackbars _should_ always sit above modals. The 200000 z-index ensures that it'll sit above Gutenberg modals, also the core media modal (160000) while still sitting below popovers (1000000).

## How?

* Update global z-index of snackbars to have a higher z-index (sit above modals but beneath popovers)
* Remove custom Snackbars context approach in the media modal, and re-use existing snackbars

Note: there are other UX issues with the notices-based approach. I'm currently exploring alternatives, but they're a little experimental. The goal in this PR is to make things as they currently work feel a little more stable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

Enable the media modal experiment in Gutenberg settings:

<img width="958" height="79" alt="image" src="https://github.com/user-attachments/assets/1cb6fe45-4f40-4662-b93e-cfc860bc353e" />

* In a post, add an image to an image block
* With the image block selected, click on the dropdown in the toolbar to replace the image, selecting from the media library again
* Drag and drop to upload to the media modal
* The snackbar notice displaying upload state should appear and update in place, without flying in weirdly as on trunk

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/457ab092-b98e-4d95-8986-fd6f4a53be13

### After

https://github.com/user-attachments/assets/4a42d04b-218d-487f-a1d0-8575af395554