### PR TITLE
Block: Add slug attribute to core/block for registered pattern references

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -83,7 +83,7 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 -	**Name:** core/block
 -	**Category:** reusable
 -	**Supports:** interactivity (clientNavigation), ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
--	**Attributes:** content, ref
+-	**Attributes:** content, ref, slug
 
 ## Breadcrumbs
 

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -11,6 +11,9 @@
 		"ref": {
 			"type": "number"
 		},
+		"slug": {
+			"type": "string"
+		},
 		"content": {
 			"type": "object",
 			"default": {}

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -105,70 +105,6 @@ export default function ReusableBlockEditRecursionWrapper( props ) {
 	);
 }
 
-function ReusableBlockControl( {
-	recordId,
-	canOverrideBlocks,
-	hasContent,
-	handleEditOriginal,
-	resetContent,
-} ) {
-	const canUserEdit = useSelect(
-		( select ) =>
-			!! select( coreStore ).canUser( 'update', {
-				kind: 'postType',
-				name: 'wp_block',
-				id: recordId,
-			} ),
-		[ recordId ]
-	);
-
-	return (
-		<>
-			{ canUserEdit && !! handleEditOriginal && (
-				<BlockControls group="other">
-					<ToolbarGroup>
-						<ToolbarButton onClick={ handleEditOriginal }>
-							{ __( 'Edit original' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-
-			{ canOverrideBlocks && (
-				<BlockControls group="other">
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ resetContent }
-							disabled={ ! hasContent }
-						>
-							{ __( 'Reset' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-		</>
-	);
-}
-
-function PatternBlockControl( { canOverrideBlocks, hasContent, resetContent } ) {
-	return (
-		<>
-			{ canOverrideBlocks && (
-				<BlockControls group="other">
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ resetContent }
-							disabled={ ! hasContent }
-						>
-							{ __( 'Reset' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-		</>
-	);
-}
-
 const EMPTY_OBJECT = {};
 
 function useCanOverrideBlocks( blocks ) {
@@ -176,8 +112,9 @@ function useCanOverrideBlocks( blocks ) {
 		( select ) => {
 			const { getSettings } = select( blockEditorStore );
 			return {
-				hasPatternOverridesSource:
-					!! getBlockBindingsSource( 'core/pattern-overrides' ),
+				hasPatternOverridesSource: !! getBlockBindingsSource(
+					'core/pattern-overrides'
+				),
 				supportedBlockTypesRaw:
 					getSettings()
 						.__experimentalBlockBindingsSupportedAttributes ||
@@ -232,6 +169,96 @@ function ReusableBlockEdit( {
 	);
 }
 
+function PatternBlockUI( {
+	name,
+	blocks,
+	hasResolved,
+	isMissing,
+	content,
+	parentLayout,
+	setAttributes,
+	children: extraControls,
+} ) {
+	const { __unstableMarkLastChangeAsPersistent } =
+		useDispatch( blockEditorStore );
+
+	const canOverrideBlocks = useCanOverrideBlocks( blocks );
+
+	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
+	const layoutClasses = useLayoutClasses( { layout }, name );
+
+	const blockProps = useBlockProps( {
+		className: clsx(
+			'block-library-block__reusable-block-container',
+			layout && layoutClasses,
+			{ [ `align${ alignment }` ]: alignment }
+		),
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		layout,
+		value: blocks,
+		onInput: NOOP,
+		onChange: NOOP,
+		renderAppender: blocks?.length
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+	} );
+
+	const resetContent = () => {
+		if ( content ) {
+			__unstableMarkLastChangeAsPersistent();
+			setAttributes( { content: undefined } );
+		}
+	};
+
+	let placeholder = null;
+
+	if ( isMissing ) {
+		placeholder = (
+			<Warning>
+				{ __( 'Block has been deleted or is unavailable.' ) }
+			</Warning>
+		);
+	}
+
+	if ( ! hasResolved ) {
+		placeholder = (
+			<Placeholder>
+				<Spinner />
+			</Placeholder>
+		);
+	}
+
+	return (
+		<>
+			{ hasResolved && ! isMissing && (
+				<>
+					{ extraControls }
+					{ canOverrideBlocks && (
+						<BlockControls group="other">
+							<ToolbarGroup>
+								<ToolbarButton
+									onClick={ resetContent }
+									disabled={ ! content }
+								>
+									{ __( 'Reset' ) }
+								</ToolbarButton>
+							</ToolbarGroup>
+						</BlockControls>
+					) }
+				</>
+			) }
+
+			{ placeholder === null ? (
+				<div { ...innerBlocksProps } />
+			) : (
+				<div { ...blockProps }>{ placeholder }</div>
+			) }
+		</>
+	);
+}
+
 function RefPatternEdit( {
 	name,
 	patternRef,
@@ -249,91 +276,35 @@ function RefPatternEdit( {
 	} );
 	const isMissing = hasResolved && ! record;
 
-	const { __unstableMarkLastChangeAsPersistent } =
-		useDispatch( blockEditorStore );
-
 	const onNavigateToEntityRecord = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().onNavigateToEntityRecord;
 	}, [] );
 
-	const canOverrideBlocks = useCanOverrideBlocks( blocks );
-
-	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
-	const layoutClasses = useLayoutClasses( { layout }, name );
-
-	const blockProps = useBlockProps( {
-		className: clsx(
-			'block-library-block__reusable-block-container',
-			layout && layoutClasses,
-			{ [ `align${ alignment }` ]: alignment }
-		),
-	} );
-
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		layout,
-		value: blocks,
-		onInput: NOOP,
-		onChange: NOOP,
-		renderAppender: blocks?.length
-			? undefined
-			: InnerBlocks.ButtonBlockAppender,
-	} );
-
-	const handleEditOriginal = () => {
-		onNavigateToEntityRecord( {
-			postId: patternRef,
-			postType: 'wp_block',
-		} );
-	};
-
-	const resetContent = () => {
-		if ( content ) {
-			__unstableMarkLastChangeAsPersistent();
-			setAttributes( { content: undefined } );
-		}
-	};
-
-	let children = null;
-
-	if ( isMissing ) {
-		children = (
-			<Warning>
-				{ __( 'Block has been deleted or is unavailable.' ) }
-			</Warning>
-		);
-	}
-
-	if ( ! hasResolved ) {
-		children = (
-			<Placeholder>
-				<Spinner />
-			</Placeholder>
-		);
-	}
+	const handleEditOriginal = onNavigateToEntityRecord
+		? () => {
+				onNavigateToEntityRecord( {
+					postId: patternRef,
+					postType: 'wp_block',
+				} );
+		  }
+		: undefined;
 
 	return (
-		<>
-			{ hasResolved && ! isMissing && (
-				<ReusableBlockControl
-					recordId={ patternRef }
-					canOverrideBlocks={ canOverrideBlocks }
-					hasContent={ !! content }
-					handleEditOriginal={
-						onNavigateToEntityRecord
-							? handleEditOriginal
-							: undefined
-					}
-					resetContent={ resetContent }
-				/>
-			) }
-
-			{ children === null ? (
-				<div { ...innerBlocksProps } />
-			) : (
-				<div { ...blockProps }>{ children }</div>
-			) }
-		</>
+		<PatternBlockUI
+			name={ name }
+			blocks={ blocks }
+			hasResolved={ hasResolved }
+			isMissing={ isMissing }
+			content={ content }
+			parentLayout={ parentLayout }
+			setAttributes={ setAttributes }
+		>
+			<EditOriginalControl
+				recordId={ patternRef }
+				handleEditOriginal={ handleEditOriginal }
+			/>
+		</PatternBlockUI>
 	);
 }
 
@@ -344,72 +315,67 @@ function SlugPatternEdit( {
 	parentLayout,
 	setAttributes,
 } ) {
-	const { blocks, isMissing } = useSelect(
+	const { blocks, hasResolved, isMissing } = useSelect(
 		( select ) => {
 			const pattern =
-				select(
-					blockEditorStore
-				).__experimentalGetParsedPattern( slug );
+				select( blockEditorStore ).__experimentalGetParsedPattern(
+					slug
+				);
+			if ( pattern ) {
+				return {
+					blocks: pattern.blocks,
+					hasResolved: true,
+					isMissing: false,
+				};
+			}
+			// Pattern not found — check whether the REST API patterns
+			// have finished loading before declaring it missing.
+			const patternsLoaded =
+				select( coreStore ).hasFinishedResolution( 'getBlockPatterns' );
 			return {
-				blocks: pattern?.blocks ?? [],
-				isMissing: ! pattern,
+				blocks: [],
+				hasResolved: patternsLoaded,
+				isMissing: patternsLoaded,
 			};
 		},
 		[ slug ]
 	);
 
-	const { __unstableMarkLastChangeAsPersistent } =
-		useDispatch( blockEditorStore );
+	return (
+		<PatternBlockUI
+			name={ name }
+			blocks={ blocks }
+			hasResolved={ hasResolved }
+			isMissing={ isMissing }
+			content={ content }
+			parentLayout={ parentLayout }
+			setAttributes={ setAttributes }
+		/>
+	);
+}
 
-	const canOverrideBlocks = useCanOverrideBlocks( blocks );
+function EditOriginalControl( { recordId, handleEditOriginal } ) {
+	const canUserEdit = useSelect(
+		( select ) =>
+			!! select( coreStore ).canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_block',
+				id: recordId,
+			} ),
+		[ recordId ]
+	);
 
-	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
-	const layoutClasses = useLayoutClasses( { layout }, name );
-
-	const blockProps = useBlockProps( {
-		className: clsx(
-			'block-library-block__reusable-block-container',
-			layout && layoutClasses,
-			{ [ `align${ alignment }` ]: alignment }
-		),
-	} );
-
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		layout,
-		value: blocks,
-		onInput: NOOP,
-		onChange: NOOP,
-		renderAppender: blocks?.length
-			? undefined
-			: InnerBlocks.ButtonBlockAppender,
-	} );
-
-	const resetContent = () => {
-		if ( content ) {
-			__unstableMarkLastChangeAsPersistent();
-			setAttributes( { content: undefined } );
-		}
-	};
-
-	if ( isMissing ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Block has been deleted or is unavailable.' ) }
-				</Warning>
-			</div>
-		);
+	if ( ! canUserEdit || ! handleEditOriginal ) {
+		return null;
 	}
 
 	return (
-		<>
-			<PatternBlockControl
-				canOverrideBlocks={ canOverrideBlocks }
-				hasContent={ !! content }
-				resetContent={ resetContent }
-			/>
-
-			<div { ...innerBlocksProps } />
-		</>
+		<BlockControls group="other">
+			<ToolbarGroup>
+				<ToolbarButton onClick={ handleEditOriginal }>
+					{ __( 'Edit original' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+		</BlockControls>
 	);
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -90,15 +90,16 @@ const NOOP = () => {};
 // that allows short-circuiting rendering as early as possible, before any
 // of the other effects in the block edit have run.
 export default function ReusableBlockEditRecursionWrapper( props ) {
-	const { ref } = props.attributes;
-	const hasAlreadyRendered = useHasRecursion( ref );
+	const { ref, slug } = props.attributes;
+	const uniqueId = ref || slug;
+	const hasAlreadyRendered = useHasRecursion( uniqueId );
 
 	if ( hasAlreadyRendered ) {
 		return <RecursionWarning />;
 	}
 
 	return (
-		<RecursionProvider uniqueId={ ref }>
+		<RecursionProvider uniqueId={ uniqueId }>
 			<ReusableBlockEdit { ...props } />
 		</RecursionProvider>
 	);
@@ -149,46 +150,44 @@ function ReusableBlockControl( {
 	);
 }
 
+function PatternBlockControl( { canOverrideBlocks, hasContent, resetContent } ) {
+	return (
+		<>
+			{ canOverrideBlocks && (
+				<BlockControls group="other">
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ resetContent }
+							disabled={ ! hasContent }
+						>
+							{ __( 'Reset' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+		</>
+	);
+}
+
 const EMPTY_OBJECT = {};
 
-function ReusableBlockEdit( {
-	name,
-	attributes: { ref, content },
-	__unstableParentLayout: parentLayout,
-	setAttributes,
-} ) {
-	const { record, hasResolved } = useEntityRecord(
-		'postType',
-		'wp_block',
-		ref
+function useCanOverrideBlocks( blocks ) {
+	const { hasPatternOverridesSource, supportedBlockTypesRaw } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			return {
+				hasPatternOverridesSource:
+					!! getBlockBindingsSource( 'core/pattern-overrides' ),
+				supportedBlockTypesRaw:
+					getSettings()
+						.__experimentalBlockBindingsSupportedAttributes ||
+					EMPTY_OBJECT,
+			};
+		},
+		[]
 	);
-	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_block', {
-		id: ref,
-	} );
-	const isMissing = hasResolved && ! record;
 
-	const { __unstableMarkLastChangeAsPersistent } =
-		useDispatch( blockEditorStore );
-
-	const {
-		onNavigateToEntityRecord,
-		hasPatternOverridesSource,
-		supportedBlockTypesRaw,
-	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		// For editing link to the site editor if the theme and user permissions support it.
-		return {
-			onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
-			hasPatternOverridesSource: !! getBlockBindingsSource(
-				'core/pattern-overrides'
-			),
-			supportedBlockTypesRaw:
-				getSettings().__experimentalBlockBindingsSupportedAttributes ||
-				EMPTY_OBJECT,
-		};
-	}, [] );
-
-	const canOverrideBlocks = useMemo( () => {
+	return useMemo( () => {
 		const supportedBlockTypes = Object.keys( supportedBlockTypesRaw );
 		const hasOverridableBlocks = ( _blocks ) =>
 			_blocks.some( ( block ) => {
@@ -202,6 +201,63 @@ function ReusableBlockEdit( {
 			} );
 		return hasPatternOverridesSource && hasOverridableBlocks( blocks );
 	}, [ hasPatternOverridesSource, blocks, supportedBlockTypesRaw ] );
+}
+
+function ReusableBlockEdit( {
+	name,
+	attributes: { ref, slug, content },
+	__unstableParentLayout: parentLayout,
+	setAttributes,
+} ) {
+	if ( slug && ! ref ) {
+		return (
+			<SlugPatternEdit
+				name={ name }
+				slug={ slug }
+				content={ content }
+				parentLayout={ parentLayout }
+				setAttributes={ setAttributes }
+			/>
+		);
+	}
+
+	return (
+		<RefPatternEdit
+			name={ name }
+			patternRef={ ref }
+			content={ content }
+			parentLayout={ parentLayout }
+			setAttributes={ setAttributes }
+		/>
+	);
+}
+
+function RefPatternEdit( {
+	name,
+	patternRef,
+	content,
+	parentLayout,
+	setAttributes,
+} ) {
+	const { record, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_block',
+		patternRef
+	);
+	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_block', {
+		id: patternRef,
+	} );
+	const isMissing = hasResolved && ! record;
+
+	const { __unstableMarkLastChangeAsPersistent } =
+		useDispatch( blockEditorStore );
+
+	const onNavigateToEntityRecord = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().onNavigateToEntityRecord;
+	}, [] );
+
+	const canOverrideBlocks = useCanOverrideBlocks( blocks );
 
 	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
 	const layoutClasses = useLayoutClasses( { layout }, name );
@@ -226,14 +282,13 @@ function ReusableBlockEdit( {
 
 	const handleEditOriginal = () => {
 		onNavigateToEntityRecord( {
-			postId: ref,
+			postId: patternRef,
 			postType: 'wp_block',
 		} );
 	};
 
 	const resetContent = () => {
 		if ( content ) {
-			// Make sure any previous changes are persisted before resetting.
 			__unstableMarkLastChangeAsPersistent();
 			setAttributes( { content: undefined } );
 		}
@@ -261,7 +316,7 @@ function ReusableBlockEdit( {
 		<>
 			{ hasResolved && ! isMissing && (
 				<ReusableBlockControl
-					recordId={ ref }
+					recordId={ patternRef }
 					canOverrideBlocks={ canOverrideBlocks }
 					hasContent={ !! content }
 					handleEditOriginal={
@@ -278,6 +333,83 @@ function ReusableBlockEdit( {
 			) : (
 				<div { ...blockProps }>{ children }</div>
 			) }
+		</>
+	);
+}
+
+function SlugPatternEdit( {
+	name,
+	slug,
+	content,
+	parentLayout,
+	setAttributes,
+} ) {
+	const { blocks, isMissing } = useSelect(
+		( select ) => {
+			const pattern =
+				select(
+					blockEditorStore
+				).__experimentalGetParsedPattern( slug );
+			return {
+				blocks: pattern?.blocks ?? [],
+				isMissing: ! pattern,
+			};
+		},
+		[ slug ]
+	);
+
+	const { __unstableMarkLastChangeAsPersistent } =
+		useDispatch( blockEditorStore );
+
+	const canOverrideBlocks = useCanOverrideBlocks( blocks );
+
+	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
+	const layoutClasses = useLayoutClasses( { layout }, name );
+
+	const blockProps = useBlockProps( {
+		className: clsx(
+			'block-library-block__reusable-block-container',
+			layout && layoutClasses,
+			{ [ `align${ alignment }` ]: alignment }
+		),
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		layout,
+		value: blocks,
+		onInput: NOOP,
+		onChange: NOOP,
+		renderAppender: blocks?.length
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+	} );
+
+	const resetContent = () => {
+		if ( content ) {
+			__unstableMarkLastChangeAsPersistent();
+			setAttributes( { content: undefined } );
+		}
+	};
+
+	if ( isMissing ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __( 'Block has been deleted or is unavailable.' ) }
+				</Warning>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<PatternBlockControl
+				canOverrideBlocks={ canOverrideBlocks }
+				hasContent={ !! content }
+				resetContent={ resetContent }
+			/>
+
+			<div { ...innerBlocksProps } />
 		</>
 	);
 }

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -37,9 +37,9 @@ export const settings = {
 
 		if ( slug ) {
 			const pattern =
-				select(
-					blockEditorStore
-				).__experimentalGetParsedPattern( slug );
+				select( blockEditorStore ).__experimentalGetParsedPattern(
+					slug
+				);
 			if ( pattern?.title ) {
 				return decodeEntities( pattern.title );
 			}

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -5,6 +5,7 @@ import { symbol as icon } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -22,21 +23,27 @@ export const settings = {
 	deprecated,
 	edit,
 	icon,
-	__experimentalLabel: ( { ref } ) => {
-		if ( ! ref ) {
-			return;
+	__experimentalLabel: ( { ref, slug } ) => {
+		if ( ref ) {
+			const entity = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				'wp_block',
+				ref
+			);
+			if ( entity?.title ) {
+				return decodeEntities( entity.title );
+			}
 		}
 
-		const entity = select( coreStore ).getEditedEntityRecord(
-			'postType',
-			'wp_block',
-			ref
-		);
-		if ( ! entity?.title ) {
-			return;
+		if ( slug ) {
+			const pattern =
+				select(
+					blockEditorStore
+				).__experimentalGetParsedPattern( slug );
+			if ( pattern?.title ) {
+				return decodeEntities( pattern.title );
+			}
 		}
-
-		return decodeEntities( entity.title );
 	},
 };
 

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -13,6 +13,8 @@
  * block context (including pattern/overrides) is propagated, then renders
  * the block.
  *
+ * @since 22.8.0
+ *
  * @param WP_Block $block_instance The block instance to render.
  * @param string   $content        The serialized block content to parse and attach.
  *
@@ -65,6 +67,7 @@ function render_block_core_block_content( $block_instance, $content ) {
  */
 function render_block_core_block( $attributes, $content, $block_instance ) {
 	static $seen_refs = array();
+	global $wp_embed;
 
 	if ( ! empty( $attributes['ref'] ) ) {
 		$reusable_block = get_post( $attributes['ref'] );
@@ -90,7 +93,6 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$seen_refs[ $attributes['ref'] ] = true;
 
 		// Handle embeds for reusable blocks.
-		global $wp_embed;
 		$content = $wp_embed->run_shortcode( $reusable_block->post_content );
 		$content = $wp_embed->autoembed( $content );
 
@@ -152,7 +154,6 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$content = $pattern['content'];
 
 		// Handle embeds for pattern content.
-		global $wp_embed;
 		$content = $wp_embed->run_shortcode( $content );
 		$content = $wp_embed->autoembed( $content );
 

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -6,81 +6,19 @@
  */
 
 /**
- * Renders the `core/block` block on server.
+ * Attaches inner blocks to a block instance and renders it.
  *
- * @since 5.0.0
+ * This helper is shared by both the ref-based and slug-based rendering paths.
+ * It attaches parsed blocks as inner blocks to the block instance so that
+ * block context (including pattern/overrides) is propagated, then renders
+ * the block.
  *
- * @global WP_Embed $wp_embed
+ * @param WP_Block $block_instance The block instance to render.
+ * @param string   $content        The serialized block content to parse and attach.
  *
- * @param array $attributes The block attributes.
- *
- * @return string Rendered HTML of the referenced block.
+ * @return string Rendered HTML.
  */
-function render_block_core_block( $attributes, $content, $block_instance ) {
-	static $seen_refs = array();
-
-	if ( empty( $attributes['ref'] ) ) {
-		return '';
-	}
-
-	$reusable_block = get_post( $attributes['ref'] );
-	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
-		return '';
-	}
-
-	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
-		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
-		// is set in `wp_debug_mode()`.
-		$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
-
-		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
-			'';
-	}
-
-	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
-		return '';
-	}
-
-	$seen_refs[ $attributes['ref'] ] = true;
-
-	// Handle embeds for reusable blocks.
-	global $wp_embed;
-	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
-	$content = $wp_embed->autoembed( $content );
-
-	// Back compat.
-	// For blocks that have not been migrated in the editor, add some back compat
-	// so that front-end rendering continues to work.
-
-	// This matches the `v2` deprecation. Removes the inner `values` property
-	// from every item.
-	if ( isset( $attributes['content'] ) ) {
-		foreach ( $attributes['content'] as &$content_data ) {
-			if ( isset( $content_data['values'] ) ) {
-				$is_assoc_array = is_array( $content_data['values'] ) && ! wp_is_numeric_array( $content_data['values'] );
-
-				if ( $is_assoc_array ) {
-					$content_data = $content_data['values'];
-				}
-			}
-		}
-	}
-
-	// This matches the `v1` deprecation. Rename `overrides` to `content`.
-	if ( isset( $attributes['overrides'] ) && ! isset( $attributes['content'] ) ) {
-		$attributes['content'] = $attributes['overrides'];
-	}
-
-	// Apply Block Hooks.
-	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
-
-	/**
-	 * We attach the blocks from $content as inner blocks to the Synced Pattern block instance.
-	 * This ensures that block context available to the Synced Pattern block instance is provided to
-	 * those blocks.
-	 */
+function render_block_core_block_content( $block_instance, $content ) {
 	$block_instance->parsed_block['innerBlocks']  = parse_blocks( $content );
 	$block_instance->parsed_block['innerContent'] = array_fill( 0, count( $block_instance->parsed_block['innerBlocks'] ), null );
 	if ( method_exists( $block_instance, 'refresh_context_dependents' ) ) {
@@ -109,10 +47,122 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$block_instance = WP_Block_Cloner::clone_instance( $block_instance );
 	}
 
-	$content = $block_instance->render( array( 'dynamic' => false ) );
-	unset( $seen_refs[ $attributes['ref'] ] );
+	return $block_instance->render( array( 'dynamic' => false ) );
+}
 
-	return $content;
+/**
+ * Renders the `core/block` block on server.
+ *
+ * @since 5.0.0
+ *
+ * @global WP_Embed $wp_embed
+ *
+ * @param array    $attributes     The block attributes.
+ * @param string   $content        The block content.
+ * @param WP_Block $block_instance The block instance.
+ *
+ * @return string Rendered HTML of the referenced block.
+ */
+function render_block_core_block( $attributes, $content, $block_instance ) {
+	static $seen_refs = array();
+
+	if ( ! empty( $attributes['ref'] ) ) {
+		$reusable_block = get_post( $attributes['ref'] );
+		if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
+			return '';
+		}
+
+		if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
+			// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
+			// is set in `wp_debug_mode()`.
+			$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
+
+			return $is_debug ?
+				// translators: Visible only in the front end, this warning takes the place of a faulty block.
+				__( '[block rendering halted]' ) :
+				'';
+		}
+
+		if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
+			return '';
+		}
+
+		$seen_refs[ $attributes['ref'] ] = true;
+
+		// Handle embeds for reusable blocks.
+		global $wp_embed;
+		$content = $wp_embed->run_shortcode( $reusable_block->post_content );
+		$content = $wp_embed->autoembed( $content );
+
+		// Back compat.
+		// For blocks that have not been migrated in the editor, add some back compat
+		// so that front-end rendering continues to work.
+
+		// This matches the `v2` deprecation. Removes the inner `values` property
+		// from every item.
+		if ( isset( $attributes['content'] ) ) {
+			foreach ( $attributes['content'] as &$content_data ) {
+				if ( isset( $content_data['values'] ) ) {
+					$is_assoc_array = is_array( $content_data['values'] ) && ! wp_is_numeric_array( $content_data['values'] );
+
+					if ( $is_assoc_array ) {
+						$content_data = $content_data['values'];
+					}
+				}
+			}
+		}
+
+		// This matches the `v1` deprecation. Rename `overrides` to `content`.
+		if ( isset( $attributes['overrides'] ) && ! isset( $attributes['content'] ) ) {
+			$attributes['content'] = $attributes['overrides'];
+		}
+
+		// Apply Block Hooks.
+		$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
+
+		$result = render_block_core_block_content( $block_instance, $content );
+		unset( $seen_refs[ $attributes['ref'] ] );
+
+		return $result;
+	}
+
+	if ( ! empty( $attributes['slug'] ) ) {
+		$slug     = $attributes['slug'];
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( ! $registry->is_registered( $slug ) ) {
+			return '';
+		}
+
+		// Use a prefixed key for recursion detection to avoid collisions
+		// with numeric ref keys in the shared static $seen_refs.
+		$seen_key = 'slug:' . $slug;
+		if ( isset( $seen_refs[ $seen_key ] ) ) {
+			$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
+
+			return $is_debug ?
+				// translators: Visible only in the front end, this warning takes the place of a faulty block. %s is the pattern slug.
+				sprintf( __( '[block rendering halted for pattern "%s"]' ), $slug ) :
+				'';
+		}
+
+		$seen_refs[ $seen_key ] = true;
+
+		$pattern = $registry->get_registered( $slug );
+		$content = $pattern['content'];
+
+		// Handle embeds for pattern content.
+		global $wp_embed;
+		$content = $wp_embed->run_shortcode( $content );
+		$content = $wp_embed->autoembed( $content );
+
+		$result = render_block_core_block_content( $block_instance, $content );
+		unset( $seen_refs[ $seen_key ] );
+
+		return $result;
+	}
+
+	return '';
 }
 
 /**

--- a/packages/e2e-tests/plugins/pattern-slug-override.php
+++ b/packages/e2e-tests/plugins/pattern-slug-override.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Pattern Slug Override
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-pattern-slug-override
+ */
+
+add_action(
+	'init',
+	function () {
+		register_block_pattern(
+			'test/slug-pattern',
+			array(
+				'title'   => 'Slug Pattern',
+				'content' => '<!-- wp:heading --><h2 class="wp-block-heading">Pattern Heading</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Pattern paragraph content</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		register_block_pattern(
+			'test/slug-pattern-with-overrides',
+			array(
+				'title'   => 'Slug Pattern With Overrides',
+				'content' => '<!-- wp:heading {"metadata":{"name":"heading","bindings":{"content":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Default Heading</h2><!-- /wp:heading --><!-- wp:paragraph {"metadata":{"name":"description","bindings":{"content":{"source":"core/pattern-overrides"}}}} --><p>Default description</p><!-- /wp:paragraph -->',
+			)
+		);
+	}
+);

--- a/packages/e2e-tests/plugins/pattern-slug-override.php
+++ b/packages/e2e-tests/plugins/pattern-slug-override.php
@@ -22,7 +22,7 @@ add_action(
 			'test/slug-pattern-with-overrides',
 			array(
 				'title'   => 'Slug Pattern With Overrides',
-				'content' => '<!-- wp:heading {"metadata":{"name":"heading","bindings":{"content":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Default Heading</h2><!-- /wp:heading --><!-- wp:paragraph {"metadata":{"name":"description","bindings":{"content":{"source":"core/pattern-overrides"}}}} --><p>Default description</p><!-- /wp:paragraph -->',
+				'content' => '<!-- wp:heading {"metadata":{"name":"heading","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Default Heading</h2><!-- /wp:heading --><!-- wp:paragraph {"metadata":{"name":"description","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><p>Default description</p><!-- /wp:paragraph -->',
 			)
 		);
 	}

--- a/test/e2e/specs/editor/various/pattern-slug-override.spec.js
+++ b/test/e2e/specs/editor/various/pattern-slug-override.spec.js
@@ -1,0 +1,160 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Pattern block with slug attribute', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme( 'emptytheme' ),
+			requestUtils.activatePlugin(
+				'gutenberg-test-pattern-slug-override'
+			),
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deactivatePlugin(
+				'gutenberg-test-pattern-slug-override'
+			),
+		] );
+	} );
+
+	test( 'should render a registered pattern referenced by slug', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: { slug: 'test/slug-pattern' },
+		} );
+
+		// Verify the pattern content appears in the editor.
+		const patternBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Pattern',
+		} );
+		await expect( patternBlock ).toBeVisible();
+		await expect(
+			patternBlock.getByRole( 'document', {
+				name: 'Block: Heading',
+			} )
+		).toHaveText( 'Pattern Heading' );
+		await expect(
+			patternBlock.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+		).toHaveText( 'Pattern paragraph content' );
+
+		// Verify the frontend renders the pattern.
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		await expect(
+			page.locator( '.wp-block-heading' )
+		).toHaveText( 'Pattern Heading' );
+		await expect(
+			page.locator( '.wp-block-paragraph' ).first()
+		).toHaveText( 'Pattern paragraph content' );
+	} );
+
+	test( 'should support pattern overrides with slug', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+
+		// Insert a pattern with slug and content overrides.
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: {
+				slug: 'test/slug-pattern-with-overrides',
+				content: {
+					heading: {
+						content: 'Custom Heading',
+					},
+					description: {
+						content: 'Custom description',
+					},
+				},
+			},
+		} );
+
+		// Verify overrides render on the frontend.
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		await expect(
+			page.locator( '.wp-block-heading' )
+		).toHaveText( 'Custom Heading' );
+		await expect(
+			page.locator( '.wp-block-paragraph' ).first()
+		).toHaveText( 'Custom description' );
+	} );
+
+	test( 'should show warning for missing slug', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: { slug: 'test/nonexistent-pattern' },
+		} );
+
+		// Should show the unavailable warning.
+		await expect(
+			editor.canvas.getByText(
+				'Block has been deleted or is unavailable.'
+			)
+		).toBeVisible();
+	} );
+
+	test( 'should allow resetting overrides on slug-based pattern', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: {
+				slug: 'test/slug-pattern-with-overrides',
+				content: {
+					heading: {
+						content: 'Overridden Heading',
+					},
+				},
+			},
+		} );
+
+		// Select the pattern block and click Reset.
+		const patternBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Pattern',
+		} );
+		await editor.selectBlocks( patternBlock );
+		await editor.showBlockToolbar();
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Reset' } )
+			.click();
+
+		// After reset, the frontend should show original content.
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		await expect(
+			page.locator( '.wp-block-heading' )
+		).toHaveText( 'Default Heading' );
+		await expect(
+			page.locator( '.wp-block-paragraph' ).first()
+		).toHaveText( 'Default description' );
+	} );
+} );

