### PR TITLE
Storybook: Add basic accent color guidance.

### DIFF
--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -8,7 +8,7 @@ This document outlines the default color set of the WordPress component system a
 
 ## Accent
 
-By default, WordPress components style accent colors using the `--wp-admin-theme-color`, or `--wp-components-color-accent` variables in your own stylesheet. If you do not provide either of those variables, then the components default to Blueberry:
+By default, WordPress components style accent colors using the `--wp-admin-theme-color` variable in your own stylesheet. If you do not provide either of those variables, then the components default to Blueberry:
 
 <ColorPalette>
 	<ColorItem

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -8,7 +8,7 @@ This document outlines the default color set of the WordPress component system a
 
 ## Accent
 
-WordPress components style accent colors using the `--wp-admin-theme-color` variable. If this variable are not found, then the components default to Blueberry:
+WordPress components style accent colors using the `--wp-admin-theme-color` variable. If this variable is not found, then the components default to Blueberry:
 
 <ColorPalette>
 	<ColorItem

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -8,7 +8,7 @@ This document outlines the default color set of the WordPress component system a
 
 ## Accent
 
-By default, WordPress components style accent colors using the `--wp-admin-theme-color` variable in your own stylesheet. If you do not provide either of those variables, then the components default to Blueberry:
+WordPress components style accent colors using the `--wp-admin-theme-color` variable. If those variables are not found, then the components default to Blueberry:
 
 <ColorPalette>
 	<ColorItem

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -8,7 +8,7 @@ This document outlines the default color set of the WordPress component system a
 
 ## Accent
 
-WordPress components style accent colors using the `--wp-admin-theme-color` variable. If those variables are not found, then the components default to Blueberry:
+WordPress components style accent colors using the `--wp-admin-theme-color` variable. If this variable are not found, then the components default to Blueberry:
 
 <ColorPalette>
 	<ColorItem

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -6,6 +6,24 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs/blocks';
 
 This document outlines the default color set of the WordPress component system as it ships. The page is a work in progress. 
 
+## Accent
+
+By default, WordPress components style accent colors using the `--wp-admin-theme-color`, or `--wp-components-color-accent` variables in your own stylesheet. If you do not provide either of those variables, then the components default to Blueberry:
+
+<ColorPalette>
+	<ColorItem
+		title="Blueberry"
+		subtitle=""
+		colors={{
+			'--wp-admin-theme-color': '#3858e9',
+		}}
+	/>
+</ColorPalette>
+
+In WordPress admin contexts, this variable is always pre-defined with the user color scheme. 
+
+The design system doesn’t dictate what the accent color “should” be, it just provides a default in case a color isn’t set explicitly. So it’s up to the designer whether to honor the user’s color in a given context or instead use a chosen brand color.
+
 ## Colors
 
 <ColorPalette>


### PR DESCRIPTION
## What?

Addsd basic accent color guidance to storybook. 

<img width="1077" height="505" alt="image" src="https://github.com/user-attachments/assets/578471b5-bfe9-4340-aad0-174dce1843b5" />

Note this is still extremely basic and deserves a larger effort, including one that documents work in progress token changes. It's a starting point. 

## Why?

Information about the accent color behavior was missing.

## Testing Instructions

Checkout the branch, run npm run storybook:dev, then look at the "Colors" page.
