### PR TITLE
Raw handling: fix shortcode conversion when separated by <br /> tags

### DIFF
--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -14,8 +14,8 @@ import { applyBuiltInValidationFixes } from '../parser/apply-built-in-validation
 const castArray = ( maybeArray ) =>
 	Array.isArray( maybeArray ) ? maybeArray : [ maybeArray ];
 
-const beforeLineRegexp = /(\n|<p>)\s*$/;
-const afterLineRegexp = /^\s*(\n|<\/p>)/;
+const beforeLineRegexp = /(\n|<p>|<br\s*\/?>)\s*$/;
+const afterLineRegexp = /^\s*(\n|<\/p>|<br\s*\/?>)/;
 
 function segmentHTMLToShortcodeBlock(
 	HTML,

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -237,6 +237,24 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		).toEqual( [ originalMultipleShortcodes ] );
 	} );
 
+	it( 'should convert a shortcode between br tags', () => {
+		const original = `<p>Some text<br />\n[foo bar="apple"]<br />\nSome other text</p>`;
+		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
+		expect( transformed ).toHaveLength( 3 );
+		const expectedBlock = createBlock( 'core/shortcode', {
+			text: '[foo bar="apple"]',
+		} );
+		expectedBlock.clientId = transformed[ 1 ].clientId;
+		expect( transformed[ 1 ] ).toEqual( expectedBlock );
+	} );
+
+	it( 'should not convert inline shortcodes near br tags', () => {
+		const original = `<p>Hello<br />[foo bar] world</p>`;
+		expect( segmentHTMLToShortcodeBlock( original, 0 ) ).toEqual( [
+			original,
+		] );
+	} );
+
 	it( 'should convert regardless of shortcode alias', () => {
 		const original = `<p>[my-gallery ids="1,2,3"]</p>
 <p>[my-bunch-of-images ids="4,5,6"]</p>`;


### PR DESCRIPTION
## What?

Closes #76140

Fixes shortcode-to-block conversion failing when shortcodes are not surrounded by empty lines.

## Why?

When the block parser applies `autop()` to freeform block content, single newlines between lines are converted to `<br />\n` HTML. The shortcode converter's line-boundary regex patterns only recognized `\n` and `<p>`/`</p>` tags, causing shortcodes wrapped by `<br />` to be incorrectly treated as inline text instead of block-level elements.

## How?

Updated the `beforeLineRegexp` and `afterLineRegexp` patterns in the shortcode converter to also recognize `<br>`, `<br/>`, and `<br />` as valid line boundaries. Added test coverage for the bug scenario.

## Testing Instructions

1. Go to the code editor and enter:
```
Some text
[gallery ids="1,2,3"]
Some other text
```
(Replace the IDs with actual image IDs from your media library)

2. Switch to the visual editor
3. Click "Convert to blocks" button
4. Verify that the gallery shortcode is now properly converted to a Gallery block

Run tests: `npm run test:unit -- --testNamePattern="segmentHTMLToShortcodeBlock"`

All 11 tests pass, including 2 new tests that verify the fix works correctly.