### PR TITLE
Block visibility: deselect hidden block when list view is not open

### DIFF
--- a/packages/block-editor/src/components/block-visibility/resolve-current-viewport.js
+++ b/packages/block-editor/src/components/block-visibility/resolve-current-viewport.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
+
+/**
+ * Resolves the effective viewport used for visibility checks.
+ *
+ * @param {string}  deviceType         Current preview device type.
+ * @param {boolean} isLargerThanMobile Whether viewport is >= mobile breakpoint.
+ * @param {boolean} isLargerThanTablet Whether viewport is >= tablet breakpoint.
+ *
+ * @return {string} Effective viewport key ('desktop'|'tablet'|'mobile').
+ */
+export function resolveCurrentViewport(
+	deviceType,
+	isLargerThanMobile,
+	isLargerThanTablet
+) {
+	const normalizedDeviceType = deviceType?.toLowerCase();
+
+	if ( normalizedDeviceType === BLOCK_VISIBILITY_VIEWPORTS.mobile.key ) {
+		return BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
+	}
+
+	if ( normalizedDeviceType === BLOCK_VISIBILITY_VIEWPORTS.tablet.key ) {
+		return BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
+	}
+
+	// Desktop preview falls back to current window width breakpoints.
+	if ( ! isLargerThanMobile ) {
+		return BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
+	}
+
+	if ( ! isLargerThanTablet ) {
+		return BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
+	}
+
+	return BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
+}

