### PR TITLE
RTC updates: use apiFetch capabilities, allow nonce refresh

### DIFF
--- a/packages/sync/src/providers/http-polling/test/utils.test.ts
+++ b/packages/sync/src/providers/http-polling/test/utils.test.ts
@@ -570,13 +570,7 @@ describe( 'http-polling utils', () => {
 		} );
 
 		it( 'sends a POST request to the sync endpoint', async () => {
-			const mockResponse = {
-				ok: true,
-				json: jest.fn().mockResolvedValue( {
-					rooms: [],
-				} as never ),
-			};
-			mockApiFetch.mockResolvedValue( mockResponse );
+			mockApiFetch.mockResolvedValue( { rooms: [] } );
 
 			const payload = {
 				rooms: [
@@ -593,12 +587,8 @@ describe( 'http-polling utils', () => {
 			await postSyncUpdate( payload );
 
 			expect( mockApiFetch ).toHaveBeenCalledWith( {
-				body: JSON.stringify( payload ),
-				headers: {
-					'Content-Type': 'application/json',
-				},
+				data: payload,
 				method: 'POST',
-				parse: false,
 				path: '/wp-sync/v1/updates',
 			} );
 		} );
@@ -614,39 +604,23 @@ describe( 'http-polling utils', () => {
 					},
 				],
 			};
-			const mockResponse = {
-				ok: true,
-				json: jest.fn().mockResolvedValue( expectedResponse as never ),
-			};
-			mockApiFetch.mockResolvedValue( mockResponse );
+			mockApiFetch.mockResolvedValue( expectedResponse );
 
 			const result = await postSyncUpdate( { rooms: [] } );
 
 			expect( result ).toEqual( expectedResponse );
 		} );
 
-		it( 'throws an error when response is not ok', async () => {
-			const mockResponse = {
-				ok: false,
-				status: 500,
-			};
-			mockApiFetch.mockResolvedValue( mockResponse as never );
+		it( 'propagates errors from apiFetch', async () => {
+			mockApiFetch.mockRejectedValue( {
+				code: 'internal_server_error',
+				message: 'Internal Server Error',
+			} );
 
-			await expect( postSyncUpdate( { rooms: [] } ) ).rejects.toThrow(
-				'Sync update failed with status 500'
-			);
-		} );
-
-		it( 'throws an error for 401 status', async () => {
-			const mockResponse = {
-				ok: false,
-				status: 401,
-			};
-			mockApiFetch.mockResolvedValue( mockResponse as never );
-
-			await expect( postSyncUpdate( { rooms: [] } ) ).rejects.toThrow(
-				'Sync update failed with status 401'
-			);
+			await expect( postSyncUpdate( { rooms: [] } ) ).rejects.toEqual( {
+				code: 'internal_server_error',
+				message: 'Internal Server Error',
+			} );
 		} );
 
 		it( 'propagates network errors', async () => {

--- a/packages/sync/src/providers/http-polling/utils.ts
+++ b/packages/sync/src/providers/http-polling/utils.ts
@@ -105,26 +105,14 @@ export function createUpdateQueue(
  * @param payload The sync payload including data and after cursor
  * @return The sync server response
  */
-export async function postSyncUpdate(
+export function postSyncUpdate(
 	payload: SyncPayload
 ): Promise< SyncResponse > {
-	const response = await apiFetch< SyncResponse, false >( {
-		body: JSON.stringify( payload ),
-		headers: {
-			'Content-Type': 'application/json',
-		},
+	return apiFetch( {
 		method: 'POST',
-		parse: false,
 		path: SYNC_API_PATH,
+		data: payload,
 	} );
-
-	if ( ! response.ok ) {
-		throw new Error(
-			`Sync update failed with status ${ response.status }`
-		);
-	}
-
-	return await response.json();
 }
 
 /**
@@ -139,11 +127,9 @@ export function postSyncUpdateNonBlocking( payload: SyncPayload ): void {
 	}
 
 	apiFetch( {
-		body: JSON.stringify( payload ),
-		headers: { 'Content-Type': 'application/json' },
-		keepalive: true,
 		method: 'POST',
-		parse: false,
 		path: SYNC_API_PATH,
+		data: payload,
+		keepalive: true,
 	} ).catch( () => {} );
 }


### PR DESCRIPTION
Fixes #76159. When `apiFetch` is used with the `parse: false` option, it doesn't make any attempt to read the response and doesn't detect an expired nonce (the `rest_cookie_invalid_nonce` error). Then the nonce auto-refresh doesn't work.

This patch simplifies the `apiFetch` calls when sending requests to `/wp-sync/v1/updates`. Existing `apiFetch` capabilities can be used: automatically serialize the `data` as JSON, add the right `content-type` header, parse the response... There's no reason why the code should do it manually, almost as if it was using the native `window.fetch`.

The `/wp-sync/v1/updates` endpoint is a very "normal" one, with JSON requests and responses, `WP_Error`s being returned... There's no need to handle it specially.
