### PR TITLE
Fields: Add `format` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60348,7 +60348,6 @@
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/blob": "file:../blob",
-				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -57,6 +57,7 @@ const form = {
 			],
 		},
 		'template',
+		'format',
 	],
 };
 

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -36,6 +36,7 @@ import {
 	patternTitleField,
 	notesField,
 	scheduledDateField,
+	formatField,
 } from '@wordpress/fields';
 import {
 	altTextField,
@@ -193,6 +194,9 @@ export const registerPostTypeSchema =
 		const currentTheme = await registry
 			.resolveSelect( coreStore )
 			.getCurrentTheme();
+		const { disablePostFormats } = registry
+			.select( editorStore )
+			.getEditorSettings();
 
 		let canDuplicate =
 			! [ 'wp_block', 'wp_template_part' ].includes(
@@ -269,6 +273,9 @@ export const registerPostTypeSchema =
 					postTypeConfig.supports?.trackbacks ) &&
 					discussionField,
 				templateField,
+				postTypeConfig.supports?.[ 'post-formats' ] &&
+					! disablePostFormats &&
+					formatField,
 				passwordField,
 				postTypeConfig.supports?.editor &&
 					postTypeConfig.viewable &&

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -71,6 +71,10 @@ Export action as JSON for Pattern.
 
 Featured Image field for BasePostWithEmbeddedFeaturedMedia.
 
+### formatField
+
+Format field for BasePost.
+
 ### MediaEdit
 
 A media edit control component that provides a media picker UI with upload functionality for selecting WordPress media attachments. Supports both the traditional WordPress media library and the experimental DataViews media modal.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -51,7 +51,6 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/blob": "file:../blob",
-		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/fields/src/fields/format/index.ts
+++ b/packages/fields/src/fields/format/index.ts
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+
+// All WP post formats, sorted alphabetically by translated name.
+const POST_FORMATS = [
+	{ id: 'aside', caption: __( 'Aside' ) },
+	{ id: 'audio', caption: __( 'Audio' ) },
+	{ id: 'chat', caption: __( 'Chat' ) },
+	{ id: 'gallery', caption: __( 'Gallery' ) },
+	{ id: 'image', caption: __( 'Image' ) },
+	{ id: 'link', caption: __( 'Link' ) },
+	{ id: 'quote', caption: __( 'Quote' ) },
+	{ id: 'standard', caption: __( 'Standard' ) },
+	{ id: 'status', caption: __( 'Status' ) },
+	{ id: 'video', caption: __( 'Video' ) },
+].sort( ( a, b ) => {
+	const normalizedA = a.caption.toUpperCase();
+	const normalizedB = b.caption.toUpperCase();
+
+	if ( normalizedA < normalizedB ) {
+		return -1;
+	}
+	if ( normalizedA > normalizedB ) {
+		return 1;
+	}
+	return 0;
+} );
+
+const formatField: Field< BasePost > = {
+	id: 'format',
+	label: __( 'Format' ),
+	type: 'text',
+	Edit: 'radio',
+	enableSorting: false,
+	enableHiding: false,
+	filterBy: false,
+	getElements: async () => {
+		const themeSupports =
+			await resolveSelect( coreStore ).getThemeSupports();
+		return POST_FORMATS.filter(
+			( f ) =>
+				( themeSupports?.formats as string[] | undefined )?.includes(
+					f.id
+				)
+		).map( ( f ) => ( { value: f.id, label: f.caption } ) );
+	},
+};
+
+/**
+ * Format field for BasePost.
+ */
+export default formatField;

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -16,3 +16,4 @@ export { default as dateField } from './date';
 export { default as scheduledDateField } from './date/scheduled';
 export { default as authorField } from './author';
 export { default as notesField } from './notes';
+export { default as formatField } from './format';

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -133,6 +133,7 @@ export interface PostType {
 		comments?: string;
 		editor?: boolean | [ EditorSupport ];
 		trackbacks?: boolean;
+		'post-formats'?: boolean;
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/76237

This PR adds a new `format` field for posts that support it.


## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment in `/wp-admin/admin.php?page=gutenberg-experiments`.
2. Go to a post and try the new format field in Post summary 


## Notes

In this PR I haven't added the `Apply suggested format` button that can render conditionally, based on the current post content. Should we add this too?

It feels to me that the fields package shouldn't have `block-editor` as a dependency, but if it's okay, we can add it and have a custom `Edit` function for this field. Actually the dependency was already there but not used anywhere, so I'm removing it in this PR.
--cc @oandregal, @jasmussen @jameskoster


|Classic Post summary|DataForm powered Post summary|
|-|-|
|<img width="993" height="727" alt="classic" src="https://github.com/user-attachments/assets/d7d1c700-d203-4503-856e-8d501ed106f0" />|<img width="993" height="727" alt="dv" src="https://github.com/user-attachments/assets/aab125c5-7554-4b73-963a-7f7bc344ed78" />|
