### PR TITLE
Try: Template dropdown in editor header

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -15,7 +15,7 @@ import {
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { BlockIcon, store as blockEditorStore } from '@wordpress/block-editor';
-import { chevronLeftSmall, chevronRightSmall, layout } from '@wordpress/icons';
+import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
@@ -27,8 +27,16 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_POST_TYPES } from '../../store/constants';
+import {
+	TEMPLATE_POST_TYPES,
+	ATTACHMENT_POST_TYPE,
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+} from '../../store/constants';
 import { store as editorStore } from '../../store';
+import TemplateDropdown from '../template-dropdown';
 import usePageTypeBadge from '../../utils/pageTypeBadge';
 import { getTemplateInfo } from '../../utils/get-template-info';
 import { getStylesCanvasTitle } from '../styles-canvas';
@@ -73,14 +81,15 @@ export default function DocumentBar( props ) {
 		isNotFound,
 		templateTitle,
 		onNavigateToPreviousEntityRecord,
-		isTemplatePreview,
 		stylesCanvasTitle,
+		showTemplateDropdown,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
 			getCurrentPostId,
 			getEditorSettings,
 			getRenderingMode,
+			getCurrentTemplateId,
 		} = select( editorStore );
 
 		const {
@@ -117,6 +126,8 @@ export default function DocumentBar( props ) {
 			_showStylebook
 		);
 
+		const _templateId = getCurrentTemplateId();
+
 		return {
 			postId: _postId,
 			postType: _postType,
@@ -135,6 +146,15 @@ export default function DocumentBar( props ) {
 				getEditorSettings().onNavigateToPreviousEntityRecord,
 			isTemplatePreview: getRenderingMode() === 'template-locked',
 			stylesCanvasTitle: _stylesCanvasTitle,
+			showTemplateDropdown:
+				!! _templateId &&
+				! [
+					ATTACHMENT_POST_TYPE,
+					TEMPLATE_POST_TYPE,
+					TEMPLATE_PART_POST_TYPE,
+					PATTERN_POST_TYPE,
+					NAVIGATION_POST_TYPE,
+				].includes( _postType ),
 		};
 	}, [] );
 
@@ -199,12 +219,7 @@ export default function DocumentBar( props ) {
 					</MotionButton>
 				) }
 			</AnimatePresence>
-			{ ! isTemplate && isTemplatePreview && ! hasBackButton && (
-				<BlockIcon
-					icon={ layout }
-					className="editor-document-bar__icon-layout"
-				/>
-			) }
+			{ ! hasBackButton && showTemplateDropdown && <TemplateDropdown /> }
 			{ isNotFound ? (
 				<Text>{ __( 'Document not found' ) }</Text>
 			) : (

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -110,15 +110,8 @@
 	}
 }
 
