### PR TITLE
Components: Consolidate focus style treatment

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -137,46 +137,48 @@
  */
 
 @mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 variables.$border-width colors.$white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
+	outline-width: var(--wp-admin-border-width-focus);
+	outline-style: solid;
+	outline-color: var(--wp-admin-theme-color);
+	outline-offset: 1px;
 }
 
 // Tabs, Inputs, Square buttons.
 @mixin input-style__neutral() {
-	box-shadow: 0 0 0 transparent;
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 	border-radius: variables.$radius-small;
 	border: variables.$border-width solid colors.$gray-600;
 
 	@media not (prefers-reduced-motion) {
-		transition: box-shadow 0.1s linear;
+		transition: outline 0.1s ease-out;
 	}
 }
 
 
 @mixin input-style__focus($accent-color: var(--wp-admin-theme-color)) {
 	border-color: $accent-color;
-	// Expand the default border focus style by .5px to be a total of 1.5px.
-	box-shadow: 0 0 0 0.5px $accent-color;
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
+	outline-width: var(--wp-admin-border-width-focus);
+	outline-style: solid;
+	outline-color: $accent-color;
+	outline-offset: 1px;
 }
 
 @mixin button-style__focus() {
-	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
+	outline-width: var(--wp-admin-border-width-focus);
+	outline-style: solid;
+	outline-color: var(--wp-admin-theme-color);
+	outline-offset: 1px;
 }
 
 
 @mixin button-style-outset__focus($focus-color) {
-	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) colors.$white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $focus-color;
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
-	outline-offset: 2px;
+	outline-width: var(--wp-admin-border-width-focus);
+	outline-style: solid;
+	outline-color: $focus-color;
+	outline-offset: 1px;
 }
 
 
