### PR TITLE
DataForm: Reduce `panel`'s dialog `min-width`

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DataForm: Reduce panel's dialog min-width. [#76345](https://github.com/WordPress/gutenberg/pull/76345)
+
 ### Bug Fixes
 
 - DataViews: Fix last column classname in table layout. [#76133](https://github.com/WordPress/gutenberg/pull/76133)

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -152,7 +152,7 @@
 }
 
 .dataforms-layouts-panel__field-dropdown .components-popover__content {
-	min-width: 320px;
+	min-width: 256px;
 	padding: $grid-unit-20;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/76325

This approach reduces the `min-width` of `panel` to `256px`, as suggested in the issue.

I'd leave it to designers if this change seems fine or not..



## Testing Instructions
1. Try editing the fields in Quick edit in site editor (pages)

### Before

https://github.com/user-attachments/assets/b8e40ba1-51da-487f-bb6c-383ac3aabc2f



### After


https://github.com/user-attachments/assets/10554e11-b329-4e96-bba5-ae3bda173c1e


