### PR TITLE
Playlist: Fix tag sanitization in track metadata

### DIFF
--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -28,6 +28,8 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
@@ -371,8 +373,16 @@ const PlaylistEdit = ( {
 				<Disabled isDisabled={ ! isSelected }>
 					<WaveformPlayer
 						src={ currentTrackData?.src }
-						title={ currentTrackData?.title }
-						artist={ currentTrackData?.artist }
+						title={ decodeEntities(
+							stripHTML(
+								currentTrackData?.title ?? ''
+							)
+						) }
+						artist={ decodeEntities(
+							stripHTML(
+								currentTrackData?.artist ?? ''
+							)
+						) }
 						image={ currentTrackData?.image }
 						onEnded={ onTrackEnded }
 					/>

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -28,6 +28,7 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
@@ -373,10 +374,14 @@ const PlaylistEdit = ( {
 					<WaveformPlayer
 						src={ currentTrackData?.src }
 						title={ decodeEntities(
-							currentTrackData?.title
+							stripHTML(
+								currentTrackData?.title ?? ''
+							)
 						) }
 						artist={ decodeEntities(
-							currentTrackData?.artist
+							stripHTML(
+								currentTrackData?.artist ?? ''
+							)
 						) }
 						image={ currentTrackData?.image }
 						onEnded={ onTrackEnded }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -28,7 +28,6 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
@@ -374,14 +373,10 @@ const PlaylistEdit = ( {
 					<WaveformPlayer
 						src={ currentTrackData?.src }
 						title={ decodeEntities(
-							stripHTML(
-								currentTrackData?.title ?? ''
-							)
+							currentTrackData?.title
 						) }
 						artist={ decodeEntities(
-							stripHTML(
-								currentTrackData?.artist ?? ''
-							)
+							currentTrackData?.artist
 						) }
 						image={ currentTrackData?.image }
 						onEnded={ onTrackEnded }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -374,14 +374,10 @@ const PlaylistEdit = ( {
 					<WaveformPlayer
 						src={ currentTrackData?.src }
 						title={ decodeEntities(
-							stripHTML(
-								currentTrackData?.title ?? ''
-							)
+							stripHTML( currentTrackData?.title ?? '' )
 						) }
 						artist={ decodeEntities(
-							stripHTML(
-								currentTrackData?.artist ?? ''
-							)
+							stripHTML( currentTrackData?.artist ?? '' )
 						) }
 						image={ currentTrackData?.image }
 						onEnded={ onTrackEnded }

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -59,16 +59,16 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 				}
 
 				// Data is passed to wp_interactivity_state() which JSON-encodes it.
-				// We use wp_kses() to strip HTML tags safely (preserving non-tag
-				// characters like </>), then wp_specialchars_decode() to convert
-				// any entities back to plain text for JSON encoding.
+				// Block attributes are already sanitized via serializeAttributes()
+				// and wp_pre_kses_block_attributes(), so entities are already
+				// encoded. We decode them back to plain text for JSON encoding.
 				$tracks_data[ $unique_id ] = array(
 					'url'       => esc_url( $url ),
-					'title'     => wp_specialchars_decode( wp_kses( $title, array() ) ),
-					'artist'    => wp_specialchars_decode( wp_kses( $artist, array() ) ),
-					'album'     => wp_specialchars_decode( wp_kses( $album, array() ) ),
+					'title'     => wp_specialchars_decode( $title ),
+					'artist'    => wp_specialchars_decode( $artist ),
+					'album'     => wp_specialchars_decode( $album ),
 					'image'     => esc_url( $image ),
-					'ariaLabel' => wp_specialchars_decode( wp_kses( $aria_label, array() ) ),
+					'ariaLabel' => wp_specialchars_decode( $aria_label ),
 				);
 
 				if ( $unique_id === $current_media_id ) {

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -58,16 +58,17 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 					);
 				}
 
-				// Data is passed to wp_interactivity_state() which JSON-encodes it,
-				// so we use wp_strip_all_tags() instead of esc_html() to prevent
-				// HTML injection without double-encoding. URLs still use esc_url().
+				// Data is passed to wp_interactivity_state() which JSON-encodes it.
+				// We use wp_kses() to strip HTML tags safely (preserving non-tag
+				// characters like </>), then wp_specialchars_decode() to convert
+				// any entities back to plain text for JSON encoding.
 				$tracks_data[ $unique_id ] = array(
 					'url'       => esc_url( $url ),
-					'title'     => wp_strip_all_tags( $title ),
-					'artist'    => wp_strip_all_tags( $artist ),
-					'album'     => wp_strip_all_tags( $album ),
+					'title'     => wp_specialchars_decode( wp_kses( $title, array() ) ),
+					'artist'    => wp_specialchars_decode( wp_kses( $artist, array() ) ),
+					'album'     => wp_specialchars_decode( wp_kses( $album, array() ) ),
 					'image'     => esc_url( $image ),
-					'ariaLabel' => wp_strip_all_tags( $aria_label ),
+					'ariaLabel' => wp_specialchars_decode( wp_kses( $aria_label, array() ) ),
 				);
 
 				if ( $unique_id === $current_media_id ) {


### PR DESCRIPTION
## What?

Fixes how track metadata (title, artist, album) is sanitized in the playlist block, both in the PHP render and in the editor's waveform player.

## Why?

This addresses two issues raised in review:

1. **Redundant `wp_kses()` in PHP render** ([review by @ramonjd](https://github.com/WordPress/gutenberg/pull/76093#discussion_r2109842955)): Block attributes are already sanitized via `serializeAttributes()` (which escapes `<`, `>`, `&`) and `wp_pre_kses_block_attributes()` before database storage. By the time we reach the render function, entities are already encoded, making `wp_kses($title, array())` a no-op.

2. **Encoded entities and raw HTML tags in editor waveform player**: The `<WaveformPlayer>` component was displaying entity-encoded text (e.g., `&amp;` instead of `&`) and not stripping HTML tags from titles containing markup like `<style>` or `<script>`.

## How?

**PHP (`index.php`)**:
- Removed redundant `wp_kses()` wrapper — kept only `wp_specialchars_decode()` to convert entities back to plain text for JSON encoding via `wp_interactivity_state()`.

**JS (`edit.js`)**:
- Added `stripHTML()` (from `@wordpress/dom`) to remove any HTML tags from the title/artist before display in the waveform player. Although the RichText fields use `allowedFormats={ [] }`, attributes could still contain HTML from other sources (Code Editor, REST API, media metadata). This matches the pattern already used in `playlist-track/edit.js` for the settings panel fields.
- Added `decodeEntities()` (from `@wordpress/html-entities`) to decode entity-encoded characters so they display correctly.

## Testing Instructions

1. Create a playlist block with tracks
2. Edit a track title to contain special characters and HTML tags, e.g.:
   `Let me in - "Test" && < && ><style>background; red; </style><script>alert('hacked');</script>!@#$%^&*()`
3. **In the editor**: Verify the waveform player title shows the text without HTML tags and with special characters displayed correctly (not encoded)
4. **On the frontend**: Verify the track title displays correctly with special characters preserved


🤖 Generated with [Claude Code](https://claude.com/claude-code)