### PR TITLE
Fields: Add post content information field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60369,6 +60369,7 @@
 				"@wordpress/router": "file:../router",
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",
+				"@wordpress/wordcount": "file:../wordcount",
 				"change-case": "4.1.2",
 				"client-zip": "^2.4.5",
 				"clsx": "2.1.1",

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -102,6 +102,10 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 				},
 			},
 			{
+				id: 'post-content-info',
+				layout: { type: 'regular', labelPosition: 'none' },
+			},
+			{
 				id: 'status',
 				label: __( 'Status' ),
 				children: [

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -12,15 +12,16 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PostCardPanel from '../post-card-panel';
-import PostLastEditedPanel from '../post-last-edited-panel';
-import PostContentInformation from '../post-content-information';
 import PostPanelSection from '../post-panel-section';
 import { store as editorStore } from '../../store';
 import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
 import { unlock } from '../../lock-unlock';
 
-const topForm = {
+const form = {
+	layout: {
+		type: 'panel',
+	},
 	fields: [
 		{
 			id: 'featured_media',
@@ -29,14 +30,13 @@ const topForm = {
 				labelPosition: 'none',
 			},
 		},
-	],
-};
-
-const bottomForm = {
-	layout: {
-		type: 'panel',
-	},
-	fields: [
+		{
+			id: 'post-content-info',
+			layout: {
+				type: 'regular',
+				labelPosition: 'none',
+			},
+		},
 		{
 			id: 'status',
 			label: __( 'Status' ),
@@ -139,17 +139,7 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 				<DataForm
 					data={ record }
 					fields={ fields }
-					form={ topForm }
-					onChange={ onChange }
-				/>
-				<VStack spacing={ 1 }>
-					<PostContentInformation />
-					<PostLastEditedPanel />
-				</VStack>
-				<DataForm
-					data={ record }
-					fields={ fields }
-					form={ bottomForm }
+					form={ form }
 					onChange={ onChange }
 				/>
 				<PostTrash onActionPerformed={ onActionPerformed } />

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -12,16 +12,15 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PostCardPanel from '../post-card-panel';
+import PostLastEditedPanel from '../post-last-edited-panel';
+import PostContentInformation from '../post-content-information';
 import PostPanelSection from '../post-panel-section';
 import { store as editorStore } from '../../store';
 import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
 import { unlock } from '../../lock-unlock';
 
-const form = {
-	layout: {
-		type: 'panel',
-	},
+const topForm = {
 	fields: [
 		{
 			id: 'featured_media',
@@ -30,6 +29,14 @@ const form = {
 				labelPosition: 'none',
 			},
 		},
+	],
+};
+
+const bottomForm = {
+	layout: {
+		type: 'panel',
+	},
+	fields: [
 		{
 			id: 'status',
 			label: __( 'Status' ),
@@ -132,7 +139,17 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 				<DataForm
 					data={ record }
 					fields={ fields }
-					form={ form }
+					form={ topForm }
+					onChange={ onChange }
+				/>
+				<VStack spacing={ 1 }>
+					<PostContentInformation />
+					<PostLastEditedPanel />
+				</VStack>
+				<DataForm
+					data={ record }
+					fields={ fields }
+					form={ bottomForm }
 					onChange={ onChange }
 				/>
 				<PostTrash onActionPerformed={ onActionPerformed } />

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -37,6 +37,7 @@ import {
 	notesField,
 	scheduledDateField,
 	formatField,
+	postContentInfoField,
 } from '@wordpress/fields';
 import {
 	altTextField,
@@ -276,6 +277,7 @@ export const registerPostTypeSchema =
 				postTypeConfig.supports?.[ 'post-formats' ] &&
 					! disablePostFormats &&
 					formatField,
+				postTypeConfig.supports?.editor && postContentInfoField,
 				passwordField,
 				postTypeConfig.supports?.editor &&
 					postTypeConfig.viewable &&

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -277,7 +277,9 @@ export const registerPostTypeSchema =
 				postTypeConfig.supports?.[ 'post-formats' ] &&
 					! disablePostFormats &&
 					formatField,
-				postTypeConfig.supports?.editor && postContentInfoField,
+				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
+					postTypeConfig.supports?.editor &&
+					postContentInfoField,
 				passwordField,
 				postTypeConfig.supports?.editor &&
 					postTypeConfig.viewable &&

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -152,6 +152,10 @@ Delete action for PostWithPermissions.
 
 Ping status field for BasePost.
 
+### postContentInfoField
+
+Post content information field for BasePost.
+
 ### PostType
 
 Undocumented declaration.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -71,6 +71,7 @@
 		"@wordpress/router": "file:../router",
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
+		"@wordpress/wordcount": "file:../wordcount",
 		"change-case": "4.1.2",
 		"client-zip": "^2.4.5",
 		"clsx": "2.1.1",

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -17,3 +17,4 @@ export { default as scheduledDateField } from './date/scheduled';
 export { default as authorField } from './author';
 export { default as notesField } from './notes';
 export { default as formatField } from './format';
+export { default as postContentInfoField } from './post-content-info';

--- a/packages/fields/src/fields/post-content-info/index.ts
+++ b/packages/fields/src/fields/post-content-info/index.ts
@@ -16,8 +16,6 @@ const postContentInfoField: Field< BasePost > = {
 	type: 'text',
 	readOnly: true,
 	render: PostContentInfoView,
-	isVisible: ( post ) =>
-		! [ 'wp_template', 'wp_template_part' ].includes( post.type ),
 	enableSorting: false,
 	enableHiding: false,
 	filterBy: false,

--- a/packages/fields/src/fields/post-content-info/index.ts
+++ b/packages/fields/src/fields/post-content-info/index.ts
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+import PostContentInfoView from './post-content-info-view';
+
+const postContentInfoField: Field< BasePost > = {
+	label: __( 'Post content information' ),
+	id: 'post-content-info',
+	type: 'text',
+	readOnly: true,
+	render: PostContentInfoView,
+	isVisible: ( post ) =>
+		! [ 'wp_template', 'wp_template_part' ].includes( post.type ),
+	enableSorting: false,
+	enableHiding: false,
+	filterBy: false,
+};
+
+/**
+ * Post content information field for BasePost.
+ */
+export default postContentInfoField;

--- a/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
+++ b/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { count as wordCount } from '@wordpress/wordcount';
+import type { Strategy } from '@wordpress/wordcount';
+import { humanTimeDiff } from '@wordpress/date';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+
+// Taken from packages/editor/src/components/time-to-read/index.js.
+const AVERAGE_READING_RATE = 189;
+
+export default function PostContentInfoView( { item }: { item: BasePost } ) {
+	const content =
+		typeof item.content === 'string'
+			? item.content
+			: item.content?.raw || '';
+
+	/*
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x(
+		'words',
+		'Word count type. Do not translate!'
+	) as Strategy;
+	const wordsCounted = useMemo(
+		() => ( content ? wordCount( content, wordCountType ) : 0 ),
+		[ content, wordCountType ]
+	);
+
+	const modified = item.modified;
+
+	if ( ! wordsCounted && ! modified ) {
+		return null;
+	}
+
+	let contentInfoText: string | undefined;
+	if ( wordsCounted ) {
+		const readingTime = Math.round( wordsCounted / AVERAGE_READING_RATE );
+		const wordsCountText = sprintf(
+			// translators: %s: the number of words in the post.
+			_n( '%s word', '%s words', wordsCounted ),
+			wordsCounted.toLocaleString()
+		);
+		const minutesText =
+			readingTime <= 1
+				? __( '1 minute' )
+				: sprintf(
+						/* translators: %s: the number of minutes to read the post. */
+						_n( '%s minute', '%s minutes', readingTime ),
+						readingTime.toLocaleString()
+				  );
+		contentInfoText = sprintf(
+			/* translators: 1: How many words a post has. 2: the number of minutes to read the post (e.g. 130 words, 2 minutes read time.) */
+			__( '%1$s, %2$s read time.' ),
+			wordsCountText,
+			minutesText
+		);
+	}
+
+	return (
+		<VStack spacing={ 1 }>
+			{ contentInfoText && (
+				<Text variant="muted">{ contentInfoText }</Text>
+			) }
+			{ modified && (
+				<Text variant="muted">
+					{ sprintf(
+						// translators: %s: Human-readable time difference, e.g. "2 days ago".
+						__( 'Last edited %s.' ),
+						humanTimeDiff( modified )
+					) }
+				</Text>
+			) }
+		</VStack>
+	);
+}

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -26,6 +26,7 @@
 		{ "path": "../router" },
 		{ "path": "../url" },
 		{ "path": "../block-editor" },
-		{ "path": "../warning" }
+		{ "path": "../warning" },
+		{ "path": "../wordcount" }
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves:  https://github.com/WordPress/gutenberg/issues/76239

This PR adds the post content and last edited information in the new DataForm powered Post summary and in Quick edit in Site editor, as a new post content info `readonly` field.



## Testing Instructions Post editor
1. Enable the `Editor Inspector: Use DataForm` experiment in `/wp-admin/admin.php?page=gutenberg-experiments`.
2. Go to a post or a page and observe the new content/last edited info

## Testing Instructions Quick edit in site editor
1. In site editor go to `pages` and select quick edit for a single item
2. Observe that the info is rendered like in Post editor
3. It's not rendered in bulk editing


## Screenshots or screencast <!-- if applicable -->

### Post editor

<img width="993" height="727" alt="Screenshot 2026-03-09 at 11 53 14 AM" src="https://github.com/user-attachments/assets/fd60346f-f9be-48bd-9abe-6d4ef2ea7661" />

### Site editor Quick edit


<img width="993" height="727" alt="Screenshot 2026-03-09 at 1 49 19 PM" src="https://github.com/user-attachments/assets/d631ab59-a09b-41ea-886a-9270a10f35f6" />

