### PR TITLE
Playlist: Fix duplicate tracks and enable track selection in editor

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -7,8 +7,9 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
-import { useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {
+	store as blockEditorStore,
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	MediaUpload,
@@ -26,7 +27,7 @@ import {
 	BaseControl,
 	Spinner,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
@@ -40,7 +41,13 @@ import { useUploadMediaFromBlobURL } from '../utils/hooks';
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const ALBUM_COVER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
-const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
+const PlaylistTrackEdit = ( {
+	attributes,
+	setAttributes,
+	context,
+	clientId,
+	isSelected,
+} ) => {
 	// Note that 'id' is the media attachment ID, while 'uniqueId' is a unique identifier.
 	// This is to make sure that the same media can be used in more than one track.
 	const { id, uniqueId, src, album, artist, image, length, title } =
@@ -51,6 +58,27 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 	const imageButton = useRef();
 	const blockProps = useBlockProps();
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	// Find the parent playlist block.
+	const parentPlaylistId = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockParentsByBlockName(
+				clientId,
+				'core/playlist'
+			)[ 0 ],
+		[ clientId ]
+	);
+
+	// When this track is selected, make it the current track in the parent playlist.
+	useEffect( () => {
+		if ( isSelected && uniqueId && parentPlaylistId ) {
+			updateBlockAttributes( parentPlaylistId, {
+				currentTrack: uniqueId,
+			} );
+		}
+	}, [ isSelected, uniqueId, parentPlaylistId, updateBlockAttributes ] );
+
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -370,6 +370,7 @@ const PlaylistEdit = ( {
 			<figure { ...blockProps }>
 				<Disabled isDisabled={ ! isSelected }>
 					<WaveformPlayer
+						key={ currentTrack }
 						src={ currentTrackData?.src }
 						title={ currentTrackData?.title }
 						artist={ currentTrackData?.artist }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -7,7 +7,7 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	MediaPlaceholder,
@@ -57,6 +57,15 @@ const PlaylistEdit = ( {
 		showArtists,
 		currentTrack,
 	} = attributes;
+	// Track whether the player has initialized so we can autoplay on
+	// subsequent track changes (but not on the initial load).
+	const hasInitializedRef = useRef( false );
+	useEffect( () => {
+		if ( currentTrack ) {
+			hasInitializedRef.current = true;
+		}
+	}, [ currentTrack ] );
+
 	const blockProps = useBlockProps();
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -119,9 +128,9 @@ const PlaylistEdit = ( {
 				updateBlockAttributes( clientId, { currentTrack: null } );
 			}
 		} else if (
-			// If the currentTrack is not the first track, update it to the first track.
-			firstTrackId &&
-			firstTrackId !== currentTrack
+			// Only set to first track if current track is unset or no longer exists.
+			! currentTrack ||
+			! tracks.some( ( t ) => t.uniqueId === currentTrack )
 		) {
 			updateBlockAttributes( clientId, { currentTrack: firstTrackId } );
 		}
@@ -368,7 +377,7 @@ const PlaylistEdit = ( {
 				</ToolsPanel>
 			</InspectorControls>
 			<figure { ...blockProps }>
-				<Disabled isDisabled={ ! isSelected }>
+				<Disabled isDisabled={ ! hasAnySelected }>
 					<WaveformPlayer
 						key={ currentTrack }
 						src={ currentTrackData?.src }
@@ -376,6 +385,7 @@ const PlaylistEdit = ( {
 						artist={ currentTrackData?.artist }
 						image={ currentTrackData?.image }
 						onEnded={ onTrackEnded }
+						autoPlay={ hasInitializedRef.current }
 					/>
 				</Disabled>
 				{ showTracklist && (

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -48,8 +48,11 @@ const { state } = store(
 
 				const existing = playerState.get( ref );
 
-				// Skip if we already initialized with this exact URL.
-				if ( existing?.url === track.url ) {
+				// Skip if we already initialized with this exact URL and track.
+				if (
+					existing?.url === track.url &&
+					existing?.currentId === context.currentId
+				) {
 					return;
 				}
 
@@ -83,6 +86,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 			} )
 			.then( () => {
 				existing.url = track.url;
+				existing.currentId = context.currentId;
 				if ( shouldAutoPlay ) {
 					existing.instance.play()?.catch( logPlayError );
 				}
@@ -120,6 +124,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 	// Store state for cleanup, including instance for loadTrack reuse.
 	playerState.set( ref, {
 		url: track.url,
+		currentId: context.currentId,
 		instance: player.instance,
 		destroy: player.destroy,
 	} );

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -48,7 +48,7 @@ const { state } = store(
 
 				const existing = playerState.get( ref );
 
-				// Skip if we already initialized with this exact URL and track.
+				// Skip if we already initialized with this exact URL and track ID.
 				if (
 					existing?.url === track.url &&
 					existing?.currentId === context.currentId

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -15,15 +15,23 @@ import { initWaveformPlayer } from './waveform-utils';
  * Renders an audio waveform visualization with play/pause controls.
  * Automatically inherits colors from the parent block's text color.
  *
- * @param {Object}   props         - Component props.
- * @param {string}   props.src     - The audio file URL.
- * @param {string}   props.title   - The track title.
- * @param {string}   props.artist  - The artist name.
- * @param {string}   props.image   - The artwork image URL.
- * @param {Function} props.onEnded - Callback when the track finishes playing.
+ * @param {Object}   props          - Component props.
+ * @param {string}   props.src      - The audio file URL.
+ * @param {string}   props.title    - The track title.
+ * @param {string}   props.artist   - The artist name.
+ * @param {string}   props.image    - The artwork image URL.
+ * @param {Function} props.onEnded  - Callback when the track finishes playing.
+ * @param {boolean}  props.autoPlay - Whether to auto-play on initialization.
  * @return {Element} The WaveformPlayer element.
  */
-export function WaveformPlayer( { src, title, artist, image, onEnded } ) {
+export function WaveformPlayer( {
+	src,
+	title,
+	artist,
+	image,
+	onEnded,
+	autoPlay,
+} ) {
 	// Store onEnded in a ref so it doesn't need to be a useRefEffect dependency.
 	// The callback changes reference on every render (its dependency chain
 	// includes an unstable array), which would cause useRefEffect to destroy
@@ -50,6 +58,7 @@ export function WaveformPlayer( { src, title, artist, image, onEnded } ) {
 					title,
 					artist,
 					image,
+					autoPlay,
 					onEnded: () => onEndedRef.current?.(),
 				} );
 				playerDestroy = destroy;
@@ -70,7 +79,7 @@ export function WaveformPlayer( { src, title, artist, image, onEnded } ) {
 				playerDestroy?.();
 			};
 		},
-		[ src, title, artist, image ]
+		[ src, title, artist, image, autoPlay ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -15,13 +15,12 @@ import { initWaveformPlayer } from './waveform-utils';
  * Renders an audio waveform visualization with play/pause controls.
  * Automatically inherits colors from the parent block's text color.
  *
- * @param {Object}   props          - Component props.
- * @param {string}   props.src      - The audio file URL.
- * @param {string}   props.title    - The track title.
- * @param {string}   props.artist   - The artist name.
- * @param {string}   props.image    - The artwork image URL.
- * @param {Function} props.onEnded  - Callback when the track finishes playing.
- * @param {boolean}  props.autoPlay - Whether to auto-play on initialization.
+ * @param {Object}   props         - Component props.
+ * @param {string}   props.src     - The audio file URL.
+ * @param {string}   props.title   - The track title.
+ * @param {string}   props.artist  - The artist name.
+ * @param {string}   props.image   - The artwork image URL.
+ * @param {Function} props.onEnded - Callback when the track finishes playing.
  * @return {Element} The WaveformPlayer element.
  */
 export function WaveformPlayer( {
@@ -39,6 +38,12 @@ export function WaveformPlayer( {
 	// during editor resizes.
 	const onEndedRef = useRef( onEnded );
 	onEndedRef.current = onEnded;
+
+	// Store autoPlay in a ref so it can be read during init without being
+	// a useRefEffect dependency. The component is remounted via key={currentTrack}
+	// when the track changes, so the value is always correct at mount time.
+	const autoPlayRef = useRef( autoPlay );
+	autoPlayRef.current = autoPlay;
 
 	const ref = useRefEffect(
 		( element ) => {
@@ -58,7 +63,7 @@ export function WaveformPlayer( {
 					title,
 					artist,
 					image,
-					autoPlay,
+					autoPlay: autoPlayRef.current,
 					onEnded: () => onEndedRef.current?.(),
 				} );
 				playerDestroy = destroy;
@@ -79,7 +84,7 @@ export function WaveformPlayer( {
 				playerDestroy?.();
 			};
 		},
-		[ src, title, artist, image, autoPlay ]
+		[ src, title, artist, image ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;


### PR DESCRIPTION
## Summary

Two related improvements to the playlist block's track playback:

### 1. Fix duplicate audio track playback
Adding the same audio file multiple times to a playlist caused duplicate entries to share the same player instance instead of playing separately.

- **Editor (edit.js)**: Added `key={ currentTrack }` to `<WaveformPlayer>` so React forces a full unmount/remount when the selected track changes, even when two tracks have identical props.
- **Frontend (view.js)**: The player state cache now tracks `currentId` alongside `url`. The skip-initialization check verifies both URL and track ID match before returning early.

### 2. Play selected track in the editor
Clicking a track in the tracklist now switches the waveform player to that track and auto-plays it.

- **playlist-track/edit.js**: When a track block is selected, it finds the parent playlist via `getBlockParentsByBlockName` and updates its `currentTrack` attribute.
- **playlist/edit.js**: Fixed the `useEffect` that previously always reset `currentTrack` to the first track — now only resets when the current track is unset or deleted. Changed the `Disabled` wrapper to keep the player interactive when a child block is selected. Added `autoPlay` support so the player starts on track switch (but not on initial load).
- **utils/waveform-player.js**: `autoPlay` is stored in a ref (same pattern as `onEnded`) and forwarded to `initWaveformPlayer`.

Addresses review feedback from @tyxla on #75203:
- https://github.com/WordPress/gutenberg/pull/75203#discussion_r2864555842
- https://github.com/WordPress/gutenberg/pull/75203#discussion_r2864572186

## Test plan

- [ ] Add the same audio file to a playlist multiple times — each entry should play independently
- [ ] Click a track in the tracklist — the waveform player should switch to it and auto-play
- [ ] Verify the first track loads on initial render without auto-playing
- [ ] Verify the player controls (play/pause) work when a child track block is selected
- [ ] Verify track-ended advances to the next track and auto-plays it
- [ ] Test on the frontend: switching between duplicate tracks works correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)