### PR TITLE
Core Data: Support reading revision data in useEntityProp (fixes footnotes in revisions UI)

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -12,26 +12,39 @@ import { EntityContext } from './entity-context';
  * Context provider component for providing
  * an entity for a specific entity.
  *
- * @param {Object} props          The component's props.
- * @param {string} props.kind     The entity kind.
- * @param {string} props.type     The entity name.
- * @param {number} props.id       The entity ID.
- * @param {*}      props.children The children to wrap.
+ * @param {Object} props              The component's props.
+ * @param {string} props.kind         The entity kind.
+ * @param {string} props.type         The entity name.
+ * @param {number} props.id           The entity ID.
+ * @param {number} [props.revisionId] Optional revision ID. When set,
+ *                                    `useEntityProp` reads from the
+ *                                    revision record instead of the
+ *                                    current entity.
+ * @param {*}      props.children     The children to wrap.
  *
  * @return {Object} The provided children, wrapped with
  *                   the entity's context provider.
  */
-export default function EntityProvider( { kind, type: name, id, children } ) {
+export default function EntityProvider( {
+	kind,
+	type: name,
+	id,
+	revisionId,
+	children,
+} ) {
 	const parent = useContext( EntityContext );
 	const childContext = useMemo(
 		() => ( {
 			...parent,
-			[ kind ]: {
-				...parent?.[ kind ],
-				[ name ]: id,
-			},
+			...( kind && {
+				[ kind ]: {
+					...parent?.[ kind ],
+					[ name ]: id,
+				},
+			} ),
+			...( revisionId !== undefined && { revisionId } ),
 		} ),
-		[ parent, kind, name, id ]
+		[ parent, kind, name, id, revisionId ]
 	);
 	return (
 		<EntityContext.Provider value={ childContext }>

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_NAME } from '../name';
+import { DEFAULT_ENTITY_KEY } from '../entities';
 import { EntityContext } from '../entity-context';
 import useEntityId from './use-entity-id';
 
@@ -55,7 +56,7 @@ export default function useEntityProp( kind, name, prop, _id ) {
 					kind,
 					name
 				);
-				const revKey = entityConfig?.revisionKey || 'id';
+				const revKey = entityConfig?.revisionKey || DEFAULT_ENTITY_KEY;
 				const revision = revisions?.find(
 					( r ) => r[ revKey ] === revisionId
 				);

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { STORE_NAME } from '../name';
+import { EntityContext } from '../entity-context';
 import useEntityId from './use-entity-id';
 
 /**
@@ -30,9 +31,42 @@ import useEntityId from './use-entity-id';
 export default function useEntityProp( kind, name, prop, _id ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
+	const context = useContext( EntityContext );
+	const revisionId = context?.revisionId;
 
 	const { value, fullValue } = useSelect(
 		( select ) => {
+			if ( revisionId ) {
+				// Use getRevisions (not getRevision) to read from the
+				// already-cached collection. Using getRevision would
+				// trigger a redundant single-revision API fetch that
+				// can wipe the collection due to a race condition.
+				// See https://github.com/WordPress/gutenberg/pull/76043.
+				const revisions = select( STORE_NAME ).getRevisions(
+					kind,
+					name,
+					id,
+					{
+						per_page: -1,
+						context: 'edit',
+					}
+				);
+				const entityConfig = select( STORE_NAME ).getEntityConfig(
+					kind,
+					name
+				);
+				const revKey = entityConfig?.revisionKey || 'id';
+				const revision = revisions?.find(
+					( r ) => r[ revKey ] === revisionId
+				);
+				return revision
+					? {
+							value: revision[ prop ],
+							fullValue: revision[ prop ],
+					  }
+					: {};
+			}
+
 			const { getEntityRecord, getEditedEntityRecord } =
 				select( STORE_NAME );
 			const record = getEntityRecord( kind, name, id ); // Trigger resolver.
@@ -44,16 +78,19 @@ export default function useEntityProp( kind, name, prop, _id ) {
 				  }
 				: {};
 		},
-		[ kind, name, id, prop ]
+		[ kind, name, id, prop, revisionId ]
 	);
 	const { editEntityRecord } = useDispatch( STORE_NAME );
 	const setValue = useCallback(
 		( newValue ) => {
+			if ( revisionId ) {
+				return;
+			}
 			editEntityRecord( kind, name, id, {
 				[ prop ]: newValue,
 			} );
 		},
-		[ editEntityRecord, kind, name, id, prop ]
+		[ editEntityRecord, kind, name, id, prop, revisionId ]
 	);
 
 	return [ value, setValue, fullValue ];

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -12,6 +12,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock, parse } from '@wordpress/blocks';
+import { EntityProvider } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
@@ -163,20 +164,27 @@ export default function RevisionsCanvas( { showDiff } ) {
 		};
 	}, [] );
 
-	const { revision, previousRevision, postType, blockEditorSettings } =
-		useSelect( ( select ) => {
-			const {
-				getCurrentRevision,
-				getPreviousRevision,
-				getCurrentPostType,
-			} = unlock( select( editorStore ) );
-			return {
-				revision: getCurrentRevision(),
-				previousRevision: getPreviousRevision(),
-				postType: getCurrentPostType(),
-				blockEditorSettings: select( blockEditorStore ).getSettings(),
-			};
-		}, [] );
+	const {
+		revision,
+		previousRevision,
+		postType,
+		currentRevisionId,
+		blockEditorSettings,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentRevision,
+			getCurrentRevisionId: getRevisionId,
+			getPreviousRevision,
+			getCurrentPostType,
+		} = unlock( select( editorStore ) );
+		return {
+			revision: getCurrentRevision(),
+			previousRevision: getPreviousRevision(),
+			postType: getCurrentPostType(),
+			currentRevisionId: getRevisionId(),
+			blockEditorSettings: select( blockEditorStore ).getSettings(),
+		};
+	}, [] );
 
 	// Track previously rendered blocks to preserve clientIds between renders.
 	const previousBlocksRef = useRef( [] );
@@ -234,12 +242,17 @@ export default function RevisionsCanvas( { showDiff } ) {
 	);
 
 	return revision ? (
-		<ExperimentalBlockEditorProvider value={ blocks } settings={ settings }>
-			<DiffStyleOverrides showDiff={ showDiff } />
-			<div className="editor-revisions-canvas__content">
-				<CanvasContent showDiff={ showDiff } />
-			</div>
-		</ExperimentalBlockEditorProvider>
+		<EntityProvider revisionId={ currentRevisionId }>
+			<ExperimentalBlockEditorProvider
+				value={ blocks }
+				settings={ settings }
+			>
+				<DiffStyleOverrides showDiff={ showDiff } />
+				<div className="editor-revisions-canvas__content">
+					<CanvasContent showDiff={ showDiff } />
+				</div>
+			</ExperimentalBlockEditorProvider>
+		</EntityProvider>
 	) : (
 		<div className="editor-revisions-canvas__loading">
 			<Spinner />

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -164,27 +164,20 @@ export default function RevisionsCanvas( { showDiff } ) {
 		};
 	}, [] );
 
-	const {
-		revision,
-		previousRevision,
-		postType,
-		currentRevisionId,
-		blockEditorSettings,
-	} = useSelect( ( select ) => {
-		const {
-			getCurrentRevision,
-			getCurrentRevisionId: getRevisionId,
-			getPreviousRevision,
-			getCurrentPostType,
-		} = unlock( select( editorStore ) );
-		return {
-			revision: getCurrentRevision(),
-			previousRevision: getPreviousRevision(),
-			postType: getCurrentPostType(),
-			currentRevisionId: getRevisionId(),
-			blockEditorSettings: select( blockEditorStore ).getSettings(),
-		};
-	}, [] );
+	const { revision, previousRevision, postType, blockEditorSettings } =
+		useSelect( ( select ) => {
+			const {
+				getCurrentRevision,
+				getPreviousRevision,
+				getCurrentPostType,
+			} = unlock( select( editorStore ) );
+			return {
+				revision: getCurrentRevision(),
+				previousRevision: getPreviousRevision(),
+				postType: getCurrentPostType(),
+				blockEditorSettings: select( blockEditorStore ).getSettings(),
+			};
+		}, [] );
 
 	// Track previously rendered blocks to preserve clientIds between renders.
 	const previousBlocksRef = useRef( [] );
@@ -242,7 +235,10 @@ export default function RevisionsCanvas( { showDiff } ) {
 	);
 
 	return revision ? (
-		<EntityProvider revisionId={ currentRevisionId }>
+		// EntityProvider without kind/type/id inherits those from the
+		// parent context. Only revisionId is added so that useEntityProp
+		// reads from the revision record instead of the current entity.
+		<EntityProvider revisionId={ revision.id }>
 			<ExperimentalBlockEditorProvider
 				value={ blocks }
 				settings={ settings }

--- a/test/e2e/specs/editor/various/footnotes-revisions.spec.js
+++ b/test/e2e/specs/editor/various/footnotes-revisions.spec.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Footnotes in Revisions UI', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should show the correct footnotes for each revision', async ( {
+		editor,
+		page,
+	} ) => {
+		// --- Revision 1: paragraph with footnote "alpha" ---
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'Paragraph one' );
+
+		await editor.showBlockToolbar();
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.getByRole( 'menuitem', { name: 'Footnote' } ).click();
+		await page.keyboard.type( 'alpha' );
+
+		await editor.saveDraft();
+
+		// --- Revision 2: change footnote to "beta" ---
+		await editor.canvas.locator( 'ol.wp-block-footnotes li span' ).click();
+		await page.keyboard.press( 'Meta+a' );
+		await page.keyboard.type( 'beta' );
+
+		await editor.saveDraft();
+
+		// --- Open the Revisions UI ---
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', { name: '2', exact: true } )
+			.click();
+
+		// Wait for the revisions mode to be active.
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// Latest revision (revision 2) — footnote should say "beta".
+		await expect(
+			editor.canvas.locator( 'ol.wp-block-footnotes' )
+		).toBeVisible();
+		await expect(
+			editor.canvas.locator( 'ol.wp-block-footnotes li' ).first()
+		).toContainText( 'beta' );
+
+		// Navigate to oldest revision (revision 1).
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await slider.focus();
+		await page.keyboard.press( 'Home' );
+
+		// Revision 1 — footnote should say "alpha", not "beta".
+		await expect(
+			editor.canvas.locator( 'ol.wp-block-footnotes li' ).first()
+		).toContainText( 'alpha' );
+		await expect(
+			editor.canvas.locator( 'ol.wp-block-footnotes li' ).first()
+		).not.toContainText( 'beta' );
+	} );
+} );


### PR DESCRIPTION
## Summary
- The `core/footnotes` block always showed the **current** post's footnotes when viewing a revision in the revisions UI, instead of the revision's footnotes
- Adds a `revisionId` prop to `EntityProvider` that gets stored in `EntityContext`
- When `useEntityProp` detects `revisionId` in context, it reads from the cached revision record (via `getRevisions()`) instead of the current entity, and makes the setter a no-op
- Wraps `RevisionsCanvas` with `<EntityProvider revisionId={currentRevisionId}>` so blocks inside the preview read revision-specific data
- Diff highlighting for footnote changes between revisions is not included and will be handled in a follow-up PR

## Test plan
- [ ] Create a post with a footnote, save
- [ ] Edit the footnote text, save again (creating a second revision)
- [ ] Open the revisions UI from the Post sidebar
- [ ] Verify the latest revision shows the updated footnote
- [ ] Navigate to the older revision via the slider
- [ ] Verify the older revision shows the original footnote text
- [ ] Run `npm run test:e2e -- test/e2e/specs/editor/various/footnotes-revisions.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)