### PR TITLE
create-block-interactive-template: Enhance block registration by using blocks-manifest for improved performance

### DIFF
--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -18,9 +18,10 @@ module.exports = {
 		viewScriptModule: 'file:./view.js',
 		render: 'file:./render.php',
 		example: {},
+		folderName: './src/$slug',
 		customScripts: {
-			build: 'wp-scripts build --experimental-modules',
-			start: 'wp-scripts start --experimental-modules',
+			build: 'wp-scripts build --experimental-modules --blocks-manifest',
+			start: 'wp-scripts start --experimental-modules --blocks-manifest',
 		},
 	},
 	variants: {

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -37,15 +37,15 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
 /**
- * Registers the block using the metadata loaded from the `block.json` file.
- * Behind the scenes, it registers also all assets so they can be enqueued
+ * Registers the block(s) metadata from the `blocks-manifest.php` and registers the block type(s)
+ * based on the registered block metadata. Behind the scenes, it registers also all assets so they can be enqueued
  * through the block editor in the corresponding context.
  *
- * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ * @see https://make.wordpress.org/core/2025/03/13/more-efficient-block-type-registration-in-6-8/
+ * @see https://make.wordpress.org/core/2024/10/17/new-block-type-registration-apis-to-improve-performance-in-wordpress-6-7/
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
-	register_block_type_from_metadata( __DIR__ . '/build' );
+	wp_register_block_types_from_metadata_collection( __DIR__ . '/build', __DIR__ . '/build/blocks-manifest.php' );
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
## What?

  Closes https://github.com/WordPress/gutenberg/issues/74701

  Updates `@wordpress/create-block-interactive-template` to use `wp_register_block_types_from_metadata_collection()` for block registration.

  ## Why?

  The interactive template still used the legacy `register_block_type_from_metadata()`, while the main `create-block` template already uses the efficient registration APIs from WordPress 6.8.

  ## How?

  - **`$slug.php.mustache`** — Replaced `register_block_type_from_metadata()` with `wp_register_block_types_from_metadata_collection()`.
  - **`index.js`** — Added `--blocks-manifest` to custom build/start scripts so `blocks-manifest.php` gets generated.
  - **`index.js`** — Added `folderName: './src/$slug'` so the build output uses the correct directory structure for the manifest.

  ## Testing Instructions

  1. Scaffold a block: `npx @wordpress/create-block@latest --template ./packages/create-block-interactive-template`
  2. `cd` into the plugin, run `npm run build`
  3. Verify `build/<slug>/blocks-manifest.php` exists with the correct block slug as key
  4. Activate in WP 6.8+ and confirm the block works in the editor