### PR TITLE
Playlist: Move getTrackAttributes to utils

### DIFF
--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -38,41 +38,9 @@ import { createBlock } from '@wordpress/blocks';
 import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
+import { getTrackAttributes } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
-
-/**
- * Transform media library data into track block attributes.
- *
- * @param {Object} media - Media object from the media library.
- * @return {Object} Track attributes for the playlist-track block.
- */
-function getTrackAttributes( media ) {
-	return {
-		id: media.id || media.url, // Attachment ID or URL.
-		uniqueId: uuid(), // Unique ID for the track.
-		src: media.url,
-		title: media.title,
-		artist:
-			media.artist ||
-			media?.meta?.artist ||
-			media?.media_details?.artist ||
-			__( 'Unknown artist' ),
-		album:
-			media.album ||
-			media?.meta?.album ||
-			media?.media_details?.album ||
-			__( 'Unknown album' ),
-		length: media?.fileLength || media?.media_details?.length_formatted,
-		// Prevent using the default media attachment icon as the track image.
-		// Note: Image is not available when a new track is uploaded.
-		image:
-			media?.image?.src &&
-			media?.image?.src.endsWith( '/images/media/audio.svg' )
-				? ''
-				: media?.image?.src,
-	};
-}
 
 const PlaylistEdit = ( {
 	attributes,
@@ -434,4 +402,3 @@ const PlaylistEdit = ( {
 };
 
 export default PlaylistEdit;
-export { getTrackAttributes };

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { getTrackAttributes } from '../edit';
+import { getTrackAttributes } from '../utils';
 
 // Mock uuid to return predictable values.
 jest.mock( 'uuid', () => ( {

--- a/packages/block-library/src/playlist/utils.js
+++ b/packages/block-library/src/playlist/utils.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { v4 as uuid } from 'uuid';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Transform media library data into track block attributes.
+ *
+ * @param {Object} media - Media object from the media library.
+ * @return {Object} Track attributes for the playlist-track block.
+ */
+export function getTrackAttributes( media ) {
+	return {
+		id: media.id || media.url, // Attachment ID or URL.
+		uniqueId: uuid(), // Unique ID for the track.
+		src: media.url,
+		title: media.title,
+		artist:
+			media.artist ||
+			media?.meta?.artist ||
+			media?.media_details?.artist ||
+			__( 'Unknown artist' ),
+		album:
+			media.album ||
+			media?.meta?.album ||
+			media?.media_details?.album ||
+			__( 'Unknown album' ),
+		length: media?.fileLength || media?.media_details?.length_formatted,
+		// Prevent using the default media attachment icon as the track image.
+		// Note: Image is not available when a new track is uploaded.
+		image:
+			media?.image?.src &&
+			media?.image?.src.endsWith( '/images/media/audio.svg' )
+				? ''
+				: media?.image?.src,
+	};
+}


### PR DESCRIPTION
## Summary

- Move the `getTrackAttributes` utility function from `edit.js` to a dedicated `utils.js` file in the playlist block directory
- Update the test file import to reference the new location
- Keep `edit.js` focused on component logic rather than exporting standalone utility functions

This addresses a review comment from @tyxla on #75203: ["This feels like an odd one to export from `edit.js`. Should we keep that in a separate file?"](https://github.com/WordPress/gutenberg/pull/75203#discussion_r2864560139)

## Test plan

- [ ] Verify the unit tests in `packages/block-library/src/playlist/test/edit.js` still pass
- [ ] Verify the playlist block functions correctly in the editor (adding tracks, media library integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)