### PR TITLE
RTC: Implement disconnection debounce after initial connection

### DIFF
--- a/packages/editor/src/components/sync-connection-modal/index.js
+++ b/packages/editor/src/components/sync-connection-modal/index.js
@@ -34,7 +34,10 @@ const { retrySyncConnection } = unlock( coreDataPrivateApis );
 
 // Debounce time for initial disconnected status to allow connection to establish.
 const INITIAL_DISCONNECTED_DEBOUNCE_MS = 5000;
-const noop = () => {};
+
+// Debounce time for showing the disconnect dialog after the intial connection,
+// allowing brief network interruptions to resolve.
+const DISCONNECTED_DEBOUNCE_MS = 2000;
 
 /**
  * Sync connection modal that displays when any entity reports a disconnection.
@@ -67,7 +70,6 @@ export function SyncConnectionModal() {
 		useState( null );
 	const debounceTimerRef = useRef( null );
 	// Track whether we've passed the initial load phase.
-	// Once true, disconnected status will show immediately without debounce.
 	const hasInitializedRef = useRef( false );
 
 	const connectionStatus = connectionState?.status;
@@ -91,9 +93,13 @@ export function SyncConnectionModal() {
 				);
 			};
 
-			// Debounce only on first load to allow connection to establish.
+			// Debounce on first load and after connection is established to allow
+			// brief network interruptions to resolve.
 			if ( hasInitializedRef.current ) {
-				showModal();
+				debounceTimerRef.current = setTimeout(
+					showModal,
+					DISCONNECTED_DEBOUNCE_MS
+				);
 			} else {
 				debounceTimerRef.current = setTimeout(
 					showModal,
@@ -142,7 +148,7 @@ export function SyncConnectionModal() {
 			<Modal
 				className="editor-sync-connection-modal"
 				isDismissible={ false }
-				onRequestClose={ noop }
+				onRequestClose={ () => {} }
 				shouldCloseOnClickOutside={ false }
 				shouldCloseOnEsc={ false }
 				size="medium"


### PR DESCRIPTION

## What?

During a collaboration session, implement separate debounce after initial connection before showing disconnection dialog.

Closes #76111

<!-- In a few words, what is the PR actually doing? -->

## Why?

Tolerate brief network issues without interrupting the user.

## How?

Add new constant `DISCONNECTED_DEBOUNCE_MS` for debouncing the disconnect dialog after the connection has already been established.


## Testing Instructions

1. Settings > Writing > Enable real-time collaboration
2. Open a post in the editor.
3. Simulate a brief network drop (e.g., toggle Wi-Fi off and back on within ~1 second, or use browser DevTools Network tab to go offline then online quickly).
4. The disconnect dialog should not appear.