### PR TITLE
HTML Block: Fix broken layout

### DIFF
--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -77,7 +77,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: $grid-unit-20;
 	min-height: 0;
 	overflow-y: auto;
 	flex: 1;

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -14,7 +14,14 @@
 
 // Modal styles
 .block-library-html__modal {
-	height: 100%;
+
+	// On medium and large screens, the modal component sets a max-height.
+	// We want the modal to be as tall as possible also when the content is short.
+	@include break-small() {
+		&:not(.is-full-screen) {
+			height: 9999rem;
+		}
+	}
 
 	.components-modal__children-container {
 		height: 100%;
@@ -22,12 +29,11 @@
 }
 
 .block-library-html__modal-tabs {
-	overflow-y: auto;
+	flex: 1;
 }
 
 .block-library-html__modal-content {
 	flex: 1;
-	min-height: 0;
 }
 
 .block-library-html__modal-tab {
@@ -72,6 +78,11 @@
 	align-items: center;
 	justify-content: center;
 	padding: $grid-unit-20;
-	flex: 1;
 	min-height: 0;
+	overflow-y: auto;
+	flex: 1;
+
+	iframe {
+		height: 100%;
+	}
 }

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -10,11 +10,12 @@ import {
 	Flex,
 	Notice,
 	privateApis as componentsPrivateApis,
+	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	__experimentalGrid as Grid,
 } from '@wordpress/components';
 import { PlainText, store as blockEditorStore } from '@wordpress/block-editor';
 import { fullscreen, square } from '@wordpress/icons';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -39,6 +40,8 @@ export default function HTMLEditModal( {
 	const [ isDirty, setIsDirty ] = useState( false );
 	const [ showUnsavedWarning, setShowUnsavedWarning ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
+
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 
 	// Check if user has permission to save scripts and get editor styles
 	const { canUserUseUnfilteredHTML } = useSelect( ( select ) => {
@@ -121,12 +124,7 @@ export default function HTMLEditModal( {
 				__experimentalHideHeader
 			>
 				<Tabs orientation="horizontal" defaultTabId="html">
-					<Grid
-						columns={ 1 }
-						templateRows="auto 1fr auto"
-						gap={ 4 }
-						style={ { height: '100%' } }
-					>
+					<VStack expanded>
 						<HStack
 							justify="space-between"
 							className="block-library-html__modal-header"
@@ -144,15 +142,21 @@ export default function HTMLEditModal( {
 									) }
 								</Tabs.TabList>
 							</div>
-							<div>
-								<Button
-									__next40pxDefaultSize
-									icon={ isFullscreen ? square : fullscreen }
-									label={ __( 'Enable/disable fullscreen' ) }
-									onClick={ toggleFullscreen }
-									variant="tertiary"
-								/>
-							</div>
+							{ ! isMobileViewport && (
+								<div>
+									<Button
+										__next40pxDefaultSize
+										icon={
+											isFullscreen ? square : fullscreen
+										}
+										label={ __(
+											'Enable/disable fullscreen'
+										) }
+										onClick={ toggleFullscreen }
+										variant="tertiary"
+									/>
+								</div>
+							) }
 						</HStack>
 						{ hasRestrictedContent && (
 							<Notice
@@ -165,11 +169,11 @@ export default function HTMLEditModal( {
 								) }
 							</Notice>
 						) }
-						<HStack
-							alignment="stretch"
-							justify="flex-start"
-							spacing={ 4 }
+						<Flex
+							direction={ isMobileViewport ? 'column' : 'row' }
 							className="block-library-html__modal-tabs"
+							align="stretch"
+							gap={ 4 }
 						>
 							<div className="block-library-html__modal-content">
 								<Tabs.TabPanel
@@ -227,7 +231,7 @@ export default function HTMLEditModal( {
 									} ) }
 								/>
 							</div>
-						</HStack>
+						</Flex>
 						<HStack
 							alignment="center"
 							justify="flex-end"
@@ -249,7 +253,7 @@ export default function HTMLEditModal( {
 								{ __( 'Update' ) }
 							</Button>
 						</HStack>
-					</Grid>
+					</VStack>
 				</Tabs>
 			</Modal>
 

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -173,7 +173,7 @@ export default function HTMLEditModal( {
 							direction={ isMobileViewport ? 'column' : 'row' }
 							className="block-library-html__modal-tabs"
 							align="stretch"
-							gap={ 4 }
+							gap={ 8 }
 						>
 							<div className="block-library-html__modal-content">
 								<Tabs.TabPanel


### PR DESCRIPTION
## What?

This PR fixes some layout issues with the Custom HTML block.


| Problem | Screenshot |
|--------|--------|
| The notice component pushes out the code editor and preview area. | <img width="886" height="520" alt="image" src="https://github.com/user-attachments/assets/e3fd7b0e-5c0c-4e2e-b039-a33aa5084b18" /> |
| Mobile layout:<br>1. The code editor is extremely narrow. <br>2. The full-screen trigger button is unnecessary <br>3. Footer buttons are pushed out | <img width="459" height="655" alt="mobile" src="https://github.com/user-attachments/assets/7d3400c6-12c5-4f7a-8232-8ab51764b382" /> | 

## How?

- Don't render the fullscreen button doesn't in mobile view.
- Replaces the Grid component with the Flex component, and changes its orientation depending on the viewport. This allows the code editor and preview area to be aligned vertically in mobile view.
Other minor CSS tweaks

## Testing Instructions

1. Insert a Custom HTML block and insert various content.
2. Resize your browser to any width you like.
3. Verify that the layout is not broken.
4. When there is a lot of content, scrolling should work well.
5. If you want to display a warning, run the following in your browser console after entering both HTML and CSS content:
  ```javascript
  window.wp.data.dispatch( 'core/block-editor' ).updateSettings( { __experimentalCanUserUseUnfilteredHTML: false } );
  ```

## Screenshots or screencast <!-- if applicable -->

### Less content

https://github.com/user-attachments/assets/82b5974d-ae43-49fb-9415-bcef4141bad9

### More content

https://github.com/user-attachments/assets/6c40e9d9-ee5e-4aa6-b943-60f97f6d05ef

