### PR TITLE
Storybook: Fix crash when resetting global toolbar selections

### DIFF
--- a/storybook/decorators/with-global-css.jsx
+++ b/storybook/decorators/with-global-css.jsx
@@ -40,7 +40,7 @@ const config = {
 
 export const WithGlobalCSS = ( Story, context ) => {
 	const { lazyStyles, externalStyles, classes } =
-		config[ context.globals.css ];
+		config[ context.globals.css ] ?? config.none;
 
 	useEffect( () => {
 		const style = document.createElement( 'style' );

--- a/storybook/decorators/with-rtl.jsx
+++ b/storybook/decorators/with-rtl.jsx
@@ -18,6 +18,10 @@ export const WithRTL = ( Story, context ) => {
 	const [ rerenderKey, setRerenderKey ] = useState( 0 );
 	const ref = useRef();
 
+	const direction = [ 'ltr', 'rtl' ].includes( context.globals.direction )
+		? context.globals.direction
+		: 'ltr';
+
 	useEffect( () => {
 		// Override the return value of i18n.isRTL()
 		addFilter(
@@ -25,7 +29,7 @@ export const WithRTL = ( Story, context ) => {
 			'storybook',
 			( translation, text, _context ) => {
 				if ( text === 'ltr' && _context === 'text direction' ) {
-					return context.globals.direction;
+					return direction;
 				}
 				return translation;
 			}
@@ -33,20 +37,20 @@ export const WithRTL = ( Story, context ) => {
 
 		ref.current.ownerDocument.documentElement.setAttribute(
 			'dir',
-			context.globals.direction
+			direction
 		);
 
 		setRerenderKey( ( prevValue ) => prevValue + 1 );
 
 		return () => removeFilter( 'i18n.gettext_with_context', 'storybook' );
-	}, [ context.globals.direction ] );
+	}, [ direction ] );
 
 	useLayoutEffect( () => {
 		const stylesToUse = [];
 
 		CONFIG.forEach( ( item ) => {
 			if ( item.componentIdMatcher.test( context.componentId ) ) {
-				stylesToUse.push( ...item[ context.globals.direction ] );
+				stylesToUse.push( ...item[ direction ] );
 			}
 		} );
 
@@ -57,7 +61,7 @@ export const WithRTL = ( Story, context ) => {
 		return () => {
 			document.head.removeChild( style );
 		};
-	}, [ context.componentId, context.globals.direction ] );
+	}, [ context.componentId, direction ] );
 
 	return (
 		<div ref={ ref } key={ rerenderKey }>


### PR DESCRIPTION
## What?

Fixes a crash that occurs when clicking "Reset selection" in the text direction or CSS environment toolbar dropdowns in Storybook.

## Why?

When a toolbar global is reset, Storybook sets the value to `_reset`, which doesn't match any key in the decorator configs. In `WithGlobalCSS`, destructuring `config['_reset']` (`undefined`) throws immediately. In `WithRTL`, `item['_reset']` is `undefined`, so spreading it into an array also throws.

This was introduced in #74396 (Storybook v10 + Vite migration).

## How?

- `WithGlobalCSS`: Falls back to `config.none` when the globals value doesn't match a known key.
- `WithRTL`: Normalizes the direction value to `'ltr'` when it's not `'ltr'` or `'rtl'`.

## Testing Instructions

1. Run Storybook (`npm run storybook:dev`).
2. Navigate to any component story (e.g. Button).
3. In the toolbar, open the "Text direction" or "CSS" dropdown and click "Reset selection".
4. The story should render without errors.