### PR TITLE
Image: Hide 'Set as featured image' for in-editor revisions

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -79,6 +79,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		<Slot
 			fillProps={ {
 				...fillProps,
+				canEdit,
 				selectedBlocks,
 				selectedClientIds,
 			} }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1241,21 +1241,20 @@ export default function Image( {
 		} );
 	};
 
-	const featuredImageControl = (
-		<BlockSettingsMenuControls>
-			{ ( { selectedClientIds } ) =>
-				selectedClientIds.length === 1 &&
-				! isDescendentOfQueryLoop &&
-				postId &&
-				id &&
-				clientId === selectedClientIds[ 0 ] && (
-					<MenuItem onClick={ setPostFeatureImage }>
-						{ __( 'Set as featured image' ) }
-					</MenuItem>
-				)
-			}
-		</BlockSettingsMenuControls>
-	);
+	const featuredImageControl =
+		! isDescendentOfQueryLoop && postId && id ? (
+			<BlockSettingsMenuControls>
+				{ ( { canEdit, selectedClientIds } ) =>
+					canEdit &&
+					selectedClientIds.length === 1 &&
+					clientId === selectedClientIds[ 0 ] && (
+						<MenuItem onClick={ setPostFeatureImage }>
+							{ __( 'Set as featured image' ) }
+						</MenuItem>
+					)
+				}
+			</BlockSettingsMenuControls>
+		) : null;
 
 	return (
 		<>


### PR DESCRIPTION
## What?
Closes #76061.

PR hides the 'Set as featured image' control for the image block when the block can't be edited, for example, when displayed by in-editor revisions.

I understand we're editing the post, not the image itself, but I think the `canEdit` check is still suitable here.

## Testing Instructions
1. Open post with revisions.
2. Add an image block and select media from the library.
3. Save the post.
4. Open the revisions.
5. The 'Set as featured image' shouldn't be visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="689" height="538" alt="CleanShot 2026-03-04 at 09 52 58" src="https://github.com/user-attachments/assets/31d69230-6c2f-4ef7-a629-6223e07f8393" />
