### PR TITLE
Add experiment: render the editor inspector with DataForm

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -31,6 +31,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalExtensibleSiteEditor = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataform-inspector' ) ) {
+		wp_add_inline_script( 'wp-editor', 'window.__experimentalDataFormInspector = true', 'before' );
+	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaEditor = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -162,6 +162,18 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
+		'gutenberg-dataform-inspector',
+		__( 'DataForm Inspector: Use DataForm for the document inspector sidebar', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Replaces the bespoke editor inspector panels with a unified DataForm-based implementation, matching the QuickEdit experience.', 'gutenberg' ),
+			'id'    => 'gutenberg-dataform-inspector',
+		)
+	);
+
+	add_settings_field(
 		'gutenberg-workflow-palette',
 		__( 'Workflow Palette', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -163,7 +163,7 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-dataform-inspector',
-		__( 'DataForm Inspector: Use DataForm for the document inspector sidebar', 'gutenberg' ),
+		__( 'Editor Inspector: Use DataForm', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -168,7 +168,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Replaces the bespoke editor inspector panels with a unified DataForm-based implementation, matching the QuickEdit experience.', 'gutenberg' ),
+			'label' => __( 'Replaces the bespoke editor inspector panels with a unified DataForm-based implementation for Pages and Posts, matching the QuickEdit experience.', 'gutenberg' ),
 			'id'    => 'gutenberg-dataform-inspector',
 		)
 	);

--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -126,7 +126,7 @@ function AuthorField( { item } ) {
 		<HStack alignment="left" spacing={ 0 }>
 			{ imageUrl && (
 				<div
-					className={ clsx( 'page-templates-author-field__avatar', {
+					className={ clsx( 'fields-controls__author-avatar', {
 						'is-loaded': isImageLoaded,
 					} ) }
 				>
@@ -138,11 +138,11 @@ function AuthorField( { item } ) {
 				</div>
 			) }
 			{ ! imageUrl && (
-				<div className="page-templates-author-field__icon">
+				<div className="fields-controls__author-icon">
 					<Icon icon={ icon } />
 				</div>
 			) }
-			<span className="page-templates-author-field__name">{ text }</span>
+			<span className="fields-controls__author-name">{ text }</span>
 		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -125,7 +125,7 @@ function AuthorField( { item } ) {
 		<HStack alignment="left" spacing={ 0 }>
 			{ imageUrl && (
 				<div
-					className={ clsx( 'page-templates-author-field__avatar', {
+					className={ clsx( 'fields-controls__author-avatar', {
 						'is-loaded': isImageLoaded,
 					} ) }
 				>
@@ -137,11 +137,11 @@ function AuthorField( { item } ) {
 				</div>
 			) }
 			{ ! imageUrl && (
-				<div className="page-templates-author-field__icon">
+				<div className="fields-controls__author-icon">
 					<Icon icon={ icon } />
 				</div>
 			) }
-			<span className="page-templates-author-field__name">{ text }</span>
+			<span className="fields-controls__author-name">{ text }</span>
 		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -38,51 +38,6 @@
 	}
 }
 
-.page-templates-author-field__avatar {
-	flex-shrink: 0;
-	overflow: hidden;
-	width: $grid-unit-30;
-	height: $grid-unit-30;
-	align-items: center;
-	justify-content: left;
-	display: flex;
-
-	img {
-		width: $grid-unit-20;
-		height: $grid-unit-20;
-		object-fit: cover;
-		opacity: 0;
-		border-radius: 100%;
-
-		@media not (prefers-reduced-motion) {
-			transition: opacity 0.1s linear;
-		}
-	}
-
-	&.is-loaded {
-		img {
-			opacity: 1;
-		}
-	}
-}
-
-.page-templates-author-field__icon {
-	display: flex;
-	flex-shrink: 0;
-	width: $grid-unit-30;
-	height: $grid-unit-30;
-
-	svg {
-		margin-left: -$grid-unit-05;
-		fill: currentColor;
-	}
-}
-
-.page-templates-author-field__name {
-	text-overflow: ellipsis;
-	overflow: hidden;
-}
-
 .edit-site-list__rename-modal {
 	// The rename dropdown popover is open at the same time as the rename modal. The latter has to be higher.
 	z-index: z-index(".edit-site-list__rename-modal");

--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -68,15 +68,6 @@
 	}
 }
 
-.edit-site-post-list__status-icon {
-	height: $grid-unit-30;
-	width: $grid-unit-30;
-	svg {
-		fill: currentColor;
-		margin-left: -$grid-unit-05;
-	}
-}
-
 .fields-controls__password {
 	border-top: $border-width solid $gray-200;
 	padding-top: $grid-unit-20;

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -1,0 +1,141 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { DataForm } from '@wordpress/dataviews';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PostCardPanel from '../post-card-panel';
+import PostPanelSection from '../post-panel-section';
+import { store as editorStore } from '../../store';
+import PostTrash from '../post-trash';
+import usePostFields from '../post-fields';
+import { unlock } from '../../lock-unlock';
+
+const form = {
+	layout: {
+		type: 'panel',
+	},
+	fields: [
+		{
+			id: 'featured_media',
+			layout: {
+				type: 'regular',
+				labelPosition: 'none',
+			},
+		},
+		{
+			id: 'status',
+			label: __( 'Status' ),
+			children: [
+				{
+					id: 'status',
+					layout: { type: 'regular', labelPosition: 'none' },
+				},
+				'password',
+			],
+		},
+		'author',
+		'date',
+		'slug',
+		'parent',
+		{
+			id: 'discussion',
+			label: __( 'Discussion' ),
+			children: [
+				{
+					id: 'comment_status',
+					layout: { type: 'regular', labelPosition: 'none' },
+				},
+				'ping_status',
+			],
+		},
+		'template',
+	],
+};
+
+export default function DataFormPostSummary( { onActionPerformed } ) {
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = unlock(
+			select( editorStore )
+		);
+		return {
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
+	}, [] );
+
+	const record = useSelect(
+		( select ) => {
+			if ( ! postType || ! postId ) {
+				return null;
+			}
+			return select( coreDataStore ).getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+		},
+		[ postType, postId ]
+	);
+
+	const { editEntityRecord } = useDispatch( coreDataStore );
+
+	const _fields = usePostFields( { postType } );
+	const fields = useMemo(
+		() =>
+			_fields?.map( ( field ) => {
+				if ( field.id === 'status' ) {
+					return {
+						...field,
+						elements: field.elements.filter(
+							( element ) => element.value !== 'trash'
+						),
+					};
+				}
+				return field;
+			} ),
+		[ _fields ]
+	);
+
+	const onChange = ( edits ) => {
+		if (
+			edits.status &&
+			edits.status !== 'future' &&
+			record?.status === 'future' &&
+			new Date( record.date ) > new Date()
+		) {
+			edits.date = null;
+		}
+		if ( edits.status && edits.status === 'private' && record?.password ) {
+			edits.password = '';
+		}
+
+		editEntityRecord( 'postType', postType, postId, edits );
+	};
+
+	return (
+		<PostPanelSection className="editor-post-summary">
+			<VStack spacing={ 4 }>
+				<PostCardPanel
+					postType={ postType }
+					postId={ postId }
+					onActionPerformed={ onActionPerformed }
+				/>
+				<DataForm
+					data={ record }
+					fields={ fields }
+					form={ form }
+					onChange={ onChange }
+				/>
+				<PostTrash onActionPerformed={ onActionPerformed } />
+			</VStack>
+		</PostPanelSection>
+	);
+}

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -45,7 +45,14 @@ import { unlock } from '../../lock-unlock';
 const PANEL_NAME = 'post-status';
 
 export default function PostSummary( { onActionPerformed } ) {
-	if ( window?.__experimentalDataFormInspector ) {
+	const postType = useSelect(
+		( select ) => select( editorStore ).getCurrentPostType(),
+		[]
+	);
+	if (
+		window?.__experimentalDataFormInspector &&
+		[ 'page', 'post' ].includes( postType )
+	) {
 		return <DataFormPostSummary onActionPerformed={ onActionPerformed } />;
 	}
 	return <ClassicPostSummary onActionPerformed={ onActionPerformed } />;

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -12,6 +12,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
+import DataFormPostSummary from './dataform-post-summary';
 import PluginPostStatusInfo from '../plugin-post-status-info';
 import PostAuthorPanel from '../post-author/panel';
 import PostCardPanel from '../post-card-panel';
@@ -44,6 +45,13 @@ import { unlock } from '../../lock-unlock';
 const PANEL_NAME = 'post-status';
 
 export default function PostSummary( { onActionPerformed } ) {
+	if ( window?.__experimentalDataFormInspector ) {
+		return <DataFormPostSummary onActionPerformed={ onActionPerformed } />;
+	}
+	return <ClassicPostSummary onActionPerformed={ onActionPerformed } />;
+}
+
+function ClassicPostSummary( { onActionPerformed } ) {
 	const { isRemovedPostStatusPanel, postType, postId, revisionId } =
 		useSelect( ( select ) => {
 			// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -2,6 +2,7 @@
 @use "@wordpress/interface/build-style/style.css" as *;
 @use "@wordpress/global-styles-ui/build-style/style.css" as *;
 @use "@wordpress/dataviews/build-style/style.css" as *;
+@use "@wordpress/fields/build-style/style.css" as *;
 @use "@wordpress/media-editor/build-style/style.css" as *;
 @use "./components/autocompleters/style.scss" as *;
 @use "./components/collab-sidebar/style.scss" as *;

--- a/packages/fields/src/fields/author/author-view.tsx
+++ b/packages/fields/src/fields/author/author-view.tsx
@@ -51,7 +51,7 @@ function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
 		<HStack alignment="left" spacing={ 0 }>
 			{ !! imageUrl && (
 				<div
-					className={ clsx( 'page-templates-author-field__avatar', {
+					className={ clsx( 'fields-controls__author-avatar', {
 						'is-loaded': isImageLoaded,
 					} ) }
 				>
@@ -63,11 +63,11 @@ function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
 				</div>
 			) }
 			{ ! imageUrl && (
-				<div className="page-templates-author-field__icon">
+				<div className="fields-controls__author-icon">
 					<Icon icon={ authorIcon } />
 				</div>
 			) }
-			<span className="page-templates-author-field__name">{ text }</span>
+			<span className="fields-controls__author-name">{ text }</span>
 		</HStack>
 	);
 }

--- a/packages/fields/src/fields/author/author-view.tsx
+++ b/packages/fields/src/fields/author/author-view.tsx
@@ -19,13 +19,13 @@ import { store as coreStore } from '@wordpress/core-data';
 import type { BasePostWithEmbeddedAuthor } from '../../types';
 
 function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
-	// When editing, item.author may differ from _embedded.author (which preserves
-	// the saved record). Fetch the updated author only when they differ, so the
-	// view reflects edits while lists preserve original data.
+	// Fetch the author record from the store when _embedded data is unavailable
+	// (e.g. in the post editor inspector) or when the author has been changed
+	// during editing (item.author differs from _embedded.author).
 	const authorId = item?.author;
 	const embeddedAuthorId = item?._embedded?.author?.[ 0 ]?.id;
 	const shouldFetch = Boolean(
-		authorId && embeddedAuthorId && authorId !== embeddedAuthorId
+		authorId && ( ! embeddedAuthorId || authorId !== embeddedAuthorId )
 	);
 	const author = useSelect(
 		( select ) => {

--- a/packages/fields/src/fields/author/style.scss
+++ b/packages/fields/src/fields/author/style.scss
@@ -1,0 +1,46 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.fields-controls__author-avatar {
+	flex-shrink: 0;
+	overflow: hidden;
+	width: $grid-unit-30;
+	height: $grid-unit-30;
+	align-items: center;
+	justify-content: left;
+	display: flex;
+
+	img {
+		width: $grid-unit-20;
+		height: $grid-unit-20;
+		object-fit: cover;
+		opacity: 0;
+		border-radius: 100%;
+
+		@media not (prefers-reduced-motion) {
+			transition: opacity 0.1s linear;
+		}
+	}
+
+	&.is-loaded {
+		img {
+			opacity: 1;
+		}
+	}
+}
+
+.fields-controls__author-icon {
+	display: flex;
+	flex-shrink: 0;
+	width: $grid-unit-30;
+	height: $grid-unit-30;
+
+	svg {
+		margin-left: -$grid-unit-05;
+		fill: currentColor;
+	}
+}
+
+.fields-controls__author-name {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}

--- a/packages/fields/src/fields/status/status-view.tsx
+++ b/packages/fields/src/fields/status/status-view.tsx
@@ -16,7 +16,7 @@ function StatusView( { item }: { item: BasePost } ) {
 	return (
 		<HStack alignment="left" spacing={ 0 }>
 			{ icon && (
-				<div className="edit-site-post-list__status-icon">
+				<div className="fields-controls__status-icon">
 					<Icon icon={ icon } />
 				</div>
 			) }

--- a/packages/fields/src/fields/status/style.scss
+++ b/packages/fields/src/fields/status/style.scss
@@ -1,0 +1,10 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.fields-controls__status-icon {
+	height: $grid-unit-30;
+	width: $grid-unit-30;
+	svg {
+		fill: currentColor;
+		margin-left: -$grid-unit-05;
+	}
+}

--- a/packages/fields/src/style.scss
+++ b/packages/fields/src/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/default-custom-properties";
 @use "./components/create-template-part-modal/style.scss" as *;
 @use "./components/media-edit/style.scss" as *;
+@use "./fields/author/style.scss" as *;
 @use "./fields/slug/style.scss" as *;
 @use "./fields/featured-image/style.scss" as *;
 @use "./fields/parent/style.scss" as *;

--- a/packages/fields/src/style.scss
+++ b/packages/fields/src/style.scss
@@ -5,5 +5,6 @@
 @use "./fields/featured-image/style.scss" as *;
 @use "./fields/parent/style.scss" as *;
 @use "./fields/password/style.scss" as *;
+@use "./fields/status/style.scss" as *;
 @use "./fields/title/style.scss" as *;
 @use "./fields/pattern-title/style.scss" as *;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76076

## What?
                                                                                                                                                                                                                                                                                                                                                                          
Bootstrap a DataForm-based inspector sidebar for the post editor, behind an experiment flag.

Note this is not a full replacement yet (hence the experiment). Check https://github.com/WordPress/gutenberg/issues/76076 for ongoing work.

## Why?

See https://github.com/WordPress/gutenberg/issues/76076

## How?

- New experiment: `gutenberg-dataform-inspector` — toggleable in Gutenberg → Experiments.
- New component: `DataFormPostSummary` in `@wordpress/editor`.
- Entry point switch: `PostSummary` checks `window.__experimentalDataFormInspector` and renders either the new DataForm or the classic panels.
- Styles migration: Author and status field styles moved from edit-site to @wordpress/fields with renamed classes (fields-controls__author-avatar, fields-controls__author-icon, fields-controls__author-name, fields-controls__status-icon). The @wordpress/editor stylesheet now imports @wordpress/fields styles.
- Author fetch fix: AuthorView now fetches the author record from the store when _embedded data is absent (as in entity records from getEditedEntityRecord), not only when the author ID has changed.

## Testing Instructions

1. Go to Gutenberg → Experiments and enable DataForm Inspector.
2. Open or create a post in the post editor.
3. In the Post sidebar, verify the new DataForm is loaded.
4. Disable the experiment — the classic sidebar panels should appear as before.
5. In the Site Editor → Templates or Posts list, verify QuickEdit still renders author/status fields correctly.

| Pages Inspector (existing) | Pages Inspector (this PR) | QuickEdit |
| --- | --- | --- |
| <img width="292" height="638" alt="Screenshot 2026-03-06 at 13 27 06" src="https://github.com/user-attachments/assets/c3a976fe-c091-4b13-b6dd-4df8e2e2b88e" /> | <img width="292" height="638" alt="Screenshot 2026-03-06 at 13 27 22" src="https://github.com/user-attachments/assets/54b4bee0-b509-42bc-9e75-9bff979f432c" /> | <img width="369" height="618" alt="Screenshot 2026-03-06 at 13 26 03" src="https://github.com/user-attachments/assets/22d1fbd3-b157-4542-a50f-c7b35a6f149c" /> |

