### PR TITLE
Core Data: Fix 'canUser' returning 'undefined' when the allow header is missing

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `canUser` no longer returns `undefined` when the allow header is missing from the response.
+
 ## 7.41.0 (2026-03-04)
 
 ## 7.40.0 (2026-02-18)

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -862,6 +862,24 @@ describe( 'canUser', () => {
 		expect( dispatch.receiveUserPermissions ).not.toHaveBeenCalled();
 	} );
 
+	it( 'receives false when the allow header is missing', async () => {
+		triggerFetch.mockImplementation( () => ( {
+			headers: new Map(),
+		} ) );
+
+		await canUser(
+			'create',
+			'media'
+		)( { dispatch, registry, resolveSelect } );
+
+		expect( dispatch.receiveUserPermissions ).toHaveBeenCalledWith( {
+			'create/media': false,
+			'read/media': false,
+			'update/media': false,
+			'delete/media': false,
+		} );
+	} );
+
 	it( 'throws an error when an entity resource object is malformed', async () => {
 		await expect(
 			canUser( 'create', { name: 'wp_block' } )( {
@@ -888,9 +906,12 @@ describe( 'canUser', () => {
 			parse: false,
 		} );
 
-		expect( dispatch.receiveUserPermissions ).toHaveBeenCalledWith(
-			expect.objectContaining( { 'create/media': false } )
-		);
+		expect( dispatch.receiveUserPermissions ).toHaveBeenCalledWith( {
+			'create/media': false,
+			'read/media': true,
+			'update/media': false,
+			'delete/media': false,
+		} );
 	} );
 
 	it( 'receives false when the user is not allowed to perform an action on entities', async () => {

--- a/packages/core-data/src/utils/user-permissions.js
+++ b/packages/core-data/src/utils/user-permissions.js
@@ -7,18 +7,17 @@ export const ALLOWED_RESOURCE_ACTIONS = [
 
 export function getUserPermissionsFromAllowHeader( allowedMethods ) {
 	const permissions = {};
-	if ( ! allowedMethods ) {
-		return permissions;
-	}
-
 	const methods = {
 		create: 'POST',
 		read: 'GET',
 		update: 'PUT',
 		delete: 'DELETE',
 	};
+
 	for ( const [ actionName, methodName ] of Object.entries( methods ) ) {
-		permissions[ actionName ] = allowedMethods.includes( methodName );
+		permissions[ actionName ] = allowedMethods
+			? allowedMethods.includes( methodName )
+			: false;
 	}
 
 	return permissions;


### PR DESCRIPTION
## What?
Cast permission values to boolean in `getUserPermissionsFromAllowHeader` so `canUser` returns `false` instead of `undefined` when the response has no allow header. e.g., React Native, or more restrictive APIs.

## Why?
I noticed this while experimenting with the Plugins endpoint and testing with low-cap users.

## Testing Instructions
The fix and resolve has good unit test coverage.
