### PR TITLE
Move site editor preview CSS to boot package

### DIFF
--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -74,7 +74,12 @@ export default function Canvas( { canvas }: CanvasProps ) {
 				<Editor
 					postType={ canvas.postType }
 					postId={ canvas.postId }
-					settings={ { isPreviewMode: canvas.isPreview } }
+					settings={ {
+						isPreviewMode: canvas.isPreview,
+						styles: canvas.isPreview
+							? [ { css: 'body{min-height:100vh;}' } ]
+							: [],
+					} }
 					backButton={ backButton }
 				/>
 			</div>

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -92,12 +92,6 @@ export function Editor( {
 		() => ( {
 			...editorSettings,
 			...settings,
-			styles: [
-				...( editorSettings.styles ?? [] ),
-				...( settings?.isPreviewMode
-					? [ { css: 'body{min-height:100vh;}' } ]
-					: [] ),
-			],
 		} ),
 		[ editorSettings, settings ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up to https://github.com/WordPress/gutenberg/pull/76201 to move the CSS for the editor preview to a better location.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This CSS isn't a Lazy Editor concern - it's more relevant to the Boot package.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move CSS from Lazy Editor to Boot package.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Turn on the extensible site editor from Gutenberg -> Experiments
- Go to the site editor
- Select Navigation
- Edit a Navigation
- The navigation preview should be centered

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
