### PR TITLE
Connectors: Show API key source for env vars and wp-config constants

### DIFF
--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -22,7 +22,7 @@ function _gutenberg_get_api_key_source( string $provider_id ): string {
 	$constant_case_id = strtoupper(
 		preg_replace( '/([a-z])([A-Z])/', '$1_$2', str_replace( '-', '_', $provider_id ) )
 	);
-	$env_var_name = "{$constant_case_id}_API_KEY";
+	$env_var_name     = "{$constant_case_id}_API_KEY";
 
 	// Check environment variable first.
 	$env_value = getenv( $env_var_name );

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -269,72 +269,7 @@ function _gutenberg_get_connector_settings(): array {
 	return $connectors;
 }
 
-/**
- * Validates connector API keys in the REST response when explicitly requested.
- *
- * Runs on `rest_post_dispatch` for `/wp/v2/settings` requests that include connector
- * fields via `_fields`. For each requested connector field, it validates the unmasked
- * key against the provider and replaces the response value with `invalid_key` if
- * validation fails.
- *
- * @access private
- *
- * @param WP_REST_Response $response The response object.
- * @param WP_REST_Server   $server   The server instance.
- * @param WP_REST_Request  $request  The request object.
- * @return WP_REST_Response The potentially modified response.
- */
-function _gutenberg_validate_connector_keys_in_rest( WP_REST_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_REST_Response {
-	if ( '/wp/v2/settings' !== $request->get_route() ) {
-		return $response;
-	}
-
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
-		return $response;
-	}
-
-	$fields = $request->get_param( '_fields' );
-	if ( ! $fields ) {
-		return $response;
-	}
-
-	if ( is_array( $fields ) ) {
-		$requested = $fields;
-	} else {
-		$requested = array_map( 'trim', explode( ',', $fields ) );
-	}
-
-	$data = $response->get_data();
-	if ( ! is_array( $data ) ) {
-		return $response;
-	}
-
-	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
-		$auth = $connector_data['authentication'];
-		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
-			continue;
-		}
-
-		$setting_name = $auth['setting_name'];
-		if ( ! in_array( $setting_name, $requested, true ) ) {
-			continue;
-		}
-
-		$real_key = _gutenberg_get_real_api_key( $setting_name, '_gutenberg_mask_api_key' );
-		if ( '' === $real_key ) {
-			continue;
-		}
-
-		if ( true !== _gutenberg_is_ai_api_key_valid( $real_key, $connector_id ) ) {
-			$data[ $setting_name ] = 'invalid_key';
-		}
-	}
-
-	$response->set_data( $data );
-	return $response;
-}
 remove_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10 );