--- a/test/e2e/specs/editor/various/pattern-slug-override.spec.js
+++ b/test/e2e/specs/editor/various/pattern-slug-override.spec.js
@@ -54,9 +54,9 @@ test.describe( 'Pattern block with slug attribute', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 
-		await expect(
-			page.locator( '.wp-block-heading' )
-		).toHaveText( 'Pattern Heading' );
+		await expect( page.locator( '.wp-block-heading' ) ).toHaveText(
+			'Pattern Heading'
+		);
 		await expect(
 			page.locator( '.wp-block-paragraph' ).first()
 		).toHaveText( 'Pattern paragraph content' );
@@ -89,9 +89,9 @@ test.describe( 'Pattern block with slug attribute', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 
-		await expect(
-			page.locator( '.wp-block-heading' )
-		).toHaveText( 'Custom Heading' );
+		await expect( page.locator( '.wp-block-heading' ) ).toHaveText(
+			'Custom Heading'
+		);
 		await expect(
 			page.locator( '.wp-block-paragraph' ).first()
 		).toHaveText( 'Custom description' );
@@ -150,9 +150,9 @@ test.describe( 'Pattern block with slug attribute', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 
-		await expect(
-			page.locator( '.wp-block-heading' )
-		).toHaveText( 'Default Heading' );
+		await expect( page.locator( '.wp-block-heading' ) ).toHaveText(
+			'Default Heading'
+		);
 		await expect(
 			page.locator( '.wp-block-paragraph' ).first()
 		).toHaveText( 'Default description' );


### PR DESCRIPTION
## What?
Closes #59272

Allows `core/block` to reference registered patterns by slug, enabling pattern overrides and persistent references without storing patterns in the database.

## Why?
Currently, `core/block` only references saved patterns (wp_block posts) by numeric ID. This prevents themes/plugins from shipping patterns that support overrides, since the pattern source must be in the database. Registered patterns can only be used via `core/pattern`, which replaces itself with inline content and loses the connection. By adding slug support to `core/block`, themes can ship patterns with overrides while maintaining version control.

## How?
- Added `slug` attribute to core/block block.json
- Server-side: Resolved patterns from WP_Block_Patterns_Registry when slug is set, with same context propagation as ref-based patterns
- Client-side: Split edit component into RefPatternEdit (existing behavior) and SlugPatternEdit (read-only registered patterns with override support)
- Block label: Updated to resolve titles from either entity or pattern registry
- Tests: Added comprehensive e2e tests for slug rendering, overrides, and missing patterns

## Testing Instructions
1. Activate the `gutenberg-test-pattern-slug-override` plugin
2. Create a post and insert a block with `<!-- wp:block {"slug":"test/slug-pattern"} /-->`
3. Verify the pattern renders in editor and frontend
4. Test with overrides: `<!-- wp:block {"slug":"test/slug-pattern-with-overrides","content":{"heading":{"content":"Custom"}}} /-->`
5. Verify overrides appear on frontend
6. Run e2e tests: `npm run test:e2e -- test/e2e/specs/editor/various/pattern-slug-override.spec.js`

### Testing Instructions for Keyboard
- Tab to the pattern block, press Space to select
- Use Shift+F10 to open block menu and activate Reset button with Enter
- All functionality is keyboard accessible