### PR TITLE
Global styles: Simplify CSS processing

### DIFF
--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -21,7 +21,6 @@ import {
 	ROOT_CSS_PROPERTIES_SELECTOR,
 	scopeSelector,
 	scopeFeatureSelectors,
-	appendToSelector,
 	getBlockStyleVariationSelector,
 	getResolvedValue,
 } from '../utils/common';
@@ -1813,61 +1812,18 @@ function updateConfigWithSeparator(
 	return config;
 }
 
-export function processCSSNesting( css: string, blockSelector: string ) {
-	let processedCSS = '';
-
-	if ( ! css || css.trim() === '' ) {
-		return processedCSS;
+export function processCSSNesting(
+	css: string,
+	blockSelector: string
+): string {
+	const ss = new CSSStyleSheet();
+	try {
+		return ss.cssRules[
+			ss.insertRule( `:root :where(${ blockSelector }){${ css }}` )
+		].cssText;
+	} catch {
+		return '';
 	}
-
-	// Split CSS nested rules.
-	const parts = css.split( '&' );
-	parts.forEach( ( part: string ) => {
-		if ( ! part || part.trim() === '' ) {
-			return;
-		}
-
-		const isRootCss = ! part.includes( '{' );
-		if ( isRootCss ) {
-			// If the part doesn't contain braces, it applies to the root level.
-			processedCSS += `:root :where(${ blockSelector }){${ part.trim() }}`;
-		} else {
-			// If the part contains braces, it's a nested CSS rule.
-			const splitPart = part.replace( '}', '' ).split( '{' );
-			if ( splitPart.length !== 2 ) {
-				return;
-			}
-
-			const [ nestedSelector, cssValue ] = splitPart;
-
-			// Handle pseudo elements such as ::before, ::after, etc. Regex will also
-			// capture any leading combinator such as >, +, or ~, as well as spaces.
-			// This allows pseudo elements as descendants e.g. `.parent ::before`.
-			const matches = nestedSelector.match( /([>+~\s]*::[a-zA-Z-]+)/ );
-			const pseudoPart = matches ? matches[ 1 ] : '';
-			const withoutPseudoElement = matches
-				? nestedSelector.replace( pseudoPart, '' ).trim()
-				: nestedSelector.trim();
-
-			let combinedSelector;
-			if ( withoutPseudoElement === '' ) {
-				// Only contained a pseudo element to use the block selector to form
-				// the final `:root :where()` selector.
-				combinedSelector = blockSelector;
-			} else {
-				// If the nested selector is a descendant of the block scope it with the
-				// block selector. Otherwise append it to the block selector.
-				combinedSelector = nestedSelector.startsWith( ' ' )
-					? scopeSelector( blockSelector, withoutPseudoElement )
-					: appendToSelector( blockSelector, withoutPseudoElement );
-			}
-
-			// Build final rule, re-adding any pseudo element outside the `:where()`
-			// to maintain valid CSS selector.
-			processedCSS += `:root :where(${ combinedSelector })${ pseudoPart }{${ cssValue.trim() }}`;
-		}
-	} );
-	return processedCSS;
 }
 
 export interface GlobalStylesRenderOptions {

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1820,7 +1820,10 @@ export function processCSSNesting(
 	try {
 		return ss.cssRules[
 			ss.insertRule( `:root :where(${ blockSelector }){${ css }}` )
-		].cssText;
+	try {
+		const cssRuleText = `:root :where(${ blockSelector }){${ css }}`;
+		new CSSStyleSheet().insertRule( cssRuleText, 0 );
+		return cssRuleText;
 	} catch {
 		return '';
 	}


### PR DESCRIPTION
# WIP exploration

## What?

Simplify JavaScript processing of nested CSS rules. Allow the rules to nest with simple correctness checking via built-in APIs.

PHP would need to be updated accordingly. A PHP-based CSS parser will likely become necessary. There is some prior art for this. [A PR contains CSS selector parsing](https://github.com/WordPress/wordpress-develop/pull/7857), and the php-toolkit contains a [CSSProcessor class](https://github.com/WordPress/php-toolkit/blob/205a54840c0e212bf73fc416f0223a49949b0307/components/DataLiberation/CSS/class-cssprocessor.php#L94).

### Input

```css
color: blue;

& > strong {
  color: green;
  &::before {
    content: "&";
  }
}
> em {
  color: red;
}
```

### Before

```html
<style>:root :where(.wp-custom-css-1){color: blue;}:root :where(.wp-custom-css-1 > strong){color: green;}:root :where(.wp-custom-css-1)::before{content: "}:root :where(.wp-custom-css-1";
  
}
> em){color: red;
}}</style>
```

### After

```html
<style>
:root :where(.wp-custom-css-1) {
  color: blue;
  & > strong {
  color: green;
  &::before { content: "&"; }
}
  & > em { color: red; }
}
</style>
```



## Why?

The existing system relies on regular expressions, and checking for the presence of and splitting on CSS syntax. However, the characters used in `{}` and `&` may be used in other ways in CSS.

This also relaxes the requirement to use `& .descendent {}` instead of simply nesting `.descendent {}` which should also work fine.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
