### PR TITLE
Project Management: Add validation for missing GitHub labels configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,14 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/a11y/**'
 
+'[Package] Abilities':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/abilities/**'
+
+'[Package] Admin UI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/admin-ui/**'
+
 '[Package] API fetch':
     - changed-files:
           - any-glob-to-any-file: 'packages/api-fetch/**'
@@ -31,6 +39,10 @@
 '[Package] Blocks':
     - changed-files:
           - any-glob-to-any-file: 'packages/blocks/**'
+
+'[Package] Boot':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/boot/**'
 
 '[Package] Commands':
     - changed-files:
@@ -72,6 +84,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/deprecated/**'
 
+'[Package] Design System MCP':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/design-system-mcp/**'
+
 '[Package] DOM ready':
     - changed-files:
           - any-glob-to-any-file: 'packages/dom-ready/**'
@@ -82,7 +98,7 @@
 
 '[Package] E2E Tests':
     - changed-files:
-          - any-glob-to-any-file: 'packages/e2e-test-utils-playwright/**'
+          - any-glob-to-any-file: 'packages/e2e-tests/**'
 
 '[Package] Edit Post':
     - changed-files:
@@ -116,6 +132,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/format-library/**'
 
+'[Package] Grid':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/grid/**'
+
 '[Package] Hooks':
     - changed-files:
           - any-glob-to-any-file: 'packages/hooks/**'
@@ -131,6 +151,10 @@
 '[Package] Icons':
     - changed-files:
           - any-glob-to-any-file: 'packages/icons/**'
+
+'[Package] Image Cropper':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/image-cropper/**'
 
 '[Package] Interactivity':
     - changed-files:
@@ -212,10 +236,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/router/**'
 
-'[Package] Sanitize':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/sanitize/**'
-
 '[Package] Server Side Render':
     - changed-files:
           - any-glob-to-any-file: 'packages/server-side-render/**'
@@ -248,10 +268,100 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/viewport/**'
 
+'[Package] Views':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/views/**'
+
 '[Package] Warning':
     - changed-files:
           - any-glob-to-any-file: 'packages/warning/**'
 
+'[Package] Widget Dashboard':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/widget-dashboard/**'
+
+'[Package] Widget primitives':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/widget-primitives/**'
+
 '[Package] Word count':
     - changed-files:
           - any-glob-to-any-file: 'packages/wordcount/**'
+
+'[Package] wp-build':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/wp-build/**'
+
+# Tool labeling rules
+
+'[Tool] Babel plugin import JSX pragma':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/babel-plugin-import-jsx-pragma/**'
+
+'[Tool] Babel plugin makepot':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/babel-plugin-makepot/**'
+
+'[Tool] Babel preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/babel-preset-default/**'
+
+'[Tool] Browserslist config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/browserslist-config/**'
+
+'[Tool] Create Block':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/create-block/**'
+
+'[Tool] Dependency Extraction Webpack Plugin':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/dependency-extraction-webpack-plugin/**'
+
+'[Tool] Docgen':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/docgen/**'
+
+'[Tool] E2E Test Utils':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/e2e-test-utils-playwright/**'
+
+'[Tool] Env':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/env/**'
+
+'[Tool] ESLint plugin':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/eslint-plugin/**'
+
+'[Tool] Jest console':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/jest-console/**'
+
+'[Tool] Jest preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/jest-preset-default/**'
+
+'[Tool] npm-package-json-lint config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/npm-package-json-lint-config/**'
+
+'[Tool] PostCSS Plugins Preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/postcss-plugins-preset/**'
+
+'[Tool] Prettier config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/prettier-config/**'
+
+'[Tool] Readable JS Assets Webpack Plugin':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/readable-js-assets-webpack-plugin/**'
+
+'[Tool] stylelint config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/stylelint-config/**'
+
+'[Tool] WP Scripts':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/scripts/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,10 +4,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/a11y/**'
 
-'[Package] Admin UI':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/admin-ui/**'
-
 '[Package] API fetch':
     - changed-files:
           - any-glob-to-any-file: 'packages/api-fetch/**'
@@ -35,10 +31,6 @@
 '[Package] Blocks':
     - changed-files:
           - any-glob-to-any-file: 'packages/blocks/**'
-
-'[Package] Boot':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/boot/**'
 
 '[Package] Commands':
     - changed-files:
@@ -139,10 +131,6 @@
 '[Package] Icons':
     - changed-files:
           - any-glob-to-any-file: 'packages/icons/**'
-
-'[Package] Image Cropper':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/image-cropper/**'
 
 '[Package] Interactivity':
     - changed-files:
@@ -248,10 +236,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/token-list/**'
 
-'[Package] UI':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/ui/**'
-
 '[Package] Url':
     - changed-files:
           - any-glob-to-any-file: 'packages/url/**'
@@ -267,85 +251,3 @@
 '[Package] Word count':
     - changed-files:
           - any-glob-to-any-file: 'packages/wordcount/**'
-
-'[Package] wp-build':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/wp-build/**'
-
-# Tool labeling rules
-
-'[Tool] Babel plugin import JSX pragma':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/babel-plugin-import-jsx-pragma/**'
-
-'[Tool] Babel plugin makepot':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/babel-plugin-makepot/**'
-
-'[Tool] Babel preset':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/babel-preset-default/**'
-
-'[Tool] Browserslist config':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/browserslist-config/**'
-
-'[Tool] Create Block':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/create-block/**'
-
-'[Tool] Dependency Extraction Webpack Plugin':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/dependency-extraction-webpack-plugin/**'
-
-'[Tool] Docgen':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/docgen/**'
-
-'[Tool] E2E Test Utils':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/e2e-tests/**'
-
-'[Tool] Env':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/env/**'
-
-'[Tool] ESLint plugin':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/eslint-plugin/**'
-
-'[Tool] Jest console':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/jest-console/**'
-
-'[Tool] Jest preset':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/jest-preset-default/**'
-
-'[Tool] Jest Puppeteer aXe':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/jest-puppeteer-axe/**'
-
-'[Tool] npm-package-json-lint config':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/npm-package-json-lint-config/**'
-
-'[Tool] PostCSS Plugins Preset':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/postcss-plugins-preset/**'
-
-'[Tool] Prettier config':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/prettier-config/**'
-
-'[Tool] Readable JS Assets Webpack Plugin':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/readable-js-assets-webpack-plugin/**'
-
-'[Tool] stylelint config':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/stylelint-config/**'
-
-'[Tool] WP Scripts':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/scripts/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/a11y/**'
 
+'[Package] Admin UI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/admin-ui/**'
+
 '[Package] API fetch':
     - changed-files:
           - any-glob-to-any-file: 'packages/api-fetch/**'
@@ -31,6 +35,10 @@
 '[Package] Blocks':
     - changed-files:
           - any-glob-to-any-file: 'packages/blocks/**'
+
+'[Package] Boot':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/boot/**'
 
 '[Package] Commands':
     - changed-files:
@@ -131,6 +139,10 @@
 '[Package] Icons':
     - changed-files:
           - any-glob-to-any-file: 'packages/icons/**'
+
+'[Package] Image Cropper':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/image-cropper/**'
 
 '[Package] Interactivity':
     - changed-files:
@@ -236,6 +248,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/token-list/**'
 
+'[Package] UI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/ui/**'
+
 '[Package] Url':
     - changed-files:
           - any-glob-to-any-file: 'packages/url/**'
@@ -251,3 +267,85 @@
 '[Package] Word count':
     - changed-files:
           - any-glob-to-any-file: 'packages/wordcount/**'
+
+'[Package] wp-build':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/wp-build/**'
+
+# Tool labeling rules
+
+'[Tool] Babel plugin import JSX pragma':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/babel-plugin-import-jsx-pragma/**'
+
+'[Tool] Babel plugin makepot':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/babel-plugin-makepot/**'
+
+'[Tool] Babel preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/babel-preset-default/**'
+
+'[Tool] Browserslist config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/browserslist-config/**'
+
+'[Tool] Create Block':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/create-block/**'
+
+'[Tool] Dependency Extraction Webpack Plugin':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/dependency-extraction-webpack-plugin/**'
+
+'[Tool] Docgen':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/docgen/**'
+
+'[Tool] E2E Test Utils':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/e2e-tests/**'
+
+'[Tool] Env':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/env/**'
+
+'[Tool] ESLint plugin':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/eslint-plugin/**'
+
+'[Tool] Jest console':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/jest-console/**'
+
+'[Tool] Jest preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/jest-preset-default/**'
+
+'[Tool] Jest Puppeteer aXe':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/jest-puppeteer-axe/**'
+
+'[Tool] npm-package-json-lint config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/npm-package-json-lint-config/**'
+
+'[Tool] PostCSS Plugins Preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/postcss-plugins-preset/**'
+
+'[Tool] Prettier config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/prettier-config/**'
+
+'[Tool] Readable JS Assets Webpack Plugin':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/readable-js-assets-webpack-plugin/**'
+
+'[Tool] stylelint config':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/stylelint-config/**'
+
+'[Tool] WP Scripts':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/scripts/**'

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -8,47 +8,6 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LABELER_CONFIG="$REPO_ROOT/.github/labeler.yml"
 
-# DO NOT ADD TO THIS LIST. These are packages which do not have an associated
-# GitHub label yet. Remove entries from this list as labels are created.
-EXCLUDED_PACKAGES="
-	abilities
-	annotations
-	asset-loader
-	block-directory
-	block-serialization-default-parser
-	block-serialization-spec-parser
-	connectors
-	core-abilities
-	create-block-interactive-template
-	create-block-tutorial-template
-	customize-widgets
-	edit-site-init
-	global-styles-engine
-	global-styles-ui
-	latex-to-mathml
-	lazy-editor
-	list-reusable-blocks
-	media-editor
-	media-fields
-	nux
-	postcss-themes
-	preferences-persistence
-	react-native-aztec
-	react-native-bridge
-	react-native-editor
-	report-flaky-tests
-	reusable-blocks
-	route
-	shortcode
-	undo-manager
-	upload-media
-	views
-	vips
-	widgets
-	worker-threads
-	workflow
-"
-
 missing=()
 
 for pkg_dir in "$REPO_ROOT"/packages/*/; do
