### PR TITLE
Block toolbar and context menu: hide pattern actions in Revisions UI

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -78,8 +78,9 @@ export function PrivateBlockToolbar( {
 		showBlockVisibilityButton,
 		showSwitchSectionStyleButton,
 		areSelectedBlocksHiddenOnViewport,
-		isPreviewMode,
+		canEdit,
 	} = useSelect( ( select ) => {
+		const { canEditBlock } = select( blockEditorStore );
 		const {
 			getBlockName,
 			getBlockMode,
@@ -123,9 +124,9 @@ export function PrivateBlockToolbar( {
 
 		const _isZoomOut = isZoomOut();
 		const _isSectionBlock = isSectionBlock( selectedBlockClientId );
-		const _isPreviewMode = !! getSettings().isPreviewMode;
+		const _canEditBlock = canEditBlock( selectedBlockClientId );
 		const _showSwitchSectionStyleButton =
-			! _isPreviewMode && ( _isZoomOut || _isSectionBlock );
+			_canEditBlock && ( _isZoomOut || _isSectionBlock );
 
 		const _currentDeviceType =
 			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
@@ -164,7 +165,7 @@ export function PrivateBlockToolbar( {
 			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
 			areSelectedBlocksHiddenOnViewport:
 				_areSelectedBlocksHiddenOnViewport,
-			isPreviewMode: _isPreviewMode,
+			canEdit: _canEditBlock,
 		};
 	}, [] );
 
@@ -249,7 +250,7 @@ export function PrivateBlockToolbar( {
 					shouldShowVisualToolbar &&
 					isMultiToolbar &&
 					showGroupButtons && <BlockGroupToolbar /> }
-				{ ! isMultiToolbar && ! isPreviewMode && (
+				{ ! isMultiToolbar && canEdit && (
 					<EditSectionButton clientId={ blockClientIds[ 0 ] } />
 				) }
 				{ ! areSelectedBlocksHiddenOnViewport && showShuffleButton && (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -78,6 +78,7 @@ export function PrivateBlockToolbar( {
 		showBlockVisibilityButton,
 		showSwitchSectionStyleButton,
 		areSelectedBlocksHiddenOnViewport,
+		isPreviewMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -122,7 +123,9 @@ export function PrivateBlockToolbar( {
 
 		const _isZoomOut = isZoomOut();
 		const _isSectionBlock = isSectionBlock( selectedBlockClientId );
-		const _showSwitchSectionStyleButton = _isZoomOut || _isSectionBlock;
+		const _isPreviewMode = !! getSettings().isPreviewMode;
+		const _showSwitchSectionStyleButton =
+			! _isPreviewMode && ( _isZoomOut || _isSectionBlock );
 
 		const _currentDeviceType =
 			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
@@ -161,6 +164,7 @@ export function PrivateBlockToolbar( {
 			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
 			areSelectedBlocksHiddenOnViewport:
 				_areSelectedBlocksHiddenOnViewport,
+			isPreviewMode: _isPreviewMode,
 		};
 	}, [] );
 
@@ -245,7 +249,7 @@ export function PrivateBlockToolbar( {
 					shouldShowVisualToolbar &&
 					isMultiToolbar &&
 					showGroupButtons && <BlockGroupToolbar /> }
-				{ ! isMultiToolbar && (
+				{ ! isMultiToolbar && ! isPreviewMode && (
 					<EditSectionButton clientId={ blockClientIds[ 0 ] } />
 				) }
 				{ ! areSelectedBlocksHiddenOnViewport && showShuffleButton && (

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -23,10 +23,10 @@ function PatternsManageButton( { clientId } ) {
 		managePatternsUrl,
 		isSyncedPattern,
 		isUnsyncedPattern,
-		isPreviewMode,
+		canEdit,
 	} = useSelect(
 		( select ) => {
-			const { canRemoveBlock, getBlock, getSettings } =
+			const { canRemoveBlock, getBlock, canEditBlock } =
 				select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const block = getBlock( clientId );
@@ -45,7 +45,7 @@ function PatternsManageButton( { clientId } ) {
 
 			return {
 				attributes: block.attributes,
-				isPreviewMode: !! getSettings().isPreviewMode,
+				canEdit: canEditBlock( clientId ),
 				// For unsynced patterns, detaching is simply removing the `patternName` attribute.
 				// For synced patterns, the `core:block` block is replaced with its inner blocks,
 				// so checking whether `canRemoveBlock` is possible is required.
@@ -81,13 +81,13 @@ function PatternsManageButton( { clientId } ) {
 		useDispatch( patternsStore )
 	);
 
-	if ( ! isVisible ) {
+	if ( ! isVisible || ! canEdit ) {
 		return null;
 	}
 
 	return (
 		<>
-			{ canDetach && ! isPreviewMode && (
+			{ canDetach && (
 				<MenuItem
 					onClick={ () => {
 						if ( isSyncedPattern ) {

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -23,9 +23,11 @@ function PatternsManageButton( { clientId } ) {
 		managePatternsUrl,
 		isSyncedPattern,
 		isUnsyncedPattern,
+		isPreviewMode,
 	} = useSelect(
 		( select ) => {
-			const { canRemoveBlock, getBlock } = select( blockEditorStore );
+			const { canRemoveBlock, getBlock, getSettings } =
+				select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const block = getBlock( clientId );
 
@@ -43,6 +45,7 @@ function PatternsManageButton( { clientId } ) {
 
 			return {
 				attributes: block.attributes,
+				isPreviewMode: !! getSettings().isPreviewMode,
 				// For unsynced patterns, detaching is simply removing the `patternName` attribute.
 				// For synced patterns, the `core:block` block is replaced with its inner blocks,
 				// so checking whether `canRemoveBlock` is possible is required.
@@ -78,7 +81,7 @@ function PatternsManageButton( { clientId } ) {
 		useDispatch( patternsStore )
 	);
 
-	if ( ! isVisible ) {
+	if ( ! isVisible || isPreviewMode ) {
 		return null;
 	}
 

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -81,13 +81,13 @@ function PatternsManageButton( { clientId } ) {
 		useDispatch( patternsStore )
 	);
 
-	if ( ! isVisible || isPreviewMode ) {
+	if ( ! isVisible ) {
 		return null;
 	}
 
 	return (
 		<>
-			{ canDetach && (
+			{ canDetach && ! isPreviewMode && (
 				<MenuItem
 					onClick={ () => {
 						if ( isSyncedPattern ) {


### PR DESCRIPTION

> [!NOTE]
> This PR is a preemptive change pending feedback from https://github.com/WordPress/gutenberg/issues/74742#issuecomment-3988587209. It removes mutating pattern-related controls only for now. 

## What?

In the Revisions UI, blocks can still be selected and the block toolbar is shown. However, several toolbar and context menu items intended for editing were still appearing:

- "Edit pattern" / "Exit pattern" (block toolbar)
- "Shuffle styles" (block toolbar)
- "Detach pattern" (block context menu).
- "Manage patterns" (block context menu).


## Why?

The aim is to [show the block icon and copy actions only in the revisions UI](https://github.com/WordPress/gutenberg/issues/74742#issuecomment-3990423311).

Furthermore, these actions all mutate block state and have no meaningful role in a read-only revision preview. 

"Manage patterns" is a distraction. It links users away from the current action (revisions UI).


## How?

The [Revisions canvas](https://github.com/WordPress/gutenberg/blob/9e8f400a1190fce8f067090328973f8d87daad3d/packages/editor/src/components/post-revisions-preview/revisions-canvas.js) sets `isPreviewMode: true` in the block editor settings.

This PR doesn't render the targeted components in preview mode.

## Testing Instructions


1. Open any post or page that has pattern blocks (synced and unsynced) and section blocks with registered styles. 
2. Make sure you have a few post revisions saved up. Edit. Save. Edit. Save. Edit. Save.
3. Open the Revisions panel (Post → Revisions in the sidebar).
4. Select a block that is inside an unsynced pattern. Confirm the block toolbar does not show an "Edit pattern" button. The "Shuffle styles" should also not appear.
5. In the Revisions UI, open the block context menu (⋮) on an unsynced/synced pattern block. Confirm "Detach/Disconnect pattern"  and "Manage patterns" doesn't appear.
6. Check for any regressions:
    1. The hidden items should display when not in the Revisions UI.
    2. Zoom out mode should remain unchanged (test in site editor)

## Screenshots or screencast <!-- if applicable -->






|Before|After|
|-|-|
|<img width="1349" height="696" alt="Screenshot 2026-03-03 at 4 04 05 pm" src="https://github.com/user-attachments/assets/4e3a9a3e-5d72-489f-ba3c-52eba6e170c7" />|<img width="931" height="410" alt="Screenshot 2026-03-04 at 9 50 08 am" src="https://github.com/user-attachments/assets/dfb88e30-010d-4b79-a054-0be2d7703547" />|

