### PR TITLE
Components: Add styles for outside days in Calendar components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Revert `word-break: break-word` addition ([#76230](https://github.com/WordPress/gutenberg/pull/76230)).
 
+### Enhancements
+
+-   `DateCalendar`, `DateRangeCalendar`: Add `showOutsideDays` and `fixedWeeks` props and style outside-month days ([#76199](https://github.com/WordPress/gutenberg/pull/76199)).
+
 ## 32.3.0 (2026-03-04)
 
 ### Code Quality

--- a/packages/components/src/calendar/stories/date-calendar.story.tsx
+++ b/packages/components/src/calendar/stories/date-calendar.story.tsx
@@ -160,6 +160,17 @@ export const WithSelectedDateAndMonth: Story = {
 };
 
 /**
+ * Shows days from adjacent months in the grid. Outside days use a lighter style
+ * and are still interactive. Use `fixedWeeks` to keep the grid height constant.
+ */
+export const WithOutsideDays: Story = {
+	args: {
+		showOutsideDays: true,
+		fixedWeeks: true,
+	},
+};
+
+/**
  * When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
  */
 export const WithTimeZone: Story = {

--- a/packages/components/src/calendar/stories/date-range-calendar.story.tsx
+++ b/packages/components/src/calendar/stories/date-range-calendar.story.tsx
@@ -163,6 +163,17 @@ export const WithSelectedRangeAndMonth: Story = {
 };
 
 /**
+ * Shows days from adjacent months in the grid. Outside days use a lighter style
+ * and are still interactive. Use `fixedWeeks` to keep the grid height constant.
+ */
+export const WithOutsideDays: Story = {
+	args: {
+		showOutsideDays: true,
+		fixedWeeks: true,
+	},
+};
+
+/**
  * When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
  */
 export const WithTimeZone: Story = {

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -253,6 +253,11 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	}
 }
 
+// Outside month days (visible when showOutsideDays is true): use a lighter text color.
+.components-calendar__day--outside {
+	color: $components-color-gray-600;
+}
+
 // Hidden button (ie. outside current month but still rendered)
 .components-calendar__day--hidden {
 	visibility: hidden;

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -188,6 +188,18 @@ export interface BaseProps
 	 */
 	numberOfMonths?: number;
 	/**
+	 * When `true`, days from adjacent months are shown in the grid and receive
+	 * the `outside` modifier and the class.
+	 * @default false
+	 */
+	showOutsideDays?: boolean;
+	/**
+	 * When `true`, the calendar always shows a fixed number of weeks (e.g. 6)
+	 * so the grid height does not change between months.
+	 * @default false
+	 */
+	fixedWeeks?: boolean;
+	/**
 	 * The earliest month to start the month navigation.
 	 */
 	startMonth?: Date;

--- a/packages/components/src/calendar/utils/constants.ts
+++ b/packages/components/src/calendar/utils/constants.ts
@@ -7,6 +7,7 @@ const CLASSNAMES = {
 	root: 'components-calendar',
 	day: 'components-calendar__day',
 	day_button: 'components-calendar__day-button',
+	outside: 'components-calendar__day--outside',
 	caption_label: 'components-calendar__caption-label',
 	button_next: 'components-calendar__button-next',
 	button_previous: 'components-calendar__button-previous',


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes https://github.com/WordPress/gutenberg/issues/76150

Expose `showOutsideDays` and `fixedWeeks` on `DateCalendar` and `DateRangeCalendar`, add styling for outside-month days (lighter text), and add a Storybook story for the outside days case.

## Why?
Consumers need to optionally show days from adjacent months in the grid and keep a fixed number of weeks so layout doesn't jump between months. These map to react-day-picker's `showOutsideDays` and `fixedWeeks`. They were only in `COMMON_PROPS` and not in the public TypeScript props. Outside days also need a clear but de-emphasized style when shown.

## How?

* Add definitions for `showOutsideDays` and `fixedWeeks` to the `BaseProps`.
* Add a custom class name `'components-calendar__day--outside` for the `outside` modifier in **constants.ts**.
* Add lighter gray text styles for `.components-calendar__day--outside`.
* Add a story with the `fixedWeeks` and `showOutsideDays` props.

## Testing Instructions
1. Run Storybook: `npm run storybook:dev` from repo root.
2. Go to **Components → Selection & Input → Time & Date → DateCalendar**.
3. Open the **WithOutsideDays** story: current month is shown with adjacent-month days in the grid in a lighter gray; grid has a fixed 6 weeks.
4. In the same story (or Default), use the month navigation and confirm outside days still render with the lighter style when changing months.
5. Optionally use the Controls panel to toggle `showOutsideDays` and `fixedWeeks` and confirm behavior.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| N/A | <img width="242" height="306" alt="noNqLOnFFojDDZjn" src="https://github.com/user-attachments/assets/6020171b-6607-45f1-95a0-b26bfd4861d9" /> |
