### PR TITLE
Try/strip custom block css without unfiltered html

### DIFF
--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -83,11 +83,9 @@ add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
  * @see https://core.trac.wordpress.org/ticket/64771
  *
  * @param string $content           Content to be run through KSES.
- * @param array[]|string $allowed_html Allowed HTML elements or context name.
- * @param string[]       $allowed_protocols Allowed URL protocols.
  * @return string Filtered content.
  */
-function gutenberg_strip_block_custom_css_for_restricted_users( $content, $allowed_html, $allowed_protocols ) {
+function gutenberg_strip_block_custom_css_for_restricted_users( $content ) {
 	if ( current_user_can( 'unfiltered_html' ) ) {
 		return $content;
 	}

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -71,6 +71,61 @@ function gutenberg_override_core_kses_init_filters() {
 add_action( 'init', 'gutenberg_override_core_kses_init_filters', 20 );
 add_action( 'set_current_user', 'gutenberg_override_core_kses_init_filters' );
 
+/**
+ * Strip block-level custom CSS for users without unfiltered_html capability.
+ *
+ * When a user without unfiltered_html saves post content, filter_block_content()
+ * runs filter_block_kses() on each block. wp_kses() treats attrs.style.css as
+ * HTML and encodes & and >, corrupting CSS (e.g. nesting selectors). This runs
+ * before wp_pre_kses_block_attributes (priority 10) so content is stripped
+ * before filter_block_content can mangle it.
+ *
+ * @see https://core.trac.wordpress.org/ticket/64771
+ *
+ * @param string $content           Content to be run through KSES.
+ * @param array[]|string $allowed_html Allowed HTML elements or context name.
+ * @param string[]       $allowed_protocols Allowed URL protocols.
+ * @return string Filtered content.
+ */
+function gutenberg_strip_block_custom_css_for_restricted_users( $content, $allowed_html, $allowed_protocols ) {
+	if ( current_user_can( 'unfiltered_html' ) ) {
+		return $content;
+	}
+	if ( false === strpos( $content, '<!-- wp:' ) ) {
+		return $content;
+	}
+
+	$blocks = parse_blocks( $content );
+	$blocks = gutenberg_strip_custom_css_from_blocks( $blocks );
+	return serialize_blocks( $blocks );
+}
+
+/**
+ * Recursively strip attrs.style.css from blocks.
+ *
+ * @param array[] $blocks Parsed blocks.
+ * @return array[] Blocks with custom CSS removed.
+ */
+function gutenberg_strip_custom_css_from_blocks( $blocks ) {
+	foreach ( $blocks as &$block ) {
+		if ( empty( $block['blockName'] ) ) {
+			continue;
+		}
+		if ( isset( $block['attrs']['style']['css'] ) && trim( (string) $block['attrs']['style']['css'] ) !== '' ) {
+			$block['attrs']['style']['css'] = '';
+			if ( empty( array_filter( (array) $block['attrs']['style'] ) ) ) {
+				unset( $block['attrs']['style'] );
+			}
+		}
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = gutenberg_strip_custom_css_from_blocks( $block['innerBlocks'] );
+		}
+	}
+	return $blocks;
+}
+
+add_filter( 'pre_kses', 'gutenberg_strip_block_custom_css_for_restricted_users', 5, 3 );
+
 if ( ! function_exists( 'allow_filter_in_styles' ) ) {
 	/**
 	 * See https://github.com/WordPress/wordpress-develop/pull/4108

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -191,6 +191,12 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		}
 	}
 
+	// Block has custom CSS that will be stripped on save (user lacks unfiltered_html).
+	&.has-custom-css-will-be-stripped {
+		border-left: 4px solid $alert-yellow;
+		box-sizing: border-box;
+	}
+
 	// Clear floats.
 	&[data-clear="true"] {
 		float: none;

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -3,12 +3,10 @@
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
-import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -65,54 +63,30 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	);
 }
 
-const CUSTOM_CSS_STRIP_WARNING_MESSAGE = __(
-	'This block contains custom CSS and you do not have permission to save it. If you update this post, the custom CSS will be removed.'
-);
-
 function CustomCSSEdit( { clientId, name, setAttributes } ) {
-	const { style, canEditCSS, canUserUseUnfilteredHTML } = useSelect(
+	const { style, canEditCSS } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
 				select( blockEditorStore );
 			return {
 				style: getBlockAttributes( clientId )?.style || EMPTY_STYLE,
 				canEditCSS: getSettings().canEditCSS,
-				canUserUseUnfilteredHTML:
-					getSettings().__experimentalCanUserUseUnfilteredHTML,
 			};
 		},
 		[ clientId ]
 	);
 
-	const hasCustomCSS = style?.css?.trim();
-	const willLoseCSSOnSave = hasCustomCSS && ! canUserUseUnfilteredHTML;
-
-	// Show panel when user can edit CSS, or when block has custom CSS that will be stripped (show warning).
-	if ( ! canEditCSS && ! willLoseCSSOnSave ) {
+	// Don't render the panel if user lacks edit_css capability.
+	if ( ! canEditCSS ) {
 		return null;
 	}
 
 	return (
-		<>
-			{ willLoseCSSOnSave && (
-				<InspectorControls group="advanced">
-					<Notice
-						status="warning"
-						isDismissible={ false }
-						className="block-editor-custom-css__strip-warning"
-					>
-						{ CUSTOM_CSS_STRIP_WARNING_MESSAGE }
-					</Notice>
-				</InspectorControls>
-			) }
-			{ canEditCSS && (
-				<CustomCSSControl
-					blockName={ name }
-					setAttributes={ setAttributes }
-					style={ style }
-				/>
-			) }
-		</>
+		<CustomCSSControl
+			blockName={ name }
+			setAttributes={ setAttributes }
+			style={ style }
+		/>
 	);
 }
 
@@ -132,13 +106,6 @@ function useBlockProps( { style } ) {
 		typeof customCSS === 'string' &&
 		customCSS.trim().length > 0 &&
 		validateCSS( customCSS );
-
-	const canUserUseUnfilteredHTML = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings()
-				.__experimentalCanUserUseUnfilteredHTML,
-		[]
-	);
 
 	const customCSSIdentifier = useInstanceId(
 		CUSTOM_CSS_INSTANCE_REFERENCE,
@@ -164,14 +131,8 @@ function useBlockProps( { style } ) {
 		return {};
 	}
 
-	const willLoseCSSOnSave = ! canUserUseUnfilteredHTML;
-
 	return {
-		className: clsx(
-			'has-custom-css',
-			customCSSIdentifier,
-			willLoseCSSOnSave && 'has-custom-css-will-be-stripped'
-		),
+		className: `has-custom-css ${ customCSSIdentifier }`,
 	};
 }
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -3,10 +3,12 @@
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -63,30 +65,54 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	);
 }
 
+const CUSTOM_CSS_STRIP_WARNING_MESSAGE = __(
+	'This block contains custom CSS and you do not have permission to save it. If you update this post, the custom CSS will be removed.'
+);
+
 function CustomCSSEdit( { clientId, name, setAttributes } ) {
-	const { style, canEditCSS } = useSelect(
+	const { style, canEditCSS, canUserUseUnfilteredHTML } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
 				select( blockEditorStore );
 			return {
 				style: getBlockAttributes( clientId )?.style || EMPTY_STYLE,
 				canEditCSS: getSettings().canEditCSS,
+				canUserUseUnfilteredHTML:
+					getSettings().__experimentalCanUserUseUnfilteredHTML,
 			};
 		},
 		[ clientId ]
 	);
 
-	// Don't render the panel if user lacks edit_css capability.
-	if ( ! canEditCSS ) {
+	const hasCustomCSS = style?.css?.trim();
+	const willLoseCSSOnSave = hasCustomCSS && ! canUserUseUnfilteredHTML;
+
+	// Show panel when user can edit CSS, or when block has custom CSS that will be stripped (show warning).
+	if ( ! canEditCSS && ! willLoseCSSOnSave ) {
 		return null;
 	}
 
 	return (
-		<CustomCSSControl
-			blockName={ name }
-			setAttributes={ setAttributes }
-			style={ style }
-		/>
+		<>
+			{ willLoseCSSOnSave && (
+				<InspectorControls group="advanced">
+					<Notice
+						status="warning"
+						isDismissible={ false }
+						className="block-editor-custom-css__strip-warning"
+					>
+						{ CUSTOM_CSS_STRIP_WARNING_MESSAGE }
+					</Notice>
+				</InspectorControls>
+			) }
+			{ canEditCSS && (
+				<CustomCSSControl
+					blockName={ name }
+					setAttributes={ setAttributes }
+					style={ style }
+				/>
+			) }
+		</>
 	);
 }
 
@@ -106,6 +132,13 @@ function useBlockProps( { style } ) {
 		typeof customCSS === 'string' &&
 		customCSS.trim().length > 0 &&
 		validateCSS( customCSS );
+
+	const canUserUseUnfilteredHTML = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.__experimentalCanUserUseUnfilteredHTML,
+		[]
+	);
 
 	const customCSSIdentifier = useInstanceId(
 		CUSTOM_CSS_INSTANCE_REFERENCE,
@@ -131,8 +164,14 @@ function useBlockProps( { style } ) {
 		return {};
 	}
 
+	const willLoseCSSOnSave = ! canUserUseUnfilteredHTML;
+
 	return {
-		className: `has-custom-css ${ customCSSIdentifier }`,
+		className: clsx(
+			'has-custom-css',
+			customCSSIdentifier,
+			willLoseCSSOnSave && 'has-custom-css-will-be-stripped'
+		),
 	};
 }
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
@@ -126,13 +131,26 @@ function useBlockProps( { style } ) {
 	// Inject the CSS via style override.
 	useStyleOverride( { css: transformedCSS } );
 
+	const canUserUseUnfilteredHTML = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.__experimentalCanUserUseUnfilteredHTML,
+		[]
+	);
+
 	// Only add the class if there's valid custom CSS.
 	if ( ! isValidCSS ) {
 		return {};
 	}
 
+	const willLoseCSSOnSave = ! canUserUseUnfilteredHTML;
+
 	return {
-		className: `has-custom-css ${ customCSSIdentifier }`,
+		className: clsx(
+			'has-custom-css',
+			customCSSIdentifier,
+			willLoseCSSOnSave && 'has-custom-css-will-be-stripped'
+		),
 	};
 }
 

--- a/packages/editor/src/components/block-custom-css-strip-notice/index.js
+++ b/packages/editor/src/components/block-custom-css-strip-notice/index.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { Notice } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Notice shown at the top of the editor when the user lacks unfiltered_html
+ * and the content has blocks with custom CSS that will be stripped on save.
+ */
+export default function BlockCustomCSSStripNotice() {
+	const hasBlocksWithCustomCSSThatWillBeStripped = useSelect( ( select ) => {
+		const { getClientIdsWithDescendants, getBlock, getSettings } =
+			select( blockEditorStore );
+
+		if ( getSettings().__experimentalCanUserUseUnfilteredHTML ) {
+			return false;
+		}
+
+		const clientIds = getClientIdsWithDescendants();
+		return clientIds.some( ( clientId ) => {
+			const block = getBlock( clientId );
+			return !! block?.attributes?.style?.css?.trim();
+		} );
+	}, [] );
+
+	if ( ! hasBlocksWithCustomCSSThatWillBeStripped ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className="editor-block-custom-css-strip-notice"
+			isDismissible={ false }
+			status="warning"
+		>
+			{ __(
+				'Some blocks contain custom CSS that you do not have permission to save. If you update this post, that custom CSS will be removed.'
+			) }
+		</Notice>
+	);
+}

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -22,6 +22,7 @@ import { InlineNotices } from '@wordpress/notices';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import TemplateValidationNotice from '../template-validation-notice';
+import BlockCustomCSSStripNotice from '../block-custom-css-strip-notice';
 import Header from '../header';
 import InserterSidebar from '../inserter-sidebar';
 import ListViewSidebar from '../list-view-sidebar';
@@ -53,6 +54,7 @@ const Notices = () => (
 		dismissibleNoticesClassName="editor-notices__dismissible"
 	>
 		<TemplateValidationNotice />
+		<BlockCustomCSSStripNotice />
 	</InlineNotices>
 );
 


### PR DESCRIPTION
## What

In this PR, for users without `unfiltered_html` save posts that contain block-level custom CSS, that CSS is now **stripped** (not passed through KSES), and the editor throws up a warning so they know it will be removed. 

## Why

This avoids KSES corrupting `&` and `>` in CSS (e.g. nesting/selectors) and makes the behavior explicit.

## How

-  In `pre_kses` (priority 5), strip `attrs.style.css` from all blocks for users without `unfiltered_html` so it is never run through KSES (`lib/experimental/kses.php`).
- When the post has any blocks with custom CSS that will be stripped, show a single notice at the top of the editor.

## Test steps

1. Create an Author user (no `unfiltered_html`). As Admin, create a post, add a block (e.g. Paragraph), open **Advanced → Additional CSS**, add e.g. `color: blue; & p { color: red; }`, save.
2. Log in as Author, open the post. **Expected:** A warning notice at the top: “Some blocks contain custom CSS that you do not have permission to save…” Block(s) with custom CSS have a yellow left border in the canvas.
3. As Author, change the paragraph text and save. Reopen as Admin. **Expected:** Additional CSS is empty (stripped); no `&amp;` / `&gt;` in saved content.
4. As Admin, add custom CSS, save, reload. **Expected:** CSS is kept; no strip, no new notices.

<img width="1296" height="772" alt="Screenshot 2026-03-05 at 12 32 59 pm" src="https://github.com/user-attachments/assets/e06885f4-401c-4ce6-909a-baf8282faa26" />

