### PR TITLE
[WIP] Experimental caching in RTC for fixing site editor perf tests

### DIFF
--- a/backport-changelog/7.0/11181.md
+++ b/backport-changelog/7.0/11181.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11181
 
 * https://github.com/WordPress/gutenberg/pull/76223
+* https://github.com/WordPress/gutenberg/pull/76224

--- a/lib/compat/wordpress-7.0/class-wp-sync-post-meta-storage.php
+++ b/lib/compat/wordpress-7.0/class-wp-sync-post-meta-storage.php
@@ -67,6 +67,15 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 		private static array $storage_post_ids = array();
 
 		/**
+		 * Cache of all updates by room, scoped to the current request.
+		 * Invalidated on writes to avoid stale reads.
+		 *
+		 * @since 7.0.0
+		 * @var array<string, array<int, array{ timestamp: int, value: mixed }>>
+		 */
+		private array $room_updates_cache = array();
+
+		/**
 		 * Adds a sync update to a given room.
 		 *
 		 * @since 7.0.0
@@ -87,7 +96,9 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 				'value'     => $update,
 			);
 
-			return (bool) add_post_meta( $post_id, self::SYNC_UPDATE_META_KEY, $envelope, false );
+			$result = (bool) add_post_meta( $post_id, self::SYNC_UPDATE_META_KEY, $envelope, false );
+			unset( $this->room_updates_cache[ $room ] );
+			return $result;
 		}
 
 		/**
@@ -99,6 +110,10 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 		 * @return array<int, array{ timestamp: int, value: mixed }> Sync updates.
 		 */
 		private function get_all_updates( string $room ): array {
+			if ( isset( $this->room_updates_cache[ $room ] ) ) {
+				return $this->room_updates_cache[ $room ];
+			}
+
 			$this->room_cursors[ $room ] = $this->get_time_marker() - 100; // Small buffer to ensure consistency.
 
 			$post_id = $this->get_storage_post_id( $room );
@@ -121,6 +136,7 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 			);
 
 			$this->room_update_counts[ $room ] = count( $updates );
+			$this->room_updates_cache[ $room ] = $updates;
 
 			return $updates;
 		}
@@ -325,6 +341,7 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 				}
 			}
 
+			unset( $this->room_updates_cache[ $room ] );
 			return $add_result;
 		}
 	}

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -140,15 +140,13 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
  * Injects the real-time collaboration setting into a global variable.
  */
 function gutenberg_inject_real_time_collaboration_setting() {
-	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
-		return;
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+		wp_add_inline_script(
+			'wp-core-data',
+			'window._wpCollaborationEnabled = true;',
+			'after'
+		);
 	}
-
-	wp_add_inline_script(
-		'wp-core-data',
-		'window._wpCollaborationEnabled = true;',
-		'after'
-	);
 }
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' );

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -140,24 +140,13 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
  * Injects the real-time collaboration setting into a global variable.
  */
 function gutenberg_inject_real_time_collaboration_setting() {
-	global $pagenow;
-
 	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
 		return;
 	}
 
-	// Disable real-time collaboration on the site editor.
-	$enabled = true;
-	if (
-		'site-editor.php' === $pagenow ||
-		( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'site-editor-v2' === $_GET['page'] )
-	) {
-		$enabled = false;
-	}
-
 	wp_add_inline_script(
 		'wp-core-data',
-		'window._wpCollaborationEnabled = ' . ( $enabled ? 'true' : 'false' ) . ';',
+		'window._wpCollaborationEnabled = true;',
 		'after'
 	);
 }

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -75,12 +75,12 @@ test.describe( 'Site Editor Performance', () => {
 		const samples = 10;
 		const throwaway = 1;
 		const iterations = samples + throwaway;
-		for ( let i = 1; i <= iterations; i++ ) {
-			test( `Run the test (${ i } of ${ iterations })`, async ( {
-				admin,
-				perfUtils,
-				metrics,
-			} ) => {
+		test( `Run ${ iterations } tests`, async ( {
+			admin,
+			perfUtils,
+			metrics,
+		} ) => {
+			for ( let i = 1; i <= iterations; i++ ) {
 				// Go to the test draft.
 				await admin.visitSiteEditor( {
 					postId: draftId,
@@ -116,8 +116,8 @@ test.describe( 'Site Editor Performance', () => {
 						results[ key ].push( value );
 					}
 				}
-			} );
-		}
+			}
+		} );
 	} );
 
 	test.describe( 'Typing', () => {
@@ -208,12 +208,12 @@ test.describe( 'Site Editor Performance', () => {
 		} );
 
 		const iterations = 5;
-		for ( let i = 1; i <= iterations; i++ ) {
-			test( `Run the test (${ i } of ${ iterations })`, async ( {
-				admin,
-				page,
-				metrics,
-			} ) => {
+		test( `Run ${ iterations } tests`, async ( {
+			admin,
+			page,
+			metrics,
+		} ) => {
+			for ( let i = 1; i <= iterations; i++ ) {
 				await admin.visitSiteEditor( {
 					// The old URL is supported in both previous versions and new versions.
 					path: '/wp_template',
@@ -250,8 +250,8 @@ test.describe( 'Site Editor Performance', () => {
 
 				// Save the results.
 				results.navigate.push( mouseClickEvents[ 0 ] );
-			} );
-		}
+			}
+		} );
 	} );
 
 	test.describe( 'Loading Patterns', () => {


### PR DESCRIPTION
## What?

Experiment with caching to fix the site editor editor performance tests when RTC is enabled. It was disabled in a previous PR just for the site editor.

## Why?

Adding some experimental caching to see if the performance tests will pass for the site editor

## How?

The site editor perf tests currently fail when RTC is enabled as there is a timeout happening. There are 500s being thrown from the sync endpoint due to OOM errors. The caching is a way to see if this'll stop happening.

Builds on https://github.com/WordPress/gutenberg/pull/76224.