### PR TITLE
Add Site Tagline and Site Title to Design > Identity panel

### DIFF
--- a/packages/edit-site/src/components/sidebar-identity/index.js
+++ b/packages/edit-site/src/components/sidebar-identity/index.js
@@ -3,44 +3,10 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import {
-	__experimentalInputControl as InputControl,
-	__experimentalText as Text,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { MediaEdit } from '@wordpress/fields';
-
-// Custom Edit component for text fields that renders the description using
-// <Text variant="muted"> to match how MediaEdit renders descriptions.
-// The built-in DataForm text control renders descriptions via InputControl's
-// `help` prop, which produces a smaller font size than MediaEdit's description.
-function TextEdit( { data, field, onChange, hideLabelFromVision } ) {
-	const value = field.getValue( { item: data } );
-	const onChangeValue = useCallback(
-		( newValue ) =>
-			onChange( field.setValue( { item: data, value: newValue } ) ),
-		[ data, field, onChange ]
-	);
-
-	return (
-		<VStack spacing={ 2 }>
-			<InputControl
-				label={ field.label }
-				hideLabelFromVision={ hideLabelFromVision }
-				value={ value ?? '' }
-				onChange={ onChangeValue }
-				__next40pxDefaultSize
-			/>
-			{ field.description && (
-				<Text variant="muted">{ field.description }</Text>
-			) }
-		</VStack>
-	);
-}
 
 const fields = [
 	{
@@ -50,7 +16,6 @@ const fields = [
 		description: __(
 			"Displays in your site's layout via the Site Title block."
 		),
-		Edit: TextEdit,
 	},
 	{
 		id: 'description',
@@ -59,7 +24,6 @@ const fields = [
 		description: __(
 			"In a few words, explain what this site is about. Displays in your site's layout via the Site Tagline block."
 		),
-		Edit: TextEdit,
 	},
 	{
 		id: 'site_logo',

--- a/packages/edit-site/src/components/sidebar-identity/index.js
+++ b/packages/edit-site/src/components/sidebar-identity/index.js
@@ -3,12 +3,64 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import {
+	__experimentalInputControl as InputControl,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { MediaEdit } from '@wordpress/fields';
 
+// Custom Edit component for text fields that renders the description using
+// <Text variant="muted"> to match how MediaEdit renders descriptions.
+// The built-in DataForm text control renders descriptions via InputControl's
+// `help` prop, which produces a smaller font size than MediaEdit's description.
+function TextEdit( { data, field, onChange, hideLabelFromVision } ) {
+	const value = field.getValue( { item: data } );
+	const onChangeValue = useCallback(
+		( newValue ) =>
+			onChange( field.setValue( { item: data, value: newValue } ) ),
+		[ data, field, onChange ]
+	);
+
+	return (
+		<VStack spacing={ 2 }>
+			<InputControl
+				label={ field.label }
+				hideLabelFromVision={ hideLabelFromVision }
+				value={ value ?? '' }
+				onChange={ onChangeValue }
+				__next40pxDefaultSize
+			/>
+			{ field.description && (
+				<Text variant="muted">{ field.description }</Text>
+			) }
+		</VStack>
+	);
+}
+
 const fields = [
+	{
+		id: 'title',
+		type: 'text',
+		label: __( 'Site Title' ),
+		description: __(
+			"Displays in your site's layout via the Site Title block."
+		),
+		Edit: TextEdit,
+	},
+	{
+		id: 'description',
+		type: 'text',
+		label: __( 'Site Tagline' ),
+		description: __(
+			"In a few words, explain what this site is about. Displays in your site's layout via the Site Tagline block."
+		),
+		Edit: TextEdit,
+	},
 	{
 		id: 'site_logo',
 		type: 'media',
@@ -42,7 +94,7 @@ const form = {
 		type: 'regular',
 		labelPosition: 'top',
 	},
-	fields: [ 'site_logo', 'site_icon' ],
+	fields: [ 'title', 'description', 'site_logo', 'site_icon' ],
 };
 
 export default function SidebarIdentity() {

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -937,7 +937,10 @@ export default function MediaEdit< Item >( {
 									setTargetItemId={ setTargetItemId }
 								/>
 								{ field.description && (
-									<Text variant="muted">
+									<Text
+										variant="muted"
+										className="fields__media-edit-description"
+									>
 										{ field.description }
 									</Text>
 								) }

--- a/packages/fields/src/components/media-edit/style.scss
+++ b/packages/fields/src/components/media-edit/style.scss
@@ -32,6 +32,7 @@ fieldset.fields__media-edit {
 
 	.fields__media-edit-description {
 		font-size: $helptext-font-size;
+		line-height: 1.5;
 	}
 
 	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */

--- a/packages/fields/src/components/media-edit/style.scss
+++ b/packages/fields/src/components/media-edit/style.scss
@@ -30,6 +30,10 @@ fieldset.fields__media-edit {
 		color: $gray-900;
 	}
 
+	.fields__media-edit-description {
+		font-size: $helptext-font-size;
+	}
+
 	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */
 	container-type: inline-size;
 


### PR DESCRIPTION
## Summary

Adds **Site Title** and **Site Tagline** text fields to the Design > Identity panel, alongside the existing Site Logo and Site Icon media fields added in #76116. Closes https://github.com/WordPress/gutenberg/issues/76261.

- Both fields edit the `root/site` entity (`title` and `description` properties from `/wp/v2/settings`), so changes are reflected by the **Site Title** and **Site Tagline** blocks in the editor preview.
- Uses a custom `TextEdit` component that renders field descriptions with `<Text variant="muted">` to match how `MediaEdit` renders its descriptions. The built-in DataForm text control renders descriptions via `InputControl`'s `help` prop, which produces a smaller font size — the custom component ensures visual consistency across all four fields.

## Test plan

- [ ] Go to Site Editor → Design → Identity
- [ ] Verify four fields appear in order: Site Title, Site Tagline, Site Logo, Site Icon
- [ ] Verify description text below each field is the same size/style
- [ ] Edit the Site Title and verify the Site Title block updates in the preview
- [ ] Edit the Site Tagline and verify the Site Tagline block updates in the preview
- [ ] Click Save and verify all edited fields appear in the save panel
- [ ] Confirm changes persist after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)