### PR TITLE
Perf tests: Await all test actions in a single closure to prevent parallelism

### DIFF
--- a/backport-changelog/7.0/11181.md
+++ b/backport-changelog/7.0/11181.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/11181
-
-* https://github.com/WordPress/gutenberg/pull/76223

--- a/backport-changelog/7.0/11181.md
+++ b/backport-changelog/7.0/11181.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/11181
+
+* https://github.com/WordPress/gutenberg/pull/76223
+* https://github.com/WordPress/gutenberg/pull/76224

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -140,26 +140,13 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
  * Injects the real-time collaboration setting into a global variable.
  */
 function gutenberg_inject_real_time_collaboration_setting() {
-	global $pagenow;
-
-	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
-		return;
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+		wp_add_inline_script(
+			'wp-core-data',
+			'window._wpCollaborationEnabled = true;',
+			'after'
+		);
 	}
-
-	// Disable real-time collaboration on the site editor.
-	$enabled = true;
-	if (
-		'site-editor.php' === $pagenow ||
-		( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'site-editor-v2' === $_GET['page'] )
-	) {
-		$enabled = false;
-	}
-
-	wp_add_inline_script(
-		'wp-core-data',
-		'window._wpCollaborationEnabled = ' . ( $enabled ? 'true' : 'false' ) . ';',
-		'after'
-	);
 }
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' );

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -80,6 +80,9 @@ test.describe( 'Site Editor Performance', () => {
 			perfUtils,
 			metrics,
 		} ) => {
+			// Give each iteration enough time since they now share one timeout.
+			test.setTimeout( iterations * 120_000 );
+
 			for ( let i = 1; i <= iterations; i++ ) {
 				// Go to the test draft.
 				await admin.visitSiteEditor( {
@@ -213,6 +216,9 @@ test.describe( 'Site Editor Performance', () => {
 			page,
 			metrics,
 		} ) => {
+			// Give each iteration enough time since they now share one timeout.
+			test.setTimeout( iterations * 120_000 );
+
 			for ( let i = 1; i <= iterations; i++ ) {
 				await admin.visitSiteEditor( {
 					// The old URL is supported in both previous versions and new versions.

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -75,12 +75,12 @@ test.describe( 'Site Editor Performance', () => {
 		const samples = 10;
 		const throwaway = 1;
 		const iterations = samples + throwaway;
-		for ( let i = 1; i <= iterations; i++ ) {
-			test( `Run the test (${ i } of ${ iterations })`, async ( {
-				admin,
-				perfUtils,
-				metrics,
-			} ) => {
+		test( `Run ${ iterations } tests`, async ( {
+			admin,
+			perfUtils,
+			metrics,
+		} ) => {
+			for ( let i = 1; i <= iterations; i++ ) {
 				// Go to the test draft.
 				await admin.visitSiteEditor( {
 					postId: draftId,
@@ -116,8 +116,8 @@ test.describe( 'Site Editor Performance', () => {
 						results[ key ].push( value );
 					}
 				}
-			} );
-		}
+			}
+		} );
 	} );
 
 	test.describe( 'Typing', () => {
@@ -208,12 +208,12 @@ test.describe( 'Site Editor Performance', () => {
 		} );
 
 		const iterations = 5;
-		for ( let i = 1; i <= iterations; i++ ) {
-			test( `Run the test (${ i } of ${ iterations })`, async ( {
-				admin,
-				page,
-				metrics,
-			} ) => {
+		test( `Run ${ iterations } tests`, async ( {
+			admin,
+			page,
+			metrics,
+		} ) => {
+			for ( let i = 1; i <= iterations; i++ ) {
 				await admin.visitSiteEditor( {
 					// The old URL is supported in both previous versions and new versions.
 					path: '/wp_template',
@@ -250,8 +250,8 @@ test.describe( 'Site Editor Performance', () => {
 
 				// Save the results.
 				results.navigate.push( mouseClickEvents[ 0 ] );
-			} );
-		}
+			}
+		} );
 	} );
 
 	test.describe( 'Loading Patterns', () => {


### PR DESCRIPTION
## What?

Await all test actions in a single closure to prevent parallelism.

## Why?

Even with a single worker (the default), I observed multiple tests running at once due to how the loop is constructed. The `test` function is called immediately and it's up to the test runner (Playwright) to determine when to execute the callback. In my local testing, I observed tests running in parallel, which causes multiple collaborators to join the session, overload the test server, and subvert the intention of the test.

## How?

Move the loop so that it executes in a single `test` and `await`s each iteration.

## Testing Instructions

```
npm run wp-env-test start
npm run test:e2e -- site-editor
```
