### PR TITLE
Only run label enforcement workflow on open PRs

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
     type-related-labels:
         runs-on: 'ubuntu-24.04'
+        if: ${{ github.event.pull_request.state == 'open' }}
         permissions:
             pull-requests: write
         steps:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds a conditional check to the "Enforce labels on Pull Request" workflow so it only runs when the PR is in the `open` state.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The workflow's purpose is to block merges until a `[Type] *` label has been added. After the PR is merged, there's no point in running it.

## How?
Using the `github.event` context, the `pull_request` [event payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request) is available and contains a `state` property.
