### PR TITLE
Navigation: Disable Mobile Menu in Isolated Editor or Site Editor Preview

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -18,6 +18,7 @@ import {
 	useBlockProps,
 	RecursionProvider,
 	useHasRecursion,
+	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 	withColors,
 	ContrastChecker,
@@ -78,6 +79,8 @@ import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
+
+const { isIsolatedEditorKey } = unlock( blockEditorPrivateApis );
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import {
@@ -319,19 +322,25 @@ function Navigation( {
 
 	// Skip recursion check when in preview mode.
 	const recursionDetected = useHasRecursion( recursionId );
-	const { isPreviewMode, onNavigateToEntityRecord, currentTheme } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			const settings = getSettings();
-			return {
-				isPreviewMode: settings.isPreviewMode,
-				onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
-				// Needed to construct the template part ID for the overlay preview.
-				currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
-			};
-		},
-		[]
-	);
+	const {
+		isPreviewMode,
+		onNavigateToEntityRecord,
+		currentTheme,
+		editorDisabledResponsive,
+	} = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const settings = getSettings();
+		return {
+			isPreviewMode: settings.isPreviewMode,
+			onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
+			// Needed to construct the template part ID for the overlay preview.
+			currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
+			// In preview mode or isolated editor, always show navigation expanded (no hamburger)
+			// so users can see and interact with all menu items.
+			editorDisabledResponsive:
+				settings.isPreviewMode || !! settings?.[ isIsolatedEditorKey ],
+		};
+	}, [] );
 	const hasAlreadyRendered = isPreviewMode ? false : recursionDetected;
 
 	const blockEditingMode = useBlockEditingMode();
@@ -603,7 +612,8 @@ function Navigation( {
 		setAttributes,
 	] );
 
-	const isResponsive = 'never' !== overlayMenu;
+	const isResponsive = 'never' !== overlayMenu && ! editorDisabledResponsive;
+
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: clsx(

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -79,14 +79,14 @@ import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
-
-const { isIsolatedEditorKey } = unlock( blockEditorPrivateApis );
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import {
 	DEFAULT_BLOCK,
 	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
 } from '../constants';
+
+const { isIsolatedEditorKey } = unlock( blockEditorPrivateApis );
 
 /**
  * Component that renders the Add page button for the Navigation block.

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -381,7 +381,7 @@ function VisualEditor( {
 						: ''
 				}${
 					isNavigationPreview
-						? `.block-editor-iframe__body{${ centerContentCSS }}`
+						? `.block-editor-iframe__body{${ centerContentCSS }padding:var(--wp--style--block-gap,2em);}`
 						: ''
 				}`,
 				// The CSS for enableResizing centers the body content vertically when resizing is enabled and applies a background


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Disables the navigation block's responsive mobile menu view when in the isolated editor view or site editor preview mode.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The navigation block in the isolated editor and site editor preview collapses to the mobile hamburger menu when the view is small enough to trigger the breakpoint. Both of these views are intended to display the navigation block structure, not the hamburger menu.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for preview or isolated editor, and disable the responsive setting if so.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to `/wp-admin/site-editor.php?p=%2Fnavigation`
- Select a navigation
- Reduce the preview canvas size 
- It should not collapse to a mobile hamburger icon
- Click the preview pane to enter the isolated editor view
- Reduce the canvas size
- It should not collapse to a mobile hamburger icon

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="824" height="742" alt="mobile menu hamburger in preview mode" src="https://github.com/user-attachments/assets/6e2deb00-54ba-408b-a1ee-31814a0fe15e" />|<img width="823" height="743" alt="full navigation block in preview mode" src="https://github.com/user-attachments/assets/a0813d54-0924-49c7-9a3e-75d05898eba5" />|




https://github.com/user-attachments/assets/99d01eb5-c0ff-4e93-9ccd-eed91c0d66ec

