### PR TITLE
Auto Cherry-Pick: Fix race condition in workflow trigger

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -1,15 +1,13 @@
 name: Auto Cherry-Pick
 
 on:
-    push:
-        branches:
-            - trunk
-    # We also want to attempt cherry-picking when a PR is labeled after the PR
-    # is merged. Using pull_request_target instead of pull_request so that
-    # the workflow has access to repository secrets for fork PRs.
+    # closed: cherry-pick when a labeled PR is merged.
+    # labeled: cherry-pick when a label is added after the PR is merged.
+    # Using pull_request_target instead of pull_request so that the workflow
+    # has access to repository secrets for fork PRs.
     # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
     pull_request_target:
-        types: [labeled]
+        types: [closed, labeled]
         branches:
             - trunk
 
@@ -29,36 +27,22 @@ jobs:
             contents: write
             issues: write
             pull-requests: write
-        # When in the context of a PR, ensure the PR is merged.
-        if: github.event.pull_request == null || github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true
         steps:
             - name: Determine if label should trigger cherry-pick
               id: label-check
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
-                      const commit_sha = context.payload.pull_request ? context.payload.pull_request.merge_commit_sha : context.sha;
+                      const pr = context.payload.pull_request;
+                      const commit_sha = pr.merge_commit_sha;
+                      const pr_number = pr.number;
                       console.log(`Commit SHA: ${commit_sha}`);
-                      core.exportVariable('commit_sha', commit_sha);
-                      const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        commit_sha,
-                      });
-                      if (prs.data.length === 0) {
-                        console.log(`No PR found for commit ${context.sha}.`);
-                        return;
-                      }
-                      const pr_number = prs.data[0].number;
                       console.log(`PR: ${pr_number}`);
+                      core.exportVariable('commit_sha', commit_sha);
                       core.exportVariable('pr_number', pr_number);
 
-                      const pr = await github.rest.pulls.get({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        pull_number: pr_number,
-                      });
-                      const labels = pr.data.labels.map(label => label.name);
+                      const labels = pr.labels.map(label => label.name);
                       console.log(`Labels: ${labels}`);
                       const regex = /^Backport to WP ([0-9]+\.[0-9]+) Beta\/RC$/;
                       let matched = false;


### PR DESCRIPTION
Unifies some auto cherry pick workflow logic. We keep having problems when PRs are merged that the PR associated with the commit is not found yet, example: https://github.com/WordPress/gutenberg/actions/runs/22608569676/job/65506086536

## Summary

- Replace the `push` trigger with `pull_request_target: [closed, labeled]` to fix a race condition where the workflow couldn't find the PR for a merge commit
- The `push` event lacks PR context, forcing an API lookup via `listPullRequestsAssociatedWithCommit` which has eventual consistency — it often returns no results when the workflow runs immediately after a merge ([example](https://github.com/WordPress/gutenberg/actions/runs/22608569676/job/65506086536))
- The `closed` event fires on merge with the full PR payload, so the PR number, merge commit SHA, and labels are read directly from `context.payload.pull_request` — no API lookups needed

## Test plan

- [ ] Merge a PR with a `Backport to WP X.Y Beta/RC` label and verify the cherry-pick workflow runs successfully
- [ ] Add a `Backport to WP X.Y Beta/RC` label to an already-merged PR and verify the cherry-pick workflow runs successfully
- [ ] Close a PR without merging and verify the workflow is skipped (the `merged == true` condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)