### PR TITLE
RTC: Do not sync role=local attributes

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -22,9 +22,14 @@ interface BlockAttributes {
 	[ key: string ]: unknown;
 }
 
+interface BlockAttributeType {
+	role?: string;
+	type?: string;
+}
+
 interface BlockType {
+	attributes?: Record< string, BlockAttributeType >;
 	name: string;
-	attributes?: Record< string, { type?: string } >;
 }
 
 // A block as represented in Gutenberg's data store.
@@ -58,10 +63,16 @@ export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
 function makeBlockAttributesSerializable(
+	blockName: string,
 	attributes: BlockAttributes
 ): BlockAttributes {
 	const newAttributes = { ...attributes };
 	for ( const [ key, value ] of Object.entries( attributes ) ) {
+		if ( isLocalAttribute( blockName, key ) ) {
+			delete newAttributes[ key ];
+			continue;
+		}
+
 		if ( value instanceof RichTextData ) {
 			newAttributes[ key ] = value.valueOf();
 		}
@@ -76,7 +87,7 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
 		return {
 			...rest,
 			name,
-			attributes: makeBlockAttributesSerializable( attributes ),
+			attributes: makeBlockAttributesSerializable( name, attributes ),
 			innerBlocks: makeBlocksSerializable( innerBlocks ),
 		};
 	} );
@@ -202,12 +213,7 @@ export function mergeCrdtBlocks(
 			makeBlocksSerializable( incomingBlocks )
 		);
 	}
-	const allBlocks = serializableBlocksCache.get( incomingBlocks ) ?? [];
-
-	// Ensure we skip blocks that we don't want to sync at the moment
-	const blocksToSync = allBlocks.filter( ( block ) =>
-		shouldBlockBeSynced( block )
-	);
+	const blocksToSync = serializableBlocksCache.get( incomingBlocks ) ?? [];
 
 	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
 	// approach.
