### PR TITLE
Content Guidelines: Add block guidelines management

### DIFF
--- a/lib/experimental/content-guidelines/load.php
+++ b/lib/experimental/content-guidelines/load.php
@@ -6,6 +6,7 @@
  */
 
 add_action( 'admin_menu', 'gutenberg_register_content_guidelines_settings_submenu', 10 );
+add_action( 'admin_enqueue_scripts', 'gutenberg_content_guidelines_enqueue_block_registry_scripts', 5 );
 
 /**
  * Registers the Content Guidelines submenu item under Settings.
@@ -20,4 +21,29 @@ function gutenberg_register_content_guidelines_settings_submenu() {
 		'content-guidelines-wp-admin',
 		'gutenberg_content_guidelines_wp_admin_render_page'
 	);
+}
+
+/**
+ * Enqueues wp-block-library on the Content Guidelines admin page so
+ * registerCoreBlocks() is available when the app bootstraps the block
+ * registry (Core blocks only) on the client.
+ *
+ * Priority 5 ensures this runs before the main asset enqueue (priority 10).
+ */
+function gutenberg_content_guidelines_enqueue_block_registry_scripts( $hook_suffix ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$current_screen = get_current_screen();
+	$is_content_guidelines_page = (
+		( isset( $_GET['page'] ) && 'content-guidelines-wp-admin' === $_GET['page'] )
+		|| ( $current_screen && 'content-guidelines' === $current_screen->id )
+	);
+
+	if ( ! $is_content_guidelines_page ) {
+		return;
+	}
+
+	wp_enqueue_script( 'wp-block-library' );
 }

--- a/lib/experimental/content-guidelines/load.php
+++ b/lib/experimental/content-guidelines/load.php
@@ -35,13 +35,7 @@ function gutenberg_content_guidelines_enqueue_block_registry_scripts( $hook_suff
 		return;
 	}
 
-	$current_screen = get_current_screen();
-	$is_content_guidelines_page = (
-		( isset( $_GET['page'] ) && 'content-guidelines-wp-admin' === $_GET['page'] )
-		|| ( $current_screen && 'content-guidelines' === $current_screen->id )
-	);
-
-	if ( ! $is_content_guidelines_page ) {
+	if ( 'settings_page_content-guidelines-wp-admin' !== $hook_suffix ) {
 		return;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63015,6 +63015,8 @@
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/api-fetch": "file:../../packages/api-fetch",
 				"@wordpress/base-styles": "file:../../packages/base-styles",
+				"@wordpress/block-library": "file:../../packages/block-library",
+				"@wordpress/blocks": "file:../../packages/blocks",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/dataviews": "file:../../packages/dataviews",

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -10,7 +10,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { STORE_NAME } from './store';
-import type { RestGuidelinesResponse } from './types';
+import type { Categories, RestGuidelinesResponse } from './types';
 
 export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse > {
 	const { setFromResponse } = dispatch( STORE_NAME ) as {
@@ -33,13 +33,15 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 	const guidelinesStore = select( STORE_NAME ) as {
 		getId: () => number | null;
 		getStatus: () => string | null;
-		getAllGuidelines: () => Partial< Record< string, string > >;
+		getAllGuidelines: () => Categories;
+		getBlockGuidelines: () => Record< string, string >;
 		getGuideline: ( category: string ) => string;
 	};
 
 	const id = guidelinesStore.getId();
 	const status = guidelinesStore.getStatus() || 'draft';
 	const categories = guidelinesStore.getAllGuidelines();
+	const blockGuidelines = guidelinesStore.getBlockGuidelines();
 
 	const data = {
 		id,
@@ -57,6 +59,14 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 			additional: {
 				guidelines: categories.additional,
 			},
+			blocks: Object.fromEntries(
+				Object.entries( blockGuidelines ).map(
+					( [ blockName, guidelines ] ) => [
+						blockName,
+						{ guidelines },
+					]
+				)
+			),
 		},
 	};
 

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -3,8 +3,6 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -70,8 +68,6 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 		},
 	};
 
-	const { createSuccessNotice } = dispatch( noticesStore );
-
 	const path = id
 		? `/wp/v2/content-guidelines/${ id }`
 		: '/wp/v2/content-guidelines';
@@ -84,10 +80,6 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 	} ) ) as RestGuidelinesResponse;
 
 	setFromResponse( response );
-
-	createSuccessNotice( __( 'Content guidelines saved.' ), {
-		type: 'snackbar',
-	} );
 
 	return response;
 }

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -28,12 +28,12 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 	// @ts-ignore
 	const { setFromResponse } = dispatch( STORE_NAME );
 
