### PR TITLE
Document bar: Only show "cmd-k" hint when fullscreen

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -19,7 +19,6 @@ import { chevronLeftSmall, chevronRightSmall, layout } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { useRef, useEffect } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -76,7 +75,6 @@ export default function DocumentBar( props ) {
 		onNavigateToPreviousEntityRecord,
 		isTemplatePreview,
 		stylesCanvasTitle,
-		isFullscreenActive,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
@@ -119,11 +117,6 @@ export default function DocumentBar( props ) {
 			_showStylebook
 		);
 
-		const _isFullscreenActive = select( preferencesStore ).get(
-			'core/edit-post',
-			'fullscreenMode'
-		);
-
 		return {
 			postId: _postId,
 			postType: _postType,
@@ -142,7 +135,6 @@ export default function DocumentBar( props ) {
 				getEditorSettings().onNavigateToPreviousEntityRecord,
 			isTemplatePreview: getRenderingMode() === 'template-locked',
 			stylesCanvasTitle: _stylesCanvasTitle,
-			isFullscreenActive: _isFullscreenActive,
 		};
 	}, [] );
 
@@ -222,9 +214,7 @@ export default function DocumentBar( props ) {
 					size="compact"
 				>
 					<motion.div
-						className={ clsx( 'editor-document-bar__title', {
-							'has-shortcut-padding': isFullscreenActive,
-						} ) }
+						className="editor-document-bar__title"
 						// Force entry animation when the back button is added or removed.
 						key={ hasBackButton }
 						initial={
@@ -277,11 +267,9 @@ export default function DocumentBar( props ) {
 								) }
 						</Text>
 					</motion.div>
-					{ isFullscreenActive && (
-						<span className="editor-document-bar__shortcut">
-							{ displayShortcut.primary( 'k' ) }
-						</span>
-					) }
+					<span className="editor-document-bar__shortcut">
+						{ displayShortcut.primary( 'k' ) }
+					</span>
 				</Button>
 			) }
 		</div>

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -19,6 +19,7 @@ import { chevronLeftSmall, chevronRightSmall, layout } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { useRef, useEffect } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -75,6 +76,7 @@ export default function DocumentBar( props ) {
 		onNavigateToPreviousEntityRecord,
 		isTemplatePreview,
 		stylesCanvasTitle,
+		isFullscreenActive,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
@@ -117,6 +119,11 @@ export default function DocumentBar( props ) {
 			_showStylebook
 		);
 
+		const _isFullscreenActive = select( preferencesStore ).get(
+			'core/edit-post',
+			'fullscreenMode'
+		);
+
 		return {
 			postId: _postId,
 			postType: _postType,
@@ -135,6 +142,7 @@ export default function DocumentBar( props ) {
 				getEditorSettings().onNavigateToPreviousEntityRecord,
 			isTemplatePreview: getRenderingMode() === 'template-locked',
 			stylesCanvasTitle: _stylesCanvasTitle,
+			isFullscreenActive: _isFullscreenActive,
 		};
 	}, [] );
 
@@ -214,7 +222,9 @@ export default function DocumentBar( props ) {
 					size="compact"
 				>
 					<motion.div
-						className="editor-document-bar__title"
+						className={ clsx( 'editor-document-bar__title', {
+							'has-shortcut-padding': isFullscreenActive,
+						} ) }
 						// Force entry animation when the back button is added or removed.
 						key={ hasBackButton }
 						initial={
@@ -267,9 +277,11 @@ export default function DocumentBar( props ) {
 								) }
 						</Text>
 					</motion.div>
-					<span className="editor-document-bar__shortcut">
-						{ displayShortcut.primary( 'k' ) }
-					</span>
+					{ isFullscreenActive && (
+						<span className="editor-document-bar__shortcut">
+							{ displayShortcut.primary( 'k' ) }
+						</span>
+					) }
 				</Button>
 			) }
 		</div>

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -54,9 +54,12 @@
 	margin: 0 auto;
 	max-width: 70%;
 
-	// Offset the layout based on the width of the ⌘K label. This ensures the title is centrally aligned.
-	@include break-medium() {
-		padding-left: $grid-unit-30;
+	// Offset the layout based on the width of the ⌘K label. This ensures the
+	// title is centrally aligned.
+	&.has-shortcut-padding {
+		@include break-medium() {
+			padding-left: $grid-unit-30;
+		}
 	}
 
 	h1 {

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -56,7 +56,7 @@
 
 	// Offset the layout based on the width of the ⌘K label. This ensures the
 	// title is centrally aligned.
-	&.has-shortcut-padding {
+	body.is-fullscreen-mode & {
 		@include break-medium() {
 			padding-left: $grid-unit-30;
 		}
@@ -94,8 +94,10 @@
 	min-width: $grid-unit-30;
 	display: none;
 
-	@include break-medium() {
-		display: initial;
+	body.is-fullscreen-mode & {
+		@include break-medium() {
+			display: initial;
+		}
 	}
 }
 


### PR DESCRIPTION
Context: https://core.trac.wordpress.org/ticket/64672

![document-bar-toggle-cmdk](https://github.com/user-attachments/assets/060cb859-4f3c-452e-be5b-a3451c4d57fa)

## To do

- [x] Handle case of Site Editor
- [ ] Run only on WP 7.0