### PR TITLE
Check for `IS_WORDPRESS_CORE` before `npm_package_config_IS_WORDPRESS_CORE`

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1801,9 +1801,9 @@ async function buildAll( baseUrlExpression ) {
 	} );
 
 	// When building for WordPress Core, exclude experimental pages.
-	const isCoreBuild = Boolean(
-		process.env.npm_package_config_IS_WORDPRESS_CORE
-	);
+	const isCoreBuild =
+		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ||
+		boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE );
 	const activePages = isCoreBuild
 		? normalizedPages.filter( ( page ) => ! page.experimental )
 		: normalizedPages;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In #76038, code was added to exclude experimental pages when building for WordPress Core.

The code merged in #75844 did not adjust this code to detect the environment variable `IS_WORDPRESS_CORE` before `npm_package_config_IS_WORDPRESS_CORE`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
This ensures that the environment variable it can be easily set through a CI workflow.
