### PR TITLE
Fix: Block pseudo-state styles incorrectly applied to default state

### DIFF
--- a/backport-changelog/7.1/11226.md
+++ b/backport-changelog/7.1/11226.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11226
+
+* https://github.com/WordPress/gutenberg/pull/76326

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3217,22 +3217,6 @@ class WP_Theme_JSON_Gutenberg {
 			$element_pseudo_allowed = static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ];
 		}
 
-		/*
-		 * Check if we're processing a block pseudo-selector.
-		 * $block_metadata['path'] = array( 'styles', 'blocks', 'core/button', ':hover' );
-		 */
-		$is_processing_block_pseudo = false;
-		$block_pseudo_selector      = null;
-		if ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 4 ) {
-			$block_name        = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
-			$last_path_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ]; // ':hover'
-
-			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) &&
-				in_array( $last_path_element, static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ], true ) ) {
-				$is_processing_block_pseudo = true;
-				$block_pseudo_selector      = $last_path_element;
-			}
-		}
 
 		/*
 		 * Check for allowed pseudo classes (e.g. ":hover") from the $selector ("a:hover").

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3041,7 +3041,7 @@ class WP_Theme_JSON_Gutenberg {
 							 * default state (e.g. '.wp-block-button').
 							 */
 							$pseudo_feature_selectors = array();
-							foreach ( $feature_selectors as $feature => $feature_selector ) {
+							foreach ( $feature_selectors ?? array() as $feature => $feature_selector ) {
 								if ( is_array( $feature_selector ) ) {
 									$pseudo_feature_selectors[ $feature ] = array();
 									foreach ( $feature_selector as $subfeature => $subfeature_selector ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3034,11 +3034,29 @@ class WP_Theme_JSON_Gutenberg {
 				if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] ) ) {
 					foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] as $pseudo_selector ) {
 						if ( isset( $theme_json['styles']['blocks'][ $name ][ $pseudo_selector ] ) ) {
+							/*
+							 * Append the pseudo-selector to each feature selector so that
+							 * get_feature_declarations_for_node generates CSS scoped to the
+							 * pseudo-state (e.g. '.wp-block-button:hover') rather than the
+							 * default state (e.g. '.wp-block-button').
+							 */
+							$pseudo_feature_selectors = array();
+							foreach ( $feature_selectors as $feature => $feature_selector ) {
+								if ( is_array( $feature_selector ) ) {
+									$pseudo_feature_selectors[ $feature ] = array();
+									foreach ( $feature_selector as $subfeature => $subfeature_selector ) {
+										$pseudo_feature_selectors[ $feature ][ $subfeature ] = static::append_to_selector( $subfeature_selector, $pseudo_selector );
+									}
+								} else {
+									$pseudo_feature_selectors[ $feature ] = static::append_to_selector( $feature_selector, $pseudo_selector );
+								}
+							}
+
 							$nodes[] = array(
 								'name'       => $name,
 								'path'       => array( 'styles', 'blocks', $name, $pseudo_selector ),
 								'selector'   => static::append_to_selector( $selector, $pseudo_selector ),
-								'selectors'  => $feature_selectors,
+								'selectors'  => $pseudo_feature_selectors,
 								'duotone'    => $duotone_selector,
 								'variations' => $variation_selectors,
 								'css'        => static::append_to_selector( $selector, $pseudo_selector ),
@@ -3245,15 +3263,12 @@ class WP_Theme_JSON_Gutenberg {
 			&& in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ], true )
 		) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, $this->theme_json, $selector, $use_root_padding );
-		} elseif ( $is_processing_block_pseudo ) {
-			// Process block pseudo-selector styles.
-			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector.
-			$block_name  = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
-			$block_data  = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
-			$pseudo_data = $block_data[ $block_pseudo_selector ] ?? array();
-
-			$declarations = static::compute_style_properties( $pseudo_data, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} else {
+			/*
+			 * For block pseudo-selector nodes (e.g. ':hover'), $node has already had any
+			 * feature-selector properties (e.g. writingMode) removed by get_feature_declarations_for_node,
+			 * so those properties are not output twice.
+			 */
 			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3217,7 +3217,6 @@ class WP_Theme_JSON_Gutenberg {
 			$element_pseudo_allowed = static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ];
 		}
 
-
 		/*
 		 * Check for allowed pseudo classes (e.g. ":hover") from the $selector ("a:hover").
 		 * This also resets the array keys.

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1424,8 +1424,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		// writing-mode should be scoped to :hover, not the root block selector.
 		$this->assertStringContainsString( '.wp-block-button:hover', $css );
-		$this->assertStringNotContainsString( ':where(.wp-block-button){writing-mode', $css );
-		$this->assertStringNotContainsString( ':where(.wp-block-button) {writing-mode', $css );
 		$this->assertSameCSS( ':root :where(.wp-block-button:hover){writing-mode: vertical-rl;}', $css );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1395,6 +1395,40 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
+	/**
+	 * Tests that when a block with a custom feature selector (e.g. core/button's writingMode
+	 * uses '.wp-block-button' rather than the root '.wp-block-button .wp-block-button__link')
+	 * has pseudo-state styles, the feature selector CSS is scoped to the pseudo-state and not
+	 * output under the block's default-state selector.
+	 */
+	public function test_get_stylesheet_pseudo_selector_scopes_feature_selector_css() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/button' => array(
+							':hover' => array(
+								'typography' => array(
+									'writingMode' => 'vertical-rl',
+								),
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$css = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+
+		// writing-mode should be scoped to :hover, not the root block selector.
+		$this->assertStringContainsString( '.wp-block-button:hover', $css );
+		$this->assertStringNotContainsString( ':where(.wp-block-button){writing-mode', $css );
+		$this->assertStringNotContainsString( ':where(.wp-block-button) {writing-mode', $css );
+		$this->assertSameCSS( ':root :where(.wp-block-button:hover){writing-mode: vertical-rl;}', $css );
+	}
+
 	public function test_get_stylesheet_custom_root_selector() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

  When a block defines a custom feature selector in its `block.json` (e.g. `core/button` uses `.wp-block-button` for `writingMode` rather than the root `.wp-block-button .wp-block-button__link`), styles  set on a pseudo-state like `:hover` via theme.json were being output under the default-state selector instead of the pseudo-state selector.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This bug will become more apparent when there's a UI to change the state of the button block after https://github.com/WordPress/gutenberg/pull/75627 lands. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 In get_block_nodes, the metadata node for a block pseudo-state was built with the original $feature_selectors (e.g. .wp-block-button) rather than the pseudo-scoped version (e.g. .wp-block-button:hover). The fix builds a $pseudo_feature_selectors array that appends the pseudo-selector to every feature selector string before the node is created.

We have added a test to catch this problem should there be a regression

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add writing mode to a button block on hover on theme.json, check the frontend and you will see the CSS generated:

Before:
  `:root :where(.wp-block-button) { writing-mode: vertical-rl; }`

After:
  `:root :where(.wp-block-button:hover) { writing-mode: vertical-rl; }`

The unit tests should all pass too