### PR TITLE
RTC: Show own presence indicators (as a preference)

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -72,6 +72,7 @@ export function initializeEditor(
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
+		showCollaborationCursor: false,
 	} );
 
 	if ( window.__clientSideMediaProcessing ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -73,6 +73,7 @@ export function initializeEditor( id, settings ) {
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		showCollaborationCursor: false,
 	} );
 
 	if ( window.__clientSideMediaProcessing ) {

--- a/packages/editor/src/components/collaborators-overlay/use-block-highlighting.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-block-highlighting.ts
@@ -4,9 +4,11 @@
 import {
 	privateApis as coreDataPrivateApis,
 	SelectionType,
-	type PostEditorAwarenessState,
+	type PostEditorAwarenessState as ActiveCollaborator,
 } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -49,8 +51,14 @@ export function useBlockHighlighting(
 	highlights: BlockHighlightData[];
 	rerenderHighlightsAfterDelay: () => () => void;
 } {
+	const showOwnCursor = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showCollaborationCursor' ),
+		[]
+	);
+
 	const highlightedBlockIds = useRef< Set< string > >( new Set() );
-	const userStates: PostEditorAwarenessState[] = useActiveCollaborators(
+	const userStates: ActiveCollaborator[] = useActiveCollaborators(
 		postId ?? null,
 		postType ?? null
 	);
@@ -78,16 +86,26 @@ export function useBlockHighlighting(
 		// even if a later render replaces it.
 		const currentHighlightedIds = highlightedBlockIds.current;
 
+		// When there are no other collaborators, we shouldn't show the user's own
+		// selection unless the preference is enabled.
+		const hasOtherCollaborators = userStates.some(
+			( u: ActiveCollaborator ) => ! u.isMe
+		);
+
 		// Deduplicate by blockId — when multiple collaborators select the
 		// same block, only the first one gets the highlight and avatar label.
 		const seen = new Set< string >();
 		const blocksToHighlight = userStates
-			.filter(
-				( userState ) =>
-					! userState.isMe &&
+			.filter( ( userState: ActiveCollaborator ) => {
+				const shouldDrawUser =
+					! userState.isMe ||
+					( showOwnCursor && hasOtherCollaborators );
+				const isWholeBlockSelected =
 					userState.editorState?.selection?.type ===
-						SelectionType.WholeBlock
-			)
+					SelectionType.WholeBlock;
+
+				return shouldDrawUser && isWholeBlockSelected;
+			} )
 			.map( ( userState ) => {
 				let localClientId;
 				try {
@@ -202,6 +220,7 @@ export function useBlockHighlighting(
 		overlayElement,
 		recomputeToken,
 		resolveSelection,
+		showOwnCursor,
 	] );
 
 	return { highlights, rerenderHighlightsAfterDelay };

--- a/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
@@ -1,8 +1,11 @@
 import {
 	privateApis as coreDataPrivateApis,
 	SelectionType,
+	type PostEditorAwarenessState as ActiveCollaborator,
 } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 import { unlock } from '../../lock-unlock';
 import { getAvatarUrl } from './get-avatar-url';
@@ -20,6 +23,7 @@ export interface CursorData {
 	x: number;
 	y: number;
 	height: number;
+	isMe?: boolean;
 }
 
 /**
@@ -48,6 +52,12 @@ export function useRenderCursors(
 		postType ?? null
 	);
 
+	const showOwnCursor = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showCollaborationCursor' ),
+		[]
+	);
+
 	const [ cursorPositions, setCursorPositions ] = useState< CursorData[] >(
 		[]
 	);
@@ -65,8 +75,12 @@ export function useRenderCursors(
 
 		const results: CursorData[] = [];
 
-		sortedUsers.forEach( ( user: any ) => {
-			if ( user.isMe ) {
+		const hasOtherCollaborators = sortedUsers.some(
+			( u: ActiveCollaborator ) => ! u.isMe
+		);
+
+		sortedUsers.forEach( ( user: ActiveCollaborator ) => {
+			if ( user.isMe && ( ! showOwnCursor || ! hasOtherCollaborators ) ) {
 				return;
 			}
 
@@ -131,6 +145,7 @@ export function useRenderCursors(
 					clientId,
 					color,
 					avatarUrl,
+					isMe: user.isMe,
 					...coords,
 				} );
 			}
@@ -142,6 +157,7 @@ export function useRenderCursors(
 		resolveSelection,
 		overlayElement,
 		sortedUsers,
+		showOwnCursor,
 		recomputeToken,
 	] );
 

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import {
 	privateApis,
 	type PostEditorAwarenessState,
 } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 import Avatar from './avatar';
 import AvatarGroup from './avatar-group';
@@ -40,10 +42,33 @@ export function CollaboratorsPresence( {
 		postType
 	) as PostEditorAwarenessState[];
 
-	// Filter out current user - we never show ourselves in the list
+	const showOwnCursor = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showCollaborationCursor' ),
+		[]
+	);
+
+	// Filter out current user for the avatar group display
 	const otherActiveCollaborators = activeCollaborators.filter(
 		( collaborator ) => ! collaborator.isMe
 	);
+
+	// When showing own cursor, include self in the dropdown list (sorted first)
+	const collaboratorsForList = useMemo( () => {
+		if ( ! showOwnCursor ) {
+			return otherActiveCollaborators;
+		}
+
+		return [ ...activeCollaborators ].sort( ( a, b ) => {
+			if ( a.isMe && ! b.isMe ) {
+				return -1;
+			}
+			if ( ! a.isMe && b.isMe ) {
+				return 1;
+			}
+			return 0;
+		} );
+	}, [ showOwnCursor, activeCollaborators, otherActiveCollaborators ] );
 
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
@@ -69,33 +94,29 @@ export function CollaboratorsPresence( {
 					aria-label={ sprintf(
 						// translators: %d: number of online collaborators.
 						__( 'Collaborators list, %d online' ),
-						otherActiveCollaborators.length
+						collaboratorsForList.length
 					) }
 				>
 					<AvatarGroup max={ 4 }>
-						{ otherActiveCollaborators.map(
-							( collaboratorState ) => (
-								<Avatar
-									key={ collaboratorState.clientId }
-									src={ getAvatarUrl(
-										collaboratorState.collaboratorInfo
-											.avatar_urls
-									) }
-									name={
-										collaboratorState.collaboratorInfo.name
-									}
-									borderColor={ getAvatarBorderColor(
-										collaboratorState.collaboratorInfo.id
-									) }
-									size="small"
-								/>
-							)
-						) }
+						{ collaboratorsForList.map( ( collaboratorState ) => (
+							<Avatar
+								key={ collaboratorState.clientId }
+								src={ getAvatarUrl(
+									collaboratorState.collaboratorInfo
+										.avatar_urls
+								) }
+								name={ collaboratorState.collaboratorInfo.name }
+								borderColor={ getAvatarBorderColor(
+									collaboratorState.collaboratorInfo.id
+								) }
+								size="small"
+							/>
+						) ) }
 					</AvatarGroup>
 				</Button>
 				{ isPopoverVisible && (
 					<CollaboratorsList
-						activeCollaborators={ otherActiveCollaborators }
+						activeCollaborators={ collaboratorsForList }
 						popoverAnchor={ popoverAnchor }
 						setIsPopoverVisible={ setIsPopoverVisible }
 					/>

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -73,6 +73,12 @@ export function CollaboratorsList( {
 							<div className="editor-collaborators-presence__list-item-info">
 								<div className="editor-collaborators-presence__list-item-name">
 									{ collaboratorState.collaboratorInfo.name }
+									{ collaboratorState.isMe && (
+										<span className="editor-collaborators-presence__list-item-you">
+											{ ' ' }
+											{ __( '(you)' ) }
+										</span>
+									) }
 								</div>
 							</div>
 						</button>

--- a/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
+++ b/packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss
@@ -99,5 +99,9 @@
 			text-overflow: ellipsis;
 			white-space: nowrap;
 		}
+
+		&-you {
+			color: $gray-700;
+		}
 	}
 }

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -120,6 +120,16 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									) }
 									label={ __( 'Show starter patterns' ) }
 								/>
+								<PreferenceToggleControl
+									scope="core"
+									featureName="showCollaborationCursor"
+									help={ __(
+										'Show your own cursor and avatar during collaborative editing sessions.'
+									) }
+									label={ __(
+										'Show own collaboration cursor'
+									) }
+								/>
 							</PreferencesModalSection>
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }

--- a/test/e2e/specs/editor/collaboration/collaboration-self-presence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-self-presence.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - self presence', () => {
+	test( 'Self user appears in popover with "(you)" label when preference is enabled', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Self Presence Test - You Label',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		// Enable the preference.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core', 'showCollaborationCursor', true );
+		} );
+
+		// Open the collaborators popover.
+		const presenceButton = page.getByRole( 'button', {
+			name: /Collaborators list/,
+		} );
+		await expect( presenceButton ).toBeVisible( { timeout: 10000 } );
+		await presenceButton.click();
+
+		// The current user should appear with the "(you)" label.
+		await expect(
+			page.locator( '.editor-collaborators-presence__list-item-you', {
+				hasText: '(you)',
+			} )
+		).toBeVisible();
+	} );
+
+	test( 'Self user does not appear in popover when preference is disabled', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Self Presence Test - Disabled',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		// Ensure the preference is off.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core', 'showCollaborationCursor', false );
+		} );
+
+		// Open the collaborators popover.
+		const presenceButton = page.getByRole( 'button', {
+			name: /Collaborators list/,
+		} );
+		await expect( presenceButton ).toBeVisible( { timeout: 10000 } );
+		await presenceButton.click();
+
+		// The "(you)" label should NOT be present.
+		await expect(
+			page.locator( '.editor-collaborators-presence__list-item-you' )
+		).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION

## What?

Add an editor preference to show the current user's presence indicators during a collaborative session.

Closes https://github.com/WordPress/gutenberg/issues/75838

## Why?

User feedback has been mixed, but some users have a strong expectation that all users in a collaborative session should receive consistent presence indicators.

## How?

Update the presence logic to conditionally show the current user's presence indicators.

## Testing Instructions

1. Check out this branch.
3. Open a post in the editor with two users in a collaborative session.
4. Go to ... > Preferences > General > Interface and toggle on "Show own collaboration cursor"
5. Verify the collaborators list button shows the current user's avatar in the toolbar.
6. Click the button to open the popover and verify the current user appears first with a "(you)" label.
7. Move the cursor and verify your own cursor line appears in the editor with your avatar badge.
8. Toggle the preference OFF and verify the self-cursor and "(you)" label disappear.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ce3f70f6-3f54-4314-a042-e21bf28f1f34

paging @dabowman for design review
