### PR TITLE
Add `fetchpriority=low` to `IMG` tags in collapsed Accordion Item blocks

### DIFF
--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -6,13 +6,12 @@
  * @package WordPress
  * @since 6.9.0
  *
- * @param array $attributes The block attributes.
- * @param string $content The block content.
- *
+ * @param array{ openByDefault: bool } $attributes The block attributes.
+ * @param string                        $content   The block content.
  * @return string Returns the updated markup.
  */
-function block_core_accordion_item_render( $attributes, $content ) {
-	if ( ! $content ) {
+function block_core_accordion_item_render( array $attributes, string $content ): string {
+	if ( '' === $content ) {
 		return $content;
 	}
 
@@ -53,6 +52,20 @@ function block_core_accordion_item_render( $attributes, $content ) {
 				$content = $p->get_updated_html();
 			}
 		}
+	}
+
+	/*
+	 * If an Accordion Item is collapsed by default, ensure any contained IMG has fetchpriority=low to deprioritize it
+	 * from contending with resources in the critical rendering path. In contrast, remove the loading attribute to
+	 * prevent the image from not being available when the item is expanded.
+	 */
+	if ( ! $attributes['openByDefault'] ) {
+		$processor = new WP_HTML_Tag_Processor( $content );
+		while ( $processor->next_tag( 'IMG' ) ) {
+			$processor->set_attribute( 'fetchpriority', 'low' );
+			$processor->remove_attribute( 'loading' );
+		}
+		$content = $processor->get_updated_html();
 	}
 
 	return $content;

--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -63,7 +63,6 @@ function block_core_accordion_item_render( array $attributes, string $content ):
 		$processor = new WP_HTML_Tag_Processor( $content );
 		while ( $processor->next_tag( 'IMG' ) ) {
 			$processor->set_attribute( 'fetchpriority', 'low' );
-			$processor->remove_attribute( 'loading' );
 		}
 		$content = $processor->get_updated_html();
 	}

