### PR TITLE
Connectors: Update page identifier to options-connectors

### DIFF
--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -384,7 +384,7 @@ remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
 add_action( 'init', '_gutenberg_pass_default_connector_keys_to_ai_client' );
 
 /**
- * Exposes connector settings to the connectors-wp-admin script module.
+ * Exposes connector settings to the options-connectors-wp-admin script module.
  *
  * @access private
  *
@@ -426,5 +426,5 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 	$data['connectors'] = $connectors;
 	return $data;
 }
-remove_filter( 'script_module_data_connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
-add_filter( 'script_module_data_connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );
+remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
+add_filter( 'script_module_data_options-connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );

--- a/lib/experimental/connectors/load.php
+++ b/lib/experimental/connectors/load.php
@@ -5,28 +5,31 @@
  * @package gutenberg
  */
 
-add_action( 'admin_menu', '_gutenberg_connectors_add_settings_menu_item' );
-remove_action( 'admin_menu', '_wp_connectors_add_settings_menu_item' );
+// Priority 11 to run after Core's menu.php sets up the connectors menu.
+add_action( 'admin_menu', '_gutenberg_connectors_add_settings_menu_item', 11 );
 
 /**
  * Registers the Connectors menu item under Settings.
+ * Removes Core's connectors menu item first to prevent duplication.
  *
  * @access private
  */
 function _gutenberg_connectors_add_settings_menu_item(): void {
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'gutenberg_connectors_wp_admin_render_page' ) ) {
+	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'gutenberg_options_connectors_wp_admin_render_page' ) ) {
 		return;
 	}
 
 	// Remove Core's connectors menu item if it exists.
 	remove_submenu_page( 'options-general.php', 'connectors-wp-admin' );
+	remove_submenu_page( 'options-general.php', 'options-connectors.php' );
+
 	add_submenu_page(
 		'options-general.php',
 		__( 'Connectors', 'gutenberg' ),
 		__( 'Connectors', 'gutenberg' ),
 		'manage_options',
-		'connectors-wp-admin',
-		'gutenberg_connectors_wp_admin_render_page',
+		'options-connectors-wp-admin',
+		'gutenberg_options_connectors_wp_admin_render_page',
 		1
 	);
 }

--- a/lib/remove-core-enqueue-scripts.php
+++ b/lib/remove-core-enqueue-scripts.php
@@ -10,4 +10,5 @@
 
 remove_action( 'admin_enqueue_scripts', 'wp_font_library_wp_admin_enqueue_scripts' );
 remove_action( 'admin_enqueue_scripts', 'wp_site_editor_v2_wp_admin_enqueue_scripts' );
-remove_action( 'admin_enqueue_scripts', 'wp_connectors_wp_admin_enqueue_scripts' );
+remove_action( 'admin_enqueue_scripts', 'wp_options_connectors_wp_admin_enqueue_scripts' );
+remove_action( 'admin_init', 'wp_options_connectors_intercept_render' );

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 				"experimental": true
 			},
 			"font-library",
-			"connectors"
+			"options-connectors"
 		]
 	},
 	"config": {

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -40,7 +40,7 @@ function getConnectorData(): Record< string, ConnectorData > {
 	try {
 		const parsed = JSON.parse(
 			document.getElementById(
-				'wp-script-module-data-connectors-wp-admin'
+				'wp-script-module-data-options-connectors-wp-admin'
 			)?.textContent ?? ''
 		);
 		return parsed?.connectors ?? {};

--- a/routes/connectors-home/package.json
+++ b/routes/connectors-home/package.json
@@ -5,7 +5,7 @@
 	"route": {
 		"path": "/",
 		"page": [
-			"connectors"
+			"options-connectors"
 		]
 	},
 	"dependencies": {

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -4,7 +4,7 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const SETTINGS_PAGE_PATH = 'options-general.php';
-const CONNECTORS_PAGE_QUERY = 'page=connectors-wp-admin';
+const CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
 
 const CONNECTORS = [
 	{


### PR DESCRIPTION
Cherry picks https://github.com/WordPress/gutenberg/pull/76142 into the 7.0 branch.
We just fixed a conflict in lib/remove-core-enqueue-scripts.php because https://github.com/WordPress/gutenberg/pull/76036 is was not backported to wp/7.0.