### PR TITLE
Fix: Use add_filter() for get_block_type_variations hook

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -485,4 +485,4 @@ add_action( 'init', 'register_block_core_navigation_link' );
  * Creates all variations for post types / taxonomies dynamically (= each time when variations are requested).
  * Do not use variation_callback, to also account for unregistering post types/taxonomies later on.
  */
-add_action( 'get_block_type_variations', 'block_core_navigation_link_filter_variations', 10, 2 );
+add_filter( 'get_block_type_variations', 'block_core_navigation_link_filter_variations', 10, 2 );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/76296

Changes `add_action()` to `add_filter()` for the `get_block_type_variations` hook in the Navigation Link block.

## Why?
The `get_block_type_variations` hook is fired via `apply_filters()` in WordPress Core, making it a filter hook. Using `add_action()` is semantically incorrect, even though it works because `add_action()` calls `add_filter()` internally.

The hook is invoked here:
https://github.com/WordPress/wordpress-develop/blob/64086b2a15ef4ccf6443de2056646da1ee17d56d/src/wp-includes/class-wp-block-type.php#L608-L616

The callback function already returns as expected:
https://github.com/WordPress/gutenberg/blob/fbeaf971e74c121495529582f6c256864ae8d265/packages/block-library/src/navigation-link/index.php#L381-L419

## How?
Replaced `add_action()` with `add_filter()` in `packages/block-library/src/navigation-link/index.php`.

## Testing Instructions
1. No functional change — `add_action()` is an alias for `add_filter()` internally.
2. Verify the Navigation Link block still works correctly with its variations (e.g. Page Link, Post Link, Category Link, Tag Link).

### Testing Instructions for Keyboard
N/A — no UI changes.

---

This PR was authored by Claude Code (AI), steered and reviewed by @apermo.