@@ -383,32 +389,6 @@ export function mergeCrdtBlocks(
 }
 
 /**
- * Determine if a block should be synced.
- *
- * Ex: A gallery block should not be synced until the images have been
- * uploaded to WordPress, and their url is available. Before that,
- * it's not possible to access the blobs on a client as those are
- * local.
- *
- * @param block The block to check.
- * @return True if the block should be synced, false otherwise.
- */
-function shouldBlockBeSynced( block: Block ): boolean {
-	// Verify that the gallery block is ready to be synced.
-	// This means that, all images have had their blobs converted to full URLs.
-	// Checking for only the blobs ensures that blocks that have just been inserted work as well.
-	if ( 'core/gallery' === block.name ) {
-		return ! block.innerBlocks.some(
-			( innerBlock ) =>
-				innerBlock.attributes && innerBlock.attributes.blob
-		);
-	}
-
-	// Allow all other blocks to be synced.
-	return true;
-}
-
-/**
  * Update a single attribute on a Yjs block attributes map (currentAttributes).
  *
  * For rich-text attributes that already exist as Y.Text instances, the update
@@ -448,38 +428,35 @@ function updateYBlockAttribute(
 	}
 }
 
-// Cached types for block attributes.
-let cachedBlockAttributeTypes: Map< string, Map< string, string > >;
+// Cached block attribute types, populated once from getBlockTypes().
+let cachedBlockAttributeTypes: Map< string, Map< string, BlockAttributeType > >;
 
 /**
- * Get the defined attribute type for a block attribute.
+ * Get the attribute type definition for a block attribute.
  *
  * @param blockName     The name of the block, e.g. 'core/paragraph'.
  * @param attributeName The name of the attribute, e.g. 'content'.
- * @return The type of the attribute, e.g. 'rich-text' or 'string'.
+ * @return The type definition of the attribute.
  */
 function getBlockAttributeType(
 	blockName: string,
 	attributeName: string
-): string | undefined {
+): BlockAttributeType | undefined {
 	if ( ! cachedBlockAttributeTypes ) {
 		// Parse the attributes for all blocks once.
-		cachedBlockAttributeTypes = new Map< string, Map< string, string > >();
+		cachedBlockAttributeTypes = new Map();
 
 		for ( const blockType of getBlockTypes() as BlockType[] ) {
-			const blockAttributeTypeMap = new Map< string, string >();
-
-			for ( const [ name, definition ] of Object.entries(
-				blockType.attributes ?? {}
-			) ) {
-				if ( definition.type ) {
-					blockAttributeTypeMap.set( name, definition.type );
-				}
-			}
-
 			cachedBlockAttributeTypes.set(
 				blockType.name,
-				blockAttributeTypeMap
+				new Map< string, BlockAttributeType >(
+					Object.entries( blockType.attributes ?? {} ).map(
+						( [ name, definition ] ) => {
+							const { role, type } = definition;
+							return [ name, { role, type } ];
+						}
+					)
+				)
 			);
 		}
 	}
@@ -503,16 +480,30 @@ function isExpectedAttributeType(
 	const expectedAttributeType = getBlockAttributeType(
 		blockName,
 		attributeName
-	);
+	)?.type;
 
 	if ( expectedAttributeType === 'rich-text' ) {
 		return attributeValue instanceof Y.Text;
-	} else if ( expectedAttributeType === 'string' ) {
+	}
+
+	if ( expectedAttributeType === 'string' ) {
 		return typeof attributeValue === 'string';
 	}
 
 	// No other types comparisons use special logic.
 	return true;
+}
+
+/**
+ * Given a block name and attribute key, return true if the attribute is local
+ * and should not be synced.
+ *
+ * @param blockName     The name of the block, e.g. 'core/image'.
+ * @param attributeName The name of the attribute to check, e.g. 'blob'.
+ * @return True if the attribute is local, false otherwise.
+ */
+function isLocalAttribute( blockName: string, attributeName: string ): boolean {
+	return 'local' === getBlockAttributeType( blockName, attributeName )?.role;
 }
 
 /**
@@ -526,7 +517,9 @@ function isRichTextAttribute(
 	blockName: string,
 	attributeName: string
 ): boolean {
-	return 'rich-text' === getBlockAttributeType( blockName, attributeName );
+	return (
+		'rich-text' === getBlockAttributeType( blockName, attributeName )?.type
+	);
 }
 
 let localDoc: Y.Doc;

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -31,6 +31,13 @@ jest.mock( '@wordpress/blocks', () => ( {
 			name: 'core/paragraph',
 			attributes: { content: { type: 'rich-text' } },
 		},
+		{
+			name: 'core/image',
+			attributes: {
+				blob: { type: 'string', role: 'local' },
+				url: { type: 'string' },
+			},
+		},
 	],
 } ) );
 
@@ -175,7 +182,29 @@ describe( 'crdt-blocks', () => {
 			expect( innerBlock.get( 'name' ) ).toBe( 'core/paragraph' );
 		} );
 
-		it( 'skips gallery blocks with unuploaded images (blob attributes)', () => {
+		it( 'strips local attributes when syncing blocks', () => {
+			const imageWithBlob: Block[] = [
+				{
+					name: 'core/image',
+					attributes: {
+						url: 'http://example.com/image.jpg',
+						blob: 'blob:...',
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, imageWithBlob, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const block = yblocks.get( 0 );
+			expect( block.get( 'name' ) ).toBe( 'core/image' );
+			const attrs = block.get( 'attributes' ) as YBlockAttributes;
+			expect( attrs.get( 'url' ) ).toBe( 'http://example.com/image.jpg' );
+			expect( attrs.has( 'blob' ) ).toBe( false );
+		} );
+
+		it( 'strips local attributes from inner blocks', () => {
 			const galleryWithBlobs: Block[] = [
 				{
 					name: 'core/gallery',
@@ -195,32 +224,15 @@ describe( 'crdt-blocks', () => {
 
 			mergeCrdtBlocks( yblocks, galleryWithBlobs, null );
 
-			// Gallery block should not be synced because it has blob attributes
-			expect( yblocks.length ).toBe( 0 );
-		} );
-
-		it( 'syncs gallery blocks without blob attributes', () => {
-			const galleryWithoutBlobs: Block[] = [
-				{
-					name: 'core/gallery',
-					attributes: {},
-					innerBlocks: [
-						{
-							name: 'core/image',
-							attributes: {
-								url: 'http://example.com/image.jpg',
-							},
-							innerBlocks: [],
-						},
-					],
-				},
-			];
-
-			mergeCrdtBlocks( yblocks, galleryWithoutBlobs, null );
-
 			expect( yblocks.length ).toBe( 1 );
-			const block = yblocks.get( 0 );
-			expect( block.get( 'name' ) ).toBe( 'core/gallery' );
+			const gallery = yblocks.get( 0 );
+			expect( gallery.get( 'name' ) ).toBe( 'core/gallery' );
+			const innerBlocks = gallery.get( 'innerBlocks' ) as YBlocks;
+			expect( innerBlocks.length ).toBe( 1 );
+			const image = innerBlocks.get( 0 );
+			const attrs = image.get( 'attributes' ) as YBlockAttributes;
+			expect( attrs.get( 'url' ) ).toBe( 'http://example.com/image.jpg' );
+			expect( attrs.has( 'blob' ) ).toBe( false );
 		} );
 
 		it( 'handles block reordering', () => {
@@ -522,7 +534,7 @@ describe( 'crdt-blocks', () => {
 			expect( content2.toString() ).toBe( 'Freeform content' );
 		} );
 
-		it( 'syncs nested blocks with blob attributes', () => {
+		it( 'strips local attributes from deeply nested blocks', () => {
 			const nestedGallery: Block[] = [
 				{
 					name: 'core/group',
@@ -554,7 +566,13 @@ describe( 'crdt-blocks', () => {
 
 			const innerBlocks = groupBlock.get( 'innerBlocks' ) as YBlocks;
 			expect( innerBlocks.length ).toBe( 1 );
-			expect( innerBlocks.get( 0 ).get( 'name' ) ).toBe( 'core/gallery' );
+			const gallery = innerBlocks.get( 0 );
+			const galleryInner = gallery.get( 'innerBlocks' ) as YBlocks;
+			expect( galleryInner.length ).toBe( 1 );
+			const image = galleryInner.get( 0 );
+			const attrs = image.get( 'attributes' ) as YBlockAttributes;
+			expect( attrs.get( 'url' ) ).toBe( 'http://example.com/image.jpg' );
+			expect( attrs.has( 'blob' ) ).toBe( false );
 		} );
 
 		it( 'handles complex block reordering', () => {


### PR DESCRIPTION

## What?

Do not sync `role=local` attributes.

Follow-up to https://github.com/WordPress/gutenberg/pull/73983

## Why?

The CRDT block sync logic hardcoded special handling for the `blob` attribute on `core/gallery` inner blocks (images), withholding the entire block tree from syncing until uploads completed. This approach was overly broad and failed to generalize to other local-only attributes on other media blocks.

Additionally, withholding a block from syncing can lead to user confusion and merge errors.

## How?

Strip attributes with `role: "local"` during block serialization via `makeBlockAttributesSerializable()`. All blocks sync immediately with local state excluded, so collaborators see content as soon as possible. The logic is driven by block definitions rather than hardcoded names. Remove `shouldBlockBeSynced()`.

## Testing Instructions

1. Check out this branch.
2. Open a post for editing in two browser tabs.
3. With both tabs visible, add an image or video block.
4. Observe that the block syncs, but that the media does not appear until it has been successfully uploaded to the media library.


https://github.com/user-attachments/assets/2a1bfd02-71e7-461f-9e42-bdb6fa88f5ac



### Caveat

Media blocks do not implement placeholder state consistently. Compare the behavior of `core/image` and `core/video` blocks with `core/gallery`:


https://github.com/user-attachments/assets/001cd4dc-293b-4347-ac60-5cedb0184f3b


Notice that they show action buttons to each peer instead of only to the peer who inserted the block. The same is true of `core/audio` and other media blocks. This will require separate attention.