### PR TITLE
Fonts: Fix font family upload name.

### DIFF
--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -33,8 +33,8 @@ export interface FontFaceMetadata {
 	 * CSS @font-face font-family value.
 	 */
 	fontFamily: string;
-	fontStyle: 'italic' | 'normal';
-	fontWeight: string | number | undefined;
+	fontStyle?: string | undefined;
+	fontWeight?: string | number | undefined;
 }
 
 function UploadFonts() {

--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -171,6 +171,27 @@ function UploadFonts() {
 		const weightRange = weightAxis
 			? `${ weightAxis.minValue } ${ weightAxis.maxValue }`
 			: null;
+
+		const cssFontFamily = normalizeCSSFontFaceFontFamily( fontName );
+
+		// Double check
+		try {
+			const stylesheet = new CSSStyleSheet();
+			/* @ts-expect-error: This narrows from CSSRule to CSSFontFaceRule, it's correct */
+			const fontFaceRule: CSSFontFaceRule =
+				stylesheet.cssRules[ stylesheet.insertRule( '@font-face {}' ) ];
+			fontFaceRule.style.fontFamily = cssFontFamily;
+
+			if ( fontFaceRule.style.fontFamily !== cssFontFamily ) {
+				throw new Error(
+					`Font family "${ fontName }" is not valid and cannot be used in CSS.`
+				);
+			}
+		} catch {}
+
+		console.log( '%o // %o', fontName, cssFontFamily );
+		debugger;
+
 		return {
 			file: fontFile,
 			fontFamily: fontName,
@@ -178,6 +199,40 @@ function UploadFonts() {
 			fontWeight: weightRange || fontWeight,
 		};
 	};
+
+	function normalizeCSSFontFaceFontFamily( fontName: string ): string {
+		return `"${ fontName
+			.trim()
+
+			/*
+			 * CSS Unicode escaping for problematic characters.
+			 * https://www.w3.org/TR/css-syntax-3/#escaping
+			 *
+			 * These characters are not required by CSS but may be problematic in WordPress:
+			 *
+			 * - Normalize and replace newlines. https://www.w3.org/TR/css-syntax-3/#input-preprocessing
+			 * - "<", ">", and "&" are replaced to prevent issues with KSES and other sanitization that
+			 *   is confused by HTML-like text.
+			 *   is confused by HTML-like text.
+			 * - `,`, `"` and `'` are replaced to prevent issues where font families may be processed later.
+			 *
+			 * Note that the Unicode escape sequences are used rather than backslash-escaping so the
+			 * problematic characters are removed completely.
+			 */
+			// Escape existing backslashes before any other processing
+			.replaceAll( '\\', '\\5C ' )
+			// Carriage return + line feed must be the first newline replacement.
+			.replaceAll( '\r\n', '\\A ' )
+			.replaceAll( '\r', '\\A ' )
+			.replaceAll( '\f', '\\A ' )
+			.replaceAll( '\n', '\\A ' )
+			.replaceAll( ',', '\\2C ' )
+			.replaceAll( '"', '\\22 ' )
+			.replaceAll( "'", '\\27 ' )
+			.replaceAll( '<', '\\3C ' )
+			.replaceAll( '>', '\\3E ' )
+			.replaceAll( '&', '\\26 ' ) }"`;
+	}
 
 	/**
 	 * Creates the font family definition and sends it to the server

--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -13,7 +13,6 @@ import {
 	ProgressBar,
 } from '@wordpress/components';
 import { useContext, useState } from '@wordpress/element';
-import type { FontFace } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -23,6 +22,20 @@ import { FontLibraryContext } from './context';
 import { Font } from './lib/lib-font.browser';
 import makeFamiliesFromFaces from './utils/make-families-from-faces';
 import { loadFontFaceInBrowser, normalizeCSSFontFaceFontFamily } from './utils';
+
+export interface FontFaceMetadata {
+	/*
+	 * Font name for display
+	 */
+	name: string;
+
+	/**
+	 * CSS @font-face font-family value.
+	 */
+	fontFamily: string;
+	fontStyle: 'italic' | 'normal';
+	fontWeight: string | number | undefined;
+}
 
 function UploadFonts() {
 	const { installFonts } = useContext( FontLibraryContext );
@@ -108,11 +121,7 @@ function UploadFonts() {
 		const fontFacesLoaded = await Promise.all(
 			files.map( async ( fontFile: File ) => {
 				const fontFaceData = await getFontFaceMetadata( fontFile );
-				await loadFontFaceInBrowser(
-					fontFaceData,
-					fontFaceData.file,
-					'all'
-				);
+				await loadFontFaceInBrowser( fontFaceData, fontFile, 'all' );
 				return fontFaceData;
 			} )
 		);
@@ -146,7 +155,9 @@ function UploadFonts() {
 		} );
 	}
 
