### PR TITLE
WIP: Disable client-side media processing for non-Chromium browsers

### DIFF
--- a/lib/compat/wordpress-7.0/media.php
+++ b/lib/compat/wordpress-7.0/media.php
@@ -25,3 +25,48 @@ function gutenberg_is_client_side_media_processing_enabled() {
 	 */
 	return apply_filters( 'wp_client_side_media_processing_enabled', true );
 }
+
+/**
+ * Returns the major Chromium version from the current request's User-Agent.
+ *
+ * Matches all Chromium-based browsers (Chrome, Edge, Opera, Brave).
+ *
+ * @return int|null The major Chromium version, or null if not a Chromium browser.
+ */
+function gutenberg_get_chromium_major_version(): ?int {
+	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		return null;
+	}
+	if ( preg_match( '/Chrome\/(\d+)/', $_SERVER['HTTP_USER_AGENT'], $matches ) ) {
+		return (int) $matches[1];
+	}
+	return null;
+}
+
+/**
+ * Disables client-side media processing for non-Chromium browsers.
+ *
+ * Safari and Firefox lack support for Document-Isolation-Policy,
+ * which is required for cross-origin isolation (SharedArrayBuffer).
+ *
+ * @param bool $enabled Whether client-side media processing is enabled.
+ * @return bool Filtered value.
+ */
+function gutenberg_disable_media_processing_for_non_chromium( $enabled ) {
+	if ( ! $enabled ) {
+		return $enabled;
+	}
+
+	// Don't gate non-HTTP contexts (CLI, cron) — no browser to check.
+	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		return $enabled;
+	}
+
+	// Only enable for Chromium-based browsers.
+	if ( null === gutenberg_get_chromium_major_version() ) {
+		return false;
+	}
+
+	return $enabled;
+}
+add_filter( 'wp_client_side_media_processing_enabled', 'gutenberg_disable_media_processing_for_non_chromium' );

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -220,23 +220,6 @@ function gutenberg_filter_mod_rewrite_rules( string $rules ): string {
 add_filter( 'mod_rewrite_rules', 'gutenberg_filter_mod_rewrite_rules' );
 
 /**
- * Returns the major Chromium version from the current request's User-Agent.
- *
- * Matches all Chromium-based browsers (Chrome, Edge, Opera, Brave).
- *
- * @return int|null The major Chromium version, or null if not a Chromium browser.
- */
-function gutenberg_get_chromium_major_version(): ?int {
-	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-		return null;
-	}
-	if ( preg_match( '/Chrome\/(\d+)/', $_SERVER['HTTP_USER_AGENT'], $matches ) ) {
-		return (int) $matches[1];
-	}
-	return null;
-}
-
-/**
  * Enables cross-origin isolation in the block editor.
  *
  * Required for enabling SharedArrayBuffer for WebAssembly-based

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -284,7 +284,7 @@ function SandBox( {
 			title={ title }
 			tabIndex={ tabIndex }
 			className="components-sandbox"
-			sandbox="allow-scripts allow-same-origin"
+			sandbox="allow-scripts allow-same-origin allow-presentation"
 			onFocus={ onFocus }
 			width={ Math.ceil( width ) }
 			height={ Math.ceil( height ) }

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -284,7 +284,7 @@ function SandBox( {
 			title={ title }
 			tabIndex={ tabIndex }
 			className="components-sandbox"
-			sandbox="allow-scripts allow-same-origin allow-presentation"
+			sandbox="allow-scripts allow-same-origin"
 			onFocus={ onFocus }
 			width={ Math.ceil( width ) }
 			height={ Math.ceil( height ) }

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -207,7 +207,64 @@ HTML;
 	 * @covers ::gutenberg_is_client_side_media_processing_enabled
 	 */
 	public function test_client_side_media_processing_enabled_by_default_in_plugin() {
+		// No UA set in CLI context, so the browser gate does not apply.
 		$this->assertTrue( gutenberg_is_client_side_media_processing_enabled() );
+	}
+
+	/**
+	 * Tests that client-side media processing is disabled for Firefox.
+	 *
+	 * @covers ::gutenberg_disable_media_processing_for_non_chromium
+	 */
+	public function test_disabled_for_firefox() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0';
+		$this->assertFalse( gutenberg_is_client_side_media_processing_enabled() );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Tests that client-side media processing is disabled for Safari.
+	 *
+	 * @covers ::gutenberg_disable_media_processing_for_non_chromium
+	 */
+	public function test_disabled_for_safari() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+		$this->assertFalse( gutenberg_is_client_side_media_processing_enabled() );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Tests that client-side media processing is enabled for Chrome.
+	 *
+	 * @covers ::gutenberg_disable_media_processing_for_non_chromium
+	 */
+	public function test_enabled_for_chrome() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+		$this->assertTrue( gutenberg_is_client_side_media_processing_enabled() );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Tests that client-side media processing is enabled with no User-Agent (CLI/cron).
+	 *
+	 * @covers ::gutenberg_disable_media_processing_for_non_chromium
+	 */
+	public function test_enabled_with_no_user_agent() {
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+		$this->assertTrue( gutenberg_is_client_side_media_processing_enabled() );
+	}
+
+	/**
+	 * Tests that the browser gate respects a prior __return_false filter.
+	 *
+	 * @covers ::gutenberg_disable_media_processing_for_non_chromium
+	 */
+	public function test_respects_prior_return_false_filter() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+		add_filter( 'wp_client_side_media_processing_enabled', '__return_false', 5 );
+		$this->assertFalse( gutenberg_is_client_side_media_processing_enabled() );
+		remove_filter( 'wp_client_side_media_processing_enabled', '__return_false', 5 );
+		unset( $_SERVER['HTTP_USER_AGENT'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds a PHP-level browser gate that disables client-side media processing for non-Chromium browsers (Safari, Firefox) via the `wp_client_side_media_processing_enabled` filter
- Moves `gutenberg_get_chromium_major_version()` from `lib/media/load.php` to `lib/compat/wordpress-7.0/media.php` so it loads before the early-return gate
- CLI/cron contexts (no User-Agent) are left ungated so server-side operations are unaffected

Safari and Firefox lack support for Document-Isolation-Policy, which is required for cross-origin isolation (SharedArrayBuffer). While the JS feature detection already catches this, this adds an explicit PHP-level disable so non-Chromium browsers never receive the JS flag, REST extensions, DIP headers, or MutationObserver setup.

## Test plan

- [ ] Run PHP tests: `npm run test:unit:php -- phpunit/media/media-processing-test.php`
- [ ] Verify in Chrome: `window.__clientSideMediaProcessing` is `true`, DIP header present
- [ ] Verify in Safari/Firefox: `window.__clientSideMediaProcessing` is `undefined`, no DIP header
- [ ] Verify CLI commands (e.g. `wp media regenerate`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)