### PR TITLE
Data: Update documentation for global 'dispatch' and 'select' methods

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -491,6 +491,8 @@ Given a store descriptor, returns an object of the store's action creators. Call
 
 Note: Action creators returned by the dispatch will return a promise when they are called.
 
+Warning: This global `dispatch` function only works with the default registry. It will not work with custom `RegistryProvider` or `BlockEditorProvider` contexts. In React components, prefer the `useDispatch` hook instead, which is registry-aware.
+
 _Usage_
 
 ```js
@@ -625,6 +627,8 @@ _Returns_
 ### select
 
 Given a store descriptor, returns an object of the store's selectors. The selector functions are been pre-bound to pass the current state automatically. As a consumer, you need only pass arguments of the selector, if applicable.
+
+Warning: This global `select` function only works with the default registry. It will not work with custom `RegistryProvider` or `BlockEditorProvider` contexts. In React components, prefer the `useSelect` hook instead, which is registry-aware.
 
 _Usage_
 

--- a/packages/data/src/dispatch.ts
+++ b/packages/data/src/dispatch.ts
@@ -11,6 +11,10 @@ import defaultRegistry from './default-registry';
  * Note: Action creators returned by the dispatch will return a promise when
  * they are called.
  *
+ * Warning: This global `dispatch` function only works with the default registry.
+ * It will not work with custom `RegistryProvider` or `BlockEditorProvider` contexts.
+ * In React components, prefer the `useDispatch` hook instead, which is registry-aware.
+ *
  * @param storeNameOrDescriptor The store descriptor. The legacy calling convention of passing
  *                              the store name is also supported.
  *

--- a/packages/data/src/select.ts
+++ b/packages/data/src/select.ts
@@ -9,6 +9,9 @@ import defaultRegistry from './default-registry';
  * The selector functions are been pre-bound to pass the current state automatically.
  * As a consumer, you need only pass arguments of the selector, if applicable.
  *
+ * Warning: This global `select` function only works with the default registry.
+ * It will not work with custom `RegistryProvider` or `BlockEditorProvider` contexts.
+ * In React components, prefer the `useSelect` hook instead, which is registry-aware.
  *
  * @param storeNameOrDescriptor The store descriptor. The legacy calling convention
  *                              of passing the store name is also supported.


### PR DESCRIPTION
## What?
Part of #75926.

PR adds explanatory warnings to global 'dispatch' and 'select' methods. They shouldn't be used in blocks or in any other extensions written as React components or hooks.

Warning is based on https://github.com/WordPress/gutenberg/pull/31078#issuecomment-981635165. Props to @youknowriad.

## Testing Instructions
Check that the documentation makes sense.