### PR TITLE
Block Bindings: Remove source items constrained by enums

### DIFF
--- a/packages/block-editor/src/components/block-bindings/attribute-control.js
+++ b/packages/block-editor/src/components/block-bindings/attribute-control.js
@@ -50,10 +50,15 @@ export default function BlockBindingsAttributeControl( {
 				getBlockType,
 			} = unlock( select( blocksStore ) );
 
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
+			const _attribute =
+				getBlockType( blockName ).attributes?.[ attribute ];
+
+			if ( _attribute?.enum ) {
+				return {};
+			}
+
 			const attributeType =
-				_attributeType === 'rich-text' ? 'string' : _attributeType;
+				_attribute?.type === 'rich-text' ? 'string' : _attribute?.type;
 
 			const sourceFields = {};
 			Object.entries( getAllBlockBindingsSources() ).forEach(

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -91,7 +91,7 @@ add_action(
 		add_filter(
 			'block_bindings_supported_attributes_test/auto-register-with-controls',
 			static function () {
-				return array( 'title', 'count', 'spacing', 'showEmojis' );
+				return array( 'title', 'count', 'spacing', 'showEmojis', 'emoji' );
 			}
 		);
 


### PR DESCRIPTION
## What?
Exempt `enum`-constrained block attributes from Block Bindings support.

Alternative to https://github.com/WordPress/gutenberg/pull/76085.

## Why?
Prior to this PR, it was possible to bind an `enum`-constrained block attribute to an unconstrained Block Bindings source, which can lead to the attribute taking on a value that it's not permitted.

In https://github.com/WordPress/gutenberg/pull/76085, I explored permitting `enum`-constrained block attributes as long as a source item was also constrained by an `enum` whose possible values were all contained in the block attribute's, but [ultimately decided against it](https://github.com/WordPress/gutenberg/pull/76085#issuecomment-4004839014).

## How?
By removing all Block Bindings source items from the UI for any block attribute whose values are constrained by an `enum`.

## Testing Instructions
- Use wp-env's test environment (start by running `npm run wp-env-test`).
- At the test instance (found at `localhost:8889`), activate the "Gutenberg Test Block Bindings" and "Gutenberg Test Server-Side Rendered Block" plugins.
- Create a new post. Insert the "Auto Register With Controls" block.
- In the block inspector's Attributes panel, verify that it's **not** possible to connect the `emoji` attribute to any Block Bindings source (should say "No sources available")

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="461" height="183" alt="image" src="https://github.com/user-attachments/assets/6bbfd4ca-50ed-41be-b4c6-5ff86324db4e" /> | <img width="278" height="187" alt="image" src="https://github.com/user-attachments/assets/43683eb7-c5bd-44a6-9afe-e47a31464193" /> |

## Follow-up

- [ ] Handle case where block binding is already present in `metadata`.