### PR TITLE
Page Parent: Change the default value of 'fieldValue' state

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -60,7 +60,7 @@ export const getItemPriority = ( name, searchValue ) => {
  */
 export function PageAttributesParent() {
 	const { editPost } = useDispatch( editorStore );
-	const [ fieldValue, setFieldValue ] = useState( false );
+	const [ fieldValue, setFieldValue ] = useState( '' );
 	const {
 		isHierarchical,
 		parentPostId,

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -114,7 +114,7 @@ export function PageAttributesParent( {
 	data: BasePost;
 	onChangeControl: ( newValue: number ) => void;
 } ) {
-	const [ fieldValue, setFieldValue ] = useState< null | string >( null );
+	const [ fieldValue, setFieldValue ] = useState< string >( '' );
 
 	const pageId = data.parent;
 	const postId = data.id;
@@ -145,7 +145,7 @@ export function PageAttributesParent( {
 				orderby: 'menu_order',
 				order: 'asc',
 				_fields: 'id,title,parent',
-				...( fieldValue !== null && {
+				...( !! fieldValue && {
 					// Perform a search by relevance when the field is changed.
 					search: fieldValue,
 					orderby: 'relevance',
@@ -192,14 +192,8 @@ export function PageAttributesParent( {
 			] );
 
 			const sortedNodes = mappedNodes.sort( ( [ a ], [ b ] ) => {
-				const priorityA = getItemPriority(
-					a.rawName,
-					fieldValue ?? ''
-				);
-				const priorityB = getItemPriority(
-					b.rawName,
-					fieldValue ?? ''
-				);
+				const priorityA = getItemPriority( a.rawName, fieldValue );
+				const priorityB = getItemPriority( b.rawName, fieldValue );
 				return priorityA >= priorityB ? 1 : -1;
 			} );
 


### PR DESCRIPTION
## What?
This is a follow-up to #73836.

PR changes the default value of 'fieldValue' state from `null|false` to an empty state. Which fixes the following issue:

* Prevents 400 error triggered by parent field. Search param needs to be a non-empty value when `orderby: 'relevance'` is set.
* Avoids collapsing the combobox values or re-running the selectors when the user focuses the input.

It looks like `onFilterValueChange` immediately updates the state as an empty string when the input is in focus. Since we're dealing with a string, it's better to use an empty string as a default value.

## Testing Instructions
1. Navigate to Site Editor > Pages
2. Open the Quick Edit for a page.
3. Open the parent fields popover.
4. Confirm it works as before and there are no HTTP errors.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="616" height="135" alt="CleanShot 2026-03-10 at 15 44 39" src="https://github.com/user-attachments/assets/f0c445e7-0e42-4f2b-a6f1-75e3d9b80706" />

https://github.com/user-attachments/assets/dcf9cc13-382b-400c-a122-b7b0ada54db6


