### PR TITLE
Playlist: Add repeat toggle

### DIFF
--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -37,6 +37,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"repeat": {
+			"type": "boolean",
+			"default": false
+		},
 		"caption": {
 			"type": "string"
 		}

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -88,6 +88,7 @@ const PlaylistEdit = ( {
 		showImages,
 		showArtists,
 		currentTrack,
+		repeat,
 	} = attributes;
 	const blockProps = useBlockProps();
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
@@ -201,16 +202,17 @@ const PlaylistEdit = ( {
 		( track ) => track.uniqueId === currentTrack
 	);
 
-	// Handle track end - advance to next track or loop to first.
+	// Handle track end - advance to next track, or loop to first if repeat is enabled.
 	const onTrackEnded = useCallback( () => {
 		const currentIndex = tracks.findIndex(
 			( track ) => track.uniqueId === currentTrack
 		);
-		const nextTrack = tracks[ currentIndex + 1 ] || tracks[ 0 ];
+		const nextTrack =
+			tracks[ currentIndex + 1 ] || ( repeat ? tracks[ 0 ] : null );
 		if ( nextTrack?.uniqueId ) {
 			setAttributes( { currentTrack: nextTrack.uniqueId } );
 		}
-	}, [ currentTrack, tracks, setAttributes ] );
+	}, [ currentTrack, tracks, repeat, setAttributes ] );
 
 	const onChangeOrder = useCallback(
 		( trackOrder ) => {
@@ -310,6 +312,7 @@ const PlaylistEdit = ( {
 							showNumbers: true,
 							showImages: true,
 							order: 'asc',
+							repeat: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -395,6 +398,20 @@ const PlaylistEdit = ( {
 								{ label: __( 'Ascending' ), value: 'asc' },
 							] }
 							onChange={ ( value ) => onChangeOrder( value ) }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Repeat' ) }
+						isShownByDefault
+						hasValue={ () => repeat !== false }
+						onDeselect={ () =>
+							setAttributes( { repeat: false } )
+						}
+					>
+						<ToggleControl
+							label={ __( 'Repeat' ) }
+							onChange={ toggleAttribute( 'repeat' ) }
+							checked={ repeat }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -125,6 +125,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 				'playlistId' => $playlist_id,
 				'currentId'  => $current_unique_id,
 				'tracks'     => $playlist_tracks,
+				'repeat'     => ! empty( $attributes['repeat'] ),
 			)
 		)
 	);

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -110,7 +110,9 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 			const currentIndex = context.tracks.findIndex(
 				( uniqueId ) => uniqueId === context.currentId
 			);
-			const nextTrack = context.tracks[ currentIndex + 1 ];
+			const nextTrack =
+				context.tracks[ currentIndex + 1 ] ||
+				( context.repeat ? context.tracks[ 0 ] : null );
 			if ( nextTrack ) {
 				context.currentId = nextTrack;
 			}


### PR DESCRIPTION
## Summary

Add a `repeat` attribute to the playlist block that controls whether the playlist loops back to the first track after the last track ends.

This addresses a review comment from @tyxla on #75203:
https://github.com/WordPress/gutenberg/pull/75203#discussion_r2864576270

> No repeat by default? Not for this PR, but we'll likely want controls for repeat/shuffle at some point.

## Problem

Previously, the playlist block had inconsistent end-of-playlist behavior:
- **Editor** (`edit.js`): Always looped back to the first track
- **Frontend** (`view.js`): Stopped after the last track (no looping)

## Changes

- Added a `repeat` boolean attribute (default: `false`) to `block.json`
- Updated `edit.js` to respect the `repeat` attribute in the `onTrackEnded` callback
- Added a "Repeat" toggle in the block's Settings panel (Inspector Controls)
- Updated `index.php` to pass the `repeat` attribute to the frontend via `data-wp-context`
- Updated `view.js` to respect the `repeat` context value in the `onEnded` callback

## Behavior

- **Repeat off (default)**: Playback stops after the last track on both editor and frontend
- **Repeat on**: Playback loops back to the first track after the last track ends

## Test plan

- [ ] Add a playlist block with multiple tracks
- [ ] Verify that with repeat off (default), playback stops after the last track
- [ ] Enable the "Repeat" toggle in the Settings panel
- [ ] Verify that with repeat on, playback loops back to the first track
- [ ] Verify the repeat setting persists after saving and reloading
- [ ] Verify the frontend respects the repeat setting
- [ ] Verify "Reset all" in the Settings panel resets repeat to off

🤖 Generated with [Claude Code](https://claude.com/claude-code)