### PR TITLE
ui/CollapsibleCard: move trigger to the whole header

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `Notice`: Improve narrow layout by letting description and actions span the icon column when a title is present ([#76202](https://github.com/WordPress/gutenberg/pull/76202)).
 -   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 -   `Card`, `CollapsibleCard`: update padding to match legacy `Card` component ([#76368](https://github.com/WordPress/gutenberg/pull/76368)).
+-   `CollapsibleCard`: move trigger to the header ([#76265](https://github.com/WordPress/gutenberg/pull/76265)).
 
 ## 0.8.0 (2026-03-04)
 

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -19,23 +19,31 @@ import type { HeaderProps } from './types';
  */
 export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 	function CollapsibleCardHeader(
-		{ children, className, ...restProps },
+		{ children, className, render, ...restProps },
 		ref
 	) {
 		return (
-			<Card.Header
-				ref={ ref }
+			<Collapsible.Trigger
 				className={ clsx( styles.header, className ) }
-				{ ...restProps }
+				render={
+					<Card.Header
+						ref={ ref }
+						render={ render }
+						{ ...restProps }
+					/>
+				}
+				nativeButton={ false }
+				tabIndex={ -1 }
 			>
-				<Collapsible.Trigger
-					className={ styles[ 'header-background-trigger' ] }
-					render={ <div /> }
-					nativeButton={ false }
-					tabIndex={ -1 }
-				/>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
-				<div className={ styles[ 'header-trigger-wrapper' ] }>
+				{ /* Stop click/keyboard events from bubbling to the outer
+				    Collapsible.Trigger, which would cause a double-toggle. */ }
+				<div
+					className={ styles[ 'header-trigger-wrapper' ] }
+					onClick={ ( event ) => event.stopPropagation() }
+					onKeyDown={ ( event ) => event.stopPropagation() }
+					role="presentation"
+				>
 					<Collapsible.Trigger
 						render={ ( props ) => (
 							<IconButton
@@ -60,7 +68,7 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 						className={ styles[ 'header-trigger' ] }
 					/>
 				</div>
-			</Card.Header>
+			</Collapsible.Trigger>
 		);
 	}
 );

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
-import type { MouseEvent } from 'react';
-import { forwardRef, useCallback, useRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import * as Card from '../card';
@@ -20,38 +19,24 @@ import type { HeaderProps } from './types';
  */
 export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 	function CollapsibleCardHeader(
-		{ children, className, onClick, ...restProps },
+		{ children, className, ...restProps },
 		ref
 	) {
-		const triggerRef = useRef< HTMLButtonElement >( null );
-
-		const handleHeaderClick = useCallback(
-			( event: MouseEvent< HTMLDivElement > ) => {
-				const trigger = triggerRef.current;
-				if (
-					trigger &&
-					event.target instanceof Node &&
-					! trigger.contains( event.target )
-				) {
-					trigger.click();
-				}
-
-				onClick?.( event );
-			},
-			[ onClick ]
-		);
-
 		return (
 			<Card.Header
 				ref={ ref }
 				className={ clsx( styles.header, className ) }
-				onClick={ handleHeaderClick }
 				{ ...restProps }
 			>
+				<Collapsible.Trigger
+					className={ styles[ 'header-background-trigger' ] }
+					render={ <div /> }
+					nativeButton={ false }
+					tabIndex={ -1 }
+				/>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
 				<div className={ styles[ 'header-trigger-wrapper' ] }>
 					<Collapsible.Trigger
-						ref={ triggerRef }
 						render={ ( props ) => (
 							<IconButton
 								{ ...props }

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -33,7 +33,6 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 					/>
 				}
 				nativeButton={ false }
-				data-wp-ui-focus-parent
 			>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
 				<div className={ styles[ 'header-trigger-wrapper' ] }>

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -33,6 +33,7 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 					/>
 				}
 				nativeButton={ false }
+				data-wp-ui-focus-parent
 			>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
 				<div className={ styles[ 'header-trigger-wrapper' ] }>

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -36,14 +36,10 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 				tabIndex={ -1 }
 			>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
-				{ /* Stop click/keyboard events from bubbling to the outer
-				    Collapsible.Trigger, which would cause a double-toggle. */ }
-				<div
-					className={ styles[ 'header-trigger-wrapper' ] }
-					onClick={ ( event ) => event.stopPropagation() }
-					onKeyDown={ ( event ) => event.stopPropagation() }
-					role="presentation"
-				>
+				<div className={ styles[ 'header-trigger-wrapper' ] }>
+					{ /* onClick/onKeyDown stop events from bubbling to the
+					     outer Collapsible.Trigger (the header), which would
+					     cause a double-toggle. */ }
 					<Collapsible.Trigger
 						render={ ( props ) => (
 							<IconButton
@@ -66,6 +62,8 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 							/>
 						) }
 						className={ styles[ 'header-trigger' ] }
+						onClick={ ( event ) => event.stopPropagation() }
+						onKeyDown={ ( event ) => event.stopPropagation() }
 					/>
 				</div>
 			</Collapsible.Trigger>

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { chevronDown, chevronUp } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 import * as Card from '../card';
 import * as Collapsible from '../collapsible';
-import { IconButton } from '../icon-button';
+import { Icon } from '../icon';
 import styles from './style.module.css';
+import focusStyles from '../utils/css/focus.module.css';
 import type { HeaderProps } from './types';
 
 /**
@@ -33,37 +33,18 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 					/>
 				}
 				nativeButton={ false }
-				tabIndex={ -1 }
 			>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
 				<div className={ styles[ 'header-trigger-wrapper' ] }>
-					{ /* onClick/onKeyDown stop events from bubbling to the
-					     outer Collapsible.Trigger (the header), which would
-					     cause a double-toggle. */ }
-					<Collapsible.Trigger
-						render={ ( props ) => (
-							<IconButton
-								{ ...props }
-								label={ __( 'Expand or collapse card' ) }
-								// The Collapsible wrapper's `render` prop
-								// uses a single-argument callback (via the
-								// ComponentProps utility), so Base UI's
-								// second `state` argument isn't available
-								// here. We derive the open state from
-								// `aria-expanded` instead of `state.open`.
-								icon={
-									props[ 'aria-expanded' ] === true
-										? chevronUp
-										: chevronDown
-								}
-								variant="minimal"
-								tone="neutral"
-								size="compact"
-							/>
+					<Icon
+						icon={ chevronDown }
+						className={ clsx(
+							styles[ 'header-trigger' ],
+							// While the interactive trigger element is the whole header,
+							// the focus ring will be displayed only on the icon to visually
+							// emulate it being the button.
+							focusStyles[ 'outset-ring--focus-parent-visible' ]
 						) }
-						className={ styles[ 'header-trigger' ] }
-						onClick={ ( event ) => event.stopPropagation() }
-						onKeyDown={ ( event ) => event.stopPropagation() }
 					/>
 				</div>
 			</Collapsible.Trigger>

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -4,9 +4,6 @@
 	.header-content {
 		flex: 1;
 		min-width: 0;
-		position: relative;
-		z-index: 1;
-		pointer-events: none;
 	}
 
 	.header-trigger-wrapper {
@@ -16,8 +13,6 @@
 		   preserving the same metrics between `Card` and `CollapsibleCard`. */
 		max-height: 0;
 		overflow: visible;
-		position: relative;
-		z-index: 1;
 	}
 
 	.header-trigger {
@@ -25,16 +20,6 @@
 		   at the wrapper's midpoint (which `align-self: center` places at
 		   the vertical center of the header). */
 		transform: translateY(-50%);
-	}
-
-	.header-background-trigger {
-		position: absolute;
-		inset: 0;
-		z-index: 0;
-
-		&:not([data-disabled]) {
-			cursor: var(--wpds-cursor-control);
-		}
 	}
 }
 
@@ -45,5 +30,9 @@
 		align-items: stretch;
 		gap: var(--wpds-dimension-gap-sm);
 		position: relative;
+
+		&:not([data-disabled]) {
+			cursor: var(--wpds-cursor-control);
+		}
 	}
 }

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -19,7 +19,19 @@
 		/* Offset by half the button's own height so it visually centers
 		   at the wrapper's midpoint (which `align-self: center` places at
 		   the vertical center of the header). */
-		transform: translateY(-50%);
+		translate: 0 -50%;
+
+		/* For an outline that looks like `IconButton`'s */
+		border-radius: var(--wpds-border-radius-sm);
+	}
+
+	.header[data-panel-open] .header-trigger {
+		rotate: 180deg;
+	}
+
+	/* Simulate disabled button styles */
+	.header[data-disabled] .header-trigger {
+		color: var(--wpds-color-fg-interactive-neutral-disabled);
 	}
 }
 
@@ -30,6 +42,7 @@
 		align-items: stretch;
 		gap: var(--wpds-dimension-gap-sm);
 		position: relative;
+		outline: none;
 
 		&:not([data-disabled]) {
 			cursor: var(--wpds-cursor-control);

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -4,6 +4,9 @@
 	.header-content {
 		flex: 1;
 		min-width: 0;
+		position: relative;
+		z-index: 1;
+		pointer-events: none;
 	}
 
 	.header-trigger-wrapper {
@@ -13,6 +16,8 @@
 		   preserving the same metrics between `Card` and `CollapsibleCard`. */
 		max-height: 0;
 		overflow: visible;
+		position: relative;
+		z-index: 1;
 	}
 
 	.header-trigger {
@@ -20,6 +25,16 @@
 		   at the wrapper's midpoint (which `align-self: center` places at
 		   the vertical center of the header). */
 		transform: translateY(-50%);
+	}
+
+	.header-background-trigger {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+
+		&:not([data-disabled]) {
+			cursor: var(--wpds-cursor-control);
+		}
 	}
 }
 
@@ -29,9 +44,6 @@
 		flex-direction: row;
 		align-items: stretch;
 		gap: var(--wpds-dimension-gap-sm);
-
-		&:has(.header-trigger:not([data-disabled])) {
-			cursor: var(--wpds-cursor-control);
-		}
+		position: relative;
 	}
 }

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -41,7 +41,6 @@
 		flex-direction: row;
 		align-items: stretch;
 		gap: var(--wpds-dimension-gap-sm);
-		position: relative;
 		outline: none;
 
 		&:not([data-disabled]) {

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -110,12 +110,16 @@ describe( 'CollapsibleCard', () => {
 			).not.toBeInTheDocument();
 		} );
 
+		// In a real browser, clicking anywhere on the header toggles the
+		// card because `pointer-events: none` on the content layer lets
+		// clicks pass through to the background Collapsible.Trigger. jsdom
+		// doesn't apply CSS, so we target the background trigger directly.
 		it( 'toggles content when clicking the header area', async () => {
 			const user = userEvent.setup();
 
 			render(
 				<CollapsibleCard.Root>
-					<CollapsibleCard.Header>
+					<CollapsibleCard.Header data-testid="header">
 						<Card.Title>Header click test</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
@@ -128,7 +132,9 @@ describe( 'CollapsibleCard', () => {
 				screen.queryByText( 'Header toggled content' )
 			).not.toBeInTheDocument();
 
-			await user.click( screen.getByText( 'Header click test' ) );
+			const header = screen.getByTestId( 'header' );
+			// eslint-disable-next-line testing-library/no-node-access -- The background trigger has no accessible role; it's a visual-only click target.
+			await user.click( header.firstElementChild! );
 
 			expect(
 				screen.getByText( 'Header toggled content' )

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -91,40 +91,25 @@ describe( 'CollapsibleCard', () => {
 				screen.queryByText( 'Toggle content' )
 			).not.toBeInTheDocument();
 
-			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Title',
+					expanded: false,
+				} )
+			);
 
 			expect( screen.getByText( 'Toggle content' ) ).toBeVisible();
 
-			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Title',
+					expanded: true,
+				} )
+			);
 
 			expect(
 				screen.queryByText( 'Toggle content' )
 			).not.toBeInTheDocument();
-		} );
-
-		it( 'toggles content when clicking the header area', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<CollapsibleCard.Root>
-					<CollapsibleCard.Header>
-						<Card.Title>Header click test</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<p>Header toggled content</p>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
-			);
-
-			expect(
-				screen.queryByText( 'Header toggled content' )
-			).not.toBeInTheDocument();
-
-			await user.click( screen.getByText( 'Header click test' ) );
-
-			expect(
-				screen.getByText( 'Header toggled content' )
-			).toBeVisible();
 		} );
 
 		it( 'calls onOpenChange when toggled', async () => {
@@ -142,7 +127,12 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Title',
+					expanded: false,
+				} )
+			);
 
 			expect( onOpenChange.mock.calls[ 0 ][ 0 ] ).toBe( true );
 		} );
