### PR TITLE
LinkControl: prepend https:// to URLs submitted without selecting sug...

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -12,6 +12,7 @@ import { URLInput } from '../';
 import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
+import normalizeUrl from './normalize-url';
 
 // Must be a function as otherwise URLInput will default
 // to the fetchLinkSuggestions passed in block editor settings
@@ -161,7 +162,9 @@ const LinkControlSearchInput = forwardRef(
 							event.preventDefault();
 						} else {
 							onSuggestionSelected(
-								hasSuggestion || { url: value }
+								hasSuggestion || {
+									url: normalizeUrl( value ).url,
+								}
 							);
 						}
 					} }


### PR DESCRIPTION
Fixes #75374

## What?

This PR fixes an issue in LinkControl where URLs typed without a protocol (e.g., `wordpress.org` or `www.wordpress.org`) and submitted by pressing Enter (without selecting from the dropdown) were saved without the `https://` protocol.

## Why?

URLs without protocols are invalid and won't work as links. The existing behavior was inconsistent:
- **Selecting a suggestion from dropdown**: URL gets `https://` prepended ✅
- **Pressing Enter directly**: URL stays as-is without protocol ❌

This created a confusing UX where users had to remember to select from the dropdown to get properly formatted URLs.

## How?

The fix imports the existing `normalizeUrl` function (which already handles prepending `https://` to bare domains) and uses it in the `onSubmit` handler of `search-input.js` when creating a direct entry suggestion object.

**Change made:**
- `packages/block-editor/src/components/link-control/search-input.js`: Import `normalizeUrl` and use it to normalize the URL value when submitting without a suggestion

## Testing Instructions

1. Add a Navigation block to a post or page
2. Add a link and type a URL without a protocol (e.g., `wordpress.org` or `www.wordpress.org`)
3. Press Enter without selecting from the dropdown
4. Verify the URL is saved with `https://` prepended (e.g., `https://wordpress.org`)

### Testing Instructions for Keyboard

1. Navigate to a Navigation block using keyboard (Tab)
2. Add a new link item
3. Type `example.com` and press Enter
4. Verify the link works correctly with `https://example.com`

## Screenshots

|Before|After|
|-|-|
|URL saved as `wordpress.org` (broken link)|URL saved as `https://wordpress.org` (working link)|