### PR TITLE
RTC: Fix 'networkidle' and other e2e tests that are flaky

### DIFF
--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -252,13 +252,6 @@ class PostEditorTemplateMode {
 				'role=button[name="Dismiss this notice"i] >> text=Custom template created. You\'re in template mode now.'
 			)
 		).toBeVisible();
-
-		// Wait for the editor to be loaded and ready before making changes.
-		// Without this, the editor will move focus to body while still typing.
-		// And the save states will not be counted as dirty.
-		// There is likely a bug in the code, waiting for the snackbar above should be enough.
-		// eslint-disable-next-line playwright/no-networkidle
-		await this.page.waitForLoadState( 'networkidle' );
 	}
 
 	async saveTemplateWithoutPublishing() {

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -252,6 +252,15 @@ class PostEditorTemplateMode {
 				'role=button[name="Dismiss this notice"i] >> text=Custom template created. You\'re in template mode now.'
 			)
 		).toBeVisible();
+
+		// Wait for the editor to be fully loaded and ready before making changes.
+		// Without this, the editor may move focus to body while still typing,
+		// and save states will not be counted as dirty.
+		await this.page.waitForFunction(
+			() =>
+				window.wp?.data?.select( 'core/block-editor' )?.getBlocks()
+					?.length > 0
+		);
 	}
 
 	async saveTemplateWithoutPublishing() {

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -44,14 +44,11 @@ test.describe( 'Site editor url navigation', () => {
 		await admin.visitSiteEditor();
 		await page.click( 'role=button[name="Templates"]' );
 		await page.click( 'role=button[name="Add Template"i]' );
-		// Wait for network idle to avoid flaky tests.
-		// eslint-disable-next-line playwright/no-networkidle
-		await page.waitForLoadState( 'networkidle' );
-		await page
-			.getByRole( 'button', {
-				name: 'Single item: Post',
-			} )
-			.click();
+		const singleItemPost = page.getByRole( 'button', {
+			name: 'Single item: Post',
+		} );
+		await singleItemPost.waitFor();
+		await singleItemPost.click();
 		await page
 			.getByRole( 'button', { name: 'For a specific item' } )
 			.click();

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -47,7 +47,7 @@ test.describe( 'Site editor url navigation', () => {
 		const singleItemPost = page.getByRole( 'button', {
 			name: 'Single item: Post',
 		} );
-		await singleItemPost.waitFor();
+		await expect( singleItemPost ).toBeEnabled();
 		await singleItemPost.click();
 		await page
 			.getByRole( 'button', { name: 'For a specific item' } )


### PR DESCRIPTION
## What?

Remove `await page.waitForLoadState( 'networkidle' )` from end-to-end tests.

## Why?

Now that real-time collaboration is [turned on by default](https://github.com/WordPress/gutenberg/pull/75739), the `networkidle` state is a lot more flaky. Once RTC has connected via the default transport, it's constantly sending `POST /wp-sync/v1/update` calls, meaning that we may not hit a period of `networkidle` during tests. These tests will eventually time out.

## How?

The only two `networkidle` uses in e2e tests appear to be workarounds for previous flaky results. We've tried to use another method and await something else instead in both cases.

## Testing Instructions

1. See these tests pass on CI consistently.