-add_filter( 'rest_post_dispatch', '_gutenberg_validate_connector_keys_in_rest', 10, 3 );
 
 /**
  * Registers default connector settings and mask/sanitize filters.

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -409,6 +409,12 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 				continue;
 			}
 
+			// Skip if the key is already provided via env var or constant.
+			$key_source = _gutenberg_get_api_key_source( $connector_id );
+			if ( 'env' === $key_source || 'constant' === $key_source ) {
+				continue;
+			}
+
 			$api_key = _gutenberg_get_real_api_key( $auth['setting_name'], '_gutenberg_mask_api_key' );
 			if ( '' === $api_key || ! $registry->hasProvider( $connector_id ) ) {
 				continue;
@@ -439,6 +445,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		return $data;
 	}
 
+	$registry   = \WordPress\AiClient\AiClient::defaultRegistry();
 	$connectors = array();
 	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth     = $connector_data['authentication'];
@@ -448,18 +455,11 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
 			$auth_out['keySource']      = _gutenberg_get_api_key_source( $connector_id );
-
-			// Check if the provider is connected (has valid credentials).
-			$is_connected = false;
 			try {
-				$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-				if ( $registry->hasProvider( $connector_id ) ) {
-					$is_connected = $registry->isProviderConfigured( $connector_id );
-				}
+				$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
 			} catch ( Exception $e ) {
-				// $is_connected remains false.
+				$auth_out['isConnected'] = false;
 			}
-			$auth_out['isConnected'] = $is_connected;
 		}
 
 		$connector_out = array(

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -6,6 +6,49 @@
  */
 
 /**
+ * Determines the source of an API key for a given provider.
+ *
+ * Checks in order: environment variable, PHP constant, database.
+ * Uses the same naming convention as the WP AI Client ProviderRegistry.
+ *
+ * @access private
+ *
+ * @param string $provider_id The provider ID (e.g., 'openai', 'anthropic', 'google').
+ * @return string The key source: 'env', 'constant', 'database', or 'none'.
+ */
+function _gutenberg_get_api_key_source( string $provider_id ): string {
+	// Convert provider ID to CONSTANT_CASE for env var name.
+	// e.g., 'openai' -> 'OPENAI', 'anthropic' -> 'ANTHROPIC'.
+	$constant_case_id = strtoupper(
+		preg_replace( '/([a-z])([A-Z])/', '$1_$2', str_replace( '-', '_', $provider_id ) )
+	);
+	$env_var_name = "{$constant_case_id}_API_KEY";
+
+	// Check environment variable first.
+	$env_value = getenv( $env_var_name );
+	if ( false !== $env_value && '' !== $env_value ) {
+		return 'env';
+	}
+
+	// Check PHP constant.
+	if ( defined( $env_var_name ) ) {
+		$const_value = constant( $env_var_name );
+		if ( is_string( $const_value ) && '' !== $const_value ) {
+			return 'constant';
+		}
+	}
+
+	// Check database.
+	$setting_name = "connectors_ai_{$provider_id}_api_key";
+	$db_value     = get_option( $setting_name, '' );
+	if ( '' !== $db_value ) {
+		return 'database';
+	}
+
+	return 'none';
+}
+
+/**
  * Masks an API key, showing only the last 4 characters.
  *
  * @access private
@@ -404,6 +447,19 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		if ( 'api_key' === $auth['method'] ) {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
+			$auth_out['keySource']      = _gutenberg_get_api_key_source( $connector_id );
+
+			// Check if the provider is connected (has valid credentials).
+			$is_connected = false;
+			try {
+				$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+				if ( $registry->hasProvider( $connector_id ) ) {
+					$is_connected = $registry->isProviderConfigured( $connector_id );
+				}
+			} catch ( Exception $e ) {
+				// $is_connected remains false.
+			}
+			$auth_out['isConnected'] = $is_connected;
 		}
 
 		$connector_out = array(

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -59,6 +59,8 @@ export function ConnectorItem( {
 	);
 }
 
+export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
+
 export interface DefaultConnectorSettingsProps {
 	onSave?: ( apiKey: string ) => void | Promise< void >;
 	onRemove?: () => void;
@@ -66,6 +68,7 @@ export interface DefaultConnectorSettingsProps {
 	helpUrl?: string;
 	helpLabel?: string;
 	readOnly?: boolean;
+	keySource?: ApiKeySource;
 }
 
 /**
@@ -78,6 +81,7 @@ export interface DefaultConnectorSettingsProps {
  * @param props.helpUrl      - URL to documentation for obtaining an API key.
  * @param props.helpLabel    - Custom label for the help link. Defaults to the URL without protocol.
  * @param props.readOnly     - Whether the form is in read-only mode.
+ * @param props.keySource    - The source of the API key: 'env', 'constant', 'database', or 'none'.
  */
 export function DefaultConnectorSettings( {
 	onSave,
@@ -86,6 +90,7 @@ export function DefaultConnectorSettings( {
 	helpUrl,
 	helpLabel,
 	readOnly = false,
+	keySource,
 }: DefaultConnectorSettingsProps ) {
 	const [ apiKey, setApiKey ] = useState( initialValue );
 	const [ isSaving, setIsSaving ] = useState( false );
@@ -110,7 +115,20 @@ export function DefaultConnectorSettings( {
 		  )
 		: undefined;
 
+	const isExternallyConfigured =
+		keySource === 'env' || keySource === 'constant';
+
 	const getHelp = () => {
+		if ( isExternallyConfigured ) {
+			if ( keySource === 'env' ) {
+				return __(
+					'This API key is configured using an environment variable.'
+				);
+			}
+			if ( keySource === 'constant' ) {
+				return __( 'This API key is configured as a constant.' );
+			}
+		}
 		if ( readOnly ) {
 			return helpUrl
 				? createInterpolateElement(
@@ -182,9 +200,11 @@ export function DefaultConnectorSettings( {
 				help={ getHelp() }
 			/>
 			{ readOnly ? (
+				onRemove && (
 				<Button variant="link" isDestructive onClick={ onRemove }>
 					{ __( 'Remove and replace' ) }
 				</Button>
+				)
 			) : (
 				<HStack justify="flex-start">
 					<Button

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -201,9 +201,9 @@ export function DefaultConnectorSettings( {
 			/>
 			{ readOnly ? (
 				onRemove && (
-				<Button variant="link" isDestructive onClick={ onRemove }>
-					{ __( 'Remove and replace' ) }
-				</Button>
+					<Button variant="link" isDestructive onClick={ onRemove }>
+						{ __( 'Remove and replace' ) }
+					</Button>
 				)
 			) : (
 				<HStack justify="flex-start">

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -3,5 +3,6 @@ export {
 	ConnectorItem as __experimentalConnectorItem,
 	DefaultConnectorSettings as __experimentalDefaultConnectorSettings,
 } from './connector-item';
+export type { ApiKeySource as __experimentalApiKeySource } from './connector-item';
 export type { ConnectorConfig, ConnectorRenderProps } from './types';
 export { privateApis } from './private-apis';

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -17,8 +17,16 @@ import { Badge } from '@wordpress/ui';
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
 
+export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
+
 type ConnectorAuthentication =
-	| { method: 'api_key'; settingName: string; credentialsUrl: string | null }
+	| {
+			method: 'api_key';
+			settingName: string;
+			credentialsUrl: string | null;
+			keySource?: ApiKeySource;
+			isConnected?: boolean;
+	  }
 	| { method: 'none' };
 
 interface ConnectorData {
@@ -80,6 +88,8 @@ interface ApiKeyConnectorConfig {
 	Logo?: React.ComponentType;
 	isInstalled?: boolean;
 	isActivated?: boolean;
+	keySource?: ApiKeySource;
+	initialIsConnected?: boolean;
 }
 
 function ApiKeyConnector( {
@@ -91,6 +101,8 @@ function ApiKeyConnector( {
 	Logo,
 	isInstalled,
 	isActivated,
+	keySource: initialKeySource,
+	initialIsConnected,
 }: ConnectorRenderProps & ApiKeyConnectorConfig ) {
 	let helpLabel: string | undefined;
 	try {
@@ -110,6 +122,8 @@ function ApiKeyConnector( {
 		isBusy,
 		isConnected,
 		currentApiKey,
+		keySource,
+		isExternallyConfigured,
 		handleButtonClick,
 		getButtonLabel,
 		saveApiKey,
@@ -119,6 +133,8 @@ function ApiKeyConnector( {
 		settingName,
 		isInstalled,
 		isActivated,
+		keySource: initialKeySource,
+		initialIsConnected,
 	} );
 	const showUnavailableBadge =
 		( pluginStatus === 'not-installed' && canInstallPlugins === false ) ||
@@ -163,11 +179,18 @@ function ApiKeyConnector( {
 			{ isExpanded && pluginStatus === 'active' && (
 				<DefaultConnectorSettings
 					key={ isConnected ? 'connected' : 'setup' }
-					initialValue={ currentApiKey }
+					initialValue={
+						isExternallyConfigured
+							? '••••••••••••••••'
+							: currentApiKey
+					}
 					helpUrl={ helpUrl }
 					helpLabel={ helpLabel }
-					readOnly={ isConnected }
-					onRemove={ removeApiKey }
+					readOnly={ isConnected || isExternallyConfigured }
+					keySource={ keySource }
+					onRemove={
+						isExternallyConfigured ? undefined : removeApiKey
+					}
 					onSave={ async ( apiKey: string ) => {
 						await saveApiKey( apiKey );
 						setIsExpanded( false );
@@ -209,6 +232,8 @@ export function registerDefaultConnectors() {
 					Logo={ CONNECTOR_LOGOS[ connectorId ] }
 					isInstalled={ data.plugin?.isInstalled }
 					isActivated={ data.plugin?.isActivated }
+					keySource={ authentication.keySource }
+					initialIsConnected={ authentication.isConnected }
 				/>
 			),
 		} );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
 	__experimentalDefaultConnectorSettings as DefaultConnectorSettings,
+	type __experimentalApiKeySource as ApiKeySource,
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
 import { __ } from '@wordpress/i18n';
@@ -16,8 +17,6 @@ import { Badge } from '@wordpress/ui';
  */
 import { useConnectorPlugin } from './use-connector-plugin';
 import { OpenAILogo, ClaudeLogo, GeminiLogo } from './logos';
-
-export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
 
 type ConnectorAuthentication =
 	| {
@@ -123,7 +122,6 @@ function ApiKeyConnector( {
 		isConnected,
 		currentApiKey,
 		keySource,
-		isExternallyConfigured,
 		handleButtonClick,
 		getButtonLabel,
 		saveApiKey,
@@ -136,6 +134,8 @@ function ApiKeyConnector( {
 		keySource: initialKeySource,
 		initialIsConnected,
 	} );
+	const isExternallyConfigured =
+		keySource === 'env' || keySource === 'constant';
 	const showUnavailableBadge =
 		( pluginStatus === 'not-installed' && canInstallPlugins === false ) ||
 		( pluginStatus === 'inactive' && canActivatePlugins === false );

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -49,6 +49,8 @@ export function useConnectorPlugin( {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ currentApiKey, setCurrentApiKey ] = useState( '' );
+	const [ connectedState, setConnectedState ] =
+		useState( initialIsConnected );
 	// Track if user can manage plugins based on REST API access.
 	// If the /wp/v2/plugins call succeeds, user has activate_plugins capability.
 	const [ canManagePlugins, setCanManagePlugins ] = useState< boolean >();
@@ -69,13 +71,7 @@ export function useConnectorPlugin( {
 	const isExternallyConfigured =
 		keySource === 'env' || keySource === 'constant';
 
-	// For externally configured keys, use the server-provided connection status.
-	// For database keys, check if we have a valid API key.
-	const isConnected =
-		pluginStatus === 'active' &&
-		( isExternallyConfigured
-			? initialIsConnected
-			: currentApiKey !== '' && currentApiKey !== 'invalid_key' );
+	const isConnected = pluginStatus === 'active' && connectedState;
 
 	// Fetch the current API key
 	const fetchApiKey = useCallback( async () => {
@@ -84,7 +80,7 @@ export function useConnectorPlugin( {
 				path: `/wp/v2/settings?_fields=${ settingName }`,
 			} );
 			const key = settings[ settingName ] || '';
-			setCurrentApiKey( key === 'invalid_key' ? '' : key );
+			setCurrentApiKey( key );
 		} catch {
 			// Ignore errors
 		}
@@ -242,6 +238,7 @@ export function useConnectorPlugin( {
 			}
 
 			setCurrentApiKey( result[ settingName ] || '' );
+			setConnectedState( true );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to save API key:', error );
@@ -259,6 +256,7 @@ export function useConnectorPlugin( {
 				},
 			} );
 			setCurrentApiKey( '' );
+			setConnectedState( false );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to remove API key:', error );

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -7,8 +7,9 @@ import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import type { __experimentalApiKeySource as ApiKeySource } from '@wordpress/connectors';
+
 export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
-export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
 
 interface UseConnectorPluginOptions {
 	pluginSlug?: string;
@@ -29,7 +30,6 @@ interface UseConnectorPluginReturn {
 	isConnected: boolean;
 	currentApiKey: string;
 	keySource: ApiKeySource;
-	isExternallyConfigured: boolean;
 	handleButtonClick: () => void;
 	getButtonLabel: () => string;
 	saveApiKey: ( apiKey: string ) => Promise< void >;
@@ -66,10 +66,6 @@ export function useConnectorPlugin( {
 
 	// Use canManagePlugins (from REST API result) for activation capability.
 	const canActivatePlugins = canManagePlugins;
-
-	// Check if the key is configured externally (env var or constant).
-	const isExternallyConfigured =
-		keySource === 'env' || keySource === 'constant';
 
 	const isConnected = pluginStatus === 'active' && connectedState;
 
@@ -274,7 +270,6 @@ export function useConnectorPlugin( {
 		isConnected,
 		currentApiKey,
 		keySource,
-		isExternallyConfigured,
 		handleButtonClick,
 		getButtonLabel,
 		saveApiKey,

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -8,12 +8,15 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
+export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
 
 interface UseConnectorPluginOptions {
 	pluginSlug?: string;
 	settingName: string;
 	isInstalled?: boolean;
 	isActivated?: boolean;
+	keySource?: ApiKeySource;
+	initialIsConnected?: boolean;
 }
 
 interface UseConnectorPluginReturn {
@@ -25,6 +28,8 @@ interface UseConnectorPluginReturn {
 	isBusy: boolean;
 	isConnected: boolean;
 	currentApiKey: string;
+	keySource: ApiKeySource;
+	isExternallyConfigured: boolean;
 	handleButtonClick: () => void;
 	getButtonLabel: () => string;
 	saveApiKey: ( apiKey: string ) => Promise< void >;
@@ -36,6 +41,8 @@ export function useConnectorPlugin( {
 	settingName,
 	isInstalled,
 	isActivated,
+	keySource = 'none',
+	initialIsConnected = false,
 }: UseConnectorPluginOptions ): UseConnectorPluginReturn {
 	const [ pluginStatus, setPluginStatus ] =
 		useState< PluginStatus >( 'checking' );
@@ -58,10 +65,17 @@ export function useConnectorPlugin( {
 	// Use canManagePlugins (from REST API result) for activation capability.
 	const canActivatePlugins = canManagePlugins;
 
+	// Check if the key is configured externally (env var or constant).
+	const isExternallyConfigured =
+		keySource === 'env' || keySource === 'constant';
+
+	// For externally configured keys, use the server-provided connection status.
+	// For database keys, check if we have a valid API key.
 	const isConnected =
 		pluginStatus === 'active' &&
-		currentApiKey !== '' &&
-		currentApiKey !== 'invalid_key';
+		( isExternallyConfigured
+			? initialIsConnected
+			: currentApiKey !== '' && currentApiKey !== 'invalid_key' );
 
 	// Fetch the current API key
 	const fetchApiKey = useCallback( async () => {
@@ -261,6 +275,8 @@ export function useConnectorPlugin( {
 		isBusy,
 		isConnected,
 		currentApiKey,
+		keySource,
+		isExternallyConfigured,
 		handleButtonClick,
 		getButtonLabel,
 		saveApiKey,


### PR DESCRIPTION
## Summary

This PR updates the Connectors screen to properly display when API keys are configured via environment variables or PHP constants (wp-config.php), rather than stored in the database.

- Detects key source (env var, constant, or database)
- Shows appropriate help text indicating how the key was configured
- Displays masked placeholder for externally configured keys
- Hides "Remove and replace" button for keys that can't be removed via UI
- Shows "Connected" status based on the AI Client's `isProviderConfigured()` check

## Test Plan

1. **Test with environment variable:**
   - Set `OPENAI_API_KEY` env var before starting wp-env
   - Navigate to Connectors screen
   - Verify UI shows "Connected" badge for OpenAI
   - Click "Edit" and verify help text says "configured using an environment variable"
   - Verify "Remove and replace" button is hidden

2. **Test with wp-config.php constant:**
   - Add `define('ANTHROPIC_API_KEY', 'your-key');` to wp-config.php
   - Navigate to Connectors screen  
   - Verify UI shows "Connected" badge for Anthropic
   - Click "Edit" and verify help text says "configured as a constant"
   - Verify "Remove and replace" button is hidden

3. **Test with database key (existing behavior):**
   - Set key via UI
   - Verify existing behavior is preserved
   - Verify "Remove and replace" button is visible

## Screenshot
<img width="1350" height="745" alt="Screenshot 2026-03-08 at 11 50 44" src="https://github.com/user-attachments/assets/cef0b00e-72ea-4d43-9dbe-0e5132407daa" />
