### PR TITLE
RTC: Fix `post-editor-template-mode` E2E test

### DIFF
--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -274,8 +274,10 @@ class PostEditorTemplateMode {
 			.getByRole( 'button', { name: 'Save', exact: true } )
 			.click();
 		// Avoid publishing the post.
-		await editorPublishRegion
-			.getByRole( 'button', { name: 'Cancel' } )
-			.click();
+		const cancelButton = editorPublishRegion.getByRole( 'button', {
+			name: 'Cancel',
+		} );
+		await expect( cancelButton ).toBeEnabled();
+		await cancelButton.click();
 	}
 }


### PR DESCRIPTION
## What?

Wait for the Cancel button to be enabled before clicking it in `saveTemplateWithoutPublishing` in the `post-editor-template-mode` E2E test.

Isolated duplicate of #76209.

## Why?

The Cancel button may be disabled while the save operation is in progress. Clicking it before it's enabled can cause a flaky test failure.

## How?

Added an `await expect( cancelButton ).toBeEnabled()` assertion before clicking the Cancel button in `saveTemplateWithoutPublishing`.

## Testing Instructions

1. Check out this branch.
2. Run `npm run test:e2e -- test/e2e/specs/editor/various/post-editor-template-mode.spec.js`.
3. Verify the test passes.

### Testing Instructions for Keyboard

No additional keyboard-specific instructions.