### PR TITLE
Fix: Settings panel not reflecting 'Sort by date' on Created Templates view

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -18,6 +18,7 @@ import { useEvent } from '@wordpress/compose';
 import { useView } from '@wordpress/views';
 import { Modal } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
+import { dateField } from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -43,8 +44,7 @@ import {
 	getActiveViewOverridesForTab,
 } from './view-utils';
 
-const { usePostActions, usePostFields, templateTitleField } =
-	unlock( editorPrivateApis );
+const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 
@@ -218,10 +218,6 @@ export default function PageTemplates() {
 		[ history, path, view?.type ]
 	);
 
-	const postTypeFields = usePostFields( {
-		postType: TEMPLATE_POST_TYPE,
-	} );
-	const dateField = postTypeFields.find( ( field ) => field.id === 'date' );
 	const themeField = useThemeField();
 	const fields = useMemo( () => {
 		const _fields = [
@@ -233,9 +229,7 @@ export default function PageTemplates() {
 		];
 		if ( activeView === 'user' ) {
 			_fields.push( themeField );
-			if ( dateField ) {
-				_fields.push( dateField );
-			}
+			_fields.push( dateField );
 		}
 		const elements = [];
 		for ( const author in users ) {
@@ -249,7 +243,7 @@ export default function PageTemplates() {
 			elements,
 		} );
 		return _fields;
-	}, [ users, activeView, themeField, dateField ] );
+	}, [ users, activeView, themeField ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( records, view, fields );

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -21,6 +21,7 @@ import { useMemo, useCallback, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { published, commentAuthorAvatar } from '@wordpress/icons';
+import { dateField } from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -143,7 +144,7 @@ function TemplateListActivation() {
 				label: users[ author ]?.name ?? author,
 			} );
 		}
-		return [
+		const _fields = [
 			previewField,
 			templateTitleField,
 			descriptionField,
@@ -154,7 +155,11 @@ function TemplateListActivation() {
 				elements,
 			},
 		];
-	}, [ users ] );
+		if ( activeView === 'user' ) {
+			_fields.push( dateField );
+		}
+		return _fields;
+	}, [ users, activeView ] );
 
 	// Apply filtering, sorting, and pagination on the client side
 	const { data: posts, paginationInfo } = useMemo( () => {


### PR DESCRIPTION
## What?
When navigating to **Site Editor → Templates → Created** (the `user` tab), templates are correctly sorted by date, but the Settings panel displays "Sort by: Template" instead of "Sort by: Date". The sort dropdown also doesn't offer a Date option.

Closes #75136.

## Why?
`wp_template` is a design post type. The `usePostFields` hook in `@wordpress/editor` explicitly excludes `dateField` for all design post types:

```ts
! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) && dateField,
```

Both rendering paths for the template list (legacy router in edit-site and new router in template-list) called `usePostFields({ postType: 'wp_template' })` to obtain `dateField`. This always returned `undefined` for templates, so `dateField` was never added to the DataViews fields array. With no registered `date` field, DataViews' `SortFieldControl` couldn't reflect `view.sort.field === 'date'` and fell back to the first available field ("Template").

## How?
Import `dateField` directly from `@wordpress/fields` in both paths, bypassing `usePostFields`. Push it to the fields array when `activeView === 'user'` (the Created Templates tab), matching the existing `getActiveViewOverridesForTab('user')` sort override.

## Testing instructions
1. Ensure that “Template Activation” experiment is enabled.
2. Open **Site Editor → Templates**.
3. Click the **Created** tab (user-created templates).
4. Open the Settings panel (top-right grid/list view options).
5. Confirm **Sort by: Date** is selected and the Date option is available in the dropdown.
6. Switch to the **All** or **Theme** tab and confirm **Sort by: Template** is shown (unchanged behaviour).

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


|Before|After|
|-|-|
|<img width="2672" height="1448" alt="image" src="https://github.com/user-attachments/assets/803038f1-cee5-4ad3-ad28-26c5ecb59444" />|<img width="2672" height="1448" alt="image" src="https://github.com/user-attachments/assets/cef70402-21d2-484d-82d0-9c0ed407f7e1" />|