### PR TITLE
Add `fetchpriority=low` to `IMG` tags in collapsed Details blocks

### DIFF
--- a/packages/block-library/src/details/index.php
+++ b/packages/block-library/src/details/index.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Server-side rendering of the `core/details` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Register the details block.
+ *
+ * @since 7.0.0
+ *
+ * @uses render_block_core_details()
+ */
+function register_block_core_details() {
+	register_block_type_from_metadata(
+		__DIR__ . '/details',
+		array(
+			'render_callback' => 'render_block_core_details',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_details' );
+
+/**
+ * Sets fetchpriority="low" on all IMG tags within the collapsed Details block.
+ *
+ * Images in the overlay are hidden until the menu is opened, so they should
+ * not compete with any actual LCP element image on the page.
+ *
+ * @since 7.0.0
+ *
+ * @param array  $attributes The block attributes.
+ * @param string $content    The saved content.
+ * @return string Modified HTML with fetchpriority="low" on all IMG tags.
+ */
+function render_block_core_details( array $attributes, string $content ): string {
+	// If the Details block is open by default, short-circuit to let core add fetchpriority=high if appropriate,
+	if ( $attributes['showContent'] ?? false ) {
+		return $content;
+	}
+
+	$tags = new WP_HTML_Tag_Processor( $content );
+	while ( $tags->next_tag( 'IMG' ) ) {
+		$tags->set_attribute( 'fetchpriority', 'low' );
+	}
+	return $tags->get_updated_html();
+}

--- a/packages/block-library/src/details/index.php
+++ b/packages/block-library/src/details/index.php
@@ -6,24 +6,6 @@
  */
 
 /**
- * Register the details block.
- *
- * @since 7.0.0
- *
- * @uses render_block_core_details()
- */
-function register_block_core_details() {
-	register_block_type_from_metadata(
-		__DIR__ . '/details',
-		array(
-			'render_callback' => 'render_block_core_details',
-		)
-	);
-}
-
-add_action( 'init', 'register_block_core_details' );
-
-/**
  * Sets fetchpriority="low" on all IMG tags within the collapsed Details block.
  *
  * Images in a collapsed Details block are hidden until the block is expanded, so they should
@@ -31,19 +13,35 @@ add_action( 'init', 'register_block_core_details' );
  *
  * @since 7.0.0
  *
- * @param array  $attributes The block attributes.
- * @param string $content    The saved content.
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
  * @return string Modified HTML with fetchpriority="low" on all IMG tags when the showContent attribute is false.
  */
-function render_block_core_details( array $attributes, string $content ): string {
-	// If the Details block is open by default, short-circuit to let core add fetchpriority=high if appropriate,
-	if ( $attributes['showContent'] ?? false ) {
-		return $content;
+function block_core_details_set_img_fetchpriority_low( $block_content, array $block ): string {
+	if ( ! is_string( $block_content ) ) {
+		return '';
 	}
 
-	$tags = new WP_HTML_Tag_Processor( $content );
+	// If the Details block is open by default, short-circuit to let core add fetchpriority=high if appropriate,
+	if ( $block['attrs']['showContent'] ?? false ) {
+		return $block_content;
+	}
+
+	$tags = new WP_HTML_Tag_Processor( $block_content );
 	while ( $tags->next_tag( 'IMG' ) ) {
 		$tags->set_attribute( 'fetchpriority', 'low' );
 	}
 	return $tags->get_updated_html();
 }
+
+add_filter( 'render_block_core/details', 'block_core_details_set_img_fetchpriority_low', 10, 2 );
+
+/**
+ * Registers the `core/details` block on server.
+ *
+ * @since 7.0.0
+ */
+function register_block_core_details() {
+	register_block_type_from_metadata( __DIR__ . '/details' );
+}
+add_action( 'init', 'register_block_core_details' );

--- a/packages/block-library/src/details/index.php
+++ b/packages/block-library/src/details/index.php
@@ -22,7 +22,7 @@ function block_core_details_set_img_fetchpriority_low( $block_content, array $bl
 		return '';
 	}
 
-	// If the Details block is open by default, short-circuit to let core add fetchpriority=high if appropriate,
+	// If the Details block is open by default, short-circuit to let core add fetchpriority=high if appropriate.
 	if ( $block['attrs']['showContent'] ?? false ) {
 		return $block_content;
 	}

--- a/packages/block-library/src/details/index.php
+++ b/packages/block-library/src/details/index.php
@@ -26,14 +26,14 @@ add_action( 'init', 'register_block_core_details' );
 /**
  * Sets fetchpriority="low" on all IMG tags within the collapsed Details block.
  *
- * Images in the overlay are hidden until the menu is opened, so they should
- * not compete with any actual LCP element image on the page.
+ * Images in a collapsed Details block are hidden until the block is expanded, so they should
+ * not compete with any resources in the critical rendering path, such as the LCP element image.
  *
  * @since 7.0.0
  *
  * @param array  $attributes The block attributes.
  * @param string $content    The saved content.
- * @return string Modified HTML with fetchpriority="low" on all IMG tags.
+ * @return string Modified HTML with fetchpriority="low" on all IMG tags when the showContent attribute is false.
  */
 function render_block_core_details( array $attributes, string $content ): string {
 	// If the Details block is open by default, short-circuit to let core add fetchpriority=high if appropriate,

--- a/phpunit/blocks/render-block-details-test.php
+++ b/phpunit/blocks/render-block-details-test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Details block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Details block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Details extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::render_block_core_details()
+	 */
+	public function test_should_add_fetchpriority_low_to_img_in_collapsed_details_block(): void {
+		$details_block = <<<'BLOCK_CONTENT'
+			<!-- wp:details -->
+			<details class="wp-block-details"><summary>Collapsed</summary><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image.jpg" alt="" /></figure>
+			<!-- /wp:image --></details>
+			<!-- /wp:details -->
+		BLOCK_CONTENT;
+
+		$rendered_block = do_blocks( $details_block );
+
+		$processor = new WP_HTML_Tag_Processor( $rendered_block );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertSame( 'low', $processor->get_attribute( 'fetchpriority' ) );
+	}
+
+	/**
+	 * @covers ::render_block_core_details()
+	 */
+	public function test_should_not_add_fetchpriority_low_to_img_in_expanded_details_block(): void {
+		$details_block = <<<'BLOCK_CONTENT'
+			<!-- wp:details {"showContent":true} -->
+			<details class="wp-block-details" open><summary>Expanded</summary><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image.jpg" alt="" /></figure>
+			<!-- /wp:image --></details>
+			<!-- /wp:details -->
+		BLOCK_CONTENT;
+
+		$rendered_block = do_blocks( $details_block );
+
+		$processor = new WP_HTML_Tag_Processor( $rendered_block );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertNull( $processor->get_attribute( 'fetchpriority' ) );
+	}
+}

--- a/phpunit/blocks/render-block-details-test.php
+++ b/phpunit/blocks/render-block-details-test.php
@@ -50,4 +50,23 @@ class Tests_Blocks_Render_Details extends WP_UnitTestCase {
 		$this->assertTrue( $processor->next_tag( 'IMG' ) );
 		$this->assertNotSame( 'low', $processor->get_attribute( 'fetchpriority' ) );
 	}
+
+	/**
+	 * @covers ::block_core_details_set_img_fetchpriority_low
+	 */
+	public function test_should_preserve_fetchpriority_high_on_img_in_expanded_details_block(): void {
+		$details_block = <<<'BLOCK_CONTENT'
+			<!-- wp:details {"showContent":true} -->
+			<details class="wp-block-details" open><summary>Expanded</summary><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image.jpg" fetchpriority="high" alt="" /></figure>
+			<!-- /wp:image --></details>
+			<!-- /wp:details -->
+		BLOCK_CONTENT;
+
+		$rendered_block = do_blocks( $details_block );
+
+		$processor = new WP_HTML_Tag_Processor( $rendered_block );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertSame( 'high', $processor->get_attribute( 'fetchpriority' ) );
+	}
 }

--- a/phpunit/blocks/render-block-details-test.php
+++ b/phpunit/blocks/render-block-details-test.php
@@ -14,7 +14,7 @@
 class Tests_Blocks_Render_Details extends WP_UnitTestCase {
 
 	/**
-	 * @covers ::render_block_core_details()
+	 * @covers ::block_core_details_set_img_fetchpriority_low()
 	 */
 	public function test_should_add_fetchpriority_low_to_img_in_collapsed_details_block(): void {
 		$details_block = <<<'BLOCK_CONTENT'
@@ -33,7 +33,7 @@ class Tests_Blocks_Render_Details extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::render_block_core_details()
+	 * @covers ::block_core_details_set_img_fetchpriority_low()
 	 */
 	public function test_should_not_add_fetchpriority_low_to_img_in_expanded_details_block(): void {
 		$details_block = <<<'BLOCK_CONTENT'

--- a/phpunit/blocks/render-block-details-test.php
+++ b/phpunit/blocks/render-block-details-test.php
@@ -14,7 +14,7 @@
 class Tests_Blocks_Render_Details extends WP_UnitTestCase {
 
 	/**
-	 * @covers ::block_core_details_set_img_fetchpriority_low()
+	 * @covers ::block_core_details_set_img_fetchpriority_low
 	 */
 	public function test_should_add_fetchpriority_low_to_img_in_collapsed_details_block(): void {
 		$details_block = <<<'BLOCK_CONTENT'
@@ -33,7 +33,7 @@ class Tests_Blocks_Render_Details extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::block_core_details_set_img_fetchpriority_low()
+	 * @covers ::block_core_details_set_img_fetchpriority_low
 	 */
 	public function test_should_not_add_fetchpriority_low_to_img_in_expanded_details_block(): void {
 		$details_block = <<<'BLOCK_CONTENT'

--- a/phpunit/blocks/render-block-details-test.php
+++ b/phpunit/blocks/render-block-details-test.php
@@ -48,6 +48,6 @@ class Tests_Blocks_Render_Details extends WP_UnitTestCase {
 
 		$processor = new WP_HTML_Tag_Processor( $rendered_block );
 		$this->assertTrue( $processor->next_tag( 'IMG' ) );
-		$this->assertNull( $processor->get_attribute( 'fetchpriority' ) );
+		$this->assertNotSame( 'low', $processor->get_attribute( 'fetchpriority' ) );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes #76268

<!-- In a few words, what is the PR actually doing? -->

<details><summary>Before ❌</summary>

```html
<details class="wp-block-details">
  <summary>Collapsed kitty</summary>
  <figure class="wp-block-image size-large">
    <img
      fetchpriority="high"
      decoding="async"
      width="1024"
      height="771"
      sizes="(max-width: 645px) 100vw, 645px"
      src="http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1024x771.jpg"
      alt=""
      class="wp-image-415"
      srcset="
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1024x771.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-300x226.jpg    300w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-768x578.jpg    768w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1536x1157.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-2048x1542.jpg 2048w
      "
    />
  </figure>
</details>

<details class="wp-block-details" open>
  <summary>Expanded bison</summary>
  <figure class="wp-block-image size-large">
    <img
      decoding="async"
      width="1024"
      height="683"
      sizes="(max-width: 645px) 100vw, 645px"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
      alt=""
      class="wp-image-37"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-300x200.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-768x512.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
      "
    />
  </figure>
</details>
```

</details> 

<details><summary>After ✅</summary>

```html
<details
  class="wp-block-details is-layout-flow wp-block-details-is-layout-flow"
>
  <summary>Collapsed kitty</summary>
  <figure class="wp-block-image size-large">
    <img
      decoding="async"
      width="1024"
      height="771"
      fetchpriority="low"
      src="http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1024x771.jpg"
      alt=""
      class="wp-image-415"
      srcset="
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1024x771.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-300x226.jpg    300w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-768x578.jpg    768w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1536x1157.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-2048x1542.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>
</details>

<details
  class="wp-block-details is-layout-flow wp-block-details-is-layout-flow"
  open
>
  <summary>Expanded bison</summary>
  <figure class="wp-block-image size-large">
    <img
      fetchpriority="high"
      decoding="async"
      width="1024"
      height="683"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
      alt=""
      class="wp-image-37"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-300x200.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-768x512.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>
</details>
```

</details> 

```diff
--- before.html	2026-03-06 16:23:40
+++ after.html	2026-03-06 16:21:48
@@ -1,14 +1,13 @@
 <details
-  class="wp-block-details"
+  class="wp-block-details is-layout-flow wp-block-details-is-layout-flow"
 >
   <summary>Collapsed kitty</summary>
   <figure class="wp-block-image size-large">
     <img
-      fetchpriority="high"
       decoding="async"
       width="1024"
       height="771"
-      sizes="(max-width: 645px) 100vw, 645px"
+      fetchpriority="low"
       src="http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1024x771.jpg"
       alt=""
       class="wp-image-415"
@@ -19,21 +18,22 @@
         http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-1536x1157.jpg 1536w,
         http://localhost:8000/wp-content/uploads/2026/03/PXL_20260302_201050363-2048x1542.jpg 2048w
       "
+      sizes="(max-width: 1024px) 100vw, 1024px"
     />
   </figure>
 </details>
 
 <details
-  class="wp-block-details"
+  class="wp-block-details is-layout-flow wp-block-details-is-layout-flow"
   open
 >
   <summary>Expanded bison</summary>
   <figure class="wp-block-image size-large">
     <img
+      fetchpriority="high"
       decoding="async"
       width="1024"
       height="683"
-      sizes="(max-width: 645px) 100vw, 645px"
       src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
       alt=""
       class="wp-image-37"
@@ -44,6 +44,7 @@
         http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
         http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
       "
+      sizes="(max-width: 1024px) 100vw, 1024px"
     />
   </figure>
 </details>
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

An `IMG` in a collapsed `DETAILS` element should get `fetchpriority=low` to prevent it from ever competing with resources in the critical rendering path. Similarly, `fetchpriority=low` must be added to prevent WordPress from erroneously adding `fetchpriority=high` with the `IMG` is the first large image in the content via `wp_get_loading_optimization_attributes()`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This implements a similar approach as https://github.com/WordPress/gutenberg/pull/76208 by using a render callback to dynamically add `fetchpriority=low` when the block is set to be collapsed by default.

## Testing Instructions

1. Add two Details blocks to a post, with a large Image block in eac.
2. Configure the second block to be open by default.
3. Ensure that the `IMG` in the first Details block has `fetchpriority=low`, and the `IMG` in the second either has no `fetchpriority` at all or it has `fetchpriority=high`.
