### PR TITLE
Content Guidelines: Add plugin extensibility via SlotFill

### DIFF
--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -358,6 +358,7 @@ export default function PostSummary( { onActionPerformed } ) {
 
 The following SlotFills are available in the `edit-post` or `editor` packages. Please refer to the individual items below for usage and example details:
 
+-   [ContentGuidelineSectionActions](/docs/reference-guides/slotfills/content-guideline-section-actions.md)
 -   [MainDashboardButton](/docs/reference-guides/slotfills/main-dashboard-button.md)
 -   [PluginBlockSettingsMenuItem](/docs/reference-guides/slotfills/plugin-block-settings-menu-item.md)
 -   [PluginDocumentSettingPanel](/docs/reference-guides/slotfills/plugin-document-setting-panel.md)

--- a/docs/reference-guides/slotfills/content-guideline-section-actions.md
+++ b/docs/reference-guides/slotfills/content-guideline-section-actions.md
@@ -1,0 +1,54 @@
+# ContentGuidelineSectionActions
+
+This SlotFill allows plugins to render additional action buttons next to the "Save guidelines" button in each section of the Content Guidelines admin page.
+
+## Available Sections
+
+Each guideline section exposes its own slot using the naming pattern `ContentGuidelineSectionActions/{slug}`:
+
+-   `ContentGuidelineSectionActions/site`
+-   `ContentGuidelineSectionActions/copy`
+-   `ContentGuidelineSectionActions/images`
+-   `ContentGuidelineSectionActions/additional`
+
+## Available Fill Props
+
+-   **section** `string`: The guideline section identifier (`site`, `copy`, `images`, or `additional`).
+-   **content** `string`: The current content of the section's textarea.
+-   **setContentGuideline** `(text: string) => void`: Callback to update the section's textarea content.
+
+## Example
+
+```js
+import { registerPlugin } from '@wordpress/plugins';
+import { Fill, Button } from '@wordpress/components';
+
+const SECTIONS = [ 'site', 'copy', 'images', 'additional' ];
+
+const ContentGuidelinesActionDemo = () => (
+	<>
+		{ SECTIONS.map( ( section ) => (
+			<Fill
+				key={ section }
+				name={ `ContentGuidelineSectionActions/${ section }` }
+			>
+				{ ( { section, content, setContentGuideline } ) => (
+					<Button
+						variant="secondary"
+						onClick={ () =>
+							setContentGuideline( content + '\nGenerated content for ' + section )
+						}
+					>
+						Generate
+					</Button>
+				) }
+			</Fill>
+		) ) }
+	</>
+);
+
+registerPlugin( 'content-guidelines-action-demo', {
+	scope: 'content-guidelines',
+	render: ContentGuidelinesActionDemo,
+} );
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -62997,6 +62997,7 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/plugins": "file:../../packages/plugins",
 				"@wordpress/ui": "file:../../packages/ui"
 			}
 		},

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -3,7 +3,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Button,
+	Slot,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
 import { Notice } from '@wordpress/ui';
@@ -116,16 +121,27 @@ export default function GuidelineAccordionForm( {
 						</Notice.Title>
 					</Notice.Root>
 				) }
-				<Button
-					variant="primary"
-					type="submit"
-					className="save-button"
-					disabled={ loading }
-					accessibleWhenDisabled
-					isBusy={ loading }
-				>
-					{ __( 'Save guidelines' ) }
-				</Button>
+				<HStack spacing={ 3 } justify="flex-start">
+					<Button
+						variant="primary"
+						type="submit"
+						className="save-button"
+						disabled={ loading }
+						accessibleWhenDisabled
+						isBusy={ loading }
+					>
+						{ __( 'Save guidelines' ) }
+					</Button>
+					<Slot
+						name={ `ContentGuidelineSectionActions/${ slug }` }
+						fillProps={ {
+							section: slug,
+							content: draft,
+							setContentGuideline: ( text: string ) =>
+								setDraft( text ),
+						} }
+					/>
+				</HStack>
 			</VStack>
 		</form>
 	);

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -19,6 +19,7 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/plugins": "file:../../packages/plugins",
 		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/block-library": "file:../../packages/block-library",
 		"@wordpress/blocks": "file:../../packages/blocks"

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -7,6 +7,7 @@ import { Page } from '@wordpress/admin-ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
+import { PluginArea } from '@wordpress/plugins';
 import { Notice } from '@wordpress/ui';
 
 /**
@@ -71,47 +72,53 @@ function ContentGuidelinesPage() {
 	}, [] );
 
 	return (
-		<Page
-			title={ __( 'Content guidelines' ) }
-			subTitle={ __(
-				"Set content standards that guide your team, inform plugins, and help AI tools generate content that matches your site's voice and requirements."
-			) }
-		>
-			{ error && (
-				<div className="content-guidelines__content">
-					<Notice.Root intent="error">
-						<Notice.Title>
-							{ sprintf(
-								/* translators: %s: Error message. */
-								__( 'Error loading content guidelines: %s' ),
-								error
-							) }
-						</Notice.Title>
-						<Notice.Description>
-							{ __(
-								'Please try again. If the problem persists, contact support.'
-							) }
-						</Notice.Description>
-					</Notice.Root>
-				</div>
-			) }
-			{ loading ? (
-				<div className="content-guidelines__loading">
-					<Spinner />
-				</div>
-			) : (
-				! error && (
+		<>
+			<Page
+				title={ __( 'Content guidelines' ) }
+				subTitle={ __(
+					"Set content standards that guide your team, inform plugins, and help AI tools generate content that matches your site's voice and requirements."
+				) }
+			>
+				{ error && (
 					<div className="content-guidelines__content">
-						{ /*
-						 * Disable reason: The `list` ARIA role is redundant but
-						 * Safari+VoiceOver won't announce the list otherwise.
-						 */
-						/* eslint-disable jsx-a11y/no-redundant-roles */ }
-						<ul role="list" className="content-guidelines__list">
-							{ GUIDELINE_ITEMS.map( ( item ) => {
-								const contentId = `content-guidelines-${ item.slug }`;
-								const headingId = `content-guidelines-${ item.slug }-heading`;
-								const descriptionId = `content-guidelines-${ item.slug }-description`;
+						<Notice.Root intent="error">
+							<Notice.Title>
+								{ sprintf(
+									/* translators: %s: Error message. */
+									__(
+										'Error loading content guidelines: %s'
+									),
+									error
+								) }
+							</Notice.Title>
+							<Notice.Description>
+								{ __(
+									'Please try again. If the problem persists, contact support.'
+								) }
+							</Notice.Description>
+						</Notice.Root>
+					</div>
+				) }
+				{ loading ? (
+					<div className="content-guidelines__loading">
+						<Spinner />
+					</div>
+				) : (
+					! error && (
+						<div className="content-guidelines__content">
+							{ /*
+							 * Disable reason: The `list` ARIA role is redundant but
+							 * Safari+VoiceOver won't announce the list otherwise.
+							 */
+							/* eslint-disable jsx-a11y/no-redundant-roles */ }
+							<ul
+								role="list"
+								className="content-guidelines__list"
+							>
+								{ GUIDELINE_ITEMS.map( ( item ) => {
+									const contentId = `content-guidelines-${ item.slug }`;
+									const headingId = `content-guidelines-${ item.slug }-heading`;
+									const descriptionId = `content-guidelines-${ item.slug }-description`;
 
 								return (
 									<li
@@ -149,6 +156,8 @@ function ContentGuidelinesPage() {
 				)
 			) }
 		</Page>
+			<PluginArea scope="content-guidelines" />
+		</>
 	);
 }
 

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -120,42 +120,50 @@ function ContentGuidelinesPage() {
 									const headingId = `content-guidelines-${ item.slug }-heading`;
 									const descriptionId = `content-guidelines-${ item.slug }-description`;
 
-								return (
-									<li
-										key={ item.slug }
-										className="content-guidelines__list-item"
-									>
-										<div className="content-guidelines__accordion-item">
-											<GuidelineAccordion
-												title={ item.title }
-												description={ item.description }
-												contentId={ contentId }
-												headingId={ headingId }
-												descriptionId={ descriptionId }
-											>
-												{ item.slug === 'blocks' ? (
-													<BlockGuidelines />
-												) : (
-													<GuidelineAccordionForm
-														slug={ item.slug }
-														contentId={ contentId }
-														headingId={ headingId }
-														descriptionId={
-															descriptionId
-														}
-													/>
-												) }
-											</GuidelineAccordion>
-										</div>
-									</li>
-								);
-							} ) }
-						</ul>
-						{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
-					</div>
-				)
-			) }
-		</Page>
+									return (
+										<li
+											key={ item.slug }
+											className="content-guidelines__list-item"
+										>
+											<div className="content-guidelines__accordion-item">
+												<GuidelineAccordion
+													title={ item.title }
+													description={
+														item.description
+													}
+													contentId={ contentId }
+													headingId={ headingId }
+													descriptionId={
+														descriptionId
+													}
+												>
+													{ item.slug === 'blocks' ? (
+														<BlockGuidelines />
+													) : (
+														<GuidelineAccordionForm
+															slug={ item.slug }
+															contentId={
+																contentId
+															}
+															headingId={
+																headingId
+															}
+															descriptionId={
+																descriptionId
+															}
+														/>
+													) }
+												</GuidelineAccordion>
+											</div>
+										</li>
+									);
+								} ) }
+							</ul>
+							{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
+						</div>
+					)
+				) }
+			</Page>
 			<PluginArea scope="content-guidelines" />
 		</>
 	);


### PR DESCRIPTION
## What?

Adds plugin extensibility to the Content Guidelines admin page via the SlotFill pattern, allowing external plugins to inject custom UI next to each section's Save button.

<img width="1516" height="586" alt="CleanShot 2026-03-10 at 11 51 15@2x" src="https://github.com/user-attachments/assets/0ee225d7-9cd2-4971-8cae-8a88d32051a1" />


## Why?

Currently, the Content Guidelines page is a closed system with no way for plugins to extend it. The SlotFill pattern is the standard Gutenberg approach for enabling third-party plugin extensibility.

## How?

- Adds `PluginArea` with scope `content-guidelines` to the page
- Adds `ContentGuidelineSectionActions/{slug}` named slots in each section
- Exposes `fillProps` (`section`, `content`, `setContentGuideline`) so plugins can read and update guideline content
- Adds SlotFill reference documentation

## Test plan

1. Navigate to **Settings → Content Guidelines** and verify the page loads without errors
2. Expand each section, edit a guideline, and click **Save guidelines** — confirm save works
3. Open browser console and run the following snippet to verify SlotFill extensibility:
```js
wp.plugins.registerPlugin( 'test-slot', {
  scope: 'content-guidelines',
  render: () => wp.element.createElement( wp.components.Fill, { name: 'ContentGuidelineSectionActions/site' }, ( { section, content, setContentGuideline } ) => wp.element.createElement( wp.components.Button, { type: 'button', variant: 'secondary', onClick: () => setContentGuideline( 'Test AI generated content for ' + section ), }, 'Generate' ) ),
} );
```
4. Confirm a **Generate** button appears next to **Save guidelines** in the Site section
5. Click **Generate** and confirm the textarea updates with the test text