### PR TITLE
RTC: Move event hooks from editor to core-data

### DIFF
--- a/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
@@ -11,6 +11,9 @@ import {
 	useResolvedSelection,
 	useGetDebugData,
 	useIsDisconnected,
+	useOnCollaboratorJoin,
+	useOnCollaboratorLeave,
+	useOnPostSave,
 } from '../use-post-editor-awareness-state';
 import { getSyncManager } from '../../sync';
 import { SelectionType } from '../../utils/crdt-user-selections';
@@ -66,6 +69,9 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		onStateChange: jest.Mock;
 		convertSelectionStateToAbsolute: jest.Mock;
 		getDebugData: jest.Mock;
+		doc: {
+			getMap: jest.Mock;
+		};
 	};
 	let mockSyncManager: {
 		getAwareness: jest.Mock;
@@ -73,9 +79,29 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 	let stateChangeCallback:
 		| ( ( newState: PostEditorAwarenessState[] ) => void )
 		| null;
+	let stateMapObserver:
+		| ( ( event: { keysChanged: Set< string > } ) => void )
+		| null;
+	let mockStateMapData: Record< string, unknown >;
+	let mockRecordMapData: Record< string, unknown >;
 
 	beforeEach( () => {
 		stateChangeCallback = null;
+		stateMapObserver = null;
+		mockStateMapData = {};
+		mockRecordMapData = {};
+
+		const mockStateMap = {
+			get: jest.fn( ( key: string ) => mockStateMapData[ key ] ),
+			observe: jest.fn( ( observer: typeof stateMapObserver ) => {
+				stateMapObserver = observer;
+			} ),
+			unobserve: jest.fn(),
+		};
+
+		const mockRecordMap = {
+			get: jest.fn( ( key: string ) => mockRecordMapData[ key ] ),
+		};
 
 		mockAwareness = {
 			setUp: jest.fn(),
@@ -86,6 +112,17 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 			} ),
 			convertSelectionStateToAbsolute: jest.fn().mockReturnValue( null ),
 			getDebugData: jest.fn().mockReturnValue( createMockDebugData() ),
+			doc: {
+				getMap: jest.fn( ( name: string ) => {
+					if ( name === 'state' ) {
+						return mockStateMap;
+					}
+					if ( name === 'document' ) {
+						return mockRecordMap;
+					}
+					return null;
+				} ),
+			},
 		};
 
 		mockSyncManager = {
@@ -479,6 +516,412 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 
 			// Should be false because *I* am connected (other user's status doesn't matter)
 			expect( result.current ).toBe( false );
+		} );
+	} );
+
+	describe( 'useOnCollaboratorJoin', () => {
+		const me = createMockActiveUser( {
+			clientId: 1,
+			isMe: true,
+			collaboratorInfo: {
+				id: 1,
+				name: 'Me',
+				slug: 'me',
+				avatar_urls: mockAvatarUrls,
+				browserType: 'Chrome',
+				enteredAt: 1704067200000,
+			},
+		} );
+
+		const alice = createMockActiveUser( {
+			clientId: 2,
+			isMe: false,
+			collaboratorInfo: {
+				id: 100,
+				name: 'Alice',
+				slug: 'alice',
+				avatar_urls: mockAvatarUrls,
+				browserType: 'Chrome',
+				enteredAt: 1704067300000,
+			},
+		} );
+
+		test( 'should not fire on initial mount', () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
+
+			expect( callback ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should not fire when collaborators load after initially empty state', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [] );
+
+			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
+
+			// Simulate store hydration: collaborators appear
+			act( () => {
+				stateChangeCallback?.( [ me, alice ] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'should fire callback when a new collaborator joins', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me ] );
+
+			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
+
+			// Alice joins
+			act( () => {
+				stateChangeCallback?.( [ me, alice ] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledWith( alice, me );
+			} );
+		} );
+
+		test( 'should not fire callback for the current user', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [] );
+
+			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
+
+			// First: hydrate with alice so prevCollaborators is non-empty
+			act( () => {
+				stateChangeCallback?.( [ alice ] );
+			} );
+
+			// Now "me" appears
+			act( () => {
+				stateChangeCallback?.( [ alice, me ] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'should not fire when postId is null', () => {
+			const callback = jest.fn();
+
+			renderHook( () => useOnCollaboratorJoin( null, 'post', callback ) );
+
+			expect( callback ).not.toHaveBeenCalled();
+			expect( mockSyncManager.getAwareness ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'useOnCollaboratorLeave', () => {
+		const me = createMockActiveUser( {
+			clientId: 1,
+			isMe: true,
+		} );
+
+		const alice = createMockActiveUser( {
+			clientId: 2,
+			isMe: false,
+			isConnected: true,
+			collaboratorInfo: {
+				id: 100,
+				name: 'Alice',
+				slug: 'alice',
+				avatar_urls: mockAvatarUrls,
+				browserType: 'Chrome',
+				enteredAt: 1704067300000,
+			},
+		} );
+
+		test( 'should fire callback when a connected collaborator disconnects', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
+
+			// Alice disconnects
+			act( () => {
+				stateChangeCallback?.( [
+					me,
+					{ ...alice, isConnected: false },
+				] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledWith( alice );
+			} );
+		} );
+
+		test( 'should fire callback when a connected collaborator disappears from the list', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
+
+			// Alice disappears entirely
+			act( () => {
+				stateChangeCallback?.( [ me ] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledWith( alice );
+			} );
+		} );
+
+		test( 'should not fire callback when an already-disconnected collaborator is removed', async () => {
+			const callback = jest.fn();
+			const disconnectedAlice = { ...alice, isConnected: false };
+			mockAwareness.getCurrentState.mockReturnValue( [
+				me,
+				disconnectedAlice,
+			] );
+
+			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
+
+			// Disconnected Alice is removed from list (cleanup after delay)
+			act( () => {
+				stateChangeCallback?.( [ me ] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'should not fire callback for the current user disconnecting', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
+
+			// "Me" disconnects
+			act( () => {
+				stateChangeCallback?.( [
+					{ ...me, isConnected: false },
+					alice,
+				] );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'should not fire on initial mount', () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
+
+			expect( callback ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'useOnPostSave', () => {
+		const me = createMockActiveUser( {
+			clientId: 1,
+			isMe: true,
+		} );
+
+		const alice = createMockActiveUser( {
+			clientId: 2,
+			isMe: false,
+			collaboratorInfo: {
+				id: 100,
+				name: 'Alice',
+				slug: 'alice',
+				avatar_urls: mockAvatarUrls,
+				browserType: 'Chrome',
+				enteredAt: 1704067300000,
+			},
+		} );
+
+		test( 'should fire callback when a remote collaborator saves', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnPostSave( 123, 'post', callback ) );
+
+			// Simulate a save event via the Y.Doc state map
+			const savedAt = Date.now() + 1000;
+			mockStateMapData = {
+				savedAt,
+				savedBy: alice.clientId,
+			};
+			mockRecordMapData = { status: 'draft' };
+
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledWith(
+					{
+						savedAt,
+						savedByClientId: alice.clientId,
+						postStatus: 'draft',
+					},
+					alice,
+					null
+				);
+			} );
+		} );
+
+		test( 'should pass previous save event on subsequent saves', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnPostSave( 123, 'post', callback ) );
+
+			// First save
+			const firstSavedAt = Date.now() + 1000;
+			mockStateMapData = {
+				savedAt: firstSavedAt,
+				savedBy: alice.clientId,
+			};
+			mockRecordMapData = { status: 'draft' };
+
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			// Second save
+			const secondSavedAt = Date.now() + 2000;
+			mockStateMapData = {
+				savedAt: secondSavedAt,
+				savedBy: alice.clientId,
+			};
+			mockRecordMapData = { status: 'publish' };
+
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledTimes( 2 );
+			} );
+
+			expect( callback ).toHaveBeenLastCalledWith(
+				{
+					savedAt: secondSavedAt,
+					savedByClientId: alice.clientId,
+					postStatus: 'publish',
+				},
+				alice,
+				{
+					savedAt: firstSavedAt,
+					savedByClientId: alice.clientId,
+					postStatus: 'draft',
+				}
+			);
+		} );
+
+		test( 'should not fire callback when the current user saves', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnPostSave( 123, 'post', callback ) );
+
+			// Simulate a save event by "me"
+			const savedAt = Date.now() + 1000;
+			mockStateMapData = {
+				savedAt,
+				savedBy: me.clientId,
+			};
+			mockRecordMapData = { status: 'draft' };
+
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'should not fire callback when saver is not in the collaborator list', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me ] );
+
+			renderHook( () => useOnPostSave( 123, 'post', callback ) );
+
+			// Simulate a save from an unknown client
+			const savedAt = Date.now() + 1000;
+			mockStateMapData = {
+				savedAt,
+				savedBy: 99999,
+			};
+			mockRecordMapData = { status: 'draft' };
+
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'should not fire duplicate callbacks for the same savedAt timestamp', async () => {
+			const callback = jest.fn();
+			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
+
+			renderHook( () => useOnPostSave( 123, 'post', callback ) );
+
+			const savedAt = Date.now() + 1000;
+			mockStateMapData = {
+				savedAt,
+				savedBy: alice.clientId,
+			};
+			mockRecordMapData = { status: 'draft' };
+
+			// First save event
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( callback ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			// Same savedAt again (e.g. component re-render)
+			act( () => {
+				stateMapObserver?.( {
+					keysChanged: new Set( [ 'savedAt' ] ),
+				} );
+			} );
+
+			// Should still be 1 call
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'should not fire when postId is null', () => {
+			const callback = jest.fn();
+
+			renderHook( () => useOnPostSave( null, 'post', callback ) );
+
+			expect( callback ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { usePrevious } from '@wordpress/compose';
 import { useEffect, useState } from '@wordpress/element';
 import type { Y } from '@wordpress/sync';
 
@@ -167,7 +168,7 @@ export function useIsDisconnected(
  * @param postId   The ID of the post.
  * @param postType The type of the post.
  */
-export function useLastPostSave(
+function useLastPostSave(
 	postId: number | null,
 	postType: string | null
 ): PostSaveEvent | null {
@@ -225,4 +226,150 @@ export function useLastPostSave(
 	}, [ postId, postType ] );
 
 	return lastSave;
+}
+
+/**
+ * Hook that fires a callback when a new collaborator joins the post.
+ * Handles initial hydration and state diffing internally—consumers
+ * only receive "join" events for collaborators that appear after the
+ * initial state has loaded.
+ *
+ * The callback receives the joining collaborator and, when available,
+ * the current user's state (useful for comparing `enteredAt` timestamps).
+ *
+ * @param postId   The ID of the post.
+ * @param postType The type of the post.
+ * @param callback Invoked for each collaborator that joins.
+ */
+export function useOnCollaboratorJoin(
+	postId: number | null,
+	postType: string | null,
+	callback: (
+		collaborator: ActiveCollaborator,
+		me?: ActiveCollaborator
+	) => void
+): void {
+	const { activeCollaborators } = usePostEditorAwarenessState(
+		postId,
+		postType
+	);
+	const prevCollaborators = usePrevious( activeCollaborators );
+
+	useEffect( () => {
+		/*
+		 * On first render usePrevious returns undefined. On subsequent
+		 * renders the list may still be empty while the store hydrates.
+		 * In both cases, skip to avoid spurious "joined" callbacks for
+		 * users already present.
+		 */
+		if ( ! prevCollaborators || prevCollaborators.length === 0 ) {
+			return;
+		}
+
+		const prevMap = new Map< number, ActiveCollaborator >(
+			prevCollaborators.map( ( c ) => [ c.clientId, c ] )
+		);
+		const me = activeCollaborators.find( ( c ) => c.isMe );
+
+		for ( const collaborator of activeCollaborators ) {
+			if (
+				! prevMap.has( collaborator.clientId ) &&
+				! collaborator.isMe
+			) {
+				callback( collaborator, me );
+			}
+		}
+	}, [ activeCollaborators, prevCollaborators, callback ] );
+}
+
+/**
+ * Hook that fires a callback when a collaborator leaves the post.
+ * A "leave" is detected when a previously-connected collaborator either
+ * transitions to `isConnected = false` or disappears from the list
+ * entirely while still connected. Already-disconnected collaborators
+ * that are later removed from the list are silently ignored.
+ *
+ * @param postId   The ID of the post.
+ * @param postType The type of the post.
+ * @param callback Invoked for each collaborator that leaves.
+ */
+export function useOnCollaboratorLeave(
+	postId: number | null,
+	postType: string | null,
+	callback: ( collaborator: ActiveCollaborator ) => void
+): void {
+	const { activeCollaborators } = usePostEditorAwarenessState(
+		postId,
+		postType
+	);
+	const prevCollaborators = usePrevious( activeCollaborators );
+
+	useEffect( () => {
+		if ( ! prevCollaborators || prevCollaborators.length === 0 ) {
+			return;
+		}
+
+		const newMap = new Map< number, ActiveCollaborator >(
+			activeCollaborators.map( ( c ) => [ c.clientId, c ] )
+		);
+
+		for ( const prevCollab of prevCollaborators ) {
+			if ( prevCollab.isMe || ! prevCollab.isConnected ) {
+				continue;
+			}
+
+			const newCollab = newMap.get( prevCollab.clientId );
+			if ( ! newCollab?.isConnected ) {
+				callback( prevCollab );
+			}
+		}
+	}, [ activeCollaborators, prevCollaborators, callback ] );
+}
+
+/**
+ * Hook that fires a callback when a remote collaborator saves the post.
+ * Only fires for saves by other collaborators (not the current user).
+ * Deduplicates by `savedAt` timestamp so the same save event is never
+ * reported twice.
+ *
+ * @param postId   The ID of the post.
+ * @param postType The type of the post.
+ * @param callback Invoked with the save event, the collaborator who saved,
+ *                 and the previous save event (if any) for transition detection.
+ */
+export function useOnPostSave(
+	postId: number | null,
+	postType: string | null,
+	callback: (
+		event: PostSaveEvent,
+		saver: ActiveCollaborator,
+		prevEvent: PostSaveEvent | null
+	) => void
+): void {
+	const { activeCollaborators } = usePostEditorAwarenessState(
+		postId,
+		postType
+	);
+	const lastPostSave = useLastPostSave( postId, postType );
+	const prevPostSave = usePrevious( lastPostSave );
+
+	useEffect( () => {
+		if ( ! lastPostSave ) {
+			return;
+		}
+
+		if ( prevPostSave && lastPostSave.savedAt === prevPostSave.savedAt ) {
+			return;
+		}
+
+		const saver = activeCollaborators.find(
+			( c ) => c.clientId === lastPostSave.savedByClientId && ! c.isMe
+		);
+
+		if ( ! saver ) {
+			return;
+		}
+
+		callback( lastPostSave, saver, prevPostSave ?? null );
+	}, [ lastPostSave, prevPostSave, activeCollaborators, callback ] );
 }

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -267,9 +267,14 @@ export function useOnCollaboratorJoin(
 		}
 
 		const prevMap = new Map< number, ActiveCollaborator >(
-			prevCollaborators.map( ( c ) => [ c.clientId, c ] )
+			prevCollaborators.map( ( collaborator ) => [
+				collaborator.clientId,
+				collaborator,
+			] )
 		);
-		const me = activeCollaborators.find( ( c ) => c.isMe );
+		const me = activeCollaborators.find(
+			( collaborator ) => collaborator.isMe
+		);
 
 		for ( const collaborator of activeCollaborators ) {
 			if (
@@ -310,7 +315,10 @@ export function useOnCollaboratorLeave(
 		}
 
 		const newMap = new Map< number, ActiveCollaborator >(
-			activeCollaborators.map( ( c ) => [ c.clientId, c ] )
+			activeCollaborators.map( ( collaborator ) => [
+				collaborator.clientId,
+				collaborator,
+			] )
 		);
 
 		for ( const prevCollab of prevCollaborators ) {
@@ -363,7 +371,9 @@ export function useOnPostSave(
 		}
 
 		const saver = activeCollaborators.find(
-			( c ) => c.clientId === lastPostSave.savedByClientId && ! c.isMe
+			( collaborator ) =>
+				collaborator.clientId === lastPostSave.savedByClientId &&
+				! collaborator.isMe
 		);
 
 		if ( ! saver ) {

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -6,7 +6,9 @@ import { RECEIVE_INTERMEDIATE_RESULTS } from './utils';
 import {
 	useActiveCollaborators,
 	useResolvedSelection,
-	useLastPostSave,
+	useOnCollaboratorJoin,
+	useOnCollaboratorLeave,
+	useOnPostSave,
 } from './hooks/use-post-editor-awareness-state';
 import { lock } from './lock-unlock';
 import { retrySyncConnection } from './sync';
@@ -18,5 +20,7 @@ lock( privateApis, {
 	retrySyncConnection,
 	useActiveCollaborators,
 	useResolvedSelection,
-	useLastPostSave,
+	useOnCollaboratorJoin,
+	useOnCollaboratorLeave,
+	useOnPostSave,
 } );

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -16,9 +16,9 @@ import { useCollaboratorNotifications } from '../use-collaborator-notifications'
 // --- Mocks ---
 
 const mockCreateNotice = jest.fn();
-let mockActiveCollaborators: any[] = [];
-let mockLastPostSave: { savedAt: number; savedByClientId: number } | null =
-	null;
+let mockOnJoinCallback: Function | null = null;
+let mockOnLeaveCallback: Function | null = null;
+let mockOnPostSaveCallback: Function | null = null;
 let mockEditorState = {
 	postStatus: 'draft',
 	isCollaborationEnabled: true,
@@ -45,8 +45,21 @@ jest.mock( '@wordpress/core-data', () => ( {
 
 jest.mock( '../../../lock-unlock', () => ( {
 	unlock: jest.fn( () => ( {
-		useActiveCollaborators: jest.fn( () => mockActiveCollaborators ),
-		useLastPostSave: jest.fn( () => mockLastPostSave ),
+		useOnCollaboratorJoin: jest.fn(
+			( _postId: unknown, _postType: unknown, callback: Function ) => {
+				mockOnJoinCallback = callback;
+			}
+		),
+		useOnCollaboratorLeave: jest.fn(
+			( _postId: unknown, _postType: unknown, callback: Function ) => {
+				mockOnLeaveCallback = callback;
+			}
+		),
+		useOnPostSave: jest.fn(
+			( _postId: unknown, _postType: unknown, callback: Function ) => {
+				mockOnPostSaveCallback = callback;
+			}
+		),
 	} ) ),
 } ) );
 
@@ -99,8 +112,9 @@ function buildMockSelect() {
 }
 
 beforeEach( () => {
-	mockActiveCollaborators = [];
-	mockLastPostSave = null;
+	mockOnJoinCallback = null;
+	mockOnLeaveCallback = null;
+	mockOnPostSaveCallback = null;
 	mockEditorState = {
 		postStatus: 'draft',
 		isCollaborationEnabled: true,
@@ -117,77 +131,7 @@ beforeEach( () => {
 // --- Tests ---
 
 describe( 'useCollaboratorNotifications', () => {
-	describe( 'initial mount', () => {
-		it( 'does not fire join notifications for collaborators already present on mount', () => {
-			mockActiveCollaborators = [ makeMe(), makeCollaborator() ];
-
-			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not fire any notification when no collaborators are present', () => {
-			mockActiveCollaborators = [];
-
-			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not fire join notifications when collaborators load after an initially empty state', () => {
-			// Simulates the store hydrating: first render has no collaborators,
-			// second render receives the full list.
-			mockActiveCollaborators = [];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			mockActiveCollaborators = [ makeMe(), makeCollaborator() ];
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-	} );
-
 	describe( 'collaborator join notifications', () => {
-		it( 'does not fire a join notification for the current user', () => {
-			mockActiveCollaborators = [];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			mockActiveCollaborators = [ makeMe() ];
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'skips join notification for collaborators who joined before current user', () => {
-			// Alice joined BEFORE the current user (smaller enteredAt)
-			const me = makeMe(); // enteredAt: BASE_ENTERED_AT + 5000
-			const aliceJoinedFirst = makeCollaborator( {
-				collaboratorInfo: {
-					id: 100,
-					name: 'Alice',
-					slug: 'alice',
-					avatar_urls: {},
-					browserType: 'Chrome',
-					enteredAt: BASE_ENTERED_AT + 1000, // joined earlier than me
-				},
-			} );
-
-			mockActiveCollaborators = [ me ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// Alice appears in the state — but she was there before us
-			mockActiveCollaborators = [ me, aliceJoinedFirst ];
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
 		it( 'fires join notification for a collaborator who joined after current user', () => {
 			const me = makeMe(); // enteredAt: BASE_ENTERED_AT + 5000
 			const bobJoinedAfter = makeCollaborator( {
@@ -202,13 +146,10 @@ describe( 'useCollaboratorNotifications', () => {
 				},
 			} );
 
-			mockActiveCollaborators = [ me ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
 
-			mockActiveCollaborators = [ me, bobJoinedAfter ];
-			rerender();
+			// Simulate the core-data hook firing the join callback
+			mockOnJoinCallback?.( bobJoinedAfter, me );
 
 			expect( mockCreateNotice ).toHaveBeenCalledWith(
 				'info',
@@ -218,67 +159,36 @@ describe( 'useCollaboratorNotifications', () => {
 				} )
 			);
 		} );
-	} );
 
-	describe( 'collaborator leave notifications', () => {
-		it( 'fires a leave notification when a collaborator disconnects (isConnected → false)', () => {
-			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
+		it( 'skips join notification for collaborators who joined before current user', () => {
+			const me = makeMe(); // enteredAt: BASE_ENTERED_AT + 5000
+			const aliceJoinedFirst = makeCollaborator( {
+				collaboratorInfo: {
+					id: 100,
+					name: 'Alice',
+					slug: 'alice',
+					avatar_urls: {},
+					browserType: 'Chrome',
+					enteredAt: BASE_ENTERED_AT + 1000, // joined earlier than me
+				},
+			} );
 
-			// Alice disconnects — still in the list but greyed out.
-			mockActiveCollaborators = [
-				makeMe(),
-				{ ...alice, isConnected: false },
-			];
-			rerender();
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
 
-			expect( mockCreateNotice ).toHaveBeenCalledWith(
-				'info',
-				'Alice has left the post.',
-				expect.objectContaining( {
-					type: 'snackbar',
-					isDismissible: false,
-					id: 'collab-user-exited-100',
-				} )
-			);
-		} );
-
-		it( 'does not fire a duplicate leave notification when a disconnected collaborator is removed from the list', () => {
-			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// Alice disconnects (greyed out).
-			mockActiveCollaborators = [
-				makeMe(),
-				{ ...alice, isConnected: false },
-			];
-			rerender();
-			mockCreateNotice.mockClear();
-
-			// After the 5s delay Alice is fully removed from the list.
-			mockActiveCollaborators = [ makeMe() ];
-			rerender();
+			// Simulate the core-data hook firing the join callback
+			mockOnJoinCallback?.( aliceJoinedFirst, me );
 
 			expect( mockCreateNotice ).not.toHaveBeenCalled();
 		} );
+	} );
 
-		it( 'fires a leave notification when a connected collaborator is removed from the list directly', () => {
+	describe( 'collaborator leave notifications', () => {
+		it( 'fires a leave notification when a collaborator leaves', () => {
 			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
 
-			// Alice disappears from the list without going through isConnected=false
-			// (e.g. polling detects the disconnect and removes in one update).
-			mockActiveCollaborators = [ makeMe() ];
-			rerender();
+			// Simulate the core-data hook firing the leave callback
+			mockOnLeaveCallback?.( alice );
 
 			expect( mockCreateNotice ).toHaveBeenCalledWith(
 				'info',
@@ -289,44 +199,24 @@ describe( 'useCollaboratorNotifications', () => {
 					id: 'collab-user-exited-100',
 				} )
 			);
-		} );
-
-		it( 'does not fire a leave notification for the current user', () => {
-			const me = makeMe();
-			mockActiveCollaborators = [ me, makeCollaborator() ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// "Me" disconnects
-			mockActiveCollaborators = [
-				{ ...me, isConnected: false },
-				makeCollaborator(),
-			];
-			rerender();
-
-			// Should not notify about self
-			const selfLeaveCall = mockCreateNotice.mock.calls.find(
-				( [ , message ] ) => message.includes( 'Me' )
-			);
-			expect( selfLeaveCall ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'post updated notifications', () => {
 		it( 'fires a post updated notification when a collaborator saves (draft)', () => {
 			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
 
-			// State map reports Alice saved
-			mockLastPostSave = {
-				savedAt: Date.now(),
-				savedByClientId: alice.clientId,
-			};
-			rerender();
+			// Simulate the core-data hook firing the save callback
+			mockOnPostSaveCallback?.(
+				{
+					savedAt: Date.now(),
+					savedByClientId: alice.clientId,
+					postStatus: undefined,
+				},
+				alice,
+				null
+			);
 
 			expect( mockCreateNotice ).toHaveBeenCalledWith(
 				'info',
@@ -345,16 +235,17 @@ describe( 'useCollaboratorNotifications', () => {
 				postStatus: 'publish',
 			};
 			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
 
-			mockLastPostSave = {
-				savedAt: Date.now(),
-				savedByClientId: alice.clientId,
-			};
-			rerender();
+			mockOnPostSaveCallback?.(
+				{
+					savedAt: Date.now(),
+					savedByClientId: alice.clientId,
+					postStatus: 'publish',
+				},
+				alice,
+				null
+			);
 
 			expect( mockCreateNotice ).toHaveBeenCalledWith(
 				'info',
@@ -365,88 +256,83 @@ describe( 'useCollaboratorNotifications', () => {
 			);
 		} );
 
-		it( 'does not fire a notification when the current user saves', () => {
-			const me = makeMe();
-			mockActiveCollaborators = [ me, makeCollaborator() ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// State map reports "me" saved
-			mockLastPostSave = {
-				savedAt: Date.now(),
-				savedByClientId: me.clientId,
+		it( 'fires a "Post published" notification on first publish (no previous save)', () => {
+			mockEditorState = {
+				...mockEditorState,
+				postStatus: 'draft',
 			};
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not fire duplicate notifications for the same savedAt timestamp', () => {
 			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const savedAt = Date.now();
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
 
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
+			mockOnPostSaveCallback?.(
+				{
+					savedAt: Date.now(),
+					savedByClientId: alice.clientId,
+					postStatus: 'publish',
+				},
+				alice,
+				null
 			);
 
-			// First save event
-			mockLastPostSave = {
-				savedAt,
-				savedByClientId: alice.clientId,
-			};
-			rerender();
-			mockCreateNotice.mockClear();
-
-			// Rerender with same savedAt — should not notify again
-			rerender();
-
-			expect( mockCreateNotice ).not.toHaveBeenCalled();
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Post published by Alice.',
+				expect.objectContaining( {
+					id: 'collab-post-updated-100',
+				} )
+			);
 		} );
 
-		it( 'does not fire a notification when a peer reconnects without a new save', () => {
+		it( 'fires a "Post published" notification using prevEvent status for transition detection', () => {
+			// Redux postStatus may already be 'publish' by the time the
+			// callback fires. The prevEvent carries the accurate prior status.
+			mockEditorState = {
+				...mockEditorState,
+				postStatus: 'publish',
+			};
 			const alice = makeCollaborator();
-			mockActiveCollaborators = [ makeMe(), alice ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			mockOnPostSaveCallback?.(
+				{
+					savedAt: Date.now() + 2000,
+					savedByClientId: alice.clientId,
+					postStatus: 'publish',
+				},
+				alice,
+				{
+					savedAt: Date.now() + 1000,
+					savedByClientId: alice.clientId,
+					postStatus: 'draft',
+				}
 			);
 
-			// Alice disconnects and reconnects — useLastPostSave filters
-			// pre-existing state map values via its baseline check, so
-			// lastPostSave stays null.
-			mockActiveCollaborators = [
-				makeMe(),
-				{ ...alice, isConnected: false },
-			];
-			rerender();
-			mockCreateNotice.mockClear();
-
-			mockActiveCollaborators = [
-				makeMe(),
-				{ ...alice, clientId: 50, isConnected: true },
-			];
-			rerender();
-
-			// Only the leave/join notices should have fired, no save notice.
-			const saveNotice = mockCreateNotice.mock.calls.find(
-				( [ , msg ] ) => ( msg as string ).includes( 'saved' )
+			expect( mockCreateNotice ).toHaveBeenCalledWith(
+				'info',
+				'Post published by Alice.',
+				expect.objectContaining( {
+					id: 'collab-post-updated-100',
+				} )
 			);
-			expect( saveNotice ).toBeUndefined();
 		} );
 
-		it( 'does not fire a notification when the saver is not in the collaborator list', () => {
-			mockActiveCollaborators = [ makeMe(), makeCollaborator() ];
-			const { rerender } = renderHook( () =>
-				useCollaboratorNotifications( 123, 'post' )
-			);
-
-			// State map reports a save by unknown clientId
-			mockLastPostSave = {
-				savedAt: Date.now(),
-				savedByClientId: 12345,
+		it( 'does not fire a notification when postStatus is undefined', () => {
+			mockEditorState = {
+				...mockEditorState,
+				postStatus: undefined as any,
 			};
-			rerender();
+			const alice = makeCollaborator();
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			mockOnPostSaveCallback?.(
+				{
+					savedAt: Date.now(),
+					savedByClientId: alice.clientId,
+					postStatus: undefined,
+				},
+				alice,
+				null
+			);
 
 			expect( mockCreateNotice ).not.toHaveBeenCalled();
 		} );

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { usePrevious } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	privateApis,
 	type PostEditorAwarenessState,
+	type PostSaveEvent,
 } from '@wordpress/core-data';
 
 /**
@@ -17,7 +17,8 @@ import {
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-const { useActiveCollaborators, useLastPostSave } = unlock( privateApis );
+const { useOnCollaboratorJoin, useOnCollaboratorLeave, useOnPostSave } =
+	unlock( privateApis );
 
 /**
  * Notice IDs for each notification type. Using stable IDs prevents duplicate
@@ -29,6 +30,10 @@ const NOTIFICATION_TYPE = {
 	COLLAB_USER_EXITED: 'collab-user-exited',
 } as const;
 
+/**
+ * Development kill-switches for each notification type. Flip to `false`
+ * to suppress a category during local testing without removing code.
+ */
 const NOTIFICATIONS_CONFIG = {
 	userEntered: true,
 	userExited: true,
@@ -72,13 +77,6 @@ export function useCollaboratorNotifications(
 	postId: number | null,
 	postType: string | null
 ): void {
-	const activeCollaborators = useActiveCollaborators(
-		postId,
-		postType
-	) as PostEditorAwarenessState[];
-
-	const lastPostSave = useLastPostSave( postId, postType );
-
 	const { postStatus, isCollaborationEnabled } = useSelect( ( select ) => {
 		const editorSel = select( editorStore );
 		return {
@@ -92,50 +90,21 @@ export function useCollaboratorNotifications(
 
 	const { createNotice } = useDispatch( noticesStore );
 
-	const prevCollaborators = usePrevious( activeCollaborators );
-	const prevPostSave = usePrevious( lastPostSave );
+	// Pass null when collaboration is disabled to prevent the hooks
+	// from subscribing to awareness state.
+	const effectivePostId = isCollaborationEnabled ? postId : null;
+	const effectivePostType = isCollaborationEnabled ? postType : null;
 
-	/*
-	 * Detect collaborator joins and leaves.
-	 */
-	useEffect( () => {
-		if ( ! isCollaborationEnabled ) {
-			return;
-		}
-
-		/*
-		 * On first render usePrevious returns undefined. On subsequent renders
-		 * the list may still be empty while the store hydrates. In both cases,
-		 * skip to avoid spurious "X joined" toasts for users already present.
-		 */
-		if ( ! prevCollaborators || prevCollaborators.length === 0 ) {
-			return;
-		}
-
-		function notify( noticeId: string, message: string ) {
-			void createNotice( 'info', message, {
-				id: noticeId,
-				type: 'snackbar',
-				isDismissible: false,
-			} );
-		}
-
-		const prevMap = new Map< number, PostEditorAwarenessState >(
-			prevCollaborators.map( ( c ) => [ c.clientId, c ] )
-		);
-		const newMap = new Map< number, PostEditorAwarenessState >(
-			activeCollaborators.map( ( c ) => [ c.clientId, c ] )
-		);
-
-		/*
-		 * Detect joins: new clientIds that weren't in the previous state.
-		 */
-		if ( NOTIFICATIONS_CONFIG.userEntered ) {
-			const me = activeCollaborators.find( ( c ) => c.isMe );
-
-			for ( const [ clientId, collaborator ] of newMap ) {
-				if ( prevMap.has( clientId ) || collaborator.isMe ) {
-					continue;
+	useOnCollaboratorJoin(
+		effectivePostId,
+		effectivePostType,
+		useCallback(
+			(
+				collaborator: PostEditorAwarenessState,
+				me?: PostEditorAwarenessState
+			) => {
+				if ( ! NOTIFICATIONS_CONFIG.userEntered ) {
+					return;
 				}
 
 				/*
@@ -148,111 +117,93 @@ export function useCollaboratorNotifications(
 					collaborator.collaboratorInfo.enteredAt <
 						me.collaboratorInfo.enteredAt
 				) {
-					continue;
+					return;
 				}
 
-				notify(
-					`${ NOTIFICATION_TYPE.COLLAB_USER_ENTERED }-${ collaborator.collaboratorInfo.id }`,
+				void createNotice(
+					'info',
 					sprintf(
 						/* translators: %s: collaborator display name */
 						__( '%s has joined the post.' ),
 						collaborator.collaboratorInfo.name
-					)
+					),
+					{
+						id: `${ NOTIFICATION_TYPE.COLLAB_USER_ENTERED }-${ collaborator.collaboratorInfo.id }`,
+						type: 'snackbar',
+						isDismissible: false,
+					}
 				);
-			}
-		}
+			},
+			[ createNotice ]
+		)
+	);
 
-		/*
-		 * Detect leaves by iterating the previous collaborator list. A leave
-		 * notification fires when a previously-connected collaborator either:
-		 *   - transitions to isConnected=false (greyed-out in the UI), or
-		 *   - disappears from the list entirely while still connected.
-		 * Already-disconnected collaborators that are later removed from the
-		 * list (after the 5 s delay) are silently ignored.
-		 */
-		if ( NOTIFICATIONS_CONFIG.userExited ) {
-			for ( const [ clientId, prevCollab ] of prevMap ) {
-				if ( prevCollab.isMe || ! prevCollab.isConnected ) {
-					continue;
+	useOnCollaboratorLeave(
+		effectivePostId,
+		effectivePostType,
+		useCallback(
+			( collaborator: PostEditorAwarenessState ) => {
+				if ( ! NOTIFICATIONS_CONFIG.userExited ) {
+					return;
 				}
 
-				const newCollab = newMap.get( clientId );
-				if ( newCollab?.isConnected ) {
-					continue;
-				}
-
-				notify(
-					`${ NOTIFICATION_TYPE.COLLAB_USER_EXITED }-${ prevCollab.collaboratorInfo.id }`,
+				void createNotice(
+					'info',
 					sprintf(
 						/* translators: %s: collaborator display name */
 						__( '%s has left the post.' ),
-						prevCollab.collaboratorInfo.name
-					)
+						collaborator.collaboratorInfo.name
+					),
+					{
+						id: `${ NOTIFICATION_TYPE.COLLAB_USER_EXITED }-${ collaborator.collaboratorInfo.id }`,
+						type: 'snackbar',
+						isDismissible: false,
+					}
 				);
-			}
-		}
-	}, [
-		activeCollaborators,
-		prevCollaborators,
-		isCollaborationEnabled,
-		createNotice,
-	] );
+			},
+			[ createNotice ]
+		)
+	);
 
-	/*
-	 * Detect remote save events via the CRDT state map. The savedByClientId
-	 * is a Y.Doc client ID which maps to a collaborator via clientId.
-	 */
-	useEffect( () => {
-		if (
-			! isCollaborationEnabled ||
-			! NOTIFICATIONS_CONFIG.postUpdated ||
-			! lastPostSave ||
-			! postStatus
-		) {
-			return;
-		}
+	useOnPostSave(
+		effectivePostId,
+		effectivePostType,
+		useCallback(
+			(
+				saveEvent: PostSaveEvent,
+				saver: PostEditorAwarenessState,
+				prevEvent: PostSaveEvent | null
+			) => {
+				if ( ! NOTIFICATIONS_CONFIG.postUpdated || ! postStatus ) {
+					return;
+				}
 
-		if ( prevPostSave && lastPostSave.savedAt === prevPostSave.savedAt ) {
-			return;
-		}
+				// Prefer the remote status from Y.Doc (accurate at save time)
+				// over the local Redux value, which may not have synced yet.
+				const effectiveStatus =
+					saveEvent.postStatus ?? postStatus ?? 'draft';
 
-		const saver = activeCollaborators.find(
-			( c ) => c.clientId === lastPostSave.savedByClientId && ! c.isMe
-		);
+				// Use the previous save event's status when available for
+				// accurate first-publish detection across rapid saves.
+				const prevStatus = prevEvent?.postStatus ?? postStatus;
+				const isFirstPublish =
+					! (
+						prevStatus && PUBLISHED_STATUSES.includes( prevStatus )
+					) && PUBLISHED_STATUSES.includes( effectiveStatus );
 
-		if ( ! saver ) {
-			return;
-		}
+				const message = getPostUpdatedMessage(
+					saver.collaboratorInfo.name,
+					effectiveStatus,
+					isFirstPublish
+				);
 
-		// Prefer the remote status from Y.Doc (accurate at save time) over
-		// the local Redux value, which may not have synced yet.
-		const effectiveStatus =
-			lastPostSave.postStatus ?? postStatus ?? 'draft';
-
-		// prevPostSave is null on the first save this session, so fall back
-		// to the Redux status (still pre-save when the notification fires).
-		const prevStatus = prevPostSave?.postStatus ?? postStatus;
-		const isFirstPublish =
-			! ( prevStatus && PUBLISHED_STATUSES.includes( prevStatus ) ) &&
-			PUBLISHED_STATUSES.includes( effectiveStatus );
-
-		const message = getPostUpdatedMessage(
-			saver.collaboratorInfo.name,
-			effectiveStatus,
-			isFirstPublish
-		);
-
-		void createNotice( 'info', message, {
-			id: `${ NOTIFICATION_TYPE.COLLAB_POST_UPDATED }-${ saver.collaboratorInfo.id }`,
-			type: 'snackbar',
-			isDismissible: false,
-		} );
-	}, [
-		lastPostSave,
-		prevPostSave,
-		activeCollaborators,
-		isCollaborationEnabled,
-		postStatus,
-		createNotice,
-	] );
+				void createNotice( 'info', message, {
+					id: `${ NOTIFICATION_TYPE.COLLAB_POST_UPDATED }-${ saver.collaboratorInfo.id }`,
+					type: 'snackbar',
+					isDismissible: false,
+				} );
+			},
+			[ createNotice, postStatus ]
+		)
+	);
 }


### PR DESCRIPTION
## What?
Follow up to #76065 ([comment](https://github.com/WordPress/gutenberg/pull/76065#discussion_r2879338495))

Move collaborator notification event hooks (`useOnCollaboratorJoin`, `useOnCollaboratorLeave`, `useOnPostSave`) from the `editor` package into `core-data`.

## Why?

As noted by @chriszarate, the editor's `useCollaboratorNotifications` was leaking implementation details from `core-data`. The event detection logic (join, leave, save) is a data-layer concern and belongs in `core-data`, not `editor`. This follows the package layering architecture and makes the hooks reusable outside the editor context.

## How?

- Extract three new hooks into `core-data`'s `use-post-editor-awareness-state`: `useOnCollaboratorJoin`, `useOnCollaboratorLeave`, and `useOnPostSave`.
- Simplify `useCollaboratorNotifications` in the `editor` package to a thin consumer that only creates notices using the new hooks.
- `useOnPostSave` now passes the previous save event to its callback, enabling accurate first-publish detection.
- `useLastPostSave` is made private as an internal detail of `useOnPostSave`.
- Expose the new hooks via `core-data` private APIs.

## Testing Instructions

No functional changes — this is a pure refactor. Follow the [testing instructions in #76065](https://github.com/WordPress/gutenberg/pull/76065) to verify existing behavior is preserved.