@@ -165,7 +155,12 @@ describe( 'CollapsibleCard', () => {
 
 			expect( screen.getByText( 'Should stay visible' ) ).toBeVisible();
 
-			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Title',
+					expanded: true,
+				} )
+			);
 
 			expect( screen.getByText( 'Should stay visible' ) ).toBeVisible();
 		} );
@@ -182,7 +177,10 @@ describe( 'CollapsibleCard', () => {
 			);
 
 			expect(
-				screen.getByRole( 'button', { name: 'Title' } )
+				screen.getByRole( 'button', {
+					name: 'Title',
+					expanded: false,
+				} )
 			).toBeVisible();
 		} );
 	} );

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -92,17 +92,13 @@ describe( 'CollapsibleCard', () => {
 			).not.toBeInTheDocument();
 
 			await user.click(
-				screen.getByRole( 'button', {
-					name: 'Expand or collapse card',
-				} )
+				screen.getByRole( 'button', { name: 'Title' } )
 			);
 
 			expect( screen.getByText( 'Toggle content' ) ).toBeVisible();
 
 			await user.click(
-				screen.getByRole( 'button', {
-					name: 'Expand or collapse card',
-				} )
+				screen.getByRole( 'button', { name: 'Title' } )
 			);
 
 			expect(
@@ -151,9 +147,7 @@ describe( 'CollapsibleCard', () => {
 			);
 
 			await user.click(
-				screen.getByRole( 'button', {
-					name: 'Expand or collapse card',
-				} )
+				screen.getByRole( 'button', { name: 'Title' } )
 			);
 
 			expect( onOpenChange.mock.calls[ 0 ][ 0 ] ).toBe( true );
@@ -178,9 +172,7 @@ describe( 'CollapsibleCard', () => {
 			expect( screen.getByText( 'Should stay visible' ) ).toBeVisible();
 
 			await user.click(
-				screen.getByRole( 'button', {
-					name: 'Expand or collapse card',
-				} )
+				screen.getByRole( 'button', { name: 'Title' } )
 			);
 
 			expect( screen.getByText( 'Should stay visible' ) ).toBeVisible();
@@ -188,7 +180,7 @@ describe( 'CollapsibleCard', () => {
 	} );
 
 	describe( 'trigger', () => {
-		it( 'renders a toggle button', () => {
+		it( 'renders the header as a toggle button', () => {
 			render(
 				<CollapsibleCard.Root>
 					<CollapsibleCard.Header>
@@ -198,10 +190,9 @@ describe( 'CollapsibleCard', () => {
 			);
 
 			expect(
-				screen.getByRole( 'button', {
-					name: 'Expand or collapse card',
-				} )
+				screen.getByRole( 'button', { name: 'Title' } )
 			).toBeVisible();
 		} );
 	} );
+
 } );

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -110,16 +110,12 @@ describe( 'CollapsibleCard', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		// In a real browser, clicking anywhere on the header toggles the
-		// card because `pointer-events: none` on the content layer lets
-		// clicks pass through to the background Collapsible.Trigger. jsdom
-		// doesn't apply CSS, so we target the background trigger directly.
 		it( 'toggles content when clicking the header area', async () => {
 			const user = userEvent.setup();
 
 			render(
 				<CollapsibleCard.Root>
-					<CollapsibleCard.Header data-testid="header">
+					<CollapsibleCard.Header>
 						<Card.Title>Header click test</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
@@ -132,9 +128,7 @@ describe( 'CollapsibleCard', () => {
 				screen.queryByText( 'Header toggled content' )
 			).not.toBeInTheDocument();
 
-			const header = screen.getByTestId( 'header' );
-			// eslint-disable-next-line testing-library/no-node-access -- The background trigger has no accessible role; it's a visual-only click target.
-			await user.click( header.firstElementChild! );
+			await user.click( screen.getByText( 'Header click test' ) );
 
 			expect(
 				screen.getByText( 'Header toggled content' )

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -91,15 +91,11 @@ describe( 'CollapsibleCard', () => {
 				screen.queryByText( 'Toggle content' )
 			).not.toBeInTheDocument();
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Title' } )
-			);
+			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
 
 			expect( screen.getByText( 'Toggle content' ) ).toBeVisible();
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Title' } )
-			);
+			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
 
 			expect(
 				screen.queryByText( 'Toggle content' )
@@ -146,9 +142,7 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Title' } )
-			);
+			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
 
 			expect( onOpenChange.mock.calls[ 0 ][ 0 ] ).toBe( true );
 		} );
@@ -171,9 +165,7 @@ describe( 'CollapsibleCard', () => {
 
 			expect( screen.getByText( 'Should stay visible' ) ).toBeVisible();
 
-			await user.click(
-				screen.getByRole( 'button', { name: 'Title' } )
-			);
+			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
 
 			expect( screen.getByText( 'Should stay visible' ) ).toBeVisible();
 		} );
@@ -194,5 +186,4 @@ describe( 'CollapsibleCard', () => {
 			).toBeVisible();
 		} );
 	} );
-
 } );

--- a/packages/ui/src/utils/css/focus.module.css
+++ b/packages/ui/src/utils/css/focus.module.css
@@ -26,7 +26,7 @@
 	.outset-ring--focus-within:focus-within,
 	.outset-ring--focus-within-except-active:focus-within:not(:has(:active)),
 	.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
-	[data-wp-ui-focus-parent]:focus-visible .outset-ring--focus-parent-visible {
+	:focus-visible .outset-ring--focus-parent-visible {
 		outline-width: var(--wpds-border-width-focus);
 		outline-color: var(--wpds-color-stroke-focus-brand);
 	}

--- a/packages/ui/src/utils/css/focus.module.css
+++ b/packages/ui/src/utils/css/focus.module.css
@@ -6,7 +6,8 @@
 	.outset-ring--focus-visible,
 	.outset-ring--focus-within,
 	.outset-ring--focus-within-except-active,
-	.outset-ring--focus-within-visible {
+	.outset-ring--focus-within-visible,
+	.outset-ring--focus-parent-visible {
 		@media not ( prefers-reduced-motion ) {
 			transition: outline 0.1s ease-out;
 		}
@@ -24,7 +25,8 @@
 	.outset-ring--focus-visible:focus-visible,
 	.outset-ring--focus-within:focus-within,
 	.outset-ring--focus-within-except-active:focus-within:not(:has(:active)),
-	.outset-ring--focus-within-visible:focus-within:has(:focus-visible) {
+	.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
+	*:has(.outset-ring--focus-parent-visible):focus-visible .outset-ring--focus-parent-visible {
 		outline-width: var(--wpds-border-width-focus);
 		outline-color: var(--wpds-color-stroke-focus-brand);
 	}

--- a/packages/ui/src/utils/css/focus.module.css
+++ b/packages/ui/src/utils/css/focus.module.css
@@ -26,7 +26,7 @@
 	.outset-ring--focus-within:focus-within,
 	.outset-ring--focus-within-except-active:focus-within:not(:has(:active)),
 	.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
-	*:has(.outset-ring--focus-parent-visible):focus-visible .outset-ring--focus-parent-visible {
+	[data-wp-ui-focus-parent]:focus-visible .outset-ring--focus-parent-visible {
 		outline-width: var(--wpds-border-width-focus);
 		outline-color: var(--wpds-color-stroke-focus-brand);
 	}


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/76252

Replace the manual click-delegation logic in `CollapsibleCard.Header` by making the `CollapsibleCard.Header` the trigger itself, and by replacing the previous trigger button with a non-interactive icon.

## Why?

The previous implementation was hacky. The new implementation is cleaner and achieves very similar visual styles with a lot less code — and is more accessible, since the new trigger (ie. the new header) has, by default, an accessible name specific for each card.

## How?

- Render the entire `Card.Header` as a `Collapsible.Trigger` 
- Refactor the previous trigger button to a non-interactive `Icon`, but still show the focus ring only around the icon when the header is `:focus-visible`


## Testing Instructions

1. Open Storybook and navigate to **Design System / Components / CollapsibleCard**.
2. Verify that clicking anywhere on the header (text, empty space) toggles the card.
3. Verify that clicking the chevron icon also toggles the card
4. Verify keyboard interaction: Tab to the card, press Enter/Space to toggle.
5. Verify the disabled state prevents toggling.
6. Run unit tests: `npm run test:unit -- packages/ui/src/collapsible-card/test/index.test.tsx`