-.editor-document-bar__icon-layout.editor-document-bar__icon-layout {
+.editor-template-dropdown.editor-template-dropdown {
 	position: absolute;
-	margin-left: $grid-unit-15;
-	display: none;
-	pointer-events: none;
-	svg {
-		fill: $gray-600;
-	}
-	@include break-small {
-		display: flex;
-	}
+	z-index: 1;
+	padding-inline-start: $grid-unit-15;
 }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -21,10 +21,12 @@ import PostPublishButtonOrToggle from '../post-publish-button/post-publish-butto
 import PostSavedState from '../post-saved-state';
 import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
+import TemplateDropdown from '../template-dropdown';
 import ZoomOutToggle from '../zoom-out-toggle';
 import { store as editorStore } from '../../store';
 import {
 	ATTACHMENT_POST_TYPE,
+	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
@@ -50,6 +52,7 @@ function Header( {
 		hasBlockSelection,
 		hasSectionRootClientId,
 		isStylesCanvasActive,
+		templateId,
 		isAttachment,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
@@ -57,6 +60,7 @@ function Header( {
 			getEditorMode,
 			getCurrentPostType,
 			getCurrentPostId,
+			getCurrentTemplateId,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
@@ -78,6 +82,7 @@ function Header( {
 			isStylesCanvasActive:
 				!! getStylesPath()?.startsWith( '/revisions' ) ||
 				getShowStylebook(),
+			templateId: getCurrentTemplateId(),
 			isAttachment:
 				getCurrentPostType() === ATTACHMENT_POST_TYPE &&
 				window?.__experimentalMediaEditor,
@@ -95,6 +100,16 @@ function Header( {
 			TEMPLATE_PART_POST_TYPE,
 			PATTERN_POST_TYPE,
 		].includes( postType ) || isStylesCanvasActive;
+
+	const showTemplateDropdown =
+		!! templateId &&
+		! [
+			ATTACHMENT_POST_TYPE,
+			TEMPLATE_POST_TYPE,
+			TEMPLATE_PART_POST_TYPE,
+			PATTERN_POST_TYPE,
+			NAVIGATION_POST_TYPE,
+		].includes( postType );
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
@@ -154,6 +169,8 @@ function Header( {
 						forceIsAutosaveable={ forceIsDirty }
 						disabled={ disablePreviewOption }
 					/>
+
+					{ showTemplateDropdown && <TemplateDropdown /> }
 
 					<PostPreviewButton
 						className="editor-header__post-preview-button"

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -21,12 +21,10 @@ import PostPublishButtonOrToggle from '../post-publish-button/post-publish-butto
 import PostSavedState from '../post-saved-state';
 import PostViewLink from '../post-view-link';
 import PreviewDropdown from '../preview-dropdown';
-import TemplateDropdown from '../template-dropdown';
 import ZoomOutToggle from '../zoom-out-toggle';
 import { store as editorStore } from '../../store';
 import {
 	ATTACHMENT_POST_TYPE,
-	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
@@ -52,7 +50,6 @@ function Header( {
 		hasBlockSelection,
 		hasSectionRootClientId,
 		isStylesCanvasActive,
-		templateId,
 		isAttachment,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
@@ -60,7 +57,6 @@ function Header( {
 			getEditorMode,
 			getCurrentPostType,
 			getCurrentPostId,
-			getCurrentTemplateId,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
 		const { getStylesPath, getShowStylebook } = unlock(
@@ -82,7 +78,6 @@ function Header( {
 			isStylesCanvasActive:
 				!! getStylesPath()?.startsWith( '/revisions' ) ||
 				getShowStylebook(),
-			templateId: getCurrentTemplateId(),
 			isAttachment:
 				getCurrentPostType() === ATTACHMENT_POST_TYPE &&
 				window?.__experimentalMediaEditor,
@@ -100,16 +95,6 @@ function Header( {
 			TEMPLATE_PART_POST_TYPE,
 			PATTERN_POST_TYPE,
 		].includes( postType ) || isStylesCanvasActive;
-
-	const showTemplateDropdown =
-		!! templateId &&
-		! [
-			ATTACHMENT_POST_TYPE,
-			TEMPLATE_POST_TYPE,
-			TEMPLATE_PART_POST_TYPE,
-			PATTERN_POST_TYPE,
-			NAVIGATION_POST_TYPE,
-		].includes( postType );
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
@@ -169,8 +154,6 @@ function Header( {
 						forceIsAutosaveable={ forceIsDirty }
 						disabled={ disablePreviewOption }
 					/>
-
-					{ showTemplateDropdown && <TemplateDropdown /> }
 
 					<PostPreviewButton
 						className="editor-header__post-preview-button"

--- a/packages/editor/src/components/post-template-panel-v2/block-theme.js
+++ b/packages/editor/src/components/post-template-panel-v2/block-theme.js
@@ -1,0 +1,153 @@
+/**
+ * WordPress dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	Modal,
+	SearchControl,
+} from '@wordpress/components';
+import { useState, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import PostPanelRow from '../post-panel-row';
+import {
+	useAvailableTemplates,
+	useEditedPostContext,
+} from '../post-template/hooks';
+import { searchTemplates } from '../../utils/search-templates';
+
+export default function BlockThemeControlV2( { id } ) {
+	const { editedRecord: template, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_template',
+		id
+	);
+
+	const { postType, postId } = useEditedPostContext();
+	const availableTemplates = useAvailableTemplates( postType );
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const [ showModal, setShowModal ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			className: 'editor-post-template__dropdown',
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+
+	if ( ! hasResolved ) {
+		return null;
+	}
+
+	const onTemplateSelect = ( selectedTemplate ) => {
+		editEntityRecord(
+			'postType',
+			postType,
+			postId,
+			{ template: selectedTemplate.name },
+			{ undoIgnore: true }
+		);
+		setShowModal( false );
+	};
+
+	return (
+		<PostPanelRow label={ __( 'Template' ) } ref={ setPopoverAnchor }>
+			<DropdownMenu
+				popoverProps={ popoverProps }
+				focusOnMount
+				toggleProps={ {
+					size: 'compact',
+					variant: 'tertiary',
+					tooltipPosition: 'middle left',
+				} }
+				label={ __( 'Template options' ) }
+				text={ decodeEntities( template.title ) }
+				icon={ null }
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup>
+						<MenuItem
+							disabled={ ! availableTemplates?.length }
+							accessibleWhenDisabled
+							onClick={ () => {
+								setShowModal( true );
+								onClose();
+							} }
+						>
+							{ __( 'Change template' ) }
+						</MenuItem>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+			{ showModal && (
+				<Modal
+					title={ __( 'Choose a template' ) }
+					onRequestClose={ () => setShowModal( false ) }
+					overlayClassName="editor-post-template__swap-template-modal"
+					isFullScreen
+				>
+					<div className="editor-post-template__swap-template-modal-content">
+						<TemplatesList
+							postType={ postType }
+							onSelect={ onTemplateSelect }
+						/>
+					</div>
+				</Modal>
+			) }
+		</PostPanelRow>
+	);
+}
+
+function TemplatesList( { postType, onSelect } ) {
+	const [ searchValue, setSearchValue ] = useState( '' );
+	const availableTemplates = useAvailableTemplates( postType );
+	const templatesAsPatterns = useMemo(
+		() =>
+			availableTemplates.map( ( t ) => ( {
+				name: t.slug,
+				blocks: parse( t.content.raw ),
+				title: decodeEntities( t.title.rendered ),
+				id: t.id,
+			} ) ),
+		[ availableTemplates ]
+	);
+
+	const filteredBlockTemplates = useMemo( () => {
+		return searchTemplates( templatesAsPatterns, searchValue );
+	}, [ templatesAsPatterns, searchValue ] );
+
+	return (
+		<>
+			<SearchControl
+				onChange={ setSearchValue }
+				value={ searchValue }
+				label={ __( 'Search' ) }
+				placeholder={ __( 'Search' ) }
+				className="editor-post-template__swap-template-search"
+			/>
+			<BlockPatternsList
+				label={ __( 'Templates' ) }
+				blockPatterns={ filteredBlockTemplates }
+				onClickPattern={ onSelect }
+			/>
+		</>
+	);
+}

--- a/packages/editor/src/components/post-template-panel-v2/block-theme.js
+++ b/packages/editor/src/components/post-template-panel-v2/block-theme.js
@@ -2,13 +2,7 @@
  * WordPress dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
-	Modal,
-	SearchControl,
-} from '@wordpress/components';
+import { Modal, Button, SearchControl } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
@@ -38,21 +32,6 @@ export default function BlockThemeControlV2( { id } ) {
 	const { editEntityRecord } = useDispatch( coreStore );
 
 	const [ showModal, setShowModal ] = useState( false );
-	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps = useMemo(
-		() => ( {
-			// Anchor the popover to the middle of the entire row so that it doesn't
-			// move around when the label changes.
-			anchor: popoverAnchor,
-			className: 'editor-post-template__dropdown',
-			placement: 'left-start',
-			offset: 36,
-			shift: true,
-		} ),
-		[ popoverAnchor ]
-	);
-
 	if ( ! hasResolved ) {
 		return null;
 	}
@@ -69,34 +48,21 @@ export default function BlockThemeControlV2( { id } ) {
 	};
 
 	return (
-		<PostPanelRow label={ __( 'Template' ) } ref={ setPopoverAnchor }>
-			<DropdownMenu
-				popoverProps={ popoverProps }
-				focusOnMount
-				toggleProps={ {
-					size: 'compact',
-					variant: 'tertiary',
-					tooltipPosition: 'middle left',
+		<PostPanelRow label={ __( 'Template' ) }>
+			<Button
+				__next40pxDefaultSize
+				disabled={ ! availableTemplates?.length }
+				accessibleWhenDisabled
+				label={ __( 'Change template' ) }
+				size="compact"
+				variant="tertiary"
+				tooltipPosition="middle left"
+				onClick={ () => {
+					setShowModal( true );
 				} }
-				label={ __( 'Template options' ) }
-				text={ decodeEntities( template.title ) }
-				icon={ null }
 			>
-				{ ( { onClose } ) => (
-					<MenuGroup>
-						<MenuItem
-							disabled={ ! availableTemplates?.length }
-							accessibleWhenDisabled
-							onClick={ () => {
-								setShowModal( true );
-								onClose();
-							} }
-						>
-							{ __( 'Change template' ) }
-						</MenuItem>
-					</MenuGroup>
-				) }
-			</DropdownMenu>
+				{ decodeEntities( template.title ) }
+			</Button>
 			{ showModal && (
 				<Modal
 					title={ __( 'Choose a template' ) }

--- a/packages/editor/src/components/post-template-panel-v2/index.js
+++ b/packages/editor/src/components/post-template-panel-v2/index.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import ClassicThemeControl from '../post-template/classic-theme';
+import BlockThemeControlV2 from './block-theme';
+
+export default function PostTemplatePanelV2() {
+	const { templateId, isBlockTheme } = useSelect( ( select ) => {
+		const { getCurrentTemplateId, getEditorSettings } =
+			select( editorStore );
+		return {
+			templateId: getCurrentTemplateId(),
+			isBlockTheme: getEditorSettings().__unstableIsBlockBasedTheme,
+		};
+	}, [] );
+
+	const isVisible = useSelect( ( select ) => {
+		const postTypeSlug = select( editorStore ).getCurrentPostType();
+		const postType = select( coreStore ).getPostType( postTypeSlug );
+		if ( ! postType?.viewable ) {
+			return false;
+		}
+
+		const settings = select( editorStore ).getEditorSettings();
+		const hasTemplates =
+			!! settings.availableTemplates &&
+			Object.keys( settings.availableTemplates ).length > 0;
+		if ( hasTemplates ) {
+			return true;
+		}
+
+		if ( ! settings.supportsTemplateMode ) {
+			return false;
+		}
+
+		const canCreateTemplates =
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ) ?? false;
+		return canCreateTemplates;
+	}, [] );
+
+	const canViewTemplates = useSelect(
+		( select ) => {
+			return isVisible
+				? select( coreStore ).canUser( 'read', {
+						kind: 'postType',
+						name: 'wp_template',
+				  } )
+				: false;
+		},
+		[ isVisible ]
+	);
+
+	if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
+		return <ClassicThemeControl />;
+	}
+
+	if ( isBlockTheme && !! templateId ) {
+		return <BlockThemeControlV2 id={ templateId } />;
+	}
+	return null;
+}

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -16,7 +16,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
+import { desktop, mobile, tablet, external } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -31,37 +31,21 @@ import PostPreviewButton from '../post-preview-button';
 import { unlock } from '../../lock-unlock';
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
-	const {
-		deviceType,
-		homeUrl,
-		isTemplate,
-		isViewable,
-		showIconLabels,
-		isTemplateHidden,
-		templateId,
-	} = useSelect( ( select ) => {
-		const {
-			getDeviceType,
-			getCurrentPostType,
-			getCurrentTemplateId,
-			getRenderingMode,
-		} = select( editorStore );
-		const { getEntityRecord, getPostType } = select( coreStore );
-		const { get } = select( preferencesStore );
-		const _currentPostType = getCurrentPostType();
-		return {
-			deviceType: getDeviceType(),
-			homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
-			isTemplate: _currentPostType === 'wp_template',
-			isViewable: getPostType( _currentPostType )?.viewable ?? false,
-			showIconLabels: get( 'core', 'showIconLabels' ),
-			isTemplateHidden: getRenderingMode() === 'post-only',
-			templateId: getCurrentTemplateId(),
-		};
-	}, [] );
-	const { setDeviceType, setRenderingMode, setDefaultRenderingMode } = unlock(
-		useDispatch( editorStore )
-	);
+	const { deviceType, homeUrl, isTemplate, isViewable, showIconLabels } =
+		useSelect( ( select ) => {
+			const { getDeviceType, getCurrentPostType } = select( editorStore );
+			const { getEntityRecord, getPostType } = select( coreStore );
+			const { get } = select( preferencesStore );
+			const _currentPostType = getCurrentPostType();
+			return {
+				deviceType: getDeviceType(),
+				homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
+				isTemplate: _currentPostType === 'wp_template',
+				isViewable: getPostType( _currentPostType )?.viewable ?? false,
+				showIconLabels: get( 'core', 'showIconLabels' ),
+			};
+		}, [] );
+	const { setDeviceType } = unlock( useDispatch( editorStore ) );
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
@@ -157,25 +141,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 										__( '(opens in a new tab)' )
 									}
 								</VisuallyHidden>
-							</MenuItem>
-						</MenuGroup>
-					) }
-					{ ! isTemplate && !! templateId && (
-						<MenuGroup>
-							<MenuItem
-								icon={ ! isTemplateHidden ? check : undefined }
-								isSelected={ ! isTemplateHidden }
-								role="menuitemcheckbox"
-								onClick={ () => {
-									const newRenderingMode = isTemplateHidden
-										? 'template-locked'
-										: 'post-only';
-									setRenderingMode( newRenderingMode );
-									setDefaultRenderingMode( newRenderingMode );
-									resetZoomLevel();
-								} }
-							>
-								{ __( 'Show template' ) }
 							</MenuItem>
 						</MenuGroup>
 					) }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -28,7 +28,7 @@ import PostPanelSection from '../post-panel-section';
 import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
 import PostSyncStatus from '../post-sync-status';
-import PostTemplatePanel from '../post-template/panel';
+import PostTemplatePanelV2 from '../post-template-panel-v2';
 import PostURLPanel from '../post-url/panel';
 import BlogTitle from '../blog-title';
 import PostsPerPage from '../posts-per-page';
@@ -127,7 +127,7 @@ function ClassicPostSummary( { onActionPerformed } ) {
 										<PostSchedulePanel />
 										<PostURLPanel />
 										<PostAuthorPanel />
-										<PostTemplatePanel />
+										<PostTemplatePanelV2 />
 										<PostDiscussionPanel />
 										<PrivatePostLastRevision />
 										<PageAttributesPanel />

--- a/packages/editor/src/components/template-dropdown/index.js
+++ b/packages/editor/src/components/template-dropdown/index.js
@@ -158,7 +158,7 @@ export default function TemplateDropdown() {
 							size="compact"
 							showTooltip={ ! showIconLabels }
 							icon={ layout }
-							label={ __( 'Template' ) }
+							label={ __( 'Template options' ) }
 							className="editor-template-dropdown"
 						/>
 					}

--- a/packages/editor/src/components/template-dropdown/index.js
+++ b/packages/editor/src/components/template-dropdown/index.js
@@ -5,7 +5,6 @@ import {
 	Button,
 	Modal,
 	SearchControl,
-	Icon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -17,7 +16,7 @@ import {
 	store as blockEditorStore,
 	__experimentalBlockPatternsList as BlockPatternsList,
 } from '@wordpress/block-editor';
-import { layout, pencil, reusableBlock, plus, backup } from '@wordpress/icons';
+import { layout } from '@wordpress/icons';
 import { useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { parse } from '@wordpress/blocks';
@@ -169,7 +168,6 @@ export default function TemplateDropdown() {
 						<Menu.GroupLabel>{ __( 'Template' ) }</Menu.GroupLabel>
 						{ canCreateTemplate && (
 							<Menu.Item
-								prefix={ <Icon icon={ pencil } /> }
 								onClick={ async () => {
 									onNavigateToEntityRecord( {
 										postId: template.id,
@@ -213,7 +211,6 @@ export default function TemplateDropdown() {
 						<Menu.Item
 							disabled={ ! availableTemplates?.length }
 							onClick={ () => setShowSwapModal( true ) }
-							prefix={ <Icon icon={ reusableBlock } /> }
 						>
 							<Menu.ItemLabel>
 								{ __( 'Change template' ) }
@@ -221,7 +218,6 @@ export default function TemplateDropdown() {
 						</Menu.Item>
 						{ !! currentTemplateSlug && allowSwitchingTemplate && (
 							<Menu.Item
-								prefix={ <Icon icon={ backup } /> }
 								onClick={ () => {
 									editEntityRecord(
 										'postType',
@@ -240,7 +236,6 @@ export default function TemplateDropdown() {
 						{ canCreateTemplate && allowSwitchingTemplate && (
 							<Menu.Item
 								onClick={ () => setShowCreateModal( true ) }
-								prefix={ <Icon icon={ plus } /> }
 							>
 								<Menu.ItemLabel>
 									{ __( 'Create new' ) }

--- a/packages/editor/src/components/template-dropdown/index.js
+++ b/packages/editor/src/components/template-dropdown/index.js
@@ -1,0 +1,337 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Modal,
+	SearchControl,
+	Icon,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	store as blockEditorStore,
+	__experimentalBlockPatternsList as BlockPatternsList,
+} from '@wordpress/block-editor';
+import { layout, pencil, reusableBlock, plus, backup } from '@wordpress/icons';
+import { useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import {
+	useAvailableTemplates,
+	useEditedPostContext,
+	useCurrentTemplateSlug,
+	useAllowSwitchingTemplates,
+} from '../post-template/hooks';
+import CreateNewTemplateModal from '../post-template/create-new-template-modal';
+import { searchTemplates } from '../../utils/search-templates';
+import { unlock } from '../../lock-unlock';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+export default function TemplateDropdown() {
+	const {
+		templateId,
+		renderingMode,
+		onNavigateToEntityRecord,
+		getEditorSettings,
+		hasGoBack,
+		hasSpecificTemplate,
+		showIconLabels,
+		canCreateTemplate,
+		hasWelcomeGuideTemplate,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentTemplateId,
+			getRenderingMode,
+			getEditorSettings: _getEditorSettings,
+			getCurrentPost,
+		} = unlock( select( editorStore ) );
+		const { get } = select( preferencesStore );
+		const editorSettings = _getEditorSettings();
+		const currentPost = getCurrentPost();
+		return {
+			templateId: getCurrentTemplateId(),
+			renderingMode: getRenderingMode(),
+			onNavigateToEntityRecord: editorSettings.onNavigateToEntityRecord,
+			getEditorSettings: _getEditorSettings,
+			hasGoBack: editorSettings.hasOwnProperty(
+				'onNavigateToPreviousEntityRecord'
+			),
+			hasSpecificTemplate: !! currentPost.template,
+			showIconLabels: get( 'core', 'showIconLabels' ),
+			canCreateTemplate: !! select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
+			hasWelcomeGuideTemplate: !! get(
+				'core/edit-site',
+				'welcomeGuideTemplate'
+			),
+		};
+	}, [] );
+
+	const { editedRecord: template, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_template',
+		templateId
+	);
+
+	const { getEntityRecord } = useSelect( coreStore );
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { setRenderingMode, setDefaultRenderingMode } = unlock(
+		useDispatch( editorStore )
+	);
+	const _blockEditorActions = useDispatch( blockEditorStore );
+
+	const { postType: editedPostType, postId: editedPostId } =
+		useEditedPostContext();
+	const availableTemplates = useAvailableTemplates( editedPostType );
+	const currentTemplateSlug = useCurrentTemplateSlug();
+	const allowSwitchingTemplate = useAllowSwitchingTemplates();
+
+	const [ showSwapModal, setShowSwapModal ] = useState( false );
+	const [ showCreateModal, setShowCreateModal ] = useState( false );
+
+	if ( ! templateId || ! hasResolved ) {
+		return null;
+	}
+
+	const { resetZoomLevel } = unlock( _blockEditorActions );
+
+	// The site editor does not have a `onNavigateToPreviousEntityRecord`
+	// setting as it uses its own routing and assigns its own backlink
+	// to focusMode pages.
+	const notificationAction = hasGoBack
+		? [
+				{
+					label: __( 'Go back' ),
+					onClick: () =>
+						getEditorSettings().onNavigateToPreviousEntityRecord(),
+				},
+		  ]
+		: undefined;
+
+	const mayShowTemplateEditNotice = () => {
+		if ( ! hasWelcomeGuideTemplate ) {
+			createSuccessNotice(
+				__(
+					'Editing template. Changes made here affect all posts and pages that use the template.'
+				),
+				{ type: 'snackbar', actions: notificationAction }
+			);
+		}
+	};
+
+	const onTemplateSelect = ( selectedTemplate ) => {
+		editEntityRecord(
+			'postType',
+			editedPostType,
+			editedPostId,
+			{ template: selectedTemplate.name },
+			{ undoIgnore: true }
+		);
+		setShowSwapModal( false );
+	};
+
+	const handleVisibilityChange = ( newRenderingMode ) => {
+		setRenderingMode( newRenderingMode );
+		setDefaultRenderingMode( newRenderingMode );
+		resetZoomLevel();
+	};
+
+	return (
+		<>
+			<Menu placement="bottom-end">
+				<Menu.TriggerButton
+					render={
+						<Button
+							size="compact"
+							showTooltip={ ! showIconLabels }
+							icon={ layout }
+							label={ __( 'Template' ) }
+							className="editor-template-dropdown"
+						/>
+					}
+				/>
+				<Menu.Popover>
+					<Menu.Group>
+						<Menu.GroupLabel>{ __( 'Template' ) }</Menu.GroupLabel>
+						{ canCreateTemplate && (
+							<Menu.Item
+								prefix={ <Icon icon={ pencil } /> }
+								onClick={ async () => {
+									onNavigateToEntityRecord( {
+										postId: template.id,
+										postType: 'wp_template',
+									} );
+									if (
+										! hasSpecificTemplate &&
+										window?.__experimentalTemplateActivate
+									) {
+										const activeTemplates =
+											await getEntityRecord(
+												'root',
+												'site'
+											).active_templates;
+										if (
+											activeTemplates[ template.slug ] !==
+											template.id
+										) {
+											editEntityRecord(
+												'root',
+												'site',
+												undefined,
+												{
+													active_templates: {
+														...activeTemplates,
+														[ template.slug ]:
+															template.id,
+													},
+												}
+											);
+										}
+									}
+									mayShowTemplateEditNotice();
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Edit template' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+						<Menu.Item
+							disabled={ ! availableTemplates?.length }
+							onClick={ () => setShowSwapModal( true ) }
+							prefix={ <Icon icon={ reusableBlock } /> }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Change template' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+						{ !! currentTemplateSlug && allowSwitchingTemplate && (
+							<Menu.Item
+								prefix={ <Icon icon={ backup } /> }
+								onClick={ () => {
+									editEntityRecord(
+										'postType',
+										editedPostType,
+										editedPostId,
+										{ template: '' },
+										{ undoIgnore: true }
+									);
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Use default' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+						{ canCreateTemplate && allowSwitchingTemplate && (
+							<Menu.Item
+								onClick={ () => setShowCreateModal( true ) }
+								prefix={ <Icon icon={ plus } /> }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Create new' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+					</Menu.Group>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>
+							{ __( 'Template visibility' ) }
+						</Menu.GroupLabel>
+						<Menu.RadioItem
+							name="template-visibility"
+							value="template-locked"
+							checked={ renderingMode === 'template-locked' }
+							onChange={ () =>
+								handleVisibilityChange( 'template-locked' )
+							}
+						>
+							<Menu.ItemLabel>{ __( 'Show' ) }</Menu.ItemLabel>
+						</Menu.RadioItem>
+						<Menu.RadioItem
+							name="template-visibility"
+							value="post-only"
+							checked={ renderingMode === 'post-only' }
+							onChange={ () =>
+								handleVisibilityChange( 'post-only' )
+							}
+						>
+							<Menu.ItemLabel>{ __( 'Hide' ) }</Menu.ItemLabel>
+						</Menu.RadioItem>
+					</Menu.Group>
+				</Menu.Popover>
+			</Menu>
+			{ showSwapModal && (
+				<Modal
+					title={ __( 'Choose a template' ) }
+					onRequestClose={ () => setShowSwapModal( false ) }
+					overlayClassName="editor-post-template__swap-template-modal"
+					isFullScreen
+				>
+					<div className="editor-post-template__swap-template-modal-content">
+						<TemplatesList
+							postType={ editedPostType }
+							onSelect={ onTemplateSelect }
+						/>
+					</div>
+				</Modal>
+			) }
+			{ showCreateModal && (
+				<CreateNewTemplateModal
+					onClose={ () => setShowCreateModal( false ) }
+				/>
+			) }
+		</>
+	);
+}
+
+function TemplatesList( { postType, onSelect } ) {
+	const [ searchValue, setSearchValue ] = useState( '' );
+	const availableTemplates = useAvailableTemplates( postType );
+	const templatesAsPatterns = useMemo(
+		() =>
+			availableTemplates.map( ( template ) => ( {
+				name: template.slug,
+				blocks: parse( template.content.raw ),
+				title: decodeEntities( template.title.rendered ),
+				id: template.id,
+			} ) ),
+		[ availableTemplates ]
+	);
+
+	const filteredBlockTemplates = useMemo( () => {
+		return searchTemplates( templatesAsPatterns, searchValue );
+	}, [ templatesAsPatterns, searchValue ] );
+
+	return (
+		<>
+			<SearchControl
+				onChange={ setSearchValue }
+				value={ searchValue }
+				label={ __( 'Search' ) }
+				placeholder={ __( 'Search' ) }
+				className="editor-post-template__swap-template-search"
+			/>
+			<BlockPatternsList
+				label={ __( 'Templates' ) }
+				blockPatterns={ filteredBlockTemplates }
+				onClickPattern={ onSelect }
+			/>
+		</>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/76104

This PR adds a `template` dropdown in editor top sidebar to get a feel of the suggestion [here](https://github.com/WordPress/gutenberg/issues/76104#issuecomment-3997362665). I have removed the actions from the template control in post summary, but the final results will be different (new design), so we should focus first on the template dropdown design discussions first.

It's in draft status and just a POC to get design feedback and there are more changes needed, even if the direction is deemed okay.


### Next steps (based on design validation)
- [ ] Remove the actions from existing `BlockThemeControl` and keep only the `change template`. The changes for this control (`radiocard-in-a-modal`) could be explored separately.
- [ ] Create new `PostTemplatePanelV2` component for all the changes since the old one is public API - I'll have to think more about it
- [ ] Check all the cases the control is used (also mentioned [here](https://github.com/WordPress/gutenberg/issues/76104#issuecomment-3996710371)). For example differences between block and classic themes etc..
- [ ] Check needed changes related to distraction free mode.

## Testing Instructions
1. In post or site editor go to pages/posts and check the new template dropdown


## Screenshots or screencast <!-- if applicable -->

<img width="993" height="727" alt="Screenshot 2026-03-06 at 5 16 46 PM" src="https://github.com/user-attachments/assets/6ab14bef-bec0-4657-ade5-12b940daa7a2" />
