### PR TITLE
Client-side media processing: only use media upload provider at the top level of the block editor provider

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -146,13 +146,9 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 		const isClientSideMediaEnabled =
 			shouldEnableClientSideMediaProcessing();
 
-		// Preview providers must not set up their own MediaUploadProvider or
-		// replace the mediaUpload setting.  Every MediaUploadProvider with
-		// useSubRegistry={false} writes to the same shared upload-media store,
-		// so a nested preview provider would overwrite the parent's original
-		// server-side mediaUpload function with the already-replaced
-		// client-side interceptor, causing uploads in the main editor to
-		// dispatch back into the upload-media store in an infinite loop.
+		// Skip the interceptor replacement and MediaUploadProvider for
+		// preview providers. See the comment above MediaUploadProvider
+		// below for details.
 		const isPreviewMode = !! _settings?.isPreviewMode;
 
 		const settings = useMemo( () => {
@@ -228,6 +224,20 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 			</SelectionContext.Provider>
 		);
 
+		// MediaUploadProvider writes the mediaUpload function from
+		// _settings into the shared upload-media store so the store can
+		// hand files off to the server. useMediaUploadSettings extracts
+		// mediaUpload from the original _settings prop — *before* the
+		// interceptor replacement above — so the store receives the
+		// real server-side upload function.
+		//
+		// Only the top-level (non-preview) provider should do this.
+		// Nested preview providers (e.g. from useBlockPreview in
+		// core/post-template) inherit settings that already contain
+		// the interceptor, so their MediaUploadProvider would
+		// overwrite the store's server-side function with the
+		// interceptor, causing uploads to loop instead of reaching
+		// the server.
 		if ( isClientSideMediaEnabled && ! isPreviewMode ) {
 			return (
 				<MediaUploadProvider

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -146,8 +146,21 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 		const isClientSideMediaEnabled =
 			shouldEnableClientSideMediaProcessing();
 
+		// Preview providers must not set up their own MediaUploadProvider or
+		// replace the mediaUpload setting.  Every MediaUploadProvider with
+		// useSubRegistry={false} writes to the same shared upload-media store,
+		// so a nested preview provider would overwrite the parent's original
+		// server-side mediaUpload function with the already-replaced
+		// client-side interceptor, causing uploads in the main editor to
+		// dispatch back into the upload-media store in an infinite loop.
+		const isPreviewMode = !! _settings?.isPreviewMode;
+
 		const settings = useMemo( () => {
-			if ( isClientSideMediaEnabled && _settings?.mediaUpload ) {
+			if (
+				isClientSideMediaEnabled &&
+				_settings?.mediaUpload &&
+				! isPreviewMode
+			) {
 				// Create a new object so that the original props.settings.mediaUpload is not modified.
 				return {
 					..._settings,
@@ -155,7 +168,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 				};
 			}
 			return _settings;
-		}, [ _settings, registry, isClientSideMediaEnabled ] );
+		}, [ _settings, registry, isClientSideMediaEnabled, isPreviewMode ] );
 
 		const { __experimentalUpdateSettings } = unlock(
 			useDispatch( blockEditorStore )
@@ -215,7 +228,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 			</SelectionContext.Provider>
 		);
 
-		if ( isClientSideMediaEnabled ) {
+		if ( isClientSideMediaEnabled && ! isPreviewMode ) {
 			return (
 				<MediaUploadProvider
 					settings={ mediaUploadSettings }

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -146,25 +146,34 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 		const isClientSideMediaEnabled =
 			shouldEnableClientSideMediaProcessing();
 
-		// Skip the interceptor replacement and MediaUploadProvider for
-		// preview providers. See the comment above MediaUploadProvider
-		// below for details.
-		const isPreviewMode = !! _settings?.isPreviewMode;
+		// Nested providers (e.g. from useBlockPreview) inherit settings
+		// where mediaUpload has already been replaced with the
+		// interceptor.  Detect this so we skip the replacement and
+		// MediaUploadProvider for them — see the longer comment below.
+		const isMediaUploadIntercepted =
+			!! _settings?.mediaUpload?.__isMediaUploadInterceptor;
 
 		const settings = useMemo( () => {
 			if (
 				isClientSideMediaEnabled &&
 				_settings?.mediaUpload &&
-				! isPreviewMode
+				! isMediaUploadIntercepted
 			) {
 				// Create a new object so that the original props.settings.mediaUpload is not modified.
+				const interceptor = mediaUpload.bind( null, registry );
+				interceptor.__isMediaUploadInterceptor = true;
 				return {
 					..._settings,
-					mediaUpload: mediaUpload.bind( null, registry ),
+					mediaUpload: interceptor,
 				};
 			}
 			return _settings;
-		}, [ _settings, registry, isClientSideMediaEnabled, isPreviewMode ] );
+		}, [
+			_settings,
+			registry,
+			isClientSideMediaEnabled,
+			isMediaUploadIntercepted,
+		] );
 
 		const { __experimentalUpdateSettings } = unlock(
 			useDispatch( blockEditorStore )
@@ -231,14 +240,14 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 		// interceptor replacement above — so the store receives the
 		// real server-side upload function.
 		//
-		// Only the top-level (non-preview) provider should do this.
-		// Nested preview providers (e.g. from useBlockPreview in
+		// Only the first (outermost) provider should do this.
+		// Nested providers (e.g. from useBlockPreview in
 		// core/post-template) inherit settings that already contain
 		// the interceptor, so their MediaUploadProvider would
 		// overwrite the store's server-side function with the
 		// interceptor, causing uploads to loop instead of reaching
 		// the server.
-		if ( isClientSideMediaEnabled && ! isPreviewMode ) {
+		if ( isClientSideMediaEnabled && ! isMediaUploadIntercepted ) {
 			return (
 				<MediaUploadProvider
 					settings={ mediaUploadSettings }


### PR DESCRIPTION
## What?

Part of:

* #74333

Fix a bug where images uploaded to an image block in the site editor would get stuck in an endless loading state without uploading.

## Why?

In the site editor when we're editing a template we typically have a Query Loop / Post Template block somewhere in the template rendering a block preview. When a block preview is present, a nested `ExperimentalBlockEditorProvider` is rendered, and this causes a problem — because the _nested_ provider's access to its block editor settings uses the overridden `mediaUpload` function that simply queues items for upload, instead of actually uploading to the server.

Because the `MediaUploadProvider` does not use a sub-registry, when we update the media upload settings, the upload-media store gets stuck in a state where subsequent calls to `mediaUpload` simply queue more images for upload without an upload ever occurring. The result is: endlessly stuck in a loading / pending state.

It's hard to describe the issue: but effectively the upload-media store gets stuck in a state where it no longer has access to the "real" `mediaUpload` that uploads to the server.

~This idea in this PR is to do something of a quick fix — skip outputting the `MediaUploadProvider` and overriding `mediaUpload` if we're in a preview state. As a bandaid and to fix the issue in 7.0, I think this is a reasonable fix for now.~

This PR adds a `__isMediaUploadInterceptor` key to the intercepted `mediaUpload` so that we only output `MediaUploadProvider` in the outer-most `BlockEditorProvider` to prevent getting stuck.

More broadly, though, I'm wondering if there's a better API for the internals of `upload-media` to avoid the problem that the server-side `mediaUpload` (that is, the function that actually submits the media to the server) has the same key as the `mediaUpload` that adds items to the queue.

I.e. possibly we could have a separate function... but that feels like a bit more of a rabbit hole than fixing the task at hand. So I've tried to keep things simple, while adding lots of comments to explain the issue.

If there's a better approach, though, happy to close this out!

## How?

* Skip overriding `mediaUpload` and outputting `MediaUploadProvider` when the block editor settings are not at the top-level (i.e. when the passed in `_settings?.mediaUpload` is the intercepted version)

## Testing Instructions

On trunk:

* Using Chrome. open up the site editor on a template that uses the Query Loop block with a Post Template in it.
* Add an image block somewhere in the template
* Go to upload an image to the image block
* Notice you get stuck in an endless loop

With this PR:

* Repeat the above, and it should upload successfully

Note: there is a separate issue with what happens when an upload completes (it appears like it's an external image). There's a separate fix for this over in: #76121 

## Screenshots or screencast <!-- if applicable -->

### Before

You'd just get stuck in this state endlessly:

<img width="2464" height="1574" alt="image" src="https://github.com/user-attachments/assets/dbd13b7f-3b73-44a2-b97c-18e1ff71b5f4" />

### After

Upload completes successfully:

https://github.com/user-attachments/assets/0f28a7ce-7a74-4f96-b2a3-ac79a80796ee