@@ -58,11 +17,6 @@ for pkg_dir in "$REPO_ROOT"/packages/*/; do
 	fi
 
 	pkg_name="$(basename "$pkg_dir")"
-
-	# Skip excluded packages
-	if echo "$EXCLUDED_PACKAGES" | grep -qw "$pkg_name"; then
-		continue
-	fi
 
 	# Check that the labeler config references this package's glob
 	if ! grep -q "packages/${pkg_name}/\*\*" "$LABELER_CONFIG"; then

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -8,6 +8,47 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LABELER_CONFIG="$REPO_ROOT/.github/labeler.yml"
 
+# DO NOT ADD TO THIS LIST. These are packages which do not have an associated
+# GitHub label yet. Remove entries from this list as labels are created.
+EXCLUDED_PACKAGES="
+	abilities
+	annotations
+	asset-loader
+	block-directory
+	block-serialization-default-parser
+	block-serialization-spec-parser
+	connectors
+	core-abilities
+	create-block-interactive-template
+	create-block-tutorial-template
+	customize-widgets
+	edit-site-init
+	global-styles-engine
+	global-styles-ui
+	latex-to-mathml
+	lazy-editor
+	list-reusable-blocks
+	media-editor
+	media-fields
+	nux
+	postcss-themes
+	preferences-persistence
+	react-native-aztec
+	react-native-bridge
+	react-native-editor
+	report-flaky-tests
+	reusable-blocks
+	route
+	shortcode
+	undo-manager
+	upload-media
+	views
+	vips
+	widgets
+	worker-threads
+	workflow
+"
+
 missing=()
 
 for pkg_dir in "$REPO_ROOT"/packages/*/; do
