### PR TITLE
Docs: Fix big_image_size_threshold xref typo

### DIFF
--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -168,7 +168,7 @@ function gutenberg_get_all_image_sizes(): array {
  * @param WP_REST_Response $response Response data.
  */
 function gutenberg_media_processing_filter_rest_index( WP_REST_Response $response ) {
-	/** This filter is documented in wp-admin/includes/images.php */
+	/** This filter is documented in wp-admin/includes/image.php */
 	$image_size_threshold = (int) apply_filters( 'big_image_size_threshold', 2560, array( 0, 0 ), '', 0 ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 	if ( current_user_can( 'upload_files' ) ) {


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/76298

Fixes a typo in the cross-reference comment for the `big_image_size_threshold` filter in `lib/media/load.php`.

## Why?
The comment references `wp-admin/includes/images.php`, but the actual file is `wp-admin/includes/image.php` (singular). This makes it harder for developers to locate the hook's primary documentation.

The primary documentation for the filter lives here:
https://github.com/WordPress/wordpress-develop/blob/64086b2a15ef4ccf6443de2056646da1ee17d56d/src/wp-admin/includes/image.php#L264-L285

## How?
Changed `images.php` to `image.php` in the cross-reference comment.

## Testing Instructions
No functional change — documentation comment only.

### Testing Instructions for Keyboard
N/A — no UI changes.

---

This PR was authored by Claude Code (AI), steered and reviewed by @apermo.