@@ -312,10 +314,10 @@
 	@include input-control;
 
 	&:focus {
-		box-shadow: 0 0 0 (variables.$border-width * 2) colors.$white, 0 0 0 (variables.$border-width * 2 + variables.$border-width-focus-fallback) var(--wp-admin-theme-color);
-
-		// Only visible in Windows High Contrast mode.
-		outline: 2px solid transparent;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-style: solid;
+		outline-color: var(--wp-admin-theme-color);
+		outline-offset: 1px;
 	}
 
 	&:checked {
@@ -379,9 +381,13 @@
 	min-width: variables.$radio-input-size-sm;
 	max-width: variables.$radio-input-size-sm;
 	position: relative;
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 
 	@media not (prefers-reduced-motion) {
-		transition: box-shadow 0.1s linear;
+		transition: outline 0.1s ease-out;
 	}
 
 	@include break-small() {
@@ -412,10 +418,10 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 (variables.$border-width * 2) colors.$white, 0 0 0 (variables.$border-width * 2 + variables.$border-width-focus-fallback) var(--wp-admin-theme-color);
-
-		// Only visible in Windows High Contrast mode.
-		outline: 2px solid transparent;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-style: solid;
+		outline-color: var(--wp-admin-theme-color);
+		outline-offset: 1px;
 	}
 
 	&:checked {
@@ -442,7 +448,10 @@
 @mixin link-reset {
 	&:focus {
 		color: var(--wp-admin-theme-color--rgb);
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color, #007cba);
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-style: solid;
+		outline-color: var(--wp-admin-theme-color, #007cba);
+		outline-offset: 1px;
 		border-radius: variables.$radius-small;
 	}
 }
@@ -465,10 +474,10 @@
 
 	&:focus {
 		border-color: var(--wp-admin-theme-color) !important;
-		box-shadow: 0 0 0 (variables.$border-width-focus-fallback - variables.$border-width) var(--wp-admin-theme-color) !important;
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent !important;
+		outline-width: var(--wp-admin-border-width-focus) !important;
+		outline-style: solid !important;
+		outline-color: var(--wp-admin-theme-color) !important;
+		outline-offset: 1px !important;
 	}
 }
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Replace `box-shadow` focus styles with `outline`-based focus rings across all components for consistency, better border-radius inheritance, and automatic forced-colors support ([#76249](https://github.com/WordPress/gutenberg/pull/76249)).
+
 ### Bug Fixes
 
 -   Revert `word-break: break-word` addition ([#76230](https://github.com/WordPress/gutenberg/pull/76230)).

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -16,8 +16,11 @@ import {
 
 import type { Border } from './types';
 
-const focusBoxShadow = css`
-	box-shadow: inset ${ CONFIG.controlBoxShadowFocus };
+const focusOutline = css`
+	outline-width: ${ CONFIG.borderWidthFocus };
+	outline-style: solid;
+	outline-color: ${ COLORS.theme.accent };
+	outline-offset: 1px;
 `;
 
 export const borderControl = css`
@@ -70,10 +73,14 @@ export const borderControlDropdown = css`
 		)() }
 		border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 
-		&:focus,
 		&:hover:not( :disabled ) {
-			${ focusBoxShadow }
 			border-color: ${ COLORS.ui.borderFocus };
+			z-index: 1;
+			position: relative;
+		}
+
+		&:focus {
+			${ focusOutline }
 			z-index: 1;
 			position: relative;
 		}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -22,9 +22,10 @@
 	appearance: none;
 	background: none;
 
-	@media not ( prefers-reduced-motion ) {
-		transition: box-shadow 0.1s linear;
-	}
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 
 	height: $button-size;
 	align-items: center;
@@ -45,12 +46,12 @@
 	// Focus.
 	// See https://github.com/WordPress/gutenberg/issues/13267 for more context on these selectors.
 	&:focus:not(:active) {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-	}
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	&:focus {
-		outline: 3px solid transparent;
+		@media not ( prefers-reduced-motion ) {
+			transition: outline 0.1s ease-out;
+		}
 	}
 
 	/**
@@ -79,7 +80,8 @@
 		}
 
 		&:focus:not(:active) {
-			box-shadow: inset 0 0 0 1px $components-color-background, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-color: $components-color-accent;
 		}
 
 		&:disabled,
@@ -91,10 +93,10 @@
 			color: rgba($white, 0.4);
 			background: $components-color-accent;
 			border-color: $components-color-accent;
-			outline: none;
 
 			&:focus:enabled {
-				box-shadow: inset 0 0 0 1px $components-color-background, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+				outline-width: var(--wp-admin-border-width-focus);
+				outline-color: $components-color-accent;
 			}
 		}
 
@@ -162,7 +164,8 @@
 		}
 
 		&:focus:not(:active) {
-			box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-color: $components-color-accent;
 		}
 	}
 
@@ -216,7 +219,8 @@
 			}
 
 			&:focus:not(:active) {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $alert-red;
+				outline-width: var(--wp-admin-border-width-focus);
+				outline-color: $alert-red;
 			}
 
 			&:active:not(:disabled, [aria-disabled="true"]) {
@@ -379,12 +383,8 @@
 		}
 
 		&:focus:not(:active) {
-			box-shadow: inset 0 0 0 1px $components-color-background, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-		}
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		&:focus {
-			outline: 2px solid transparent;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-color: $components-color-accent;
 		}
 	}
 

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -29,7 +29,6 @@
 	display: inline-block;
 	line-height: 0;
 	margin: 0 $grid-unit-05 0 0;
-	outline: 0;
 	padding: 0 !important;
 	text-align: center;
 	vertical-align: top;

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -23,9 +23,8 @@ $border-as-box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	box-shadow: $border-as-box-shadow;
 
 	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-		// Show a outline in Windows high contrast mode.
-		outline-width: 2px;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 	}
 
 	&::after {

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/mixins" as *;
+@use "../utils/theme-variables" as *;
 
 $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 16px handles inside, that leaves 32px padding, half of which is 1å6.
 
@@ -63,18 +64,20 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 		border-radius: $radius-round;
 		padding: 0;
 
-		// Shadow and stroke.
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 $border-width-focus-fallback 0 rgba($black, 0.25);
+		outline-width: 0;
+		outline-style: solid;
+		outline-color: transparent;
+		outline-offset: 1px;
 
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
+		@media not (prefers-reduced-motion) {
+			transition: outline 0.1s ease-out;
+		}
 
 		&:focus,
 		&.is-active {
-			box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) $white, 0 0 $border-width-focus-fallback 0 rgba($black, 0.25);
-
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: $border-width-tab solid transparent;
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-color: $components-color-accent;
 		}
 	}
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -15,7 +15,6 @@
 	.components-menu-item {
 		width: 100%;
 		padding: 6px;
-		outline: none;
 		cursor: pointer;
 		white-space: nowrap;
 		font-weight: $font-weight-regular;

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -29,11 +29,16 @@ $transition-duration: 0.2s;
 		width: $toggle-width;
 		height: $toggle-height;
 		border-radius: math.div($toggle-height, 2);
+		outline-width: 0;
+		outline-style: solid;
+		outline-color: transparent;
+		outline-offset: 1px;
 
 		@media not (prefers-reduced-motion) {
 			transition:
 				$transition-duration background-color ease,
-				$transition-duration border-color ease;
+				$transition-duration border-color ease,
+				outline 0.1s ease-out;
 		}
 
 		overflow: hidden;

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -69,6 +69,14 @@ export const BackdropUI = styled.div< BackdropProps >`
 		position: absolute;
 		right: 0;
 		top: 0;
+		outline-width: 0;
+		outline-style: solid;
+		outline-color: transparent;
+		outline-offset: 1px;
+
+		@media not ( prefers-reduced-motion ) {
+			transition: outline 0.1s ease-out;
+		}
 
 		${ rtl( { paddingLeft: 2 } ) }
 	}
@@ -84,10 +92,8 @@ export const Root = styled( Flex )`
 	&:focus-within:not( :has( :is( ${ Prefix }, ${ Suffix } ):focus-within ) ) {
 		${ BackdropUI } {
 			border-color: ${ COLORS.ui.borderFocus };
-			box-shadow: ${ CONFIG.controlBoxShadowFocus };
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 2px solid transparent;
-			outline-offset: -2px;
+			outline-width: ${ CONFIG.borderWidthFocus };
+			outline-color: ${ COLORS.theme.accent };
 		}
 	}
 `;

--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -28,17 +28,14 @@ export const unstyledButton = ( as: 'a' | 'button' ) => {
 			color: ${ COLORS.theme.accent };
 		}
 
-		&:focus {
-			box-shadow: none;
-			outline: none;
-		}
+		outline-width: 0;
+		outline-style: solid;
+		outline-color: transparent;
+		outline-offset: 1px;
 
 		&:focus-visible {
-			box-shadow: 0 0 0 var( --wp-admin-border-width-focus )
-				${ COLORS.theme.accent };
-			// Windows high contrast mode.
-			outline: 2px solid transparent;
-			outline-offset: 0;
+			outline-width: var( --wp-admin-border-width-focus );
+			outline-color: ${ COLORS.theme.accent };
 		}
 	`;
 };

--- a/packages/components/src/menu/styles.ts
+++ b/packages/components/src/menu/styles.ts
@@ -153,7 +153,6 @@ const baseItem = css`
 	scroll-margin: ${ CONTENT_WRAPPER_PADDING };
 
 	user-select: none;
-	outline: none;
 
 	&[aria-disabled='true'] {
 		color: ${ COLORS.ui.textDisabled };
@@ -168,12 +167,15 @@ const baseItem = css`
 		color: ${ COLORS.theme.accentInverted };
 	}
 
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
+
 	/* Keyboard focus (focus-visible) */
 	&[data-focus-visible] {
-		box-shadow: 0 0 0 1.5px ${ COLORS.theme.accent };
-
-		/* Only visible in Windows High Contrast mode */
-		outline: 2px solid transparent;
+		outline-width: var( --wp-admin-border-width-focus );
+		outline-color: ${ COLORS.theme.accent };
 	}
 
 	/* Active (ie. pressed, mouse down) */

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -215,10 +215,9 @@
 	}
 
 	&.is-scrollable:focus-visible {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
-		outline-offset: -2px;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-style: solid;
+		outline-color: $components-color-accent;
+		outline-offset: 1px;
 	}
 }

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -87,7 +87,6 @@
 .components-panel__body-toggle.components-button {
 	position: relative;
 	padding: $grid-unit-20 $grid-unit-60 $grid-unit-20 $grid-unit-20;
-	outline: none;
 	width: 100%;
 	font-weight: $font-weight-medium;
 	text-align: left;
@@ -102,7 +101,8 @@
 	height: auto;
 
 	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 		border-radius: 0;
 	}
 

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -217,32 +217,28 @@ export const ThumbWrapper = styled.span`
 `;
 
 const thumbFocus = ( { isFocused }: ThumbProps ) => {
-	return isFocused
-		? css`
-				&::before {
-					content: ' ';
-					position: absolute;
-					background-color: ${ COLORS.theme.accent };
-					opacity: 0.4;
-					border-radius: ${ CONFIG.radiusRound };
-					height: ${ thumbSize + 8 }px;
-					width: ${ thumbSize + 8 }px;
-					top: -4px;
-					left: -4px;
+	return css`
+		outline-style: solid;
+		outline-offset: 1px;
+		outline-width: 0;
+		outline-color: transparent;
 
-					@media ( forced-colors: active ) {
-						background: GrayText;
-					}
-				}
-		  `
-		: '';
+		@media not ( prefers-reduced-motion ) {
+			transition: outline 0.1s ease-out;
+		}
+
+		${ isFocused &&
+		css`
+			outline-width: ${ CONFIG.borderWidthFocus };
+			outline-color: ${ COLORS.theme.accent };
+		` }
+	`;
 };
 
 export const Thumb = styled.span< ThumbProps >`
 	align-items: center;
 	border-radius: ${ CONFIG.radiusRound };
 	height: 100%;
-	outline: 0;
 	position: absolute;
 	user-select: none;
 	width: 100%;

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -26,8 +26,18 @@
 		width: fit-content;
 	}
 
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
+
+	@media not (prefers-reduced-motion) {
+		transition: outline 0.1s ease-out;
+	}
+
 	&:focus {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 	}
 
 	&.components-snackbar-explicit-dismiss {
@@ -57,9 +67,13 @@
 	color: $white;
 	flex-shrink: 0;
 
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
+
 	&:focus {
-		box-shadow: none;
-		outline: 1px dotted $white;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 	}
 
 	&:hover {

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -26,7 +26,6 @@
 	&:focus:not(:disabled) {
 		position: relative;
 		box-shadow: none;
-		outline: none;
 	}
 
 	// Tab indicator
@@ -59,44 +58,29 @@
 	}
 
 	// Focus.
-	&::before {
-		content: "";
-		position: absolute;
-		top: $grid-unit-15;
-		right: $grid-unit-15;
-		bottom: $grid-unit-15;
-		left: $grid-unit-15;
-		pointer-events: none;
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 
-		// Draw the indicator.
-		box-shadow: 0 0 0 0 transparent;
-		border-radius: $radius-small;
-
-		// Animation
-		@media not (prefers-reduced-motion) {
-			transition: all 0.1s linear;
-		}
+	@media not (prefers-reduced-motion) {
+		transition: outline 0.1s ease-out;
 	}
 
-	&:focus-visible::before {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
+	&:focus-visible {
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 	}
 }
 
 .components-tab-panel__tab-content {
-	&:focus {
-		box-shadow: none;
-		outline: none;
-	}
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 
 	&:focus-visible {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
-		outline-offset: 0;
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-color: $components-color-accent;
 	}
 }

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -272,16 +272,13 @@ export const TabChevron = styled( Icon )`
 `;
 
 export const TabPanel = styled( Ariakit.TabPanel )`
-	&:focus {
-		box-shadow: none;
-		outline: none;
-	}
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 
 	&[data-focus-visible] {
-		box-shadow: 0 0 0 var( --wp-admin-border-width-focus )
-			${ COLORS.theme.accent };
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
-		outline-offset: 0;
+		outline-width: var( --wp-admin-border-width-focus );
+		outline-color: ${ COLORS.theme.accent };
 	}
 `;

--- a/packages/components/src/textarea-control/styles/textarea-control-styles.ts
+++ b/packages/components/src/textarea-control/styles/textarea-control-styles.ts
@@ -13,23 +13,22 @@ import { CONFIG } from '../../utils';
 import { breakpoint } from '../../utils/breakpoint';
 
 const inputStyleNeutral = css`
-	box-shadow: 0 0 0 transparent;
+	outline-width: 0;
+	outline-style: solid;
+	outline-color: transparent;
+	outline-offset: 1px;
 	border-radius: ${ CONFIG.radiusSmall };
 	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 
 	@media not ( prefers-reduced-motion ) {
-		transition: box-shadow 0.1s linear;
+		transition: outline 0.1s ease-out;
 	}
 `;
 
 const inputStyleFocus = css`
 	border-color: ${ COLORS.theme.accent };
-	box-shadow: 0 0 0
-		calc( ${ CONFIG.borderWidthFocus } - ${ CONFIG.borderWidth } )
-		${ COLORS.theme.accent };
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
+	outline-width: ${ CONFIG.borderWidthFocus };
+	outline-color: ${ COLORS.theme.accent };
 `;
 
 export const StyledTextarea = styled.textarea`

--- a/packages/components/src/toolbar/toolbar/style.scss
+++ b/packages/components/src/toolbar/toolbar/style.scss
@@ -40,6 +40,7 @@
 		padding-right: $grid-unit-20;
 
 		// Don't show the focus inherited by the Button component.
+		// The toolbar uses ::before for its own focus ring.
 		&:focus:not(:disabled) {
 			box-shadow: none;
 			outline: none;
@@ -57,6 +58,10 @@
 			left: $grid-unit-10;
 			right: $grid-unit-10;
 			z-index: -1;
+			outline-width: 0;
+			outline-style: solid;
+			outline-color: transparent;
+			outline-offset: 1px;
 
 			// Animate in.
 			@media not ( prefers-reduced-motion ) {
@@ -89,6 +94,10 @@
 		// Focus style.
 		&:focus::before {
 			@include block-toolbar-button-style__focus();
+
+			@media not ( prefers-reduced-motion ) {
+				transition: outline 0.1s ease-out;
+			}
 		}
 
 		// Ensure the icon buttons remain square.

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -29,7 +29,7 @@ export const ValueInput = styled( NumberControl )`
 		}
 
 		${ BackdropUI } {
-			transition: box-shadow 0.1s linear;
+			transition: outline 0.1s ease-out;
 		}
 	}
 `;
@@ -90,8 +90,12 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 		small: css`
 			height: 100%;
 			border: 1px solid transparent;
+			outline-width: 0;
+			outline-style: solid;
+			outline-color: transparent;
+			outline-offset: 1px;
 			transition:
-				box-shadow 0.1s linear,
+				outline 0.1s ease-out,
 				border 0.1s linear;
 
 			${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
@@ -102,10 +106,8 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 
 			&:focus {
 				border: 1px solid ${ COLORS.ui.borderFocus };
-				box-shadow: inset 0 0 0
-					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
-				outline-offset: 0;
-				outline: 2px solid transparent;
+				outline-width: ${ CONFIG.borderWidthFocus };
+				outline-color: ${ COLORS.ui.borderFocus };
 				z-index: 1;
 			}
 		`,
@@ -113,17 +115,23 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			display: flex;
 			justify-content: center;
 			align-items: center;
+			outline-width: 0;
+			outline-style: solid;
+			outline-color: transparent;
+			outline-offset: 1px;
+
+			@media not ( prefers-reduced-motion ) {
+				transition: outline 0.1s ease-out;
+			}
 
 			&:where( :not( :disabled ) ):hover {
-				box-shadow: 0 0 0
-					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
-				outline: ${ CONFIG.borderWidth } solid transparent; // For High Contrast Mode
+				outline-width: ${ CONFIG.borderWidth };
+				outline-color: ${ COLORS.ui.borderFocus };
 			}
 
 			&:focus {
-				box-shadow: 0 0 0
-					${ CONFIG.borderWidthFocus + ' ' + COLORS.ui.borderFocus };
-				outline: ${ CONFIG.borderWidthFocus } solid transparent; // For High Contrast Mode
+				outline-width: ${ CONFIG.borderWidthFocus };
+				outline-color: ${ COLORS.ui.borderFocus };
 			}
 		`,
 	};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76135.

## What

Replaces the variety of focus style techniques used across the components package (primarily `box-shadow`) with a single, consistent approach using `outline` with `outline-offset`, matching the pattern already established in the `@wordpress/ui` package.

20 files updated across shared mixins and individual components including Button, InputControl, CheckboxControl, RadioControl, RangeControl, TabPanel, Toolbar, Modal, Snackbar, BorderControl, and others.

## Why

Focus styles in the components package have accumulated organically over time, resulting in a mix of techniques:

- `box-shadow` (single and dual) to simulate focus rings
- `outline` with WHCM-only `transparent` fallbacks
- Pseudo-element (`::before`) backgrounds with opacity
- Various combinations of the above

This inconsistency creates visual and behavioral differences between components and makes the system harder to maintain.

Beyond consistency, `outline` with `outline-offset` is the superior approach for focus rings because:

- **Outline follows border-radius natively** in modern browsers, so it inherits the component's shape without any extra work — rounded buttons get rounded focus rings, circular radio inputs get circular focus rings.
- **Outline doesn't affect layout.** Unlike `box-shadow` (which participates in visual overflow and can be clipped by `overflow: hidden` on ancestors), outlines are designed for this exact purpose.
- **Outline-offset provides a clean gap** between the component boundary and the focus ring, improving visual clarity without needing to calculate shadow spreads or layer multiple shadows.
- **Forced-colors / Windows High Contrast Mode support is automatic.** Outlines are rendered using system colors in WHCM, removing the need for the `outline: 2px solid transparent` fallback pattern that was scattered across many components.

## How

- **Shared mixins** (`_mixins.scss`): All focus mixins (`block-toolbar-button-style__focus`, `input-style__focus`, `button-style__focus`, `button-style-outset__focus`, `checkbox-control`, `radio-control`, `link-reset`, `editor-input-reset`) updated to use `outline-width`, `outline-style`, `outline-color`, and `outline-offset` instead of `box-shadow`. Focus rules explicitly set `outline-style: solid` and `outline-offset: 1px` for robustness against shorthand resets from external stylesheets.
- **Button**: Outline base state (`outline-width: 0; outline-style: solid; outline-color: transparent; outline-offset: 1px`) set on `.components-button`. The `transition` moved from the base state into the `:focus` rule so the ring animates in but disappears instantly on blur, preventing flash artifacts during rapid focus navigation (e.g. arrow keys in toolbars).
- **RangeControl**: The semi-transparent `::before` halo on the thumb replaced with a standard outline focus ring for consistency.
- **BorderControl**: Hover and focus styles separated — hover only darkens the border, focus shows the outline ring.
- **Toolbar**: Focus suppression on the button element preserved (`outline: none`), since the toolbar renders its own focus ring via `::before`.
- **Cleanup**: Removed `outline: none` / `outline: 0` declarations that were suppressing the new outline-based focus rings (DropdownMenu, CheckboxControl), and removed now-redundant WHCM `outline: 2px solid transparent` fallbacks from focus rules.

## Testing Instructions

- Tab / keyboard-navigate through various components and verify a consistent outset focus ring with a small gap appears.
- Test in Windows High Contrast Mode (or forced-colors emulation in DevTools) to confirm focus rings remain visible.
- Verify toolbar button focus: arrow between buttons and confirm no flash or shadow artifact on blur.
- Spot-check: Button (all variants), InputControl, CheckboxControl, RadioControl, RangeControl, TabPanel, Modal, Snackbar, FormToggle, BorderControl, DropdownMenu, ColorPalette.
- Smoke test the site/block editor
