### PR TITLE
Feature : Categories List - new Inline display

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -129,7 +129,7 @@ Display a list of all terms of a given taxonomy. ([Source](https://github.com/Wo
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-	**Attributes:** delimiter, displayLayout, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -129,7 +129,7 @@ Display a list of all terms of a given taxonomy. ([Source](https://github.com/Wo
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** delimiter, displayLayout, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-	**Attributes:** customDelimiter, delimiter, displayLayout, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -19,8 +19,11 @@
 		},
 		"delimiter": {
 			"type": "string",
-			"default": "comma",
-			"enum": [ "comma", "dot", "pipe", "slash" ]
+			"default": "comma"
+		},
+		"customDelimiter": {
+			"type": "string",
+			"default": ""
 		},
 		"showHierarchy": {
 			"type": "boolean",

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -12,9 +12,15 @@
 			"type": "string",
 			"default": "category"
 		},
-		"displayAsDropdown": {
-			"type": "boolean",
-			"default": false
+		"displayLayout": {
+			"type": "string",
+			"default": "list",
+			"enum": [ "list", "dropdown", "inline" ]
+		},
+		"delimiter": {
+			"type": "string",
+			"default": "comma",
+			"enum": [ "comma", "dot", "pipe", "slash" ]
 		},
 		"showHierarchy": {
 			"type": "boolean",
@@ -92,6 +98,10 @@
 			}
 		}
 	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "tag", "label": "Tag Style" }
+	],
 	"editorStyle": "wp-block-categories-editor",
 	"style": "wp-block-categories"
 }

