### PR TITLE
Fix writing flow navigation for annotation style, or any other block with border radius

### DIFF
--- a/packages/dom/src/dom/hidden-caret-range-from-point.js
+++ b/packages/dom/src/dom/hidden-caret-range-from-point.js
@@ -19,6 +19,7 @@ import getComputedStyle from './get-computed-style';
 export default function hiddenCaretRangeFromPoint( doc, x, y, container ) {
 	const originalZIndex = container.style.zIndex;
 	const originalPosition = container.style.position;
+	const originalBorderRadius = container.style.borderRadius;
 
 	const { position = 'static' } = getComputedStyle( container );
 
@@ -29,10 +30,17 @@ export default function hiddenCaretRangeFromPoint( doc, x, y, container ) {
 
 	container.style.zIndex = '10000';
 
+	// When an element has border radius, the x/y coordinates can incorrectly fall
+	// outside the element because of the radius. Temporarily reset the value
+	// to ensure the coordinates are tested against a rectangle and not a pill-shaped
+	// element. See https://github.com/WordPress/gutenberg/issues/72053 for more info.
+	container.style.borderRadius = '0';
+
 	const range = caretRangeFromPoint( doc, x, y );
 
 	container.style.zIndex = originalZIndex;
 	container.style.position = originalPosition;
+	container.style.borderRadius = originalBorderRadius;
 
 	return range;
 }

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -539,6 +539,31 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	// Regression test for https://github.com/WordPress/gutenberg/issues/72053.
+	test( 'should navigate contenteditable with border radius', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await editor.canvas.locator( ':root' ).evaluate( () => {
+			document.activeElement.style.borderRadius = '50px';
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( '1' );
+
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: '1' },
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: '' },
+			},
+		] );
+	} );
+
 	test( 'should not prematurely multi-select', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Fixes #72053

Proposes a fix for writing flow navigation for blocks that have the Annotation Style from TT5 or a certain amount of border radius applied.

## Why?
The explanation here is very good - https://github.com/WordPress/gutenberg/issues/72053#issuecomment-3377198846.

The Writing Flow code performs a check of whether x/y coordinates derived from the selection range are within the current element. If not, writing flow navigation between blocks doesn't happen.

The problem is that when border radius is applied to an element, the coordinate checks are no longer testing against a rectangle, but instead a pill shaped object. If the coordinates fall right on the corner of the element, a little bit of border radius can cause the check to fail.

## How?
Temporarily reset the border radius before performing the `caretRangeFromPoint` test. This seems like the simplest fix. There's already some similar resets happening in the code. My one concern is it might cause a style glitch, but that doesn't seem to happen (I guess browser styles only recompute/re-render when the stack unwinds fully).

An alternative might be changing the way the coordinates are calculated - e.g. choosing the midpoint of an edge. I don't know the code well enough to know if that could cause an issue, so open to feedback.

## Testing Instructions
1. With TT5 active, add the 'Overlapping images and paragraph on right' pattern
2. Using the keyboard, move the caret into the 'About Us' heading
3. Try pressing up/down/left/right to move the caret out of the heading block

In trunk: the caret is trapped inside the heading block
In this PR: the caret moves to the next block or post title.

## Screenshots or screencast <!-- if applicable -->

#### Before

https://github.com/user-attachments/assets/ad751197-8e11-4959-9a44-0d629bc1e7ad


#### After

https://github.com/user-attachments/assets/76966711-72d1-4e10-859f-a8e3153579a8


