### PR TITLE
Revert global snackbar z-index bump, implement alternative fix for Media Upload Modal notices

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -112,8 +112,8 @@ $z-layers: (
 	// Below the block toolbar.
 	".block-editor-grid-visualizer": 30,
 
-	// Show snackbars above modals so transient notifications remain visible.
-	".components-snackbar-list": 200000,
+	// Show snackbars above everything (similar to popovers)
+	".components-snackbar-list": 100000,
 
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -359,7 +359,6 @@ export function MediaUploadModal( {
 						type: 'snackbar',
 						context: NOTICES_CONTEXT,
 						id: NOTICE_ID_UPLOAD_PROGRESS,
-						explicitDismiss: true,
 					}
 				);
 

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -26,7 +26,7 @@ import {
 	mediaThumbnailField,
 	mimeTypeField,
 } from '@wordpress/media-fields';
-import { store as noticesStore } from '@wordpress/notices';
+import { store as noticesStore, SnackbarNotices } from '@wordpress/notices';
 import { isBlobURL } from '@wordpress/blob';
 
 /**
@@ -42,6 +42,9 @@ const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 // Layout constants - matching the picker layout types
 const LAYOUT_PICKER_GRID = 'pickerGrid';
 const LAYOUT_PICKER_TABLE = 'pickerTable';
+
+// Custom notices context for the media modal
+const NOTICES_CONTEXT = 'media-modal';
 
 // Notice ID - reused for all upload-related notices to prevent flooding
 const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
@@ -349,7 +352,7 @@ export function MediaUploadModal( {
 					),
 					{
 						type: 'snackbar',
-
+						context: NOTICES_CONTEXT,
 						id: NOTICE_ID_UPLOAD_PROGRESS,
 					}
 				);
@@ -384,6 +387,7 @@ export function MediaUploadModal( {
 			// Show error notice (replaces progress notice via ID)
 			createErrorNotice( error.message, {
 				type: 'snackbar',
+				context: NOTICES_CONTEXT,
 				id: NOTICE_ID_UPLOAD_PROGRESS,
 			} );
 		},
@@ -409,7 +413,7 @@ export function MediaUploadModal( {
 					),
 					{
 						type: 'snackbar',
-
+						context: NOTICES_CONTEXT,
 						id: NOTICE_ID_UPLOAD_PROGRESS,
 						explicitDismiss: true,
 					}
@@ -529,7 +533,7 @@ export function MediaUploadModal( {
 							),
 							{
 								type: 'snackbar',
-
+								context: NOTICES_CONTEXT,
 								id: NOTICE_ID_UPLOAD_PROGRESS,
 								explicitDismiss: true,
 							}
@@ -560,6 +564,10 @@ export function MediaUploadModal( {
 				search={ search }
 				searchLabel={ searchLabel }
 				itemListLabel={ __( 'Media items' ) }
+			/>
+			<SnackbarNotices
+				className="media-upload-modal__snackbar"
+				context={ NOTICES_CONTEXT }
 			/>
 		</Modal>
 	);

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	createPortal,
+	useState,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import {
 	privateApis as coreDataPrivateApis,
@@ -354,6 +359,7 @@ export function MediaUploadModal( {
 						type: 'snackbar',
 						context: NOTICES_CONTEXT,
 						id: NOTICE_ID_UPLOAD_PROGRESS,
+						explicitDismiss: true,
 					}
 				);
 
@@ -565,10 +571,13 @@ export function MediaUploadModal( {
 				searchLabel={ searchLabel }
 				itemListLabel={ __( 'Media items' ) }
 			/>
-			<SnackbarNotices
-				className="media-upload-modal__snackbar"
-				context={ NOTICES_CONTEXT }
-			/>
+			{ createPortal(
+				<SnackbarNotices
+					className="media-upload-modal__snackbar"
+					context={ NOTICES_CONTEXT }
+				/>,
+				document.body
+			) }
 		</Modal>
 	);
 }

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
 
 .media-upload-modal {
 	.components-modal__header {
@@ -21,4 +22,7 @@
 		padding-bottom: $grid-unit-10;
 	}
 
+	.media-upload-modal__snackbar {
+		@include snackbar-container();
+	}
 }

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -21,8 +21,20 @@
 	.dataviews-footer {
 		padding-bottom: $grid-unit-10;
 	}
+}
 
-	.media-upload-modal__snackbar {
-		@include snackbar-container();
+.media-upload-modal__snackbar {
+	@include snackbar-container();
+	z-index: 200000;
+
+	// Override the transform and transform-origin applied by the Snackbar component
+	// to prevent the snackbar from shifting position when its content changes while
+	// the media upload modal is open. This is an edge case particular to the media
+	// upload modal when instantiated from a popover, such as the Replace control in
+	// the Image Block. In that case, the Framer Motion transform appears to get
+	// confused by the Snackbars being a child of the popover.
+	> div {
+		transform: none !important;
+		transform-origin: 0 !important;
 	}
 }


### PR DESCRIPTION
## What?

Reverts #76063 while adding an alternative fix.

This restores the `z-index` for snackbars in general to what it was, and instead applies the higher z-index to a version of the Snackbars particular to the media modal, rendered to the document via a portal.

It then overrides the transforms that are causing an issue in this context.

## Why?

As flagged in a post-merge comment in #76063, changing the z-index globally of snackbars has broader accessibility (and design) concerns. The approach in this PR is a bit more conservative and only affects notices generated by the media modal.

The move to using a portal and overriding transforms is a way to mitigate the conflict caused by the Image block's Replace flow popover with the Framer Motion transforms applied to the snackbars.

By using an isolated version of Snackbars that are just used by the media modal, we contain our logic, overrides, and hacks, and (hopefully) cause less impact on other areas of the editor.

## How?

* Revert #76063
* Then, use a portal to render Snackbars outside of the media modal itself
* Add some styling overrides to compensation for / mitigate the transforms that are applied when the replace flow is used

## Testing Instructions

Enable the media modal experiment in Gutenberg settings:

<img width="958" height="79" alt="image" src="https://github.com/user-attachments/assets/1cb6fe45-4f40-4662-b93e-cfc860bc353e" />

* In a post, add an image to an image block
* With the image block selected, click on the dropdown in the toolbar to replace the image, selecting from the media library again
* Drag and drop to upload to the media modal
* The snackbar notice displaying upload state should appear and update in place, without flying in weirdly as on trunk

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

See screenshots in #76063. It should still look like this:

https://github.com/user-attachments/assets/4a42d04b-218d-487f-a1d0-8575af395554