### PR TITLE
Docs: document controlled/uncontrolled prop naming conventions for `@wordpress/ui`

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -108,7 +108,7 @@ For a given state `x`, the convention is:
 | --- | --- |
 | `defaultX` | Sets the initial value in **uncontrolled** mode. The component manages subsequent state changes internally. |
 | `x` | Sets the current value in **controlled** mode. The consumer is responsible for updating the value in response to changes. |
-| `onXChange` | Callback invoked when the state changes. Receives the new value as an argument. Works in both controlled and uncontrolled modes. |
+| `onXChange` | Callback invoked when the state changes. Receives the new value as its first argument. Works in both controlled and uncontrolled modes. |
 
 For example, a component with an open/closed state would expose:
 
@@ -151,7 +151,7 @@ function MyTabs() {
 In controlled mode, the consumer owns the state and passes it via `x`. State changes are handled through `onXChange`:
 
 ```tsx
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import { CollapsibleCard } from '@wordpress/ui';
 
 function MyCard() {
@@ -168,7 +168,7 @@ function MyCard() {
 }
 ```
 
-When both `x` and `defaultX` are provided, `x` takes precedence and the component behaves in controlled mode.
+When both `x` and `defaultX` are provided, `x` takes precedence and the component behaves in controlled mode. When neither is provided, the component uses its own internal default (typically documented via a `@default` JSDoc tag on the `defaultX` prop).
 
 #### Difference from native `onChange`
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -96,6 +96,112 @@ function MyComponent() {
 }
 ```
 
+### Controlled and Uncontrolled Modes
+
+Interactive components that manage internal state (such as open/closed, selected value, etc.) follow a consistent prop naming convention that supports both **controlled** and **uncontrolled** usage.
+
+#### Prop naming pattern
+
+For a given state `x`, the convention is:
+
+| Prop | Purpose |
+| --- | --- |
+| `defaultX` | Sets the initial value in **uncontrolled** mode. The component manages subsequent state changes internally. |
+| `x` | Sets the current value in **controlled** mode. The consumer is responsible for updating the value in response to changes. |
+| `onXChange` | Callback invoked when the state changes. Receives the new value as an argument. Works in both controlled and uncontrolled modes. |
+
+For example, a component with an open/closed state would expose:
+
+-   `defaultOpen` — initial open state (uncontrolled)
+-   `open` — current open state (controlled)
+-   `onOpenChange` — called when the open state changes
+
+And a component with a selectable value would expose:
+
+-   `defaultValue` — initial value (uncontrolled)
+-   `value` — current value (controlled)
+-   `onValueChange` — called when the value changes
+
+#### Uncontrolled usage
+
+In uncontrolled mode, the component manages its own state. Use `defaultX` to set the initial value, and optionally `onXChange` to react to changes:
+
+```tsx
+import { Tabs } from '@wordpress/ui';
+
+function MyTabs() {
+	return (
+		<Tabs.Root
+			defaultValue="tab1"
+			onValueChange={ ( value ) => console.log( value ) }
+		>
+			<Tabs.List>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1">Content 1</Tabs.Panel>
+			<Tabs.Panel value="tab2">Content 2</Tabs.Panel>
+		</Tabs.Root>
+	);
+}
+```
+
+#### Controlled usage
+
+In controlled mode, the consumer owns the state and passes it via `x`. State changes are handled through `onXChange`:
+
+```tsx
+import { useState } from 'react';
+import { CollapsibleCard } from '@wordpress/ui';
+
+function MyCard() {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<CollapsibleCard.Root open={ isOpen } onOpenChange={ setIsOpen }>
+			<CollapsibleCard.Header>Details</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				Collapsible content here.
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	);
+}
+```
+
+When both `x` and `defaultX` are provided, `x` takes precedence and the component behaves in controlled mode.
+
+#### Difference from native `onChange`
+
+The `onXChange` callback is distinct from the native DOM `onChange` event handler. Native `onChange` fires a `React.ChangeEvent` tied to a specific DOM element, while `onXChange` provides the new **value** directly — making it simpler to use and consistent across all components, including compound and non-form components.
+
+Components that wrap native form elements may still support native event handlers (like `onChange`, `onInput`) for interoperability, but `onXChange` is the recommended approach within this package.
+
+#### Guidelines for component authors
+
+When designing props for a new component:
+
+-   Always offer both controlled and uncontrolled modes when the component has user-facing state.
+-   Name the uncontrolled prop `defaultX`, the controlled prop `x`, and the callback `onXChange`.
+-   In JSDoc comments, indicate which mode each prop is for and cross-reference the alternative:
+    ```ts
+    /**
+     * Whether the panel is currently open (controlled).
+     *
+     * To render an uncontrolled component, use the `defaultOpen` prop instead.
+     */
+    open?: boolean;
+    /**
+     * Whether the panel is initially open (uncontrolled).
+     * @default false
+     */
+    defaultOpen?: boolean;
+    /**
+     * Event handler called when the open state changes.
+     */
+    onOpenChange?: ( open: boolean ) => void;
+    ```
+-   Provide a `@default` JSDoc tag for the uncontrolled prop when there is a sensible default.
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/ui/src/tabs/stories/best-practices.mdx
+++ b/packages/ui/src/tabs/stories/best-practices.mdx
@@ -6,8 +6,6 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 ## Usage
 
-The `Tabs` component supports both controlled and uncontrolled modes following the [package-wide conventions](https://github.com/WordPress/gutenberg/blob/HEAD/packages/ui/README.md#controlled-and-uncontrolled-modes) (`defaultValue` / `value` / `onValueChange`).
-
 ### Uncontrolled Mode
 
 `Tabs` can be used in an uncontrolled mode, where the component manages its own state. In this mode, the `defaultValue` prop can be used to set the initially selected tab.

--- a/packages/ui/src/tabs/stories/best-practices.mdx
+++ b/packages/ui/src/tabs/stories/best-practices.mdx
@@ -6,6 +6,8 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 ## Usage
 
+The `Tabs` component supports both controlled and uncontrolled modes following the [package-wide conventions](https://github.com/WordPress/gutenberg/blob/HEAD/packages/ui/README.md#controlled-and-uncontrolled-modes) (`defaultValue` / `value` / `onValueChange`).
+
 ### Uncontrolled Mode
 
 `Tabs` can be used in an uncontrolled mode, where the component manages its own state. In this mode, the `defaultValue` prop can be used to set the initially selected tab.


### PR DESCRIPTION
## What?

Document the controlled/uncontrolled prop naming conventions (`defaultX` / `x` / `onXChange`) for the `@wordpress/ui` package.

## Why?

As noted in https://github.com/WordPress/gutenberg/pull/76252#discussion_r2896825451, these conventions should be documented so that both component authors and consumers have a single, authoritative reference for the pattern.

The `@wordpress/ui` package already follows a consistent pattern across its interactive components (inherited from Base UI), but it was not yet documented.

## How?

- Added a new "Controlled and Uncontrolled Modes" subsection under "Core Design Principles" in the `@wordpress/ui` README, covering:
  - The `defaultX` / `x` / `onXChange` prop naming pattern
  - Concrete examples for open/closed and value state domains
  - Uncontrolled and controlled usage examples
  - Difference from native `onChange`
  - Guidelines for component authors (including JSDoc conventions)

## Testing Instructions

- Review the documentation in `packages/ui/README.md`
- Verify the conventions match existing component implementations (`CollapsibleCard`, `Dialog`, `Tabs`, `Input`, `Textarea`, `Select`)
- Check that the Storybook introduction page renders the new section correctly (`npm run storybook:dev` → Design System > Components > Introduction)


Made with [Cursor](https://cursor.com)