### PR TITLE
Fix: Document Bar: Back button flickers

### DIFF
--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -25,7 +25,7 @@
 		border-radius: $grid-unit-05;
 
 		@media not (prefers-reduced-motion) {
-			transition: all 0.1s ease-out;
+			transition: background-color 0.1s ease-out;
 		}
 
 		&:hover {
@@ -103,10 +103,6 @@
 	gap: 0;
 	z-index: 1;
 	position: absolute;
-
-	@media not (prefers-reduced-motion) {
-		transition: color 0.1s ease-out, background-color 0.1s ease-out;
-	}
 
 	&:hover {
 		color: $gray-900;

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -104,6 +104,10 @@
 	z-index: 1;
 	position: absolute;
 
+	@media not (prefers-reduced-motion) {
+		transition: color 0.1s ease-out, background-color 0.1s ease-out;
+	}
+
 	&:hover {
 		color: $gray-900;
 		background-color: transparent;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76279 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR fixes the button flicker issue.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Detailed comment here - https://github.com/WordPress/gutenberg/issues/76279#issuecomment-4023620930

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open page/post.
2. Create a normal and synced pattern.
3. Edit the patterns.
4. Check back button, it should have smooth animation.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

## Synced Pattern

https://github.com/user-attachments/assets/524f2bb3-4908-4b86-92a4-03749494605e

## Content-Only pattern

https://github.com/user-attachments/assets/932fb2eb-9fc9-44ab-b813-141fb4e616cf