@@ -17,6 +58,11 @@ for pkg_dir in "$REPO_ROOT"/packages/*/; do
 	fi
 
 	pkg_name="$(basename "$pkg_dir")"
+
+	# Skip excluded packages
+	if echo "$EXCLUDED_PACKAGES" | grep -qw "$pkg_name"; then
+		continue
+	fi
 
 	# Check that the labeler config references this package's glob
 	if ! grep -q "packages/${pkg_name}/\*\*" "$LABELER_CONFIG"; then

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Validates that every package in packages/ has a corresponding entry
+# in .github/labeler.yml.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LABELER_CONFIG="$REPO_ROOT/.github/labeler.yml"
+
+missing=()
+
+for pkg_dir in "$REPO_ROOT"/packages/*/; do
+	# Skip directories without a package.json (not real packages)
+	if [ ! -f "$pkg_dir/package.json" ]; then
+		continue
+	fi
+
+	pkg_name="$(basename "$pkg_dir")"
+
+	# Check that the labeler config references this package's glob
+	if ! grep -q "packages/${pkg_name}/\*\*" "$LABELER_CONFIG"; then
+		missing+=("$pkg_name")
+	fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+	echo "The following packages are missing from .github/labeler.yml:"
+	for pkg in "${missing[@]}"; do
+		echo "  - packages/$pkg"
+	done
+	echo ""
+	echo "Add a labeling rule for each missing package to .github/labeler.yml."
+	exit 1
+fi
+
+echo "All packages have labeler config entries."

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -10,7 +10,7 @@ LABELER_CONFIG="$REPO_ROOT/.github/labeler.yml"
 
 # DO NOT ADD TO THIS LIST. These are packages which do not have an associated
 # GitHub label yet. Remove entries from this list as labels are created.
