### PR TITLE
Hide template part replace button when viewing revisions

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -128,11 +128,13 @@ export default function TemplatePartEdit( {
 		onNavigateToEntityRecord,
 		title,
 		canUserEdit,
+		canUserEditBlock,
 	} = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const { getBlockCount, getSettings } = select( blockEditorStore );
+			const { getBlockCount, getSettings, canEditBlock } =
+				select( blockEditorStore );
 
 			const getEntityArgs = [
 				'postType',
@@ -170,6 +172,7 @@ export default function TemplatePartEdit( {
 					getSettings().onNavigateToEntityRecord,
 				title: entityRecord?.title,
 				canUserEdit: !! _canUserEdit,
+				canUserEditBlock: canEditBlock( clientId ),
 			};
 		},
 		[ templatePartId, attributes.area, clientId ]
@@ -284,6 +287,7 @@ export default function TemplatePartEdit( {
 						// Only enable for single selection that matches the current block.
 						// Ensures menu item doesn't render multiple times.
 						if (
+							! canUserEditBlock ||
 							! (
 								selectedClientIds.length === 1 &&
 								clientId === selectedClientIds[ 0 ]


### PR DESCRIPTION
## What?
Address the feedback in [this comment](https://github.com/WordPress/gutenberg/pull/76066#pullrequestreview-3880594549) by hiding the Template Part 'Replace' button when Revision mode is active.
 
## Why?
You shouldn't be able to edit blocks while viewing revisions.

## How?
Uses the `canEdit` selector to check if the block is editable, and if not hide the replace option

## Testing Instructions
1. Open a template that has a template part
2. Open the Template tab in the inspector
3. If there are no revisions, make some edits and save changes
4. Select a Template Part
5. Open the settings menu
6. Check that Replace is present.
7. Now go back to the Template tab in the inspector and select the revision count to enter revision mode
8. Repeat steps 4-6. Replace should now not be present in the menu.

## Screenshots or screencast <!-- if applicable -->

#### Before

<img width="355" height="186" alt="Screenshot 2026-03-03 at 2 44 08 pm" src="https://github.com/user-attachments/assets/926ceaf7-3f41-4418-af11-f1f746b75c2e" />


#### After

<img width="398" height="138" alt="Screenshot 2026-03-05 at 11 00 53 am" src="https://github.com/user-attachments/assets/fd3653fe-19e5-4383-9612-d4f2e6b8ca41" />