-	const guidelinesStore = select( STORE_NAME ) as {
+	const guidelinesStore = select( STORE_NAME ) as unknown as {
 		getId: () => number | null;
 		getStatus: () => string | null;
 		getAllGuidelines: () => Categories;
 		getBlockGuidelines: () => Record< string, string >;
-		getGuideline: ( category: string ) => string;
+		getGuideline: ( category: string ) => string | Record< string, string >;
 	};
 
 	const id = guidelinesStore.getId();

--- a/routes/content-guidelines/bootstrap-block-registry.ts
+++ b/routes/content-guidelines/bootstrap-block-registry.ts
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+let bootstrapped = false;
+
+/**
+ * Bootstraps the block registry with Core blocks only.
+ * Used on the Content Guidelines admin page so block icons (and later
+ * 3rd party/experimental block support) are available without loading
+ * the full block editor.
+ */
+export function bootstrapBlockRegistry(): void {
+	if ( bootstrapped ) {
+		return;
+	}
+	bootstrapped = true;
+
+	dispatch( blocksStore ).reapplyBlockTypeFilters();
+	registerCoreBlocks();
+}

--- a/routes/content-guidelines/components/block-guideline-modal.scss
+++ b/routes/content-guidelines/components/block-guideline-modal.scss
@@ -1,0 +1,11 @@
+.block-guideline-modal {
+	width: min(100%, 660px);
+
+	.components-modal__header-heading {
+		font-weight: 500;
+	}
+
+	&__actions {
+		margin-top: 8px;
+	}
+}

--- a/routes/content-guidelines/components/block-guideline-modal.scss
+++ b/routes/content-guidelines/components/block-guideline-modal.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/variables" as *;
+
 .block-guideline-modal {
 	width: min(100%, 660px);
 
@@ -6,6 +8,6 @@
 	}
 
 	&__actions {
-		margin-top: 8px;
+		margin-top: $grid-unit-10;
 	}
 }

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -99,11 +99,9 @@ export default function BlockGuidelineModal( {
 			.then( () => {
 				setError( null );
 				createSuccessNotice(
-					sprintf(
-						/* translators: %s: Block label. */
-						__( 'Block guideline %s.' ),
-						value ? 'saved' : 'removed'
-					),
+					value
+						? __( 'Block guideline saved.' )
+						: __( 'Block guideline removed.' ),
 					{ type: 'snackbar' }
 				);
 				closeModal();

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -1,3 +1,5 @@
+/* @jsx createElement */
+
 /**
  * WordPress dependencies
  */
@@ -5,13 +7,14 @@ import {
 	Button,
 	ComboboxControl,
 	Modal,
+	TextControl,
 	TextareaControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
-import { useState, useEffect } from '@wordpress/element';
+import { createElement, useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 
@@ -31,7 +34,6 @@ export default function BlockGuidelineModal( {
 	closeModal,
 	initialBlock,
 }: BlockGuidelineModalProps ) {
-	const [ guidelineText, setGuidelineText ] = useState( '' );
 	const [ selectedBlock, setSelectedBlock ] = useState< string | undefined >(
 		initialBlock
 	);
@@ -39,26 +41,42 @@ export default function BlockGuidelineModal( {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
-	const currentGuideline = useSelect(
+	const blockGuidelines = useSelect(
 		// @ts-ignore
-		( select ) => select( STORE_NAME ).getBlockGuideline( selectedBlock ),
-		[ selectedBlock ]
+		( select ) => select( STORE_NAME ).getBlockGuidelines(),
+		[]
 	);
 
-	const isEditing = !! currentGuideline;
+	const isEditing = !! initialBlock;
 
-	useEffect( () => {
-		setSelectedBlock( initialBlock );
-	}, [ initialBlock ] );
-
-	useEffect( () => {
-		setGuidelineText( currentGuideline ?? '' );
-	}, [ currentGuideline ] );
+	const currentGuideline = blockGuidelines[ selectedBlock ] ?? '';
+	const [ guidelineText, setGuidelineText ] = useState( currentGuideline );
 
 	const blockOptions = useSelect(
 		// @ts-ignore
 		( select ) => select( blocksStore ).getBlockTypes(),
 		[]
+	);
+
+	const availableBlockOptions = useMemo( () => {
+		const set = new Set( Object.keys( blockGuidelines ) );
+		if ( initialBlock ) {
+			set.delete( initialBlock );
+		}
+
+		return blockOptions
+			.filter( ( block ) => ! set.has( block.name ) )
+			.map( ( block ) => ( {
+				value: block.name,
+				label: block.title,
+			} ) );
+	}, [ blockGuidelines, blockOptions, initialBlock ] );
+
+	const selectedBlockLabel = useMemo(
+		() =>
+			blockOptions.find( ( block ) => block.name === selectedBlock )
+				?.title || '',
+		[ blockOptions, selectedBlock ]
 	);
 
 	const { setBlockGuideline } = useDispatch( STORE_NAME );
@@ -116,19 +134,26 @@ export default function BlockGuidelineModal( {
 			onRequestClose={ closeModal }
 		>
 			<VStack spacing={ 4 }>
-				<ComboboxControl
-					__next40pxDefaultSize
-					label={ __( 'Block' ) }
-					options={ blockOptions.map( ( block ) => ( {
-						value: block.name,
-						label: block.title,
-					} ) ) }
-					value={ selectedBlock }
-					onChange={ ( value ) =>
-						setSelectedBlock( value ?? undefined )
-					}
-					placeholder={ __( 'Search for a block…' ) }
-				/>
+				{ isEditing ? (
+					<TextControl
+						__next40pxDefaultSize
+						label={ __( 'Block' ) }
+						value={ selectedBlockLabel }
+						onChange={ () => {} }
+						disabled
+					/>
+				) : (
+					<ComboboxControl
+						__next40pxDefaultSize
+						label={ __( 'Block' ) }
+						options={ availableBlockOptions }
+						value={ selectedBlock }
+						onChange={ ( value ) =>
+							setSelectedBlock( value ?? undefined )
+						}
+						placeholder={ __( 'Search for a block…' ) }
+					/>
+				) }
 				<TextareaControl
 					label={ __( 'Guideline text' ) }
 					value={ guidelineText }

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -101,7 +101,7 @@ export default function BlockGuidelineModal( {
 				createSuccessNotice(
 					sprintf(
 						/* translators: %s: Block label. */
-						__( 'Block guideline "%s"' ),
+						__( 'Block guideline %s' ),
 						value ? 'saved' : 'removed'
 					),
 					{ type: 'snackbar' }

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -101,7 +101,7 @@ export default function BlockGuidelineModal( {
 				createSuccessNotice(
 					sprintf(
 						/* translators: %s: Block label. */
-						__( 'Block guideline %s' ),
+						__( 'Block guideline %s.' ),
 						value ? 'saved' : 'removed'
 					),
 					{ type: 'snackbar' }

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -17,6 +17,7 @@ import { Notice } from '@wordpress/ui';
 import { createElement, useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -80,6 +81,7 @@ export default function BlockGuidelineModal( {
 	);
 
 	const { setBlockGuideline } = useDispatch( STORE_NAME );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const handleAddGuideline = () => {
 		if ( ! selectedBlock || ! guidelineText.trim() ) {
@@ -91,6 +93,9 @@ export default function BlockGuidelineModal( {
 			.then( () => {
 				setError( null );
 				closeModal();
+				createSuccessNotice( __( 'Block guideline saved.' ), {
+					type: 'snackbar',
+				} );
 			} )
 			.catch( ( e: Error ) => setError( e.message ) )
 			.finally( () => setIsSaving( false ) );
@@ -105,6 +110,9 @@ export default function BlockGuidelineModal( {
 		saveContentGuidelines()
 			.then( () => {
 				setError( null );
+				createSuccessNotice( __( 'Block guideline removed.' ), {
+					type: 'snackbar',
+				} );
 				closeModal();
 			} )
 			.catch( ( e: Error ) => {

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -64,6 +64,9 @@ export default function BlockGuidelineModal( {
 		if ( initialBlock ) {
 			set.delete( initialBlock );
 		}
+		if ( selectedBlock ) {
+			set.delete( selectedBlock );
+		}
 
 		return blockOptions
 			.filter( ( block ) => ! set.has( block.name ) )
@@ -71,7 +74,7 @@ export default function BlockGuidelineModal( {
 				value: block.name,
 				label: block.title,
 			} ) );
-	}, [ blockGuidelines, blockOptions, initialBlock ] );
+	}, [ blockGuidelines, blockOptions, initialBlock, selectedBlock ] );
 
 	const selectedBlockLabel = useMemo(
 		() =>
@@ -83,41 +86,31 @@ export default function BlockGuidelineModal( {
 	const { setBlockGuideline } = useDispatch( STORE_NAME );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
-	const handleAddGuideline = () => {
-		if ( ! selectedBlock || ! guidelineText.trim() ) {
-			return;
-		}
-		setIsSaving( true );
-		setBlockGuideline( selectedBlock, guidelineText.trim() );
-		saveContentGuidelines()
-			.then( () => {
-				setError( null );
-				closeModal();
-				createSuccessNotice( __( 'Block guideline saved.' ), {
-					type: 'snackbar',
-				} );
-			} )
-			.catch( ( e: Error ) => setError( e.message ) )
-			.finally( () => setIsSaving( false ) );
-	};
-
-	const handleRemoveGuideline = () => {
+	const handleSave = ( value: string ) => {
+		value = value.trim();
 		if ( ! selectedBlock ) {
 			return;
 		}
+
 		setIsSaving( true );
-		setBlockGuideline( selectedBlock, '' );
+		const oldValue = blockGuidelines[ selectedBlock ];
+		setBlockGuideline( selectedBlock, value );
 		saveContentGuidelines()
 			.then( () => {
 				setError( null );
-				createSuccessNotice( __( 'Block guideline removed.' ), {
-					type: 'snackbar',
-				} );
+				createSuccessNotice(
+					sprintf(
+						/* translators: %s: Block label. */
+						__( 'Block guideline "%s"' ),
+						value ? 'saved' : 'removed'
+					),
+					{ type: 'snackbar' }
+				);
 				closeModal();
 			} )
 			.catch( ( e: Error ) => {
 				setError( e.message );
-				setBlockGuideline( selectedBlock, currentGuideline );
+				setBlockGuideline( selectedBlock, oldValue );
 			} )
 			.finally( () => setIsSaving( false ) );
 	};
@@ -191,7 +184,7 @@ export default function BlockGuidelineModal( {
 						<Button
 							variant="tertiary"
 							isDestructive
-							onClick={ handleRemoveGuideline }
+							onClick={ () => handleSave( '' ) }
 							disabled={ isSaving }
 						>
 							{ __( 'Remove' ) }
@@ -199,7 +192,7 @@ export default function BlockGuidelineModal( {
 					) }
 					<Button
 						variant="primary"
-						onClick={ handleAddGuideline }
+						onClick={ () => handleSave( guidelineText ) }
 						disabled={ ! canSubmit || isSaving }
 						isBusy={ isSaving }
 					>

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -16,7 +16,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
 import { createElement, useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as blocksStore } from '@wordpress/blocks';
+import {
+	privateApis as blocksPrivateApis,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -24,7 +27,10 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { saveContentGuidelines } from '../api';
 import { STORE_NAME } from '../store';
+import { unlock } from '../../lock-unlock';
 import './block-guideline-modal.scss';
+
+const { isContentBlock } = unlock( blocksPrivateApis );
 
 interface BlockGuidelineModalProps {
 	closeModal: () => void;
@@ -69,7 +75,10 @@ export default function BlockGuidelineModal( {
 		}
 
 		return blockOptions
-			.filter( ( block ) => ! set.has( block.name ) )
+			.filter(
+				( block ) =>
+					isContentBlock( block.name ) && ! set.has( block.name )
+			)
 			.map( ( block ) => ( {
 				value: block.name,
 				label: block.title,

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -184,6 +184,8 @@ export default function BlockGuidelineModal( {
 						<Button
 							variant="tertiary"
 							isDestructive
+							// We need to pass an empty string to remove the guideline.
+							// This is because the API will only remove the guideline if the value is an empty string.
 							onClick={ () => handleSave( '' ) }
 							disabled={ isSaving }
 						>

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -186,6 +186,7 @@ export default function BlockGuidelineModal( {
 							// This is because the API will only remove the guideline if the value is an empty string.
 							onClick={ () => handleSave( '' ) }
 							disabled={ isSaving }
+							accessibleWhenDisabled
 						>
 							{ __( 'Remove' ) }
 						</Button>
@@ -195,6 +196,7 @@ export default function BlockGuidelineModal( {
 						onClick={ () => handleSave( guidelineText ) }
 						disabled={ ! canSubmit || isSaving }
 						isBusy={ isSaving }
+						accessibleWhenDisabled
 					>
 						{ submitButtonLabel }
 					</Button>

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -1,0 +1,179 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	ComboboxControl,
+	Modal,
+	TextareaControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
+import { useState, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { saveContentGuidelines } from '../api';
+import { STORE_NAME } from '../store';
+import './block-guideline-modal.scss';
+
+interface BlockGuidelineModalProps {
+	closeModal: () => void;
+	initialBlock?: string;
+}
+
+export default function BlockGuidelineModal( {
+	closeModal,
+	initialBlock,
+}: BlockGuidelineModalProps ) {
+	const [ guidelineText, setGuidelineText ] = useState( '' );
+	const [ selectedBlock, setSelectedBlock ] = useState< string | undefined >(
+		initialBlock
+	);
+
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const currentGuideline = useSelect(
+		// @ts-ignore
+		( select ) => select( STORE_NAME ).getBlockGuideline( selectedBlock ),
+		[ selectedBlock ]
+	);
+
+	const isEditing = !! currentGuideline;
+
+	useEffect( () => {
+		setSelectedBlock( initialBlock );
+	}, [ initialBlock ] );
+
+	useEffect( () => {
+		setGuidelineText( currentGuideline ?? '' );
+	}, [ currentGuideline ] );
+
+	const blockOptions = useSelect(
+		// @ts-ignore
+		( select ) => select( blocksStore ).getBlockTypes(),
+		[]
+	);
+
+	const { setBlockGuideline } = useDispatch( STORE_NAME );
+
+	const handleAddGuideline = () => {
+		if ( ! selectedBlock || ! guidelineText.trim() ) {
+			return;
+		}
+		setIsSaving( true );
+		setBlockGuideline( selectedBlock, guidelineText.trim() );
+		saveContentGuidelines()
+			.then( () => {
+				setError( null );
+				closeModal();
+			} )
+			.catch( ( e: Error ) => setError( e.message ) )
+			.finally( () => setIsSaving( false ) );
+	};
+
+	const handleRemoveGuideline = () => {
+		if ( ! selectedBlock ) {
+			return;
+		}
+		setIsSaving( true );
+		setBlockGuideline( selectedBlock, '' );
+		saveContentGuidelines()
+			.then( () => {
+				setError( null );
+				closeModal();
+			} )
+			.catch( ( e: Error ) => {
+				setError( e.message );
+				setBlockGuideline( selectedBlock, currentGuideline );
+			} )
+			.finally( () => setIsSaving( false ) );
+	};
+
+	const canSubmit = selectedBlock && guidelineText.trim().length > 0;
+
+	let submitButtonLabel: string = __( 'Add guideline' );
+	if ( isSaving ) {
+		submitButtonLabel = __( 'Saving…' );
+	} else if ( isEditing ) {
+		submitButtonLabel = __( 'Update guideline' );
+	}
+
+	return (
+		<Modal
+			className="block-guideline-modal"
+			title={
+				isEditing
+					? __( 'Edit block guidelines' )
+					: __( 'Add block guidelines' )
+			}
+			onRequestClose={ closeModal }
+		>
+			<VStack spacing={ 4 }>
+				<ComboboxControl
+					__next40pxDefaultSize
+					label={ __( 'Block' ) }
+					options={ blockOptions.map( ( block ) => ( {
+						value: block.name,
+						label: block.title,
+					} ) ) }
+					value={ selectedBlock }
+					onChange={ ( value ) =>
+						setSelectedBlock( value ?? undefined )
+					}
+					placeholder={ __( 'Search for a block…' ) }
+				/>
+				<TextareaControl
+					label={ __( 'Guideline text' ) }
+					value={ guidelineText }
+					onChange={ setGuidelineText }
+					placeholder={ __(
+						'Enter guidelines for how this block should be used…'
+					) }
+					rows={ 6 }
+				/>
+				{ error && (
+					<Notice.Root intent="error">
+						<Notice.Title>
+							{ sprintf(
+								/* translators: %s: Error message. */
+								__( 'Error: %s' ),
+								error
+							) }
+						</Notice.Title>
+					</Notice.Root>
+				) }
+				<HStack
+					justify="flex-end"
+					spacing={ 2 }
+					className="block-guideline-modal__actions"
+				>
+					{ isEditing && (
+						<Button
+							variant="tertiary"
+							isDestructive
+							onClick={ handleRemoveGuideline }
+							disabled={ isSaving }
+						>
+							{ __( 'Remove' ) }
+						</Button>
+					) }
+					<Button
+						variant="primary"
+						onClick={ handleAddGuideline }
+						disabled={ ! canSubmit || isSaving }
+						isBusy={ isSaving }
+					>
+						{ submitButtonLabel }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/routes/content-guidelines/components/block-guidelines.scss
+++ b/routes/content-guidelines/components/block-guidelines.scss
@@ -1,0 +1,20 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.block-guidelines {
+	margin-top: $grid-unit-30;
+
+	&__add-button {
+		width: 155px;
+	}
+
+	.dataviews-view-list__media-wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.dataviews-view-list__field-wrapper {
+		display: flex;
+		justify-content: center;
+	}
+}

--- a/routes/content-guidelines/components/block-guidelines.scss
+++ b/routes/content-guidelines/components/block-guidelines.scss
@@ -22,4 +22,9 @@
 		margin-right: -$grid-unit-30;
 		margin-left: -$grid-unit-30;
 	}
+
+	.dataviews-search {
+		margin-right: $grid-unit-30;
+		margin-left: $grid-unit-30;
+	}
 }

--- a/routes/content-guidelines/components/block-guidelines.scss
+++ b/routes/content-guidelines/components/block-guidelines.scss
@@ -3,10 +3,12 @@
 .block-guidelines {
 	margin-top: $grid-unit-30;
 
-	.dataviews-view-list__media-wrapper {
+	.block-guidelines__icon {
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		height: 100%;
+		width: 100%;
 	}
 
 	.dataviews-view-list__field-wrapper {

--- a/routes/content-guidelines/components/block-guidelines.scss
+++ b/routes/content-guidelines/components/block-guidelines.scss
@@ -17,4 +17,9 @@
 		display: flex;
 		justify-content: center;
 	}
+
+	.dataviews-wrapper {
+		margin-right: -$grid-unit-30;
+		margin-left: -$grid-unit-30;
+	}
 }

--- a/routes/content-guidelines/components/block-guidelines.scss
+++ b/routes/content-guidelines/components/block-guidelines.scss
@@ -28,3 +28,9 @@
 		margin-left: $grid-unit-30;
 	}
 }
+
+.block-guidelines__remove-modal {
+	.components-modal__header-heading {
+		font-weight: 500;
+	}
+}

--- a/routes/content-guidelines/components/block-guidelines.scss
+++ b/routes/content-guidelines/components/block-guidelines.scss
@@ -3,10 +3,6 @@
 .block-guidelines {
 	margin-top: $grid-unit-30;
 
-	&__add-button {
-		width: 155px;
-	}
-
 	.dataviews-view-list__media-wrapper {
 		display: flex;
 		align-items: center;

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -135,18 +135,24 @@ export default function BlockGuidelines() {
 		if ( ! itemToDelete ) {
 			return;
 		}
+		const oldValue = blockGuidelines[ itemToDelete.id ];
 		setBlockGuideline( itemToDelete.id, '' );
 		setBusy( true );
 		saveContentGuidelines()
 			.then( () => {
 				setError( null );
-				setItemToDelete( null );
 				createSuccessNotice( __( 'Block guidelines removed.' ), {
 					type: 'snackbar',
 				} );
 			} )
-			.catch( ( e: Error ) => setError( e.message ) )
-			.finally( () => setBusy( false ) );
+			.catch( ( e: Error ) => {
+				setError( e.message );
+				setBlockGuideline( itemToDelete.id, oldValue );
+			} )
+			.finally( () => {
+				setBusy( false );
+				setItemToDelete( null );
+			} );
 	};
 
 	const { data: processedData, paginationInfo } = useMemo(

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -143,6 +143,8 @@ export default function BlockGuidelines() {
 			return;
 		}
 		const oldValue = blockGuidelines[ itemToDelete.id ];
+		// We need to pass an empty string to remove the guideline.
+		// This is because the API will only remove the guideline if the value is an empty string.
 		setBlockGuideline( itemToDelete.id, '' );
 		setBusy( true );
 		saveContentGuidelines()

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -113,7 +113,7 @@ export default function BlockGuidelines() {
 			{
 				id: 'edit',
 				label: __( 'Edit' ),
-				callback: ( items ) => {
+				callback: ( items: DataRow[] ) => {
 					const item = items[ 0 ];
 					setSelectedItem( item.id );
 					setIsOpen( true );
@@ -122,7 +122,7 @@ export default function BlockGuidelines() {
 			{
 				id: 'remove',
 				label: __( 'Remove' ),
-				callback: ( items ) => {
+				callback: ( items: DataRow[] ) => {
 					const item = items[ 0 ];
 					setItemToDelete( item );
 				},

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -1,0 +1,179 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Icon,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Notice } from '@wordpress/ui';
+import {
+	DataViews,
+	filterSortAndPaginate,
+	type View,
+} from '@wordpress/dataviews';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { blockDefault } from '@wordpress/icons';
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import BlockGuidelineModal from './block-guideline-modal';
+import { saveContentGuidelines } from '../api';
+import { STORE_NAME } from '../store';
+import './block-guidelines.scss';
+
+const initialView: View = {
+	type: 'list',
+	search: '',
+	page: 1,
+	perPage: 5,
+	filters: [],
+	mediaField: 'icon',
+	showMedia: true,
+	titleField: 'label',
+	layout: {
+		density: 'compact',
+	},
+};
+
+const fields = [
+	{
+		id: 'icon',
+		label: __( 'Icon' ),
+		type: 'media' as const,
+		render: ( { item } ) => (
+			<Icon icon={ item.icon ?? blockDefault } size={ 16 } />
+		),
+	},
+	{
+		id: 'label',
+		label: __( 'Label' ),
+		type: 'text' as const,
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => item.label,
+		render: ( { item } ) => item.label,
+	},
+];
+
+export default function BlockGuidelines() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ view, setView ] = useState< View >( initialView );
+	const [ selectedItem, setSelectedItem ] = useState< string >();
+	const [ error, setError ] = useState< string | null >( null );
+
+	const blockGuidelines = useSelect(
+		// @ts-ignore
+		( select ) => select( STORE_NAME ).getBlockGuidelines(),
+		[]
+	);
+
+	const blockTypes = useSelect(
+		// @ts-ignore
+		( select ) => select( blocksStore ).getBlockTypes(),
+		[]
+	);
+
+	const rows = useMemo(
+		() =>
+			blockTypes
+				.filter( ( blockType ) => blockGuidelines[ blockType.name ] )
+				.map( ( blockType ) => ( {
+					id: blockType.name,
+					label: blockType.title,
+					guidelines: blockGuidelines[ blockType.name ] ?? '',
+					icon: blockType.icon?.src,
+				} ) ),
+		[ blockGuidelines, blockTypes ]
+	);
+
+	const { setBlockGuideline } = useDispatch( STORE_NAME );
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit' ),
+				callback: ( items ) => {
+					const item = items[ 0 ];
+					setSelectedItem( item.id );
+					setIsOpen( true );
+				},
+			},
+			{
+				id: 'remove',
+				label: __( 'Remove' ),
+				callback: ( items ) => {
+					const item = items[ 0 ];
+					setBlockGuideline( item.id, '' );
+					saveContentGuidelines()
+						.then( () => setError( null ) )
+						.catch( ( e: Error ) => setError( e.message ) );
+				},
+			},
+		],
+		[ setBlockGuideline ]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( rows, view, fields ),
+		[ rows, view ]
+	);
+
+	const closeModal = () => {
+		setIsOpen( false );
+		setSelectedItem( undefined );
+	};
+
+	const openModal = () => {
+		setSelectedItem( undefined );
+		setIsOpen( true );
+	};
+
+	return (
+		<VStack spacing={ 4 } className="block-guidelines">
+			{ error && (
+				<Notice.Root intent="error">
+					<Notice.Title>
+						{ sprintf(
+							/* translators: %s: Error message. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</Notice.Title>
+				</Notice.Root>
+			) }
+			{ rows.length > 0 && (
+				<DataViews
+					paginationInfo={ paginationInfo }
+					data={ processedData }
+					view={ view }
+					onChangeView={ setView }
+					fields={ fields }
+					actions={ actions }
+					config={ { perPageSizes: [ 5, 10, 20, 50 ] } }
+					defaultLayouts={ {
+						list: {},
+					} }
+				></DataViews>
+			) }
+			<Button
+				variant="primary"
+				onClick={ openModal }
+				className="block-guidelines__add-button"
+			>
+				{ __( 'Add block guidelines' ) }
+			</Button>
+
+			{ isOpen && (
+				<BlockGuidelineModal
+					closeModal={ closeModal }
+					initialBlock={ selectedItem }
+				/>
+			) }
+		</VStack>
+	);
+}

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -115,6 +115,11 @@ export default function BlockGuidelines() {
 
 	const { setBlockGuideline } = useDispatch( STORE_NAME );
 
+	const handleRowClick = ( id: string ) => {
+		setSelectedItem( id );
+		setIsOpen( true );
+	};
+
 	const actions = useMemo(
 		() => [
 			{
@@ -122,8 +127,7 @@ export default function BlockGuidelines() {
 				label: __( 'Edit' ),
 				callback: ( items: DataRow[] ) => {
 					const item = items[ 0 ];
-					setSelectedItem( item.id );
-					setIsOpen( true );
+					handleRowClick( item.id );
 				},
 			},
 			{
@@ -218,6 +222,10 @@ export default function BlockGuidelines() {
 					fields={ fields }
 					actions={ actions }
 					config={ { perPageSizes: [ PER_PAGE ] } }
+					onChangeSelection={ ( items ) => {
+						const id = items[ 0 ];
+						handleRowClick( id );
+					} }
 					defaultLayouts={ {
 						list: {},
 					} }

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -64,7 +64,9 @@ const fields = [
 		label: __( 'Icon' ),
 		type: 'media' as const,
 		render: ( { item } ) => (
-			<Icon icon={ item.icon ?? blockDefault } size={ 16 } />
+			<div className="block-guidelines__icon">
+				<Icon icon={ item.icon ?? blockDefault } size={ 16 } />
+			</div>
 		),
 	},
 	{

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -1,3 +1,5 @@
+/* @jsx createElement */
+
 /**
  * WordPress dependencies
  */
@@ -13,7 +15,7 @@ import {
 	type View,
 } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
+import { createElement, useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -133,6 +135,8 @@ export default function BlockGuidelines() {
 		setIsOpen( true );
 	};
 
+	const shouldShowDataViewControls = rows.length > 5;
+
 	return (
 		<VStack spacing={ 4 } className="block-guidelines">
 			{ error && (
@@ -158,7 +162,15 @@ export default function BlockGuidelines() {
 					defaultLayouts={ {
 						list: {},
 					} }
-				></DataViews>
+				>
+					<VStack spacing={ 4 }>
+						{ shouldShowDataViewControls && (
+							<DataViews.Search label={ __( 'Search blocks' ) } />
+						) }
+						<DataViews.Layout />
+						{ shouldShowDataViewControls && <DataViews.Footer /> }
+					</VStack>
+				</DataViews>
 			) }
 			<Button
 				variant="primary"

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -18,7 +18,12 @@ import {
 	type View,
 } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { createElement, useMemo, useState } from '@wordpress/element';
+import {
+	createElement,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -32,11 +37,13 @@ import { saveContentGuidelines } from '../api';
 import { STORE_NAME } from '../store';
 import './block-guidelines.scss';
 
+const PER_PAGE = 5;
+
 const initialView: View = {
 	type: 'list',
 	search: '',
 	page: 1,
-	perPage: 5,
+	perPage: PER_PAGE,
 	filters: [],
 	mediaField: 'icon',
 	showMedia: true,
@@ -160,6 +167,21 @@ export default function BlockGuidelines() {
 		[ rows, view ]
 	);
 
+	useEffect( () => {
+		const lastPage = Math.max( paginationInfo.totalPages, 1 );
+
+		if ( view.page && view.page > lastPage ) {
+			setView( ( currentView ) =>
+				currentView.page && currentView.page > lastPage
+					? {
+							...currentView,
+							page: lastPage,
+					  }
+					: currentView
+			);
+		}
+	}, [ paginationInfo.totalPages, view.page ] );
+
 	const closeModal = () => {
 		setIsOpen( false );
 		setSelectedItem( undefined );
@@ -170,7 +192,7 @@ export default function BlockGuidelines() {
 		setIsOpen( true );
 	};
 
-	const shouldShowDataViewControls = rows.length > 5;
+	const shouldShowDataViewControls = rows.length > PER_PAGE;
 
 	return (
 		<VStack spacing={ 4 } className="block-guidelines">
@@ -193,7 +215,7 @@ export default function BlockGuidelines() {
 					onChangeView={ setView }
 					fields={ fields }
 					actions={ actions }
-					config={ { perPageSizes: [ 5, 10, 20, 50 ] } }
+					config={ { perPageSizes: [ PER_PAGE ] } }
 					defaultLayouts={ {
 						list: {},
 					} }

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -6,7 +6,10 @@
 import {
 	Button,
 	Icon,
+	Modal,
 	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { Notice } from '@wordpress/ui';
 import {
@@ -19,6 +22,7 @@ import { createElement, useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 import { store as blocksStore } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -41,6 +45,11 @@ const initialView: View = {
 		density: 'compact',
 	},
 };
+
+interface DataRow {
+	id: string;
+	label: string;
+}
 
 const fields = [
 	{
@@ -66,6 +75,11 @@ export default function BlockGuidelines() {
 	const [ view, setView ] = useState< View >( initialView );
 	const [ selectedItem, setSelectedItem ] = useState< string >();
 	const [ error, setError ] = useState< string | null >( null );
+	const [ busy, setBusy ] = useState( false );
+	const [ itemToDelete, setItemToDelete ] = useState< DataRow | null >(
+		null
+	);
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const blockGuidelines = useSelect(
 		// @ts-ignore
@@ -110,15 +124,30 @@ export default function BlockGuidelines() {
 				label: __( 'Remove' ),
 				callback: ( items ) => {
 					const item = items[ 0 ];
-					setBlockGuideline( item.id, '' );
-					saveContentGuidelines()
-						.then( () => setError( null ) )
-						.catch( ( e: Error ) => setError( e.message ) );
+					setItemToDelete( item );
 				},
 			},
 		],
-		[ setBlockGuideline ]
+		[ setItemToDelete ]
 	);
+
+	const handleDelete = () => {
+		if ( ! itemToDelete ) {
+			return;
+		}
+		setBlockGuideline( itemToDelete.id, '' );
+		setBusy( true );
+		saveContentGuidelines()
+			.then( () => {
+				setError( null );
+				setItemToDelete( null );
+				createSuccessNotice( __( 'Block guidelines removed.' ), {
+					type: 'snackbar',
+				} );
+			} )
+			.catch( ( e: Error ) => setError( e.message ) )
+			.finally( () => setBusy( false ) );
+	};
 
 	const { data: processedData, paginationInfo } = useMemo(
 		() => filterSortAndPaginate( rows, view, fields ),
@@ -185,6 +214,54 @@ export default function BlockGuidelines() {
 					closeModal={ closeModal }
 					initialBlock={ selectedItem }
 				/>
+			) }
+			{ itemToDelete && (
+				<Modal
+					className="block-guidelines__remove-modal"
+					title={ __( 'Remove block guidelines' ) }
+					onRequestClose={ () => setItemToDelete( null ) }
+					size="small"
+				>
+					<VStack spacing={ 6 }>
+						<VStack spacing={ 4 }>
+							<Text size={ 13 } weight={ 400 }>
+								{ sprintf(
+									/* translators: %s: Block name. */
+									__(
+										'You are about to remove the block guidelines for the %s block.'
+									),
+									itemToDelete.label
+								) }
+							</Text>
+							<Text size={ 13 } weight={ 400 }>
+								{ __(
+									'This can be undone from revision history.'
+								) }
+							</Text>
+						</VStack>
+						<HStack justify="flex-end">
+							<Button
+								variant="tertiary"
+								onClick={ () => setItemToDelete( null ) }
+								disabled={ busy }
+								accessibleWhenDisabled
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								disabled={ busy }
+								accessibleWhenDisabled
+								isBusy={ busy }
+								variant="primary"
+								onClick={ handleDelete }
+								isDestructive
+								__next40pxDefaultSize
+							>
+								{ __( 'Remove' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</Modal>
 			) }
 		</VStack>
 	);

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -207,13 +207,11 @@ export default function BlockGuidelines() {
 					</VStack>
 				</DataViews>
 			) }
-			<Button
-				variant="primary"
-				onClick={ openModal }
-				className="block-guidelines__add-button"
-			>
-				{ __( 'Add block guidelines' ) }
-			</Button>
+			<HStack>
+				<Button variant="primary" onClick={ openModal }>
+					{ __( 'Add block guidelines' ) }
+				</Button>
+			</HStack>
 
 			{ isOpen && (
 				<BlockGuidelineModal

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -1,3 +1,5 @@
+/* @jsx createElement */
+
 /**
  * WordPress dependencies
  */
@@ -6,8 +8,14 @@ import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
 import { Notice } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	createElement,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -24,6 +32,7 @@ export default function GuidelineAccordionForm( {
 }: GuidelineAccordionFormProps ) {
 	// @ts-ignore
 	const { setGuideline } = useDispatch( STORE_NAME );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ loading, setLoading ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
@@ -69,7 +78,12 @@ export default function GuidelineAccordionForm( {
 		setGuideline( slug, draft );
 		setLoading( true );
 		saveContentGuidelines()
-			.then( () => setError( null ) )
+			.then( () => {
+				setError( null );
+				createSuccessNotice( __( 'Guideline category saved.' ), {
+					type: 'snackbar',
+				} );
+			} )
 			.catch( ( e: Error ) => setError( e.message ) )
 			.finally( () => setLoading( false ) );
 	};
@@ -107,6 +121,8 @@ export default function GuidelineAccordionForm( {
 					type="submit"
 					className="save-button"
 					disabled={ loading }
+					accessibleWhenDisabled
+					isBusy={ loading }
 				>
 					{ __( 'Save guidelines' ) }
 				</Button>

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -19,6 +19,8 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/notices": "file:../../packages/notices",
-		"@wordpress/ui": "file:../../packages/ui"
+		"@wordpress/ui": "file:../../packages/ui",
+		"@wordpress/block-library": "file:../../packages/block-library",
+		"@wordpress/blocks": "file:../../packages/blocks"
 	}
 }

--- a/routes/content-guidelines/route.ts
+++ b/routes/content-guidelines/route.ts
@@ -3,6 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { bootstrapBlockRegistry } from './bootstrap-block-registry';
+
 export const route = {
+	beforeLoad: bootstrapBlockRegistry,
 	title: () => __( 'Content Guidelines' ),
 };

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -14,6 +14,8 @@ import './style.scss';
 import GuidelineAccordion from './components/guideline-accordion';
 import GuidelineAccordionForm from './components/guideline-accordion-form';
 import { fetchContentGuidelines } from './api';
+import BlockGuidelines from './components/block-guidelines';
+import { bootstrapBlockRegistry } from './bootstrap-block-registry';
 
 const GUIDELINE_ITEMS = [
 	{
@@ -41,6 +43,13 @@ const GUIDELINE_ITEMS = [
 		slug: 'images',
 	},
 	{
+		title: __( 'Blocks' ),
+		description: __(
+			'Create tailored guidelines for specific block types.'
+		),
+		slug: 'blocks',
+	},
+	{
 		title: __( 'Additional' ),
 		description: __( 'Add additional guidelines for your team.' ),
 
@@ -53,6 +62,8 @@ function ContentGuidelinesPage() {
 	const [ error, setError ] = useState< string | null >( null );
 
 	useEffect( () => {
+		// Bootstrap Core blocks so block icons are available (e.g. in Block Guidelines).
+		bootstrapBlockRegistry();
 		// Populate the store with the content guidelines.
 		fetchContentGuidelines()
 			.then( () => setError( null ) )
@@ -116,14 +127,18 @@ function ContentGuidelinesPage() {
 												headingId={ headingId }
 												descriptionId={ descriptionId }
 											>
-												<GuidelineAccordionForm
-													slug={ item.slug }
-													contentId={ contentId }
-													headingId={ headingId }
-													descriptionId={
-														descriptionId
-													}
-												/>
+												{ item.slug === 'blocks' ? (
+													<BlockGuidelines />
+												) : (
+													<GuidelineAccordionForm
+														slug={ item.slug }
+														contentId={ contentId }
+														headingId={ headingId }
+														descriptionId={
+															descriptionId
+														}
+													/>
+												) }
 											</GuidelineAccordion>
 										</div>
 									</li>

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -17,10 +17,6 @@ import GuidelineAccordion from './components/guideline-accordion';
 import GuidelineAccordionForm from './components/guideline-accordion-form';
 import { fetchContentGuidelines } from './api';
 import BlockGuidelines from './components/block-guidelines';
-import { bootstrapBlockRegistry } from './bootstrap-block-registry';
-
-// Bootstrap Core blocks so block icons are available (e.g. in Block Guidelines).
-bootstrapBlockRegistry();
 
 const GUIDELINE_ITEMS = [
 	{

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -1,9 +1,11 @@
+/* @jsx createElement */
+
 /**
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { createElement, useEffect, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { Notice } from '@wordpress/ui';
 
@@ -16,6 +18,9 @@ import GuidelineAccordionForm from './components/guideline-accordion-form';
 import { fetchContentGuidelines } from './api';
 import BlockGuidelines from './components/block-guidelines';
 import { bootstrapBlockRegistry } from './bootstrap-block-registry';
+
+// Bootstrap Core blocks so block icons are available (e.g. in Block Guidelines).
+bootstrapBlockRegistry();
 
 const GUIDELINE_ITEMS = [
 	{
@@ -62,8 +67,6 @@ function ContentGuidelinesPage() {
 	const [ error, setError ] = useState< string | null >( null );
 
 	useEffect( () => {
-		// Bootstrap Core blocks so block icons are available (e.g. in Block Guidelines).
-		bootstrapBlockRegistry();
 		// Populate the store with the content guidelines.
 		fetchContentGuidelines()
 			.then( () => setError( null ) )

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -81,9 +81,8 @@ function parseResponse(
 			result.categories[ category ] = guidelines;
 		} else if ( category === 'blocks' ) {
 			const blocks = categoriesFromResponse?.blocks ?? {};
-			for ( const blockName in blocks ) {
-				result.categories.blocks[ blockName ] =
-					blocks[ blockName ]?.guidelines;
+			for ( const [ blockName, blockData ] of Object.entries( blocks ) ) {
+				result.categories.blocks[ blockName ] = blockData?.guidelines;
 			}
 		}
 	} );

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -110,14 +110,20 @@ function reducer(
 				},
 			};
 		case 'SET_BLOCK_GUIDELINE': {
+			const blocks = {
+				...state.categories.blocks,
+				[ action.blockName ]: action.value,
+			};
+
+			if ( ! action.value ) {
+				delete blocks[ action.blockName ];
+			}
+
 			return {
 				...state,
 				categories: {
 					...state.categories,
-					blocks: {
-						...state.categories.blocks,
-						[ action.blockName ]: action.value,
-					},
+					blocks,
 				},
 			};
 		}

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -6,17 +6,28 @@ import { createReduxStore, register } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import type { ContentGuidelinesState, RestGuidelinesResponse } from './types';
+import type {
+	Categories,
+	ContentGuidelinesState,
+	RestGuidelinesResponse,
+} from './types';
 
+export type { Categories };
 export const STORE_NAME = 'core/content-guidelines';
 
 const DEFAULT_STATE: ContentGuidelinesState = {
 	id: null,
 	status: null,
-	categories: {},
+	categories: {
+		site: '',
+		copy: '',
+		images: '',
+		additional: '',
+		blocks: {},
+	},
 };
 
-const CATEGORIES = [ 'site', 'copy', 'images', 'additional' ];
+const CATEGORIES = [ 'site', 'copy', 'images', 'additional', 'blocks' ];
 
 const actions = {
 	setFromResponse( response: RestGuidelinesResponse ) {
@@ -29,6 +40,13 @@ const actions = {
 		return {
 			type: 'SET_GUIDELINE' as const,
 			category,
+			value,
+		};
+	},
+	setBlockGuideline( blockName: string, value: string ) {
+		return {
+			type: 'SET_BLOCK_GUIDELINE' as const,
+			blockName,
 			value,
 		};
 	},
@@ -48,13 +66,25 @@ function parseResponse(
 	const result = {
 		id: response.id ?? null,
 		status: response.status ?? null,
-		categories: {},
+		categories: {
+			site: '',
+			copy: '',
+			images: '',
+			additional: '',
+			blocks: {},
+		},
 	};
 
 	CATEGORIES.forEach( ( category ) => {
 		const guidelines = categoriesFromResponse?.[ category ]?.guidelines;
 		if ( typeof guidelines === 'string' ) {
 			result.categories[ category ] = guidelines;
+		} else if ( category === 'blocks' ) {
+			const blocks = categoriesFromResponse?.blocks ?? {};
+			for ( const blockName in blocks ) {
+				result.categories.blocks[ blockName ] =
+					blocks[ blockName ]?.guidelines;
+			}
 		}
 	} );
 
@@ -79,19 +109,43 @@ function reducer(
 					[ action.category ]: action.value,
 				},
 			};
+		case 'SET_BLOCK_GUIDELINE': {
+			return {
+				...state,
+				categories: {
+					...state.categories,
+					blocks: {
+						...state.categories.blocks,
+						[ action.blockName ]: action.value,
+					},
+				},
+			};
+		}
 		default:
 			return state;
 	}
 }
 
 const selectors = {
-	getGuideline( state: ContentGuidelinesState, category: string ): string {
-		return state.categories[ category ] ?? '';
+	getGuideline(
+		state: ContentGuidelinesState,
+		category: string
+	): string | Record< string, string > {
+		return state.categories[ category ];
 	},
-	getAllGuidelines(
-		state: ContentGuidelinesState
-	): Partial< Record< string, string > > {
+	getAllGuidelines( state: ContentGuidelinesState ): Categories {
 		return state.categories;
+	},
+	getBlockGuidelines(
+		state: ContentGuidelinesState
+	): Record< string, string > {
+		return state.categories.blocks;
+	},
+	getBlockGuideline(
+		state: ContentGuidelinesState,
+		blockName: string
+	): string {
+		return state.categories.blocks[ blockName ] ?? '';
 	},
 	getId( state: ContentGuidelinesState ): number | null {
 		return state.id;

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -115,10 +115,6 @@ function reducer(
 				[ action.blockName ]: action.value,
 			};
 
-			if ( ! action.value ) {
-				delete blocks[ action.blockName ];
-			}
-
 			return {
 				...state,
 				categories: {

--- a/routes/content-guidelines/store.ts
+++ b/routes/content-guidelines/store.ts
@@ -115,6 +115,10 @@ function reducer(
 				[ action.blockName ]: action.value,
 			};
 
+			if ( action.value === undefined ) {
+				delete blocks[ action.blockName ];
+			}
+
 			return {
 				...state,
 				categories: {

--- a/routes/content-guidelines/types.ts
+++ b/routes/content-guidelines/types.ts
@@ -4,10 +4,18 @@
 
 import type { ReactNode } from 'react';
 
+export interface Categories {
+	site: string;
+	copy: string;
+	images: string;
+	additional: string;
+	blocks: Record< string, string >;
+}
+
 export interface ContentGuidelinesState {
 	id: number | null;
 	status: string | null;
-	categories: Record< string, string >;
+	categories: Categories;
 }
 
 export interface RestGuidelinesResponse {

--- a/routes/content-guidelines/types.ts
+++ b/routes/content-guidelines/types.ts
@@ -18,10 +18,14 @@ export interface ContentGuidelinesState {
 	categories: Categories;
 }
 
+interface BlockGuideline {
+	guidelines: string | Record< string, string >;
+}
+
 export interface RestGuidelinesResponse {
 	id: number;
 	status: string;
-	guideline_categories?: Record< string, { guidelines?: string } >;
+	guideline_categories?: Record< string, BlockGuideline >;
 }
 
 export interface GuidelineAccordionProps {


### PR DESCRIPTION
## What?
Related issue: https://github.com/WordPress/gutenberg/issues/75260

Adds a new **Blocks** section to the Content Guidelines page, allowing administrators to define and manage tailored guidelines for specific block types.


## Why?
The Content Guidelines feature currently supports site-wide categories (Site, Copy, Images, Additional), but has no way to express guidelines scoped to a particular block type. This is useful for teams who want to constrain or document how specific blocks should be used — for example, requiring alt text on image blocks or restricting heading hierarchy.

## How?
- Added a new `blocks` category to the guidelines data model and REST payload. Each entry maps a block name (e.g. `core/image`) to a guidelines string.
- Added `fetchBlockTypes()` in `api.ts` to load all registered top-level block types via `/wp/v2/block-types` and store them as searchable options.
- Added a `BlockGuidelines` component that renders a `DataViews` list of all configured block guidelines, with each row showing the block's icon, name, and guideline text. Row-level **Edit** and **Delete** actions are available.
- Added a `BlockGuidelineModal` component for adding or editing a block guideline. It uses a `ComboboxControl` to search and select a block, and a `TextareaControl` for the guideline content. The modal title and submit label adapt between add and edit modes.
- Added `blockIconMap` in `utils.tsx` — a mapping of core block names to their `@wordpress/icons` equivalents, used for visual display in the list.
- Extended the Redux store with new `blocks` state, `SET_BLOCK_GUIDELINE` / `SET_BLOCK_TYPES` actions, and `getBlockGuideline` / `getBlockGuidelines` / `getBlockTypes` selectors.

## Testing Instructions
1. Navigate to the Content Guidelines admin page.
2. Open the **Blocks** accordion section.
3. Click **Add guideline** — the modal should open.
4. Search for a block (e.g. "Image") using the combobox and enter some guideline text.
5. Click **Add guideline** — the modal should close and the new entry should appear in the list.
6. Click the **Edit** action on an existing row — the modal should reopen pre-filled with the block and its guideline text. Update the text and save; verify the list reflects the change.
7. Click the **Delete** action on a row and confirm the entry is removed.
8. Reload the page and verify all saved guidelines persist.
### Testing Instructions for Keyboard
1. Tab to the **Blocks** accordion header and press `Enter` to expand it.
2. Tab to the **Add guideline** button and press `Enter` to open the modal.
3. Tab to the block combobox, type to search, and use arrow keys to select a block.
4. Tab to the guideline textarea and type content.
5. Tab to the **Add guideline** submit button and press `Enter` to save.
6. Verify focus returns appropriately after the modal closes.

## Screenshots
<img width="711" height="552" alt="Screenshot 2026-03-05 at 2 37 39 PM" src="https://github.com/user-attachments/assets/b7d3e5e3-4e9e-47eb-bf0b-8103728750a7" />
<img width="711" height="552" alt="Screenshot 2026-03-05 at 2 37 50 PM" src="https://github.com/user-attachments/assets/46926a89-e980-4fbc-8060-e9989822e300" />
<img width="711" height="165" alt="Screenshot 2026-03-05 at 2 38 26 PM" src="https://github.com/user-attachments/assets/41d34f71-714d-47c4-869b-5cae217d53b8" />
<img width="692" height="435" alt="Screenshot 2026-03-05 at 2 38 39 PM" src="https://github.com/user-attachments/assets/563adc01-9624-4f1d-b987-40e8bfc147c6" />
<img width="692" height="562" alt="Screenshot 2026-03-05 at 2 39 00 PM" src="https://github.com/user-attachments/assets/ab07b6f5-8066-4f39-a950-db78a196ae6a" />
<img width="692" height="500" alt="Screenshot 2026-03-05 at 2 39 48 PM" src="https://github.com/user-attachments/assets/35e76980-033c-4152-80eb-3610aff1c1d0" />


