### PR TITLE
Extensible Site Editor: Make canvas previews full height

### DIFF
--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -92,6 +92,12 @@ export function Editor( {
 		() => ( {
 			...editorSettings,
 			...settings,
+			styles: [
+				...( editorSettings.styles ?? [] ),
+				...( settings?.isPreviewMode
+					? [ { css: 'body{min-height:100vh;}' } ]
+					: [] ),
+			],
 		} ),
 		[ editorSettings, settings ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/75741

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes the navigation being stuck to the top of the page in the preview canvas instead of centered.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
UX

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The current site editor [adds height: 100vh when the canvas is in "view" mode](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/block-editor/use-site-editor-settings.js#L89-L90). The Extensible Site Editor doesn't include this, which causes the navigation preview to be stuck to the top of the page instead of centered.

I added a 100vh height to the Extensible Site Editor version of the canvas as well. I did not bring the pointer style over, as it doesn't seem needed since there's a full size button covering the canvas preview which has the pointer hand.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Turn on the extensible site editor from Gutenberg -> Experiments
- Go to the site editor
- Select Navigation
- Edit a Navigation
- The navigation preview should be centered

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1504" height="750" alt="Navigation block stuck to top of iframe canvas" src="https://github.com/user-attachments/assets/68efaf0c-bd8d-4d89-87be-50b307dadfb6" />|<img width="1507" height="744" alt="navigation centered in preview canvas" src="https://github.com/user-attachments/assets/cbe93ae3-39eb-45d9-ad8a-a3d244077dcb" />|

