### PR TITLE
Navigation Overlay: Explicitly set fetchpriority for images

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1124,8 +1124,6 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
  * Images in the overlay are hidden until the menu is opened, so they should
  * not compete with the actual LCP image on the page.
  *
- * fetchpriority="low" is set explicitly so the browser deprioritizes the fetch.
- *
  * @since 7.0.0
  *
  * @param string $overlay_blocks_html The rendered HTML of the overlay blocks.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1129,7 +1129,7 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
  * @param string $overlay_blocks_html The rendered HTML of the overlay blocks.
  * @return string Modified HTML with fetchpriority="low" on all IMG tags.
  */
-function block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html ) {
+function block_core_navigation_set_overlay_image_lazy_loading( string $overlay_blocks_html ): string {
 	$tags = new WP_HTML_Tag_Processor( $overlay_blocks_html );
 	while ( $tags->next_tag( 'IMG' ) ) {
 		$tags->set_attribute( 'fetchpriority', 'low' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1121,7 +1121,7 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
  * Sets fetchpriority="low" on all IMG tags within the navigation overlay.
  *
  * Images in the overlay are hidden until the menu is opened, so they should
- * not compete with the actual LCP image on the page.
+ * not compete with any actual LCP element image on the page.
  *
  * @since 7.0.0
  *

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1127,7 +1127,7 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
  * @since 7.0.0
  *
  * @param string $overlay_blocks_html The rendered HTML of the overlay blocks.
- * @return string Modified HTML with loading="lazy" and fetchpriority="low" on all img elements.
+ * @return string Modified HTML with fetchpriority="low" on all IMG tags.
  */
 function block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html ) {
 	$tags = new WP_HTML_Tag_Processor( $overlay_blocks_html );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -711,9 +711,9 @@ class WP_Navigation_Block_Renderer {
 				$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
 			}
 			// Images in the overlay are hidden until the menu is opened. Pre-set
-			// loading="lazy" so that when wp_filter_content_tags() processes the
+			// fetchpriority="low" so that when wp_filter_content_tags() processes the
 			// parent template part, it sees the attribute already present and calls
-			// wp_get_loading_optimization_attributes with loading="lazy", which both prevents
+			// wp_get_loading_optimization_attributes() with fetchpriority="low", which both prevents
 			// fetchpriority="high" from being added and stops the LCP counter from being incremented.
 			$overlay_blocks_html = block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html );
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -710,6 +710,12 @@ class WP_Navigation_Block_Renderer {
 				$tags                = new WP_HTML_Tag_Processor( $overlay_blocks_html );
 				$overlay_blocks_html = block_core_navigation_add_directives_to_overlay_close( $tags );
 			}
+			// Images in the overlay are hidden until the menu is opened. Pre-set
+			// loading="lazy" so that when wp_filter_content_tags() processes the
+			// parent template part, it sees the attribute already present and calls
+			// wp_get_loading_optimization_attributes with loading="lazy", which both prevents
+			// fetchpriority="high" from being added and stops the LCP counter from being incremented.
+			$overlay_blocks_html = block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html );
 		}
 
 		$has_custom_overlay = ! empty( $overlay_blocks_html );
@@ -1107,6 +1113,27 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
 	) ) {
 		// Add the same close directive as the default close button.
 		$tags->set_attribute( 'data-wp-on--click', 'actions.closeMenuOnClick' );
+	}
+	return $tags->get_updated_html();
+}
+
+/**
+ * Sets loading="lazy" on all img elements within navigation overlay HTML.
+ *
+ * By pre-setting loading="lazy" on overlay images (which are hidden until the
+ * menu is opened), the loading optimization function sees $attr['loading'] = 'lazy'
+ * and sets $maybe_in_viewport = false — preventing both fetchpriority="high" from
+ * being added and the shared LCP counter from being incremented for these images.
+ *
+ * @since 7.0.0
+ *
+ * @param string $overlay_blocks_html The rendered HTML of the overlay blocks.
+ * @return string Modified HTML with loading="lazy" on all img elements.
+ */
+function block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html ) {
+	$tags = new WP_HTML_Tag_Processor( $overlay_blocks_html );
+	while ( $tags->next_tag( 'IMG' ) ) {
+		$tags->set_attribute( 'loading', 'lazy' );
 	}
 	return $tags->get_updated_html();
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1132,7 +1132,6 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
 function block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html ) {
 	$tags = new WP_HTML_Tag_Processor( $overlay_blocks_html );
 	while ( $tags->next_tag( 'IMG' ) ) {
-		$tags->set_attribute( 'loading', 'lazy' );
 		$tags->set_attribute( 'fetchpriority', 'low' );
 	}
 	return $tags->get_updated_html();

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1118,22 +1118,24 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
 }
 
 /**
- * Sets loading="lazy" on all img elements within navigation overlay HTML.
+ * Sets loading="lazy" and fetchpriority="low" on all img elements within
+ * navigation overlay HTML.
  *
- * By pre-setting loading="lazy" on overlay images (which are hidden until the
- * menu is opened), the loading optimization function sees $attr['loading'] = 'lazy'
- * and sets $maybe_in_viewport = false — preventing both fetchpriority="high" from
- * being added and the shared LCP counter from being incremented for these images.
+ * Images in the overlay are hidden until the menu is opened, so they should
+ * not compete with the actual LCP image on the page.
+ *
+ * fetchpriority="low" is set explicitly so the browser deprioritizes the fetch.
  *
  * @since 7.0.0
  *
  * @param string $overlay_blocks_html The rendered HTML of the overlay blocks.
- * @return string Modified HTML with loading="lazy" on all img elements.
+ * @return string Modified HTML with loading="lazy" and fetchpriority="low" on all img elements.
  */
 function block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html ) {
 	$tags = new WP_HTML_Tag_Processor( $overlay_blocks_html );
 	while ( $tags->next_tag( 'IMG' ) ) {
 		$tags->set_attribute( 'loading', 'lazy' );
+		$tags->set_attribute( 'fetchpriority', 'low' );
 	}
 	return $tags->get_updated_html();
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -715,7 +715,7 @@ class WP_Navigation_Block_Renderer {
 			// parent template part, it sees the attribute already present and calls
 			// wp_get_loading_optimization_attributes() with fetchpriority="low", which both prevents
 			// fetchpriority="high" from being added and stops the LCP counter from being incremented.
-			$overlay_blocks_html = block_core_navigation_set_overlay_image_lazy_loading( $overlay_blocks_html );
+			$overlay_blocks_html = block_core_navigation_set_overlay_image_fetch_priority( $overlay_blocks_html );
 		}
 
 		$has_custom_overlay = ! empty( $overlay_blocks_html );
@@ -1128,7 +1128,7 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
  * @param string $overlay_blocks_html The rendered HTML of the overlay blocks.
  * @return string Modified HTML with fetchpriority="low" on all IMG tags.
  */
-function block_core_navigation_set_overlay_image_lazy_loading( string $overlay_blocks_html ): string {
+function block_core_navigation_set_overlay_image_fetch_priority( string $overlay_blocks_html ): string {
 	$tags = new WP_HTML_Tag_Processor( $overlay_blocks_html );
 	while ( $tags->next_tag( 'IMG' ) ) {
 		$tags->set_attribute( 'fetchpriority', 'low' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1118,8 +1118,7 @@ function block_core_navigation_add_directives_to_overlay_close( $tags ) {
 }
 
 /**
- * Sets loading="lazy" and fetchpriority="low" on all img elements within
- * navigation overlay HTML.
+ * Sets fetchpriority="low" on all IMG tags within the navigation overlay.
  *
  * Images in the overlay are hidden until the menu is opened, so they should
  * not compete with the actual LCP image on the page.

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -105,7 +105,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
+	 * @covers ::block_core_navigation_set_overlay_image_fetch_priority
 	 */
 	public function test_block_core_navigation_set_overlay_image_fetch_priority_overrides_high_priority() {
 		$html   = '<div><img src="example.jpg" fetchpriority="high" /></div>';

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -122,7 +122,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$tags   = new WP_HTML_Tag_Processor( $result );
-		$tags->next_tag( 'IMG' );
+		$this->assertTrue( $tags->next_tag( 'IMG' ) );
 		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
 		$tags->next_tag( 'IMG' );
 		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -93,21 +93,21 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
 	 */
-	public function test_block_core_navigation_set_overlay_image_lazy_loading_adds_lazy_and_low_priority() {
+	public function test_block_core_navigation_set_overlay_image_fetch_priority_adds_low_priority() {
 		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';
-		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$this->assertStringNotContainsString( 'loading="lazy"', $result );
 		$this->assertStringContainsString( 'fetchpriority="low"', $result );
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
 	 */
-	public function test_block_core_navigation_set_overlay_image_lazy_loading_overrides_eager_and_high() {
+	public function test_block_core_navigation_set_overlay_image_fetch_priority_overrides_eager_and_high() {
 		$html   = '<div><img src="example.jpg" loading="eager" fetchpriority="high" /></div>';
-		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$this->assertStringNotContainsString( 'loading="lazy"', $result );
 		$this->assertStringNotContainsString( 'loading="eager"', $result );
 		$this->assertStringContainsString( 'fetchpriority="low"', $result );
@@ -115,21 +115,21 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
 	 */
-	public function test_block_core_navigation_set_overlay_image_lazy_loading_multiple_images() {
+	public function test_block_core_navigation_set_overlay_image_fetch_priority_multiple_images() {
 		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';
-		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$this->assertSame( 0, substr_count( $result, 'loading="lazy"' ) );
 		$this->assertSame( 2, substr_count( $result, 'fetchpriority="low"' ) );
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
 	 */
-	public function test_block_core_navigation_set_overlay_image_lazy_loading_no_images() {
+	public function test_block_core_navigation_set_overlay_image_fetch_priority_no_images() {
 		$html   = '<div><p>No images here</p></div>';
-		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$this->assertSame( $html, $result );
 	}
 }

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -91,4 +91,41 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$inner_blocks  = new WP_Block_List( $parsed_blocks );
 		$this->assertFalse( gutenberg_block_core_navigation_block_tree_has_block_type( $inner_blocks, 'core/navigation' ) );
 	}
+
+	/**
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 */
+	public function test_block_core_navigation_set_overlay_image_lazy_loading_adds_lazy() {
+		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';
+		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$this->assertStringContainsString( 'loading="lazy"', $result );
+	}
+
+	/**
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 */
+	public function test_block_core_navigation_set_overlay_image_lazy_loading_overrides_eager() {
+		$html   = '<div><img src="example.jpg" loading="eager" /></div>';
+		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$this->assertStringContainsString( 'loading="lazy"', $result );
+		$this->assertStringNotContainsString( 'loading="eager"', $result );
+	}
+
+	/**
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 */
+	public function test_block_core_navigation_set_overlay_image_lazy_loading_multiple_images() {
+		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';
+		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$this->assertSame( 2, substr_count( $result, 'loading="lazy"' ) );
+	}
+
+	/**
+	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
+	 */
+	public function test_block_core_navigation_set_overlay_image_lazy_loading_no_images() {
+		$html   = '<div><p>No images here</p></div>';
+		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
+		$this->assertSame( $html, $result );
+	}
 }

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -111,7 +111,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$html   = '<div><img src="example.jpg" fetchpriority="high" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$tags   = new WP_HTML_Tag_Processor( $result );
-		$tags->next_tag( 'IMG' );
+		$this->assertTrue( $tags->next_tag( 'IMG' ) );
 		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
 	}
 

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -98,20 +98,21 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	public function test_block_core_navigation_set_overlay_image_fetch_priority_adds_low_priority() {
 		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
-		$this->assertStringNotContainsString( 'loading="lazy"', $result );
-		$this->assertStringContainsString( 'fetchpriority="low"', $result );
+		$tags   = new WP_HTML_Tag_Processor( $result );
+		$tags->next_tag( 'IMG' );
+		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
+		$this->assertNull( $tags->get_attribute( 'loading' ) );
 	}
 
 	/**
 	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
 	 */
-	public function test_block_core_navigation_set_overlay_image_fetch_priority_overrides_eager_and_high() {
-		$html   = '<div><img src="example.jpg" loading="eager" fetchpriority="high" /></div>';
+	public function test_block_core_navigation_set_overlay_image_fetch_priority_overrides_high_priority() {
+		$html   = '<div><img src="example.jpg" fetchpriority="high" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
-		$this->assertStringNotContainsString( 'loading="lazy"', $result );
-		$this->assertStringNotContainsString( 'loading="eager"', $result );
-		$this->assertStringContainsString( 'fetchpriority="low"', $result );
-		$this->assertStringNotContainsString( 'fetchpriority="high"', $result );
+		$tags   = new WP_HTML_Tag_Processor( $result );
+		$tags->next_tag( 'IMG' );
+		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
 	}
 
 	/**
@@ -120,8 +121,11 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	public function test_block_core_navigation_set_overlay_image_fetch_priority_multiple_images() {
 		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
-		$this->assertSame( 0, substr_count( $result, 'loading="lazy"' ) );
-		$this->assertSame( 2, substr_count( $result, 'fetchpriority="low"' ) );
+		$tags   = new WP_HTML_Tag_Processor( $result );
+		$tags->next_tag( 'IMG' );
+		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
+		$tags->next_tag( 'IMG' );
+		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
 	}
 
 	/**

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -124,7 +124,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$tags   = new WP_HTML_Tag_Processor( $result );
 		$this->assertTrue( $tags->next_tag( 'IMG' ) );
 		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
-		$tags->next_tag( 'IMG' );
+		$this->assertTrue( $tags->next_tag( 'IMG' ) );
 		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
 	}
 

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -108,7 +108,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	public function test_block_core_navigation_set_overlay_image_lazy_loading_overrides_eager_and_high() {
 		$html   = '<div><img src="example.jpg" loading="eager" fetchpriority="high" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
-		$this->assertStringContainsString( 'loading="lazy"', $result );
+		$this->assertStringNotContainsString( 'loading="lazy"', $result );
 		$this->assertStringNotContainsString( 'loading="eager"', $result );
 		$this->assertStringContainsString( 'fetchpriority="low"', $result );
 		$this->assertStringNotContainsString( 'fetchpriority="high"', $result );

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -95,20 +95,23 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	/**
 	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
 	 */
-	public function test_block_core_navigation_set_overlay_image_lazy_loading_adds_lazy() {
+	public function test_block_core_navigation_set_overlay_image_lazy_loading_adds_lazy_and_low_priority() {
 		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
 		$this->assertStringContainsString( 'loading="lazy"', $result );
+		$this->assertStringContainsString( 'fetchpriority="low"', $result );
 	}
 
 	/**
 	 * @covers gutenberg_block_core_navigation_set_overlay_image_lazy_loading
 	 */
-	public function test_block_core_navigation_set_overlay_image_lazy_loading_overrides_eager() {
-		$html   = '<div><img src="example.jpg" loading="eager" /></div>';
+	public function test_block_core_navigation_set_overlay_image_lazy_loading_overrides_eager_and_high() {
+		$html   = '<div><img src="example.jpg" loading="eager" fetchpriority="high" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
 		$this->assertStringContainsString( 'loading="lazy"', $result );
 		$this->assertStringNotContainsString( 'loading="eager"', $result );
+		$this->assertStringContainsString( 'fetchpriority="low"', $result );
+		$this->assertStringNotContainsString( 'fetchpriority="high"', $result );
 	}
 
 	/**
@@ -118,6 +121,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
 		$this->assertSame( 2, substr_count( $result, 'loading="lazy"' ) );
+		$this->assertSame( 2, substr_count( $result, 'fetchpriority="low"' ) );
 	}
 
 	/**

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -93,7 +93,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
+	 * @covers ::block_core_navigation_set_overlay_image_fetch_priority
 	 */
 	public function test_block_core_navigation_set_overlay_image_fetch_priority_adds_low_priority() {
 		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -99,7 +99,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_fetch_priority( $html );
 		$tags   = new WP_HTML_Tag_Processor( $result );
-		$tags->next_tag( 'IMG' );
+		$this->assertTrue( $tags->next_tag( 'IMG' ) );
 		$this->assertSame( 'low', $tags->get_attribute( 'fetchpriority' ) );
 		$this->assertNull( $tags->get_attribute( 'loading' ) );
 	}

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -116,7 +116,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
+	 * @covers ::block_core_navigation_set_overlay_image_fetch_priority
 	 */
 	public function test_block_core_navigation_set_overlay_image_fetch_priority_multiple_images() {
 		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -129,7 +129,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers gutenberg_block_core_navigation_set_overlay_image_fetch_priority
+	 * @covers ::block_core_navigation_set_overlay_image_fetch_priority
 	 */
 	public function test_block_core_navigation_set_overlay_image_fetch_priority_no_images() {
 		$html   = '<div><p>No images here</p></div>';

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -120,7 +120,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	public function test_block_core_navigation_set_overlay_image_lazy_loading_multiple_images() {
 		$html   = '<div><img src="a.jpg" /><img src="b.jpg" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
-		$this->assertSame( 2, substr_count( $result, 'loading="lazy"' ) );
+		$this->assertSame( 0, substr_count( $result, 'loading="lazy"' ) );
 		$this->assertSame( 2, substr_count( $result, 'fetchpriority="low"' ) );
 	}
 

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -98,7 +98,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	public function test_block_core_navigation_set_overlay_image_lazy_loading_adds_lazy_and_low_priority() {
 		$html   = '<div><img src="example.jpg" width="300" height="300" /></div>';
 		$result = gutenberg_block_core_navigation_set_overlay_image_lazy_loading( $html );
-		$this->assertStringContainsString( 'loading="lazy"', $result );
+		$this->assertStringNotContainsString( 'loading="lazy"', $result );
 		$this->assertStringContainsString( 'fetchpriority="low"', $result );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76181

This PR sets `fetchpriority="low"` on images inside a Navigation Overlay template part so they don't compete with the page's actual LCP image.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a navigation block uses a custom overlay template part containing an image, that image can incorrectly receive `fetchpriority="high"` even though it is hidden until the user opens the menu. This happens because the template part block calls `wp_filter_content_tags()` on its rendered content with the context "template_part_header", which `wp_get_loading_optimization_attributes()` treats as an in-viewport context and may assign `fetchpriority="high"`.

This has two negative effects on LCP:
1. The overlay image gets `fetchpriority="high"`, causing the browser to fetch it with high priority even though it is not visible.
2. The shared LCP counter (`wp_increase_content_media_count`) is incremented by the hidden image, potentially using up the budget before the actual LCP image (e.g. the post's featured image) is processed, causing it not to receive `fetchpriority="high"`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

After the overlay blocks are rendered in `WP_Navigation_Block_Renderer::get_responsive_container_markup()`, a new helper function `block_core_navigation_set_overlay_image_lazy_loading()` uses `WP_HTML_Tag_Processor` to set `fetchpriority="low"` on every `<img>` in the overlay HTML.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the Site Editor, create or edit a Navigation block and set it to use a custom overlay template part (Navigation block settings > Overlay > select or create a template part)
2. Add an Image block to the overlay template part with dimensions of at least 250×250px
3. Create or edit a post/page and add a Featured Image
4. View the post/page on the frontend
5. Inspect the page source or DevTools network panel:
    - The `<img>` inside the Navigation Overlay should have `fetchpriority="low"`
    - The featured image should have `fetchpriority="high"`
