### PR TITLE
Block Visibility: change visibility class

### DIFF
--- a/backport-changelog/7.0/11169.md
+++ b/backport-changelog/7.0/11169.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11169
+
+* https://github.com/WordPress/gutenberg/pull/76166

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -114,7 +114,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			 * If these values ever become user-defined,
 			 * they should be sanitized and kebab-cased.
 			 */
-			$visibility_class = 'is-block-hidden-on-' . $hidden_viewport_size;
+			$visibility_class = 'is-hidden-on-' . $hidden_viewport_size;
 			$class_names[]    = $visibility_class;
 			$css_rules[]      = array(
 				'selector'     => '.' . $visibility_class,

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -114,7 +114,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			 * If these values ever become user-defined,
 			 * they should be sanitized and kebab-cased.
 			 */
-			$visibility_class = 'is-block-hidden-' . $hidden_viewport_size;
+			$visibility_class = 'is-block-hidden-on-' . $hidden_viewport_size;
 			$class_names[]    = $visibility_class;
 			$css_rules[]      = array(
 				'selector'     => '.' . $visibility_class,

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -114,7 +114,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			 * If these values ever become user-defined,
 			 * they should be sanitized and kebab-cased.
 			 */
-			$visibility_class = 'wp-block-hidden-' . $hidden_viewport_size;
+			$visibility_class = 'is-block-hidden-' . $hidden_viewport_size;
 			$class_names[]    = $visibility_class;
 			$css_rules[]      = array(
 				'selector'     => '.' . $visibility_class,

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -153,12 +153,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'is-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
+		$this->assertStringContainsString( 'is-block-hidden-on-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width <= 480px){.is-block-hidden-mobile{display:none !important;}}',
+			'@media (width <= 480px){.is-block-hidden-on-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain mobile visibility rule'
 		);
@@ -186,12 +186,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div class="existing-class">Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="existing-class is-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
+		$this->assertStringContainsString( 'class="existing-class is-block-hidden-on-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (480px < width <= 782px){.is-block-hidden-tablet{display:none !important;}}',
+			'@media (480px < width <= 782px){.is-block-hidden-on-tablet{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain tablet visibility rule'
 		);
@@ -220,12 +220,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="is-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
+		$this->assertStringContainsString( 'class="is-block-hidden-on-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width > 782px){.is-block-hidden-desktop{display:none !important;}}',
+			'@media (width > 782px){.is-block-hidden-on-desktop{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop visibility rule'
 		);
@@ -255,7 +255,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'class="is-block-hidden-desktop is-block-hidden-mobile"',
+			'class="is-block-hidden-on-desktop is-block-hidden-on-mobile"',
 			$result,
 			'Block should have both visibility classes in the class attribute'
 		);
@@ -263,7 +263,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width > 782px){.is-block-hidden-desktop{display:none !important;}}@media (width <= 480px){.is-block-hidden-mobile{display:none !important;}}',
+			'@media (width > 782px){.is-block-hidden-on-desktop{display:none !important;}}@media (width <= 480px){.is-block-hidden-on-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop and mobile visibility rules'
 		);
@@ -320,7 +320,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '<div class="is-block-hidden-desktop is-block-hidden-mobile is-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
+		$this->assertSame( '<div class="is-block-hidden-on-desktop is-block-hidden-on-mobile is-block-hidden-on-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_object() {
@@ -369,7 +369,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'class="is-block-hidden-mobile"',
+			'class="is-block-hidden-on-mobile"',
 			$result,
 			'Block should have the visibility class for the mobile viewport size in the class attribute'
 		);

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -153,12 +153,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'is-block-hidden-on-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
+		$this->assertStringContainsString( 'is-hidden-on-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width <= 480px){.is-block-hidden-on-mobile{display:none !important;}}',
+			'@media (width <= 480px){.is-hidden-on-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain mobile visibility rule'
 		);
@@ -186,12 +186,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div class="existing-class">Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="existing-class is-block-hidden-on-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
+		$this->assertStringContainsString( 'class="existing-class is-hidden-on-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (480px < width <= 782px){.is-block-hidden-on-tablet{display:none !important;}}',
+			'@media (480px < width <= 782px){.is-hidden-on-tablet{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain tablet visibility rule'
 		);
