### PR TITLE
Editor canvas iframe: use load event and default body element

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -132,6 +132,9 @@ function getIframeSrc( resolvedAssets ) {
 		${ resolvedAssets.styles ?? '' }
 		${ resolvedAssets.scripts ?? '' }
 	</head>
+	<body>
+		<script>document.currentScript.parentElement.remove()</script>
+	</body>
 </html>`;
 
 	src = URL.createObjectURL( new Blob( [ html ], { type: 'text/html' } ) );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -116,7 +116,6 @@ function getIframeSrc( resolvedAssets ) {
 	<head>
 		<meta charset="utf-8">
 		<base href="${ window.location.href }">
-		<script>window.frameElement._load()</script>
 		<style>
 			html{
 				height: auto !important;
@@ -133,9 +132,6 @@ function getIframeSrc( resolvedAssets ) {
 		${ resolvedAssets.styles ?? '' }
 		${ resolvedAssets.scripts ?? '' }
 	</head>
-	<body>
-		<script>document.currentScript.parentElement.remove()</script>
-	</body>
 </html>`;
 
 	src = URL.createObjectURL( new Blob( [ html ], { type: 'text/html' } ) );
@@ -168,9 +164,6 @@ function Iframe( {
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 
 	const setRef = useRefEffect( ( node ) => {
-		node._load = () => {
-			setIframeDocument( node.contentDocument );
-		};
 		let iFrameDocument;
 		// Prevent the default browser action for files dropped outside of dropzones.
 		function preventFileDropDefault( event ) {
@@ -218,6 +211,7 @@ function Iframe( {
 			const { contentDocument } = node;
 			const { documentElement } = contentDocument;
 			iFrameDocument = contentDocument;
+			setIframeDocument( contentDocument );
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
 
@@ -257,7 +251,7 @@ function Iframe( {
 		node.addEventListener( 'load', onLoad );
 
 		return () => {
-			delete node._load;
+			setIframeDocument( undefined );
 			node.removeEventListener( 'load', onLoad );
 			iFrameDocument?.removeEventListener(
 				'dragover',
@@ -284,12 +278,25 @@ function Iframe( {
 	} );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
-	const bodyRef = useMergeRefs( [
+
+	const unguardedBodyRef = useMergeRefs( [
 		useBubbleEvents( iframeDocument ),
 		contentRef,
 		writingFlowRef,
 		disabledRef,
 	] );
+
+	// Attach the body ref only when the iframe document and window are available.
+	const bodyRef = useRefEffect(
+		( node ) => {
+			if ( node.ownerDocument.defaultView ) {
+				unguardedBodyRef( node );
+				return () => unguardedBodyRef( null );
+			}
+			return () => {};
+		},
+		[ unguardedBodyRef ]
+	);
 
 	const src = getIframeSrc( resolvedAssets );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -290,6 +290,9 @@ function Iframe( {
 	] );
 
 	// Attach the body ref only when the iframe document and window are available.
+	// When an iframe element is moved in the DOM, like when reordering a list,
+	// its `window` object is destroyed and recreated, and the `defaultView` field is
+	// briefly `null`. We need to guard for such calls of the ref callbacks.
 	const bodyRef = useRefEffect(
 		( node ) => {
 			if ( node.ownerDocument.defaultView ) {

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -115,21 +115,15 @@ export function useMouseMoveTypingReset() {
  *   field, presses ESC or TAB, or moves the mouse in the document.
  */
 export function useTypingObserver() {
-	const { isTyping } = useSelect( ( select ) => {
-		const { isTyping: _isTyping } = select( blockEditorStore );
-		return {
-			isTyping: _isTyping(),
-		};
-	}, [] );
+	const isTyping = useSelect(
+		( select ) => select( blockEditorStore ).isTyping(),
+		[]
+	);
 	const { startTyping, stopTyping } = useDispatch( blockEditorStore );
 
 	const ref1 = useMouseMoveTypingReset();
 	const ref2 = useRefEffect(
 		( node ) => {
-			const { ownerDocument } = node;
-			const { defaultView } = ownerDocument;
-			const selection = defaultView.getSelection();
-
 			// Listeners to stop typing should only be added when typing.
 			// Listeners to start typing should only be added when not typing.
 			if ( isTyping ) {
@@ -147,7 +141,7 @@ export function useTypingObserver() {
 					// before the keydown event, wait until after current stack
 					// before evaluating whether typing is to be stopped. Otherwise,
 					// typing will re-start.
-					timerId = defaultView.setTimeout( () => {
+					timerId = node.ownerDocument.defaultView.setTimeout( () => {
 						if ( ! isTextField( target ) ) {
 							stopTyping();
 						}
@@ -174,6 +168,8 @@ export function useTypingObserver() {
 				 * uncollapsed (shift) selection.
 				 */
 				function stopTypingOnSelectionUncollapse() {
+					const selection =
+						node.ownerDocument.defaultView.getSelection();
 					if ( ! selection.isCollapsed ) {
 						stopTyping();
 					}
@@ -182,13 +178,13 @@ export function useTypingObserver() {
 				node.addEventListener( 'focus', stopTypingOnNonTextField );
 				node.addEventListener( 'keydown', stopTypingOnEscapeKey );
 
-				ownerDocument.addEventListener(
+				node.ownerDocument.addEventListener(
 					'selectionchange',
 					stopTypingOnSelectionUncollapse
 				);
 
 				return () => {
-					defaultView.clearTimeout( timerId );
+					node.ownerDocument.defaultView.clearTimeout( timerId );
 					node.removeEventListener(
 						'focus',
 						stopTypingOnNonTextField
@@ -197,7 +193,7 @@ export function useTypingObserver() {
 						'keydown',
 						stopTypingOnEscapeKey
 					);
-					ownerDocument.removeEventListener(
+					node.ownerDocument.removeEventListener(
 						'selectionchange',
 						stopTypingOnSelectionUncollapse
 					);

--- a/packages/e2e-tests/plugins/iframed-enqueue-block-assets/script.js
+++ b/packages/e2e-tests/plugins/iframed-enqueue-block-assets/script.js
@@ -1,4 +1,4 @@
 window.addEventListener( 'load', () => {
-	document.body.dataset.iframedEnqueueBlockAssetsL10n =
+	document.documentElement.dataset.iframedEnqueueBlockAssetsL10n =
 		window.iframedEnqueueBlockAssetsL10n.test;
 } );

--- a/test/e2e/specs/editor/plugins/iframed-equeue-block-assets.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-equeue-block-assets.spec.js
@@ -29,6 +29,7 @@ test.describe( 'iframed enqueue block assets', () => {
 	test( 'should load styles added through enqueue_block_assets', async ( {
 		editor,
 	} ) => {
+		const canvasHtml = editor.canvas.locator( 'html' );
 		const canvasBody = editor.canvas.locator( 'body' );
 
 		await expect( canvasBody ).toHaveCSS(
@@ -36,7 +37,7 @@ test.describe( 'iframed enqueue block assets', () => {
 			'rgb(33, 117, 155)'
 		);
 		await expect( canvasBody ).toHaveCSS( 'padding', '20px' );
-		await expect( canvasBody ).toHaveAttribute(
+		await expect( canvasHtml ).toHaveAttribute(
 			'data-iframed-enqueue-block-assets-l10n',
 			'Iframed Enqueue Block Assets!'
 		);


### PR DESCRIPTION
Trying to isolate the iframe loading changes from #61521. Turns out it works also with React 18. The only additional change I had to make is to keep the auto-deletion of the HTML-parsed `body` element. React 18 portal will create a duplicate `body` element. React 19 portal will (correctly) take over ownership of the existing one.
