### PR TITLE
Navigation Editor: Allow any blocks to be inserted by gating contentOnly insertion rules to section blocks

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1742,20 +1742,22 @@ const canInsertBlockTypeUnmemoized = (
 
 	// In content only mode, check if this container allows insertion.
 	if (
-		( isParentSectionBlock || blockEditingMode === 'contentOnly' ) &&
+		isWithinSection &&
+		blockEditingMode === 'contentOnly' &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			blockName,
 			rootClientId
 		)
 	) {
+		const defaultBlockName = getDefaultBlockName();
 		// Allow inserting the default block anywhere that another default block already exists
 		// when in contentOnly mode.
-		if ( blockName === getDefaultBlockName() ) {
+		if ( blockName === defaultBlockName ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
 			const hasDefaultBlock = existingBlocks.some(
 				( clientId ) =>
-					getBlockName( state, clientId ) === getDefaultBlockName()
+					getBlockName( state, clientId ) === defaultBlockName
 			);
 			if ( ! hasDefaultBlock ) {
 				return false;
@@ -1938,11 +1940,13 @@ export function canRemoveBlock( state, clientId ) {
 
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	const blockName = getBlockName( state, clientId );
+	const defaultBlockName = getDefaultBlockName();
+
 	// Check if the parent container allows insertion/removal in contentOnly mode.
 	if (
-		( isParentSectionBlock ||
-			rootBlockEditingMode === 'contentOnly' ||
-			blockName === getDefaultBlockName() ) &&
+		isWithinSection &&
+		( blockName === defaultBlockName ||
+			rootBlockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
@@ -1951,10 +1955,10 @@ export function canRemoveBlock( state, clientId ) {
 	) {
 		// Allow removing the default block when other default blocks exist
 		// in contentOnly mode.
-		if ( blockName === getDefaultBlockName() ) {
+		if ( blockName === defaultBlockName ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
 			const defaultBlocks = existingBlocks.filter(
-				( id ) => getBlockName( state, id ) === getDefaultBlockName()
+				( id ) => getBlockName( state, id ) === defaultBlockName
 			);
 			// Allow removal if there are other default blocks besides this one
 			if ( defaultBlocks.length > 1 ) {
@@ -2018,10 +2022,10 @@ export function canMoveBlock( state, clientId ) {
 
 	// If the parent is a section or is `contentOnly`, then check is the inner block
 	// should be allowed to move.
-	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	if (
-		( isParentSectionBlock || rootBlockEditingMode === 'contentOnly' ) &&
+		isBlockWithinSection &&
+		rootBlockEditingMode === 'contentOnly' &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1741,9 +1741,13 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	// In content only mode, check if this container allows insertion.
+	// We need the `isParentSectionBlock` check because section blocks
+	// (synced patterns, contentOnly groups) have a `getBlockEditingMode`
+	// of 'default', not 'contentOnly' — the 'contentOnly' mode is only
+	// set on their *children*.
 	if (
 		isWithinSection &&
-		blockEditingMode === 'contentOnly' &&
+		( isParentSectionBlock || blockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			blockName,
@@ -1942,10 +1946,15 @@ export function canRemoveBlock( state, clientId ) {
 	const blockName = getBlockName( state, clientId );
 	const defaultBlockName = getDefaultBlockName();
 
-	// Check if the parent container allows insertion/removal in contentOnly mode.
+	// Check if the parent container allows insertion/removal in contentOnly
+	// mode. We need the `isParentSectionBlock` check because section blocks
+	// (synced patterns, contentOnly groups) have a `getBlockEditingMode` of
+	// 'default', not 'contentOnly' — the 'contentOnly' mode is only set on
+	// their *children*.
 	if (
 		isWithinSection &&
-		( blockName === defaultBlockName ||
+		( isParentSectionBlock ||
+			blockName === defaultBlockName ||
 			rootBlockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
@@ -2020,12 +2029,17 @@ export function canMoveBlock( state, clientId ) {
 		return false;
 	}
 
-	// If the parent is a section or is `contentOnly`, then check is the inner block
-	// should be allowed to move.
+	// If the block is within a section and the parent is either a section
+	// block itself or has contentOnly editing mode, check whether the inner
+	// block should be allowed to move. We need the `isParentSectionBlock`
+	// check because section blocks (synced patterns, contentOnly groups)
+	// have a `getBlockEditingMode` of 'default', not 'contentOnly' — the
+	// 'contentOnly' mode is only set on their *children*.
+	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
 	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	if (
 		isBlockWithinSection &&
-		rootBlockEditingMode === 'contentOnly' &&
+		( isParentSectionBlock || rootBlockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -5,6 +5,7 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 	setFreeformContentHandlerName,
+	setDefaultBlockName,
 } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 import { symbol } from '@wordpress/icons';
@@ -16,6 +17,7 @@ import { select, dispatch } from '@wordpress/data';
 import * as selectors from '../selectors';
 import { store } from '../';
 import { lock } from '../../lock-unlock';
+import { sectionRootClientIdKey } from '../private-keys';
 
 const {
 	getBlockName,
@@ -72,6 +74,8 @@ const {
 	wasBlockJustInserted,
 	getBlocksByName,
 	getBlockEditingMode,
+	canRemoveBlock,
+	canMoveBlock,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -187,6 +191,20 @@ describe( 'selectors', () => {
 			ancestor: [ 'core/test-block-ancestor' ],
 		} );
 
+		registerBlockType( 'core/test-content-block', {
+			apiVersion: 3,
+			save: ( props ) => props.attributes.text,
+			category: 'text',
+			title: 'Test Content Block',
+			icon: 'test',
+			attributes: {
+				text: {
+					type: 'string',
+					role: 'content',
+				},
+			},
+		} );
+
 		setFreeformContentHandlerName( 'core/freeform' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
@@ -203,6 +221,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-parent' );
 		unregisterBlockType( 'core/test-block-requires-ancestor' );
 		unregisterBlockType( 'core/test-block-requires-ancestor-parent' );
+		unregisterBlockType( 'core/test-content-block' );
 
 		setFreeformContentHandlerName( undefined );
 	} );
@@ -3090,6 +3109,163 @@ describe( 'selectors', () => {
 			).toBe( false );
 		} );
 
+		it( 'allows inserting blocks into a non-section contentOnly container', () => {
+			// When the parent has contentOnly editing mode but is NOT
+			// within a section hierarchy, the contentOnly insertion
+			// restriction does not apply.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							parent: { name: 'core/test-block-a' },
+							child: { name: 'core/test-block-b' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							parent: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							parent: '',
+							child: 'parent',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'parent' ] ],
+						[ 'parent', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					parent: {},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'parent', 'contentOnly' ],
+				] ),
+			};
+			expect(
+				canInsertBlockType( state, 'core/test-block-b', 'parent' )
+			).toBe( true );
+		} );
+
+		it( 'prevents inserting content blocks into a non-insertable contentOnly container within a section', () => {
+			// When a contentOnly container is inside a section and is not
+			// the section root or a content-to-content match, the
+			// contentOnly insertion restriction blocks it.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-block-a',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			// A content block into a non-content container that is not the
+			// section root is blocked by the contentOnly gating.
+			expect(
+				canInsertBlockType(
+					state,
+					'core/test-content-block',
+					'container'
+				)
+			).toBe( false );
+		} );
+
+		it( 'allows inserting content blocks into a content container within a section', () => {
+			// When the container is a content block and the block being
+			// inserted is also a content block, insertion is allowed
+			// even within a section (content-to-content match).
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-content-block',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			expect(
+				canInsertBlockType(
+					state,
+					'core/test-content-block',
+					'container'
+				)
+			).toBe( true );
+		} );
+
 		it( 'should allow blocks to be inserted if both parent and ancestor restrictions are met', () => {
 			const state = {
 				blocks: {
@@ -3499,6 +3675,7 @@ describe( 'selectors', () => {
 				'core/freeform',
 				'core/test-block-ancestor',
 				'core/test-block-parent',
+				'core/test-content-block',
 				'core/block/1',
 				'core/block/2',
 			] );
@@ -3518,6 +3695,7 @@ describe( 'selectors', () => {
 				'core/freeform',
 				'core/test-block-ancestor',
 				'core/test-block-parent',
+				'core/test-content-block',
 				'core/block/1',
 				'core/block/2',
 			] );
@@ -4265,6 +4443,366 @@ describe( 'selectors', () => {
 			expect(
 				wasBlockJustInserted( state, clientId, expectedSource )
 			).toBe( false );
+		} );
+	} );
+
+	describe( 'canRemoveBlock', () => {
+		it( 'allows removal from a non-section contentOnly container', () => {
+			// When the parent has contentOnly editing mode but is NOT
+			// within a section, the contentOnly removal restriction
+			// does not apply.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							parent: { name: 'core/test-block-a' },
+							child: { name: 'core/test-block-b' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							parent: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							parent: '',
+							child: 'parent',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'parent' ] ],
+						[ 'parent', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					parent: {},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'parent', 'contentOnly' ],
+				] ),
+			};
+			expect( canRemoveBlock( state, 'child' ) ).toBe( true );
+		} );
+
+		it( 'prevents removal from a contentOnly container within a section', () => {
+			// When the parent is within a section and has contentOnly
+			// editing mode, blocks in a non-insertable container
+			// cannot be removed.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-block-a',
+							},
+							child: { name: 'core/test-content-block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+							child: 'container',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			expect( canRemoveBlock( state, 'child' ) ).toBe( false );
+		} );
+
+		it( 'allows removal of a content block from a content container within a section', () => {
+			// When both the container and the child are content blocks,
+			// the contentOnly gating allows removal
+			// (content-to-content match).
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-content-block',
+							},
+							child: { name: 'core/test-content-block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+							child: 'container',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			expect( canRemoveBlock( state, 'child' ) ).toBe( true );
+		} );
+
+		it( 'allows removing one of multiple default blocks in a contentOnly section container', () => {
+			// When in contentOnly mode within a section, default blocks
+			// can be removed as long as at least one other default block
+			// remains.
+			setDefaultBlockName( 'core/test-content-block' );
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-block-a',
+							},
+							child1: {
+								name: 'core/test-content-block',
+							},
+							child2: {
+								name: 'core/test-content-block',
+							},
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+							child1: {},
+							child2: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+							child1: 'container',
+							child2: 'container',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [ 'child1', 'child2' ] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			expect( canRemoveBlock( state, 'child1' ) ).toBe( true );
+			setDefaultBlockName( undefined );
+		} );
+	} );
+
+	describe( 'canMoveBlock', () => {
+		it( 'allows moving within a non-section contentOnly container', () => {
+			// When the parent has contentOnly editing mode but is NOT
+			// within a section, the contentOnly move restriction does
+			// not apply.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							parent: { name: 'core/test-block-a' },
+							child: { name: 'core/test-block-b' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							parent: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							parent: '',
+							child: 'parent',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'parent' ] ],
+						[ 'parent', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					parent: {},
+				},
+				settings: {},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'parent', 'contentOnly' ],
+				] ),
+			};
+			expect( canMoveBlock( state, 'child' ) ).toBe( true );
+		} );
+
+		it( 'prevents moving within a contentOnly container inside a section', () => {
+			// When the parent is within a section and has contentOnly
+			// editing mode, blocks in a non-insertable container
+			// cannot be moved.
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-block-a',
+							},
+							child: { name: 'core/test-content-block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+							child: 'container',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			expect( canMoveBlock( state, 'child' ) ).toBe( false );
+		} );
+
+		it( 'allows moving a content block within a content container inside a section', () => {
+			// When both the container and the child are content blocks,
+			// the contentOnly gating allows moving
+			// (content-to-content match).
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							container: {
+								name: 'core/test-content-block',
+							},
+							child: { name: 'core/test-content-block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							container: {},
+							child: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							container: 'section',
+							child: 'container',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'container' ] ],
+						[ 'container', [ 'child' ] ],
+					] ),
+				},
+				blockListSettings: {
+					section: {},
+					container: {},
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map( [
+					[ 'container', 'contentOnly' ],
+				] ),
+			};
+			expect( canMoveBlock( state, 'child' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -6,6 +6,7 @@ import {
 	unregisterBlockType,
 	setFreeformContentHandlerName,
 	setDefaultBlockName,
+	getDefaultBlockName,
 } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 import { symbol } from '@wordpress/icons';
@@ -4598,6 +4599,7 @@ describe( 'selectors', () => {
 			// When in contentOnly mode within a section, default blocks
 			// can be removed as long as at least one other default block
 			// remains.
+			const previousDefaultBlockName = getDefaultBlockName();
 			setDefaultBlockName( 'core/test-content-block' );
 			const state = {
 				blocks: {
@@ -4653,7 +4655,7 @@ describe( 'selectors', () => {
 				] ),
 			};
 			expect( canRemoveBlock( state, 'child1' ) ).toBe( true );
-			setDefaultBlockName( undefined );
+			setDefaultBlockName( previousDefaultBlockName );
 		} );
 	} );
 


### PR DESCRIPTION
## What's the problem?
Fixes #73826

There's a bug of sorts in gutenberg where the navigation editor only allows content blocks to be inserted. The research in #73826 indicated that this is `contentOnly` mode insertion rules applying to the navigation editor. It happens because the navigation block in that editor has `blockEditingMode: contentOnly` applied and it also has `role: content`.

## What's the solution in this PR?
This PR fixes the issue by gating the `contentOnly` insertion rules to 'section' blocks only (a section block is typically a pattern, template part or block with `templateLock: contentOnly` applied). Because the navigation editor doesn't have sections, this allows any block to be inserted there

My mental model is that section blocks are the providers of contentOnly mode to all inner blocks.

On the other hand `blockEditingMode: contentOnly` isn't a full contentOnly mode, it's more of a tool used internally by the editor to create a different experience for an individual block.

## How was that implemented?
Updates the `if` statement that gates this behavior to use `isWithinSection`.

I've also backfilled a lot of unit tests that were missing.

## Testing Instructions
1. Open the navigation editor
2. Try inserting a Spacer into the Nav block
3. In this PR it should be possible while in trunk it isn't.

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="545" height="425" alt="Screenshot 2026-03-05 at 4 55 19 pm" src="https://github.com/user-attachments/assets/90e6d003-67f7-4338-816c-c34c249e4f19" />

#### After
<img width="518" height="402" alt="Screenshot 2026-03-05 at 4 54 49 pm" src="https://github.com/user-attachments/assets/e1094c72-c661-48f3-b8b8-7df9e7ee5d5d" />
