### PR TITLE
DataForm `datetime` control: fix date handling

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - DataViews: Fix last column classname in table layout. [#76133](https://github.com/WordPress/gutenberg/pull/76133)
+- DataForm: Properly handle dates in datetime control. [#76193](https://github.com/WordPress/gutenberg/pull/76193)
 
 ### Code Quality
 
@@ -18,7 +19,6 @@
 
 ### Bug Fixes
 
-- DataForm: Properly handle dates in datetime control. [#76193](https://github.com/WordPress/gutenberg/pull/76193)
 - DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)
 - DataForm: Fix text overflow for long unhyphenated text in panel layout. [#76073](https://github.com/WordPress/gutenberg/pull/76073)
 - DataForm: Fix `card` layout's toggle button screen reader text. [#76039](https://github.com/WordPress/gutenberg/pull/76039)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 
+- DataForm: Properly handle dates in datetime control. [#76193](https://github.com/WordPress/gutenberg/pull/76193)
 - DataForm: Fix label color of array control. [#75730](https://github.com/WordPress/gutenberg/pull/75730)
 - DataForm: Fix text overflow for long unhyphenated text in panel layout. [#76073](https://github.com/WordPress/gutenberg/pull/76073)
 - DataForm: Fix `card` layout's toggle button screen reader text. [#76039](https://github.com/WordPress/gutenberg/pull/76039)

--- a/packages/dataviews/src/components/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/components/dataform-controls/datetime.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { format } from 'date-fns';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -12,7 +7,7 @@ import {
 } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { getSettings } from '@wordpress/date';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -27,15 +22,12 @@ import { unlock } from '../../lock-unlock';
 
 const { DateCalendar, ValidatedInputControl } = unlock( componentsPrivateApis );
 
-const formatDateTime = ( date?: Date | string ): string => {
-	if ( ! date ) {
+const formatDateTime = ( value?: string ): string => {
+	if ( ! value ) {
 		return '';
 	}
-	if ( typeof date === 'string' ) {
-		return date;
-	}
-	// Format as datetime-local input expects: YYYY-MM-DDTHH:mm
-	return format( date, "yyyy-MM-dd'T'HH:mm" );
+	// Format in WordPress timezone for datetime-local input: YYYY-MM-DDTHH:mm
+	return dateI18n( 'Y-m-d\\TH:i', getDate( value ) );
 };
 
 function CalendarDateTimeControl< Item >( {
@@ -79,21 +71,19 @@ function CalendarDateTimeControl< Item >( {
 		( newDate: Date | undefined | null ) => {
 			let dateTimeValue: string | undefined;
 			if ( newDate ) {
-				// Preserve time if it exists in current value, otherwise use current time
-				let finalDateTime = newDate;
+				// Extract the date part in WP timezone from the calendar selection
+				const wpDate = dateI18n( 'Y-m-d', newDate );
 
+				// Preserve time if it exists in current value, otherwise use current time
+				let wpTime: string;
 				if ( value ) {
-					const currentDateTime = parseDateTime( value );
-					if ( currentDateTime ) {
-						// Preserve the time part
-						finalDateTime = new Date( newDate );
-						finalDateTime.setHours( currentDateTime.getHours() );
-						finalDateTime.setMinutes(
-							currentDateTime.getMinutes()
-						);
-					}
+					wpTime = dateI18n( 'H:i', getDate( value ) );
+				} else {
+					wpTime = dateI18n( 'H:i', newDate );
 				}
 
+				// Combine date and time in WP timezone and convert to ISO
+				const finalDateTime = getDate( `${ wpDate }T${ wpTime }` );
 				dateTimeValue = finalDateTime.toISOString();
 				onChangeCallback( dateTimeValue );
 
@@ -133,8 +123,8 @@ function CalendarDateTimeControl< Item >( {
 	const handleManualDateTimeChange = useCallback(
 		( newValue?: string ) => {
 			if ( newValue ) {
-				// Convert from datetime-local format to ISO string
-				const dateTime = new Date( newValue );
+				// Interpret the datetime-local value in WordPress timezone
+				const dateTime = getDate( newValue );
 				onChangeCallback( dateTime.toISOString() );
 
 				// Update calendar month to match
@@ -185,13 +175,7 @@ function CalendarDateTimeControl< Item >( {
 					type="datetime-local"
 					label={ __( 'Date time' ) }
 					hideLabelFromVision
-					value={
-						value
-							? formatDateTime(
-									parseDateTime( value ) || undefined
-							  )
-							: ''
-					}
+					value={ formatDateTime( value ) }
 					onChange={ handleManualDateTimeChange }
 				/>
 				{ /* Calendar widget */ }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/75511
Alternative to https://github.com/WordPress/gutenberg/pull/75561

## What?                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                        
Fix the `datetime` DataForm control to display and interpret times in the WordPress configured timezone.

## Why?

Datetimes are displayed differently across field's render and Edit. This is visible when visiting Site Editor > Pages and compare the value of QuickEdit (Edit) vs what's displayed in the panel (modal) or DataViews. Also in the "date" filter. 

This is the issue:

https://github.com/user-attachments/assets/230bb3b5-273b-4f3a-af46-58ef6ab906aa

The same happens in the storybook:

https://github.com/user-attachments/assets/dcd908f9-18a5-497d-84bb-1608b56f098f

## How?

The reason why this happens is that datetimes were handled via `@wordpress/date` utilities in render, but via mix of `@wordpress/date` and `date-fns` utilities in Edit. This created issues with the Edit datetime component because an user timezone (via browser) can be different than the site (WordPress) timezone. For example, if a user timezone is UTC+1 while the site timezone is UTC-1, a value stored as 12:10 UTC shows as "13:10" in the Edit input but as "11:10" in the render.

Replaced `date-fns` with `@wordpress/date` utilities (dateI18n, getDate):

1. `formatDateTime` — Used date-fns `format()` (browser timezone). Now uses `dateI18n('Y-m-d\\TH:i', getDate(value))` to format in WP timezone.
2. `handleManualDateTimeChange` — Used `new Date(newValue)` which interprets in browser timezone. Now uses `getDate(newValue)` which interprets in WP timezone.
3. `onSelectDate` — Used `.getHours()/.getMinutes()` (browser-local) and `new Date()`. Now uses `dateI18n()` to extract date/time parts in WP timezone and `getDate()` to recombine them.

## Testing Instructions

**Site Editor > Pages:**

- Set WordPress timezone to something different from your browser (e.g., Settings → General → Timezone = UTC-5, while your browser is in UTC+1, for example).
- Go to Site Editor > Pages and open QuickEdit. Click the date field to open the datetime popup.
- Verify the datetime-local input shows the same time as the panel.
- Now, go the "date" filter and verify the datetimes displayed in the chip and the input control are the same as well.

This is the expected behaviour:

https://github.com/user-attachments/assets/4eab357b-0602-4708-8113-68b07006b05f


**Storybook:**

- Run the local storybook (`npm run storybook:dev`).
- Visit the Field Types > Datetime story.
- Verify the DataForm and DataViews display the same datetime. Edit the values and it should still display the same.
- Now, verify the filter date as well.

This is the expected behaviour:

https://github.com/user-attachments/assets/c5ae796b-53d9-4963-9c85-2835fcc2cf09
