### PR TITLE
Show spinner when replacing media via drag-and-drop

### DIFF
--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -4,6 +4,7 @@
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { cover as icon } from '@wordpress/icons';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -18,6 +19,12 @@ export default function CoverPlaceholder( {
 	style,
 	toggleUseFeaturedImage,
 } ) {
+	const onFilesPreUpload = ( files ) => {
+		if ( files.length === 1 ) {
+			onSelectMedia( { url: createBlobURL( files[ 0 ] ) } );
+		}
+	};
+
 	return (
 		<MediaPlaceholder
 			icon={ <BlockIcon icon={ icon } /> }
@@ -28,6 +35,7 @@ export default function CoverPlaceholder( {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }
+			onFilesPreUpload={ onFilesPreUpload }
 			onError={ onError }
 			style={ style }
 		>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -159,12 +159,19 @@ export function ImageEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
+		setTemporaryURL();
 		setAttributes( {
 			src: undefined,
 			id: undefined,
 			url: undefined,
 			blob: undefined,
 		} );
+	}
+
+	function onFilesPreUpload( files ) {
+		if ( files.length === 1 ) {
+			setTemporaryURL( createBlobURL( files[ 0 ] ) );
+		}
 	}
 
 	function onSelectImagesList( images ) {
@@ -479,6 +486,7 @@ export function ImageEdit( {
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectImage }
 					onSelectURL={ onSelectURL }
+					onFilesPreUpload={ onFilesPreUpload }
 					onError={ onUploadError }
 					placeholder={ placeholder }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -18,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
-import { isBlobURL } from '@wordpress/blob';
+import { createBlobURL, isBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
 import { media as icon } from '@wordpress/icons';
 
@@ -82,6 +82,12 @@ function PlaceholderContainer( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
+	const onFilesPreUpload = ( files ) => {
+		if ( files.length === 1 ) {
+			onSelectMedia( { url: createBlobURL( files[ 0 ] ) } );
+		}
+	};
+
 	return (
 		<MediaPlaceholder
 			icon={ <BlockIcon icon={ icon } /> }
@@ -92,6 +98,7 @@ function PlaceholderContainer( {
 			onSelect={ onSelectMedia }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
+			onFilesPreUpload={ onFilesPreUpload }
 			onError={ onUploadError }
 			disableMediaButtons={ mediaUrl }
 		/>


### PR DESCRIPTION
## What?

Add visual feedback (spinner) when dragging files onto existing media blocks to replace them. Currently only initial uploads show a spinner—replacements happen silently.

## Why?

When users drag-and-drop a file onto an existing image, cover, or media-text block, the media upload can take several seconds, but there's no loading indicator. Users don't know if anything is happening, making the experience feel broken or slow.

## How?

Added `onFilesPreUpload` callback to MediaPlaceholder in all three affected blocks (image, cover, media-text). This callback creates a blob URL immediately when files are dropped, which triggers the existing spinner/opacity UI (`temporaryURL` state + `is-transient` CSS class).

Also fixed a bug in the image block where `onUploadError` didn't clear `temporaryURL`, leaving the spinner visible on error.

## Testing Instructions

1. Open a post or page in the editor
2. Add an image block and upload an image
3. Drag a new image file from desktop onto the existing image
4. Verify: spinner appears immediately, image fades to 30% opacity
5. Verify: when upload completes, new image displays at full opacity
6. Repeat for cover and media-text blocks

### Testing Instructions for Keyboard

1. Insert an image block (via `/image` command)
2. Upload an image using the media library (keyboard navigation to upload button)
3. Use Tab to focus the placeholder area
4. While not currently keyboard-accessible for drop, verify the spinner renders correctly during file uploads initiated via the media library