### PR TITLE
Core Data: Avoid stale values when in autosave payloads

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -677,40 +677,25 @@ export const saveEntityRecord =
 					? select.getRawEntityRecord( kind, name, recordId )
 					: {};
 
+				// Most of this autosave logic is very specific to posts.
+				// This is fine for now as it is the only supported autosave,
+				// but ideally this should all be handled in the back end,
+				// so the client just sends and receives objects.
 				if ( isAutosave ) {
-					// Most of this autosave logic is very specific to posts.
-					// This is fine for now as it is the only supported autosave,
-					// but ideally this should all be handled in the back end,
-					// so the client just sends and receives objects.
-					const currentUser = select.getCurrentUser();
-					const currentUserId = currentUser
-						? currentUser.id
-						: undefined;
-					const autosavePost = await resolveSelect.getAutosave(
-						persistedRecord.type,
-						persistedRecord.id,
-						currentUserId
-					);
-					// Autosaves need all expected fields to be present.
-					// So we fallback to the previous autosave and then
-					// to the actual persisted entity if the edits don't
-					// have a value.
-					let data = {
-						...persistedRecord,
-						...autosavePost,
-						...record,
-					};
-					data = Object.keys( data ).reduce(
+					// Build the autosave payload from the persisted
+					// record and the incoming edits. The previous autosave
+					// is intentionally excluded to avoid stale values
+					// overriding reverted fields.
+					const merged = { ...persistedRecord, ...record };
+					const data = [
+						'title',
+						'excerpt',
+						'content',
+						'meta',
+					].reduce(
 						( acc, key ) => {
-							if (
-								[
-									'title',
-									'excerpt',
-									'content',
-									'meta',
-								].includes( key )
-							) {
-								acc[ key ] = data[ key ];
+							if ( key in merged ) {
+								acc[ key ] = merged[ key ];
 							}
 							return acc;
 						},
@@ -720,7 +705,7 @@ export const saveEntityRecord =
 							// because it can lead to unexpected results. An example would be to
 							// have a draft post and change the status to publish.
 							status:
-								data.status === 'auto-draft'
+								merged.status === 'auto-draft'
 									? 'draft'
 									: undefined,
 						}

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -144,6 +144,48 @@ test.describe( 'Preview', () => {
 		await previewPage.close();
 	} );
 
+	// See: https://github.com/WordPress/gutenberg/issues/33758.
+	test( 'should not use stale autosave data after reverting title', async ( {
+		editor,
+		page,
+		previewUtils,
+	} ) => {
+		const editorPage = page;
+
+		// Create and publish a post.
+		await editor.canvas
+			.locator( 'role=textbox[name="Add title"i]' )
+			.fill( 'Sample Page' );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'original content' },
+		} );
+		await editor.publishPost();
+
+		// Close the panel.
+		await page.click( 'role=button[name="Close panel"i]' );
+
+		// Change the title and preview to trigger an autosave.
+		await editor.canvas
+			.locator( 'role=textbox[name="Add title"i]' )
+			.fill( 'Sample Page 2' );
+		const previewPage = await editor.openPreviewPage( editorPage );
+		const previewTitle = previewPage.locator( 'role=heading[level=1]' );
+		await expect( previewTitle ).toHaveText( 'Sample Page 2' );
+
+		// Return to editor, revert the title, and preview again.
+		await editorPage.bringToFront();
+		await editor.canvas
+			.locator( 'role=textbox[name="Add title"i]' )
+			.fill( 'Sample Page' );
+		await previewUtils.waitForPreviewNavigation( previewPage );
+
+		// Preview should show the reverted title, not the stale autosave.
+		await expect( previewTitle ).toHaveText( 'Sample Page' );
+
+		await previewPage.close();
+	} );
+
 	// Verify correct preview. See: https://github.com/WordPress/gutenberg/issues/33616
 	test( 'should display the correct preview when switching between published and draft statuses', async ( {
 		editor,


### PR DESCRIPTION
## What?
Closes #33758.

PR removes `autosavePost` record from merge chain when building the new autosave payload, which fixes the bug with stale autosaves.

## Why?
When a user reverted a field (e.g., title back to its original value), `autosavePost` still retained the old value and overwrote `persistedRecord`'s correct value. 

I think the [original logic was overprotecting](https://github.com/WordPress/gutenberg/pull/16903/changes#r310658401). If the user doesn't intentionally restore the previous autosave, the core shouldn't try to merge it with the new one. Autosaves are meant to be snapshots - `{ ...persistedRecord, ...currentEdits }`.

## Testing Instructions
PR includes e2e tests based on the issue's reproduction steps.

### Testing Instructions for Keyboard
Same.