--- a/phpunit/blocks/render-block-accordion-test.php
+++ b/phpunit/blocks/render-block-accordion-test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Accordion block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Accordion block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Accordion extends WP_UnitTestCase {
+
+	/**
+	 * Tests Accordion with two items, both closed by default.
+	 *
+	 * @covers ::block_core_accordion_item_render
+	 */
+	public function test_should_add_fetchpriority_low_to_img_in_collapsed_accordion_block(): void {
+		$accordion_block = <<<'BLOCK_CONTENT'
+			<!-- wp:accordion -->
+			<div role="group" class="wp-block-accordion"><!-- wp:accordion-item -->
+			<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
+			<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">First Image</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+			<!-- /wp:accordion-heading -->
+
+			<!-- wp:accordion-panel -->
+			<div role="region" class="wp-block-accordion-panel"><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt=""/></figure>
+			<!-- /wp:image --></div>
+			<!-- /wp:accordion-panel --></div>
+			<!-- /wp:accordion-item -->
+
+			<!-- wp:accordion-item -->
+			<div class="wp-block-accordion-item is-open"><!-- wp:accordion-heading -->
+			<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Second Image</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+			<!-- /wp:accordion-heading -->
+
+			<!-- wp:accordion-panel -->
+			<div role="region" class="wp-block-accordion-panel"><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt=""/></figure>
+			<!-- /wp:image --></div>
+			<!-- /wp:accordion-panel --></div>
+			<!-- /wp:accordion-item --></div>
+			<!-- /wp:accordion -->
+		BLOCK_CONTENT;
+
+		$rendered_block = do_blocks( $accordion_block );
+
+		$processor = new WP_HTML_Tag_Processor( $rendered_block );
+		$this->assertTrue( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertSame( 'low', $processor->get_attribute( 'fetchpriority' ), 'Expected fetchpriority=low to be set on IMG in default collapsed Accordion Item.' );
+
+		$this->assertTrue( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertSame( 'low', $processor->get_attribute( 'fetchpriority' ), 'Expected fetchpriority=low to be set on IMG in default collapsed Accordion Item.' );
+
+		$this->assertFalse( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
+	}
+
+	/**
+	 * Tests Accordion with two items, the first closed and the second open by default.
+	 *
+	 * @covers ::block_core_accordion_item_render
+	 */
+	public function test_should_add_fetchpriority_low_to_img_in_collapsed_accordion_block_but_not_open_block(): void {
+		$accordion_block = <<<'BLOCK_CONTENT'
+			<!-- wp:accordion -->
+			<div role="group" class="wp-block-accordion"><!-- wp:accordion-item -->
+			<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
+			<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">First Image</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+			<!-- /wp:accordion-heading -->
+
+			<!-- wp:accordion-panel -->
+			<div role="region" class="wp-block-accordion-panel"><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg" alt=""/></figure>
+			<!-- /wp:image --></div>
+			<!-- /wp:accordion-panel --></div>
+			<!-- /wp:accordion-item -->
+
+			<!-- wp:accordion-item {"openByDefault":true} -->
+			<div class="wp-block-accordion-item is-open"><!-- wp:accordion-heading -->
+			<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Second Image</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+			<!-- /wp:accordion-heading -->
+
+			<!-- wp:accordion-panel -->
+			<div role="region" class="wp-block-accordion-panel"><!-- wp:image {"linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://example.com/image2.jpg" alt=""/></figure>
+			<!-- /wp:image --></div>
+			<!-- /wp:accordion-panel --></div>
+			<!-- /wp:accordion-item --></div>
+			<!-- /wp:accordion -->
+		BLOCK_CONTENT;
+
+		$rendered_block = do_blocks( $accordion_block );
+
+		$processor = new WP_HTML_Tag_Processor( $rendered_block );
+		$this->assertTrue( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertSame( 'low', $processor->get_attribute( 'fetchpriority' ), 'Expected fetchpriority=low to be set on IMG in default collapsed Accordion Item.' );
+
+		$this->assertTrue( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
+		$this->assertTrue( $processor->next_tag( 'IMG' ) );
+		$this->assertNotSame( 'low', $processor->get_attribute( 'fetchpriority' ), 'Expected fetchpriority=low to not be set on IMG in default expanded Accordion Item.' );
+
+		$this->assertFalse( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes #76335

Given the following, where the initial Accordion Item is collapsed by default (as is the default) but the second is expanded by default:

<details><summary>Sample Post Content</summary>

```html
<!-- wp:accordion -->
<div role="group" class="wp-block-accordion"><!-- wp:accordion-item -->
<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">First Image</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
<!-- /wp:accordion-heading -->

<!-- wp:accordion-panel -->
<div role="region" class="wp-block-accordion-panel"><!-- wp:image {"id":36,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-36"/></figure>
<!-- /wp:image --></div>
<!-- /wp:accordion-panel --></div>
<!-- /wp:accordion-item -->

<!-- wp:accordion-item {"openByDefault":true} -->
<div class="wp-block-accordion-item is-open"><!-- wp:accordion-heading -->
<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Second Image</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
<!-- /wp:accordion-heading -->

<!-- wp:accordion-panel -->
<div role="region" class="wp-block-accordion-panel"><!-- wp:image {"id":37,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg" alt="" class="wp-image-37"/></figure>
<!-- /wp:image --></div>
<!-- /wp:accordion-panel --></div>
<!-- /wp:accordion-item --></div>
<!-- /wp:accordion -->
```

</details> 

The diff on the rendered HTML with this PR:

```diff
--- before.html	2026-03-09 21:16:42
+++ after.html	2026-03-09 21:17:17
@@ -40,10 +40,10 @@
     >
       <figure class="wp-block-image size-large">
         <img
-          fetchpriority="high"
           decoding="async"
           width="1024"
           height="668"
+          fetchpriority="low"
           sizes="(max-width: 645px) 100vw, 645px"
           src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg"
           alt=""
@@ -96,6 +96,7 @@
     >
       <figure class="wp-block-image size-large">
         <img
+          fetchpriority="high"
           decoding="async"
           width="1024"
           height="683"
```

This is a follow-up to:

- https://github.com/WordPress/gutenberg/pull/76269
- https://github.com/WordPress/gutenberg/pull/76302
- https://github.com/WordPress/gutenberg/pull/76208

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Images which are hidden from view should never get `fetchpriority=high`. They should instead get `fetchpriority=low` to prevent adding network contention to actual resources in the critical rendering path.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The existing `block_core_accordion_item_render()` function is amended to set `fetchpriority=low` on all `IMG` tags when `openByDefault` is `false`.

## Testing Instructions

See testing instructions on the issue:

- #76335
