### PR TITLE
DataForm: Consolidate `date` and `datetime` input placement

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - DataViews: Fix last column classname in table layout. [#76133](https://github.com/WordPress/gutenberg/pull/76133)
 
+### Code Quality
+
+- DataForm: Consolidate `date` and `datetime` input placement. [#76136](https://github.com/WordPress/gutenberg/pull/76136)
+
 ## 13.0.0 (2026-03-04)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -293,6 +293,7 @@ function CalendarDateControl< Item >( {
 	const {
 		id,
 		label,
+		description,
 		setValue,
 		getValue,
 		isValid,
@@ -385,6 +386,7 @@ function CalendarDateControl< Item >( {
 				id={ id }
 				className="dataviews-controls__date"
 				label={ displayLabel }
+				help={ description }
 				hideLabelFromVision={ hideLabelFromVision }
 			>
 				<Stack direction="column" gap="lg">
@@ -462,7 +464,14 @@ function CalendarDateRangeControl< Item >( {
 	markWhenOptional,
 	validity,
 }: DataFormControlProps< Item > ) {
-	const { id, label, getValue, setValue, format: fieldFormat } = field;
+	const {
+		id,
+		label,
+		description,
+		getValue,
+		setValue,
+		format: fieldFormat,
+	} = field;
 	let value: DateRange;
 	const fieldValue = getValue( { item: data } );
 	if (
@@ -597,6 +606,7 @@ function CalendarDateRangeControl< Item >( {
 				id={ id }
 				className="dataviews-controls__date"
 				label={ displayLabel }
+				help={ description }
 				hideLabelFromVision={ hideLabelFromVision }
 			>
 				<Stack direction="column" gap="lg">

--- a/packages/dataviews/src/components/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/components/dataform-controls/datetime.tsx
@@ -176,18 +176,6 @@ function CalendarDateTimeControl< Item >( {
 			hideLabelFromVision={ hideLabelFromVision }
 		>
 			<Stack direction="column" gap="lg">
-				{ /* Calendar widget */ }
-				<DateCalendar
-					style={ { width: '100%' } }
-					selected={
-						value ? parseDateTime( value ) || undefined : undefined
-					}
-					onSelect={ onSelectDate }
-					month={ calendarMonth }
-					onMonthChange={ setCalendarMonth }
-					timeZone={ timezoneString || undefined }
-					weekStartsOn={ weekStartsOn }
-				/>
 				{ /* Manual datetime input */ }
 				<ValidatedInputControl
 					ref={ inputControlRef }
@@ -205,6 +193,18 @@ function CalendarDateTimeControl< Item >( {
 							: ''
 					}
 					onChange={ handleManualDateTimeChange }
+				/>
+				{ /* Calendar widget */ }
+				<DateCalendar
+					style={ { width: '100%' } }
+					selected={
+						value ? parseDateTime( value ) || undefined : undefined
+					}
+					onSelect={ onSelectDate }
+					month={ calendarMonth }
+					onMonthChange={ setCalendarMonth }
+					timeZone={ timezoneString || undefined }
+					weekStartsOn={ weekStartsOn }
 				/>
 			</Stack>
 		</BaseControl>

--- a/packages/dataviews/src/components/dataform-controls/utils/relative-date-control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/relative-date-control.tsx
@@ -58,7 +58,7 @@ export default function RelativeDateControl< Item >( {
 			operator === OPERATOR_IN_THE_PAST ? 'inThePast' : 'over'
 		];
 
-	const { id, label, getValue, setValue } = field;
+	const { id, label, description, getValue, setValue } = field;
 	const fieldValue = getValue( { item: data } );
 	const { value: relValue = '', unit = options[ 0 ].value } =
 		fieldValue && typeof fieldValue === 'object' ? fieldValue : {};
@@ -91,6 +91,7 @@ export default function RelativeDateControl< Item >( {
 			className={ clsx( className, 'dataviews-controls__relative-date' ) }
 			label={ label }
 			hideLabelFromVision={ hideLabelFromVision }
+			help={ description }
 		>
 			<Stack direction="row" gap="sm">
 				<NumberControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Mentioned in this [PR](https://github.com/WordPress/gutenberg/issues/73329#issuecomment-3983683746):

>date controls have the input above the calendar, but datetime has it below. Should we consolidate here?

And the [reply](https://github.com/WordPress/gutenberg/issues/73329#issuecomment-3984914490):

>Yes I think so. I prefer how the UI looks when the input appears below the calendar, but I think it's marginally more accessible to place the input first so I'd lean in that direction.


This PR consolidates the two controls to have the input first.

Additionally I noticed that in `date` control we weren't using the field `description` as the `help` message which I don't think it was intentional, so I'm adding it here.

## Testing Instructions
1. in storybook (`?path=/story/dataviews-fieldtypes--date-component`). To start it: `npm run storybook:dev`
2. in site editor go to `pages` page and apply the `date` filter
3. observe that the input is above the calendar





|Before|After|
|-|-|
|<img width="658" height="654" alt="before" src="https://github.com/user-attachments/assets/2b672046-e71e-4bb8-955f-70e75b79f6c1" />|<img width="658" height="654" alt="after" src="https://github.com/user-attachments/assets/f04f29d0-6940-4be1-a317-c94a1725d8b5" />|
