### PR TITLE
Connectors: Improve responsive layout for small viewports

### DIFF
--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -25,14 +25,22 @@
 	}
 
 	@media (max-width: 480px) {
-		padding: 16px;
+		padding: 8px;
 
 		.components-item {
-			padding: 16px;
+			padding: 12px;
 
-			> .components-v-stack > .components-h-stack:first-child svg {
-				width: 32px;
-				height: 32px;
+			> .components-v-stack > .components-h-stack:first-child {
+				svg {
+					width: 32px;
+					height: 32px;
+				}
+
+				// Stack badge and action button vertically on small screens.
+				> .components-h-stack:last-child {
+					flex-direction: column;
+					align-items: flex-end;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What?

Improves the connectors page responsive layout at the `480px` breakpoint per feedback in https://github.com/WordPress/gutenberg/pull/76186#issuecomment-4006807218.

## Why?

The current responsive styles don't go far enough for narrow viewports — cards still have too much padding and the badge/action button overflow horizontally.

## How?

Adjusts the `@media (max-width: 480px)` styles in `routes/connectors-home/style.scss`:

- **Outer padding**: 16px → 8px (tighter margins around the card list)
- **Inner card padding**: 16px → 12px (more room for content)
- **Badge + action button**: stack vertically via `flex-direction: column` on the action area HStack
- **Icon size**: 40px → 32px (already present, restructured selector)

<img width="298" height="495" alt="Screenshot 2026-03-06 at 08 41 24" src="https://github.com/user-attachments/assets/55ca21a5-581a-4036-a924-1fb1597e953c" />
<img width="292" height="497" alt="Screenshot 2026-03-06 at 08 41 37" src="https://github.com/user-attachments/assets/c1ea47c5-645a-4cfc-a91a-c776f09006b7" />


## Testing Instructions

1. Navigate to `/wp-admin/options-connectors.php`
2. Resize the browser to ≤480px width
3. Verify cards have reduced padding, icons are smaller, and the badge/button stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)