### PR TITLE
iAPI Docs: Add client-side navigation compatibility guide

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -534,12 +534,6 @@
 		"parent": "core-concepts"
 	},
 	{
-		"title": "Client-Side Navigation",
-		"slug": "client-side-navigation",
-		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md",
-		"parent": "core-concepts"
-	},
-	{
 		"title": "Using TypeScript",
 		"slug": "using-typescript",
 		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/using-typescript.md",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -546,6 +546,18 @@
 		"parent": "core-concepts"
 	},
 	{
+		"title": "Client-Side Navigation",
+		"slug": "client-side-navigation",
+		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md",
+		"parent": "core-concepts"
+	},
+	{
+		"title": "Client-Side Navigation Compatibility",
+		"slug": "client-side-navigation-compatibility",
+		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md",
+		"parent": "core-concepts"
+	},
+	{
 		"title": "Quick start guide",
 		"slug": "iapi-quick-start-guide",
 		"markdown_source": "../docs/reference-guides/interactivity-api/iapi-quick-start-guide.md",

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -771,8 +771,7 @@ supports: {
 
 Indicates if the block is using Interactivity API features.
 
-The `clientNavigation` sub-property indicates whether a block is compatible with the Interactivity API client-side navigation.
-Set it to true only if the block is not interactive or if it is interactive using the Interactivity API. Set it to false if the block is interactive but uses vanilla JS, jQuery or another JS framework/library other than the Interactivity API.
+The `clientNavigation` sub-property indicates whether a block is compatible with the Interactivity API client-side navigation. See the [Client-Side Navigation Compatibility](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md) guide for details.
 
 The `interactive` sub-property indicates whether the block is using the Interactivity API directives.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/README.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/README.md
@@ -11,3 +11,5 @@ This section provides some guides on important concepts and mental models relate
 4. **[Using TypeScript](/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md):** This guide will walk you through the process of using TypeScript with Interactivity API stores, covering everything from basic type definitions to advanced techniques for handling complex store structures.
 
 5. **[Client-Side Navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md):** This guide explains how to use the `@wordpress/interactivity-router` package to implement client-side navigation, enabling faster page transitions by updating only the parts of the page that change.
+
+6. **[Client-Side Navigation Compatibility](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md):** This guide explains how to declare that a block is compatible with client-side navigation and what to consider when evaluating compatibility.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -202,11 +202,9 @@ Block hydration and initialization code should not depend on DOM ready events su
 For code that needs to run on every navigation — such as analytics page-view tracking — use `data-wp-watch` with a reactive value that changes on each navigation, like the current URL from the global state:
 
 ```js
-import { store, getConfig } from '@wordpress/interactivity';
+import { store } from '@wordpress/interactivity';
 
-const { namespace } = getConfig();
-
-store( namespace, {
+store( 'myPlugin', {
 	callbacks: {
 		logPageView() {
 			// Re-runs on every navigation because state.url changes.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -1,6 +1,6 @@
 # Client-Side Navigation Compatibility
 
-Client-side navigation (CSN) enables page transitions without a full page reload by updating only the parts of the page that change. For this to work correctly, **every block on the page must be compatible with client-side navigation**. If a single block on the page is not compatible, the Interactivity API will fall back to a full page reload for that navigation, losing all the performance and UX benefits.
+Client-side navigation (CSN) enables page transitions without a full page reload by updating only the parts of the page that change. For this to work correctly, **every block on the page must be compatible with client-side navigation**. If any block is incompatible, it may break silently after a navigation — losing state, failing to initialize, or rendering incorrectly. Some core blocks like `core/query` detect incompatible descendants and automatically fall back to a full page reload, but this safety net does not apply to custom implementations. In general, a single incompatible block on the page can compromise the entire navigation experience.
 
 This guide explains what to consider when evaluating compatibility. While the examples focus on blocks, the same principles apply to any code that outputs markup on the front end — including classic PHP themes and plugins.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -289,7 +289,7 @@ Interactive blocks should avoid injecting new HTML elements into the DOM outside
 
 The Interactivity API's client-side navigation only manages content inside [router regions](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#setting-up-router-regions). Any HTML created outside these regions won't be tracked, cleaned up, or updated during navigation.
 
-If a block needs to render content outside its main region — for example, an overlay that must be a direct child of `<body>` — use the router's `attachTo` property to define a region that can be dynamically created during navigation. This is explained in the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#attaching-new-router-regions).
+If a block needs to render content outside its main region — for example, an overlay that must be a direct child of `<body>` — use the router's `attachTo` property to define a region that can be dynamically created during navigation. This is explained in the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#adding-new-regions-on-navigation).
 
 ## Verifying compatibility
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -162,8 +162,7 @@ For cases where you need to update the inner HTML of an element or make other im
 <div
 	data-wp-interactive="myPlugin"
 	data-wp-watch="callbacks.updateContent"
->
-</div>
+></div>
 ```
 
 ```js
@@ -204,12 +203,12 @@ Before marking your block as compatible with client-side navigation, verify the 
 
 ## Quick reference
 
-| Block type | Compatible? | Action |
-|---|---|---|
-| Non-interactive block (no JS) | Yes | Set `clientNavigation` to `true` |
-| Interactive block using the Interactivity API | Yes (if guidelines are followed) | Set `interactivity` to `true` |
-| Interactive block using other libraries | No | Omit or set `clientNavigation` to `false` |
-| Block injecting or modifying CSS at runtime | No | Use server-rendered styles or `data-wp-class` |
-| Block using `wp_unique_id()` for CSS selectors | No | Use `wp_unique_id_from_values()` |
-| Block mutating the DOM outside the Interactivity API | No | Use directives or `data-wp-watch` |
-| Block using regular scripts (not script modules) | No | Migrate to script modules |
+| Block type                                           | Compatible?                      | Action                                        |
+| ---------------------------------------------------- | -------------------------------- | --------------------------------------------- |
+| Non-interactive block (no JS)                        | Yes                              | Set `clientNavigation` to `true`              |
+| Interactive block using the Interactivity API        | Yes (if guidelines are followed) | Set `interactivity` to `true`                 |
+| Interactive block using other libraries              | No                               | Omit or set `clientNavigation` to `false`     |
+| Block injecting or modifying CSS at runtime          | No                               | Use server-rendered styles or `data-wp-class` |
+| Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`              |
+| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
+| Block using regular scripts (not script modules)     | No                               | Migrate to script modules                     |

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -101,7 +101,7 @@ The same applies for interactive regions included in classic PHP themes or plugi
 
 ## Ensuring compatibility
 
-Any code that outputs front-end markup — whether it uses the Interactivity API, server-side rendering only, or a combination — needs to follow certain guidelines to work correctly with client-side navigation. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
+Interactive blocks and regions that use the Interactivity API need to follow certain guidelines to work correctly with client-side navigation. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
 
 ### CSS
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -2,7 +2,7 @@
 
 Client-side navigation (CSN) enables page transitions without a full page reload by updating only the parts of the page that change. For this to work correctly, **every block on the page must be compatible with client-side navigation**. If a single block on the page is not compatible, the Interactivity API will fall back to a full page reload for that navigation, losing all the performance and UX benefits.
 
-This guide explains how to declare that your block is compatible with CSN and what to consider when evaluating compatibility.
+This guide explains what to consider when evaluating compatibility. While the examples focus on blocks, the same principles apply to any code that outputs markup on the front end — including classic PHP themes and plugins.
 
 ## Declaring compatibility in `block.json`
 
@@ -51,9 +51,9 @@ Even if a block appears to work fine with CSN, the compatibility must always be 
 
 ## What makes a block compatible
 
-### Static blocks
+### Non-interactive blocks
 
-Static blocks — those that render HTML without any client-side interactivity — are generally compatible with CSN. Since they don't rely on JavaScript to function, client-side navigation can safely replace their HTML without breaking anything.
+Blocks that render HTML without any client-side interactivity — no JavaScript, no event listeners, no dynamic behavior — are generally compatible with CSN. Since they don't rely on scripts to function, client-side navigation can safely replace their HTML without breaking anything.
 
 However, compatibility must still be declared explicitly in `block.json`. The Interactivity API cannot infer compatibility on its own.
 
@@ -61,17 +61,17 @@ However, compatibility must still be declared explicitly in `block.json`. The In
 
 Blocks that use the Interactivity API for their client-side behavior are designed to work with CSN. The Interactivity API manages DOM updates through a virtual DOM diffing algorithm, ensuring that interactive state is preserved across navigations.
 
-That said, interactive blocks must follow certain practices to remain compatible. See [Ensuring compatibility for interactive blocks](#ensuring-compatibility-for-interactive-blocks) below.
+That said, interactive blocks must follow certain practices to remain compatible. See [Ensuring compatibility](#ensuring-compatibility) for details.
 
-### Blocks using vanilla JS, jQuery, or other frameworks
+### Interactive blocks using other libraries
 
 Blocks that use vanilla JavaScript, jQuery, or any framework other than the Interactivity API for client-side behavior are **not compatible** with CSN. Set `clientNavigation` to `false` (or omit it) for these blocks.
 
 These blocks typically rely on scripts that run once on page load to initialize behavior — attaching event listeners, manipulating the DOM, or setting up widgets. During client-side navigation, the HTML may be replaced, but those initialization scripts won't run again, leaving the block non-functional.
 
-## Ensuring compatibility for interactive blocks
+## Ensuring compatibility
 
-Even blocks built with the Interactivity API need to follow certain guidelines to work correctly with CSN. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
+Even code built with the Interactivity API needs to follow certain guidelines to work correctly with CSN. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
 
 ### CSS
 
@@ -91,6 +91,10 @@ Instead, use server-side logic to produce the correct stylesheets, or toggle CSS
 
 CSS selectors (class names, IDs, etc.) must be **stable across navigations**. If a selector changes between page loads, styles may break or apply to the wrong elements after a client-side navigation.
 
+This is especially important for elements **outside router regions**. Since those elements are not replaced during navigation, the incoming page's stylesheets must continue to match them. If both pages share the same template this is usually the case, but mismatches can occur when different templates produce different wrapper elements or class names for the same structural areas.
+
+CSS selectors applied to elements **inside router regions** must also be stable. Since regions are replaced during navigation, the incoming HTML must use the same selectors so that existing stylesheets continue to apply correctly.
+
 A common source of unstable selectors is [`wp_unique_id()`](https://developer.wordpress.org/reference/functions/wp_unique_id/). This function generates sequential IDs (`id-1`, `id-2`, etc.) based on a global counter that resets on each page load. When navigating between two pages, the same block may receive a different ID on each page, causing the CSS selector to no longer match the element.
 
 Instead, use [`wp_unique_id_from_values()`](https://developer.wordpress.org/reference/functions/wp_unique_id_from_values/) (available since WordPress 6.8). This function generates a deterministic hash-based identifier from an array of values, producing the same ID for the same inputs regardless of rendering order:
@@ -108,12 +112,6 @@ $id = wp_unique_id_from_values(
 
 This applies to any selector used in CSS — class names, IDs, or `data-*` attributes used in stylesheets.
 
-#### CSS selectors must match across navigations
-
-When using client-side navigation to navigate between two pages, the HTML elements and their CSS selectors **outside router regions** must match. This is usually the case when both pages share the same template, but mismatches can occur when different templates produce different wrapper elements or class names for the same structural areas.
-
-CSS selectors applied to elements **inside router regions** must also be stable across navigations. Since router regions are the parts of the page that get replaced during navigation, the incoming HTML must use the same selectors so that existing stylesheets continue to apply correctly. If the selectors change — for example, because of dynamically generated class names — styles may break after navigation.
-
 ### JavaScript
 
 #### Use script modules, not regular scripts
@@ -122,7 +120,9 @@ Client-side navigation only supports [script modules](https://make.wordpress.org
 
 Additionally, only **external** script modules (those with a `src` attribute) are processed during client-side navigation. Inline script modules — where the code is written directly inside the `<script>` tag — are not re-executed during navigation.
 
-Script modules that should be loaded during client-side navigation must be registered with the appropriate dependency declaration so that WordPress includes the `loadOnClientNavigation` flag. This happens automatically when a block declares its script module in `block.json` and sets `supports.interactivity.clientNavigation` to `true`.
+Script modules that should be loaded during client-side navigation must be registered with the appropriate dependency declaration so that WordPress includes the `loadOnClientNavigation` flag. For blocks, this happens automatically when the script module is declared in `block.json` and `supports.interactivity.clientNavigation` is set to `true`.
+
+For script modules that don't belong to a block — for example, those enqueued by a classic PHP theme or a plugin — you need to mark them manually by passing `loadOnClientNavigation: true` when registering the module with [`wp_register_script_module()`](https://developer.wordpress.org/reference/functions/wp_register_script_module/).
 
 For more details on how script modules are handled during navigation, see the [Script module handling](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#script-module-handling) section of the Client-Side Navigation guide.
 
@@ -130,7 +130,7 @@ For more details on how script modules are handled during navigation, see the [S
 
 #### Keep consistent HTML structures
 
-The Interactivity API uses Preact under the hood for virtual DOM diffing. When navigating between pages, Preact compares the current and incoming HTML to calculate the minimum set of DOM changes. Inconsistencies between the two can cause elements to be remounted instead of updated, which may result in lost state.
+The Interactivity API uses Preact under the hood for virtual DOM diffing. When navigating between pages, Preact compares the current and incoming HTML to calculate the minimum set of DOM changes. Inconsistencies between the two can cause elements to be remounted instead of updated — which may result in lost state — or cause different elements to be treated as the same node, breaking internal state or preventing lifecycle callbacks (like `data-wp-init` or `data-wp-watch`) from re-executing when they should.
 
 Common issues include:
 
@@ -206,9 +206,9 @@ Before marking your block as compatible with client-side navigation, verify the 
 
 | Block type | Compatible? | Action |
 |---|---|---|
-| Static block (no JS) | Yes | Set `clientNavigation` to `true` |
+| Non-interactive block (no JS) | Yes | Set `clientNavigation` to `true` |
 | Interactive block using the Interactivity API | Yes (if guidelines are followed) | Set `interactivity` to `true` |
-| Block using vanilla JS, jQuery, or other frameworks | No | Omit or set `clientNavigation` to `false` |
+| Interactive block using other libraries | No | Omit or set `clientNavigation` to `false` |
 | Block injecting or modifying CSS at runtime | No | Use server-rendered styles or `data-wp-class` |
 | Block using `wp_unique_id()` for CSS selectors | No | Use `wp_unique_id_from_values()` |
 | Block mutating the DOM outside the Interactivity API | No | Use directives or `data-wp-watch` |

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -150,7 +150,7 @@ The `data-wp-key` directive works like the `key` prop in React or Preact — it 
 </ul>
 ```
 
-Use a value that uniquely identifies each element across navigations, such as a post ID or slug — not an array index, which would change if items are reordered.
+Use a value that uniquely identifies each element across navigations, such as a post ID or slug — not an array index, which would change if items are reordered. Common places where `data-wp-key` is needed include pagination controls, image galleries, and any query-driven list where items can change between pages.
 
 #### Do not mutate the DOM outside the Interactivity API
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -1,0 +1,215 @@
+# Client-Side Navigation Compatibility
+
+Client-side navigation (CSN) enables page transitions without a full page reload by updating only the parts of the page that change. For this to work correctly, **every block on the page must be compatible with client-side navigation**. If a single block on the page is not compatible, the Interactivity API will fall back to a full page reload for that navigation, losing all the performance and UX benefits.
+
+This guide explains how to declare that your block is compatible with CSN and what to consider when evaluating compatibility.
+
+## Declaring compatibility in `block.json`
+
+Blocks declare CSN compatibility through the `supports.interactivity.clientNavigation` property in `block.json`:
+
+```json
+{
+	"supports": {
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}
+```
+
+Set `clientNavigation` to `true` to indicate that the block works correctly during client-side navigation. If not declared, it defaults to `false`, meaning the block is considered incompatible.
+
+If the block also uses the Interactivity API directives, declare both properties:
+
+```json
+{
+	"supports": {
+		"interactivity": {
+			"clientNavigation": true,
+			"interactive": true
+		}
+	}
+}
+```
+
+Setting `supports.interactivity` to `true` is a shorthand equivalent to setting both `clientNavigation` and `interactive` to `true`:
+
+```json
+{
+	"supports": {
+		"interactivity": true
+	}
+}
+```
+
+<div class="callout callout-info">
+
+Even if a block appears to work fine with CSN, the compatibility must always be explicitly declared in `block.json`. The Interactivity API checks this property for every block on the page to decide whether client-side navigation can be used.
+
+</div>
+
+## What makes a block compatible
+
+### Static blocks
+
+Static blocks — those that render HTML without any client-side interactivity — are generally compatible with CSN. Since they don't rely on JavaScript to function, client-side navigation can safely replace their HTML without breaking anything.
+
+However, compatibility must still be declared explicitly in `block.json`. The Interactivity API cannot infer compatibility on its own.
+
+### Interactive blocks using the Interactivity API
+
+Blocks that use the Interactivity API for their client-side behavior are designed to work with CSN. The Interactivity API manages DOM updates through a virtual DOM diffing algorithm, ensuring that interactive state is preserved across navigations.
+
+That said, interactive blocks must follow certain practices to remain compatible. See [Ensuring compatibility for interactive blocks](#ensuring-compatibility-for-interactive-blocks) below.
+
+### Blocks using vanilla JS, jQuery, or other frameworks
+
+Blocks that use vanilla JavaScript, jQuery, or any framework other than the Interactivity API for client-side behavior are **not compatible** with CSN. Set `clientNavigation` to `false` (or omit it) for these blocks.
+
+These blocks typically rely on scripts that run once on page load to initialize behavior — attaching event listeners, manipulating the DOM, or setting up widgets. During client-side navigation, the HTML may be replaced, but those initialization scripts won't run again, leaving the block non-functional.
+
+## Ensuring compatibility for interactive blocks
+
+Even blocks built with the Interactivity API need to follow certain guidelines to work correctly with CSN. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
+
+### CSS
+
+#### Do not inject CSS dynamically
+
+Blocks that inject `<style>` elements through JavaScript at runtime are not compatible with CSN. The Interactivity API manages stylesheets during navigation by tracking the `<link>` and `<style>` elements that the server includes in the page's `<head>`. Styles created dynamically by client-side code fall outside this system and may be lost or disabled during navigation.
+
+If a block needs conditional styles, use server-side logic to include the appropriate stylesheets when the block is rendered. For example, use [`wp_enqueue_block_support_styles()`](https://developer.wordpress.org/reference/functions/wp_enqueue_block_support_styles/) or conditionally enqueue a stylesheet in your block's `render_callback`.
+
+#### Do not modify existing stylesheets using JavaScript
+
+Programmatically modifying CSS rules at runtime — for example, using the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) APIs like `CSSStyleSheet.insertRule()`, `CSSStyleSheet.deleteRule()`, or modifying `CSSStyleDeclaration` objects directly — is not compatible with CSN. These changes are not tracked by the Interactivity API and will be lost when the page's stylesheets are reconciled during navigation.
+
+Instead, use server-side logic to produce the correct stylesheets, or toggle CSS classes on elements using Interactivity API directives like `data-wp-class`.
+
+#### Use stable CSS selectors
+
+CSS selectors (class names, IDs, etc.) must be **stable across navigations**. If a selector changes between page loads, styles may break or apply to the wrong elements after a client-side navigation.
+
+A common source of unstable selectors is [`wp_unique_id()`](https://developer.wordpress.org/reference/functions/wp_unique_id/). This function generates sequential IDs (`id-1`, `id-2`, etc.) based on a global counter that resets on each page load. When navigating between two pages, the same block may receive a different ID on each page, causing the CSS selector to no longer match the element.
+
+Instead, use [`wp_unique_id_from_values()`](https://developer.wordpress.org/reference/functions/wp_unique_id_from_values/) (available since WordPress 6.8). This function generates a deterministic hash-based identifier from an array of values, producing the same ID for the same inputs regardless of rendering order:
+
+```php
+// Avoid: Sequential IDs change between pages.
+$id = wp_unique_id( 'my-block-' );
+
+// Preferred: Hash-based IDs are stable across navigations.
+$id = wp_unique_id_from_values(
+	array( $block->parsed_block['attrs'] ),
+	'my-block-'
+);
+```
+
+This applies to any selector used in CSS — class names, IDs, or `data-*` attributes used in stylesheets.
+
+#### CSS selectors must match across navigations
+
+When using client-side navigation to navigate between two pages, the HTML elements and their CSS selectors **outside router regions** must match. This is usually the case when both pages share the same template, but mismatches can occur when different templates produce different wrapper elements or class names for the same structural areas.
+
+CSS selectors applied to elements **inside router regions** must also be stable across navigations. Since router regions are the parts of the page that get replaced during navigation, the incoming HTML must use the same selectors so that existing stylesheets continue to apply correctly. If the selectors change — for example, because of dynamically generated class names — styles may break after navigation.
+
+### JavaScript
+
+#### Use script modules, not regular scripts
+
+Client-side navigation only supports [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) (`<script type="module">`). Regular scripts (`<script>` tags without `type="module"`) that run on page load will **not** be re-executed when a page is visited through client-side navigation.
+
+Additionally, only **external** script modules (those with a `src` attribute) are processed during client-side navigation. Inline script modules — where the code is written directly inside the `<script>` tag — are not re-executed during navigation.
+
+Script modules that should be loaded during client-side navigation must be registered with the appropriate dependency declaration so that WordPress includes the `loadOnClientNavigation` flag. This happens automatically when a block declares its script module in `block.json` and sets `supports.interactivity.clientNavigation` to `true`.
+
+For more details on how script modules are handled during navigation, see the [Script module handling](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#script-module-handling) section of the Client-Side Navigation guide.
+
+### HTML
+
+#### Keep consistent HTML structures
+
+The Interactivity API uses Preact under the hood for virtual DOM diffing. When navigating between pages, Preact compares the current and incoming HTML to calculate the minimum set of DOM changes. Inconsistencies between the two can cause elements to be remounted instead of updated, which may result in lost state.
+
+Common issues include:
+
+-   **Different element structures**: If the same block renders a `<div>` on one page and a `<section>` on another, Preact treats them as entirely different elements and replaces the node, losing any state associated with it.
+-   **Elements gaining or losing directives**: If an element has no Interactivity API directives on one page but gains `data-wp-bind` or similar on another, the diffing may not reconcile them correctly.
+-   **Dynamic siblings**: When elements appear or disappear between pages (for example, conditional content), Preact may struggle to match the remaining elements correctly.
+
+To help Preact reconcile elements, use the `data-wp-key` directive on sibling elements that may change between navigations. This is especially important for **lists of elements** where items can appear, disappear, or reorder between pages. Without keys, Preact may incorrectly reuse DOM nodes, leading to mismatched state or visual glitches.
+
+The `data-wp-key` directive works like the `key` prop in React or Preact — it gives the diffing algorithm a stable identity for each element:
+
+```html
+<ul>
+	<li data-wp-key="item-1">First</li>
+	<li data-wp-key="item-2">Second</li>
+	<li data-wp-key="item-3">Third</li>
+</ul>
+```
+
+Use a value that uniquely identifies each element across navigations, such as a post ID or slug — not an array index, which would change if items are reordered.
+
+#### Do not mutate the DOM outside the Interactivity API
+
+All DOM modifications should go through Interactivity API directives. Directly manipulating the DOM using vanilla JavaScript APIs — such as `document.createElement()`, `element.appendChild()`, `element.remove()`, or jQuery methods — is not compatible with CSN. The Interactivity API's virtual DOM diffing won't be aware of these changes, and they will be lost or cause conflicts during navigation.
+
+For cases where you need to update the inner HTML of an element or make other imperative DOM changes, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/api-reference.md#wp-watch) directive. This directive runs a callback whenever reactive state changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
+
+```html
+<div
+	data-wp-interactive="myPlugin"
+	data-wp-watch="callbacks.updateContent"
+>
+</div>
+```
+
+```js
+import { store } from '@wordpress/interactivity';
+
+store( 'myPlugin', {
+	callbacks: {
+		updateContent() {
+			const element = getElement();
+			// Imperative DOM update driven by reactive state.
+			element.ref.innerHTML = sanitizeHTML( state.dynamicContent );
+		},
+	},
+} );
+```
+
+#### Do not create HTML dynamically outside router regions
+
+Interactive blocks should avoid injecting new HTML elements into the DOM outside of router regions — for example, creating overlays, modals, or tooltips that are appended to the `<body>`.
+
+The Interactivity API's client-side navigation only manages content inside [router regions](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#setting-up-router-regions). Any HTML created outside these regions won't be tracked, cleaned up, or updated during navigation.
+
+If a block needs to render content outside its main region — for example, an overlay that must be a direct child of `<body>` — use the router's `attachTo` property to define a region that can be dynamically created during navigation. This is explained in the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#attaching-new-router-regions).
+
+## Compatibility checklist
+
+Before marking your block as compatible with client-side navigation, verify the following:
+
+-   [ ] The block does not inject `<style>` elements dynamically through JavaScript.
+-   [ ] The block does not modify existing stylesheets at runtime (e.g., via CSSOM APIs).
+-   [ ] CSS selectors (class names, IDs) are stable across navigations — no use of `wp_unique_id()` for selectors.
+-   [ ] The block does not manipulate the DOM using APIs outside the Interactivity API (e.g., `document.createElement`, jQuery).
+-   [ ] Any HTML that needs to live outside the block's region (e.g., overlays on `<body>`) uses `attachTo` to define its own region.
+-   [ ] Lists of sibling elements that can change between navigations use `data-wp-key`.
+-   [ ] The block uses script modules, not regular `<script>` tags.
+-   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
+-   [ ] The block works correctly with the [experimental full-page client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#full-page-client-side-navigation-experimental) mode.
+
+## Quick reference
+
+| Block type | Compatible? | Action |
+|---|---|---|
+| Static block (no JS) | Yes | Set `clientNavigation` to `true` |
+| Interactive block using the Interactivity API | Yes (if guidelines are followed) | Set `interactivity` to `true` |
+| Block using vanilla JS, jQuery, or other frameworks | No | Omit or set `clientNavigation` to `false` |
+| Block injecting or modifying CSS at runtime | No | Use server-rendered styles or `data-wp-class` |
+| Block using `wp_unique_id()` for CSS selectors | No | Use `wp_unique_id_from_values()` |
+| Block mutating the DOM outside the Interactivity API | No | Use directives or `data-wp-watch` |
+| Block using regular scripts (not script modules) | No | Migrate to script modules |

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -55,7 +55,7 @@ Setting `supports.interactivity` to `true` is a shorthand equivalent to setting 
 
 <div class="callout callout-info">
 
-Even if a block appears to work fine with client-side navigation, the compatibility must always be explicitly declared in `block.json`. The Interactivity API checks this property for every block on the page to decide whether client-side navigation can be used.
+Even if a block appears to work fine with client-side navigation, the compatibility must always be explicitly declared in `block.json`. Right now, this property is the only way WordPress — other blocks, plugins, and themes — can determine whether your block is compatible with client-side navigation and, if it is not, disable it. For example, the `core/query` block checks this property on all its descendant blocks and falls back to full-page reloads when any of them are incompatible. In the future, this check may be automatically incorporated into the Interactivity API itself.
 
 </div>
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -1,8 +1,10 @@
 # Client-Side Navigation Compatibility
 
-Client-side navigation (CSN) enables page transitions without a full page reload by updating only the parts of the page that change. For this to work correctly, **every block on the page must be compatible with client-side navigation**. If any block is incompatible, it may break silently after a navigation — losing state, failing to initialize, or rendering incorrectly. Some core blocks like `core/query` detect incompatible descendants and automatically fall back to a full page reload, but this safety net does not apply to custom implementations. In general, a single incompatible block on the page can compromise the entire navigation experience.
+Client-side navigation enables page transitions without a full page reload by updating only the parts of the page that change. For this to work correctly, **every interactive region on the page must be compatible with client-side navigation**. If any interactive region is incompatible, it may break silently after a navigation — losing state, failing to initialize, or rendering incorrectly.
 
-This guide explains what to consider when evaluating compatibility. While the examples focus on blocks, the same principles apply to any code that outputs markup on the front end — including classic PHP themes and plugins.
+Some core blocks like `core/query` detect incompatible descendants and automatically fall back to a full page reload, but this safety net does not apply to custom implementations. In general, a single incompatible interactive region on the page can compromise the entire navigation experience.
+
+This guide explains what to consider when evaluating compatibility. While the examples focus on internative blocks, the same principles apply to any interactive region on the front end — including those included in classic PHP themes or plugins.
 
 <div class="callout callout-info">
 
@@ -10,11 +12,11 @@ This guide assumes familiarity with [blocks](https://developer.wordpress.org/blo
 
 </div>
 
-For an overview of how client-side navigation works — including the fetch-diff-apply cycle, router regions, and script module handling — see the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md).
+For an overview of how client-side navigation works — including the fetch-diff-apply cycle, router regions, and styles and script module handling — see the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md).
 
 ## Declaring compatibility in `block.json`
 
-Blocks declare CSN compatibility through the `supports.interactivity.clientNavigation` property in `block.json`:
+Blocks declare client-side navigation compatibility through the `supports.interactivity.clientNavigation` property in `block.json`:
 
 ```json
 {
@@ -53,7 +55,7 @@ Setting `supports.interactivity` to `true` is a shorthand equivalent to setting 
 
 <div class="callout callout-info">
 
-Even if a block appears to work fine with CSN, the compatibility must always be explicitly declared in `block.json`. The Interactivity API checks this property for every block on the page to decide whether client-side navigation can be used.
+Even if a block appears to work fine with client-side navigation, the compatibility must always be explicitly declared in `block.json`. The Interactivity API checks this property for every block on the page to decide whether client-side navigation can be used.
 
 </div>
 
@@ -61,65 +63,71 @@ Even if a block appears to work fine with CSN, the compatibility must always be 
 
 ### Non-interactive blocks
 
-Blocks that render HTML without any client-side interactivity — no JavaScript, no event listeners, no dynamic behavior — are generally compatible with CSN. Since they don't rely on scripts to function, client-side navigation can safely replace their HTML without breaking anything.
+Blocks that render HTML without any client-side interactivity — no JavaScript, no event listeners, no dynamic behavior — are generally compatible with client-side navigation. Since they don't rely on scripts to function, client-side navigation can safely replace their HTML without breaking anything.
 
 However, compatibility must still be declared explicitly in `block.json`. The Interactivity API cannot infer compatibility on its own.
 
 ### Interactive blocks using the Interactivity API
 
-Blocks that use the Interactivity API for their client-side behavior are designed to work with CSN. The Interactivity API manages DOM updates through its [virtual DOM diffing algorithm](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md), ensuring that interactive state is preserved across navigations.
+Blocks that use the Interactivity API for their client-side behavior are designed to work with client-side navigation. The Interactivity API manages DOM updates through its [virtual DOM diffing algorithm](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md), ensuring that interactive state is preserved across navigations.
 
 That said, interactive blocks must follow certain practices to remain compatible. These guidelines cover three areas — CSS, JavaScript, and HTML — and are detailed in [Ensuring compatibility](#ensuring-compatibility).
 
-### Interactive blocks using other libraries
+The same applies for interactive regions included in classic PHP themes or plugins.
 
-Blocks that use vanilla JavaScript, jQuery, or any framework other than the Interactivity API for client-side behavior are **not compatible** with CSN. Set `clientNavigation` to `false` (or omit it) for these blocks.
+### Interactive blocks using vanilla JavaScript (DOM APIs) other interactive libraries
 
-These blocks typically rely on scripts that run once on page load to initialize behavior — attaching event listeners, manipulating the DOM, or setting up widgets. During client-side navigation, the HTML may be replaced, but those initialization scripts won't run again, leaving the block non-functional.
+Blocks that use vanilla JavaScript, jQuery, or any framework other than the Interactivity API for client-side behavior are **not compatible** with client-side navigation. Set `clientNavigation` to `false` (or omit it) for these blocks.
+
+These blocks typically rely on scripts that run once on page load to initialize behavior — attaching event listeners, manipulating the DOM, or setting up widgets. During client-side navigation, the HTML may be replaced, but those initialization scripts won't run again and the internal JS representation of the actual DOM state might get out of sync, leaving the block non-functional.
 
 ### Quick reference
 
 The table below summarizes the compatibility status and required action for each block type:
 
-| Block type                                           | Compatible?                      | Action                                        |
-| ---------------------------------------------------- | -------------------------------- | --------------------------------------------- |
-| Non-interactive block (no JS)                        | Yes                              | Set `clientNavigation` to `true`              |
-| Interactive block using the Interactivity API        | Yes (if guidelines are followed) | Set `interactivity` to `true` (shorthand)     |
-| Interactive block using other libraries              | No                               | Omit or set `clientNavigation` to `false`     |
-| Block injecting or modifying CSS at runtime          | No                               | Use server-rendered styles or `data-wp-class` |
-| Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`              |
-| Block using regular scripts (not script modules)     | No                               | Migrate to script modules                     |
-| Block importing from `window.wp.*` globals           | No                               | Use ES module imports                         |
-| Block relying on DOM ready events for initialization | No                               | Use `data-wp-init`                            |
-| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
+| Block type                                           | Compatible?                      | Action                                          |
+| ---------------------------------------------------- | -------------------------------- | ----------------------------------------------- |
+| Non-interactive block (no JS)                        | Yes                              | Set `clientNavigation` to `true`                |
+| Interactive block using the Interactivity API        | Yes (if guidelines are followed) | Set `interactivity` to `true` (shorthand)       |
+| Interactive block using other interactive libraries  | No                               | Omit or set `clientNavigation` to `false`       |
+| Block injecting or modifying CSS at runtime          | No                               | Use server-rendered styles with `data-wp-class` |
+| Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`                |
+| Block using regular scripts (not script modules)     | No                               | Migrate to script modules                       |
+| Block importing from `window.wp.*` globals           | No                               | Use ES module imports                           |
+| Block relying on DOM ready events for initialization | No                               | Use `data-wp-init`                              |
+| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`               |
+
+The same applies for interactive regions included in classic PHP themes or plugins.
 
 ## Ensuring compatibility
 
-Any code that outputs front-end markup — whether it uses the Interactivity API, server-side rendering only, or a combination — needs to follow certain guidelines to work correctly with CSN. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
+Any code that outputs front-end markup — whether it uses the Interactivity API, server-side rendering only, or a combination — needs to follow certain guidelines to work correctly with client-side navigation. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
 
 ### CSS
 
 #### Do not inject CSS dynamically
 
-Blocks that inject `<style>` elements through JavaScript at runtime are not compatible with CSN. The Interactivity API manages stylesheets during navigation by tracking the `<link>` and `<style>` elements that the server includes in the page's `<head>`. Styles created dynamically by client-side code fall outside this system — after navigating, the block may appear unstyled or with broken layout.
+Blocks that inject `<style>` or `<link>` elements through JavaScript at runtime are not compatible with client-side navigation.
 
-**Instead:** Use server-side logic to include the appropriate stylesheets when the block is rendered. For example, use [`wp_enqueue_block_support_styles()`](https://developer.wordpress.org/reference/functions/wp_enqueue_block_support_styles/) or conditionally enqueue a stylesheet in your block's `render_callback`.
+The Interactivity API manages stylesheets during navigation by tracking the `<link>` and `<style>` elements that the server includes in the page. Styles created dynamically by client-side code fall outside this system — after navigating, the block may appear unstyled or with broken layout.
+
+**Instead:** Use server-side logic to include the appropriate stylesheets when the block is rendered. For example, use the `style` property of your `block.json`, or conditionally enqueue a stylesheet in your block's render template.
 
 #### Do not modify existing stylesheets using JavaScript
 
-Programmatically modifying CSS rules at runtime is not compatible with CSN. This includes using [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) APIs like `CSSStyleSheet.insertRule()`, `CSSStyleSheet.deleteRule()`, or modifying `CSSStyleDeclaration` objects directly. These changes are not tracked by the Interactivity API and will be lost when the page's stylesheets are reconciled during navigation.
+Programmatically modifying CSS rules at runtime is not compatible with client-side navigation. This includes using [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) APIs like `CSSStyleSheet.insertRule()`, `CSSStyleSheet.deleteRule()`, or modifying `CSSStyleDeclaration` objects directly. These changes are not tracked by the Interactivity API and will be lost when the page's stylesheets are reconciled during navigation.
 
-**Instead:** Use server-side logic to produce the correct stylesheets, or toggle CSS classes on elements using Interactivity API directives like `data-wp-class`.
+**Instead:** Use server-side logic to produce the correct stylesheets, or toggle CSS classes on elements using Interactivity API directives like `data-wp-class` or `data-wp-style`.
 
 #### Use stable CSS selectors
 
 CSS selectors (class names, IDs, etc.) must be **stable across navigations**. If a selector changes between page loads, styles may break or apply to the wrong elements after a client-side navigation.
 
-This is especially important for elements **outside [router regions](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#setting-up-router-regions)** — the areas of the page that the Interactivity API replaces during navigation. Since elements outside those regions are not replaced, the incoming page's stylesheets must continue to match them. If both pages share the same template this is usually the case, but mismatches can occur when different templates produce different wrapper elements or class names for shared layout elements like headers, footers, or sidebars.
+This is especially important for elements **outside [router regions](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#setting-up-router-regions)** (regions are the areas of the page that the Interactivity API replaces during navigation). Since elements outside those regions are not replaced, the incoming page's stylesheets must continue to match them. If both pages share the same template this is usually the case, but mismatches can occur when different templates produce different wrapper elements or class names for shared layout elements like headers, footers, or sidebars.
 
 CSS selectors applied to elements **inside router regions** must also be stable. Since regions are replaced during navigation, the incoming HTML must use the same selectors so that existing stylesheets continue to apply correctly.
 
-One of the most frequent causes of CSN compatibility failures is [`wp_unique_id()`](https://developer.wordpress.org/reference/functions/wp_unique_id/). This function generates sequential IDs (`id-1`, `id-2`, etc.) based on a global counter that resets on each page load. When navigating between two pages, the same block may receive a different ID on each page, causing the CSS selector to no longer match the element.
+One of the most frequent causes of client-side navigation compatibility failures is [`wp_unique_id()`](https://developer.wordpress.org/reference/functions/wp_unique_id/). This function generates sequential IDs (`id-1`, `id-2`, etc.) based on a global counter that resets on each page load. When navigating between two pages, the same block may receive a different ID on each page, causing the CSS selector to no longer match the element.
 
 Instead, use [`wp_unique_id_from_values()`](https://developer.wordpress.org/reference/functions/wp_unique_id_from_values/) (available since WordPress 6.8). This function generates a deterministic hash-based identifier from an array of values, producing the same ID for the same inputs regardless of rendering order:
 
@@ -156,26 +164,28 @@ To re-trigger animations after navigation, toggle the animation's CSS class usin
 
 #### Use script modules, not regular scripts
 
-Client-side navigation only supports [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) (`<script type="module">`). Regular scripts will **not** be re-executed when a page is visited through client-side navigation — so a jQuery slider or vanilla JS accordion will initialize on the first page load but stop working after the first navigation.
+Client-side navigation only supports [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) (`<script type="module">`).
 
-The key rules for script modules and CSN:
+Regular scripts will **not** be re-executed when a page is visited through client-side navigation — so, for example, a jQuery slider or vanilla JS accordion will initialize only if it's included on the first page load, but not if it's only included on subsequent navigations.
+
+The key rules for script modules and client-side navigation:
 
 -   Only `<script type="module">` tags are supported. Regular `<script>` tags without `type="module"` are ignored during navigation.
 -   Only **external** script modules (those with a `src` attribute) are processed. Inline script modules — where the code is written directly inside the `<script>` tag — are not re-executed.
--   For blocks, the `loadOnClientNavigation` flag is set automatically when the script module is declared in `block.json` and `supports.interactivity.clientNavigation` is `true`.
--   For non-block script modules (e.g., those enqueued by a theme or plugin), register the script module for client-side navigation explicitly using [`add_client_navigation_support_to_script_module()`](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#ensuring-script-modules-load-during-navigation):
-
-```php
-wp_interactivity()->add_client_navigation_support_to_script_module(
-	'my-plugin/navigation-handler'
-);
-```
+-   The Interactivity API only loads modules that contain the `data-wp-router-options='{"loadOnClientNavigation":true}'` attribute.
+    -   For blocks, the `loadOnClientNavigation` flag is set automatically when the script module is declared in `block.json` and `supports.interactivity` or `supports.interactivity.clientNavigation` is `true`.
+    -   For non-block script modules (e.g., those enqueued by a theme or plugin), register the script module for client-side navigation explicitly using [`add_client_navigation_support_to_script_module()`](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#ensuring-script-modules-load-during-navigation):
+        ```php
+        wp_interactivity()->add_client_navigation_support_to_script_module(
+        	'my-plugin/navigation-handler'
+        );
+        ```
 
 For more details on how script modules are handled during navigation, see the [Script module handling](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#script-module-handling) section of the Client-Side Navigation guide.
 
 #### Do not import from `window.wp.*` globals
 
-Accessing WordPress packages through global variables like `window.wp.element` or `window.wp.data` is not compatible with CSN. These globals are set by regular scripts, which are not re-executed during client-side navigation.
+Accessing WordPress packages through global variables like `window.wp.element` or `window.wp.data` is not compatible with client-side navigation. These globals are set by regular scripts, which are not re-executed during client-side navigation.
 
 **Instead:** Use ES module imports from the corresponding `@wordpress/*` script module, if one is available. For example, `@wordpress/a11y` is available both as a regular script (`window.wp.a11y`) and as a script module:
 
@@ -222,6 +232,18 @@ store( 'myPlugin', {
 </div>
 ```
 
+From WordPress 7.0, you can also use the `watch` util to reexecute code on every navigation.
+
+```js
+import { store, watch } from '@wordpress/interactivity';
+
+watch( () => {
+	const { url } = store( 'core/router' ).state;
+	// Send analytics event for the new URL.
+	sendPageView( url );
+} );
+```
+
 #### Use `getServerState()` and `getServerContext()` to sync server data
 
 If your block's state or context needs to reflect server-rendered values on each navigation — for example, resetting a counter, updating a label, or syncing data that changes per page — use `getServerState()` and `getServerContext()` inside your callbacks. These functions return the values from the server-rendered HTML of the newly navigated page, allowing you to reconcile client-side state with fresh server data after each navigation.
@@ -232,17 +254,17 @@ For more details, see the [Server state and context](/docs/reference-guides/inte
 
 #### Keep consistent HTML structures
 
-Inconsistent HTML between pages can cause a modal to lose its open/closed state, interactive elements to stop responding, or lifecycle callbacks (like `data-wp-init` or `data-wp-watch`) to not re-execute when they should. This happens because the Interactivity API uses [Preact](https://preactjs.com/) (a lightweight React-compatible library) under the hood, which compares the current and incoming HTML to calculate the minimum set of DOM changes. When the structure doesn't match, Preact may remount elements (losing state) or incorrectly reuse nodes (breaking behavior).
+Inconsistent HTML between pages can cause a modal to lose its open/closed state, interactive elements to stop responding, or lifecycle callbacks (like `data-wp-init` or `data-wp-watch`) to not re-execute when they should. This happens because the Interactivity API uses a [virtual DOM diffing algorithm under the hood](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md), which compares the current and incoming HTML to calculate the minimum set of DOM changes. When the structure doesn't match, this algorithm may remount elements (losing state) or incorrectly reuse nodes (breaking behavior).
 
 Common issues include:
 
--   **Different element structures**: If the same block renders a `<div>` on one page and a `<section>` on another, Preact treats them as entirely different elements and replaces the node, losing any state associated with it.
+-   **Different element structures**: If the same block renders a `<div>` on one page and a `<section>` on another, the virtual DOM algorithm treats them as entirely different elements and replaces the node, losing any state associated with it.
 -   **Elements gaining or losing directives**: If an element has no Interactivity API directives on one page but gains `data-wp-bind` or similar on another, the diffing may not reconcile them correctly.
--   **Dynamic siblings**: When elements appear or disappear between pages (for example, conditional content), Preact may struggle to match the remaining elements correctly.
+-   **Dynamic siblings**: When elements appear or disappear between pages (for example, conditional content), the virtual DOM algorithm may struggle to match the remaining elements correctly.
 
-To help Preact reconcile elements, use the `data-wp-key` directive on sibling elements that may change between navigations. This is especially important for **lists of elements** where items can appear, disappear, or reorder between pages. Without keys, Preact may incorrectly reuse DOM nodes, leading to mismatched state or visual glitches.
+To help the virtual DOM algorithm reconcile elements, use the `data-wp-key` directive on sibling elements that may change between navigations. This is especially important for **lists of elements** where items can appear, disappear, or reorder between pages. Without keys, the virtual DOM algorithm may incorrectly reuse DOM nodes, leading to mismatched state or visual glitches.
 
-The `data-wp-key` directive works like the `key` prop in React or Preact — it gives the diffing algorithm a stable identity for each element:
+The `data-wp-key` directive works like the `key` prop in React — it gives the diffing algorithm a stable identity for each element:
 
 ```html
 <ul>
@@ -256,9 +278,11 @@ Use a value that uniquely identifies each element across navigations, such as a 
 
 #### Do not mutate the DOM outside the Interactivity API
 
-All DOM modifications should go through Interactivity API directives. Directly manipulating the DOM using vanilla JavaScript APIs — such as `document.createElement()`, `element.appendChild()`, `element.remove()`, or jQuery methods — is not compatible with CSN. Elements added this way (like dynamically created tooltips or injected widgets) will vanish after navigating away and back, because the virtual DOM diffing is not aware of them.
+Directly manipulating the DOM using vanilla JavaScript APIs — such as `document.createElement()`, `element.appendChild()`, `element.remove()`, or jQuery methods — is not compatible with client-side navigation. Elements added this way (like dynamically created tooltips or injected widgets) will vanish after navigating away and back, because the virtual DOM diffing is not aware of them.
 
-For cases where you need to update the inner HTML of an element or make other imperative DOM changes, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/directives-and-store.md#wp-watch) directive. This directive runs a callback whenever [reactive state](/docs/reference-guides/interactivity-api/directives-and-store.md#the-store) — the global state managed by the Interactivity API's `store()` — changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
+Always use Interactivity API directives to modify DOM elements. For example, `data-wp-text`, `data-wp-bind`, `data-wp-each`, `data-wp-class`, `data-wp-style`, etc.
+
+For cases where you need to update the inner HTML of an element or make other imperative DOM changes that are not possible using the existing directives, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/directives-and-store.md#wp-watch) directive. This directive runs a callback whenever [reactive state](/docs/reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config.md) changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
 
 ```html
 <div
@@ -273,9 +297,9 @@ import { store } from '@wordpress/interactivity';
 store( 'myPlugin', {
 	callbacks: {
 		updateContent() {
-			const element = getElement();
+			const { ref } = getElement();
 			// Imperative DOM update driven by reactive state.
-			element.ref.innerHTML = sanitizeHTML( state.dynamicContent );
+			ref.innerHTML = state.dynamicContent;
 		},
 	},
 } );
@@ -287,21 +311,21 @@ Interactive blocks should avoid injecting new HTML elements into the DOM outside
 
 The Interactivity API's client-side navigation only manages content inside [router regions](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#setting-up-router-regions). Any HTML created outside these regions won't be tracked, cleaned up, or updated during navigation.
 
-If a block needs to render content outside its main region — for example, an overlay that must be a direct child of `<body>` — use the router's `attachTo` property to define a region that can be dynamically created during navigation. This is explained in the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#adding-new-regions-on-navigation).
+If a block needs to render content outside its main boundaries — for example, an overlay that must be a direct child of `<body>` — use the router's `attachTo` property to define a region that can be dynamically created during navigation. This is explained in the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#adding-new-regions-on-navigation).
 
 ## Verifying compatibility
 
 After implementing the guidelines above, use the following approach to confirm that client-side navigation is working correctly with your block:
 
-1. **Check for full-page reloads.** Open the browser's Network tab (DevTools), then click a link that navigates to a page containing your block. If CSN is active, you'll see a `fetch` request for the new page's HTML instead of a full document navigation. A full document load means something on the page is incompatible — the Interactivity API fell back to a traditional navigation.
-2. **Test interactive state preservation.** Open a modal, expand an accordion, or trigger any interactive state in your block. Navigate to another page and then back. If the block's state is preserved (or correctly re-initialized via `data-wp-init`), CSN is working as expected. If the block appears frozen or unresponsive, check for DOM mutations or scripts running outside the Interactivity API.
+1. **Check for full-page reloads.** Open the browser's Network tab (DevTools), then click a link that navigates to a page containing your block. If client-side navigation is active, you'll see a `fetch` request for the new page's HTML instead of a full document navigation. A full document load means something on the page is incompatible — the Interactivity API fell back to a traditional navigation.
+2. **Test interactive state preservation.** Open a modal, expand an accordion, or trigger any interactive state in your block. Navigate to another page and then back. If the block's state is preserved (or correctly re-initialized via `data-wp-init`), client-side navigation is working as expected. If the block appears frozen or unresponsive, check for DOM mutations or scripts running outside the Interactivity API.
 3. **Test across different templates.** Navigate between pages that use different templates (e.g., a single post and an archive). This exercises the CSS selector stability and HTML structure consistency rules, since different templates may produce different wrapper elements.
 
 ## Compatibility checklist
 
 Before marking your block as compatible with client-side navigation, verify the following:
 
--   [ ] The block does not inject `<style>` elements dynamically through JavaScript.
+-   [ ] The block does not inject `<style>` or `<link>` elements dynamically through JavaScript.
 -   [ ] The block does not modify existing stylesheets at runtime (e.g., via CSSOM APIs).
 -   [ ] CSS selectors (class names, IDs) are stable across navigations — no use of `wp_unique_id()` for selectors.
 -   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
@@ -311,5 +335,5 @@ Before marking your block as compatible with client-side navigation, verify the 
 -   [ ] If the block needs to sync state or context from the server on each navigation, it uses `getServerState()` or `getServerContext()`.
 -   [ ] Lists of sibling elements that can change between navigations use `data-wp-key`.
 -   [ ] The block does not manipulate the DOM using APIs outside the Interactivity API (e.g., `document.createElement`, jQuery).
--   [ ] Any HTML that needs to live outside the block's region (e.g., overlays on `<body>`) uses `attachTo` to define its own region.
+-   [ ] Any HTML that needs to live outside the block's boundaries (e.g., overlays on `<body>`) uses `attachTo` to define its own region.
 -   [ ] (Optional) The block works correctly with the [experimental full-page client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#full-page-client-side-navigation-experimental) mode.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -144,22 +144,6 @@ $id = wp_unique_id_from_values(
 
 This applies to any selector used in CSS — class names, IDs, or `data-*` attributes used in stylesheets.
 
-#### Handle CSS animations and transitions
-
-CSS animations and transitions may not replay after a client-side navigation. When the virtual DOM diffing algorithm updates an element in place rather than remounting it, the browser does not restart its CSS animations — the element was never removed from the DOM, so no new animation cycle begins.
-
-To re-trigger animations after navigation, toggle the animation's CSS class using `data-wp-class` combined with a state value that changes on each navigation, or use `data-wp-init` to programmatically restart the animation by removing and re-adding the relevant class:
-
-```html
-<div
-	data-wp-interactive="myPlugin"
-	data-wp-init="callbacks.restartAnimation"
-	data-wp-class--animate="state.shouldAnimate"
->
-	Animated content
-</div>
-```
-
 ### JavaScript
 
 #### Use script modules, not regular scripts
@@ -328,7 +312,6 @@ Before marking your block as compatible with client-side navigation, verify the 
 -   [ ] The block does not inject `<style>` or `<link>` elements dynamically through JavaScript.
 -   [ ] The block does not modify existing stylesheets at runtime (e.g., via CSSOM APIs).
 -   [ ] CSS selectors (class names, IDs) are stable across navigations — no use of `wp_unique_id()` for selectors.
--   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
 -   [ ] The block uses script modules, not regular `<script>` tags.
 -   [ ] The block does not import from `window.wp.*` globals — it uses ES module imports instead.
 -   [ ] The block does not rely on `DOMContentLoaded` or `load` events for initialization — it uses `data-wp-init` instead.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -4,6 +4,14 @@ Client-side navigation (CSN) enables page transitions without a full page reload
 
 This guide explains what to consider when evaluating compatibility. While the examples focus on blocks, the same principles apply to any code that outputs markup on the front end — including classic PHP themes and plugins.
 
+<div class="callout callout-info">
+
+This guide assumes familiarity with [blocks](https://developer.wordpress.org/block-editor/getting-started/), [`block.json`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/), and the basics of the [Interactivity API](/docs/reference-guides/interactivity-api/). If you're new to the Interactivity API, start with the [Quick Start Guide](/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md) first.
+
+</div>
+
+For an overview of how client-side navigation works — including the fetch-diff-apply cycle, router regions, and script module handling — see the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md).
+
 ## Declaring compatibility in `block.json`
 
 Blocks declare CSN compatibility through the `supports.interactivity.clientNavigation` property in `block.json`:
@@ -59,9 +67,9 @@ However, compatibility must still be declared explicitly in `block.json`. The In
 
 ### Interactive blocks using the Interactivity API
 
-Blocks that use the Interactivity API for their client-side behavior are designed to work with CSN. The Interactivity API manages DOM updates through a virtual DOM diffing algorithm, ensuring that interactive state is preserved across navigations.
+Blocks that use the Interactivity API for their client-side behavior are designed to work with CSN. The Interactivity API manages DOM updates through its [virtual DOM diffing algorithm](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md), ensuring that interactive state is preserved across navigations.
 
-That said, interactive blocks must follow certain practices to remain compatible. See [Ensuring compatibility](#ensuring-compatibility) for details.
+That said, interactive blocks must follow certain practices to remain compatible. These guidelines cover three areas — CSS, JavaScript, and HTML — and are detailed in [Ensuring compatibility](#ensuring-compatibility).
 
 ### Interactive blocks using other libraries
 
@@ -69,33 +77,47 @@ Blocks that use vanilla JavaScript, jQuery, or any framework other than the Inte
 
 These blocks typically rely on scripts that run once on page load to initialize behavior — attaching event listeners, manipulating the DOM, or setting up widgets. During client-side navigation, the HTML may be replaced, but those initialization scripts won't run again, leaving the block non-functional.
 
+### Quick reference
+
+The table below summarizes the compatibility status and required action for each block type:
+
+| Block type                                           | Compatible?                      | Action                                        |
+| ---------------------------------------------------- | -------------------------------- | --------------------------------------------- |
+| Non-interactive block (no JS)                        | Yes                              | Set `clientNavigation` to `true`              |
+| Interactive block using the Interactivity API        | Yes (if guidelines are followed) | Set `interactivity` to `true` (shorthand)     |
+| Interactive block using other libraries              | No                               | Omit or set `clientNavigation` to `false`     |
+| Block injecting or modifying CSS at runtime          | No                               | Use server-rendered styles or `data-wp-class` |
+| Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`              |
+| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
+| Block using regular scripts (not script modules)     | No                               | Migrate to script modules                     |
+
 ## Ensuring compatibility
 
-Even code built with the Interactivity API needs to follow certain guidelines to work correctly with CSN. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
+Any code that outputs front-end markup — whether it uses the Interactivity API, server-side rendering only, or a combination — needs to follow certain guidelines to work correctly with CSN. The sections below are organized by the type of issue: CSS, JavaScript, and HTML.
 
 ### CSS
 
 #### Do not inject CSS dynamically
 
-Blocks that inject `<style>` elements through JavaScript at runtime are not compatible with CSN. The Interactivity API manages stylesheets during navigation by tracking the `<link>` and `<style>` elements that the server includes in the page's `<head>`. Styles created dynamically by client-side code fall outside this system and may be lost or disabled during navigation.
+Blocks that inject `<style>` elements through JavaScript at runtime are not compatible with CSN. The Interactivity API manages stylesheets during navigation by tracking the `<link>` and `<style>` elements that the server includes in the page's `<head>`. Styles created dynamically by client-side code fall outside this system — after navigating, the block may appear unstyled or with broken layout.
 
-If a block needs conditional styles, use server-side logic to include the appropriate stylesheets when the block is rendered. For example, use [`wp_enqueue_block_support_styles()`](https://developer.wordpress.org/reference/functions/wp_enqueue_block_support_styles/) or conditionally enqueue a stylesheet in your block's `render_callback`.
+**Instead:** Use server-side logic to include the appropriate stylesheets when the block is rendered. For example, use [`wp_enqueue_block_support_styles()`](https://developer.wordpress.org/reference/functions/wp_enqueue_block_support_styles/) or conditionally enqueue a stylesheet in your block's `render_callback`.
 
 #### Do not modify existing stylesheets using JavaScript
 
-Programmatically modifying CSS rules at runtime — for example, using the [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) APIs like `CSSStyleSheet.insertRule()`, `CSSStyleSheet.deleteRule()`, or modifying `CSSStyleDeclaration` objects directly — is not compatible with CSN. These changes are not tracked by the Interactivity API and will be lost when the page's stylesheets are reconciled during navigation.
+Programmatically modifying CSS rules at runtime is not compatible with CSN. This includes using [CSSOM](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model) APIs like `CSSStyleSheet.insertRule()`, `CSSStyleSheet.deleteRule()`, or modifying `CSSStyleDeclaration` objects directly. These changes are not tracked by the Interactivity API and will be lost when the page's stylesheets are reconciled during navigation.
 
-Instead, use server-side logic to produce the correct stylesheets, or toggle CSS classes on elements using Interactivity API directives like `data-wp-class`.
+**Instead:** Use server-side logic to produce the correct stylesheets, or toggle CSS classes on elements using Interactivity API directives like `data-wp-class`.
 
 #### Use stable CSS selectors
 
 CSS selectors (class names, IDs, etc.) must be **stable across navigations**. If a selector changes between page loads, styles may break or apply to the wrong elements after a client-side navigation.
 
-This is especially important for elements **outside router regions**. Since those elements are not replaced during navigation, the incoming page's stylesheets must continue to match them. If both pages share the same template this is usually the case, but mismatches can occur when different templates produce different wrapper elements or class names for the same structural areas.
+This is especially important for elements **outside [router regions](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#setting-up-router-regions)** — the areas of the page that the Interactivity API replaces during navigation. Since elements outside those regions are not replaced, the incoming page's stylesheets must continue to match them. If both pages share the same template this is usually the case, but mismatches can occur when different templates produce different wrapper elements or class names for shared layout elements like headers, footers, or sidebars.
 
 CSS selectors applied to elements **inside router regions** must also be stable. Since regions are replaced during navigation, the incoming HTML must use the same selectors so that existing stylesheets continue to apply correctly.
 
-A common source of unstable selectors is [`wp_unique_id()`](https://developer.wordpress.org/reference/functions/wp_unique_id/). This function generates sequential IDs (`id-1`, `id-2`, etc.) based on a global counter that resets on each page load. When navigating between two pages, the same block may receive a different ID on each page, causing the CSS selector to no longer match the element.
+One of the most frequent causes of CSN compatibility failures is [`wp_unique_id()`](https://developer.wordpress.org/reference/functions/wp_unique_id/). This function generates sequential IDs (`id-1`, `id-2`, etc.) based on a global counter that resets on each page load. When navigating between two pages, the same block may receive a different ID on each page, causing the CSS selector to no longer match the element.
 
 Instead, use [`wp_unique_id_from_values()`](https://developer.wordpress.org/reference/functions/wp_unique_id_from_values/) (available since WordPress 6.8). This function generates a deterministic hash-based identifier from an array of values, producing the same ID for the same inputs regardless of rendering order:
 
@@ -112,17 +134,43 @@ $id = wp_unique_id_from_values(
 
 This applies to any selector used in CSS — class names, IDs, or `data-*` attributes used in stylesheets.
 
+#### Handle CSS animations and transitions
+
+CSS animations and transitions may not replay after a client-side navigation. When the virtual DOM diffing algorithm updates an element in place rather than remounting it, the browser does not restart its CSS animations — the element was never removed from the DOM, so no new animation cycle begins.
+
+To re-trigger animations after navigation, toggle the animation's CSS class using `data-wp-class` combined with a state value that changes on each navigation, or use `data-wp-init` to programmatically restart the animation by removing and re-adding the relevant class:
+
+```html
+<div
+	data-wp-interactive="myPlugin"
+	data-wp-init="callbacks.restartAnimation"
+	data-wp-class--animate="state.shouldAnimate"
+>
+	Animated content
+</div>
+```
+
 ### JavaScript
 
 #### Use script modules, not regular scripts
 
-Client-side navigation only supports [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) (`<script type="module">`). Regular scripts (`<script>` tags without `type="module"`) that run on page load will **not** be re-executed when a page is visited through client-side navigation.
+Client-side navigation only supports [script modules](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) (`<script type="module">`). Regular scripts will **not** be re-executed when a page is visited through client-side navigation — so a jQuery slider or vanilla JS accordion will initialize on the first page load but stop working after the first navigation.
 
-Additionally, only **external** script modules (those with a `src` attribute) are processed during client-side navigation. Inline script modules — where the code is written directly inside the `<script>` tag — are not re-executed during navigation.
+The key rules for script modules and CSN:
 
-Script modules that should be loaded during client-side navigation must be registered with the appropriate dependency declaration so that WordPress includes the `loadOnClientNavigation` flag. For blocks, this happens automatically when the script module is declared in `block.json` and `supports.interactivity.clientNavigation` is set to `true`.
+-   Only `<script type="module">` tags are supported. Regular `<script>` tags without `type="module"` are ignored during navigation.
+-   Only **external** script modules (those with a `src` attribute) are processed. Inline script modules — where the code is written directly inside the `<script>` tag — are not re-executed.
+-   For blocks, the `loadOnClientNavigation` flag is set automatically when the script module is declared in `block.json` and `supports.interactivity.clientNavigation` is `true`.
+-   For non-block script modules (e.g., those enqueued by a theme or plugin), set `loadOnClientNavigation` to `true` manually when registering with [`wp_register_script_module()`](https://developer.wordpress.org/reference/functions/wp_register_script_module/):
 
-For script modules that don't belong to a block — for example, those enqueued by a classic PHP theme or a plugin — you need to mark them manually by passing `loadOnClientNavigation: true` when registering the module with [`wp_register_script_module()`](https://developer.wordpress.org/reference/functions/wp_register_script_module/).
+```php
+wp_register_script_module(
+	'my-plugin/navigation-handler',
+	plugin_dir_url( __FILE__ ) . 'assets/navigation-handler.js',
+	array(),
+	array( 'loadOnClientNavigation' => true )
+);
+```
 
 For more details on how script modules are handled during navigation, see the [Script module handling](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#script-module-handling) section of the Client-Side Navigation guide.
 
@@ -130,7 +178,7 @@ For more details on how script modules are handled during navigation, see the [S
 
 #### Keep consistent HTML structures
 
-The Interactivity API uses Preact under the hood for virtual DOM diffing. When navigating between pages, Preact compares the current and incoming HTML to calculate the minimum set of DOM changes. Inconsistencies between the two can cause elements to be remounted instead of updated — which may result in lost state — or cause different elements to be treated as the same node, breaking internal state or preventing lifecycle callbacks (like `data-wp-init` or `data-wp-watch`) from re-executing when they should.
+Inconsistent HTML between pages can cause a modal to lose its open/closed state, interactive elements to stop responding, or lifecycle callbacks (like `data-wp-init` or `data-wp-watch`) to not re-execute when they should. This happens because the Interactivity API uses [Preact](https://preactjs.com/) (a lightweight React-compatible library) under the hood, which compares the current and incoming HTML to calculate the minimum set of DOM changes. When the structure doesn't match, Preact may remount elements (losing state) or incorrectly reuse nodes (breaking behavior).
 
 Common issues include:
 
@@ -154,9 +202,9 @@ Use a value that uniquely identifies each element across navigations, such as a 
 
 #### Do not mutate the DOM outside the Interactivity API
 
-All DOM modifications should go through Interactivity API directives. Directly manipulating the DOM using vanilla JavaScript APIs — such as `document.createElement()`, `element.appendChild()`, `element.remove()`, or jQuery methods — is not compatible with CSN. The Interactivity API's virtual DOM diffing won't be aware of these changes, and they will be lost or cause conflicts during navigation.
+All DOM modifications should go through Interactivity API directives. Directly manipulating the DOM using vanilla JavaScript APIs — such as `document.createElement()`, `element.appendChild()`, `element.remove()`, or jQuery methods — is not compatible with CSN. Elements added this way (like dynamically created tooltips or injected widgets) will vanish after navigating away and back, because the virtual DOM diffing is not aware of them.
 
-For cases where you need to update the inner HTML of an element or make other imperative DOM changes, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/api-reference.md#wp-watch) directive. This directive runs a callback whenever reactive state changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
+For cases where you need to update the inner HTML of an element or make other imperative DOM changes, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/api-reference.md#wp-watch) directive. This directive runs a callback whenever [reactive state](/docs/reference-guides/interactivity-api/api-reference.md#the-store) — the global state managed by the Interactivity API's `store()` — changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
 
 ```html
 <div
@@ -187,6 +235,14 @@ The Interactivity API's client-side navigation only manages content inside [rout
 
 If a block needs to render content outside its main region — for example, an overlay that must be a direct child of `<body>` — use the router's `attachTo` property to define a region that can be dynamically created during navigation. This is explained in the [Client-Side Navigation guide](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#attaching-new-router-regions).
 
+## Verifying compatibility
+
+After implementing the guidelines above, use the following approach to confirm that client-side navigation is working correctly with your block:
+
+1. **Check for full-page reloads.** Open the browser's Network tab (DevTools), then click a link that navigates to a page containing your block. If CSN is active, you'll see a `fetch` request for the new page's HTML instead of a full document navigation. A full document load means something on the page is incompatible — the Interactivity API fell back to a traditional navigation.
+2. **Test interactive state preservation.** Open a modal, expand an accordion, or trigger any interactive state in your block. Navigate to another page and then back. If the block's state is preserved (or correctly re-initialized via `data-wp-init`), CSN is working as expected. If the block appears frozen or unresponsive, check for DOM mutations or scripts running outside the Interactivity API.
+3. **Test across different templates.** Navigate between pages that use different templates (e.g., a single post and an archive). This exercises the CSS selector stability and HTML structure consistency rules, since different templates may produce different wrapper elements.
+
 ## Compatibility checklist
 
 Before marking your block as compatible with client-side navigation, verify the following:
@@ -199,16 +255,4 @@ Before marking your block as compatible with client-side navigation, verify the 
 -   [ ] Lists of sibling elements that can change between navigations use `data-wp-key`.
 -   [ ] The block uses script modules, not regular `<script>` tags.
 -   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
--   [ ] The block works correctly with the [experimental full-page client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#full-page-client-side-navigation-experimental) mode.
-
-## Quick reference
-
-| Block type                                           | Compatible?                      | Action                                        |
-| ---------------------------------------------------- | -------------------------------- | --------------------------------------------- |
-| Non-interactive block (no JS)                        | Yes                              | Set `clientNavigation` to `true`              |
-| Interactive block using the Interactivity API        | Yes (if guidelines are followed) | Set `interactivity` to `true`                 |
-| Interactive block using other libraries              | No                               | Omit or set `clientNavigation` to `false`     |
-| Block injecting or modifying CSS at runtime          | No                               | Use server-rendered styles or `data-wp-class` |
-| Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`              |
-| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
-| Block using regular scripts (not script modules)     | No                               | Migrate to script modules                     |
+-   [ ] (Optional) The block works correctly with the [experimental full-page client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#full-page-client-side-navigation-experimental) mode.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -88,10 +88,10 @@ The table below summarizes the compatibility status and required action for each
 | Interactive block using other libraries              | No                               | Omit or set `clientNavigation` to `false`     |
 | Block injecting or modifying CSS at runtime          | No                               | Use server-rendered styles or `data-wp-class` |
 | Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`              |
-| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
 | Block using regular scripts (not script modules)     | No                               | Migrate to script modules                     |
 | Block importing from `window.wp.*` globals           | No                               | Use ES module imports                         |
 | Block relying on DOM ready events for initialization | No                               | Use `data-wp-init`                            |
+| Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
 
 ## Ensuring compatibility
 
@@ -306,12 +306,12 @@ Before marking your block as compatible with client-side navigation, verify the 
 -   [ ] The block does not inject `<style>` elements dynamically through JavaScript.
 -   [ ] The block does not modify existing stylesheets at runtime (e.g., via CSSOM APIs).
 -   [ ] CSS selectors (class names, IDs) are stable across navigations — no use of `wp_unique_id()` for selectors.
--   [ ] The block does not manipulate the DOM using APIs outside the Interactivity API (e.g., `document.createElement`, jQuery).
--   [ ] Any HTML that needs to live outside the block's region (e.g., overlays on `<body>`) uses `attachTo` to define its own region.
--   [ ] Lists of sibling elements that can change between navigations use `data-wp-key`.
+-   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
 -   [ ] The block uses script modules, not regular `<script>` tags.
 -   [ ] The block does not import from `window.wp.*` globals — it uses ES module imports instead.
 -   [ ] The block does not rely on `DOMContentLoaded` or `load` events for initialization — it uses `data-wp-init` instead.
 -   [ ] If the block needs to sync state or context from the server on each navigation, it uses `getServerState()` or `getServerContext()`.
--   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
+-   [ ] Lists of sibling elements that can change between navigations use `data-wp-key`.
+-   [ ] The block does not manipulate the DOM using APIs outside the Interactivity API (e.g., `document.createElement`, jQuery).
+-   [ ] Any HTML that needs to live outside the block's region (e.g., overlays on `<body>`) uses `attachTo` to define its own region.
 -   [ ] (Optional) The block works correctly with the [experimental full-page client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#full-page-client-side-navigation-experimental) mode.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -161,14 +161,11 @@ The key rules for script modules and CSN:
 -   Only `<script type="module">` tags are supported. Regular `<script>` tags without `type="module"` are ignored during navigation.
 -   Only **external** script modules (those with a `src` attribute) are processed. Inline script modules — where the code is written directly inside the `<script>` tag — are not re-executed.
 -   For blocks, the `loadOnClientNavigation` flag is set automatically when the script module is declared in `block.json` and `supports.interactivity.clientNavigation` is `true`.
--   For non-block script modules (e.g., those enqueued by a theme or plugin), set `loadOnClientNavigation` to `true` manually when registering with [`wp_register_script_module()`](https://developer.wordpress.org/reference/functions/wp_register_script_module/):
+-   For non-block script modules (e.g., those enqueued by a theme or plugin), register the script module for client-side navigation explicitly using [`add_client_navigation_support_to_script_module()`](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#ensuring-script-modules-load-during-navigation):
 
 ```php
-wp_register_script_module(
-	'my-plugin/navigation-handler',
-	plugin_dir_url( __FILE__ ) . 'assets/navigation-handler.js',
-	array(),
-	array( 'loadOnClientNavigation' => true )
+wp_interactivity()->add_client_navigation_support_to_script_module(
+	'my-plugin/navigation-handler'
 );
 ```
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -201,7 +201,7 @@ Use a value that uniquely identifies each element across navigations, such as a 
 
 All DOM modifications should go through Interactivity API directives. Directly manipulating the DOM using vanilla JavaScript APIs — such as `document.createElement()`, `element.appendChild()`, `element.remove()`, or jQuery methods — is not compatible with CSN. Elements added this way (like dynamically created tooltips or injected widgets) will vanish after navigating away and back, because the virtual DOM diffing is not aware of them.
 
-For cases where you need to update the inner HTML of an element or make other imperative DOM changes, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/api-reference.md#wp-watch) directive. This directive runs a callback whenever [reactive state](/docs/reference-guides/interactivity-api/api-reference.md#the-store) — the global state managed by the Interactivity API's `store()` — changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
+For cases where you need to update the inner HTML of an element or make other imperative DOM changes, use the [`data-wp-watch`](/docs/reference-guides/interactivity-api/directives-and-store.md#wp-watch) directive. This directive runs a callback whenever [reactive state](/docs/reference-guides/interactivity-api/directives-and-store.md#the-store) — the global state managed by the Interactivity API's `store()` — changes, giving you a controlled way to perform side effects — including imperative DOM updates — that re-execute correctly after each navigation:
 
 ```html
 <div

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -75,7 +75,7 @@ That said, interactive blocks must follow certain practices to remain compatible
 
 The same applies for interactive regions included in classic PHP themes or plugins.
 
-### Interactive blocks using vanilla JavaScript (DOM APIs) other interactive libraries
+### Interactive blocks using vanilla JavaScript (DOM APIs) or other interactive libraries
 
 Blocks that use vanilla JavaScript, jQuery, or any framework other than the Interactivity API for client-side behavior are **not compatible** with client-side navigation. Set `clientNavigation` to `false` (or omit it) for these blocks.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -63,7 +63,7 @@ Even if a block appears to work fine with client-side navigation, the compatibil
 
 ### Non-interactive blocks
 
-Blocks that render HTML without any client-side interactivity — no JavaScript, no event listeners, no dynamic behavior — are generally compatible with client-side navigation. Since they don't rely on scripts to function, client-side navigation can safely replace their HTML without breaking anything.
+Blocks that render HTML without any client-side interactivity — no JavaScript, no event listeners, no dynamic behavior — are compatible with client-side navigation. Since they don't rely on scripts to function, client-side navigation can safely replace their HTML without breaking anything.
 
 However, compatibility must still be declared explicitly in `block.json`. The Interactivity API cannot infer compatibility on its own.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md
@@ -90,6 +90,8 @@ The table below summarizes the compatibility status and required action for each
 | Block using `wp_unique_id()` for CSS selectors       | No                               | Use `wp_unique_id_from_values()`              |
 | Block mutating the DOM outside the Interactivity API | No                               | Use directives or `data-wp-watch`             |
 | Block using regular scripts (not script modules)     | No                               | Migrate to script modules                     |
+| Block importing from `window.wp.*` globals           | No                               | Use ES module imports                         |
+| Block relying on DOM ready events for initialization | No                               | Use `data-wp-init`                            |
 
 ## Ensuring compatibility
 
@@ -171,6 +173,63 @@ wp_interactivity()->add_client_navigation_support_to_script_module(
 
 For more details on how script modules are handled during navigation, see the [Script module handling](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#script-module-handling) section of the Client-Side Navigation guide.
 
+#### Do not import from `window.wp.*` globals
+
+Accessing WordPress packages through global variables like `window.wp.element` or `window.wp.data` is not compatible with CSN. These globals are set by regular scripts, which are not re-executed during client-side navigation.
+
+**Instead:** Use ES module imports from the corresponding `@wordpress/*` script module, if one is available. For example, `@wordpress/a11y` is available both as a regular script (`window.wp.a11y`) and as a script module:
+
+```js
+// Avoid: Relies on a global set by a regular script.
+const { speak } = window.wp.a11y;
+
+// Preferred: ES module import, resolved by the script module system.
+import { speak } from '@wordpress/a11y';
+```
+
+#### Do not rely on DOM ready events for initialization
+
+Block hydration and initialization code should not depend on DOM ready events such as `DOMContentLoaded` or `load`. These events fire only once — on the initial full page load — and will not fire again after a client-side navigation. Any setup logic inside these listeners will not run when the user navigates to a new page.
+
+**Instead:** Use the `data-wp-init` directive for code that needs to run each time the block enters the page:
+
+```html
+<div data-wp-interactive="myPlugin" data-wp-init="callbacks.setup">
+	Block content
+</div>
+```
+
+For code that needs to run on every navigation — such as analytics page-view tracking — use `data-wp-watch` with a reactive value that changes on each navigation, like the current URL from the global state:
+
+```js
+import { store, getConfig } from '@wordpress/interactivity';
+
+const { namespace } = getConfig();
+
+store( namespace, {
+	callbacks: {
+		logPageView() {
+			// Re-runs on every navigation because state.url changes.
+			const { url } = store( 'core/router' ).state;
+			// Send analytics event for the new URL.
+			sendPageView( url );
+		},
+	},
+} );
+```
+
+```html
+<div data-wp-interactive="myPlugin" data-wp-watch="callbacks.logPageView">
+	Tracked content
+</div>
+```
+
+#### Use `getServerState()` and `getServerContext()` to sync server data
+
+If your block's state or context needs to reflect server-rendered values on each navigation — for example, resetting a counter, updating a label, or syncing data that changes per page — use `getServerState()` and `getServerContext()` inside your callbacks. These functions return the values from the server-rendered HTML of the newly navigated page, allowing you to reconcile client-side state with fresh server data after each navigation.
+
+For more details, see the [Server state and context](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#server-state-and-context) section of the Client-Side Navigation guide.
+
 ### HTML
 
 #### Keep consistent HTML structures
@@ -251,5 +310,8 @@ Before marking your block as compatible with client-side navigation, verify the 
 -   [ ] Any HTML that needs to live outside the block's region (e.g., overlays on `<body>`) uses `attachTo` to define its own region.
 -   [ ] Lists of sibling elements that can change between navigations use `data-wp-key`.
 -   [ ] The block uses script modules, not regular `<script>` tags.
+-   [ ] The block does not import from `window.wp.*` globals — it uses ES module imports instead.
+-   [ ] The block does not rely on `DOMContentLoaded` or `load` events for initialization — it uses `data-wp-init` instead.
+-   [ ] If the block needs to sync state or context from the server on each navigation, it uses `getServerState()` or `getServerContext()`.
 -   [ ] CSS animations and transitions work correctly after a client-side navigation (they may need to be re-triggered).
 -   [ ] (Optional) The block works correctly with the [experimental full-page client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md#full-page-client-side-navigation-experimental) mode.

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -103,15 +103,19 @@ For **blocks**, this attribute is added automatically when the block declares in
 }
 ```
 
-If your block's `block.json` already includes one of these, no additional setup is needed — WordPress handles the rest. To understand what makes a block compatible and how to verify compatibility, see the [Client-Side Navigation Compatibility](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md) guide.
+If your block's `block.json` already includes one of these, no additional setup is needed — WordPress handles the rest.
 
-For **classic themes** and other script modules registered outside of `block.json`, the attribute is not added automatically. You must register your script module for client-side navigation explicitly using `add_client_navigation_support_to_script_module()`:
+For **classic PHP themes** and other script modules registered outside of `block.json`, the attribute is not added automatically. You must register your script module for client-side navigation explicitly using `add_client_navigation_support_to_script_module()`:
 
 ```php
 wp_interactivity()->add_client_navigation_support_to_script_module(
     'my-theme/navigation'
 );
 ```
+
+<div class="callout callout-info">
+To understand what makes a block (or interactive elements in a classic PHP theme) compatible with client-side navigation, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility/">Client-Side Navigation Compatibility</a> guide.
+</div>
 
 Without this, the router will not load your script module when navigating to a page that needs it.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -9,6 +9,10 @@ The Interactivity API supports two navigation modes:
 -   **Region-based client-side navigation** — The recommended approach for implementing client-side navigation in WordPress.
 -   **Full-page client-side navigation** _(experimental)_ — Treats the entire `<body>` element as a single region, effectively updating the whole page content without a traditional reload. Covered at the end of this guide in [Full-page client-side navigation (experimental)](#full-page-client-side-navigation-experimental).
 
+<div class="callout callout-info">
+To learn how to ensure your blocks and interactive elements are compatible with client-side navigation, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility/">Client-Side Navigation Compatibility</a> guide.
+</div>
+
 ## How client-side navigation works
 
 When a user triggers a navigation, for example, by clicking a link that has a `data-wp-on--click` directive that calls `actions.navigate()`, the Interactivity Router:
@@ -99,7 +103,7 @@ For **blocks**, this attribute is added automatically when the block declares in
 }
 ```
 
-If your block's `block.json` already includes one of these, no additional setup is needed — WordPress handles the rest.
+If your block's `block.json` already includes one of these, no additional setup is needed — WordPress handles the rest. To understand what makes a block compatible and how to verify compatibility, see the [Client-Side Navigation Compatibility](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md) guide.
 
 For **classic themes** and other script modules registered outside of `block.json`, the attribute is not added automatically. You must register your script module for client-side navigation explicitly using `add_client_navigation_support_to_script_module()`:
 

--- a/docs/reference-guides/interactivity-api/iapi-faq.md
+++ b/docs/reference-guides/interactivity-api/iapi-faq.md
@@ -71,7 +71,7 @@ To summarize, using the Interactivity API rather than just using React comes wit
 
 ## What are the benefits of Interactivity API over just using jQuery or vanilla JavaScript?
 
-The main difference is that the Interactivity API is **declarative and reactive**, so writing and maintaining complex interactive experiences should become way easier. Additionally, it has been **specially designed to work with blocks**, providing a standard that comes with the benefits mentioned above, like inter-block communication, compatibility, or site-wide features such as client-side navigation.
+The main difference is that the Interactivity API is **declarative and reactive**, so writing and maintaining complex interactive experiences should become way easier. Additionally, it has been **specially designed to work with blocks**, providing a standard that comes with the benefits mentioned above, like inter-block communication, compatibility, or site-wide features such as [client-side navigation](/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md).
 
 Finally, comparing it with jQuery, **the Interactivity API runtime is ~10kb**, which is much more lightweight. Actually, there is an ongoing effort to remove heavy frameworks like jQuery across the WordPress ecosystem, and this would help in this regard.
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -223,9 +223,6 @@
 								"docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md": []
 							},
 							{
-								"docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md": []
-							},
-							{
 								"docs/reference-guides/interactivity-api/core-concepts/using-typescript.md": []
 							},
 							{

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -227,6 +227,12 @@
 							},
 							{
 								"docs/reference-guides/interactivity-api/core-concepts/using-typescript.md": []
+							},
+							{
+								"docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md": []
+							},
+							{
+								"docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md": []
 							}
 						]
 					},

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -7,7 +7,7 @@ The package defines an Interactivity API store with the `core/router` namespace,
 The `@wordpress/interactivity-router` package was [introduced in WordPress Core in v6.5](https://make.wordpress.org/core/2024/02/19/merge-announcement-interactivity-api/). This means this package is already bundled in Core in any version of WordPress higher than v6.5.
 
 <div class="callout callout-info">
-    For a comprehensive guide on how client-side navigation works, including getting started, block compatibility, and advanced use cases, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation/">Client-Side Navigation guide</a>.
+    For a comprehensive guide on how client-side navigation works, including getting started, block compatibility, and advanced use cases, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation/">Client-Side Navigation guide</a>. To learn how to ensure your blocks are compatible with client-side navigation, see the <a href="https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility/">Client-Side Navigation Compatibility guide</a>.
 </div>
 
 <div class="callout callout-info">


### PR DESCRIPTION
## What?

Adds a new documentation page: **Client-Side Navigation Compatibility Guide** for the Interactivity API.

## Why?

Block developers and theme authors need clear guidance on what makes their code compatible with client-side navigation. Without this, developers may unknowingly introduce patterns that break client-side navigation — causing fallbacks to full page reloads or potentially breaking the site, degrading the user experience.

There was no centralized reference for CSN compatibility, nor a checklist that developers could use to verify compatibility before declaring their blocks compatible.

## How?

Adds a new document at `docs/reference-guides/interactivity-api/core-concepts/client-side-navigation-compatibility.md` and links it from the Core Concepts README. The guide covers:

- **Declaring compatibility** in `block.json` via `supports.interactivity.clientNavigation`.
- **What makes a block compatible** — non-interactive blocks, Interactivity API blocks, and blocks using other libraries.
- **CSS requirements** — no dynamic CSS injection, no runtime stylesheet modifications, stable CSS selectors (with `wp_unique_id_from_values()` as the recommended alternative to `wp_unique_id()`), and selector consistency across navigations.
- **JavaScript requirements** — use of script modules instead of regular scripts, and how to handle script modules outside blocks (e.g., classic PHP themes) via `wp_register_script_module()` with `loadOnClientNavigation`.
- **HTML requirements** — consistent HTML structures, proper use of `data-wp-key` for dynamic lists, avoiding DOM mutations outside the Interactivity API (with `data-wp-watch` as the escape hatch), and using `attachTo` for HTML outside router regions.
- **Compatibility checklist** — a pre-flight checklist for developers to verify before marking a block as CSN-compatible.
- **Quick reference table** summarizing block types and their compatibility status.

The guide is written to be useful for both block developers and classic PHP theme/plugin authors.