### PR TITLE
Font Library: Gracefully handle Chrome OTS font rejection during browser preview

### DIFF
--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -123,7 +123,15 @@ export async function loadFontFaceInBrowser(
 		}
 	);
 
-	const loadedFace = await newFont.load();
+	let loadedFace;
+	try {
+		loadedFace = await newFont.load();
+	} catch {
+		// Some fonts contain non-standard tables (e.g. vhea) that the browser's
+		// OTS parser rejects. The font can still be installed server-side;
+		// only the in-browser preview fails, so we bail out silently here.
+		return;
+	}
 
 	if ( addTo === 'document' || addTo === 'all' ) {
 		document.fonts.add( loadedFace );


### PR DESCRIPTION
## What?

Wraps `newFont.load()` in a try-catch inside `loadFontFaceInBrowser()` so that fonts rejected by Chrome's OpenType Sanitizer (OTS) no longer block the upload.

Closes #72265

## Why?

Certain TTF fonts (e.g. `AaDaoShuRi-LangManHeiTi-2.ttf`) contain non-standard or unsupported OpenType tables, specifically a `vhea` table with version `0x10001` that Chrome's OTS parser rejects with:

```
OTS parsing error: vhea: Unsupported table version: 0x10001
SyntaxError: Invalid font data in ArrayBuffer
```

This error is **Chrome-specific**, the same font loads without issue in Safari, which uses WebKit's more permissive font parser.

The throw from `FontFace.load()` propagated as an unhandled promise rejection and aborted the entire upload flow, even though the server-side font installation would have succeeded. `loadFontFaceInBrowser()` is a best-effort browser preview
utility, it should never block installation.

## How?

Single-file change in `utils/index.ts`: wrap `newFont.load()` in a try-catch. On failure (OTS rejection or any other browser-side parse error), the function returns early and silently. All four call sites across `upload-fonts.tsx` and `context.tsx` are automatically protected with no changes required there.

## Testing Instructions

1. Go to **Appearance → Editor → Styles → Fonts** in **Chrome**
2. Upload [AaDaoShuRi-LangManHeiTi-2.ttf](https://github.com/user-attachments/files/22896884/AaDaoShuRi-LangManHeiTi-2.ttf.zip)
3. The font should now install successfully (previously failed with console errors)
4. Upload a standard `.woff2` or common `.ttf`, should still install **and** preview correctly
5. Confirm no regressions in Safari (font installs and previews as before)


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/9e8a9733-91eb-47af-a797-be4b57302c15



After:

https://github.com/user-attachments/assets/10e0deb7-5e36-4467-8280-740802e8d696

