### PR TITLE
Icon block: Fix icons becoming too small when padding is applied

### DIFF
--- a/packages/block-library/src/icon/style.scss
+++ b/packages/block-library/src/icon/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	svg {
-		box-sizing: border-box;
+		box-sizing: content-box;
 		fill: currentColor;
 	}
 }


### PR DESCRIPTION
## What?
Closes #76288 
Fix icons becoming too small when padding is applied to the icon block by changing SVG box-sizing from border-box to content-box.


## Why?
When users added padding to icon blocks, the SVG icons would become too small because they were using border-box sizing, which included the wrapper's padding in the size calculation.

## How?
Changed SVG box-sizing from border-box to content-box in `.wp-block-icon svg`.

## Testing Instructions
1. Open a post or page. 
2. Insert an Icon block.
3. Add padding to the icon block using the padding dimensions controls
4. Verify the icon maintains proper size

## Screenshots or screencast 
### Before
https://github.com/user-attachments/assets/61124e03-da84-4c35-a971-b4859fa1bbf7

### After
https://github.com/user-attachments/assets/01ce53ec-30bc-4e8b-bda7-6493ef8c7e85

