### PR TITLE
DataViews: Fix last column classname in `table` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: Fix last column classname in table layout. [#76133](https://github.com/WordPress/gutenberg/pull/76133)
+
 ## 13.0.0 (2026-03-04)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -444,7 +444,7 @@ function ViewTable< Item >( {
 							className={ clsx(
 								`dataviews-view-table__col-${ column }`,
 								{
-									'dataviews-view-table__col-first-expand':
+									'dataviews-view-table__col-expand':
 										! hasPrimaryColumn &&
 										index === columns.length - 1,
 								}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While working on a different issue I observed that in https://github.com/WordPress/gutenberg/pull/74572 I accidentally updated incorrectly the classname that is responsible to expand the last column in `table` layout. 

This PR fixes that. 

## Notes
Even though the PR that had this wrong classname was backported for 7.0, this classname was not because the original [PR](https://github.com/WordPress/gutenberg/pull/75410) for that change hasn't been backported.

## Testing Instructions
1. Check in storybook (`?path=/story/dataviews-dataviews--layout-table`) that when a `titleField` is not provided the last column is expanded. `npm run storybook:dev`





|Before|After|
|-|-|
|<img width="943" height="346" alt="before" src="https://github.com/user-attachments/assets/02ee6d5e-3883-4658-994c-a5b2702487e4" />|<img width="943" height="346" alt="after" src="https://github.com/user-attachments/assets/470361dc-09d7-4e9d-b672-d73ca9c5e878" />|