-EXCLUDED_PACKAGES="
+EXCLUDED_PACKAGES=(
 	annotations
 	asset-loader
 	block-directory
@@ -47,7 +47,20 @@ EXCLUDED_PACKAGES="
 	widgets
 	worker-threads
 	workflow
-"
+)
+
+is_excluded_package() {
+	local pkg_name="$1"
+	local excluded_package
+
+	for excluded_package in "${EXCLUDED_PACKAGES[@]}"; do
+		if [[ "$excluded_package" == "$pkg_name" ]]; then
+			return 0
+		fi
+	done
+
+	return 1
+}
 
 missing=()
 
@@ -60,7 +73,7 @@ for pkg_dir in "$REPO_ROOT"/packages/*/; do
 	pkg_name="$(basename "$pkg_dir")"
 
 	# Skip excluded packages
-	if echo "$EXCLUDED_PACKAGES" | grep -qw "$pkg_name"; then
+	if is_excluded_package "$pkg_name"; then
 		continue
 	fi
 

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -34,7 +34,6 @@ EXCLUDED_PACKAGES=(
 	nux
 	postcss-themes
 	preferences-persistence
-	react-native-editor
 	report-flaky-tests
 	reusable-blocks
 	route

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -82,6 +82,16 @@ for pkg_dir in "$REPO_ROOT"/packages/*/; do
 	fi
 done
 
