### PR TITLE
Tests: Skip connector logo URL tests when AI Client is unavailable

### DIFF
--- a/phpunit/experimental/connectors/resolve-ai-provider-logo-url-test.php
+++ b/phpunit/experimental/connectors/resolve-ai-provider-logo-url-test.php
@@ -6,6 +6,14 @@
  */
 class Tests_Resolve_AI_Provider_Logo_URL extends WP_UnitTestCase {
 
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! function_exists( '_gutenberg_resolve_ai_provider_logo_url' ) ) {
+			$this->markTestSkipped( 'The AI Client library is not available.' );
+		}
+	}
+
 	public function test_returns_null_when_path_is_empty() {
 		$this->assertNull( _gutenberg_resolve_ai_provider_logo_url( '' ) );
 	}


### PR DESCRIPTION
## Summary
- Adds a `set_up` guard that skips `Tests_Resolve_AI_Provider_Logo_URL` when `_gutenberg_resolve_ai_provider_logo_url` is not defined
- The connectors PHP code is only loaded when the AI Client library is present (`class_exists('\WordPress\AiClient\AiClient')`), so these tests would error on older WP versions

Follow-up to #76190.

## Test plan
- [ ] Tests pass when AI Client is available (5 passing)
- [ ] Tests skip gracefully when AI Client is unavailable (5 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)