### PR TITLE
Revert "`Button`: Add `word-break: break-word`"

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Revert `word-break: break-word` addition ([#76230](https://github.com/WordPress/gutenberg/pull/76230)).
+
 ## 32.3.0 (2026-03-04)
 
 ### Code Quality

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -13,7 +13,6 @@
 .components-button {
 	display: inline-flex;
 	text-decoration: none;
-	word-break: break-word;
 	font-family: inherit;
 	font-size: $default-font-size;
 	font-weight: $font-weight-medium;

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -226,6 +226,7 @@ function PostParentToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
+			className="editor-post-parent__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			aria-label={

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -90,6 +90,7 @@ function PostURLToggle( { isOpen, onClick } ) {
 	return (
 		<Button
 			size="compact"
+			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
 			aria-label={

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -47,6 +47,11 @@
 	padding-inline-start: 0 !important;
 }
 
+.editor-post-url__panel-toggle,
+.editor-post-parent__panel-toggle {
+	word-break: break-word;
+}
+
 .editor-post-url__intro {
 	margin: 0;
 }

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -36,7 +36,7 @@ test.describe( 'Test Custom Post Types', () => {
 			} )
 			.click();
 
-		await page.getByRole( 'button', { name: /^Change parent:/ } ).click();
+		await page.locator( '.editor-post-parent__panel-toggle' ).click();
 
 		const parentPageLocator = page.getByRole( 'combobox', {
 			name: 'Parent',
@@ -53,7 +53,7 @@ test.describe( 'Test Custom Post Types', () => {
 		await editor.publishPost();
 		await page.reload();
 
-		await page.getByRole( 'button', { name: /^Change parent:/ } ).click();
+		await page.locator( '.editor-post-parent__panel-toggle' ).click();
 
 		// Confirm parent page selection matches after reloading.
 		await expect( parentPageLocator ).toHaveValue( parentPage );


### PR DESCRIPTION
Reverts WordPress/gutenberg#76071

I preserved this [removal](https://github.com/WordPress/gutenberg/pull/76071/changes#diff-09b6ad671a1ef1866895fcc984689f90884517ede6334c56e45f9ee02ecb5398L33) because it wan't used anywhere.