### PR TITLE
Playlist: Clip content to respect border-radius

### DIFF
--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -4,6 +4,11 @@
 $waveform-player-height: 100px;
 
 .wp-block-playlist {
+	// Clip content to respect border-radius.
+	// `overflow: hidden` is a fallback for browsers that don't support `overflow: clip`.
+	overflow: hidden;
+	overflow: clip;
+
 	// Main waveform player container.
 	.wp-block-playlist__waveform-player {
 		width: 100%;


### PR DESCRIPTION
## What?
Add `overflow: clip` to the playlist block so content is clipped to the border-radius.

## Why?
When a border-radius is applied to the playlist block, child content (waveform player, tracklist) bleeds outside the rounded corners.

## How?
Adds `overflow: clip` (with `overflow: hidden` as a fallback for older browsers) to `.wp-block-playlist` in `style.scss`. This follows the same pattern used by the cover block.

## Testing Instructions
1. Add a playlist block with some tracks.
2. In the block sidebar, set a border-radius (e.g. 20px).
3. Verify the waveform player and tracklist are clipped to the rounded corners and no content bleeds outside.
4. Verify normal behavior (no border-radius) is unaffected.

### Testing Instructions for Keyboard
No UI interaction changes — this is a CSS-only fix. Standard keyboard navigation should work as before.

## Screenshots or screencast
|Before|After|
|-|-|
| <img width="596" height="768" alt="Screenshot 2026-03-04 at 15 40 37" src="https://github.com/user-attachments/assets/23917152-e8f9-4814-a668-1fbd46239086" /> | <img width="611" height="769" alt="Screenshot 2026-03-04 at 15 38 58" src="https://github.com/user-attachments/assets/05e3944c-d652-4834-8d44-5292419cfd27" />
  |