### PR TITLE
Block Visibility: Add `fetchpriority=auto` to `IMG` tags in blocks with conditional viewport visibility to prevent potential erroneous high loading priority

### DIFF
--- a/backport-changelog/7.0/11196.md
+++ b/backport-changelog/7.0/11196.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11196
+
+* https://github.com/WordPress/gutenberg/pull/76302

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -137,8 +137,16 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
 				$processor->add_class( implode( ' ', $class_names ) );
-				$block_content = $processor->get_updated_html();
 			}
+
+			/*
+			 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
+			 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+			 */
+			while ( $processor->next_tag( 'IMG' ) ) {
+				$processor->set_attribute( 'fetchpriority', 'auto' );
+			}
+			$block_content = $processor->get_updated_html();
 		}
 	}
 

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -140,7 +140,7 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 
 				/*
 				 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
-				 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+				 * `fetchpriority=high` or increment the media count to affect whether subsequent IMG tags get `loading=lazy`.
 				 */
 				do {
 					if ( 'IMG' === $processor->get_tag() ) {

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -137,16 +137,18 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
 				$processor->add_class( implode( ' ', $class_names ) );
-			}
 
-			/*
-			 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
-			 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
-			 */
-			while ( $processor->next_tag( 'IMG' ) ) {
-				$processor->set_attribute( 'fetchpriority', 'auto' );
+				/*
+				 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
+				 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+				 */
+				do {
+					if ( 'IMG' === $processor->get_tag() ) {
+						$processor->set_attribute( 'fetchpriority', 'auto' );
+					}
+				} while ( $processor->next_tag() );
+				$block_content = $processor->get_updated_html();
 			}
-			$block_content = $processor->get_updated_html();
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes #76301

This adds `fetchpriority=auto` to `IMG` tags which appear in viewport-conditional blocks.

See companion ticket Core-64823 and PR for WordPress core: https://github.com/WordPress/wordpress-develop/pull/11196 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A hidden image with `fetchpriority=high` negatively impacts the LCP metric since it gets prioritized over images which are actually in the critical rendering path.

## How?

<details><summary>Before ❌</summary>

```html
<div
  class="entry-content alignfull wp-block-post-content has-global-padding is-layout-constrained wp-block-post-content-is-layout-constrained"
>
  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-tablet"
  >
    <img
      fetchpriority="high"
      decoding="async"
      width="1024"
      height="741"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg"
      alt="Mobile"
      class="wp-image-38"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-300x217.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-768x556.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1536x1112.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-2048x1483.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-mobile"
  >
    <img
      decoding="async"
      width="1024"
      height="683"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
      alt="Tablet"
      class="wp-image-37"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-300x200.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-768x512.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-mobile wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="668"
      src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg"
      alt="Desktop"
      class="wp-image-36"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-300x196.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-768x501.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1536x1002.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-2048x1336.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>
</div>
```

</details> 

<details><summary>After ✅</summary>

```html
<div
  class="entry-content alignfull wp-block-post-content has-global-padding is-layout-constrained wp-block-post-content-is-layout-constrained"
>
  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="741"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg"
      alt="Mobile"
      class="wp-image-38"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-300x217.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-768x556.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1536x1112.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-2048x1483.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-mobile"
  >
    <img
      decoding="async"
      width="1024"
      height="683"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
      alt="Tablet"
      class="wp-image-37"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-300x200.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-768x512.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-mobile wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="668"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg"
      alt="Desktop"
      class="wp-image-36"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-300x196.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-768x501.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1536x1002.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-2048x1336.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>
</div>
```

</details> 

Diff:

```diff
--- before.html	2026-03-08 19:01:46
+++ after.html	2026-03-08 19:01:13
@@ -5,10 +5,10 @@
     class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-tablet"
   >
     <img
-      fetchpriority="high"
       decoding="async"
       width="1024"
       height="741"
+      fetchpriority="auto"
       src="http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg"
       alt="Mobile"
       class="wp-image-38"
@@ -30,6 +30,7 @@
       decoding="async"
       width="1024"
       height="683"
+      fetchpriority="auto"
       src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
       alt="Tablet"
       class="wp-image-37"
@@ -51,6 +52,7 @@
       decoding="async"
       width="1024"
       height="668"
+      fetchpriority="auto"
       src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg"
       alt="Desktop"
       class="wp-image-36"

```


## Testing Instructions

1. Add an Image block with a large image size to a post.
2. Configure block visibility to hide the block one or two viewports.
3. Verify that the added `IMG` on the frontend has `fetchpriority=auto` as opposed to `fetchpriority=high`.
