### PR TITLE
Block Bindings: Add `enum` support

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -50,10 +50,10 @@ export default function BlockBindingsAttributeControl( {
 				getBlockType,
 			} = unlock( select( blocksStore ) );
 
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
+			const _attribute =
+				getBlockType( blockName ).attributes?.[ attribute ];
 			const attributeType =
-				_attributeType === 'rich-text' ? 'string' : _attributeType;
+				_attribute?.type === 'rich-text' ? 'string' : _attribute?.type;
 
 			const sourceFields = {};
 			Object.entries( getAllBlockBindingsSources() ).forEach(
@@ -66,7 +66,17 @@ export default function BlockBindingsAttributeControl( {
 						return;
 					}
 					const compatibleFieldsList = fieldsList.filter(
-						( field ) => field.type === attributeType
+						( field ) => {
+							if ( field.type !== attributeType ) {
+								return false;
+							}
+							if ( _attribute?.enum ) {
+								return field?.enum?.every( ( item ) =>
+									_attribute.enum.includes( item )
+								);
+							}
+							return true;
+						}
 					);
 					if ( compatibleFieldsList.length ) {
 						sourceFields[ sourceName ] = compatibleFieldsList;

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -38,6 +38,12 @@ function gutenberg_test_block_bindings_registration() {
 			'value' => 10.5,
 			'type'  => 'number',
 		),
+		'text_field_with_enum' => array(
+			'label' => 'Text Field with Enum Label',
+			'value' => '🌈',
+			'type'  => 'string',
+			'enum'  => array( '⭐', '❤️', '🌈' ),
+		),
 	);
 
 	// Enqueue a custom script for the plugin.

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -18,22 +18,22 @@ function gutenberg_test_block_bindings_registration() {
 	$upload_dir  = wp_upload_dir();
 	$testing_url = $upload_dir['url'] . '/1024x768_e2e_test_image_size.jpeg';
 	$fields_list = array(
-		'text_field'          => array(
+		'text_field'           => array(
 			'label' => 'Text Field Label',
 			'value' => 'Text Field Value',
 			'type'  => 'string',
 		),
-		'url_field'           => array(
+		'url_field'            => array(
 			'label' => 'URL Field Label',
 			'value' => $testing_url,
 			'type'  => 'string',
 		),
-		'empty_field'         => array(
+		'empty_field'          => array(
 			'label' => 'Empty Field Label',
 			'value' => '',
 			'type'  => 'string',
 		),
-		'number_custom_field' => array(
+		'number_custom_field'  => array(
 			'label' => 'Number Custom Field Label',
 			'value' => 10.5,
 			'type'  => 'number',

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -33,6 +33,7 @@ registerBlockBindingsSource( {
 		return Object.entries( fieldsList || {} ).map( ( [ key, field ] ) => ( {
 			label: field.label || key,
 			type: field.type || 'string',
+			enum: field.enum,
 			args: field.args || { key },
 		} ) );
 	},

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -91,7 +91,7 @@ add_action(
 		add_filter(
 			'block_bindings_supported_attributes_test/auto-register-with-controls',
 			static function () {
-				return array( 'title', 'count', 'spacing', 'showEmojis' );
+				return array( 'title', 'count', 'spacing', 'showEmojis', 'emoji' );
 			}
 		);
 

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -303,6 +303,10 @@ test.describe( 'PHP-only auto-register blocks', () => {
 								source: 'core/post-meta',
 								args: { key: 'boolean' },
 							},
+							emoji: {
+								source: 'testing/complete-source',
+								args: { key: 'text_field_with_enum' },
+							},
 						},
 					},
 				},
@@ -318,6 +322,9 @@ test.describe( 'PHP-only auto-register blocks', () => {
 			await expect( page.getByLabel( 'Count' ) ).toHaveValue( '3' );
 			await expect( page.getByLabel( 'Spacing' ) ).toHaveValue( '0.5' );
 			await expect( page.getByLabel( 'Show Emojis' ) ).toBeChecked();
+			await expect(
+				page.getByLabel( 'Emoji', { exact: true } )
+			).toHaveValue( '🌈' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
Introduce an optional `enum` field in the return value of Block Bindings source's `getFieldsList()` function, and use it to filter source fields by attribute compatibility.

Fixes an issue found during discussion on https://github.com/WordPress/gutenberg/pull/75543. Follow-up to https://github.com/WordPress/gutenberg/pull/76040.

## Why?
Prior to this PR, it was possible to bind an `enum`-constrained block attribute to an unconstrained Block Bindings source, which can lead to the attribute taking on a value that it's not permitted.

## How?
By ensuring that `enum`-constrained block attributes can only be bound to a Block Bindings source if the latter is also constrained by an `enum` whose values are all included in the block attribute's.

## Testing Instructions

- Use wp-env's test environment (start by running `npm run wp-env-test`).
- At the test instance (found at `localhost:8889`), activate the "Gutenberg Test Block Bindings" and "Gutenberg Test Server-Side Rendered Block" plugins.
- Create a new post. Insert the "Auto Register With Controls" block.
- In the block inspector's Attributes panel, verify that it's possible to connect the `emoji` attribute to the "Complete Source"'s "Text Field with Enum label" item.
- Verify that after connecting, the block attribute controls in the sidebar show the correct bound 🌈 value (rather than the default ⭐ ).
- Also verify that these settings are reflected by the block itself (i.e. in the editor canvas).

## Screenshots or screencast

<img width="707" height="297" alt="image" src="https://github.com/user-attachments/assets/8178dd23-0792-409d-8320-5170d185366a" />

## Tradeoffs / Alternatives considered

This introduces `enum` support for Block Bindings sources as part of a bugfix, where it's used solely for test data. None of the Block Bindings sources included with Gutenberg right now (`core/post-meta`, `core/post-data`, `core/term-data`) currently have any fields to which `enum` support could be added. While a plausible enhancement, this means that there's currently no demonstrable real-world usage within Core and GB.

An alternative -- at least for the time being -- would be to exempt `enum`-constrained block attributes from Block Bindings support altogether (instead of introducing `enum` support for Block Bindings source items):

```diff
diff --git a/packages/block-editor/src/components/block-bindings/attribute-control.js b/packages/block-editor/src/components/block-bindings/attribute-control.js
index b92ae3abbfe..62c1bbf901b 100644
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -50,10 +50,15 @@ export default function BlockBindingsAttributeControl( {
                                getBlockType,
                        } = unlock( select( blocksStore ) );
 
-                       const _attributeType =
-                               getBlockType( blockName ).attributes?.[ attribute ]?.type;
+                       const _attribute =
+                               getBlockType( blockName ).attributes?.[ attribute ];
+
+                       if ( _attribute?.enum ) {
+                               return {};
+                       }
+
                        const attributeType =
-                               _attributeType === 'rich-text' ? 'string' : _attributeType;
+                               _attribute?.type === 'rich-text' ? 'string' : _attribute?.type;
 
                        const sourceFields = {};
                        Object.entries( getAllBlockBindingsSources() ).forEach(
diff --git a/packages/e2e-tests/plugins/server-side-rendered-block.php b/packages/e2e-tests/plugins/server-side-rendered-block.php
index 29962e90798..28dc70af756 100644
--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -91,7 +91,7 @@ add_action(
                add_filter(
                        'block_bindings_supported_attributes_test/auto-register-with-controls',
                        static function () {
-                               return array( 'title', 'count', 'spacing', 'showEmojis' );
+                               return array( 'title', 'count', 'spacing', 'showEmojis', 'emoji' );
                        }
                );
 
```

