### PR TITLE
Revisions: use useSubRegistry={false} to fix global store selectors

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -92,19 +92,21 @@ export default function EditContents( { clientId } ) {
 		stopEditingContentOnlySection,
 	} = useContentOnlySectionEdit( clientId );
 
-	const { block, onNavigateToEntityRecord } = useSelect(
+	const { block, onNavigateToEntityRecord, canEdit } = useSelect(
 		( select ) => {
-			const { getBlock, getSettings } = select( blockEditorStore );
+			const { getBlock, getSettings, canEditBlock } =
+				select( blockEditorStore );
 			return {
 				block: getBlock( clientId ),
 				onNavigateToEntityRecord:
 					getSettings().onNavigateToEntityRecord,
+				canEdit: canEditBlock( clientId ),
 			};
 		},
 		[ clientId ]
 	);
 
-	if ( ! isWithinSection && ! isWithinEditedSection ) {
+	if ( ! canEdit || ( ! isWithinSection && ! isWithinEditedSection ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -7,6 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { debounce } from '@wordpress/compose';
 import {
 	Button,
@@ -23,11 +24,16 @@ import PreviewBlockPopover from '../block-switcher/preview-block-popover';
 import useStylesForBlocks from './use-styles-for-block';
 import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
 import { getDefaultStyle, replaceActiveStyle } from './utils';
+import { store as blockEditorStore } from '../../store';
 
 const noop = () => {};
 
 // Block Styles component for the Settings Sidebar.
 function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
+	const canEdit = useSelect(
+		( select ) => select( blockEditorStore ).canEditBlock( clientId ),
+		[ clientId ]
+	);
 	const {
 		onSelect,
 		stylesToRender,
@@ -62,7 +68,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 		];
 	}, [ hoveredStyle, genericPreviewBlock, className, activeStyle ] );
 
-	if ( ! stylesToRender || stylesToRender.length === 0 ) {
+	if ( ! canEdit || ! stylesToRender || stylesToRender.length === 0 ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -146,41 +146,46 @@ function VariationsToggleGroupControl( {
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { activeBlockVariation, variations, isContentOnly, isSection } =
-		useSelect(
-			( select ) => {
-				const { getActiveBlockVariation, getBlockVariations } =
-					select( blocksStore );
+	const {
+		activeBlockVariation,
+		variations,
+		canEdit,
+		isContentOnly,
+		isSection,
+	} = useSelect(
+		( select ) => {
+			const { getActiveBlockVariation, getBlockVariations } =
+				select( blocksStore );
 
-				const {
-					getBlockName,
-					getBlockAttributes,
-					getBlockEditingMode,
-					isSectionBlock,
-				} = unlock( select( blockEditorStore ) );
+			const {
+				getBlockName,
+				getBlockAttributes,
+				getBlockEditingMode,
+				isSectionBlock,
+			} = unlock( select( blockEditorStore ) );
+			const { canEditBlock } = select( blockEditorStore );
 
-				const name = blockClientId && getBlockName( blockClientId );
+			const name = blockClientId && getBlockName( blockClientId );
 
-				const { hasContentRoleAttribute } = unlock(
-					select( blocksStore )
-				);
-				const isContentBlock = hasContentRoleAttribute( name );
+			const { hasContentRoleAttribute } = unlock( select( blocksStore ) );
+			const isContentBlock = hasContentRoleAttribute( name );
 
-				return {
-					activeBlockVariation: getActiveBlockVariation(
-						name,
-						getBlockAttributes( blockClientId ),
-						'transform'
-					),
-					variations: name && getBlockVariations( name, 'transform' ),
-					isContentOnly:
-						getBlockEditingMode( blockClientId ) ===
-							'contentOnly' && ! isContentBlock,
-					isSection: isSectionBlock( blockClientId ),
-				};
-			},
-			[ blockClientId ]
-		);
+			return {
+				activeBlockVariation: getActiveBlockVariation(
+					name,
+					getBlockAttributes( blockClientId ),
+					'transform'
+				),
+				variations: name && getBlockVariations( name, 'transform' ),
+				canEdit: canEditBlock( blockClientId ),
+				isContentOnly:
+					getBlockEditingMode( blockClientId ) === 'contentOnly' &&
+					! isContentBlock,
+				isSection: isSectionBlock( blockClientId ),
+			};
+		},
+		[ blockClientId ]
+	);
 
 	const selectedValue = activeBlockVariation?.name;
 
@@ -205,7 +210,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	if ( ! variations?.length || isContentOnly || isSection ) {
+	if ( ! variations?.length || ! canEdit || isContentOnly || isSection ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { BlockBreadcrumb, BlockToolbar } from '@wordpress/block-editor';
@@ -82,6 +82,7 @@ export default function EditorInterface( {
 		stylesPath,
 		showStylebook,
 		isRevisionsMode,
+		showDiff,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const {
@@ -94,6 +95,7 @@ export default function EditorInterface( {
 			getStylesPath,
 			getShowStylebook,
 			isRevisionsMode: _isRevisionsMode,
+			isShowingRevisionDiff,
 		} = unlock( select( editorStore ) );
 		const editorSettings = getEditorSettings();
 
@@ -121,8 +123,11 @@ export default function EditorInterface( {
 				getCurrentPostType() === 'attachment' &&
 				window?.__experimentalMediaEditor,
 			isRevisionsMode: _isRevisionsMode(),
+			showDiff: isShowingRevisionDiff(),
 		};
 	}, [] );
+	const { setShowRevisionDiff } = unlock( useDispatch( editorStore ) );
+
 	// Runs unconditionally so join/leave/save notifications are dispatched
 	// regardless of viewport width or whether the header centre area is visible.
 	useCollaboratorNotifications( postId, postType );
@@ -152,9 +157,6 @@ export default function EditorInterface( {
 		[ entitiesSavedStatesCallback ]
 	);
 
-	// Local state for diff toggle in revisions mode.
-	const [ showDiff, setShowDiff ] = useState( true );
-
 	// When in revisions mode, render the revisions interface.
 	if ( isRevisionsMode ) {
 		return (
@@ -164,10 +166,10 @@ export default function EditorInterface( {
 				header={
 					<RevisionsHeader
 						showDiff={ showDiff }
-						onToggleDiff={ () => setShowDiff( ! showDiff ) }
+						onToggleDiff={ () => setShowRevisionDiff( ! showDiff ) }
 					/>
 				}
-				content={ <RevisionsCanvas showDiff={ showDiff } /> }
+				content={ <RevisionsCanvas /> }
 				sidebar={ <ComplementaryArea.Slot scope="core" /> }
 			/>
 		);

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -7,14 +7,9 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
-import {
-	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import { createBlock, parse } from '@wordpress/blocks';
-import { EntityProvider } from '@wordpress/core-data';
-import { useSelect, useRegistry } from '@wordpress/data';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 
 /**
@@ -28,12 +23,8 @@ import {
 	unregisterDiffFormatTypes,
 } from './diff-format-types';
 import { useDiffMarkers } from './diff-markers';
-import { preserveClientIds } from './preserve-client-ids';
-import { diffRevisionContent } from './block-diff';
 
-const { ExperimentalBlockEditorProvider, usePrivateStyleOverride } = unlock(
-	blockEditorPrivateApis
-);
+const { usePrivateStyleOverride } = unlock( blockEditorPrivateApis );
 
 // SVG filter for removed blocks: grayscale + red tint
 const REVISION_REMOVED_FILTER_SVG = `
@@ -151,12 +142,11 @@ function CanvasContent( { showDiff } ) {
 
 /**
  * Canvas component that renders a post revision in read-only mode.
+ * Block preparation and settings are handled by the parent EditorProvider.
  *
- * @param {Object}  props          Component props.
- * @param {boolean} props.showDiff Whether to show diff highlighting.
  * @return {React.JSX.Element} The revisions canvas component.
  */
-export default function RevisionsCanvas( { showDiff } ) {
+export default function RevisionsCanvas() {
 	useEffect( () => {
 		registerDiffFormatTypes();
 		return () => {
@@ -164,97 +154,23 @@ export default function RevisionsCanvas( { showDiff } ) {
 		};
 	}, [] );
 
-	const { revision, previousRevision, postType } = useSelect( ( select ) => {
-		const { getCurrentRevision, getPreviousRevision, getCurrentPostType } =
-			unlock( select( editorStore ) );
+	const { revision, showDiff } = useSelect( ( select ) => {
+		const { getCurrentRevision, isShowingRevisionDiff } = unlock(
+			select( editorStore )
+		);
 		return {
 			revision: getCurrentRevision(),
-			previousRevision: getPreviousRevision(),
-			postType: getCurrentPostType(),
+			showDiff: isShowingRevisionDiff(),
 		};
 	}, [] );
 
-	// Capture block editor settings once on mount to avoid a feedback loop
-	// when useSubRegistry={false}: the provider writes settings back to the
-	// same store, which would re-trigger useSelect and create an infinite loop.
-	const registry = useRegistry();
-	const [ blockEditorSettings ] = useState( () =>
-		registry.select( blockEditorStore ).getSettings()
-	);
-
-	// Track previously rendered blocks to preserve clientIds between renders.
-	const previousBlocksRef = useRef( [] );
-
-	const blocks = useMemo( () => {
-		const currentContent = revision?.content?.raw ?? '';
-
-		let parsedBlocks;
-		if ( showDiff ) {
-			const previousContent = previousRevision?.content?.raw || '';
-			// diffRevisionContent handles both normal diffing and the case
-			// where there's no previous revision (oldest revision shows all as added).
-			parsedBlocks = diffRevisionContent(
-				currentContent,
-				previousContent
-			);
-		} else {
-			// When diff is disabled, just parse the current revision content.
-			parsedBlocks = parse( currentContent );
-		}
-
-		if ( postType === 'wp_navigation' ) {
-			parsedBlocks = [
-				createBlock(
-					'core/navigation',
-					{ templateLock: false },
-					parsedBlocks
-				),
-			];
-		}
-
-		// Preserve clientIds from previous render to prevent React unmount/remount.
-		const blocksWithStableIds = preserveClientIds(
-			parsedBlocks,
-			previousBlocksRef.current
-		);
-
-		// Update ref for next render.
-		previousBlocksRef.current = blocksWithStableIds;
-
-		return blocksWithStableIds;
-	}, [
-		revision?.content?.raw,
-		previousRevision?.content?.raw,
-		postType,
-		showDiff,
-	] );
-
-	const settings = useMemo(
-		() => ( {
-			...blockEditorSettings,
-			isPreviewMode: true,
-		} ),
-		[ blockEditorSettings ]
-	);
-
 	return revision ? (
-		// EntityProvider without kind/type/id inherits those from the
-		// parent context. Only revisionId is added so that useEntityProp
-		// reads from the revision record instead of the current entity.
-		<EntityProvider revisionId={ revision.id }>
-			<ExperimentalBlockEditorProvider
-				value={ blocks }
-				settings={ settings }
-				// Since we take over the whole editor, we can take over the global
-				// registry which would be similar to a new screen/route.
-				useSubRegistry={ false }
-			>
-				<DiffStyleOverrides showDiff={ showDiff } />
-				<div className="editor-revisions-canvas__content">
-					<CanvasContent showDiff={ showDiff } />
-				</div>
-			</ExperimentalBlockEditorProvider>
-		</EntityProvider>
+		<>
+			<DiffStyleOverrides showDiff={ showDiff } />
+			<div className="editor-revisions-canvas__content">
+				<CanvasContent showDiff={ showDiff } />
+			</div>
+		</>
 	) : (
 		<div className="editor-revisions-canvas__loading">
 			<Spinner />

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -13,8 +13,8 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock, parse } from '@wordpress/blocks';
 import { EntityProvider } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useSelect, useRegistry } from '@wordpress/data';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 
 /**
@@ -164,20 +164,23 @@ export default function RevisionsCanvas( { showDiff } ) {
 		};
 	}, [] );
 
-	const { revision, previousRevision, postType, blockEditorSettings } =
-		useSelect( ( select ) => {
-			const {
-				getCurrentRevision,
-				getPreviousRevision,
-				getCurrentPostType,
-			} = unlock( select( editorStore ) );
-			return {
-				revision: getCurrentRevision(),
-				previousRevision: getPreviousRevision(),
-				postType: getCurrentPostType(),
-				blockEditorSettings: select( blockEditorStore ).getSettings(),
-			};
-		}, [] );
+	const { revision, previousRevision, postType } = useSelect( ( select ) => {
+		const { getCurrentRevision, getPreviousRevision, getCurrentPostType } =
+			unlock( select( editorStore ) );
+		return {
+			revision: getCurrentRevision(),
+			previousRevision: getPreviousRevision(),
+			postType: getCurrentPostType(),
+		};
+	}, [] );
+
+	// Capture block editor settings once on mount to avoid a feedback loop
+	// when useSubRegistry={false}: the provider writes settings back to the
+	// same store, which would re-trigger useSelect and create an infinite loop.
+	const registry = useRegistry();
+	const [ blockEditorSettings ] = useState( () =>
+		registry.select( blockEditorStore ).getSettings()
+	);
 
 	// Track previously rendered blocks to preserve clientIds between renders.
 	const previousBlocksRef = useRef( [] );
@@ -242,6 +245,9 @@ export default function RevisionsCanvas( { showDiff } ) {
 			<ExperimentalBlockEditorProvider
 				value={ blocks }
 				settings={ settings }
+				// Since we take over the whole editor, we can take over the global
+				// registry which would be similar to a new screen/route.
+				useSubRegistry={ false }
 			>
 				<DiffStyleOverrides showDiff={ showDiff } />
 				<div className="editor-revisions-canvas__content">

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -34,6 +34,7 @@ import { unlock } from '../../lock-unlock';
 import DisableNonPageContentBlocks from './disable-non-page-content-blocks';
 import NavigationBlockEditingMode from './navigation-block-editing-mode';
 import { useHideBlocksFromInserter } from './use-hide-blocks-from-inserter';
+import { useRevisionBlocks } from './use-revision-blocks';
 import useCommands from '../commands';
 import useUploadSaveLock from './use-upload-save-lock';
 import BlockRemovalWarnings from '../block-removal-warnings';
@@ -178,6 +179,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			defaultMode,
 			postTypeEntities,
 			isInRevisionsMode,
+			currentRevisionId,
 		} = useSelect(
 			( select ) => {
 				const {
@@ -186,6 +188,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					__unstableIsEditorReady,
 					getDefaultRenderingMode,
 					isRevisionsMode: _isRevisionsMode,
+					getCurrentRevisionId: _getCurrentRevisionId,
 				} = unlock( select( editorStore ) );
 				const { getEntitiesConfig, getEntityRecordEdits } =
 					select( coreStore );
@@ -227,6 +230,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							? getEntitiesConfig( 'postType' )
 							: null,
 					isInRevisionsMode: _isRevisionsMode(),
+					currentRevisionId: _getCurrentRevisionId(),
 				};
 			},
 			[ post.type, post.id, hasTemplate ]
@@ -285,10 +289,20 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			id,
 			mode
 		);
-		const [ blocks, onInput, onChange ] = useBlockEditorProps(
+		const [ entityBlocks, onInput, onChange ] = useBlockEditorProps(
 			post,
 			template,
 			mode
+		);
+
+		const revisionBlocks = useRevisionBlocks();
+		const blocks = revisionBlocks !== null ? revisionBlocks : entityBlocks;
+		const finalSettings = useMemo(
+			() =>
+				isInRevisionsMode
+					? { ...blockEditorSettings, isPreviewMode: true }
+					: blockEditorSettings,
+			[ isInRevisionsMode, blockEditorSettings ]
 		);
 
 		const {
@@ -421,15 +435,20 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					kind="postType"
 					type={ post.type }
 					id={ post.id }
+					revisionId={ currentRevisionId ?? undefined }
 				>
 					<BlockContextProvider value={ defaultBlockContext }>
 						<BlockEditorProviderComponent
-							value={ isInRevisionsMode ? undefined : blocks }
+							value={ blocks }
 							onChange={ isInRevisionsMode ? noop : onChange }
 							onInput={ isInRevisionsMode ? noop : onInput }
-							selection={ selection }
-							onChangeSelection={ onChangeSelection }
-							settings={ blockEditorSettings }
+							selection={
+								isInRevisionsMode ? undefined : selection
+							}
+							onChangeSelection={
+								isInRevisionsMode ? noop : onChangeSelection
+							}
+							settings={ finalSettings }
 							useSubRegistry={ false }
 						>
 							{ children }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -79,6 +79,7 @@ const NON_CONTEXTUAL_POST_TYPES = [
  * @return {Array} Block editor props.
  */
 function useBlockEditorProps( post, template, mode ) {
+	const revisionBlocks = useRevisionBlocks();
 	const rootLevelPost = mode === 'template-locked' ? 'template' : 'post';
 	const [ postBlocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
@@ -116,6 +117,11 @@ function useBlockEditorProps( post, template, mode ) {
 
 		return postBlocks;
 	}, [ maybeNavigationBlocks, rootLevelPost, templateBlocks, postBlocks ] );
+
+	// In revisions mode, use the revision blocks and disable editing.
+	if ( revisionBlocks !== null ) {
+		return [ revisionBlocks, noop, noop ];
+	}
 
 	// Handle fallback to postBlocks outside of the above useMemo, to ensure
 	// that constructed block templates that call `createBlock` are not generated
@@ -289,20 +295,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			id,
 			mode
 		);
-		const [ entityBlocks, onInput, onChange ] = useBlockEditorProps(
+		const [ blocks, onInput, onChange ] = useBlockEditorProps(
 			post,
 			template,
 			mode
-		);
-
-		const revisionBlocks = useRevisionBlocks();
-		const blocks = revisionBlocks !== null ? revisionBlocks : entityBlocks;
-		const finalSettings = useMemo(
-			() =>
-				isInRevisionsMode
-					? { ...blockEditorSettings, isPreviewMode: true }
-					: blockEditorSettings,
-			[ isInRevisionsMode, blockEditorSettings ]
 		);
 
 		const {
@@ -440,15 +436,15 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					<BlockContextProvider value={ defaultBlockContext }>
 						<BlockEditorProviderComponent
 							value={ blocks }
-							onChange={ isInRevisionsMode ? noop : onChange }
-							onInput={ isInRevisionsMode ? noop : onInput }
+							onChange={ onChange }
+							onInput={ onInput }
 							selection={
 								isInRevisionsMode ? undefined : selection
 							}
 							onChangeSelection={
 								isInRevisionsMode ? noop : onChangeSelection
 							}
-							settings={ finalSettings }
+							settings={ blockEditorSettings }
 							useSubRegistry={ false }
 						>
 							{ children }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -177,6 +177,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			mode,
 			defaultMode,
 			postTypeEntities,
+			isInRevisionsMode,
 		} = useSelect(
 			( select ) => {
 				const {
@@ -184,6 +185,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					getRenderingMode,
 					__unstableIsEditorReady,
 					getDefaultRenderingMode,
+					isRevisionsMode: _isRevisionsMode,
 				} = unlock( select( editorStore ) );
 				const { getEntitiesConfig, getEntityRecordEdits } =
 					select( coreStore );
@@ -224,6 +226,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 						post.type === 'wp_template'
 							? getEntitiesConfig( 'postType' )
 							: null,
+					isInRevisionsMode: _isRevisionsMode(),
 				};
 			},
 			[ post.type, post.id, hasTemplate ]
@@ -421,9 +424,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				>
 					<BlockContextProvider value={ defaultBlockContext }>
 						<BlockEditorProviderComponent
-							value={ blocks }
-							onChange={ onChange }
-							onInput={ onInput }
+							value={ isInRevisionsMode ? undefined : blocks }
+							onChange={ isInRevisionsMode ? noop : onChange }
+							onInput={ isInRevisionsMode ? noop : onInput }
 							selection={ selection }
 							onChangeSelection={ onChangeSelection }
 							settings={ blockEditorSettings }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -139,6 +139,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		sectionRootClientId,
 		deviceType,
 		isNavigationOverlayContext,
+		isRevisionsMode,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -150,7 +151,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			} = select( coreStore );
 			const { get } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
-			const { getDeviceType } = unlock( select( editorStore ) );
+			const { getDeviceType, isRevisionsMode: _isRevisionsMode } = unlock(
+				select( editorStore )
+			);
 			const { getBlocksByName, getBlockAttributes } =
 				select( blockEditorStore );
 			const siteSettings = canUser( 'read', {
@@ -218,6 +221,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 								postId
 						  )?.area === 'navigation-overlay'
 						: false,
+				isRevisionsMode: _isRevisionsMode(),
 			};
 		},
 		[ postType, postId, isLargeViewport, renderingMode ]
@@ -399,8 +403,13 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			[ isNavigationOverlayContextKey ]: isNavigationOverlayContext,
 		};
 
+		if ( isRevisionsMode ) {
+			blockEditorSettings.isPreviewMode = true;
+		}
+
 		return blockEditorSettings;
 	}, [
+		isRevisionsMode,
 		allowedBlockTypes,
 		allowRightClickOverrides,
 		focusMode,

--- a/packages/editor/src/components/provider/use-revision-blocks.js
+++ b/packages/editor/src/components/provider/use-revision-blocks.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo, useRef } from '@wordpress/element';
+import { createBlock, parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+import { diffRevisionContent } from '../post-revisions-preview/block-diff';
+import { preserveClientIds } from '../post-revisions-preview/preserve-client-ids';
+
+/**
+ * Hook that computes revision blocks when in revisions mode.
+ *
+ * Returns `null` when not in revisions mode, `[]` when loading,
+ * or the computed blocks array when ready.
+ *
+ * @return {Array|null} The revision blocks, or null if not in revisions mode.
+ */
+export function useRevisionBlocks() {
+	const {
+		isInRevisionsMode,
+		showDiff,
+		revision,
+		previousRevision,
+		postType,
+	} = useSelect( ( select ) => {
+		const {
+			isRevisionsMode,
+			isShowingRevisionDiff,
+			getCurrentRevision,
+			getPreviousRevision,
+		} = unlock( select( editorStore ) );
+		const { getCurrentPostType } = select( editorStore );
+
+		const inRevisions = isRevisionsMode();
+		return {
+			isInRevisionsMode: inRevisions,
+			showDiff: isShowingRevisionDiff(),
+			revision: inRevisions ? getCurrentRevision() : undefined,
+			previousRevision: inRevisions ? getPreviousRevision() : undefined,
+			postType: getCurrentPostType(),
+		};
+	}, [] );
+
+	// Track previously rendered blocks to preserve clientIds between renders.
+	const previousBlocksRef = useRef( [] );
+
+	const blocks = useMemo( () => {
+		if ( ! isInRevisionsMode ) {
+			// Clear the ref when exiting revisions mode.
+			previousBlocksRef.current = [];
+			return null;
+		}
+
+		// Revision not loaded yet.
+		if ( ! revision ) {
+			return [];
+		}
+
+		const currentContent = revision?.content?.raw ?? '';
+
+		let parsedBlocks;
+		if ( showDiff ) {
+			const previousContent = previousRevision?.content?.raw || '';
+			parsedBlocks = diffRevisionContent(
+				currentContent,
+				previousContent
+			);
+		} else {
+			parsedBlocks = parse( currentContent );
+		}
+
+		if ( postType === 'wp_navigation' ) {
+			parsedBlocks = [
+				createBlock(
+					'core/navigation',
+					{ templateLock: false },
+					parsedBlocks
+				),
+			];
+		}
+
+		const blocksWithStableIds = preserveClientIds(
+			parsedBlocks,
+			previousBlocksRef.current
+		);
+		previousBlocksRef.current = blocksWithStableIds;
+
+		return blocksWithStableIds;
+	}, [
+		isInRevisionsMode,
+		revision,
+		revision?.content?.raw,
+		previousRevision?.content?.raw,
+		postType,
+		showDiff,
+	] );
+
+	return blocks;
+}

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -55,7 +55,7 @@ const SidebarHeader = ( _, ref ) => {
 			>
 				{ documentLabel }
 			</Tabs.Tab>
-			{ ! isAttachment && ! isRevisionsMode && (
+			{ ! isAttachment && (
 				<Tabs.Tab
 					tabId={ sidebars.block }
 					// Used for focus management in the SettingsSidebar component.

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -603,6 +603,19 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
+ * Set whether the revision diff highlighting is shown.
+ *
+ * @param {boolean} showDiff Whether to show diff highlighting.
+ * @return {Object} Action object.
+ */
+export function setShowRevisionDiff( showDiff ) {
+	return {
+		type: 'SET_SHOW_REVISION_DIFF',
+		showDiff,
+	};
+}
+
+/**
  * Restore a revision by replacing the current content with the revision's content
  * and auto-saving.
  *

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -307,6 +307,16 @@ export function isRevisionsMode( state ) {
 }
 
 /**
+ * Returns whether the revision diff highlighting is shown.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} Whether revision diff is being shown.
+ */
+export function isShowingRevisionDiff( state ) {
+	return state.showRevisionDiff;
+}
+
+/**
  * Returns the current revision ID in revisions mode.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -456,6 +456,24 @@ export function revisionId( state = null, action ) {
  * @param {Object} action Dispatched action.
  * @return {Object} Updated state.
  */
+/**
+ * Reducer for whether the revision diff is shown.
+ * Resets to true when entering/exiting revisions mode.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ * @return {boolean} Updated state.
+ */
+export function showRevisionDiff( state = true, action ) {
+	switch ( action.type ) {
+		case 'SET_SHOW_REVISION_DIFF':
+			return action.showDiff;
+		case 'SET_CURRENT_REVISION_ID':
+			return true; // reset on enter/exit revisions
+	}
+	return state;
+}
+
 export function selectedNote( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SELECT_NOTE':
@@ -487,6 +505,7 @@ export default combineReducers( {
 	showStylebook,
 	canvasMinHeight,
 	revisionId,
+	showRevisionDiff,
 	selectedNote,
 	dataviews: dataviewsReducer,
 } );

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -150,4 +150,79 @@ test.describe( 'Revisions', () => {
 		const clientIdAfter = await headingBlock.getAttribute( 'data-block' );
 		expect( clientIdAfter ).toBe( clientIdBefore );
 	} );
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/75926
+	// Global wp.data.select() calls should see blocks in revisions mode.
+	test( 'should expose blocks to global selectors in revisions mode', async ( {
+		editor,
+		page,
+	} ) => {
+		// Register a test block that renders its parent block name
+		// using the global wp.data.select() (not useSelect).
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'test/selectors-in-revisions', {
+				apiVersion: 3,
+				title: 'Test Selectors in Revisions',
+				edit: function Edit( { clientId } ) {
+					const [ parentName, setParentName ] =
+						window.wp.element.useState( 'none' );
+					window.wp.element.useEffect( () => {
+						const parents = window.wp.data
+							.select( 'core/block-editor' )
+							.getBlockParentsByBlockName(
+								clientId,
+								'core/group'
+							);
+						setParentName(
+							parents.length > 0
+								? 'has-group-parent'
+								: 'no-group-parent'
+						);
+					}, [ clientId ] );
+					return window.wp.element.createElement(
+						'p',
+						window.wp.blockEditor.useBlockProps(),
+						parentName
+					);
+				},
+				save: () => null,
+			} );
+		} );
+
+		// Insert a group with the test block inside.
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [ { name: 'test/selectors-in-revisions' } ],
+		} );
+
+		// Save draft to create first revision.
+		await editor.saveDraft();
+
+		// Add a paragraph after the group to create a second revision.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Extra paragraph' },
+		} );
+		await editor.saveDraft();
+
+		// Enter revisions mode.
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', { name: '2', exact: true } )
+			.click();
+
+		// Wait for revisions mode.
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// The test block should see its group parent via global select().
+		await expect(
+			editor.canvas.locator( '[data-type="test/selectors-in-revisions"]' )
+		).toHaveText( 'has-group-parent' );
+	} );
 } );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/75926

## Why?
The revisions canvas creates its own `ExperimentalBlockEditorProvider` with a sub-registry. Global `wp.data.select('core/block-editor')` calls can't see the revision blocks, so any block using global selectors to find parents or siblings breaks in revisions mode.

As noted in https://github.com/WordPress/gutenberg/pull/76152#issuecomment-4003999186, there's no need for two providers — the parent provider's props can be swapped when entering revisions mode.

## How?
- **`useRevisionBlocks` hook** — computes revision blocks (diff or plain parse) in the parent provider. Returns `null` when not in revisions mode.
- **Provider props swap** — in revisions mode: `value={revisionBlocks}`, `onChange/onInput/onChangeSelection={noop}`, `settings={...settings, isPreviewMode: true}`. Otherwise: normal entity blocks and handlers.
- **`showDiff` lifted to editor store** — the provider needs it for block preparation, so it moves from `useState` in `EditorInterface` to a reducer/action/selector.
- **`RevisionsCanvas` simplified** — no more nested provider, block preparation, or settings capture. Just diff styles and `VisualEditor`.

## Testing Instructions
1. Create a post, publish, edit + update to create revisions.
2. Open Revisions panel — preview should render correctly.
3. Slide between revisions, toggle diff on/off.
4. Exit revisions — blocks should be selectable and editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)