### PR TITLE
UI/Badge: Add border and neutral-strong background to `none` intent

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Enhancements
 
+-   `Badge`: Add border and `neutral-strong` background to `none` intent for better contrast against neutral surfaces ([#76356](https://github.com/WordPress/gutenberg/pull/76356)).
 -   `Notice`: Improve narrow layout by letting description and actions span the icon column when a title is present ([#76202](https://github.com/WordPress/gutenberg/pull/76202)).
 -   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Enhancements
 
--   `Badge`: Add border and `neutral-strong` background to `none` intent for better contrast against neutral surfaces ([#76356](https://github.com/WordPress/gutenberg/pull/76356)).
+-   `Badge`: Add border, update text color, and apply `neutral-strong` background to `none` intent for better contrast against neutral surfaces ([#76356](https://github.com/WordPress/gutenberg/pull/76356)).
 -   `Notice`: Improve narrow layout by letting description and actions span the icon column when a title is present ([#76202](https://github.com/WordPress/gutenberg/pull/76202)).
 -   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 

--- a/packages/ui/src/badge/style.module.css
+++ b/packages/ui/src/badge/style.module.css
@@ -43,9 +43,9 @@
 
 	.is-none-intent {
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
+		color: var(--wpds-color-fg-content-neutral);
 		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		padding-block: calc(var(--wpds-dimension-padding-xs) - var(--wpds-border-width-xs));
 		padding-inline: calc(var(--wpds-dimension-padding-sm) - var(--wpds-border-width-xs));
-		color: var(--wpds-color-fg-content-neutral);
 	}
 }

--- a/packages/ui/src/badge/style.module.css
+++ b/packages/ui/src/badge/style.module.css
@@ -46,6 +46,6 @@
 		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 		padding-block: calc(var(--wpds-dimension-padding-xs) - var(--wpds-border-width-xs));
 		padding-inline: calc(var(--wpds-dimension-padding-sm) - var(--wpds-border-width-xs));
-		color: var(--wpds-color-fg-content-neutral-weak);
+		color: var(--wpds-color-fg-content-neutral);
 	}
 }

--- a/packages/ui/src/badge/style.module.css
+++ b/packages/ui/src/badge/style.module.css
@@ -42,7 +42,10 @@
 	}
 
 	.is-none-intent {
-		background-color: var(--wpds-color-bg-surface-neutral);
+		background-color: var(--wpds-color-bg-surface-neutral-strong);
+		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+		padding-block: calc(var(--wpds-dimension-padding-xs) - var(--wpds-border-width-xs));
+		padding-inline: calc(var(--wpds-dimension-padding-sm) - var(--wpds-border-width-xs));
 		color: var(--wpds-color-fg-content-neutral-weak);
 	}
 }


### PR DESCRIPTION
## What

Add a subtle border, update text color and background color for the `Badge` component's `none` intent (the default).

## Why

The `none` intent badge uses `--wpds-color-bg-surface-neutral` as its background, which is identical to `surface-neutral` container backgrounds. When placed inside such containers, the badge becomes visually indistinguishable from its surroundings — the pill shape is lost and the text appears to float without any visual containment.

Fixes #76321.

## How

- Changed the background from `surface-neutral` to `surface-neutral-strong` to differentiate it from the `draft` intent while providing a distinct surface.
- Added a `1px` solid border using `--wpds-color-stroke-surface-neutral` so the badge boundary is always visible regardless of the container background.
- Changed the text color to `--wpds-color-fg-content-neutral`.
- Compensated for the border width by subtracting `--wpds-border-width-xs` from both `padding-block` and `padding-inline`, keeping the badge's overall dimensions unchanged.

| Before | After |
| --- | --- |
| <img width="246" height="407" alt="Screenshot 2026-03-10 at 12 41 51" src="https://github.com/user-attachments/assets/a245570d-d484-4091-b6d0-757f54669ff1" /> |  <img width="247" height="410" alt="Screenshot 2026-03-10 at 16 57 28" src="https://github.com/user-attachments/assets/206b8c46-739e-4b3d-86da-45892475cc27" /> |

## Testing
* `npm run storybook:dev`
* Observe the updated `none` `intent` badge at http://localhost:50240/?path=/story/design-system-components-badge--all-intents
