### PR TITLE
Set placeholder to featured image field

### DIFF
--- a/packages/fields/src/fields/featured-image/index.tsx
+++ b/packages/fields/src/fields/featured-image/index.tsx
@@ -15,6 +15,7 @@ const featuredImageField: Field< BasePostWithEmbeddedFeaturedMedia > = {
 	id: 'featured_media',
 	type: 'media',
 	label: __( 'Featured Image' ),
+	placeholder: __( 'Set featured image' ),
 	Edit: ( props ) => <MediaEdit { ...props } isExpanded />,
 	render: FeaturedImageView,
 	setValue: ( { value } ) => ( {

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Page List', () => {
 			featuredImage: {
 				performEdit: async ( page ) => {
 					const placeholder = page.getByRole( 'button', {
-						name: 'Choose file',
+						name: 'Set featured image',
 					} );
 					await placeholder.click();
 					const mediaLibrary = page.getByRole( 'dialog' );
@@ -95,16 +95,16 @@ test.describe( 'Page List', () => {
 						.click();
 				},
 				assertInitialState: async ( page ) => {
-					const el = page.getByText( 'Choose file' );
+					const el = page.getByText( 'Set featured image' );
 					const placeholder = page.getByRole( 'button', {
-						name: 'Choose file',
+						name: 'Set featured image',
 					} );
 					await expect( el ).toBeVisible();
 					await expect( placeholder ).toBeVisible();
 				},
 				assertEditedState: async ( page ) => {
 					const placeholder = page.getByRole( 'button', {
-						name: 'Choose file',
+						name: 'Set featured image',
 					} );
 					await expect( placeholder ).toBeHidden();
 					const img = page.locator( '.fields__media-edit-thumbnail' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses: https://github.com/WordPress/gutenberg/issues/76076#issuecomment-4029220443

Just updates the placeholder of the featured image field.
<img width="695" height="739" alt="Screenshot 2026-03-10 at 10 49 14 AM" src="https://github.com/user-attachments/assets/ddbdb5af-b5fd-4ecf-9e01-3a3995429f79" />