--- a/packages/block-library/src/categories/deprecated.js
+++ b/packages/block-library/src/categories/deprecated.js
@@ -1,0 +1,79 @@
+const migrateDisplayAsDropdown = ( attributes ) => {
+	const { displayAsDropdown, ...restAttributes } = attributes;
+	return {
+		...restAttributes,
+		displayLayout: displayAsDropdown ? 'dropdown' : 'list',
+	};
+};
+
+const v1 = {
+	attributes: {
+		taxonomy: {
+			type: 'string',
+			default: 'category',
+		},
+		displayAsDropdown: {
+			type: 'boolean',
+			default: false,
+		},
+		showHierarchy: {
+			type: 'boolean',
+			default: false,
+		},
+		showPostCounts: {
+			type: 'boolean',
+			default: false,
+		},
+		showOnlyTopLevel: {
+			type: 'boolean',
+			default: false,
+		},
+		showEmpty: {
+			type: 'boolean',
+			default: false,
+		},
+		label: {
+			type: 'string',
+		},
+		showLabel: {
+			type: 'boolean',
+			default: true,
+		},
+	},
+	supports: {
+		anchor: true,
+		align: true,
+		html: false,
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+		},
+		color: {
+			gradients: true,
+			link: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+		},
+	},
+	isEligible( { displayAsDropdown } ) {
+		return displayAsDropdown !== undefined;
+	},
+	migrate: migrateDisplayAsDropdown,
+	save: () => null,
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -33,9 +33,30 @@ import { store as noticeStore } from '@wordpress/notices';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
+const DELIMITER_OPTIONS = [
+	{ label: __( 'Comma' ), value: 'comma' },
+	{ label: __( 'Dot' ), value: 'dot' },
+	{ label: __( 'Pipe' ), value: 'pipe' },
+	{ label: __( 'Slash' ), value: 'slash' },
+];
+
+const DISPLAY_LAYOUT_OPTIONS = [
+	{ label: __( 'List' ), value: 'list' },
+	{ label: __( 'Dropdown' ), value: 'dropdown' },
+	{ label: __( 'Inline' ), value: 'inline' },
+];
+
+const DELIMITER_CHARS = {
+	comma: ', ',
+	dot: ' · ',
+	pipe: ' | ',
+	slash: ' / ',
+};
+
 export default function CategoriesEdit( {
 	attributes: {
-		displayAsDropdown,
+		displayLayout,
+		delimiter,
 		showHierarchy,
 		showPostCounts,
 		showOnlyTopLevel,
@@ -129,6 +150,39 @@ export default function CategoriesEdit( {
 		);
 	};
 
+	const renderCategoryInline = () => {
+		const delimiterChar =
+			DELIMITER_CHARS[ delimiter ] || DELIMITER_CHARS.comma;
+		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
+		const categoriesList = getCategoriesList( parentId );
+
+		const items = [];
+		categoriesList.forEach( ( category, index ) => {
+			const { id, link, count, name } = category;
+			items.push(
+				<span key={ id } className="wp-block-categories__inline-item">
+					<a href={ link } onClick={ showRedirectionPreventedNotice }>
+						{ renderCategoryName( name ) }
+					</a>
+					{ showPostCounts && ` (${ count })` }
+				</span>
+			);
+			if ( index < categoriesList.length - 1 ) {
+				items.push(
+					<span
+						key={ `delimiter-${ id }` }
+						className="wp-block-categories__inline-delimiter"
+						aria-hidden="true"
+					>
+						{ delimiterChar.trim() }
+					</span>
+				);
+			}
+		} );
+
+		return items;
+	};
+
 	const renderCategoryDropdown = () => {
 		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
 		const categoriesList = getCategoriesList( parentId );
@@ -184,19 +238,28 @@ export default function CategoriesEdit( {
 		];
 	};
 
-	const TagName =
-		!! categories?.length && ! displayAsDropdown && ! isResolving
-			? 'ul'
-			: 'div';
+	const isDropdown = displayLayout === 'dropdown';
+	const isInline = displayLayout === 'inline';
+	const hasContent = !! categories?.length && ! isResolving;
+
+	let TagName = 'div';
+	if ( hasContent && ! isDropdown ) {
+		TagName = isInline ? 'div' : 'ul';
+	}
 
 	const classes = clsx(
 		className,
 		`wp-block-categories-taxonomy-${ taxonomySlug }`,
 		{
 			'wp-block-categories-list':
-				!! categories?.length && ! displayAsDropdown && ! isResolving,
+				!! categories?.length &&
+				! isDropdown &&
+				! isInline &&
+				! isResolving,
 			'wp-block-categories-dropdown':
-				!! categories?.length && displayAsDropdown && ! isResolving,
+				!! categories?.length && isDropdown && ! isResolving,
+			'wp-block-categories-inline':
+				!! categories?.length && isInline && ! isResolving,
 		}
 	);
 
@@ -213,7 +276,8 @@ export default function CategoriesEdit( {
 					resetAll={ () => {
 						setAttributes( {
 							taxonomy: 'category',
-							displayAsDropdown: false,
+							displayLayout: 'list',
+							delimiter: 'comma',
 							showHierarchy: false,
 							showPostCounts: false,
 							showOnlyTopLevel: false,
@@ -251,20 +315,24 @@ export default function CategoriesEdit( {
 						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem
-						hasValue={ () => !! displayAsDropdown }
-						label={ __( 'Display as dropdown' ) }
+						hasValue={ () => displayLayout !== 'list' }
+						label={ __( 'Display layout' ) }
 						onDeselect={ () =>
-							setAttributes( { displayAsDropdown: false } )
+							setAttributes( { displayLayout: 'list' } )
 						}
 						isShownByDefault
 					>
-						<ToggleControl
-							label={ __( 'Display as dropdown' ) }
-							checked={ displayAsDropdown }
-							onChange={ toggleAttribute( 'displayAsDropdown' ) }
+						<SelectControl
+							__next40pxDefaultSize
+							label={ __( 'Display layout' ) }
+							options={ DISPLAY_LAYOUT_OPTIONS }
+							value={ displayLayout }
+							onChange={ ( value ) =>
+								setAttributes( { displayLayout: value } )
+							}
 						/>
 					</ToolsPanelItem>
-					{ displayAsDropdown && (
+					{ isDropdown && (
 						<ToolsPanelItem
 							hasValue={ () => ! showLabel }
 							label={ __( 'Show label' ) }
@@ -278,6 +346,26 @@ export default function CategoriesEdit( {
 								label={ __( 'Show label' ) }
 								checked={ showLabel }
 								onChange={ toggleAttribute( 'showLabel' ) }
+							/>
+						</ToolsPanelItem>
+					) }
+					{ isInline && (
+						<ToolsPanelItem
+							hasValue={ () => delimiter !== 'comma' }
+							label={ __( 'Delimiter' ) }
+							onDeselect={ () =>
+								setAttributes( { delimiter: 'comma' } )
+							}
+							isShownByDefault
+						>
+							<SelectControl
+								__next40pxDefaultSize
+								label={ __( 'Delimiter' ) }
+								options={ DELIMITER_OPTIONS }
+								value={ delimiter }
+								onChange={ ( value ) =>
+									setAttributes( { delimiter: value } )
+								}
 							/>
 						</ToolsPanelItem>
 					) }
@@ -327,22 +415,26 @@ export default function CategoriesEdit( {
 							onChange={ toggleAttribute( 'showEmpty' ) }
 						/>
 					</ToolsPanelItem>
-					{ isHierarchicalTaxonomy && ! showOnlyTopLevel && (
-						<ToolsPanelItem
-							hasValue={ () => !! showHierarchy }
-							label={ __( 'Show hierarchy' ) }
-							onDeselect={ () =>
-								setAttributes( { showHierarchy: false } )
-							}
-							isShownByDefault
-						>
-							<ToggleControl
+					{ isHierarchicalTaxonomy &&
+						! showOnlyTopLevel &&
+						! isInline && (
+							<ToolsPanelItem
+								hasValue={ () => !! showHierarchy }
 								label={ __( 'Show hierarchy' ) }
-								checked={ showHierarchy }
-								onChange={ toggleAttribute( 'showHierarchy' ) }
-							/>
-						</ToolsPanelItem>
-					) }
+								onDeselect={ () =>
+									setAttributes( { showHierarchy: false } )
+								}
+								isShownByDefault
+							>
+								<ToggleControl
+									label={ __( 'Show hierarchy' ) }
+									checked={ showHierarchy }
+									onChange={ toggleAttribute(
+										'showHierarchy'
+									) }
+								/>
+							</ToolsPanelItem>
+						) }
 				</ToolsPanel>
 			</InspectorControls>
 			{ isResolving && (
@@ -353,11 +445,13 @@ export default function CategoriesEdit( {
 			{ ! isResolving && categories?.length === 0 && (
 				<p>{ taxonomy.labels.no_terms }</p>
 			) }
-			{ ! isResolving &&
-				categories?.length > 0 &&
-				( displayAsDropdown
-					? renderCategoryDropdown()
-					: renderCategoryList() ) }
+			{ ! isResolving && categories?.length > 0 && (
+				<>
+					{ isDropdown && renderCategoryDropdown() }
+					{ isInline && renderCategoryInline() }
+					{ ! isDropdown && ! isInline && renderCategoryList() }
+				</>
+			) }
 		</TagName>
 	);
 }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -10,10 +10,12 @@ import {
 	Placeholder,
 	SelectControl,
 	Spinner,
+	TextControl,
 	ToggleControl,
 	VisuallyHidden,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
@@ -38,6 +40,7 @@ const DELIMITER_OPTIONS = [
 	{ label: __( 'Dot' ), value: 'dot' },
 	{ label: __( 'Pipe' ), value: 'pipe' },
 	{ label: __( 'Slash' ), value: 'slash' },
+	{ label: __( 'Custom' ), value: 'custom' },
 ];
 
 const DISPLAY_LAYOUT_OPTIONS = [
@@ -57,6 +60,7 @@ export default function CategoriesEdit( {
 	attributes: {
 		displayLayout,
 		delimiter,
+		customDelimiter,
 		showHierarchy,
 		showPostCounts,
 		showOnlyTopLevel,
@@ -152,7 +156,9 @@ export default function CategoriesEdit( {
 
 	const renderCategoryInline = () => {
 		const delimiterChar =
-			DELIMITER_CHARS[ delimiter ] || DELIMITER_CHARS.comma;
+			delimiter === 'custom'
+				? customDelimiter || ','
+				: DELIMITER_CHARS[ delimiter ] || DELIMITER_CHARS.comma;
 		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
 		const categoriesList = getCategoriesList( parentId );
 
@@ -278,6 +284,7 @@ export default function CategoriesEdit( {
 							taxonomy: 'category',
 							displayLayout: 'list',
 							delimiter: 'comma',
+							customDelimiter: '',
 							showHierarchy: false,
 							showPostCounts: false,
 							showOnlyTopLevel: false,
@@ -351,22 +358,42 @@ export default function CategoriesEdit( {
 					) }
 					{ isInline && (
 						<ToolsPanelItem
-							hasValue={ () => delimiter !== 'comma' }
+							hasValue={ () =>
+								delimiter !== 'comma' || customDelimiter
+							}
 							label={ __( 'Delimiter' ) }
 							onDeselect={ () =>
-								setAttributes( { delimiter: 'comma' } )
+								setAttributes( {
+									delimiter: 'comma',
+									customDelimiter: '',
+								} )
 							}
 							isShownByDefault
 						>
-							<SelectControl
-								__next40pxDefaultSize
-								label={ __( 'Delimiter' ) }
-								options={ DELIMITER_OPTIONS }
-								value={ delimiter }
-								onChange={ ( value ) =>
-									setAttributes( { delimiter: value } )
-								}
-							/>
+							<VStack spacing={ 2 }>
+								<SelectControl
+									__next40pxDefaultSize
+									label={ __( 'Delimiter' ) }
+									options={ DELIMITER_OPTIONS }
+									value={ delimiter }
+									onChange={ ( value ) =>
+										setAttributes( { delimiter: value } )
+									}
+								/>
+								{ delimiter === 'custom' && (
+									<TextControl
+										__next40pxDefaultSize
+										label={ __( 'Custom delimiter' ) }
+										value={ customDelimiter }
+										onChange={ ( value ) =>
+											setAttributes( {
+												customDelimiter: value,
+											} )
+										}
+										placeholder={ __( 'e.g., •' ) }
+									/>
+								) }
+							</VStack>
 						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem

--- a/packages/block-library/src/categories/editor.scss
+++ b/packages/block-library/src/categories/editor.scss
@@ -14,3 +14,8 @@
 .wp-block-categories__indentation {
 	padding-left: 16px;
 }
+
+/* Editor styles for inline layout. */
+.wp-block-categories-inline {
+	padding-left: 0;
+}

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import variations from './variations';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 
@@ -20,6 +21,7 @@ export const settings = {
 	example: {},
 	edit,
 	variations,
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -80,7 +80,13 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			'pipe'  => ' | ',
 			'slash' => ' / ',
 		);
-		$delimiter_char = isset( $delimiter_chars[ $delimiter ] ) ? $delimiter_chars[ $delimiter ] : ', ';
+		
+		if ( 'custom' === $delimiter ) {
+			$custom_delimiter = isset( $attributes['customDelimiter'] ) ? $attributes['customDelimiter'] : '';
+			$delimiter_char = $custom_delimiter ? $custom_delimiter : ', ';
+		} else {
+			$delimiter_char = isset( $delimiter_chars[ $delimiter ] ) ? $delimiter_chars[ $delimiter ] : ', ';
+		}
 
 		$categories = get_categories( $args );
 		$items_markup = '';

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -36,7 +36,9 @@ function render_block_core_categories( $attributes, $content, $block ) {
 		$args['parent'] = 0;
 	}
 
-	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
+	$display_layout = isset( $attributes['displayLayout'] ) ? $attributes['displayLayout'] : 'list';
+
+	if ( 'dropdown' === $display_layout ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
 		$args['name']             = $taxonomy->query_var;
@@ -65,6 +67,53 @@ function render_block_core_categories( $attributes, $content, $block ) {
 				$items_markup,
 				1
 			);
+		}
+	} elseif ( 'inline' === $display_layout ) {
+		$args['show_option_none'] = $taxonomy->labels->no_terms;
+		$args['title_li']         = '';
+		$args['style']            = 'none';
+
+		$delimiter = isset( $attributes['delimiter'] ) ? $attributes['delimiter'] : 'comma';
+		$delimiter_chars = array(
+			'comma' => ', ',
+			'dot'   => ' · ',
+			'pipe'  => ' | ',
+			'slash' => ' / ',
+		);
+		$delimiter_char = isset( $delimiter_chars[ $delimiter ] ) ? $delimiter_chars[ $delimiter ] : ', ';
+
+		$categories = get_categories( $args );
+		$items_markup = '';
+
+		if ( ! empty( $categories ) ) {
+			$items = array();
+			foreach ( $categories as $category ) {
+				$link = get_term_link( $category );
+				if ( is_wp_error( $link ) ) {
+					continue;
+				}
+				$item = '<span class="wp-block-categories__inline-item"><a href="' . esc_url( $link ) . '">' . esc_html( $category->name ) . '</a>';
+				if ( ! empty( $attributes['showPostCounts'] ) ) {
+					$item .= ' (' . esc_html( $category->count ) . ')';
+				}
+				$item .= '</span>';
+				$items[] = $item;
+			}
+			$delimiter_markup = '<span class="wp-block-categories__inline-delimiter" aria-hidden="true">' . esc_html( trim( $delimiter_char ) ) . '</span>';
+			$items_markup = implode( $delimiter_markup, $items );
+		} else {
+			$items_markup = esc_html( $taxonomy->labels->no_terms );
+		}
+
+		$wrapper_markup = '<div %1$s>%2$s</div>';
+		$type           = 'inline';
+
+		if ( ! empty( $block->context['enhancedPagination'] ) ) {
+			$p = new WP_HTML_Tag_Processor( $items_markup );
+			while ( $p->next_tag( 'a' ) ) {
+				$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+			}
+			$items_markup = $p->get_updated_html();
 		}
 	} else {
 		$args['show_option_none'] = $taxonomy->labels->no_terms;

--- a/packages/block-library/src/categories/style.scss
+++ b/packages/block-library/src/categories/style.scss
@@ -19,3 +19,63 @@
 		display: block;
 	}
 }
+
+// Inline display layout.
+.wp-block-categories-inline {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 0;
+
+	.wp-block-categories__inline-item {
+		display: inline;
+	}
+
+	.wp-block-categories__inline-delimiter {
+		margin: 0 0.25em;
+	}
+}
+
+// Tag style block style (pill/chip style).
+:root :where(.wp-block-categories.is-style-tag) {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5ch;
+
+	a {
+		display: inline-block;
+		padding: 0.25em 0.75em;
+		border: 1px solid currentColor;
+		border-radius: 2px;
+		text-decoration: none;
+		transition: transform 0.15s ease-in-out;
+
+		&:hover,
+		&:focus {
+			transform: translateY(-2px);
+		}
+	}
+
+	span {
+		margin-left: 0.5em;
+	}
+}
+
+// Tag style for inline layout.
+:root :where(.wp-block-categories-inline.is-style-tag) {
+	gap: 0.5ch;
+
+	.wp-block-categories__inline-item a {
+		display: inline-block;
+		padding: 0.25em 0.75em;
+		border: 1px solid currentColor;
+		border-radius: 2px;
+		text-decoration: none;
+		transition: transform 0.15s ease-in-out;
+
+		&:hover,
+		&:focus {
+			transform: translateY(-2px);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

-   Closes https://github.com/WordPress/gutenberg/issues/75127

This PR adds new display options to the Categories/Terms List block:

-   **Inline layout** - displays terms horizontally with configurable delimiters (comma, dot, pipe, slash)
-   **Tag style** - a new block style that presents terms as pill/chip elements with borders and padding

## Why?

The Categories List block previously only supported two display modes: a bulleted list or a dropdown. However, many common design patterns require:

-   **Inline lists** - showing categories/tags as a horizontal sequence (e.g., "News, Updates, Events")

Previously, these layouts required custom CSS or custom blocks, which added friction for designers and content creators.

## How?

### Block Attributes

-   Replaced `displayAsDropdown` (boolean) with `displayLayout` (string enum: `list`, `dropdown`, `inline`)
-   Added `delimiter` attribute (string enum: `comma`, `dot`, `pipe`, `slash`) for inline layout
-   Added block styles: `default` and `tag`

### Editor Changes (`edit.js`)

-   Replaced "Display as dropdown" toggle with a "Display layout" SelectControl
-   Added "Delimiter" SelectControl (visible only when inline layout is selected)
-   Added `renderCategoryInline()` function for horizontal rendering
-   "Show hierarchy" option is hidden when inline layout is selected (not applicable)

### Server-Side Rendering (`index.php`)

-   Added rendering logic for inline layout using `get_categories()`
-   Delimiter markup rendered with `aria-hidden="true"` for accessibility
-   Backward compatibility for existing `displayAsDropdown` attribute

### Styles (`style.scss`, `editor.scss`)

-   Added `.wp-block-categories-inline` styles for horizontal flex layout
-   Added `.is-style-tag` block style for pill/chip appearance
-   Delimiter spacing and tag styling with hover effects

### Migration (`deprecated.js`)

-   Created migration from `displayAsDropdown` → `displayLayout` for existing blocks

## Testing Instructions

1. Start the development environment: `npm run wp-env start`
2. Create a new post or page
3. Insert a **Terms List** (Categories List) block
4. In the block settings sidebar, verify the new **Display layout** dropdown with options: List, Dropdown, Inline
5. Select **Inline** and verify:
    - Terms display horizontally
    - The **Delimiter** option appears with choices: Comma, Dot, Pipe, Slash
    - Each delimiter renders correctly between terms
7. Test with different taxonomies (Categories, Tags)
8. Verify existing blocks with `displayAsDropdown: true` still render as dropdowns

### Preview

https://github.com/user-attachments/assets/000f3a8c-8072-42b3-bbe7-1cd8e4c777d3

