### PR TITLE
Tooltip: Change default placement from bottom to top

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 -   `ToggleGroupControl`: Make unselected item color consistent across all variants ([#75737](https://github.com/WordPress/gutenberg/pull/75737)).
 -   `Button`: Add `word-break: break-word`. ([#76071](https://github.com/WordPress/gutenberg/pull/76071)).
+-   `Tooltip`: Change default `placement` from `bottom` to `top`.
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 -   `ToggleGroupControl`: Make unselected item color consistent across all variants ([#75737](https://github.com/WordPress/gutenberg/pull/75737)).
 -   `Button`: Add `word-break: break-word`. ([#76071](https://github.com/WordPress/gutenberg/pull/76071)).
--   `Tooltip`: Change default `placement` from `bottom` to `top`.
+-   `Tooltip`: Change default `placement` from `bottom` to `top`. ([#76131](https://github.com/WordPress/gutenberg/pull/76131)).
 
 ### Internal
 

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -51,7 +51,7 @@ Option to hide the tooltip when the anchor is clicked.
 Used to specify the tooltip's placement with respect to its anchor.
 
 -   Required: No
--   Default: `'bottom'`
+-   Default: `'top'`
 
 #### `position`: `string`
 
@@ -60,7 +60,7 @@ _Note: use the `placement` prop instead when possible._
 Legacy way to specify the popover's position with respect to its anchor. Specify y- and x-axis as a space-separated string. Supports `'top'`, `'middle'`, `'bottom'` y axis, and `'left'`, `'center'`, `'right'` x axis.
 
 -   Required: No
--   Default: `'bottom'`
+-   Default: `'top'`
 
 #### `shortcut`: `string` | `object`
 

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -58,7 +58,7 @@ function UnforwardedTooltip(
 	// Compute tooltip's placement:
 	// - give priority to `placement` prop, if defined
 	// - otherwise, compute it from the legacy `position` prop (if defined)
-	// - finally, fallback to the default placement: 'bottom'
+	// - finally, fallback to the default placement: 'top'
 	let computedPlacement;
 	if ( placement !== undefined ) {
 		computedPlacement = placement;
@@ -69,7 +69,7 @@ function UnforwardedTooltip(
 			alternative: '`placement` prop',
 		} );
 	}
-	computedPlacement = computedPlacement || 'bottom';
+	computedPlacement = computedPlacement || 'top';
 
 	const tooltipStore = Ariakit.useTooltipStore( {
 		placement: computedPlacement,

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -35,7 +35,7 @@ export type TooltipProps = {
 	/**
 	 * Where the tooltip should be positioned relative to its parent.
 	 *
-	 * @default bottom
+	 * @default top
 	 */
 	placement?: Placement;
 	/**
@@ -47,7 +47,7 @@ export type TooltipProps = {
 	 * `"bottom"` y axis, and `"left"`, `"center"`, `"right"` x axis.
 	 *
 	 * @deprecated
-	 * @default bottom
+	 * @default top
 	 */
 	position?: PopoverProps[ 'position' ];
 	/**

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Enhancements
 
 -   `Dialog`: Add `--wp-ui-dialog-z-index` CSS custom property for legacy z-index compatibility ([#75874](https://github.com/WordPress/gutenberg/pull/75874)).
--   `Tooltip`: Change default `side` from `bottom` to `top`.
+-   `Tooltip`: Change default `side` from `bottom` to `top`. ([#76131](https://github.com/WordPress/gutenberg/pull/76131)).
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Enhancements
 
 -   `Dialog`: Add `--wp-ui-dialog-z-index` CSS custom property for legacy z-index compatibility ([#75874](https://github.com/WordPress/gutenberg/pull/75874)).
+-   `Tooltip`: Change default `side` from `bottom` to `top`.
 
 ### Bug Fixes
 

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -16,7 +16,7 @@ const ThemeProvider: typeof ThemeProviderType =
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function TooltipPopup(
 	{
 		align = 'center',
-		side = 'bottom',
+		side = 'top',
 		sideOffset = 4,
 		children,
 		className,


### PR DESCRIPTION
<img width="483" height="117" alt="Screenshot 2026-03-04 at 09 42 11" src="https://github.com/user-attachments/assets/9fb77bdb-7914-4760-881c-061376a78fee" />

## What

Changes the default placement of `Tooltip` from `bottom` to `top` in both `@wordpress/components` and `@wordpress/ui`.

## Why

The Tooltip's original default position was `top`. This was inadvertently changed to `bottom` back in #21476, which updated the `Popover` default `position` from `top` to `bottom right` for consistency across popovers. Because `Tooltip` inherited its positioning from `Popover` at the time, its default shifted too, without anyone noticing.

Beyond restoring the original intent, `top` is a more sensible default for tooltips. The cursor's hotspot sits at the top-left pixel of the pointer sprite, meaning the rest of the pointer graphic extends downward and to the right. Placing the tooltip _above_ the anchor helps avoid situations where the pointer obscures the tooltip content, like in the screenshot below:

<img width="225" height="120" alt="Screenshot 2026-03-04 at 09 46 23" src="https://github.com/user-attachments/assets/ef7f96fe-e848-4d78-8bbd-058065593fcf" />

## How

- `@wordpress/components`: Updated the fallback placement from `'bottom'` to `'top'` in the `Tooltip` component, along with the corresponding `@default` JSDoc annotations in the type definitions.
- `@wordpress/ui`: Updated the default `side` prop from `'bottom'` to `'top'` in the `Tooltip.Popup` component.

## Testing Instructions

### 1. Storybook

- Run `npm run storybook:dev`
- Navigate to the `Tooltip` stories 
- Confirm the tooltip appears **above** the anchor element by default
- Confirm that passing `placement="bottom"` (or any other valid placement) still works as expected

### 2. Smoke test in the Editor

- Open the block editor (post or site editor)
- Hover over toolbar icons (e.g. bold, italic, link) — tooltips should appear **above** the buttons
- Hover over icons in the editor header (e.g. Settings, Block Inserter) — tooltips should still appear below the buttons because there's not space for them to appear above
- Confirm no usability regressions with tooltip positioning across the editor