### PR TITLE
Notes: Disable for in-editor revisions

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -252,11 +252,14 @@ function NotesSidebar( { postId } ) {
 }
 
 export default function NotesSidebarContainer() {
-	const { postId, editorMode } = useSelect( ( select ) => {
-		const { getCurrentPostId, getEditorMode } = select( editorStore );
+	const { postId, editorMode, revisionsMode } = useSelect( ( select ) => {
+		const { getCurrentPostId, getEditorMode, isRevisionsMode } = unlock(
+			select( editorStore )
+		);
 		return {
 			postId: getCurrentPostId(),
 			editorMode: getEditorMode(),
+			revisionsMode: isRevisionsMode(),
 		};
 	}, [] );
 
@@ -264,8 +267,8 @@ export default function NotesSidebarContainer() {
 		return null;
 	}
 
-	// Hide Notes sidebar in Code Editor mode since block-level commenting.
-	if ( editorMode === 'text' ) {
+	// Hide Notes sidebar for Code Editor and in-editor revision mode.
+	if ( editorMode === 'text' || revisionsMode ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
PR disabled Notes when in-editor revisions are enabled. Notes don't have revisions, and they're not relevant in this mode.

## Testing Instructions
1. Open a post or page with notes.
2. Switch to in-editor revisions.
3. Select the block with notes.
4. Confirm that the toolbar indicator isn't displayed.

### Testing Instructions for Keyboard
Same.