### PR TITLE
Core Data: Treat single-item responses specially

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1122,6 +1122,7 @@ export const receiveRevisions =
 			type: 'RECEIVE_ITEM_REVISIONS',
 			key,
 			items: Array.isArray( records ) ? records : [ records ],
+			singleItem: ! Array.isArray( records ),
 			recordKey,
 			meta,
 			query,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -26,6 +26,10 @@ import {
 } from './sync';
 import logEntityDeprecation from './utils/log-entity-deprecation';
 
+function addTitleToAutoDraft( record ) {
+	return record.status === 'auto-draft' ? { ...record, title: '' } : record;
+}
+
 /**
  * Returns an action object used in signalling that authors have been received.
  * Ignored from documentation as it's internal to the data store.
@@ -100,11 +104,9 @@ export function receiveEntityRecords(
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
 	if ( kind === 'postType' ) {
-		const mapAutoDraft = ( record ) =>
-			record.status === 'auto-draft' ? { ...record, title: '' } : record;
 		records = Array.isArray( records )
-			? records.map( mapAutoDraft )
-			: mapAutoDraft( records );
+			? records.map( addTitleToAutoDraft )
+			: addTitleToAutoDraft( records );
 	}
 	let action;
 	if ( query ) {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -100,12 +100,11 @@ export function receiveEntityRecords(
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
 	if ( kind === 'postType' ) {
-		records = ( Array.isArray( records ) ? records : [ records ] ).map(
-			( record ) =>
-				record.status === 'auto-draft'
-					? { ...record, title: '' }
-					: record
-		);
+		const mapAutoDraft = ( record ) =>
+			record.status === 'auto-draft' ? { ...record, title: '' } : record;
+		records = Array.isArray( records )
+			? records.map( mapAutoDraft )
+			: mapAutoDraft( records );
 	}
 	let action;
 	if ( query ) {
@@ -1121,8 +1120,7 @@ export const receiveRevisions =
 		dispatch( {
 			type: 'RECEIVE_ITEM_REVISIONS',
 			key,
-			items: Array.isArray( records ) ? records : [ records ],
-			singleItem: ! Array.isArray( records ),
+			items: records,
 			recordKey,
 			meta,
 			query,

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -103,7 +103,7 @@ export const editMediaEntity =
 					dispatch.receiveEntityRecords(
 						kind,
 						name,
-						[ newRecord ],
+						newRecord,
 						undefined,
 						true,
 						undefined,

--- a/packages/core-data/src/queried-data/actions.js
+++ b/packages/core-data/src/queried-data/actions.js
@@ -10,8 +10,7 @@
 export function receiveItems( items, edits, meta ) {
 	return {
 		type: 'RECEIVE_ITEMS',
-		items: Array.isArray( items ) ? items : [ items ],
-		singleItem: ! Array.isArray( items ),
+		items,
 		persistedEdits: edits,
 		meta,
 	};

--- a/packages/core-data/src/queried-data/actions.js
+++ b/packages/core-data/src/queried-data/actions.js
@@ -11,6 +11,7 @@ export function receiveItems( items, edits, meta ) {
 	return {
 		type: 'RECEIVE_ITEMS',
 		items: Array.isArray( items ) ? items : [ items ],
+		singleItem: ! Array.isArray( items ),
 		persistedEdits: edits,
 		meta,
 	};

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -240,7 +240,7 @@ const receiveQueries = compose( [
 		return state;
 	}
 
-	const key = action.key || DEFAULT_ENTITY_KEY;
+	const key = action.key ?? DEFAULT_ENTITY_KEY;
 
 	return {
 		itemIds: getMergedItemIds(

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -105,22 +105,22 @@ export function items( state = {}, action ) {
 		case 'RECEIVE_ITEMS': {
 			const context = getContextFromAction( action );
 			const key = action.key || DEFAULT_ENTITY_KEY;
-			const actionItems = Array.isArray( action.items )
+			const itemsList = Array.isArray( action.items )
 				? action.items
 				: [ action.items ];
 			return {
 				...state,
 				[ context ]: {
 					...state[ context ],
-					...actionItems.reduce( ( accumulator, value ) => {
-						const itemId = value?.[ key ];
-
-						accumulator[ itemId ] = conservativeMapItem(
-							state?.[ context ]?.[ itemId ],
-							value
-						);
-						return accumulator;
-					}, {} ),
+					...Object.fromEntries(
+						itemsList.map( ( item ) => [
+							item?.[ key ],
+							conservativeMapItem(
+								state?.[ context ]?.[ item?.[ key ] ],
+								item
+							),
+						] )
+					),
 				},
 			};
 		}
@@ -152,7 +152,7 @@ export function itemIsComplete( state = {}, action ) {
 		case 'RECEIVE_ITEMS': {
 			const context = getContextFromAction( action );
 			const { query, key = DEFAULT_ENTITY_KEY } = action;
-			const actionItems = Array.isArray( action.items )
+			const itemsList = Array.isArray( action.items )
 				? action.items
 				: [ action.items ];
 
@@ -170,7 +170,7 @@ export function itemIsComplete( state = {}, action ) {
 				...state,
 				[ context ]: {
 					...state[ context ],
-					...actionItems.reduce( ( result, item ) => {
+					...itemsList.reduce( ( result, item ) => {
 						const itemId = item?.[ key ];
 
 						// Defer to completeness if already assigned. Technically the
@@ -238,12 +238,12 @@ const receiveQueries = compose( [
 		return state;
 	}
 
+	const key = action.key || DEFAULT_ENTITY_KEY;
+
 	return {
 		itemIds: getMergedItemIds(
 			state?.itemIds || [],
-			action.items
-				.map( ( item ) => item?.[ action.key ?? DEFAULT_ENTITY_KEY ] )
-				.filter( Boolean ),
+			action.items.map( ( item ) => item?.[ key ] ).filter( Boolean ),
 			action.page,
 			action.perPage
 		),

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -234,6 +234,8 @@ const receiveQueries = compose( [
 		return state;
 	}
 
+	// Single items don't have page or total count metadata
+	// (only collection query responses do), so skip updating itemIds.
 	if ( ! Array.isArray( action.items ) ) {
 		return state;
 	}

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -224,18 +224,22 @@ const receiveQueries = compose( [
 	// reducer tracks only a single query object.
 	onSubKey( 'stableKey' ),
 ] )( ( state = {}, action ) => {
-	const { type, page, perPage, key = DEFAULT_ENTITY_KEY } = action;
+	if ( action.type !== 'RECEIVE_ITEMS' ) {
+		return state;
+	}
 
-	if ( type !== 'RECEIVE_ITEMS' ) {
+	if ( action.singleItem ) {
 		return state;
 	}
 
 	return {
 		itemIds: getMergedItemIds(
 			state?.itemIds || [],
-			action.items.map( ( item ) => item?.[ key ] ).filter( Boolean ),
-			page,
-			perPage
+			action.items
+				.map( ( item ) => item?.[ action.key ?? DEFAULT_ENTITY_KEY ] )
+				.filter( Boolean ),
+			action.page,
+			action.perPage
 		),
 		meta: action.meta,
 	};

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -105,11 +105,14 @@ export function items( state = {}, action ) {
 		case 'RECEIVE_ITEMS': {
 			const context = getContextFromAction( action );
 			const key = action.key || DEFAULT_ENTITY_KEY;
+			const actionItems = Array.isArray( action.items )
+				? action.items
+				: [ action.items ];
 			return {
 				...state,
 				[ context ]: {
 					...state[ context ],
-					...action.items.reduce( ( accumulator, value ) => {
+					...actionItems.reduce( ( accumulator, value ) => {
 						const itemId = value?.[ key ];
 
 						accumulator[ itemId ] = conservativeMapItem(
@@ -149,6 +152,9 @@ export function itemIsComplete( state = {}, action ) {
 		case 'RECEIVE_ITEMS': {
 			const context = getContextFromAction( action );
 			const { query, key = DEFAULT_ENTITY_KEY } = action;
+			const actionItems = Array.isArray( action.items )
+				? action.items
+				: [ action.items ];
 
 			// An item is considered complete if it is received without an associated
 			// fields query. Ideally, this would be implemented in such a way where the
@@ -164,7 +170,7 @@ export function itemIsComplete( state = {}, action ) {
 				...state,
 				[ context ]: {
 					...state[ context ],
-					...action.items.reduce( ( result, item ) => {
+					...actionItems.reduce( ( result, item ) => {
 						const itemId = item?.[ key ];
 
 						// Defer to completeness if already assigned. Technically the
@@ -228,7 +234,7 @@ const receiveQueries = compose( [
 		return state;
 	}
 
-	if ( action.singleItem ) {
+	if ( ! Array.isArray( action.items ) ) {
 		return state;
 	}
 

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -214,8 +214,11 @@ function entity( entityConfig ) {
 						}
 
 						const nextState = { ...state };
+						const actionItems = Array.isArray( action.items )
+							? action.items
+							: [ action.items ];
 
-						for ( const record of action.items ) {
+						for ( const record of actionItems ) {
 							const recordId = record?.[ action.key ];
 							const edits = nextState[ recordId ];
 							if ( ! edits ) {

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -214,11 +214,11 @@ function entity( entityConfig ) {
 						}
 
 						const nextState = { ...state };
-						const actionItems = Array.isArray( action.items )
+						const itemsList = Array.isArray( action.items )
 							? action.items
 							: [ action.items ];
 
-						for ( const record of actionItems ) {
+						for ( const record of itemsList ) {
 							const recordId = record?.[ action.key ];
 							const edits = nextState[ recordId ];
 							if ( ! edits ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -991,9 +991,11 @@ export const getDefaultTemplateId =
 			template.id = id;
 			registry.batch( () => {
 				dispatch.receiveDefaultTemplateId( query, id );
-				dispatch.receiveEntityRecords( 'postType', template.type, [
-					template,
-				] );
+				dispatch.receiveEntityRecords(
+					'postType',
+					template.type,
+					template
+				);
 				// Avoid further network requests.
 				dispatch.finishResolution( 'getEntityRecord', [
 					'postType',

--- a/packages/core-data/src/test/private-actions.js
+++ b/packages/core-data/src/test/private-actions.js
@@ -102,7 +102,7 @@ describe( 'editMediaEntity', () => {
 		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
 			'postType',
 			'attachment',
-			[ updatedRecord ],
+			updatedRecord,
 			undefined,
 			true,
 			undefined,

--- a/packages/core-data/src/test/store.js
+++ b/packages/core-data/src/test/store.js
@@ -181,7 +181,7 @@ describe( 'getEntityRecords', () => {
 		const allPosts = registry
 			.select( coreDataStore )
 			.getEntityRecords( 'postType', 'post', { context: 'edit' } );
-		expect( allPosts ).toHaveLength( POSTS.length );
+		expect( allPosts.map( ( p ) => p.id ) ).toEqual( [ 1, 2, 3 ] );
 	} );
 
 	it( 'preserves collection when getEntityRecord is called after getEntityRecords', async () => {
@@ -225,7 +225,7 @@ describe( 'getEntityRecords', () => {
 		const allPosts = registry
 			.select( coreDataStore )
 			.getEntityRecords( 'postType', 'post', { context: 'edit' } );
-		expect( allPosts ).toHaveLength( POSTS.length );
+		expect( allPosts.map( ( p ) => p.id ) ).toEqual( [ 1, 2, 3 ] );
 	} );
 } );
 

--- a/packages/core-data/src/test/store.js
+++ b/packages/core-data/src/test/store.js
@@ -113,6 +113,122 @@ describe( 'getEntityRecord', () => {
 	} );
 } );
 
+describe( 'getEntityRecords', () => {
+	const POSTS = [
+		createTestPost( 1 ),
+		createTestPost( 2 ),
+		createTestPost( 3 ),
+	];
+
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		triggerFetch.mockReset();
+	} );
+
+	it( 'preserves collection when getEntityRecord resolves after getEntityRecords', async () => {
+		let resolveSlowFetch;
+		const slowFetchPromise = new Promise( ( resolve ) => {
+			resolveSlowFetch = resolve;
+		} );
+
+		triggerFetch.mockImplementation( ( { path } ) => {
+			// Single post fetch (e.g. /wp/v2/posts/1): return slow promise.
+			if ( /\/wp\/v2\/posts\/\d+/.test( path ) ) {
+				return slowFetchPromise;
+			}
+			// Collection fetch: return immediately.
+			return Promise.resolve( {
+				json: () => Promise.resolve( POSTS ),
+				headers: {
+					get: ( header ) => {
+						if ( header === 'X-WP-Total' ) {
+							return String( POSTS.length );
+						}
+						if ( header === 'X-WP-TotalPages' ) {
+							return '1';
+						}
+						return null;
+					},
+				},
+			} );
+		} );
+
+		const resolveSelectStore = registry.resolveSelect( coreDataStore );
+
+		// Start getEntityRecord first (slow), then getEntityRecords (fast).
+		const singlePromise = resolveSelectStore.getEntityRecord(
+			'postType',
+			'post',
+			1,
+			{ context: 'edit' }
+		);
+		await resolveSelectStore.getEntityRecords( 'postType', 'post', {
+			context: 'edit',
+		} );
+
+		// Now resolve the slow single-record fetch.
+		resolveSlowFetch( {
+			json: () => Promise.resolve( POSTS[ 0 ] ),
+			headers: { get: () => null },
+		} );
+		await singlePromise;
+
+		// Wait for all pending thunks to settle.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		const allPosts = registry
+			.select( coreDataStore )
+			.getEntityRecords( 'postType', 'post', { context: 'edit' } );
+		expect( allPosts ).toHaveLength( POSTS.length );
+	} );
+
+	it( 'preserves collection when getEntityRecord is called after getEntityRecords', async () => {
+		triggerFetch.mockImplementation( ( { path } ) => {
+			// Collection fetch.
+			if ( ! /\/wp\/v2\/posts\/\d+/.test( path ) ) {
+				return Promise.resolve( {
+					json: () => Promise.resolve( POSTS ),
+					headers: {
+						get: ( header ) => {
+							if ( header === 'X-WP-Total' ) {
+								return String( POSTS.length );
+							}
+							if ( header === 'X-WP-TotalPages' ) {
+								return '1';
+							}
+							return null;
+						},
+					},
+				} );
+			}
+			// Single post fetch.
+			return Promise.resolve( {
+				json: () => Promise.resolve( POSTS[ 0 ] ),
+				headers: { get: () => null },
+			} );
+		} );
+
+		const resolveSelectStore = registry.resolveSelect( coreDataStore );
+
+		// First resolve the collection.
+		await resolveSelectStore.getEntityRecords( 'postType', 'post', {
+			context: 'edit',
+		} );
+
+		// Then resolve a single record.
+		await resolveSelectStore.getEntityRecord( 'postType', 'post', 1, {
+			context: 'edit',
+		} );
+
+		const allPosts = registry
+			.select( coreDataStore )
+			.getEntityRecords( 'postType', 'post', { context: 'edit' } );
+		expect( allPosts ).toHaveLength( POSTS.length );
+	} );
+} );
+
 describe( 'clearEntityRecordEdits', () => {
 	let registry;
 


### PR DESCRIPTION
## What?
Extracted from #76043. Props to @jsnajdr!

PR fixes a bug where receiving a single-entity item could override or corrupt the entire collection.

* Moves data normalization into reducers.
* Doesn't change `queries.itemIds` unless we're dealing with collections.

## Why?
See https://github.com/WordPress/gutenberg/pull/76043#issuecomment-4022943292.

## Testing Instructions
I've included basic integration tests, happy to include more.

### Testing Instructions for Keyboard
Same.