+stale=()
+
+for excluded_package in "${EXCLUDED_PACKAGES[@]}"; do
+	if [ ! -f "$REPO_ROOT/packages/$excluded_package/package.json" ]; then
+		stale+=("$excluded_package")
+	fi
+done
+
+status=0
+
 if [ ${#missing[@]} -gt 0 ]; then
 	echo "The following packages are missing from .github/labeler.yml:"
 	for pkg in "${missing[@]}"; do
@@ -89,6 +99,20 @@ if [ ${#missing[@]} -gt 0 ]; then
 	done
 	echo ""
 	echo "Add a labeling rule for each missing package to .github/labeler.yml."
+	status=1
+fi
+
+if [ ${#stale[@]} -gt 0 ]; then
+	echo "The following excluded packages no longer exist:"
+	for pkg in "${stale[@]}"; do
+		echo "  - packages/$pkg"
+	done
+	echo ""
+	echo "Remove each one from EXCLUDED_PACKAGES in this script."
+	status=1
+fi
+
+if [ "$status" -ne 0 ]; then
 	exit 1
 fi
 

--- a/.github/scripts/validate-labeler-config.sh
+++ b/.github/scripts/validate-labeler-config.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Validates that every package in packages/ has a corresponding entry
+# in .github/labeler.yml.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LABELER_CONFIG="$REPO_ROOT/.github/labeler.yml"
+
+# DO NOT ADD TO THIS LIST. These are packages which do not have an associated
+# GitHub label yet. Remove entries from this list as labels are created.
+EXCLUDED_PACKAGES="
+	annotations
+	asset-loader
+	block-directory
+	block-serialization-default-parser
+	block-serialization-spec-parser
+	connectors
+	core-abilities
+	create-block-interactive-template
+	create-block-tutorial-template
+	customize-widgets
+	dashboard-init
+	edit-site-init
+	global-styles-engine
+	global-styles-ui
+	kebab-case
+	latex-to-mathml
+	lazy-editor
+	list-reusable-blocks
+	media-editor
+	media-fields
+	nux
+	postcss-themes
+	preferences-persistence
+	react-native-editor
+	report-flaky-tests
+	reusable-blocks
+	route
+	shortcode
+	style-runtime
+	undo-manager
+	upload-media
+	video-conversion
+	vips
+	widgets
+	worker-threads
+	workflow
+"
+
+missing=()
+
+for pkg_dir in "$REPO_ROOT"/packages/*/; do
+	# Skip directories without a package.json (not real packages)
+	if [ ! -f "$pkg_dir/package.json" ]; then
+		continue
+	fi
+
+	pkg_name="$(basename "$pkg_dir")"
+
+	# Skip excluded packages
+	if echo "$EXCLUDED_PACKAGES" | grep -qw "$pkg_name"; then
+		continue
+	fi
+
+	# Check that the labeler config references this package's glob
+	if ! grep -q "packages/${pkg_name}/\*\*" "$LABELER_CONFIG"; then
+		missing+=("$pkg_name")
+	fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+	echo "The following packages are missing from .github/labeler.yml:"
+	for pkg in "${missing[@]}"; do
+		echo "  - packages/$pkg"
+	done
+	echo ""
+	echo "Add a labeling rule for each missing package to .github/labeler.yml."
+	exit 1
+fi
+
+echo "All packages have labeler config entries."

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -8,6 +8,14 @@ on:
 permissions: {}
 
 jobs:
+    validate_labeler_config:
+        permissions:
+            contents: read
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - run: .github/scripts/validate-labeler-config.sh
+
     auto_label_pull_request:
         permissions:
             contents: read

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -8,14 +8,6 @@ on:
 permissions: {}
 
 jobs:
-    validate_labeler_config:
-        permissions:
-            contents: read
-        runs-on: ubuntu-24.04
-        steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-            - run: .github/scripts/validate-labeler-config.sh
-
     auto_label_pull_request:
         permissions:
             contents: read

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -95,3 +95,12 @@ jobs:
 
             - name: License compatibility
               run: npm run other:check-licenses
+
+    labeler-config:
+        name: Validate labeler config
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - run: .github/scripts/validate-labeler-config.sh

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -137,3 +137,12 @@ jobs:
 
             - name: License compatibility
               run: npm run other:check-licenses
+
+    labeler-config:
+        name: Validate labeler config
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - run: .github/scripts/validate-labeler-config.sh

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -144,5 +144,5 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - run: .github/scripts/validate-labeler-config.sh

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -58,6 +58,10 @@ jobs:
                   fetch-depth: ${{ matrix.annotations && github.event_name == 'pull_request' && 2 || 1 }}
                   persist-credentials: false
 
+            - name: Validate labeler config
+              if: ${{ matrix.annotations }}
+              run: .github/scripts/validate-labeler-config.sh
+
             - name: Use desired version of Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
@@ -137,12 +141,3 @@ jobs:
 
             - name: License compatibility
               run: npm run other:check-licenses
-
-    labeler-config:
-        name: Validate labeler config
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-            - run: .github/scripts/validate-labeler-config.sh


### PR DESCRIPTION
## What?

- Adds validation that the "auto-labeler" configuration includes entries for every package
- Adds missing configuration if labels exist
- Exempts packages that are unlabeled

Builds on: #52729

## Why?

I noticed #76218 was not initially labeled with "[Package] UI". I didn't realize that this was manually managed with configuration in [`.github/labeler.yml`](https://github.com/WordPress/gutenberg/blob/trunk/.github/labeler.yml). While I could have easily just added the configuration, it seems that we should want to keep these in sync with what exists in `packages/`. With this workflow, someone adding a new package would see a CI failure that hints them toward updating the labeler configuration.

## How?

Adds a script and related CI job which validates that each package in `packages/` is configured in `.github/labeler.yml`.

I added some exemptions to get things passing with minimal effort, but I might just go ahead and create these labels so we can have as few exceptions as possible.

## Testing Instructions

Observe that the initial commit fails CI because it didn't have the updated configuration.

You can also clone it directly into trunk and validate:

```
git co github-labeler-missing -- .github/scripts/validate-labeler-config.sh
chmod +x .github/scripts/validate-labeler-config.sh
.github/scripts/validate-labeler-config.sh
```
```
[...]
The following packages are missing from .github/labeler.yml:
  - packages/abilities
  - packages/admin-ui
  - packages/annotations
  - packages/asset-loader
  - packages/babel-plugin-import-jsx-pragma
  - packages/babel-plugin-makepot
  - packages/babel-preset-default
```