@@ -220,12 +220,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="is-block-hidden-on-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
+		$this->assertStringContainsString( 'class="is-hidden-on-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width > 782px){.is-block-hidden-on-desktop{display:none !important;}}',
+			'@media (width > 782px){.is-hidden-on-desktop{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop visibility rule'
 		);
@@ -255,7 +255,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'class="is-block-hidden-on-desktop is-block-hidden-on-mobile"',
+			'class="is-hidden-on-desktop is-hidden-on-mobile"',
 			$result,
 			'Block should have both visibility classes in the class attribute'
 		);
@@ -263,7 +263,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width > 782px){.is-block-hidden-on-desktop{display:none !important;}}@media (width <= 480px){.is-block-hidden-on-mobile{display:none !important;}}',
+			'@media (width > 782px){.is-hidden-on-desktop{display:none !important;}}@media (width <= 480px){.is-hidden-on-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop and mobile visibility rules'
 		);
@@ -320,7 +320,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '<div class="is-block-hidden-on-desktop is-block-hidden-on-mobile is-block-hidden-on-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
+		$this->assertSame( '<div class="is-hidden-on-desktop is-hidden-on-mobile is-hidden-on-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_object() {
@@ -369,7 +369,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'class="is-block-hidden-on-mobile"',
+			'class="is-hidden-on-mobile"',
 			$result,
 			'Block should have the visibility class for the mobile viewport size in the class attribute'
 		);

--- a/phpunit/block-supports/block-visibility-test.php
+++ b/phpunit/block-supports/block-visibility-test.php
@@ -153,12 +153,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
+		$this->assertStringContainsString( 'is-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile viewport size.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (width <= 480px){.is-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain mobile visibility rule'
 		);
@@ -186,12 +186,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div class="existing-class">Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="existing-class wp-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
+		$this->assertStringContainsString( 'class="existing-class is-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (480px < width <= 782px){.wp-block-hidden-tablet{display:none !important;}}',
+			'@media (480px < width <= 782px){.is-block-hidden-tablet{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain tablet visibility rule'
 		);
@@ -220,12 +220,12 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="wp-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
+		$this->assertStringContainsString( 'class="is-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop viewport size in the class attribute.' );
 
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}',
+			'@media (width > 782px){.is-block-hidden-desktop{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop visibility rule'
 		);
@@ -255,7 +255,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'class="wp-block-hidden-desktop wp-block-hidden-mobile"',
+			'class="is-block-hidden-desktop is-block-hidden-mobile"',
 			$result,
 			'Block should have both visibility classes in the class attribute'
 		);
@@ -263,7 +263,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports' );
 
 		$this->assertSame(
-			'@media (width > 782px){.wp-block-hidden-desktop{display:none !important;}}@media (width <= 480px){.wp-block-hidden-mobile{display:none !important;}}',
+			'@media (width > 782px){.is-block-hidden-desktop{display:none !important;}}@media (width <= 480px){.is-block-hidden-mobile{display:none !important;}}',
 			$actual_stylesheet,
 			'CSS should contain desktop and mobile visibility rules'
 		);
@@ -320,7 +320,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$block_content = '<div>Test content</div>';
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '<div class="wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
+		$this->assertSame( '<div class="is-block-hidden-desktop is-block-hidden-mobile is-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
 	}
 
 	public function test_block_visibility_support_generated_css_with_empty_object() {
@@ -369,7 +369,7 @@ class WP_Block_Supports_Block_Visibility_Test extends WP_UnitTestCase {
 		$result        = gutenberg_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'class="wp-block-hidden-mobile"',
+			'class="is-block-hidden-mobile"',
 			$result,
 			'Block should have the visibility class for the mobile viewport size in the class attribute'
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR changes the CSS classes for viewport-based visibility as follows:

| Before | After |
|--------|--------|
| `wp-block-hidden-desktop` | `is-hidden-on-desktop` |
| `wp-block-hidden-mobile` | `is-hidden-on-mobile` |
| `wp-block-hidden-tablet` | `is-hidden-on-tablet` |

## Why? How?

Traditionally, blocks have used the `is-` prefix for state classes:

- `is-position-sticky`
- `is-nowrap`
- `is-layout-constrained`
- `is-repeated`

The `wp-block-` prefix appears to be a bit unnatural, as it's used as a prefix for block names.

**I propose changing the class names before the viewport-based visibility feature ships in 7.0. If you agree with this change, I'd also be happy to submit a core patch.**

## Testing Instructions

The block visibility feature should works as before.