### PR TITLE
Block toolbar: hide styles dropdown for content only blocks inside unsynced patterns in Revisions UI

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -71,7 +71,12 @@ function getBlockIconVariant( { select, clientIds } ) {
 
 	if ( _showBlockSwitcher ) {
 		return 'switcher';
-	} else if ( isContentOnlyMode && hasBlockStyles && ! hasPatternOverrides ) {
+	} else if (
+		isContentOnlyMode &&
+		hasBlockStyles &&
+		! hasPatternOverrides &&
+		canEdit
+	) {
 		return 'styles-only';
 	} else if ( _showPatternOverrides ) {
 		return 'pattern-overrides';


### PR DESCRIPTION


## What?

Follow up to:

- https://github.com/WordPress/gutenberg/pull/76066#pullrequestreview-3886127137



In the Revisions UI, @andrewserong noticed that the block styles dropdown (shown as the block icon when a block is in `contentOnly` mode and has registered styles) was still appearing and allowing style changes.



## Why?

The Revisions canvas sets `isPreviewMode: true`, which makes `canEditBlock` return `false`. 

The `styles-only` block icon variant — which renders `BlockStylesDropdown` — was not checking `canEdit`, so the dropdown remained available in contexts where block editing is disabled.


## How?

Gate the `'styles-only'` variant in `getBlockIconVariant` behind `canEdit` (which is derived from `canEditBlock`). When editing is not allowed, the block icon falls back to the `'default'` variant — a plain disabled icon button — consistent with the intent of the Revisions UI.

## Testing Instructions

1. Insert or create an unsynced pattern that contains blocks with registered styles (e.g. a Button block, Image block, or any block with style variations).
2. Save a few revisions: edit → save → edit → save.
3. Open the Revisions UI panel (Post → Revisions in the sidebar).
4. In the Revisions UI, click to select a block that has registered styles and is inside an unsynced pattern (so its editing mode is `contentOnly`).
5. Confirm that the block toolbar shows a plain disabled block icon — the styles dropdown should not appear.
6. Check for regressions: exit the Revisions UI and select the same block in the normal editor. The styles dropdown should still appear in the block toolbar as before.

## Screenshots or screencast <!-- if applicable -->

Here I'm testing a Heading block inside an unsynced pattern, but Button, Image also work

|Before|After|
|-|-|
|<img width="915" height="385" alt="Screenshot 2026-03-04 at 2 46 25 pm" src="https://github.com/user-attachments/assets/e9426661-664a-41cc-8d6d-215fb49948b6" />|<img width="903" height="419" alt="Screenshot 2026-03-04 at 2 49 01 pm" src="https://github.com/user-attachments/assets/9779e157-7cc9-49c2-a66f-690d60e76161" />|