-	const getFontFaceMetadata = async ( fontFile: File ) => {
+	const getFontFaceMetadata = async (
+		fontFile: File
+	): Promise< FontFaceMetadata > => {
 		const buffer = await readFileAsArrayBuffer( fontFile );
 		const fontObj: Font & {
 			onload?: ( val: { detail: { font: any } } ) => void;
@@ -175,7 +186,7 @@ function UploadFonts() {
 		const cssFontFamily = normalizeCSSFontFaceFontFamily( fontName );
 
 		return {
-			file: fontFile,
+			name: fontName,
 			fontFamily: cssFontFamily,
 			fontStyle: isItalic ? 'italic' : 'normal',
 			fontWeight: weightRange || fontWeight,
@@ -188,7 +199,7 @@ function UploadFonts() {
 	 * @param {Array} fontFaces The font faces to be installed
 	 * @return {void}
 	 */
-	const handleInstall = async ( fontFaces: FontFace[] ) => {
+	const handleInstall = async ( fontFaces: FontFaceMetadata[] ) => {
 		const fontFamilies = makeFamiliesFromFaces( fontFaces );
 
 		try {

--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -22,7 +22,7 @@ import { ALLOWED_FILE_EXTENSIONS } from './utils/constants';
 import { FontLibraryContext } from './context';
 import { Font } from './lib/lib-font.browser';
 import makeFamiliesFromFaces from './utils/make-families-from-faces';
-import { loadFontFaceInBrowser } from './utils';
+import { loadFontFaceInBrowser, normalizeCSSFontFaceFontFamily } from './utils';
 
 function UploadFonts() {
 	const { installFonts } = useContext( FontLibraryContext );
@@ -174,65 +174,13 @@ function UploadFonts() {
 
 		const cssFontFamily = normalizeCSSFontFaceFontFamily( fontName );
 
-		// Double check
-		try {
-			const stylesheet = new CSSStyleSheet();
-			/* @ts-expect-error: This narrows from CSSRule to CSSFontFaceRule, it's correct */
-			const fontFaceRule: CSSFontFaceRule =
-				stylesheet.cssRules[ stylesheet.insertRule( '@font-face {}' ) ];
-			fontFaceRule.style.fontFamily = cssFontFamily;
-
-			if ( fontFaceRule.style.fontFamily !== cssFontFamily ) {
-				throw new Error(
-					`Font family "${ fontName }" is not valid and cannot be used in CSS.`
-				);
-			}
-		} catch {}
-
-		console.log( '%o // %o', fontName, cssFontFamily );
-		debugger;
-
 		return {
 			file: fontFile,
-			fontFamily: fontName,
+			fontFamily: cssFontFamily,
 			fontStyle: isItalic ? 'italic' : 'normal',
 			fontWeight: weightRange || fontWeight,
 		};
 	};
-
-	function normalizeCSSFontFaceFontFamily( fontName: string ): string {
-		return `"${ fontName
-			.trim()
-
-			/*
-			 * CSS Unicode escaping for problematic characters.
-			 * https://www.w3.org/TR/css-syntax-3/#escaping
-			 *
-			 * These characters are not required by CSS but may be problematic in WordPress:
-			 *
-			 * - Normalize and replace newlines. https://www.w3.org/TR/css-syntax-3/#input-preprocessing
-			 * - "<", ">", and "&" are replaced to prevent issues with KSES and other sanitization that
-			 *   is confused by HTML-like text.
-			 *   is confused by HTML-like text.
-			 * - `,`, `"` and `'` are replaced to prevent issues where font families may be processed later.
-			 *
-			 * Note that the Unicode escape sequences are used rather than backslash-escaping so the
-			 * problematic characters are removed completely.
-			 */
-			// Escape existing backslashes before any other processing
-			.replaceAll( '\\', '\\5C ' )
-			// Carriage return + line feed must be the first newline replacement.
-			.replaceAll( '\r\n', '\\A ' )
-			.replaceAll( '\r', '\\A ' )
-			.replaceAll( '\f', '\\A ' )
-			.replaceAll( '\n', '\\A ' )
-			.replaceAll( ',', '\\2C ' )
-			.replaceAll( '"', '\\22 ' )
-			.replaceAll( "'", '\\27 ' )
-			.replaceAll( '<', '\\3C ' )
-			.replaceAll( '>', '\\3E ' )
-			.replaceAll( '&', '\\26 ' ) }"`;
-	}
 
 	/**
 	 * Creates the font family definition and sends it to the server

--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -13,6 +13,7 @@ import { fetchInstallFontFace } from '../api';
 import { formatFontFaceName } from './preview-styles';
 import type { FontFamilyToUpload, FontUploadResult } from '../types';
 import { unlock } from '../../lock-unlock';
+import type { FontFaceMetadata } from '../upload-fonts';
 
 /**
  * Browser dependencies
@@ -100,7 +101,7 @@ export function mergeFontFamilies(
  * It also adds it to the iframe document.
  */
 export async function loadFontFaceInBrowser(
-	fontFace: FontFace,
+	fontFace: FontFaceMetadata,
 	source: string | File,
 	addTo: 'all' | 'document' | 'iframe' = 'all'
 ): Promise< void > {
@@ -369,36 +370,36 @@ export function checkFontFaceInstalled(
 	);
 }
 
-export	function normalizeCSSFontFaceFontFamily( fontName: string ): string {
-		return `"${ fontName
-			.trim()
+export function normalizeCSSFontFaceFontFamily( fontName: string ): string {
+	return `"${ fontName
+		.trim()
 
-			/*
-			 * CSS Unicode escaping for problematic characters.
-			 * https://www.w3.org/TR/css-syntax-3/#escaping
-			 *
-			 * These characters are not required by CSS but may be problematic in WordPress:
-			 *
-			 * - Normalize and replace newlines. https://www.w3.org/TR/css-syntax-3/#input-preprocessing
-			 * - "<", ">", and "&" are replaced to prevent issues with KSES and other sanitization that
-			 *   is confused by HTML-like text.
-			 *   is confused by HTML-like text.
-			 * - `,`, `"` and `'` are replaced to prevent issues where font families may be processed later.
-			 *
-			 * Note that the Unicode escape sequences are used rather than backslash-escaping so the
-			 * problematic characters are removed completely.
-			 */
-			// Escape existing backslashes before any other processing
-			.replaceAll( '\\', '\\5C ' )
-			// Carriage return + line feed must be the first newline replacement.
-			.replaceAll( '\r\n', '\\A ' )
-			.replaceAll( '\r', '\\A ' )
-			.replaceAll( '\f', '\\A ' )
-			.replaceAll( '\n', '\\A ' )
-			.replaceAll( ',', '\\2C ' )
-			.replaceAll( '"', '\\22 ' )
-			.replaceAll( "'", '\\27 ' )
-			.replaceAll( '<', '\\3C ' )
-			.replaceAll( '>', '\\3E ' )
-			.replaceAll( '&', '\\26 ' ) }"`;
-	}
+		/*
+		 * CSS Unicode escaping for problematic characters.
+		 * https://www.w3.org/TR/css-syntax-3/#escaping
+		 *
+		 * These characters are not required by CSS but may be problematic in WordPress:
+		 *
+		 * - Normalize and replace newlines. https://www.w3.org/TR/css-syntax-3/#input-preprocessing
+		 * - "<", ">", and "&" are replaced to prevent issues with KSES and other sanitization that
+		 *   is confused by HTML-like text.
+		 *   is confused by HTML-like text.
+		 * - `,`, `"` and `'` are replaced to prevent issues where font families may be processed later.
+		 *
+		 * Note that the Unicode escape sequences are used rather than backslash-escaping so the
+		 * problematic characters are removed completely.
+		 */
+		// Escape existing backslashes before any other processing
+		.replaceAll( '\\', '\\5C ' )
+		// Carriage return + line feed must be the first newline replacement.
+		.replaceAll( '\r\n', '\\A ' )
+		.replaceAll( '\r', '\\A ' )
+		.replaceAll( '\f', '\\A ' )
+		.replaceAll( '\n', '\\A ' )
+		.replaceAll( ',', '\\2C ' )
+		.replaceAll( '"', '\\22 ' )
+		.replaceAll( "'", '\\27 ' )
+		.replaceAll( '<', '\\3C ' )
+		.replaceAll( '>', '\\3E ' )
+		.replaceAll( '&', '\\26 ' ) }"`;
+}

--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -10,10 +10,8 @@ import type { DataRegistry } from '@wordpress/data';
  */
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
 import { fetchInstallFontFace } from '../api';
-import { formatFontFaceName } from './preview-styles';
 import type { FontFamilyToUpload, FontUploadResult } from '../types';
 import { unlock } from '../../lock-unlock';
-import type { FontFaceMetadata } from '../upload-fonts';
 
 /**
  * Browser dependencies
@@ -101,7 +99,7 @@ export function mergeFontFamilies(
  * It also adds it to the iframe document.
  */
 export async function loadFontFaceInBrowser(
-	fontFace: FontFaceMetadata,
+	fontFace: FontFace,
 	source: string | File,
 	addTo: 'all' | 'document' | 'iframe' = 'all'
 ): Promise< void > {
@@ -115,14 +113,10 @@ export async function loadFontFaceInBrowser(
 		return;
 	}
 
-	const newFont = new window.FontFace(
-		formatFontFaceName( fontFace.fontFamily ),
-		dataSource,
-		{
-			style: fontFace.fontStyle,
-			weight: String( fontFace.fontWeight ),
-		}
-	);
+	const newFont = new window.FontFace( fontFace.fontFamily, dataSource, {
+		style: fontFace.fontStyle,
+		weight: String( fontFace.fontWeight ),
+	} );
 
 	const loadedFace = await newFont.load();
 
@@ -156,7 +150,7 @@ export function unloadFontFaceInBrowser(
 	const unloadFontFace = ( fonts: FontFaceSet ) => {
 		fonts.forEach( ( f ) => {
 			if (
-				f.family === formatFontFaceName( fontFace?.fontFamily ) &&
+				f.family === fontFace?.fontFamily &&
 				f.weight === fontFace?.fontWeight &&
 				f.style === fontFace?.fontStyle
 			) {

--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -368,3 +368,37 @@ export function checkFontFaceInstalled(
 		} )
 	);
 }
+
+export	function normalizeCSSFontFaceFontFamily( fontName: string ): string {
+		return `"${ fontName
+			.trim()
+
+			/*
+			 * CSS Unicode escaping for problematic characters.
+			 * https://www.w3.org/TR/css-syntax-3/#escaping
+			 *
+			 * These characters are not required by CSS but may be problematic in WordPress:
+			 *
+			 * - Normalize and replace newlines. https://www.w3.org/TR/css-syntax-3/#input-preprocessing
+			 * - "<", ">", and "&" are replaced to prevent issues with KSES and other sanitization that
+			 *   is confused by HTML-like text.
+			 *   is confused by HTML-like text.
+			 * - `,`, `"` and `'` are replaced to prevent issues where font families may be processed later.
+			 *
+			 * Note that the Unicode escape sequences are used rather than backslash-escaping so the
+			 * problematic characters are removed completely.
+			 */
+			// Escape existing backslashes before any other processing
+			.replaceAll( '\\', '\\5C ' )
+			// Carriage return + line feed must be the first newline replacement.
+			.replaceAll( '\r\n', '\\A ' )
+			.replaceAll( '\r', '\\A ' )
+			.replaceAll( '\f', '\\A ' )
+			.replaceAll( '\n', '\\A ' )
+			.replaceAll( ',', '\\2C ' )
+			.replaceAll( '"', '\\22 ' )
+			.replaceAll( "'", '\\27 ' )
+			.replaceAll( '<', '\\3C ' )
+			.replaceAll( '>', '\\3E ' )
+			.replaceAll( '&', '\\26 ' ) }"`;
+	}

--- a/packages/global-styles-ui/src/font-library/utils/make-families-from-faces.ts
+++ b/packages/global-styles-ui/src/font-library/utils/make-families-from-faces.ts
@@ -2,33 +2,31 @@
  * WordPress dependencies
  */
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import type { FontFamily, FontFace } from '@wordpress/core-data';
+import type { FontFamily } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import type { FontFaceMetadata } from '../upload-fonts';
 
 const { kebabCase } = unlock( componentsPrivateApis );
 
 export default function makeFamiliesFromFaces(
-	fontFaces: FontFace[]
+	fontFaces: FontFaceMetadata[]
 ): FontFamily[] {
-	const fontFamiliesObject = fontFaces.reduce(
-		( acc: Record< string, FontFamily >, item: FontFace ) => {
-			if ( ! acc[ item.fontFamily ] ) {
-				acc[ item.fontFamily ] = {
-					name: item.fontFamily,
-					fontFamily: item.fontFamily,
-					slug: kebabCase( item.fontFamily.toLowerCase() ),
-					fontFace: [],
-				};
-			}
-			// @ts-expect-error
-			acc[ item.fontFamily ].fontFace.push( item );
-			return acc;
-		},
-		{}
-	);
+	const fontFamiliesObject = new Map< string, FontFamily >();
+	for ( const item of fontFaces ) {
+		if ( fontFamiliesObject.has( item.fontFamily ) ) {
+			fontFamiliesObject.get( item.fontFamily )!.fontFace!.push( item );
+		}
+
+		fontFamiliesObject.set( item.fontFamily, {
+			name: item.name,
+			fontFamily: item.fontFamily,
+			slug: kebabCase( item.fontFamily.toLowerCase() ),
+			fontFace: [],
+		} );
+	}
 	return Object.values( fontFamiliesObject ) as FontFamily[];
 }

--- a/packages/global-styles-ui/src/font-library/utils/preview-styles.ts
+++ b/packages/global-styles-ui/src/font-library/utils/preview-styles.ts
@@ -82,44 +82,6 @@ export function formatFontFamily( input: string ) {
 	return formatItem( output );
 }
 
-/*
- * Format the font face name to use in the font-family property of a font face.
- *
- * The input can be a string with the font face name or a string with multiple font face names separated by commas.
- * It removes the leading and trailing quotes from the font face name.
- *
- * @param {string} input - The font face name.
- * @return {string} The formatted font face name.
- *
- * Example:
- * formatFontFaceName("Open Sans") => "Open Sans"
- * formatFontFaceName("'Open Sans', sans-serif") => "Open Sans"
- * formatFontFaceName(", 'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
- */
-export function formatFontFaceName( input: string ) {
-	if ( ! input ) {
-		return '';
-	}
-
-	let output = input.trim();
-	if ( output.includes( ',' ) ) {
-		output = (
-			output
-				.split( ',' )
-				// finds the first item that is not an empty string.
-				.find( ( item ) => item.trim() !== '' ) ?? ''
-		).trim();
-	}
-	// removes leading and trailing quotes.
-	output = output.replace( /^["']|["']$/g, '' );
-
-	// Firefox needs the font name to be wrapped in double quotes meanwhile other browsers don't.
-	if ( window.navigator.userAgent.toLowerCase().includes( 'firefox' ) ) {
-		output = `"${ output }"`;
-	}
-	return output;
-}
-
 export function getFamilyPreviewStyle(
 	family: FontFamily | FontFace
 ): CSSProperties {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63568

# Work in progress

Current status:

The upload-font extracts a safely escaped CSS fontFamily. From the report. The generated CSS is correct:

```css
:root {
    --wp--preset--font-family--o-27-reilly-sans: "O\27 Reilly Sans";
}
@font-face{
  font-family:"O\27 Reilly Sans";
  font-style:normal;
  font-weight:400;
  font-display:fallback;
  src:url('http://localhost:8888/wp-content/uploads/fonts/O-Reilly-Sans-Regular.ttf') format('truetype');
}
```

The stored font's `fontFamily` seems to be used to generate CSS and to generate titles like this: 


<img width="1986" height="1002" alt="css-as-label" src="https://github.com/user-attachments/assets/995a7f51-a244-449a-bf66-78f2955204f7" />

That suggests this may not be the correct approach and the font family is a human readable name that should be transformed to CSS later.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
