### PR TITLE
Interactivity: Fix incomplete `Window.scheduler` type causing TS2430 in downstream projects

### DIFF
--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -25,7 +25,11 @@ interface Flusher {
 declare global {
 	interface Window {
 		scheduler?: {
-			readonly yield?: () => Promise< void >;
+			postTask: (
+				callback: () => unknown,
+				options?: object
+			) => Promise< unknown >;
+			yield: () => Promise< void >;
 		};
 	}
 }


### PR DESCRIPTION
## What?

Closes #76069

Update the `Window.scheduler` global augmentation in `@wordpress/interactivity` to include `postTask` and make `yield` required, matching the W3C Prioritized Task Scheduling spec.

## Why?

The existing declaration only typed `yield` (as optional) and omitted `postTask` entirely:

```ts
declare global {
	interface Window {
		scheduler?: {
			readonly yield?: () => Promise< void >;
		};
	}
}
```

This was written before `Scheduler` was standardised in the DOM lib. TypeScript versions that now include `Scheduler` in `lib.dom.d.ts` define it with both `postTask` and `yield` as required members on `WindowOrWorkerGlobalScope`. Because of this, any downstream TypeScript project that imports `@wordpress/interactivity` **and** augments `Window` in a source `.ts` file gets:

```
error TS2430: Interface 'Window' incorrectly extends interface 'WindowOrWorkerGlobalScope'.
  Types of property 'scheduler' are incompatible.
    Property 'postTask' is missing in type '{ readonly yield?: () => Promise<void>; }'
    but required in type 'Scheduler'.
```

The error surfaces in the consumer's source file (not in the package's `.d.ts`, which is skipped by `skipLibCheck`) and propagates to every other file in the project that also augments `Window`.

## How?

Add `postTask` and make `yield` required in the `Window.scheduler` augmentation to match the spec:

```ts
declare global {
	interface Window {
		scheduler?: {
			postTask: (
				callback: () => unknown,
				options?: object
			) => Promise< unknown >;
			yield: () => Promise< void >;
		};
	}
}
```

- `postTask` uses broad-but-compatible types (`() => unknown`, `object`, `Promise<unknown>`) so the merged type satisfies the standard `Scheduler` interface in any TypeScript version that includes it.
- `yield` is made required per spec; the existing runtime guard (`typeof window.scheduler?.yield === 'function'`) handles browsers that don't yet implement it.

## Testing Instructions

1. Add `@wordpress/interactivity` as a dependency in a TypeScript project configured with `lib: ["dom"]` (TypeScript 5.5+ or `tsgo`).
2. In a source `.ts` file, add a global `Window` augmentation:
   ```ts
   declare global {
     interface Window {
       myProperty?: string;
     }
   }
   ```
3. Run `tsc --noEmit`.
4. Confirm no `TS2430` error is reported.

### Testing Instructions for Keyboard

N/A — this is a type-only change with no UI impact.
