### PR TITLE
Fix backport changelog PR for Gutenberg #75746

### DIFF
--- a/backport-changelog/7.0/10894.md
+++ b/backport-changelog/7.0/10894.md
@@ -5,6 +5,5 @@ https://github.com/WordPress/wordpress-develop/pull/10894
 * https://github.com/WordPress/gutenberg/pull/75682
 * https://github.com/WordPress/gutenberg/pull/75708
 * https://github.com/WordPress/gutenberg/pull/75711
-* https://github.com/WordPress/gutenberg/pull/75746
 * https://github.com/WordPress/gutenberg/pull/75869
 * https://github.com/WordPress/gutenberg/pull/76060

--- a/backport-changelog/7.0/10981.md
+++ b/backport-changelog/7.0/10981.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10981
+
+* https://github.com/WordPress/gutenberg/pull/75746


### PR DESCRIPTION
## What?

See [this comment](https://github.com/WordPress/gutenberg/pull/75746/changes#r2885141595). The backport PR for https://github.com/WordPress/gutenberg/pull/75746 was mistakenly associated with a different backport (`10894`) but was actually backported in https://github.com/WordPress/wordpress-develop/pull/10981. Fix the backport changelog.
