### PR TITLE
DateTimePicker: Fix day text wrapping

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `ToggleGroupControl`: Fix hover styles on disabled items ([#75737](https://github.com/WordPress/gutenberg/pull/75737)).
 -   `FormTokenField`: Fixed incorrect height of input field when rendered on pages using WordPress 7.0 form styles ([#75880](https://github.com/WordPress/gutenberg/pull/75880)).
 -   `SelectControl`: Fixed misalignment of option label on some variants when rendered on pages using WordPress 7.0 form styles ([#75880](https://github.com/WordPress/gutenberg/pull/75880)).
+-   `DateTimePicker`: Fix day text wrapping ([#76084](https://github.com/WordPress/gutenberg/pull/76084)).
 
 ### Enhancements
 

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -68,6 +68,7 @@ export const DayButton = styled( Button, {
 	grid-column: ${ ( props ) => props.column };
 	position: relative;
 	justify-content: center;
+	padding: 0;
 
 	${ ( props ) =>
 		props.disabled &&


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/76071#issuecomment-3990785933

## What?

The addition of `word-break: break-word` to the `Button` component caused unintended wrapping in the `DateTimePicker` component.

The text was probably already overflowing, and `word-break: break-word` just exposed the problem. 

## Why?

I suspect the text had already been overflowing before, and `word-break: break-word` seemed to expose the issue.

## How?
The padding isn't necessary in the first place, so we'll remove it.

## Testing Instructions

- Open a new post
- Open thi sidebar and open the publish popover


## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|<img width="354" height="509" alt="image" src="https://github.com/user-attachments/assets/13214925-8abc-43ba-808c-33d884baee19" /> | <img width="360" height="501" alt="image" src="https://github.com/user-attachments/assets/74314440-252f-4255-a478-9bd4ab7c4948" /> | 