### PR TITLE
HTML & Shortcode: Disable viewport visibility support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -426,7 +426,7 @@ Add custom HTML code and preview it as you edit. ([Source](https://github.com/Wo
 
 -	**Name:** core/html
 -	**Category:** widgets
--	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
 -	**Attributes:** content
 
 ## Icon

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -929,7 +929,7 @@ Insert additional custom elements with a WordPress shortcode. ([Source](https://
 
 -	**Name:** core/shortcode
 -	**Category:** widgets
--	**Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~
+-	**Supports:** ~~className~~, ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~visibility~~
 -	**Attributes:** text
 
 ## Site Logo

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -21,7 +21,8 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"customCSS": false
+		"customCSS": false,
+		"visibility": false
 	},
 	"editorStyle": "wp-block-html-editor"
 }

--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -17,7 +17,8 @@
 		"className": false,
 		"customClassName": false,
 		"html": false,
-		"customCSS": false
+		"customCSS": false,
+		"visibility": false
 	},
 	"editorStyle": "wp-block-shortcode-editor"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #76128

Explicitly disables viewport visibility support for the Custom HTML and Shortcode blocks.

## Why?
Viewport visibility relies on wrapper-level class injection via block supports.  
The `core/html` block disables `className` support and does not render a wrapper element in `save`, meaning the responsive hide CSS has no DOM target.

As a result, the visibility controls appear in the UI but do not function correctly for this block.

Since modifying the block to inject a wrapper would introduce markup changes and potential backward-compatibility concerns, this PR aligns block capabilities with its rendering behavior by opting out of viewport visibility support.

## How?
This PR adds the following to `packages/block-library/src/html/block.json`:

```
"visibility": false
```

This explicitly disables viewport visibility support for the HTML block while leaving other blocks unaffected.

No changes to rendering logic or frontend markup were introduced.

## Testing Instructions

1. Checkout this branch.
2. Run `npm install` (if needed).
3. Run `npm run build`.
4. Start a local WordPress environment with Gutenberg active.
5. Open a post or page.
6. Insert a **Custom HTML** block.
7. Check the block settings sidebar.

Expected result:
- The viewport visibility controls (e.g., “Hide on Desktop”) should no longer appear for the Custom HTML block.

Verification:
1. Insert a **Paragraph** block.
2. Confirm viewport visibility controls are still available for that block.
3. Confirm no frontend markup changes occur for the HTML block.

### Testing Instructions for Keyboard

1. Open a post or page.
2. Use `/html` to insert a Custom HTML block.
3. Press `Shift + Tab` to move to the block settings sidebar.
4. Navigate through available controls using `Tab`.

Expected result:
- No viewport visibility controls should be present for the Custom HTML block.
- Keyboard navigation should remain unaffected.

## Screenshots or screencast

### Before
Visibility controls visible but non-functional for Custom HTML block.

<img width="1215" height="709" alt="Screenshot 2026-03-04 at 4 59 14 PM" src="https://github.com/user-attachments/assets/d8d85f93-2841-4efa-809e-5c62ce9f24e9" />


### After
Visibility controls no longer displayed for Custom HTML block.

<img width="1238" height="754" alt="Screenshot 2026-03-04 at 4 53 03 PM" src="https://github.com/user-attachments/assets/a01f583e-c750-4a97-bfbd-d6bb1acf0f8e" />
|