### PR TITLE
Fields: Hide `scheduledDateField` from the list and filters

### DIFF
--- a/packages/fields/src/fields/date/scheduled/index.tsx
+++ b/packages/fields/src/fields/date/scheduled/index.tsx
@@ -16,6 +16,9 @@ const scheduledDateField: Field< BasePost > = {
 	getValue: ( { item } ) => item.date,
 	setValue: ( { value } ) => ( { date: value } ),
 	isVisible: ( item ) => item.status === 'future',
+	enableHiding: false,
+	enableSorting: false,
+	filterBy: false,
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/76129

Hide `scheduledDateField` from the list and filters. It's similar to `password` field and the existing `dateField` renders the scheduled date if set.
