### PR TITLE
Image: Replace 'getEntityRecordPermissions` with 'canUser'

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -323,20 +323,15 @@ export default function Image( {
 					  )
 					: null;
 
-			// Check edit permissions. When the media editor experiment is enabled,
-			// use getEntityRecordPermissions which checks via canUser API.
-			// Only check when the image is selected to avoid unnecessary API requests.
+			// Check edit permissions when the media editor experiment is enabled.
+			// Only check when imageRecord is available to avoid unnecessary API requests.
 			let canEdit = false;
-			if ( id && isSingleSelected && window?.__experimentalMediaEditor ) {
-				const { getEntityRecordPermissions } = unlock(
-					select( coreStore )
-				);
-				const permissions = getEntityRecordPermissions(
-					'postType',
-					'attachment',
-					id
-				);
-				canEdit = permissions?.update || false;
+			if ( imageRecord && window?.__experimentalMediaEditor ) {
+				canEdit = !! select( coreStore ).canUser( 'update', {
+					kind: 'postType',
+					name: 'attachment',
+					id,
+				} );
 			}
 
 			return {


### PR DESCRIPTION
## What?
This is a follow-up to #74601.

Use the public `canUser` selector instead of the private `getEntityRecordPermissions`. Gate the check on `imageRecord` availability to avoid fetching permissions before the record is loaded.

## Why?
* Using `canUser` directly should be preferred, just checking a single permission.
* Waiting for imageRecord ensures there's no separate `OPTIONS` requests. Selector will use pre-resolved data. It also ensures we don't display control if media is missing.

## Testing Instructions
1. Enable media editor experiment.
2. Add an image block to a post (and either upload an image or select one from the media library)
3. Select the block, and you should see an "Edit media" button in the block toolbar

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1369" height="186" alt="CleanShot 2026-03-04 at 09 58 51" src="https://github.com/user-attachments/assets/7a7d9e9a-a619-46e0-a35f-31840480498a" />
