### PR TITLE
Image block: fix lightbox srcset size

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -218,7 +218,9 @@ function block_core_image_render_lightbox( $block_content, $block, $block_instan
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
-		$img_srcset       = wp_get_attachment_image_srcset( $block['attrs']['id'] );
+		$has_dimensions   = ( $img_metadata['width'] ?? '' ) && ( $img_metadata['height'] ?? '' );
+		$srcset_size      = $has_dimensions ? array( $img_metadata['width'], $img_metadata['height'] ) : 'large';
+		$img_srcset       = wp_get_attachment_image_srcset( $block['attrs']['id'], $srcset_size );
 		$img_width        = $img_metadata['width'] ?? 'none';
 		$img_height       = $img_metadata['height'] ?? 'none';
 	}


### PR DESCRIPTION
## What?

The image block currently generates the lightbox `srcset` without specifying a `$size` parameter to `wp_get_attachment_image_srcset`. This means that the `$size` parameter defaults to `'medium'`, per the method signature.

This PR changes that, to specify a larger size.

## Why?

Some systems, like WordPress.com, rely on the `$size` parameter to determine the range of sizes to include in the `srcset`, to avoid including excessively large ones. In this case, since we're talking about a lightbox, the size that we're defaulting to (`'medium'`) is not adequate, which leads to blurry images being shown, due to a lack of higher resolution options in the resulting `srcset`.

## How?

This PR passes in an array with the image dimensions, when the image size is known. This ensures that the image can get displayed at the best possible resolution in the lightbox.

When the image size is unknown, it defaults to `'large'` instead.

## Testing Instructions

- Create an image block with a very large image attachment (above 2000px wide, if possible)
- Click the image to open the lightbox
- Analyse the `srcset` on the image in the lightbox
- Ensure that it includes large enough versions of the image

### Testing Instructions for Keyboard

See the above instructions, but instead of clicking the image to open the lightbox, move focus to the image and hit the spacebar instead.