### PR TITLE
Navigation Overlays: Fix submenu overflow when parent nav is right-justified

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -700,8 +700,18 @@ button.wp-block-navigation-item__content {
 					display: none;
 				}
 
+				// Override justification dropdown menu positioning rules inside custom overlays.
+				// Mirrors the protection at lines 674-678 for default overlays, which does not
+				// apply here. Prevents .items-justified-right descendant rules from cascading
+				// right: 0 into the overlay and anchoring submenus off the left edge of the viewport.
+				// See: https://github.com/WordPress/gutenberg/issues/76276
 				.wp-block-navigation__overlay-container {
 					display: block;
+
+					.wp-block-navigation__submenu-container {
+						right: auto;
+						left: 0;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What

Fixes submenu items being clipped off the left edge of the viewport when a Navigation block using a custom overlay has its parent block set to right-justified.

Fixes #76276

## Why

The `items-justified-right` CSS rule sets `right: 0` on all descendant `.wp-block-navigation__submenu-container` elements via a broad descendant selector:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation/style.scss#L440-L462

```scss
.wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
    .wp-block-navigation__submenu-container {
        left: auto;
        right: 0;
    }
}
```

This rule cascades into the inner Navigation block inside a custom overlay template part (since it is a DOM descendant of the outer right-justified nav block). With `position: absolute; right: 0`, the submenu anchors its right edge to the parent item and extends leftward, falling outside the overlay boundary on narrow viewports.

The default overlay already has equivalent protection at lines 674–678, which resets `right: auto; left: auto` using a high-specificity selector:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation/style.scss#L674-L678

```scss
.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
    right: auto;
    left: auto;
}
```

The default overlay also resets submenu containers to `position: static` at line 631, making `right`/`left` inert regardless:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation/style.scss#L631

Neither of these protections applies in the custom overlay context.

## How

Adds a scoped CSS override inside the custom overlay open state (`&.disable-default-overlay.is-menu-open`) that resets `right: auto; left: 0` on submenu containers within `.wp-block-navigation__overlay-container`. This is added alongside the existing `display: block` rule for the overlay container to avoid a duplicate selector lint error.

The compiled selector has specificity `(0,6,0)`, sufficient to override the justification rule at `(0,4,0)`.

## Testing Instructions

**To verify the bug on `trunk`:**

1. Appearance → Editor → edit a template containing a Navigation block
2. Select the Navigation block → set **Justify items** to **Right**
3. In the Navigation block settings → **Overlay template** → select a custom overlay using **Edit with collapsed submenu**
4. Edit the Navigation block inside the overlay: increase the font size to make items larger
5. Set submenus inside the overlay to open **on click** or **on hover** (not always open)
6. Ensure at least one navigation item has submenu children. One submenu item should have a **long unbroken string** of text with no spaces (e.g. `longwordlongwordlongword`) — this forces a wide submenu and reliably triggers the overflow. This is a good stress test for non-English languages where unbroken strings are common
7. Visit the front end on a narrow viewport (or browser DevTools mobile emulation)
8. Open the overlay via the hamburger button
9. Expand the submenu — items will be clipped/cut off on the left edge of the overlay ❌

Toggle the parent Navigation block between **right-justified** and **left-justified** to confirm the bug appears with right and disappears with left.

**To verify the fix on this branch:**

Repeat all steps above — submenu items should display correctly within the overlay regardless of the parent's justification setting ✅

## Known Related Issue (Out of Scope)

During investigation, a separate issue was identified: navigation items containing long unbroken strings (no spaces or word-break opportunities) can overflow the right edge of the overlay regardless of justification setting. This is distinct from the bug fixed here and requires its own fix (likely `overflow-wrap: break-word` on submenu item content). It will be tracked and addressed separately.

## Screenshots

<img width="639" height="670" alt="Screen Shot 2026-03-10 at 13 52 01" src="https://github.com/user-attachments/assets/a804e233-eceb-46f8-9a2c-7f8737321198" />
<img width="539" height="518" alt="Screen Shot 2026-03-10 at 13 52 13" src="https://github.com/user-attachments/assets/ac914df1-716d-446d-a747-91d582e54d2a" />