--- a/packages/block-editor/src/components/block-visibility/test/resolve-current-viewport.js
+++ b/packages/block-editor/src/components/block-visibility/test/resolve-current-viewport.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { resolveCurrentViewport } from '../resolve-current-viewport';
+
+describe( 'resolveCurrentViewport', () => {
+	it( 'returns mobile for Mobile device preview', () => {
+		expect( resolveCurrentViewport( 'mobile', true, true ) ).toBe(
+			'mobile'
+		);
+	} );
+
+	it( 'returns tablet for Tablet device preview', () => {
+		expect( resolveCurrentViewport( 'tablet', true, true ) ).toBe(
+			'tablet'
+		);
+	} );
+
+	it( 'falls back to mobile in Desktop preview on narrow width', () => {
+		expect( resolveCurrentViewport( 'desktop', false, false ) ).toBe(
+			'mobile'
+		);
+	} );
+
+	it( 'falls back to tablet in Desktop preview on medium width', () => {
+		expect( resolveCurrentViewport( 'desktop', true, false ) ).toBe(
+			'tablet'
+		);
+	} );
+
+	it( 'returns desktop in Desktop preview on wide width', () => {
+		expect( resolveCurrentViewport( 'desktop', true, true ) ).toBe(
+			'desktop'
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -7,6 +7,7 @@ import { useViewportMatch } from '@wordpress/compose';
  * Internal dependencies
  */
 import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
+import { resolveCurrentViewport } from './resolve-current-viewport';
 
 /**
  * Returns information about the current block visibility state.
@@ -27,23 +28,11 @@ export default function useBlockVisibility( options = {} ) {
 	const isLargerThanMobile = useViewportMatch( 'mobile', '>=', view ); // >= 480px
 	const isLargerThanTablet = useViewportMatch( 'medium', '>=', view ); // >= 782px
 
-	/*
-	 * Priority:
-	 * 1. Device type override (Mobile/Tablet) - uses device type to determine viewport
-	 * 2. Actual window size (Desktop mode) - uses viewport detection
-	 */
-	let currentViewport;
-	if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.mobile.key ) {
-		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
-	} else if ( deviceType === BLOCK_VISIBILITY_VIEWPORTS.tablet.key ) {
-		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
-	} else if ( ! isLargerThanMobile ) {
-		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.mobile.key;
-	} else if ( isLargerThanMobile && ! isLargerThanTablet ) {
-		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.tablet.key;
-	} else {
-		currentViewport = BLOCK_VISIBILITY_VIEWPORTS.desktop.key;
-	}
+	const currentViewport = resolveCurrentViewport(
+		deviceType,
+		isLargerThanMobile,
+		isLargerThanTablet
+	);
 
 	// Determine if block is currently hidden.
 	const isBlockCurrentlyHidden =

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -83,6 +83,7 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
+import { resolveCurrentViewport } from './components/block-visibility/resolve-current-viewport';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -157,4 +158,5 @@ lock( privateApis, {
 	isHashLink,
 	isRelativePath,
 	InnerContent,
+	resolveCurrentViewport,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -74,6 +74,7 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
+import { resolveCurrentViewport } from './components/block-visibility/resolve-current-viewport';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -141,4 +142,5 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
+	resolveCurrentViewport,
 } );

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -16,11 +16,14 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem } from '@wordpress/interface';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/ui';
 
 /**
@@ -30,6 +33,8 @@ import { store as editorStore } from '../../store';
 import PostPreviewButton from '../post-preview-button';
 import { VIEWPORT_STATE_BY_DEVICE_TYPE } from '../../utils/device-type';
 import { unlock } from '../../lock-unlock';
+
+const { resolveCurrentViewport } = unlock( blockEditorPrivateApis );
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const {
@@ -68,10 +73,47 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const { setDeviceType, setRenderingMode, setDefaultRenderingMode } = unlock(
 		useDispatch( editorStore )
 	);
+	const blockEditorDispatch = useDispatch( blockEditorStore );
+	const { clearSelectedBlock } = blockEditorDispatch;
 	const { resetZoomLevel, setStyleStateViewport, setResponsiveEditing } =
-		unlock( useDispatch( blockEditorStore ) );
+		unlock( blockEditorDispatch );
+	const registry = useRegistry();
+
+	const isLargerThanMobile = useViewportMatch( 'mobile', '>=' ); // >= 480px
+	const isLargerThanTablet = useViewportMatch( 'medium', '>=' ); // >= 782px
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
+		const isListViewOpened = registry
+			.select( editorStore )
+			.isListViewOpened();
+		const selectedBlockClientId = registry
+			.select( blockEditorStore )
+			.getSelectedBlockClientId();
+
+		if ( ! isListViewOpened && selectedBlockClientId ) {
+			const targetViewport = resolveCurrentViewport(
+				newDeviceType,
+				isLargerThanMobile,
+				isLargerThanTablet
+			);
+			const blockEditorSelectors = unlock(
+				registry.select( blockEditorStore )
+			);
+			const isSelectedBlockHiddenInTargetViewport =
+				blockEditorSelectors.isBlockHiddenAtViewport(
+					selectedBlockClientId,
+					targetViewport
+				) ||
+				blockEditorSelectors.isBlockParentHiddenAtViewport(
+					selectedBlockClientId,
+					targetViewport
+				);
+
+			if ( isSelectedBlockHiddenInTargetViewport ) {
+				clearSelectedBlock();
+			}
+		}
+
 		setDeviceType( newDeviceType );
 		resetZoomLevel();
 	};

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -17,11 +17,14 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem } from '@wordpress/interface';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -29,6 +32,8 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 import PostPreviewButton from '../post-preview-button';
 import { unlock } from '../../lock-unlock';
+
+const { resolveCurrentViewport } = unlock( blockEditorPrivateApis );
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const {
@@ -62,9 +67,46 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const { setDeviceType, setRenderingMode, setDefaultRenderingMode } = unlock(
 		useDispatch( editorStore )
 	);
-	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
+	const blockEditorDispatch = useDispatch( blockEditorStore );
+	const { clearSelectedBlock } = blockEditorDispatch;
+	const { resetZoomLevel } = unlock( blockEditorDispatch );
+	const registry = useRegistry();
+
+	const isLargerThanMobile = useViewportMatch( 'mobile', '>=' ); // >= 480px
+	const isLargerThanTablet = useViewportMatch( 'medium', '>=' ); // >= 782px
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
+		const isListViewOpened = registry
+			.select( editorStore )
+			.isListViewOpened();
+		const selectedBlockClientId = registry
+			.select( blockEditorStore )
+			.getSelectedBlockClientId();
+
+		if ( ! isListViewOpened && selectedBlockClientId ) {
+			const targetViewport = resolveCurrentViewport(
+				newDeviceType,
+				isLargerThanMobile,
+				isLargerThanTablet
+			);
+			const blockEditorSelectors = unlock(
+				registry.select( blockEditorStore )
+			);
+			const isSelectedBlockHiddenInTargetViewport =
+				blockEditorSelectors.isBlockHiddenAtViewport(
+					selectedBlockClientId,
+					targetViewport
+				) ||
+				blockEditorSelectors.isBlockParentHiddenAtViewport(
+					selectedBlockClientId,
+					targetViewport
+				);
+
+			if ( isSelectedBlockHiddenInTargetViewport ) {
+				clearSelectedBlock();
+			}
+		}
+
 		setDeviceType( newDeviceType );
 		resetZoomLevel();
 	};

--- a/packages/editor/src/components/preview-dropdown/test/index.js
+++ b/packages/editor/src/components/preview-dropdown/test/index.js
@@ -1,0 +1,213 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import PreviewDropdown from '..';
+import { store as editorStore } from '../../../store';
+
+jest.mock( '../../../store', () => ( {
+	store: { name: 'editor' },
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	useViewportMatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+	useRegistry: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: { name: 'core' },
+} ) );
+
+jest.mock( '@wordpress/preferences', () => ( {
+	store: { name: 'preferences' },
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) => value,
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: { name: 'block-editor' },
+	privateApis: {
+		resolveCurrentViewport: (
+			deviceType,
+			isLargerThanMobile,
+			isLargerThanTablet
+		) => {
+			const normalized = deviceType?.toLowerCase();
+			if ( normalized === 'mobile' || normalized === 'tablet' ) {
+				return normalized;
+			}
+			if ( ! isLargerThanMobile ) {
+				return 'mobile';
+			}
+			if ( ! isLargerThanTablet ) {
+				return 'tablet';
+			}
+			return 'desktop';
+		},
+	},
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	DropdownMenu: ( { children } ) => (
+		<div>{ children( { onClose: jest.fn() } ) }</div>
+	),
+	MenuGroup: ( { children } ) => <div>{ children }</div>,
+	MenuItem: ( { children } ) => <div>{ children }</div>,
+	MenuItemsChoice: ( { onSelect } ) => (
+		<button onClick={ () => onSelect( 'Mobile' ) }>switch-to-mobile</button>
+	),
+	VisuallyHidden: ( { children } ) => <span>{ children }</span>,
+	Icon: () => null,
+} ) );
+
+jest.mock( '@wordpress/interface', () => ( {
+	ActionItem: {
+		Slot: () => null,
+	},
+} ) );
+
+jest.mock( '../../post-preview-button', () => () => null );
+
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: ( value ) => value,
+} ) );
+
+describe( 'PreviewDropdown', () => {
+	const editorDispatch = {
+		setDeviceType: jest.fn(),
+		setRenderingMode: jest.fn(),
+		setDefaultRenderingMode: jest.fn(),
+	};
+	const blockEditorDispatch = {
+		clearSelectedBlock: jest.fn(),
+		resetZoomLevel: jest.fn(),
+	};
+	const registry = {
+		select: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		useViewportMatch.mockImplementation( ( breakpoint, operator ) => {
+			if ( breakpoint === 'mobile' && operator === '>=' ) {
+				return true;
+			}
+			if ( breakpoint === 'medium' && operator === '>=' ) {
+				return true;
+			}
+			if ( breakpoint === 'medium' && operator === '<' ) {
+				return false;
+			}
+			return true;
+		} );
+
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( ( store ) => {
+				if ( store === editorStore ) {
+					return {
+						getDeviceType: () => 'Desktop',
+						getCurrentPostType: () => 'post',
+						getCurrentTemplateId: () => null,
+						getRenderingMode: () => 'template-locked',
+						isListViewOpened: () => false,
+					};
+				}
+				return {
+					getEntityRecord: () => ( { home: 'https://example.com' } ),
+					getPostType: () => ( { viewable: true } ),
+					get: () => false,
+				};
+			} )
+		);
+
+		useDispatch.mockImplementation( ( store ) => {
+			if ( store === editorStore ) {
+				return editorDispatch;
+			}
+			if ( store === blockEditorStore ) {
+				return blockEditorDispatch;
+			}
+			return {};
+		} );
+
+		registry.select.mockImplementation( ( store ) => {
+			if ( store === editorStore ) {
+				return {
+					isListViewOpened: () => false,
+				};
+			}
+			if ( store === blockEditorStore ) {
+				return {
+					getSelectedBlockClientId: () => 'client-1',
+					isBlockHiddenAtViewport: () => true,
+					isBlockParentHiddenAtViewport: () => false,
+				};
+			}
+			return {};
+		} );
+		useRegistry.mockReturnValue( registry );
+	} );
+
+	it( 'deselects when list view is closed and selected block is hidden', async () => {
+		const user = userEvent.setup();
+		render( <PreviewDropdown /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'switch-to-mobile' } )
+		);
+
+		expect( blockEditorDispatch.clearSelectedBlock ).toHaveBeenCalledTimes(
+			1
+		);
+		expect( editorDispatch.setDeviceType ).toHaveBeenCalledWith( 'Mobile' );
+		expect( blockEditorDispatch.resetZoomLevel ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not deselect when list view is open', async () => {
+		const user = userEvent.setup();
+		registry.select.mockImplementation( ( store ) => {
+			if ( store === editorStore ) {
+				return {
+					isListViewOpened: () => true,
+				};
+			}
+			if ( store === blockEditorStore ) {
+				return {
+					getSelectedBlockClientId: () => 'client-1',
+					isBlockHiddenAtViewport: () => true,
+					isBlockParentHiddenAtViewport: () => false,
+				};
+			}
+			return {};
+		} );
+
+		render( <PreviewDropdown /> );
+		await user.click(
+			screen.getByRole( 'button', { name: 'switch-to-mobile' } )
+		);
+
+		expect( blockEditorDispatch.clearSelectedBlock ).not.toHaveBeenCalled();
+		expect( editorDispatch.setDeviceType ).toHaveBeenCalledWith( 'Mobile' );
+		expect( blockEditorDispatch.resetZoomLevel ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/editor/src/components/preview-dropdown/test/index.js
+++ b/packages/editor/src/components/preview-dropdown/test/index.js
@@ -132,6 +132,11 @@ describe( 'PreviewDropdown', () => {
 						isListViewOpened: () => false,
 					};
 				}
+				if ( store === blockEditorStore ) {
+					return {
+						isResponsiveEditing: () => false,
+					};
+				}
 				return {
 					getEntityRecord: () => ( { home: 'https://example.com' } ),
 					getPostType: () => ( { viewable: true } ),

--- a/test/e2e/specs/editor/various/block-hiding.spec.js
+++ b/test/e2e/specs/editor/various/block-hiding.spec.js
@@ -193,6 +193,7 @@ test.describe( 'Block Hiding', () => {
 	test( 'should hide a block only on Mobile viewport', async ( {
 		page,
 		editor,
+		pageUtils,
 	} ) => {
 		// Insert a paragraph block.
 		await editor.insertBlock( {
@@ -214,6 +215,13 @@ test.describe( 'Block Hiding', () => {
 			.getByRole( 'dialog', { name: 'Hide block' } )
 			.getByRole( 'button', { name: 'Apply' } )
 			.click();
+
+		/*
+		 * Open List View so switching device preview does not clear selection for a block
+		 * that becomes hidden in the target viewport (inspector needs a selected block).
+		 * See: https://github.com/WordPress/gutenberg/issues/76275
+		 */
+		await pageUtils.pressKeys( 'access+o' );
 
 		// Toggle to mobile preview.
 		await page


### PR DESCRIPTION


## What?

Testing something out for https://github.com/WordPress/gutenberg/issues/76275

This PR:


- Deselects hidden selected blocks on viewport preview switch when List View is closed.
- Keeps viewport resolution logic shared via `resolveCurrentViewport`.
- Adds	 unit coverage for viewport resolution and preview dropdown deselection behavior.

## Test Steps

1. Create blocks with viewport-specific visibility.
2. Select a block that is visible in Desktop but hidden in Mobile.
3. With List View **closed**, switch View -> Mobile and confirm selection clears.
4. With List View **open**, repeat and confirm selection is preserved.

```
npm run test:unit -- packages/block-editor/src/components/block-visibility/test/resolve-current-viewport.js packages/editor/src/components/preview-dropdown/test/index.js
```

### Before

https://github.com/user-attachments/assets/449e4243-c8d0-451d-9859-5284e3908905



### After

https://github.com/user-attachments/assets/f6f1e77d-75af-46a3-b470-cdd29026f945


