### PR TITLE
Interactivity: Make `Window.scheduler` required to match DOM lib

### DIFF
--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -24,7 +24,7 @@ interface Flusher {
 
 declare global {
 	interface Window {
-		scheduler?: {
+		scheduler: {
 			postTask: (
 				callback: () => unknown,
 				options?: object


### PR DESCRIPTION
## What?

Follow up to #76070

Make the `Window.scheduler` augmentation required (non-optional) to match the DOM lib's `WindowOrWorkerGlobalScope.scheduler` declaration.

## Why?

#76070 fixed the missing `postTask` member but kept `scheduler` as optional (`scheduler?`). The DOM lib declares `scheduler` as **required** on `WindowOrWorkerGlobalScope`:

```ts
interface WindowOrWorkerGlobalScope {
    readonly scheduler: Scheduler;
}
```

Our augmentation still marks it optional:

```ts
interface Window {
    scheduler?: { ... }; // optional — conflicts with required inherited property
}
```

This mismatch can still trigger **TS2430** in downstream projects that augment `Window`, because the optional declaration is incompatible with the required inherited property from `WindowOrWorkerGlobalScope`.

## How?

Remove the `?` from `scheduler` in the global `Window` augmentation so it matches the DOM lib:

```diff
 declare global {
 	interface Window {
-		scheduler?: {
+		scheduler: {
 			postTask: ( ... ) => Promise< unknown >;
 			yield: () => Promise< void >;
 		};
 	}
 }
```

The existing runtime guard (`typeof window.scheduler?.yield === 'function'`) remains unchanged and safely handles browsers where `yield` is not yet implemented.

## Testing Instructions

1. Add `@wordpress/interactivity` as a dependency in a TypeScript project configured with `lib: ["dom"]` (TypeScript 5.5+ or `tsgo`).
2. In a source `.ts` file, add a global `Window` augmentation:
   ```ts
   declare global {
     interface Window {
       myProperty?: string;
     }
   }
   ```
3. Run `tsc --noEmit`.
4. Confirm no `TS2430` error is reported.

### Testing Instructions for Keyboard

N/A — this is a type-only change with no UI impact.
