### PR TITLE
Add Client-Side Navigation documentation to manifest and table of contents

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -534,6 +534,12 @@
 		"parent": "core-concepts"
 	},
 	{
+		"title": "Client-Side Navigation",
+		"slug": "client-side-navigation",
+		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md",
+		"parent": "core-concepts"
+	},
+	{
 		"title": "Using TypeScript",
 		"slug": "using-typescript",
 		"markdown_source": "../docs/reference-guides/interactivity-api/core-concepts/using-typescript.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -223,6 +223,9 @@
 								"docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md": []
 							},
 							{
+								"docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md": []
+							},
+							{
 								"docs/reference-guides/interactivity-api/core-concepts/using-typescript.md": []
 							}
 						]


### PR DESCRIPTION
## What?

  Follow up to #75263

  Add the Client-Side Navigation documentation page to the docs manifest and table of contents so it appears in the developer documentation site.

  ## Why?

  PR #75263 added the `client-side-navigation.md` guide under Interactivity API Core Concepts, but the file was not registered in `docs/manifest.json` or `docs/toc.json`.
  Without these entries, the page won't appear in the documentation site's navigation or be discoverable by readers.

  ## How?

  - Added an entry in `docs/manifest.json` for the `client-side-navigation` page under the `core-concepts` parent.
  - Added an entry in `docs/toc.json` placing it after "Server-side rendering" and before "Using TypeScript", matching the order in the Core Concepts README.

  ## Testing Instructions

Once merged, the Client Side Navigation guide should be available at https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation/

_Note: Final documentation in the Block Editor Handbook is automatically regenerated from Gutenberg repo .md files every 15 minutes._