### PR TITLE
theme.json schema: fix pseudo-class definition for button block

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1826,6 +1826,31 @@
 				}
 			]
 		},
+		"stylesBlocksPseudoSelectorsProperties": {
+			"type": "object",
+			"properties": {
+				":hover": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus-visible": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":active": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesBlocksPseudoSelectorsPropertyNames": {
+			"enum": [
+				":hover",
+				":focus",
+				":focus-visible",
+				":active"
+			]
+		},
 		"stylesElementsPseudoSelectorsProperties": {
 			"type": "object",
 			"properties": {
@@ -1848,23 +1873,6 @@
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				},
 				":visited": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				}
-			}
-		},
-		"stylesBlocksPseudoSelectorsProperties": {
-			"type": "object",
-			"properties": {
-				":hover": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				":focus": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				":focus-visible": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				":active": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			}
@@ -2000,10 +2008,59 @@
 				"core/button": {
 					"allOf": [
 						{
-							"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"type": "object",
+							"properties": {
+								"variations": {
+									"type": "object",
+									"patternProperties": {
+										"^[a-z][a-z0-9-]*$": {
+											"allOf": [
+												{
+													"$ref": "#/definitions/stylesProperties"
+												},
+												{
+													"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+												},
+												{
+													"type": "object",
+													"propertyNames": {
+														"anyOf": [
+															{
+																"$ref": "#/definitions/stylesPropertyNames"
+															},
+															{
+																"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
+															}
+														]
+													}
+												}
+											]
+										}
+									}
+								}
+							}
 						},
 						{
 							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"enum": [ "variations" ]
+									},
+									{
+										"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
+									}
+								]
+							}
 						}
 					]
 				},
@@ -2455,7 +2512,27 @@
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/button": {
-					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
 				},
 				"core/buttons": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"


### PR DESCRIPTION
## What?

#71418 added pseudo-class support for the button block, but its schema is not correct. Even though the four pseudo-classes are available directly under `styles.core/button`, the code editor will warn us about them as invalid properties.

## How?

In this PR, the diff is a little hard to see, but the definitions that were actually changed are the following three places.

- `stylesBlocksPropertiesComplete.core/button`
- `stylesVariationBlocksPropertiesComplete.core/button`
- `stylesBlocksPseudoSelectorsPropertyNames`

## Testing Instructions

Update `test/emptytheme/theme.json` with the following code:

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"styles": {
		"blocks": {
			"core/button": {
				":active": {},
				":focus": {},
				":focus-visible": {},
				":hover": {},
				":link": {},
				"color": {},
				"invalid": {},
				"variations": {
					"my-variation": {
						":active": {},
						":focus": {},
						":focus-visible": {},
						":hover": {},
						":link": {},
						"color": {},
						"invalid": {}
					}
				}
			},
			"core/paragraph": {
				":active": {},
				":focus": {},
				":focus-visible": {},
				":hover": {},
				":link": {},
				"color": {},
				"variations": {
					"my-variation": {
						":active": {},
						":focus": {},
						":focus-visible": {},
						":hover": {},
						":link": {},
						"color": {}
					}
				}
			}
		}
	}
}
```

This PR should fix unintended warnings for the following defginitions:

- `styles.blocks.core/button.:active`
- `styles.blocks.core/button.:focus`
- `styles.blocks.core/button.:focus-visible`
- `styles.blocks.core/button.:hover`
- `styles.blocks.core/button.variations.{vairation-name}.:active`
- `styles.blocks.core/button.variations.{vairation-name}.:focus`
- `styles.blocks.core/button.variations.{vairation-name}.:focus-visible`
- `styles.blocks.core/button.variations.{vairation-name}.:hover`


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| <img width="359" height="886" alt="image" src="https://github.com/user-attachments/assets/42f7bfcd-49e1-40c9-bb7e-879ea4d13dd2" /> | <img width="401" height="888" alt="image" src="https://github.com/user-attachments/assets/8bf5391c-5566-4a4a-b986-8f94ae297554" /> |