### PR TITLE
Client-side media processing: Try plumbing invalidation to the block-editor's mediaUpload onSuccess callback

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -20,6 +20,7 @@ import { BlockRefsProvider } from './block-refs-provider';
 import { unlock } from '../../lock-unlock';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 import useMediaUploadSettings from './use-media-upload-settings';
+import { mediaUploadOnSuccessKey } from '../../store/private-keys';
 import { SelectionContext } from './selection-context';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
@@ -89,6 +90,7 @@ function shouldEnableClientSideMediaProcessing() {
  * or when adding a file to the editor via drag & drop.
  *
  * @param {WPDataRegistry} registry
+ * @param {Object}         settings          Block editor settings.
  * @param {Object}         $3                Parameters object passed to the function.
  * @param {Array}          $3.allowedTypes   Array with the types of media that can be uploaded, if unset all types are allowed.
  * @param {Object}         $3.additionalData Additional data to include in the request.
@@ -100,6 +102,7 @@ function shouldEnableClientSideMediaProcessing() {
  */
 function mediaUpload(
 	registry,
+	settings,
 	{
 		allowedTypes,
 		additionalData = {},
@@ -113,7 +116,10 @@ function mediaUpload(
 	void registry.dispatch( uploadStore ).addItems( {
 		files: Array.from( filesList ),
 		onChange: onFileChange,
-		onSuccess,
+		onSuccess: ( attachments ) => {
+			settings?.[ mediaUploadOnSuccessKey ]?.( attachments );
+			onSuccess?.( attachments );
+		},
 		onBatchSuccess,
 		onError: ( { message } ) => onError( message ),
 		additionalData,
@@ -160,7 +166,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 				! isMediaUploadIntercepted
 			) {
 				// Create a new object so that the original props.settings.mediaUpload is not modified.
-				const interceptor = mediaUpload.bind( null, registry );
+				const interceptor = mediaUpload.bind( null, registry, _settings );
 				interceptor.__isMediaUploadInterceptor = true;
 				return {
 					..._settings,

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -166,7 +166,11 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 				! isMediaUploadIntercepted
 			) {
 				// Create a new object so that the original props.settings.mediaUpload is not modified.
-				const interceptor = mediaUpload.bind( null, registry, _settings );
+				const interceptor = mediaUpload.bind(
+					null,
+					registry,
+					_settings
+				);
 				interceptor.__isMediaUploadInterceptor = true;
 				return {
 					..._settings,

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -48,6 +48,7 @@ import {
 	deviceTypeKey,
 	isIsolatedEditorKey,
 	isNavigationOverlayContextKey,
+	mediaUploadOnSuccessKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
@@ -129,6 +130,7 @@ lock( privateApis, {
 	deviceTypeKey,
 	isIsolatedEditorKey,
 	isNavigationOverlayContextKey,
+	mediaUploadOnSuccessKey,
 	useBlockElement,
 	useBlockElementRef,
 	LinkPicker,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -10,3 +10,4 @@ export const deviceTypeKey = Symbol( 'deviceTypeKey' );
 export const isNavigationOverlayContextKey = Symbol(
 	'isNavigationOverlayContext'
 );
+export const mediaUploadOnSuccessKey = Symbol( 'mediaUploadOnSuccess' );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -23,6 +23,7 @@ import {
  */
 import inserterMediaCategories from '../media-categories';
 import { mediaUpload } from '../../utils';
+import mediaUploadOnSuccess from '../../utils/media-upload/on-success';
 import { default as mediaSideload } from '../../utils/media-sideload';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
@@ -103,6 +104,7 @@ const {
 	isIsolatedEditorKey,
 	deviceTypeKey,
 	isNavigationOverlayContextKey,
+	mediaUploadOnSuccessKey,
 } = unlock( privateApis );
 
 /**
@@ -336,6 +338,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				? editMediaEntity
 				: undefined,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
+			[ mediaUploadOnSuccessKey ]: hasUploadPermissions
+				? mediaUploadOnSuccess
+				: undefined,
 			mediaSideload: hasUploadPermissions ? mediaSideload : undefined,
 			__experimentalBlockPatterns: blockPatterns,
 			[ selectBlockPatternsKey ]: ( select ) => {

--- a/packages/editor/src/utils/media-upload/on-success.js
+++ b/packages/editor/src/utils/media-upload/on-success.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * Invalidates core-data entity records for uploaded attachments so that
+ * blocks re-fetch updated data (e.g. `media_details.sizes` after
+ * thumbnails have been generated via client-side media processing).
+ *
+ * @param {Object[]} attachments Array of attachment objects from the upload queue.
+ */
+export default function mediaUploadOnSuccess( attachments ) {
+	const { invalidateResolution } = dispatch( coreDataStore );
+	for ( const attachment of attachments ) {
+		if ( attachment.id ) {
+			// Invalidate with and without the query argument, since
+			// resolution keys must exactly match the args used by
+			// each consumer's getEntityRecord() call.
+			invalidateResolution( 'getEntityRecord', [
+				'postType',
+				'attachment',
+				attachment.id,
+				{ context: 'view' },
+			] );
+			invalidateResolution( 'getEntityRecord', [
+				'postType',
+				'attachment',
+				attachment.id,
+			] );
+		}
+	}
+}


### PR DESCRIPTION
## What?

Alternative to #76121 to invalidate media cache once an update has completed for the client-side media processing.

This fixes a bug where if you upload an image to an image block to the post editor on trunk, the block editor thinks it's an external image until you reload the editor.

The approach in this PR is to plumb an `onSuccess` callback down to the block-editor so that it can pass an `onSuccess` callback to the `upload-media` package's `addItems` calls. This ensures that when an item (and all its sub-sizes) has completely finished uploading, we can fire the `onSuccess` callback at the right time.

## Why?

The approach in #76121 is a little indirect as it's watching the store to see if items disappear from the queue rather than actually firing directly on `onSuccess`.

The reasoning as to why we need to do this plumbing is fairly complex:

* The `editor` package can know about `core-data`
* The block-editor package cannot
* The upload-media package cannot
* `media-utils`' `mediaUpload` doesn't have a proper concept of `onSuccess`
* We need the `upload-media` package to be able to call `onSuccess` with the invalidation code at just the right time

I'm happy to expand on this further, but it's unfortunately quite challenging to describe!

## How?

* Add a small function in the `editor` package to invalidateResolution for media entity records
* Plumb this function down through block editor settings so that it's available to the upload-media package's internal functions so that when `onSuccess` is called, it fires off the invalidation

## Testing Instructions

Follow the instructions in #76121

## Screenshots or screencast <!-- if applicable -->

It should work just the same as #76121. That is, after uploading an image with the client-side media processing active, you should be able to go to the settings tab and select a different image size.