### PR TITLE
Connectors: Improve responsive layout on small screens

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -39,7 +39,7 @@ export function ConnectorItem( {
 	return (
 		<Item className={ className }>
 			<VStack spacing={ 4 }>
-				<HStack alignment="center" spacing={ 4 }>
+				<HStack alignment="center" spacing={ 4 } wrap>
 					{ icon }
 					<FlexBlock>
 						<VStack spacing={ 0 }>

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/colors" as *;
 
 .connectors-page {
+	box-sizing: border-box;
 	width: 100%;
 	max-width: 680px;
 	margin: 0 auto;

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -30,17 +30,9 @@
 		.components-item {
 			padding: 16px;
 
-			> .components-v-stack > .components-h-stack:first-child {
-				svg {
-					width: 32px;
-					height: 32px;
-				}
-
-				// Force wrapping when space is tight
-				> .components-flex-block {
-					min-width: 0;
-					flex-basis: 60%;
-				}
+			> .components-v-stack > .components-h-stack:first-child svg {
+				width: 32px;
+				height: 32px;
 			}
 		}
 	}

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -22,4 +22,25 @@
 		text-align: center;
 		color: $gray-600;
 	}
+
+	@media (max-width: 480px) {
+		padding: 16px;
+
+		.components-item {
+			padding: 16px;
+
+			> .components-v-stack > .components-h-stack:first-child {
+				svg {
+					width: 32px;
+					height: 32px;
+				}
+
+				// Force wrapping when space is tight
+				> .components-flex-block {
+					min-width: 0;
+					flex-basis: 60%;
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Fix horizontal overflow caused by missing `box-sizing: border-box` on the page container (`width: 100%` + `padding` exceeded the available space)
- Enable flex wrapping on the ConnectorItem header row via the HStack `wrap` prop so the action area (badges + buttons) gracefully wraps below the icon and text on narrow viewports
- Add a CSS media query for viewports under 480px that reduces page/card padding and icon size for a tighter mobile fit

## Screenshots

### Before (375px mobile)

| Collapsed | Expanded |
|---|---|
| <img width="375" height="900" alt="connectors-mobile" src="https://github.com/user-attachments/assets/4f3ed8b2-6a9e-4719-a138-8b258cd3bfce" />) | <img width="375" height="900" alt="connectors-mobile-expanded" src="https://github.com/user-attachments/assets/13c86e27-b8e4-4a50-aef7-6c79c986ae40" /> |

### After (375px mobile)

| Collapsed | Expanded |
|---|---|
| <img width="375" height="900" alt="v5-mobile" src="https://github.com/user-attachments/assets/856448a5-72b8-4150-ba84-9dbfcff538c6" /> | <img width="375" height="900" alt="v5-mobile-expanded" src="https://github.com/user-attachments/assets/228c4522-81cc-4ff3-988a-8102fd2fa10d" /> |

### After (600px) – no longer clipped

<img width="600" height="900" alt="v4-narrow" src="https://github.com/user-attachments/assets/14892d98-c535-4f8b-becc-1c88487a66fb" />

### Desktop (1280px) — unchanged

<img width="1280" height="900" alt="v4-wide" src="https://github.com/user-attachments/assets/ae19951b-56ab-4987-a13d-e20bcf98b42e" />

## Test plan
- [ ] Open `Settings > Connectors` in wp-admin
- [ ] Resize the browser to various widths: 1280px, 600px, 480px, 375px
- [ ] Verify no horizontal scrolling at any width
- [ ] Verify wide layout is unchanged
- [ ] Verify on mobile (375px) that cards with wider action areas (e.g. "Connected" badge + "Edit" button) wrap naturally
- [ ] Click "Set up" / "Edit" to expand connector cards and verify the API key form renders correctly at all widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)