### PR TITLE
Edit Site: Reset `word-break` for TemplateListItem

### DIFF
--- a/packages/edit-site/src/components/add-new-template-legacy/index.js
+++ b/packages/edit-site/src/components/add-new-template-legacy/index.js
@@ -164,7 +164,8 @@ function NewTemplateModal( { onClose } ) {
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 	const containerRef = useRef( null );
-	const isMobile = useViewportMatch( 'medium', '<' );
+	const isMedium = useViewportMatch( 'medium', '<' );
+	const isMobile = useViewportMatch( 'mobile', '<' );
 
 	const homeUrl = useSelect( ( select ) => {
 		// Site index.
@@ -261,7 +262,10 @@ function NewTemplateModal( { onClose } ) {
 	} else if ( modalContent === modalContentMap.customGenericTemplate ) {
 		modalTitle = __( 'Create custom template' );
 	}
-
+	let gridColumns = 3;
+	if ( isMobile || isMedium ) {
+		gridColumns = isMobile ? 1 : 2;
+	}
 	return (
 		<Modal
 			title={ modalTitle }
@@ -281,7 +285,7 @@ function NewTemplateModal( { onClose } ) {
 		>
 			{ modalContent === modalContentMap.templatesList && (
 				<Grid
-					columns={ isMobile ? 2 : 3 }
+					columns={ gridColumns }
 					gap={ 4 }
 					align="flex-start"
 					justify="center"

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -140,7 +140,6 @@
 		flex-direction: column;
 		border: $border-width solid $gray-300;
 		justify-content: center;
-		word-break: normal;
 
 		// Show the boundary of the button, in High Contrast Mode.
 		outline: 1px solid transparent;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -140,6 +140,7 @@
 		flex-direction: column;
 		border: $border-width solid $gray-300;
 		justify-content: center;
+		word-break: normal;
 
 		// Show the boundary of the button, in High Contrast Mode.
 		outline: 1px solid transparent;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/76071

I manually checked lots of components but Claude helped me with a more thorough audit.

After #76071 added `word-break: break-word` to the base `.components-button` class, #76084 fixed the first regression in `DateTimePicker`. This PR addresses another at-risk component found during a broader audit.

### What was audited

The `word-break: break-word` rule can cause issues on buttons that meet **all three** conditions:

1. **Default variant** — `primary`, `secondary`, and `tertiary` are protected by `white-space: nowrap`
3. **Text content** — icon-only buttons have nothing to break
5. **Constrained width** — fixed dimensions, narrow grid columns, or padding reducing the content area

The audit covered all packages: `components`, `editor`, `edit-post`, `edit-site`, `block-editor`, `block-library`, `dataviews`, `commands`, `boot`, `global-styles-ui`, `interface`, `edit-widgets`, `customize-widgets`, and `admin-ui`.


### What was found

Most constrained buttons are safe because they're either icon-only, use a variant with `nowrap`, or have `width: 100%` with ample space.

**`TemplateListItem`** (`edit-site`, add-new-template) was the one component that needed a fix — default variant buttons with template name text inside a 2–3 column grid. `word-break: break-word` could cause mid-word breaks.

I updated the grid columns number to be `1` on mobile. 


The screenshots below are with a really small screen size, but it could possibly occur in different languages in bigger screens.


|Before|After|
|-|-|
|<img width="297" height="723" alt="Screenshot 2026-03-03 at 8 56 52 PM" src="https://github.com/user-attachments/assets/a3320f8a-7618-4f4c-be8a-127d30bcc1a0" />|<img width="312" height="740" alt="Screenshot 2026-03-04 at 7 04 19 PM" src="https://github.com/user-attachments/assets/20a4b304-141c-4570-a33f-c2a15cc07d3e" />|
