### PR TITLE
DataForm: Fix text overflow for long unhyphenated text in panel layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)
+- DataForm: Fix text overflow for long unhyphenated text in panel layout. [#76073](https://github.com/WordPress/gutenberg/pull/76073)
 - DataForm: Fix `card` layout's toggle button screen reader text. [#76039](https://github.com/WordPress/gutenberg/pull/76039)
 - DataViews: Fix focus transfer while searching in `list` layout. [#75999](https://github.com/WordPress/gutenberg/pull/75999)
 - DataForm: Fix focus loss when collapsing in Card view. [#75689](https://github.com/WordPress/gutenberg/pull/75689)

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -127,6 +127,7 @@
 	display: flex;
 	align-items: center;
 	overflow: hidden;
+	word-break: break-word;
 	font-weight: var(--wpds-font-weight-medium);
 
 	> * {

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -75,6 +75,10 @@ const fields: Field< SamplePost >[] = [
 			{ value: 2, label: 'John' },
 			{ value: 3, label: 'Alice' },
 			{ value: 4, label: 'Bob' },
+			{
+				value: 5,
+				label: 'Superadministratoraccountwithalongunhyphenatedusername',
+			},
 		],
 		setValue: ( { value } ) => ( {
 			author: Number( value ),
@@ -310,7 +314,7 @@ const LayoutPanelComponent = ( {
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
 		order: 2,
-		author: 1,
+		author: 5,
 		status: 'draft',
 		reviewer: 'fulano',
 		date: '2021-01-01T12:00:00',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/73707


>In DataForm panel buttons, if the text is long and not hyphenated and doesn't contain spaces, then it'll overflow its container.

This PR handles the DataForm panel layout. The Post Summary part is handled [here](https://github.com/WordPress/gutenberg/pull/76071).

## Testing Instructions
1. You can test this in storybook (?path=/story/dataviews-dataform--layout-panel) `npm run storybook:dev` if you resize the panel a bit
2. In site editor in pages page, quick edit an item with a long and not hyphenated with no spaces value.
3. Observe that the wrapping takes place
4. Ensure no visual regressions has been introduced





|Before|After|
|-|-|
|<img width="524" height="588" alt="Screenshot 2026-03-03 at 10 57 52 AM" src="https://github.com/user-attachments/assets/cb2fee4d-db18-43ea-b3de-166021674c9a" />|<img width="524" height="588" alt="after" src="https://github.com/user-attachments/assets/42a49580-c1de-4d4c-8ce2-b0fd2f25f165" />|
