### PR TITLE
Client-side media processing: Invalidate media after upload

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -36,6 +36,7 @@ import NavigationBlockEditingMode from './navigation-block-editing-mode';
 import { useHideBlocksFromInserter } from './use-hide-blocks-from-inserter';
 import useCommands from '../commands';
 import useUploadSaveLock from './use-upload-save-lock';
+import useInvalidateMediaAfterUpload from './use-invalidate-media-after-upload';
 import BlockRemovalWarnings from '../block-removal-warnings';
 import StartPageOptions from '../start-page-options';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
@@ -382,6 +383,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Lock post saving when media uploads are in progress (experimental feature).
 		useUploadSaveLock();
+
+		// Invalidate attachment entities after uploads complete so blocks see updated data.
+		useInvalidateMediaAfterUpload();
 
 		if ( ! isReady || ! mode ) {
 			return null;

--- a/packages/editor/src/components/provider/use-invalidate-media-after-upload.js
+++ b/packages/editor/src/components/provider/use-invalidate-media-after-upload.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { usePrevious } from '@wordpress/compose';
+import { store as uploadStore } from '@wordpress/upload-media';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+const EMPTY_ARRAY = [];
+
+function getAttachmentIds( items ) {
+	const ids = new Set();
+	for ( const item of items ) {
+		if ( item.attachment?.id ) {
+			ids.add( item.attachment.id );
+		}
+	}
+	return ids;
+}
+
+/**
+ * After client-side media processing completes, the entity store has stale
+ * attachment data (empty `media_details.sizes`) because the initial upload
+ * uses `generate_sub_sizes: false`. This hook watches the upload queue and
+ * invalidates each attachment's entity record once its item (including any
+ * sideloads) is removed from the queue, so blocks re-fetch updated data.
+ *
+ * When client-side media processing is not enabled, invalidation is handled
+ * by `receiveEntityRecords` in the `onFileChange` callback of
+ * `packages/editor/src/utils/media-upload/index.js`.
+ */
+export default function useInvalidateMediaAfterUpload() {
+	const items = useSelect( ( select ) => {
+		if ( ! window.__clientSideMediaProcessing ) {
+			return EMPTY_ARRAY;
+		}
+		return select( uploadStore ).getItems();
+	}, [] );
+
+	const previousItems = usePrevious( items );
+	const { invalidateResolution } = useDispatch( coreDataStore );
+
+	useEffect( () => {
+		if ( ! window.__clientSideMediaProcessing || ! previousItems ) {
+			return;
+		}
+
+		const currentIds = getAttachmentIds( items );
+		const previousIds = getAttachmentIds( previousItems );
+
+		for ( const id of previousIds ) {
+			if ( ! currentIds.has( id ) ) {
+				// Invalidate with and without the query argument, since
+				// resolution keys must exactly match the args used by
+				// each consumer's getEntityRecord() call.
+				invalidateResolution( 'getEntityRecord', [
+					'postType',
+					'attachment',
+					id,
+					{ context: 'view' }, // Used by the image block.
+				] );
+				invalidateResolution( 'getEntityRecord', [
+					'postType',
+					'attachment',
+					id, // Used by the editor's mediaUpload onFileChange.
+				] );
+			}
+		}
+	}, [ items, previousItems, invalidateResolution ] );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/74333

When the client-side media processing feature is active, invalidate media items in the core data store, so that their data can be freshly fetched.

This fixes a bug where if you upload an image to an image block to the post editor on trunk, the block editor thinks it's an external image until you reload the editor.

## Why?

While testing the client-side media processing feature, I noticed that in the post editors if I go to upload to an image block directly, that after upload, the block thinks the image is an external image and not a real image uploaded to the site. This appears to be because now that sub-sized images are generated on the client (https://github.com/WordPress/gutenberg/pull/74566) the image block will update prematurely with an `id` before it has access to all the different size and media_details information.

In the existing logic for server-side media processing, we invalidate [the cache here](https://github.com/WordPress/gutenberg/blob/94bff7de7848d7fb27c2e0261cbe15696e1840be/packages/editor/src/utils/media-upload/index.js#L102-L110), however that approach isn't applicable for the client-side media processing feature — in this case, we have a store that keeps track of the items in progress, and so we need a different approach to invalidate when items are emptied out of the queue.

Similar to how we have a `useUploadSaveLock()` hook for watching the upload media store in the editor package to handle watching for unlocking / locking the post, this PR attempts a similar approach for invalidating the cache of uploaded items.

## How?

* Add an `useInvalidateMediaAfterUpload()` hook that effectively only does anything if the client side media processing feature is active
* Within it, keep track of items in the upload queue, and when they leave the queue, invalidate the resolver cache for the entity record — this forces the image block to grab fresh data in the block editor

## Testing Instructions

On trunk while running Chrome (so the client-side media processing is active):

* Open up the post editor
* Add an image block
* Upload an image to the block
* Notice in the sidebar that the image file url is not the full file url, and that you can't select different image sizes

With this PR applied

* Repeat the above
* The filename should be as expected (i.e. a scaled version of your uploaded file)
* Under settings you should be able to adjust the different image sizes

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/1612c5f4-35ea-4acd-b6a7-d1f4acd1f6a1

### After

https://github.com/user-attachments/assets/31dfd623-e3e5-4d64-9e0b-ad9124c355a3