### PR TITLE
Prevent non-reproducible Sass/CSS builds

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -228,6 +228,7 @@ function createStyleBundlingPlugins( workingDir ) {
 		// Handle CSS modules (.module.css and .module.scss)
 		sassPlugin( {
 			embedded: true,
+			sourceMap: false,
 			filter: /\.module\.(css|scss)$/,
 			transform: compileInlineStyle( { cssModules: true } ),
 			type: inlineStyle,
@@ -237,6 +238,7 @@ function createStyleBundlingPlugins( workingDir ) {
 		// Note: .module.css and .module.scss already handled by plugin above
 		sassPlugin( {
 			embedded: true,
+			sourceMap: false,
 			filter: /\.(css|scss)$/,
 			transform: compileInlineStyle(),
 			type: inlineStyle,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This aims to improve the reproducibility of the `build` script in `wp-build` to ensure consistent results regardless of surrounding circumstances that shouldn't impact the script's output.

## Why?
Non-reproducible builds can result in unnecessary code churn and inconsistent build script results, which can make it difficult to validate that build tool-related changes do not have unexpected outcomes.

## How?
This adds `sourceMap: false` to `sassPlugin` calls to prevent scenarios where CSS builds are inconsistent and non-reproducible due to the fact that `esbuild-sass-plugin` uses absolute paths when creating the `sourceMappingURLs` included in generated CSS.

The `wp-build` package creates a hash of each CSS file to serve as a value of the `data-wp-hash` attribute. While `/*# sourceMappingURL=... */` is stripped out of the built CSS files, this is handled by `postcss` after the hash is generated from the file's contents.

Instead of relying on `postcss` to strip source maps out at the end, `sourceMap: false` ensures it's never included. This results in consistent hash generation when the file contents are unchanged regardless of where the repository is cloned or which operating system is being used.

## Testing

- Clone gutenberg twice into two different paths (ie. `gutenberg-one`, `gutenberg-two`.
- Run `npm install && npm run build` in both. 
- Run the following command: `git diff --no-index /path/to/gutenberg-one/build /path/to/gutenberg-two/build`
- Notice the differences in build output despite source files being exactly the same.

Note: ignore the changes in `build/modules/vips/worker.min.js` and `build/modules/vips/worker.min.asset.php`. Those are being addressed separately in 

## AI Disclosure
Claude was used to investigate and find the underlying source of the hash differences.

Related: Core-64393.