### PR TITLE
Navigation block: Submenu block settings should be discoverable from the Submenu block itself

### DIFF
--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -57,7 +57,8 @@
 		"maxNestingLevel",
 		"openSubmenusOnClick",
 		"submenuVisibility",
-		"style"
+		"style",
+		"layout"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -7,7 +7,16 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import {
+	ToolbarButton,
+	ToolbarGroup,
+	ToggleControl,
+	Notice,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import {
@@ -22,7 +31,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
@@ -48,6 +57,7 @@ import {
 	getNavigationChildBlockProps,
 } from '../navigation/edit/utils';
 import { DEFAULT_BLOCK } from '../navigation/constants';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
@@ -84,8 +94,12 @@ export default function NavigationSubmenuEdit( {
 } ) {
 	const { label, url, description, kind, type, id } = attributes;
 
-	const { showSubmenuIcon, maxNestingLevel, submenuVisibility } = context;
+	const { showSubmenuIcon, maxNestingLevel, submenuVisibility, layout } =
+		context;
 	const blockEditingMode = useBlockEditingMode();
+
+	// Get orientation from layout context
+	const orientation = layout?.orientation || 'horizontal';
 
 	// Force click-only behavior in contentOnly mode to prevent hover dropdowns
 	const openSubmenusOnClick =
@@ -105,6 +119,35 @@ export default function NavigationSubmenuEdit( {
 
 	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
 		useDispatch( blockEditorStore );
+
+	// Get the parent navigation block's clientId
+	const parentNavigationBlockClientId = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName } = select( blockEditorStore );
+			const parentBlocks = getBlockParentsByBlockName(
+				clientId,
+				'core/navigation'
+			);
+			// Return the immediate parent navigation block
+			return parentBlocks?.[ 0 ];
+		},
+		[ clientId ]
+	);
+
+	// Function to update parent navigation block attributes
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const updateParentNavigationAttributes = useCallback(
+		( newAttributes ) => {
+			if ( parentNavigationBlockClientId ) {
+				updateBlockAttributes(
+					parentNavigationBlockClientId,
+					newAttributes
+				);
+			}
+		},
+		[ parentNavigationBlockClientId, updateBlockAttributes ]
+	);
+
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -309,6 +352,25 @@ export default function NavigationSubmenuEdit( {
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;
 
+	const submenuAccessibilityNotice =
+		! showSubmenuIcon &&
+		submenuVisibility !== 'click' &&
+		submenuVisibility !== 'always'
+			? __(
+					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
+			  )
+			: '';
+
+	const isFirstRender = useRef( true ); // Don't speak on first render.
+	useEffect( () => {
+		if ( ! isFirstRender.current && submenuAccessibilityNotice ) {
+			speak( submenuAccessibilityNotice );
+		}
+		isFirstRender.current = false;
+	}, [ submenuAccessibilityNotice ] );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	return (
 		<>
 			<BlockControls>
@@ -342,6 +404,117 @@ export default function NavigationSubmenuEdit( {
 					clientId={ clientId }
 					isLinkEditable={ ! openSubmenusOnClick }
 				/>
+			</InspectorControls>
+			<InspectorControls>
+				{ hasChildren && (
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () => {
+							updateParentNavigationAttributes( {
+								showSubmenuIcon: true,
+								submenuVisibility: 'hover',
+								overlayMenu: 'mobile',
+								hasIcon: true,
+								icon: 'handle',
+							} );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							hasValue={ () => submenuVisibility !== 'hover' }
+							label={ __( 'Submenu Visibility' ) }
+							onDeselect={ () =>
+								updateParentNavigationAttributes( {
+									submenuVisibility: 'hover',
+								} )
+							}
+							isShownByDefault
+						>
+							<ToggleGroupControl
+								__next40pxDefaultSize
+								label={ __( 'Submenu Visibility' ) }
+								value={ submenuVisibility }
+								onChange={ ( value ) => {
+									const newAttributes = {
+										submenuVisibility: value,
+									};
+									const prevSubmenuVisibility =
+										submenuVisibility;
+									// If "always" is selected, hide the arrow
+									if ( value === 'always' ) {
+										newAttributes.showSubmenuIcon = false;
+									} else if (
+										value === 'click' ||
+										prevSubmenuVisibility === 'always'
+									) {
+										// When switching to "click" or away from "always", show the arrow
+										newAttributes.showSubmenuIcon = true;
+									}
+
+									updateParentNavigationAttributes(
+										newAttributes
+									);
+								} }
+								isBlock
+							>
+								<ToggleGroupControlOption
+									value="hover"
+									label={ __( 'Hover' ) }
+								/>
+								<ToggleGroupControlOption
+									value="click"
+									label={ __( 'Click' ) }
+								/>
+								{ orientation === 'vertical' && (
+									<ToggleGroupControlOption
+										value="always"
+										label={ __( 'Always' ) }
+									/>
+								) }
+							</ToggleGroupControl>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => ! showSubmenuIcon }
+							label={ __( 'Show arrow' ) }
+							onDeselect={ () =>
+								updateParentNavigationAttributes( {
+									showSubmenuIcon: true,
+								} )
+							}
+							isDisabled={
+								submenuVisibility === 'click' ||
+								submenuVisibility === 'always'
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								checked={ showSubmenuIcon }
+								onChange={ ( value ) => {
+									updateParentNavigationAttributes( {
+										showSubmenuIcon: value,
+									} );
+								} }
+								disabled={
+									submenuVisibility === 'click' ||
+									submenuVisibility === 'always'
+								}
+								label={ __( 'Show arrow' ) }
+							/>
+						</ToolsPanelItem>
+
+						{ submenuAccessibilityNotice && (
+							<Notice
+								spokenMessage={ null }
+								status="warning"
+								isDismissible={ false }
+								className="wp-block-navigation__submenu-accessibility-notice"
+							>
+								{ submenuAccessibilityNotice }
+							</Notice>
+						) }
+					</ToolsPanel>
+				) }
 			</InspectorControls>
 			<div { ...blockProps }>
 				<ParentElement className="wp-block-navigation-item__content">

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -420,6 +420,19 @@ export default function NavigationSubmenuEdit( {
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
+						<div style={ { gridColumn: '1 / -1' } }>
+							<Notice
+								spokenMessage={ null }
+								status="info"
+								isDismissible={ false }
+								className="wp-block-navigation-submenu__global-settings-notice"
+								style={ { margin: 0 } }
+							>
+								{ __(
+									'These settings apply to all submenus within this navigation block.'
+								) }
+							</Notice>
+						</div>
 						<ToolsPanelItem
 							hasValue={ () => submenuVisibility !== 'hover' }
 							label={ __( 'Submenu Visibility' ) }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -106,7 +106,8 @@
 		"submenuVisibility": "submenuVisibility",
 		"openSubmenusOnClick": "openSubmenusOnClick",
 		"style": "style",
-		"maxNestingLevel": "maxNestingLevel"
+		"maxNestingLevel": "maxNestingLevel",
+		"layout": "layout"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -34,17 +34,7 @@ import {
 	useEntityRecords,
 } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-	ToggleControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	Spinner,
-	Notice,
-	ToolbarButton,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { Spinner, ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { page } from '@wordpress/icons';
@@ -78,7 +68,6 @@ import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
-import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import {
 	DEFAULT_BLOCK,
@@ -285,7 +274,6 @@ function Navigation( {
 		submenuVisibility,
 		overlayMenu,
 		overlay,
-		showSubmenuIcon,
 		templateLock,
 		layout: {
 			justifyContent,
@@ -378,51 +366,7 @@ function Navigation( {
 		hasUncontrolledInnerBlocks,
 		uncontrolledInnerBlocks,
 		isInnerBlockSelected,
-		innerBlocks,
 	} = useInnerBlocks( clientId );
-
-	// Use a ref to store whether we've confirmed a page-list has submenus.
-	// Once confirmed, we don't need to keep checking the page-list blocks.
-	const hasPageListWithSubmenuRef = useRef( false );
-
-	// Check for submenus using getBlocks to include controlled innerBlocks
-	const hasSubmenus = useSelect(
-		( select ) => {
-			// First check for navigation-submenu (fast, no selector needed)
-			const hasNavigationSubmenu = innerBlocks.some(
-				( block ) => block.name === 'core/navigation-submenu'
-			);
-			if ( hasNavigationSubmenu ) {
-				return true;
-			}
-
-			// Only check page-list if we didn't find a submenu already
-			const pageList = innerBlocks.find(
-				( block ) => block.name === 'core/page-list'
-			);
-			if ( ! pageList ) {
-				hasPageListWithSubmenuRef.current = false;
-				return false;
-			}
-
-			// If we've already confirmed page-list has submenus, return early
-			if ( hasPageListWithSubmenuRef.current ) {
-				return true;
-			}
-
-			// Check if the page-list has controlled innerBlocks
-			const { getBlocks } = select( blockEditorStore );
-			const pageListBlocks = getBlocks( pageList.clientId );
-			if ( pageListBlocks.length > 0 ) {
-				hasPageListWithSubmenuRef.current = true;
-				return true;
-			}
-
-			// No pageList returned with confirmed submenus, so assume it will not have submenus
-			return false;
-		},
-		[ innerBlocks ]
-	);
 
 	// Check if any overlay template parts exist
 	const { records: overlayTemplateParts } = useEntityRecords(
@@ -760,151 +704,13 @@ function Navigation( {
 		{ open: overlayMenuPreview }
 	);
 
-	const submenuAccessibilityNotice =
-		! showSubmenuIcon &&
-		submenuVisibility !== 'click' &&
-		submenuVisibility !== 'always'
-			? __(
-					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
-			  )
-			: '';
-
-	const isFirstRender = useRef( true ); // Don't speak on first render.
-	useEffect( () => {
-		if ( ! isFirstRender.current && submenuAccessibilityNotice ) {
-			speak( submenuAccessibilityNotice );
-		}
-		isFirstRender.current = false;
-	}, [ submenuAccessibilityNotice ] );
-
 	const overlayMenuPreviewId = useInstanceId(
 		OverlayMenuPreview,
 		`overlay-menu-preview`
 	);
 
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
 	const stylingInspectorControls = (
 		<>
-			<InspectorControls>
-				{ hasSubmenus && (
-					<ToolsPanel
-						label={ __( 'Display' ) }
-						resetAll={ () => {
-							setAttributes( {
-								showSubmenuIcon: true,
-								submenuVisibility: 'hover',
-								overlayMenu: 'mobile',
-								hasIcon: true,
-								icon: 'handle',
-							} );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						{ hasSubmenus && (
-							<>
-								<h3 className="wp-block-navigation__submenu-header">
-									{ __( 'Submenus' ) }
-								</h3>
-								<ToolsPanelItem
-									hasValue={ () =>
-										submenuVisibility !== 'hover'
-									}
-									label={ __( 'Submenu Visibility' ) }
-									onDeselect={ () =>
-										setAttributes( {
-											submenuVisibility: 'hover',
-										} )
-									}
-									isShownByDefault
-								>
-									<ToggleGroupControl
-										__next40pxDefaultSize
-										label={ __( 'Submenu Visibility' ) }
-										value={ submenuVisibility }
-										onChange={ ( value ) => {
-											const newAttributes = {
-												submenuVisibility: value,
-											};
-											const prevSubmenuVisibility =
-												submenuVisibility;
-											// If "always" is selected, hide the arrow because the formatting is broken for it when using center alignment.
-											if ( value === 'always' ) {
-												newAttributes.showSubmenuIcon = false;
-											} else if (
-												value === 'click' ||
-												prevSubmenuVisibility ===
-													'always'
-											) {
-												// When switching to "click" or away from "always", show the arrow
-												newAttributes.showSubmenuIcon = true;
-											}
-
-											setAttributes( newAttributes );
-										} }
-										isBlock
-									>
-										<ToggleGroupControlOption
-											value="hover"
-											label={ __( 'Hover' ) }
-										/>
-										<ToggleGroupControlOption
-											value="click"
-											label={ __( 'Click' ) }
-										/>
-										{ orientation === 'vertical' && (
-											<ToggleGroupControlOption
-												value="always"
-												label={ __( 'Always' ) }
-											/>
-										) }
-									</ToggleGroupControl>
-								</ToolsPanelItem>
-
-								<ToolsPanelItem
-									hasValue={ () => ! showSubmenuIcon }
-									label={ __( 'Show arrow' ) }
-									onDeselect={ () =>
-										setAttributes( {
-											showSubmenuIcon: true,
-										} )
-									}
-									isDisabled={
-										submenuVisibility === 'click' ||
-										submenuVisibility === 'always'
-									}
-									isShownByDefault
-								>
-									<ToggleControl
-										checked={ showSubmenuIcon }
-										onChange={ ( value ) => {
-											setAttributes( {
-												showSubmenuIcon: value,
-											} );
-										} }
-										disabled={
-											submenuVisibility === 'click' ||
-											submenuVisibility === 'always'
-										}
-										label={ __( 'Show arrow' ) }
-									/>
-								</ToolsPanelItem>
-
-								{ submenuAccessibilityNotice && (
-									<Notice
-										spokenMessage={ null }
-										status="warning"
-										isDismissible={ false }
-										className="wp-block-navigation__submenu-accessibility-notice"
-									>
-										{ submenuAccessibilityNotice }
-									</Notice>
-								) }
-							</>
-						) }
-					</ToolsPanel>
-				) }
-			</InspectorControls>
 			{ ! isWithinOverlay && (
 				<InspectorControls>
 					<OverlayPanel


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/75977

## Why?
The settings for the Submenu block should be visible in the Submenu block only and not Navigation block.

## How?
Moved the Submenu block settings from Navigation block to the Submenu block.

## Testing Instructions

- Open a page.
- Add a Navigation block.
- Create Submenu inside of it.
- Check the Submenu block settings now, `Submenu Visibility` and `Show Arrow` settings is now visible.
- Check the Navigation block settings, Submenu related setting has been removed from there.

## Screenshots or screencast <!-- if applicable -->
<img width="282" height="510" alt="Screenshot at Mar 06 08-51-28" src="https://github.com/user-attachments/assets/2c4f9e2e-05f8-4f1d-954a-9da1bc5dda19" />