### PR TITLE
Fix: Block style variations not rendering in Site Editor Patterns page

### DIFF
--- a/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
+++ b/packages/edit-site/src/components/page-patterns/use-pattern-settings.js
@@ -4,6 +4,7 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { generateGlobalStyles } from '@wordpress/global-styles-engine';
 
@@ -15,6 +16,7 @@ import { store as editSiteStore } from '../../store';
 import { filterOutDuplicatesByName } from './utils';
 
 const { useGlobalStyles } = unlock( editorPrivateApis );
+const { globalStylesDataKey } = unlock( blockEditorPrivateApis );
 
 export default function usePatternSettings() {
 	/*
@@ -66,10 +68,17 @@ export default function usePatternSettings() {
 			...restStoredSettings,
 			styles: globalStyles,
 			__experimentalFeatures: globalSettings,
+			[ globalStylesDataKey ]: mergedConfig.styles ?? {},
 			__experimentalBlockPatterns: blockPatterns,
 			isPreviewMode: true,
 		};
-	}, [ storedSettings, blockPatterns, globalStyles, globalSettings ] );
+	}, [
+		storedSettings,
+		blockPatterns,
+		globalStyles,
+		globalSettings,
+		mergedConfig,
+	] );
 
 	return settings;
 }


### PR DESCRIPTION
## What?
Block style variations (e.g. the outline button) were not rendering in the Site Editor > Patterns page, they displayed as the default style instead.

Closes #76089

## Why?
The `useBlockStyleVariation` hook reads `settings[globalStylesDataKey]` to generate per-block variation CSS via `toStyles({ variationStyles: true })`. This Symbol key is set by `useBlockEditorSettings` in the main editor provider path, but the Patterns page uses a separate `ExperimentalBlockEditorProvider` whose settings are built by `usePatternSettings`. That function spreads raw `storedSettings` from the edit-site store (PHP-initialized, carries no Symbol keys), so `settings[globalStylesDataKey]` was always `undefined`, no variation CSS was ever generated.

## How?
Pass `mergedConfig.styles` (from `useGlobalStyles()`, already used in the same hook) as `[ globalStylesDataKey ]` in the pattern preview settings. This is the exact same data the main editor path uses.

## Testing Instructions
1. Activate TT5 theme
2. Go to Editor > Patterns
3. Select Call to action
4. View patterns


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="610" height="719" alt="image" src="https://github.com/user-attachments/assets/4c101eb4-dc47-453d-a945-44aea7ba7ba7" />|<img width="610" height="737" alt="image" src="https://github.com/user-attachments/assets/346b832a-1bf2-4266-adc1-b1ddf0a60d93" />|
