### PR TITLE
DataForm: Add customizable button text to panel modal

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Enhancements
 
+- DataForm: Add `applyButtonText` and `cancelButtonText` options to `panel` layout for customizing modal button labels. [#76099](https://github.com/WordPress/gutenberg/pull/76099)
 - Documentation: Update README.md. [#75881](https://github.com/WordPress/gutenberg/pull/75881)
 - DataViews: Adjust column spacing in table layout when no titleField is provided. [#75410](https://github.com/WordPress/gutenberg/pull/75410)
 - DataViews: minimize padding for primary actions. [#75721](https://github.com/WordPress/gutenberg/pull/75721)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Enhancements
 
-- DataForm: Add `applyButtonText` and `cancelButtonText` options to `panel` layout for customizing modal button labels. [#76099](https://github.com/WordPress/gutenberg/pull/76099)
+- DataForm: Add `applyLabel` and `cancelLabel` options to `panel` layout's `openAs` modal config for customizing modal button labels. [#76099](https://github.com/WordPress/gutenberg/pull/76099)
 - Documentation: Update README.md. [#75881](https://github.com/WordPress/gutenberg/pull/75881)
 - DataViews: Adjust column spacing in table layout when no titleField is provided. [#75410](https://github.com/WordPress/gutenberg/pull/75410)
 - DataViews: minimize padding for primary actions. [#75721](https://github.com/WordPress/gutenberg/pull/75721)

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -55,14 +55,22 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			? summary
 			: [ summary ];
 
+		const openAs = layout?.openAs;
+		const modalConfig =
+			typeof openAs === 'object' && openAs.type === 'modal'
+				? openAs
+				: undefined;
+		const resolvedOpenAs: 'dropdown' | 'modal' =
+			modalConfig || openAs === 'modal' ? 'modal' : 'dropdown';
+
 		normalizedLayout = {
 			type: 'panel',
 			labelPosition: layout?.labelPosition ?? 'side',
-			openAs: layout?.openAs ?? 'dropdown',
+			openAs: resolvedOpenAs,
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
-			applyButtonText: layout?.applyButtonText,
-			cancelButtonText: layout?.cancelButtonText,
+			applyLabel: modalConfig?.applyLabel,
+			cancelLabel: modalConfig?.cancelLabel,
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type {
@@ -56,10 +61,22 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			: [ summary ];
 
 		const openAs = layout?.openAs;
-		const normalizedOpenAs: NormalizedPanelLayout[ 'openAs' ] =
-			typeof openAs === 'object'
-				? openAs
-				: { type: openAs ?? 'dropdown' };
+		let normalizedOpenAs: NormalizedPanelLayout[ 'openAs' ];
+		if ( typeof openAs === 'object' && openAs.type === 'modal' ) {
+			normalizedOpenAs = {
+				type: 'modal',
+				applyLabel: openAs.applyLabel?.trim() || __( 'Apply' ),
+				cancelLabel: openAs.cancelLabel?.trim() || __( 'Cancel' ),
+			};
+		} else if ( openAs === 'modal' ) {
+			normalizedOpenAs = {
+				type: 'modal',
+				applyLabel: __( 'Apply' ),
+				cancelLabel: __( 'Cancel' ),
+			};
+		} else {
+			normalizedOpenAs = { type: 'dropdown' };
+		}
 
 		normalizedLayout = {
 			type: 'panel',

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -55,10 +55,16 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			? summary
 			: [ summary ];
 
+		const openAs = layout?.openAs;
+		const normalizedOpenAs: NormalizedPanelLayout[ 'openAs' ] =
+			typeof openAs === 'object'
+				? openAs
+				: { type: openAs ?? 'dropdown' };
+
 		normalizedLayout = {
 			type: 'panel',
 			labelPosition: layout?.labelPosition ?? 'side',
-			openAs: layout?.openAs ?? 'dropdown',
+			openAs: normalizedOpenAs,
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
 		} satisfies NormalizedPanelLayout;

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -61,6 +61,12 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			openAs: layout?.openAs ?? 'dropdown',
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
+			...( layout?.applyButtonText !== undefined && {
+				applyButtonText: layout.applyButtonText,
+			} ),
+			...( layout?.cancelButtonText !== undefined && {
+				cancelButtonText: layout.cancelButtonText,
+			} ),
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -55,22 +55,12 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			? summary
 			: [ summary ];
 
-		const openAs = layout?.openAs;
-		const modalConfig =
-			typeof openAs === 'object' && openAs.type === 'modal'
-				? openAs
-				: undefined;
-		const resolvedOpenAs: 'dropdown' | 'modal' =
-			modalConfig || openAs === 'modal' ? 'modal' : 'dropdown';
-
 		normalizedLayout = {
 			type: 'panel',
 			labelPosition: layout?.labelPosition ?? 'side',
-			openAs: resolvedOpenAs,
+			openAs: layout?.openAs ?? 'dropdown',
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
-			applyLabel: modalConfig?.applyLabel,
-			cancelLabel: modalConfig?.cancelLabel,
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -61,12 +61,8 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			openAs: layout?.openAs ?? 'dropdown',
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
-			...( layout?.applyButtonText !== undefined && {
-				applyButtonText: layout.applyButtonText,
-			} ),
-			...( layout?.cancelButtonText !== undefined && {
-				cancelButtonText: layout.cancelButtonText,
-			} ),
+			applyButtonText: layout?.applyButtonText,
+			cancelButtonText: layout?.cancelButtonText,
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -13,7 +13,7 @@ export default function FormPanelField< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const layout = field.layout as NormalizedPanelLayout;
 
-	if ( layout.openAs !== 'dropdown' ) {
+	if ( layout.openAs.type === 'modal' ) {
 		return (
 			<PanelModal
 				data={ data }

--- a/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/index.tsx
@@ -13,7 +13,7 @@ export default function FormPanelField< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const layout = field.layout as NormalizedPanelLayout;
 
-	if ( layout.openAs === 'modal' ) {
+	if ( layout.openAs !== 'dropdown' ) {
 		return (
 			<PanelModal
 				data={ data }

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -23,6 +23,7 @@ import type {
 	Field,
 	NormalizedForm,
 	NormalizedFormField,
+	NormalizedPanelLayout,
 	FieldLayoutProps,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
@@ -181,8 +182,8 @@ function PanelModal< Item >( {
 		return null;
 	}
 
-	const panelLayout =
-		field.layout.type === 'panel' ? field.layout : undefined;
+	const { openAs } = field.layout as NormalizedPanelLayout;
+	const modalConfig = typeof openAs === 'object' ? openAs : undefined;
 
 	const handleClose = () => {
 		setIsOpen( false );
@@ -210,8 +211,8 @@ function PanelModal< Item >( {
 					fieldLabel={ fieldLabel ?? '' }
 					onClose={ handleClose }
 					touched={ touched }
-					applyLabel={ panelLayout?.applyLabel }
-					cancelLabel={ panelLayout?.cancelLabel }
+					applyLabel={ modalConfig?.applyLabel }
+					cancelLabel={ modalConfig?.cancelLabel }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -11,7 +11,7 @@ import {
 	Button,
 	Modal,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+
 import { useContext, useMemo, useRef, useState } from '@wordpress/element';
 import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
@@ -151,14 +151,14 @@ function ModalContent< Item >( {
 					onClick={ onClose }
 					__next40pxDefaultSize
 				>
-					{ cancelLabel || __( 'Cancel' ) }
+					{ cancelLabel }
 				</Button>
 				<Button
 					variant="primary"
 					onClick={ onApply }
 					__next40pxDefaultSize
 				>
-					{ applyLabel || __( 'Apply' ) }
+					{ applyLabel }
 				</Button>
 			</Stack>
 		</Modal>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -23,7 +23,6 @@ import type {
 	Field,
 	NormalizedForm,
 	NormalizedFormField,
-	NormalizedPanelLayout,
 	FieldLayoutProps,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
@@ -152,14 +151,14 @@ function ModalContent< Item >( {
 					onClick={ onClose }
 					__next40pxDefaultSize
 				>
-					{ cancelButtonText ?? __( 'Cancel' ) }
+					{ cancelButtonText || __( 'Cancel' ) }
 				</Button>
 				<Button
 					variant="primary"
 					onClick={ onApply }
 					__next40pxDefaultSize
 				>
-					{ applyButtonText ?? __( 'Apply' ) }
+					{ applyButtonText || __( 'Apply' ) }
 				</Button>
 			</Stack>
 		</Modal>
@@ -183,9 +182,7 @@ function PanelModal< Item >( {
 	}
 
 	const panelLayout =
-		field.layout.type === 'panel'
-			? ( field.layout as NormalizedPanelLayout )
-			: undefined;
+		field.layout.type === 'panel' ? field.layout : undefined;
 
 	const handleClose = () => {
 		setIsOpen( false );

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -24,6 +24,7 @@ import type {
 	NormalizedForm,
 	NormalizedFormField,
 	NormalizedPanelLayout,
+	PanelOpenAsModal,
 	FieldLayoutProps,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
@@ -41,8 +42,6 @@ function ModalContent< Item >( {
 	fieldLabel,
 	onClose,
 	touched,
-	applyLabel,
-	cancelLabel,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -50,9 +49,9 @@ function ModalContent< Item >( {
 	onClose: () => void;
 	fieldLabel: string;
 	touched: boolean;
-	applyLabel?: string;
-	cancelLabel?: string;
 } ) {
+	const { openAs } = field.layout as NormalizedPanelLayout;
+	const { applyLabel, cancelLabel } = openAs as PanelOpenAsModal;
 	const { fields } = useContext( DataFormContext );
 	const [ changes, setChanges ] = useState< Partial< Item > >( {} );
 	const modalData = useMemo( () => {
@@ -182,9 +181,6 @@ function PanelModal< Item >( {
 		return null;
 	}
 
-	const { openAs } = field.layout as NormalizedPanelLayout;
-	const modalConfig = typeof openAs === 'object' ? openAs : undefined;
-
 	const handleClose = () => {
 		setIsOpen( false );
 		setTouched( true );
@@ -211,8 +207,6 @@ function PanelModal< Item >( {
 					fieldLabel={ fieldLabel ?? '' }
 					onClose={ handleClose }
 					touched={ touched }
-					applyLabel={ modalConfig?.applyLabel }
-					cancelLabel={ modalConfig?.cancelLabel }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -40,8 +40,8 @@ function ModalContent< Item >( {
 	fieldLabel,
 	onClose,
 	touched,
-	applyButtonText,
-	cancelButtonText,
+	applyLabel,
+	cancelLabel,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -49,8 +49,8 @@ function ModalContent< Item >( {
 	onClose: () => void;
 	fieldLabel: string;
 	touched: boolean;
-	applyButtonText?: string;
-	cancelButtonText?: string;
+	applyLabel?: string;
+	cancelLabel?: string;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const [ changes, setChanges ] = useState< Partial< Item > >( {} );
@@ -151,14 +151,14 @@ function ModalContent< Item >( {
 					onClick={ onClose }
 					__next40pxDefaultSize
 				>
-					{ cancelButtonText || __( 'Cancel' ) }
+					{ cancelLabel || __( 'Cancel' ) }
 				</Button>
 				<Button
 					variant="primary"
 					onClick={ onApply }
 					__next40pxDefaultSize
 				>
-					{ applyButtonText || __( 'Apply' ) }
+					{ applyLabel || __( 'Apply' ) }
 				</Button>
 			</Stack>
 		</Modal>
@@ -210,8 +210,8 @@ function PanelModal< Item >( {
 					fieldLabel={ fieldLabel ?? '' }
 					onClose={ handleClose }
 					touched={ touched }
-					applyButtonText={ panelLayout?.applyButtonText }
-					cancelButtonText={ panelLayout?.cancelButtonText }
+					applyLabel={ panelLayout?.applyLabel }
+					cancelLabel={ panelLayout?.cancelLabel }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -23,6 +23,7 @@ import type {
 	Field,
 	NormalizedForm,
 	NormalizedFormField,
+	NormalizedPanelLayout,
 	FieldLayoutProps,
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
@@ -40,6 +41,8 @@ function ModalContent< Item >( {
 	fieldLabel,
 	onClose,
 	touched,
+	applyButtonText,
+	cancelButtonText,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -47,6 +50,8 @@ function ModalContent< Item >( {
 	onClose: () => void;
 	fieldLabel: string;
 	touched: boolean;
+	applyButtonText?: string;
+	cancelButtonText?: string;
 } ) {
 	const { fields } = useContext( DataFormContext );
 	const [ changes, setChanges ] = useState< Partial< Item > >( {} );
@@ -147,14 +152,14 @@ function ModalContent< Item >( {
 					onClick={ onClose }
 					__next40pxDefaultSize
 				>
-					{ __( 'Cancel' ) }
+					{ cancelButtonText ?? __( 'Cancel' ) }
 				</Button>
 				<Button
 					variant="primary"
 					onClick={ onApply }
 					__next40pxDefaultSize
 				>
-					{ __( 'Apply' ) }
+					{ applyButtonText ?? __( 'Apply' ) }
 				</Button>
 			</Stack>
 		</Modal>
@@ -176,6 +181,11 @@ function PanelModal< Item >( {
 	if ( ! fieldDefinition ) {
 		return null;
 	}
+
+	const panelLayout =
+		field.layout.type === 'panel'
+			? ( field.layout as NormalizedPanelLayout )
+			: undefined;
 
 	const handleClose = () => {
 		setIsOpen( false );
@@ -203,6 +213,8 @@ function PanelModal< Item >( {
 					fieldLabel={ fieldLabel ?? '' }
 					onClose={ handleClose }
 					touched={ touched }
+					applyButtonText={ panelLayout?.applyButtonText }
+					cancelButtonText={ panelLayout?.cancelButtonText }
 				/>
 			) }
 		</>

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -185,7 +185,7 @@ describe( 'normalizeFormFields', () => {
 			} );
 		} );
 
-		it( 'panel: openAs string "modal" normalizes without labels', () => {
+		it( 'panel: openAs string "modal" stays as string', () => {
 			const form: Form = {
 				layout: { type: 'panel', openAs: 'modal' },
 				fields: [ 'field1' ],
@@ -200,7 +200,7 @@ describe( 'normalizeFormFields', () => {
 			} );
 		} );
 
-		it( 'panel: openAs object normalizes to string with labels', () => {
+		it( 'panel: openAs object preserves labels', () => {
 			const form: Form = {
 				layout: {
 					type: 'panel',
@@ -216,11 +216,13 @@ describe( 'normalizeFormFields', () => {
 			expect( result.layout ).toEqual( {
 				type: 'panel',
 				labelPosition: 'side',
-				openAs: 'modal',
+				openAs: {
+					type: 'modal',
+					applyLabel: 'Save',
+					cancelLabel: 'Dismiss',
+				},
 				summary: [],
 				editVisibility: 'on-hover',
-				applyLabel: 'Save',
-				cancelLabel: 'Dismiss',
 			} );
 		} );
 
@@ -236,7 +238,7 @@ describe( 'normalizeFormFields', () => {
 			expect( result.layout ).toEqual( {
 				type: 'panel',
 				labelPosition: 'side',
-				openAs: 'modal',
+				openAs: { type: 'modal' },
 				summary: [],
 				editVisibility: 'on-hover',
 			} );

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -137,7 +137,7 @@ describe( 'normalizeFormFields', () => {
 				layout: {
 					labelPosition: 'side',
 					type: 'panel',
-					openAs: 'dropdown',
+					openAs: { type: 'dropdown' },
 					summary: [],
 					editVisibility: 'on-hover',
 				},
@@ -147,7 +147,7 @@ describe( 'normalizeFormFields', () => {
 						layout: {
 							type: 'panel',
 							labelPosition: 'side',
-							openAs: 'dropdown',
+							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
 						},
@@ -166,7 +166,7 @@ describe( 'normalizeFormFields', () => {
 				layout: {
 					labelPosition: 'top',
 					type: 'panel',
-					openAs: 'dropdown',
+					openAs: { type: 'dropdown' },
 					summary: [],
 					editVisibility: 'on-hover',
 				},
@@ -176,7 +176,7 @@ describe( 'normalizeFormFields', () => {
 						layout: {
 							type: 'panel',
 							labelPosition: 'top',
-							openAs: 'dropdown',
+							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
 						},
@@ -185,7 +185,7 @@ describe( 'normalizeFormFields', () => {
 			} );
 		} );
 
-		it( 'panel: openAs string "modal" stays as string', () => {
+		it( 'panel: openAs string "modal" normalizes to object', () => {
 			const form: Form = {
 				layout: { type: 'panel', openAs: 'modal' },
 				fields: [ 'field1' ],
@@ -194,7 +194,7 @@ describe( 'normalizeFormFields', () => {
 			expect( result.layout ).toEqual( {
 				type: 'panel',
 				labelPosition: 'side',
-				openAs: 'modal',
+				openAs: { type: 'modal' },
 				summary: [],
 				editVisibility: 'on-hover',
 			} );
@@ -419,7 +419,7 @@ describe( 'normalizeFormFields', () => {
 						layout: {
 							type: 'panel',
 							labelPosition: 'side',
-							openAs: 'dropdown',
+							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
 						},

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -185,7 +185,7 @@ describe( 'normalizeFormFields', () => {
 			} );
 		} );
 
-		it( 'panel: openAs string "modal" normalizes to object', () => {
+		it( 'panel: openAs string "modal" normalizes to object with defaults', () => {
 			const form: Form = {
 				layout: { type: 'panel', openAs: 'modal' },
 				fields: [ 'field1' ],
@@ -194,7 +194,11 @@ describe( 'normalizeFormFields', () => {
 			expect( result.layout ).toEqual( {
 				type: 'panel',
 				labelPosition: 'side',
-				openAs: { type: 'modal' },
+				openAs: {
+					type: 'modal',
+					applyLabel: 'Apply',
+					cancelLabel: 'Cancel',
+				},
 				summary: [],
 				editVisibility: 'on-hover',
 			} );
@@ -226,7 +230,7 @@ describe( 'normalizeFormFields', () => {
 			} );
 		} );
 
-		it( 'panel: openAs object without labels normalizes correctly', () => {
+		it( 'panel: openAs object without labels gets defaults', () => {
 			const form: Form = {
 				layout: {
 					type: 'panel',
@@ -238,7 +242,37 @@ describe( 'normalizeFormFields', () => {
 			expect( result.layout ).toEqual( {
 				type: 'panel',
 				labelPosition: 'side',
-				openAs: { type: 'modal' },
+				openAs: {
+					type: 'modal',
+					applyLabel: 'Apply',
+					cancelLabel: 'Cancel',
+				},
+				summary: [],
+				editVisibility: 'on-hover',
+			} );
+		} );
+
+		it( 'panel: openAs object trims whitespace and falls back to defaults', () => {
+			const form: Form = {
+				layout: {
+					type: 'panel',
+					openAs: {
+						type: 'modal',
+						applyLabel: '  ',
+						cancelLabel: '',
+					},
+				},
+				fields: [ 'field1' ],
+			};
+			const result = normalizeForm( form );
+			expect( result.layout ).toEqual( {
+				type: 'panel',
+				labelPosition: 'side',
+				openAs: {
+					type: 'modal',
+					applyLabel: 'Apply',
+					cancelLabel: 'Cancel',
+				},
 				summary: [],
 				editVisibility: 'on-hover',
 			} );

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -185,6 +185,63 @@ describe( 'normalizeFormFields', () => {
 			} );
 		} );
 
+		it( 'panel: openAs string "modal" normalizes without labels', () => {
+			const form: Form = {
+				layout: { type: 'panel', openAs: 'modal' },
+				fields: [ 'field1' ],
+			};
+			const result = normalizeForm( form );
+			expect( result.layout ).toEqual( {
+				type: 'panel',
+				labelPosition: 'side',
+				openAs: 'modal',
+				summary: [],
+				editVisibility: 'on-hover',
+			} );
+		} );
+
+		it( 'panel: openAs object normalizes to string with labels', () => {
+			const form: Form = {
+				layout: {
+					type: 'panel',
+					openAs: {
+						type: 'modal',
+						applyLabel: 'Save',
+						cancelLabel: 'Dismiss',
+					},
+				},
+				fields: [ 'field1' ],
+			};
+			const result = normalizeForm( form );
+			expect( result.layout ).toEqual( {
+				type: 'panel',
+				labelPosition: 'side',
+				openAs: 'modal',
+				summary: [],
+				editVisibility: 'on-hover',
+				applyLabel: 'Save',
+				cancelLabel: 'Dismiss',
+			} );
+		} );
+
+		it( 'panel: openAs object without labels normalizes correctly', () => {
+			const form: Form = {
+				layout: {
+					type: 'panel',
+					openAs: { type: 'modal' },
+				},
+				fields: [ 'field1' ],
+			};
+			const result = normalizeForm( form );
+			expect( result.layout ).toEqual( {
+				type: 'panel',
+				labelPosition: 'side',
+				openAs: 'modal',
+				summary: [],
+				editVisibility: 'on-hover',
+			} );
+		} );
+
 		it( 'card: with default layout options', () => {
 			const form: Form = {
 				layout: { type: 'card' },

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -59,8 +59,9 @@ export const LayoutPanel = {
 		},
 		openAs: {
 			control: { type: 'select' },
-			description: 'Chooses how to open the panel.',
-			options: [ 'default', 'dropdown', 'modal' ],
+			description:
+				'Chooses how to open the panel. "modalConfig" opens as modal with custom button labels.',
+			options: [ 'default', 'dropdown', 'modal', 'modalConfig' ],
 		},
 		editVisibility: {
 			control: { type: 'select' },
@@ -71,17 +72,19 @@ export const LayoutPanel = {
 			control: { type: 'text' },
 			description:
 				'Custom text for the modal apply button. Defaults to "Apply".',
-			if: { arg: 'openAs', eq: 'modal' },
+			if: { arg: 'openAs', eq: 'modalConfig' },
 		},
 		cancelLabel: {
 			control: { type: 'text' },
 			description:
 				'Custom text for the modal cancel button. Defaults to "Cancel".',
-			if: { arg: 'openAs', eq: 'modal' },
+			if: { arg: 'openAs', eq: 'modalConfig' },
 		},
 	},
 	args: {
-		openAs: 'modal',
+		openAs: 'modalConfig',
+		applyLabel: 'Save',
+		cancelLabel: 'Dismiss',
 	},
 };
 

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -59,9 +59,8 @@ export const LayoutPanel = {
 		},
 		openAs: {
 			control: { type: 'select' },
-			description:
-				'Chooses how to open the panel. "modalConfig" opens as modal with custom button labels.',
-			options: [ 'default', 'dropdown', 'modal', 'modalConfig' ],
+			description: 'Chooses how to open the panel.',
+			options: [ 'default', 'dropdown', 'modal' ],
 		},
 		editVisibility: {
 			control: { type: 'select' },
@@ -72,19 +71,17 @@ export const LayoutPanel = {
 			control: { type: 'text' },
 			description:
 				'Custom text for the modal apply button. Defaults to "Apply".',
-			if: { arg: 'openAs', eq: 'modalConfig' },
+			if: { arg: 'openAs', eq: 'modal' },
 		},
 		cancelLabel: {
 			control: { type: 'text' },
 			description:
 				'Custom text for the modal cancel button. Defaults to "Cancel".',
-			if: { arg: 'openAs', eq: 'modalConfig' },
+			if: { arg: 'openAs', eq: 'modal' },
 		},
 	},
 	args: {
-		openAs: 'modalConfig',
-		applyLabel: 'Save',
-		cancelLabel: 'Dismiss',
+		openAs: 'default',
 	},
 };
 

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -67,6 +67,19 @@ export const LayoutPanel = {
 			description: 'Chooses when the edit icon is visible.',
 			options: [ 'default', 'always', 'on-hover' ],
 		},
+		applyButtonText: {
+			control: { type: 'text' },
+			description:
+				'Custom text for the modal apply button. Defaults to "Apply".',
+		},
+		cancelButtonText: {
+			control: { type: 'text' },
+			description:
+				'Custom text for the modal cancel button. Defaults to "Cancel".',
+		},
+	},
+	args: {
+		openAs: 'modal',
 	},
 };
 

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -67,15 +67,17 @@ export const LayoutPanel = {
 			description: 'Chooses when the edit icon is visible.',
 			options: [ 'default', 'always', 'on-hover' ],
 		},
-		applyButtonText: {
+		applyLabel: {
 			control: { type: 'text' },
 			description:
 				'Custom text for the modal apply button. Defaults to "Apply".',
+			if: { arg: 'openAs', eq: 'modal' },
 		},
-		cancelButtonText: {
+		cancelLabel: {
 			control: { type: 'text' },
 			description:
 				'Custom text for the modal cancel button. Defaults to "Cancel".',
+			if: { arg: 'openAs', eq: 'modal' },
 		},
 	},
 	args: {

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -311,17 +311,6 @@ const LayoutPanelComponent = ( {
 	applyLabel?: string;
 	cancelLabel?: string;
 } ) => {
-	let openAs: PanelLayout[ 'openAs' ];
-	if ( openAsArg === 'modalConfig' ) {
-		openAs = {
-			type: 'modal',
-			applyLabel: applyLabel || undefined,
-			cancelLabel: cancelLabel || undefined,
-		};
-	} else if ( openAsArg !== 'default' ) {
-		openAs = openAsArg;
-	}
-
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
 		order: 2,
@@ -346,6 +335,17 @@ const LayoutPanelComponent = ( {
 	} );
 
 	const form: Form = useMemo( () => {
+		let openAs: PanelLayout[ 'openAs' ];
+		if ( openAsArg === 'modalConfig' ) {
+			openAs = {
+				type: 'modal',
+				applyLabel: applyLabel || undefined,
+				cancelLabel: cancelLabel || undefined,
+			};
+		} else if ( openAsArg !== 'default' ) {
+			openAs = openAsArg;
+		}
+
 		return {
 			layout: getPanelLayoutFromStoryArgs( {
 				labelPosition,
@@ -403,7 +403,7 @@ const LayoutPanelComponent = ( {
 				},
 			],
 		};
-	}, [ labelPosition, openAs, editVisibility ] );
+	}, [ labelPosition, openAsArg, applyLabel, cancelLabel, editVisibility ] );
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -306,7 +306,7 @@ const LayoutPanelComponent = ( {
 }: {
 	type: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
-	openAs: 'default' | 'dropdown' | 'modal' | 'modalConfig';
+	openAs: 'default' | 'dropdown' | 'modal';
 	editVisibility: 'default' | EditVisibility;
 	applyLabel?: string;
 	cancelLabel?: string;
@@ -336,7 +336,7 @@ const LayoutPanelComponent = ( {
 
 	const form: Form = useMemo( () => {
 		let openAs: PanelLayout[ 'openAs' ];
-		if ( openAsArg === 'modalConfig' ) {
+		if ( openAsArg === 'modal' && ( applyLabel || cancelLabel ) ) {
 			openAs = {
 				type: 'modal',
 				applyLabel: applyLabel || undefined,

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -268,15 +268,11 @@ const getPanelLayoutFromStoryArgs = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
-	applyLabel,
-	cancelLabel,
 }: {
 	summary?: string[];
 	labelPosition?: 'default' | 'top' | 'side' | 'none';
-	openAs?: 'default' | 'dropdown' | 'modal';
+	openAs?: PanelLayout[ 'openAs' ];
 	editVisibility?: 'default' | EditVisibility;
-	applyLabel?: string;
-	cancelLabel?: string;
 } ): Layout | undefined => {
 	const panelLayout: PanelLayout = {
 		type: 'panel',
@@ -286,16 +282,8 @@ const getPanelLayoutFromStoryArgs = ( {
 		panelLayout.labelPosition = labelPosition;
 	}
 
-	if ( openAs !== 'default' ) {
-		if ( openAs === 'modal' && ( applyLabel || cancelLabel ) ) {
-			panelLayout.openAs = {
-				type: 'modal',
-				...( applyLabel && { applyLabel } ),
-				...( cancelLabel && { cancelLabel } ),
-			};
-		} else {
-			panelLayout.openAs = openAs;
-		}
+	if ( openAs ) {
+		panelLayout.openAs = openAs;
 	}
 
 	if ( summary !== undefined ) {
@@ -311,18 +299,29 @@ const getPanelLayoutFromStoryArgs = ( {
 
 const LayoutPanelComponent = ( {
 	labelPosition,
-	openAs,
+	openAs: openAsArg,
 	editVisibility,
 	applyLabel,
 	cancelLabel,
 }: {
 	type: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
-	openAs: 'default' | 'dropdown' | 'modal';
+	openAs: 'default' | 'dropdown' | 'modal' | 'modalConfig';
 	editVisibility: 'default' | EditVisibility;
 	applyLabel?: string;
 	cancelLabel?: string;
 } ) => {
+	let openAs: PanelLayout[ 'openAs' ];
+	if ( openAsArg === 'modalConfig' ) {
+		openAs = {
+			type: 'modal',
+			applyLabel: applyLabel || undefined,
+			cancelLabel: cancelLabel || undefined,
+		};
+	} else if ( openAsArg !== 'default' ) {
+		openAs = openAsArg;
+	}
+
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
 		order: 2,
@@ -352,8 +351,6 @@ const LayoutPanelComponent = ( {
 				labelPosition,
 				openAs,
 				editVisibility,
-				applyLabel,
-				cancelLabel,
 			} ),
 			fields: [
 				'title',
@@ -391,8 +388,6 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						applyLabel,
-						cancelLabel,
 					} ),
 				},
 				{
@@ -404,13 +399,11 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						applyLabel,
-						cancelLabel,
 					} ),
 				},
 			],
 		};
-	}, [ labelPosition, openAs, editVisibility, applyLabel, cancelLabel ] );
+	}, [ labelPosition, openAs, editVisibility ] );
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -268,15 +268,15 @@ const getPanelLayoutFromStoryArgs = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
-	applyButtonText,
-	cancelButtonText,
+	applyLabel,
+	cancelLabel,
 }: {
 	summary?: string[];
 	labelPosition?: 'default' | 'top' | 'side' | 'none';
 	openAs?: 'default' | 'dropdown' | 'modal';
 	editVisibility?: 'default' | EditVisibility;
-	applyButtonText?: string;
-	cancelButtonText?: string;
+	applyLabel?: string;
+	cancelLabel?: string;
 } ): Layout | undefined => {
 	const panelLayout: PanelLayout = {
 		type: 'panel',
@@ -287,7 +287,15 @@ const getPanelLayoutFromStoryArgs = ( {
 	}
 
 	if ( openAs !== 'default' ) {
-		panelLayout.openAs = openAs;
+		if ( openAs === 'modal' && ( applyLabel || cancelLabel ) ) {
+			panelLayout.openAs = {
+				type: 'modal',
+				...( applyLabel && { applyLabel } ),
+				...( cancelLabel && { cancelLabel } ),
+			};
+		} else {
+			panelLayout.openAs = openAs;
+		}
 	}
 
 	if ( summary !== undefined ) {
@@ -298,14 +306,6 @@ const getPanelLayoutFromStoryArgs = ( {
 		panelLayout.editVisibility = editVisibility;
 	}
 
-	if ( applyButtonText ) {
-		panelLayout.applyButtonText = applyButtonText;
-	}
-
-	if ( cancelButtonText ) {
-		panelLayout.cancelButtonText = cancelButtonText;
-	}
-
 	return panelLayout;
 };
 
@@ -313,15 +313,15 @@ const LayoutPanelComponent = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
-	applyButtonText,
-	cancelButtonText,
+	applyLabel,
+	cancelLabel,
 }: {
 	type: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 	openAs: 'default' | 'dropdown' | 'modal';
 	editVisibility: 'default' | EditVisibility;
-	applyButtonText?: string;
-	cancelButtonText?: string;
+	applyLabel?: string;
+	cancelLabel?: string;
 } ) => {
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
@@ -352,8 +352,8 @@ const LayoutPanelComponent = ( {
 				labelPosition,
 				openAs,
 				editVisibility,
-				applyButtonText,
-				cancelButtonText,
+				applyLabel,
+				cancelLabel,
 			} ),
 			fields: [
 				'title',
@@ -391,8 +391,8 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						applyButtonText,
-						cancelButtonText,
+						applyLabel,
+						cancelLabel,
 					} ),
 				},
 				{
@@ -404,19 +404,13 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						applyButtonText,
-						cancelButtonText,
+						applyLabel,
+						cancelLabel,
 					} ),
 				},
 			],
 		};
-	}, [
-		labelPosition,
-		openAs,
-		editVisibility,
-		applyButtonText,
-		cancelButtonText,
-	] );
+	}, [ labelPosition, openAs, editVisibility, applyLabel, cancelLabel ] );
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -268,11 +268,15 @@ const getPanelLayoutFromStoryArgs = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
+	applyButtonText,
+	cancelButtonText,
 }: {
 	summary?: string[];
 	labelPosition?: 'default' | 'top' | 'side' | 'none';
 	openAs?: 'default' | 'dropdown' | 'modal';
 	editVisibility?: 'default' | EditVisibility;
+	applyButtonText?: string;
+	cancelButtonText?: string;
 } ): Layout | undefined => {
 	const panelLayout: PanelLayout = {
 		type: 'panel',
@@ -294,6 +298,14 @@ const getPanelLayoutFromStoryArgs = ( {
 		panelLayout.editVisibility = editVisibility;
 	}
 
+	if ( applyButtonText ) {
+		panelLayout.applyButtonText = applyButtonText;
+	}
+
+	if ( cancelButtonText ) {
+		panelLayout.cancelButtonText = cancelButtonText;
+	}
+
 	return panelLayout;
 };
 
@@ -301,11 +313,15 @@ const LayoutPanelComponent = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
+	applyButtonText,
+	cancelButtonText,
 }: {
 	type: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 	openAs: 'default' | 'dropdown' | 'modal';
 	editVisibility: 'default' | EditVisibility;
+	applyButtonText?: string;
+	cancelButtonText?: string;
 } ) => {
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
@@ -336,6 +352,8 @@ const LayoutPanelComponent = ( {
 				labelPosition,
 				openAs,
 				editVisibility,
+				applyButtonText,
+				cancelButtonText,
 			} ),
 			fields: [
 				'title',
@@ -373,6 +391,8 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						applyButtonText,
+						cancelButtonText,
 					} ),
 				},
 				{
@@ -384,11 +404,19 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						applyButtonText,
+						cancelButtonText,
 					} ),
 				},
 			],
 		};
-	}, [ labelPosition, openAs, editVisibility ] );
+	}, [
+		labelPosition,
+		openAs,
+		editVisibility,
+		applyButtonText,
+		cancelButtonText,
+	] );
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -23,14 +23,18 @@ export type NormalizedRegularLayout = {
 
 export type EditVisibility = 'always' | 'on-hover';
 
+export type PanelOpenAsModal = {
+	type: 'modal';
+	applyLabel?: string;
+	cancelLabel?: string;
+};
+
 export type PanelLayout = {
 	type: 'panel';
 	labelPosition?: LabelPosition;
-	openAs?: 'dropdown' | 'modal';
+	openAs?: 'dropdown' | 'modal' | PanelOpenAsModal;
 	summary?: PanelSummaryField;
 	editVisibility?: EditVisibility;
-	applyButtonText?: string;
-	cancelButtonText?: string;
 };
 export type NormalizedPanelLayout = {
 	type: 'panel';
@@ -38,8 +42,8 @@ export type NormalizedPanelLayout = {
 	openAs: 'dropdown' | 'modal';
 	summary: NormalizedPanelSummaryField;
 	editVisibility: EditVisibility;
-	applyButtonText?: string;
-	cancelButtonText?: string;
+	applyLabel?: string;
+	cancelLabel?: string;
 };
 
 export type CardSummaryField =

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -29,6 +29,8 @@ export type PanelLayout = {
 	openAs?: 'dropdown' | 'modal';
 	summary?: PanelSummaryField;
 	editVisibility?: EditVisibility;
+	applyButtonText?: string;
+	cancelButtonText?: string;
 };
 export type NormalizedPanelLayout = {
 	type: 'panel';
@@ -36,6 +38,8 @@ export type NormalizedPanelLayout = {
 	openAs: 'dropdown' | 'modal';
 	summary: NormalizedPanelSummaryField;
 	editVisibility: EditVisibility;
+	applyButtonText?: string;
+	cancelButtonText?: string;
 };
 
 export type CardSummaryField =

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -39,11 +39,9 @@ export type PanelLayout = {
 export type NormalizedPanelLayout = {
 	type: 'panel';
 	labelPosition: LabelPosition;
-	openAs: 'dropdown' | 'modal';
+	openAs: 'dropdown' | 'modal' | PanelOpenAsModal;
 	summary: NormalizedPanelSummaryField;
 	editVisibility: EditVisibility;
-	applyLabel?: string;
-	cancelLabel?: string;
 };
 
 export type CardSummaryField =

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -23,6 +23,9 @@ export type NormalizedRegularLayout = {
 
 export type EditVisibility = 'always' | 'on-hover';
 
+type PanelOpenAsDropdown = {
+	type: 'dropdown';
+};
 export type PanelOpenAsModal = {
 	type: 'modal';
 	applyLabel?: string;
@@ -32,14 +35,14 @@ export type PanelOpenAsModal = {
 export type PanelLayout = {
 	type: 'panel';
 	labelPosition?: LabelPosition;
-	openAs?: 'dropdown' | 'modal' | PanelOpenAsModal;
+	openAs?: 'dropdown' | 'modal' | PanelOpenAsDropdown | PanelOpenAsModal;
 	summary?: PanelSummaryField;
 	editVisibility?: EditVisibility;
 };
 export type NormalizedPanelLayout = {
 	type: 'panel';
 	labelPosition: LabelPosition;
-	openAs: 'dropdown' | 'modal' | PanelOpenAsModal;
+	openAs: PanelOpenAsDropdown | PanelOpenAsModal;
 	summary: NormalizedPanelSummaryField;
 	editVisibility: EditVisibility;
 };

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -28,14 +28,18 @@ type PanelOpenAsDropdown = {
 };
 export type PanelOpenAsModal = {
 	type: 'modal';
-	applyLabel?: string;
-	cancelLabel?: string;
+	applyLabel: string;
+	cancelLabel: string;
 };
 
 export type PanelLayout = {
 	type: 'panel';
 	labelPosition?: LabelPosition;
-	openAs?: 'dropdown' | 'modal' | PanelOpenAsDropdown | PanelOpenAsModal;
+	openAs?:
+		| 'dropdown'
+		| 'modal'
+		| { type: 'dropdown' }
+		| { type: 'modal'; applyLabel?: string; cancelLabel?: string };
 	summary?: PanelSummaryField;
 	editVisibility?: EditVisibility;
 };


### PR DESCRIPTION
## What?
Adds optional `applyLabel` and `cancelLabel` configuration to the DataForm panel modal layout's `openAs` config, allowing customization of modal action button labels.

## Why?
Some use cases need different button labels—for example, using "Save" instead of "Apply" when the modal closes after the action. This change enables that flexibility while maintaining backward compatibility with existing code that relies on the default "Apply" and "Cancel" labels.

## How?
- Added `PanelOpenAsDropdown` and `PanelOpenAsModal` types for the normalized `openAs` property — normalization always produces objects so consumers use `openAs.type` consistently
- `PanelLayout.openAs` (input) still accepts strings (`'dropdown' | 'modal'`) or an object (`{ type: 'modal', applyLabel?, cancelLabel? }`)
- Normalization trims whitespace and falls back to i18n'd defaults (`__('Apply')` / `__('Cancel')`), ensuring labels are always present — consumers don't need runtime fallbacks
- `PanelOpenAsModal.applyLabel` and `cancelLabel` are required strings on the normalized type
- `ModalContent` extracts labels directly from `field.layout` — no prop drilling needed
- Added 4 unit tests for the normalization paths (string modal, object with labels, object without labels, whitespace/empty string handling)
- Added storybook controls with conditional visibility (shown when `openAs` is `modal`)

### API example

```ts
// Simple string form (existing behavior)
{ type: 'panel', openAs: 'modal' }

// Object form with custom labels
{ type: 'panel', openAs: { type: 'modal', applyLabel: 'Save', cancelLabel: 'Dismiss' } }
```

## Testing Instructions
1. Open storybook: `npm run storybook:dev`
2. Navigate to **DataViews > DataForm > LayoutPanel**
3. Set **openAs** to `modal` in the Controls panel
4. Fill in **applyLabel** (e.g. "Save") and **cancelLabel** (e.g. "Dismiss")
5. Click any field to open its modal and verify the buttons display the custom text
6. Clear the label fields to verify defaults ("Apply" / "Cancel") reappear
7. Enter whitespace-only labels and verify they also fall back to defaults

### Testing Instructions for Keyboard
1. Tab through the form fields until reaching a modal-opening field
2. Press Enter or Space to open the modal
3. Tab through the modal content
4. Tab to the buttons at the bottom and verify the custom text is present
5. Press Enter on either button to confirm the label doesn't affect functionality

## Screenshots or screencast

<img width="541" height="410" alt="Screenshot 2026-03-03 at 17 23 44" src="https://github.com/user-attachments/assets/294b2806-adc7-4fbe-af30-c325c6103faf" />