### PR TITLE
Fix : Note position

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -388,7 +388,7 @@ export function useFloatingThread( {
 	);
 
 	// Use floating-ui to track the block element's position with the calculated offset.
-	const { y, refs } = useFloating( {
+	const { y: floatingY, refs } = useFloating( {
 		placement: 'right-start',
 		middleware: [
 			offsetMiddleware( {
@@ -397,6 +397,9 @@ export function useFloatingThread( {
 		],
 		whileElementsMounted: autoUpdate,
 	} );
+
+	// Clamp y to minimum of 0 to prevent negative positioning.
+	const y = Math.max( 0, floatingY );
 
 	// Store the block reference for each thread.
 	useEffect( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

- Closes https://github.com/WordPress/gutenberg/issues/73565
- Fixes an issue where floating note positions could become negative during certain block operations, causing notes to be positioned incorrectly.

## Why?

The Notes feature uses `@floating-ui/react-dom` to position floating comment threads alongside their associated blocks. However, in one scenario the calculated `y` position was found to become negative:

1. **Hidden blocks** - When a block with a note is hidden and then reselected

Negative `y` values cause the floating note to be positioned outside the visible viewport, making it appear as if the note position was "lost".

## How?

### Changes to `packages/editor/src/components/collab-sidebar/hooks.js`

-   Modified `useFloatingThread` hook to clamp the `y` position to a minimum of 0
-   Renamed the returned `y` value from `useFloating` to `floatingY` before applying the clamp
-   Added `Math.max( 0, floatingY )` to ensure the note is never positioned at a negative coordinate

### Preview

https://github.com/user-attachments/assets/98a12331-a0c1-4892-bc3c-ae8ce375da52

