### PR TITLE
`Button`: Add `word-break: break-word`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Enhancements
 
 -   `ToggleGroupControl`: Make unselected item color consistent across all variants ([#75737](https://github.com/WordPress/gutenberg/pull/75737)).
+-   `Button`: Add `word-break: break-word`. ([#76071](https://github.com/WordPress/gutenberg/pull/76071)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -13,6 +13,7 @@
 .components-button {
 	display: inline-flex;
 	text-decoration: none;
+	word-break: break-word;
 	font-family: inherit;
 	font-size: $default-font-size;
 	font-weight: $font-weight-medium;

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -226,7 +226,6 @@ function PostParentToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
-			className="editor-post-parent__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			aria-label={

--- a/packages/editor/src/components/post-author/panel.js
+++ b/packages/editor/src/components/post-author/panel.js
@@ -30,7 +30,6 @@ function PostAuthorToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
-			className="editor-post-author__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			aria-label={

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -90,7 +90,6 @@ function PostURLToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
-			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			aria-label={

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -47,11 +47,6 @@
 	padding-inline-start: 0 !important;
 }
 
-.editor-post-url__panel-toggle,
-.editor-post-parent__panel-toggle {
-	word-break: break-word;
-}
-
 .editor-post-url__intro {
 	margin: 0;
 }

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -36,7 +36,7 @@ test.describe( 'Test Custom Post Types', () => {
 			} )
 			.click();
 
-		await page.locator( '.editor-post-parent__panel-toggle' ).click();
+		await page.getByRole( 'button', { name: /^Change parent:/ } ).click();
 
 		const parentPageLocator = page.getByRole( 'combobox', {
 			name: 'Parent',
@@ -53,7 +53,7 @@ test.describe( 'Test Custom Post Types', () => {
 		await editor.publishPost();
 		await page.reload();
 
-		await page.locator( '.editor-post-parent__panel-toggle' ).click();
+		await page.getByRole( 'button', { name: /^Change parent:/ } ).click();
 
 		// Confirm parent page selection matches after reloading.
 		await expect( parentPageLocator ).toHaveValue( parentPage );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/73707

Alternative of: https://github.com/WordPress/gutenberg/pull/73711

From the main issue:

>if the text is long and not hyphenated and doesn't contain spaces, then it'll overflow its container.

This currently affects only the buttons in Post Summary (editor) and we previously had some ad-hoc css rules per use case.

As suggested by @mirka [here](https://github.com/WordPress/gutenberg/pull/73711#discussion_r2592871590):

>I just noticed something wild though, which is that the non-default variants (e.g. primary) of Button have white-space: nowrap set, while the default variant does not 😅 I don't understand the reasoning for that choice, but in any case I think it'd be fine to add word-break: break-word to Button. It wouldn't affect variants that don't allow wrapping, and will result in better wrapping behavior for the variant that does allow it.

This PR does that and also removes some of these ad-hoc styles/classnames from the editor components that had them.

## Testing Instructions
1. In post editor's Post Summary try some long values (not hyphenated and no spaces)
2. Observe that they wrap properly
3. Ensure no visual regressions introduced in other buttons


### Notes
I'll open a follow up to handle the DataForms wrapping, since it doesn't use Buttons anymore.


|Before|After|
|-|-|
|<img width="284" height="705" alt="Screenshot 2026-03-03 at 10 20 57 AM" src="https://github.com/user-attachments/assets/039f43f3-b8ba-4087-becf-16ae0c9d9862" />|<img width="284" height="705" alt="after" src="https://github.com/user-attachments/assets/5f768aea-5b20-493b-93c5-1582fb7abfe3" />|
