### PR TITLE
RTC: Remove post list lock icon and replace user-specific lock text

### DIFF
--- a/backport-changelog/7.0/11234.md
+++ b/backport-changelog/7.0/11234.md
@@ -1,3 +1,3 @@
 https://github.com/WordPress/wordpress-develop/pull/11234
 
-*  https://github.com/WordPress/gutenberg/pull/76322
+* https://github.com/WordPress/gutenberg/pull/76322

--- a/backport-changelog/7.0/11234.md
+++ b/backport-changelog/7.0/11234.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11234
+
+*  https://github.com/WordPress/gutenberg/pull/76322

--- a/backport-changelog/7.1/11234.md
+++ b/backport-changelog/7.1/11234.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/11234
-
-* https://github.com/WordPress/gutenberg/pull/76322

--- a/backport-changelog/7.1/11234.md
+++ b/backport-changelog/7.1/11234.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11234
+
+* https://github.com/WordPress/gutenberg/pull/76322

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -163,3 +163,157 @@ function gutenberg_inject_real_time_collaboration_setting() {
 }
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' );
+
+/**
+ * Modifies the post list UI and heartbeat responses for real-time collaboration.
+ *
+ * When RTC is enabled, hides the lock icon and user avatar, replaces the
+ * user-specific lock text with "Currently being edited", changes the "Edit"
+ * row action to "Join", and re-enables controls that core normally hides
+ * for locked posts (since collaborative editing is possible).
+ */
+function gutenberg_post_list_collaboration_ui() {
+	global $pagenow;
+
+	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
+		return;
+	}
+
+	// Heartbeat filter applies globally (not just edit.php) since the
+	// heartbeat API can fire from any admin page.
+	add_filter( 'heartbeat_received', 'gutenberg_filter_locked_posts_heartbeat_for_rtc', 20 );
+
+	// CSS, JS, and row action overrides only apply on the posts list page.
+	if ( 'edit.php' !== $pagenow ) {
+		return;
+	}
+
+	add_action( 'admin_head', 'gutenberg_post_list_collaboration_styles' );
+	add_action( 'admin_footer', 'gutenberg_post_list_collaboration_scripts' );
+	add_filter( 'post_row_actions', 'gutenberg_post_list_collaboration_row_actions', 10, 2 );
+	add_filter( 'page_row_actions', 'gutenberg_post_list_collaboration_row_actions', 10, 2 );
+}
+add_action( 'admin_init', 'gutenberg_post_list_collaboration_ui' );
+
+/**
+ * Filters the heartbeat response to remove user-specific lock information
+ * when real-time collaboration is enabled.
+ *
+ * WordPress core's wp_check_locked_posts() runs at priority 10 and populates
+ * the 'wp-check-locked-posts' key with user name, avatar, and text. This
+ * filter runs at priority 20 to replace that data with a generic message,
+ * preventing user-specific lock info from reaching the client.
+ *
+ * @param array $response The heartbeat response.
+ * @return array Modified heartbeat response.
+ */
+function gutenberg_filter_locked_posts_heartbeat_for_rtc( $response ) {
+	if ( ! empty( $response['wp-check-locked-posts'] ) ) {
+		foreach ( $response['wp-check-locked-posts'] as $key => $lock_data ) {
+			$response['wp-check-locked-posts'][ $key ]['text'] = __( 'Currently being edited', 'gutenberg' );
+			unset( $response['wp-check-locked-posts'][ $key ]['avatar_src'] );
+			unset( $response['wp-check-locked-posts'][ $key ]['avatar_src_2x'] );
+		}
+	}
+
+	return $response;
+}
+
+/**
+ * Outputs CSS to hide the post lock icon and user avatar in the post list
+ * when real-time collaboration is enabled.
+ *
+ * Also re-enables checkboxes and row actions that WordPress core hides for
+ * locked posts, since collaborative editing means the post is not exclusively
+ * locked.
+ */
+function gutenberg_post_list_collaboration_styles() {
+	?>
+	<style type="text/css">
+		/*
+		 * Hide the lock indicator icon in the checkbox column.
+		 * WordPress core shows it via .wp-locked .locked-indicator { display: block },
+		 * so we match that specificity to override it.
+		 */
+		.wp-locked .locked-indicator {
+			display: none;
+		}
+		/* Hide the user avatar in the locked info area. */
+		.wp-locked .locked-info .locked-avatar {
+			display: none;
+		}
+		/*
+		 * Re-enable controls that core hides for locked posts,
+		 * since RTC allows collaborative editing.
+		 */
+		.wp-locked .check-column label,
+		.wp-locked .check-column input[type="checkbox"] {
+			display: revert;
+		}
+		.wp-locked .row-actions .inline {
+			display: revert;
+		}
+	</style>
+	<?php
+}
+
+/**
+ * Outputs JavaScript to replace the user-specific lock text with a generic
+ * "Currently being edited" message on initial page render.
+ *
+ * The heartbeat filter handles dynamic updates server-side, but the initial
+ * page render contains user-specific text from WordPress core's PHP output
+ * that must be replaced client-side.
+ */
+function gutenberg_post_list_collaboration_scripts() {
+	$locked_text      = __( 'Currently being edited', 'gutenberg' );
+	$locked_text_json = wp_json_encode( $locked_text, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	?>
+	<script type="text/javascript">
+		( function() {
+			var lockedText = <?php echo $locked_text_json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode with HEX flags is safe. ?>;
+
+			function updateLockedText() {
+				document.querySelectorAll( '.locked-text' ).forEach( function( el ) {
+					el.textContent = lockedText;
+				} );
+			}
+
+			if ( document.readyState === 'loading' ) {
+				document.addEventListener( 'DOMContentLoaded', updateLockedText );
+			} else {
+				updateLockedText();
+			}
+		} )();
+	</script>
+	<?php
+}
+
+/**
+ * Filters post row actions to change "Edit" to "Join" for locked posts
+ * when real-time collaboration is enabled.
+ *
+ * @param string[] $actions An array of row action links.
+ * @param WP_Post  $post    The post object.
+ * @return string[] Modified row action links.
+ */
+function gutenberg_post_list_collaboration_row_actions( $actions, $post ) {
+	if ( ! function_exists( 'wp_check_post_lock' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/post.php';
+	}
+
+	$lock_holder = wp_check_post_lock( $post->ID );
+	if ( ! $lock_holder ) {
+		return $actions;
+	}
+
+	if ( isset( $actions['edit'] ) ) {
+		$actions['edit'] = preg_replace(
+			'/>Edit</',
+			'>' . esc_html__( 'Join', 'gutenberg' ) . '<',
+			$actions['edit']
+		);
+	}
+
+	return $actions;
+}

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -189,7 +189,7 @@ function gutenberg_post_list_collaboration_ui() {
 	}
 
 	add_action( 'admin_head', 'gutenberg_post_list_collaboration_styles' );
-	add_action( 'admin_footer', 'gutenberg_post_list_collaboration_scripts' );
+	add_filter( 'gettext', 'gutenberg_filter_locked_post_text_for_rtc', 10, 3 );
 	add_filter( 'post_row_actions', 'gutenberg_post_list_collaboration_row_actions', 10, 2 );
 	add_filter( 'page_row_actions', 'gutenberg_post_list_collaboration_row_actions', 10, 2 );
 }
@@ -258,35 +258,25 @@ function gutenberg_post_list_collaboration_styles() {
 }
 
 /**
- * Outputs JavaScript to replace the user-specific lock text with a generic
- * "Currently being edited" message on initial page render.
+ * Filters the translation of the lock text to replace user-specific
+ * "%s is currently editing" with a generic "Currently being edited"
+ * message on initial page render.
  *
- * The heartbeat filter handles dynamic updates server-side, but the initial
- * page render contains user-specific text from WordPress core's PHP output
- * that must be replaced client-side.
+ * WordPress core outputs this text server-side in WP_Posts_List_Table.
+ * Using a gettext filter replaces it before it reaches the browser,
+ * avoiding a flash of the original text.
+ *
+ * @param string $translation Translated text.
+ * @param string $text        Original text to translate.
+ * @param string $domain      Text domain.
+ * @return string Modified translation.
  */
-function gutenberg_post_list_collaboration_scripts() {
-	$locked_text      = __( 'Currently being edited', 'gutenberg' );
-	$locked_text_json = wp_json_encode( $locked_text, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
-	?>
-	<script type="text/javascript">
-		( function() {
-			var lockedText = <?php echo $locked_text_json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode with HEX flags is safe. ?>;
+function gutenberg_filter_locked_post_text_for_rtc( $translation, $text, $domain ) {
+	if ( 'default' === $domain && '%s is currently editing' === $text ) {
+		return __( 'Currently being edited', 'gutenberg' );
+	}
 
-			function updateLockedText() {
-				document.querySelectorAll( '.locked-text' ).forEach( function( el ) {
-					el.textContent = lockedText;
-				} );
-			}
-
-			if ( document.readyState === 'loading' ) {
-				document.addEventListener( 'DOMContentLoaded', updateLockedText );
-			} else {
-				updateLockedText();
-			}
-		} )();
-	</script>
-	<?php
+	return $translation;
 }
 
 /**


### PR DESCRIPTION
## What?

Closes #75313

When RTC is enabled, the post list should not show an exclusive lock icon or user-specific lock text since multiple users can collaboratively edit the same post.

## Why?

With real-time collaboration, users can edit posts simultaneously. The current lock icon and "{user} is currently editing" text imply exclusive locking semantics that no longer apply. The MVP is to show a generic "Currently being edited" message instead.

## How?

- **Heartbeat filter** (priority 20): Modifies WordPress core's `wp_check_locked_posts` response to replace user-specific data with a generic message before it reaches the client
- **CSS injection**: Hides the lock icon (`.locked-indicator`) and user avatar (`.locked-avatar`), and re-enables checkboxes/actions on locked rows
- **JS injection**: Replaces the initial page render lock text with "Currently being edited"
- **Row actions filter**: Changes "Edit" to "Join" for locked posts
- **Consistent pattern**: Follows best practices from concurrent PR #76255, using `wp_json_encode()` with HEX flags and coordinator pattern

## Testing Instructions

1. Enable RTC (Settings > Writing > Collaboration checkbox)
2. Open a post/page in one browser tab or as a different user to create a lock
3. In another browser/tab, navigate to the Posts or Pages list
4. Verify:
   - No padlock icon appears
   - No user avatar appears
   - Lock status text says "Currently being edited"
   - The "Edit" link text says "Join"
5. Wait for a heartbeat cycle (~10s) and verify text is not overwritten
6. Disable RTC and verify classic lock behavior is unchanged

### Testing Instructions for Keyboard

All changes are visual/UI. Test with keyboard navigation:
1. Tab through the post list
2. Verify the "Join" link is focusable and functional
3. Verify checkboxes remain functional for locked posts

---

💡 Combines best practices from both our approach and concurrent PR #76255 for robust, maintainable RTC lock UI handling.