### PR TITLE
Extract inserter-toggle mixin from duplicated button styles

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -668,9 +668,13 @@
 }
 
 @mixin inserter-toggle() {
+	// Basic look
 	background: colors.$gray-900;
 	color: colors.$white;
 	padding: 0;
+
+	// TODO: Consider passing size="small" to the Inserter toggle instead.
+	// Special dimensions for this button.
 	min-width: variables.$button-size-small;
 	height: variables.$button-size-small;
 

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -667,6 +667,19 @@
 	}
 }
 
+@mixin inserter-toggle() {
+	background: colors.$gray-900;
+	color: colors.$white;
+	padding: 0;
+	min-width: variables.$button-size-small;
+	height: variables.$button-size-small;
+
+	&:hover {
+		color: colors.$white;
+		background: var(--wp-admin-theme-color);
+	}
+}
+
 @mixin selected-block-outline($widthRatio: 1) {
 	outline-color: var(--wp-admin-theme-color);
 	outline-style: solid;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -76,20 +76,7 @@
 .block-editor-block-list__empty-block-inserter,
 .block-editor-block-list__insertion-point-inserter {
 	.block-editor-inserter__toggle.components-button.has-icon {
-		// Basic look
-		background: $gray-900;
-		color: $white;
-		padding: 0;
-
-		// TODO: Consider passing size="small" to the Inserter toggle instead.
-		// Special dimensions for this button.
-		min-width: $button-size-small;
-		height: $button-size-small;
-
-		&:hover {
-			color: $white;
-			background: var(--wp-admin-theme-color);
-		}
+		@include inserter-toggle;
 	}
 }
 

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
@@ -41,20 +42,7 @@
 	}
 
 	.block-editor-inserter__toggle.components-button.has-icon {
-		// Basic look
-		background: $gray-900;
-		color: $white;
-		padding: 0;
-
-		// TODO: Consider passing size="small" to the Inserter toggle instead.
-		// Special dimensions for this button.
-		min-width: $button-size-small;
-		height: $button-size-small;
-
-		&:hover {
-			color: $white;
-			background: var(--wp-admin-theme-color);
-		}
+		@include inserter-toggle;
 	}
 }
 
@@ -103,26 +91,16 @@
 	// treating them the same, one or both can be retired.
 	.block-editor-inserter__toggle.components-button.has-icon,
 	.block-list-appender__toggle {
+		@include inserter-toggle;
 		flex-direction: row;
 		box-shadow: none;
-		height: $button-size-small;
 		width: $button-size-small;
-		min-width: $button-size-small;
 
 		// Hide by default, then we unhide it when the selected block is a direct ancestor.
 		display: none;
 
 		// Important to override styles form Button component.
 		padding: 0 !important;
-
-		// Basic look
-		background: $gray-900;
-		color: $white;
-
-		&:hover {
-			color: $white;
-			background: var(--wp-admin-theme-color);
-		}
 	}
 
 	// This content only shows up inside the empty appender.


### PR DESCRIPTION
## What?

Extracts the dark inserter toggle button styles into a shared `inserter-toggle` mixin in `packages/base-styles/_mixins.scss`.

## Why?

The same button appearance rules (dark background, white icon, 24px size, theme-color hover) were duplicated across three SCSS files:
- `default-block-appender/content.scss` (2 occurrences)
- `block-tools/style.scss` (1 occurrence)

This duplication makes it easy for the styles to drift apart and harder to maintain. A shared mixin ensures consistency. This will also make it easier to have consistent styles in https://github.com/WordPress/gutenberg/pull/75674/

## How?

- Added `@mixin inserter-toggle()` to `packages/base-styles/_mixins.scss` containing the common rules: `background`, `color`, `padding`, `min-width`, `height`, and `:hover` state.
- Replaced inline styles in `content.scss` and `style.scss` with `@include inserter-toggle`, keeping any site-specific overrides (e.g. `display: none`, `flex-direction`, `width`).
- Added `@use` import for mixins in `content.scss` (already present in `style.scss`).

## Testing Instructions

1. Open the editor and verify the "+" inserter buttons look the same as before:
   - The black "+" at the end of the canvas (after the last block)
   - The "+" on the right of empty paragraph blocks
   - The "+" inside nesting containers (e.g. Group, Columns)
   - The blue "+" between blocks (inbetweenserter)
2. Hover over each — should change to the admin theme color (blue by default)