### PR TITLE
Connectors: align Gutenberg init hook priorities with Core

### DIFF
--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -341,8 +341,8 @@ function _gutenberg_register_default_connector_settings(): void {
 		add_filter( "option_{$setting_name}", '_gutenberg_mask_api_key' );
 	}
 }
-remove_action( 'init', '_wp_register_default_connector_settings' );
-add_action( 'init', '_gutenberg_register_default_connector_settings' );
+remove_action( 'init', '_wp_register_default_connector_settings', 20 );
+add_action( 'init', '_gutenberg_register_default_connector_settings', 20 );
 
 /**
  * Passes stored connector API keys to the WP AI client.
@@ -380,8 +380,8 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 		wp_trigger_error( __FUNCTION__, $e->getMessage() );
 	}
 }
-remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
-add_action( 'init', '_gutenberg_pass_default_connector_keys_to_ai_client' );
+remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
+add_action( 'init', '_gutenberg_pass_default_connector_keys_to_ai_client', 20 );
 
 /**
  * Exposes connector settings to the options-connectors-wp-admin script module.


### PR DESCRIPTION
## What?
- Aligns Gutenberg connector init hook priorities with Core equivalents in the connectors override file.
- Ensures the Core action removal for _wp_connectors_pass_default_keys_to_ai_client explicitly targets priority 20.
- Keeps Gutenberg replacement init callbacks at priority 20 to match Core timing.

## Why?
On https://github.com/WordPress/wordpress-develop/pull/11080 the priorities were changed and we did not changed them back on gutenberg this makes core masking behavior still present and it was impossible to retrieve real keys and do connections.

## Testing Instructions
1. Activate environment where both Core + Gutenberg connector codepaths are present.
2. Save a connector API key.
3. Verify it is possible to connect with success and it stays connected after the reload.
5. Open Connectors settings page and confirm it still loads and displays masked values in UI.

## Testing
- Not run (manual verification pending).
