### PR TITLE
Storybook: Rename "Components (Deprecated)" to "Deprecated"

### DIFF
--- a/packages/components/src/button-group/stories/index.story.tsx
+++ b/packages/components/src/button-group/stories/index.story.tsx
@@ -16,7 +16,7 @@ import Button from '../../button';
  * This component is deprecated. Use `ToggleGroupControl` instead.
  */
 const meta: Meta< typeof ButtonGroup > = {
-	title: 'Components (Deprecated)/ButtonGroup',
+	title: 'Deprecated/ButtonGroup',
 	id: 'components-buttongroup',
 	component: ButtonGroup,
 	argTypes: {

--- a/packages/components/src/button-group/stories/index.story.tsx
+++ b/packages/components/src/button-group/stories/index.story.tsx
@@ -16,7 +16,7 @@ import Button from '../../button';
  * This component is deprecated. Use `ToggleGroupControl` instead.
  */
 const meta: Meta< typeof ButtonGroup > = {
-	title: 'Deprecated/ButtonGroup',
+	title: 'Components/Deprecated/ButtonGroup',
 	id: 'components-buttongroup',
 	component: ButtonGroup,
 	argTypes: {

--- a/packages/components/src/composite/legacy/stories/index.story.tsx
+++ b/packages/components/src/composite/legacy/stories/index.story.tsx
@@ -15,7 +15,7 @@ import {
 import { UseCompositeStatePlaceholder, transform } from './utils';
 
 const meta: Meta< typeof UseCompositeStatePlaceholder > = {
-	title: 'Components (Deprecated)/Composite (Unstable)',
+	title: 'Deprecated/Composite (Unstable)',
 	id: 'components-composite-unstable',
 	component: UseCompositeStatePlaceholder,
 	subcomponents: {

--- a/packages/components/src/composite/legacy/stories/index.story.tsx
+++ b/packages/components/src/composite/legacy/stories/index.story.tsx
@@ -15,7 +15,7 @@ import {
 import { UseCompositeStatePlaceholder, transform } from './utils';
 
 const meta: Meta< typeof UseCompositeStatePlaceholder > = {
-	title: 'Deprecated/Composite (Unstable)',
+	title: 'Components/Deprecated/Composite (Unstable)',
 	id: 'components-composite-unstable',
 	component: UseCompositeStatePlaceholder,
 	subcomponents: {

--- a/packages/components/src/navigation/stories/index.story.tsx
+++ b/packages/components/src/navigation/stories/index.story.tsx
@@ -26,7 +26,7 @@ import './style.css';
  * This component is deprecated. Consider using `Navigator` instead.
  */
 const meta: Meta< typeof Navigation > = {
-	title: 'Deprecated/Navigation',
+	title: 'Components/Deprecated/Navigation',
 	id: 'components-navigation',
 	component: Navigation,
 	subcomponents: {

--- a/packages/components/src/navigation/stories/index.story.tsx
+++ b/packages/components/src/navigation/stories/index.story.tsx
@@ -26,7 +26,7 @@ import './style.css';
  * This component is deprecated. Consider using `Navigator` instead.
  */
 const meta: Meta< typeof Navigation > = {
-	title: 'Components (Deprecated)/Navigation',
+	title: 'Deprecated/Navigation',
 	id: 'components-navigation',
 	component: Navigation,
 	subcomponents: {

--- a/packages/components/src/radio-group/stories/index.story.tsx
+++ b/packages/components/src/radio-group/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { RadioGroup } from '..';
 import { Radio } from '../radio';
 
 const meta: Meta< typeof RadioGroup > = {
-	title: 'Deprecated/RadioGroup',
+	title: 'Components/Deprecated/RadioGroup',
 	id: 'components-radiogroup',
 	component: RadioGroup,
 	subcomponents: { Radio },

--- a/packages/components/src/radio-group/stories/index.story.tsx
+++ b/packages/components/src/radio-group/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { RadioGroup } from '..';
 import { Radio } from '../radio';
 
 const meta: Meta< typeof RadioGroup > = {
-	title: 'Components (Deprecated)/RadioGroup',
+	title: 'Deprecated/RadioGroup',
 	id: 'components-radiogroup',
 	component: RadioGroup,
 	subcomponents: { Radio },

--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -109,6 +109,7 @@ export const parameters = {
 					'Selection & Input',
 					'Typography',
 					'Utilities',
+					'Deprecated',
 				],
 				'Icons',
 				'Design System',


### PR DESCRIPTION
## What?

Renames "Components (Deprecated)" to "Deprecated" in Storybook. Before:

<img width="579" height="827" alt="Skærmbillede 2026-03-10 kl  15 34 53" src="https://github.com/user-attachments/assets/a8cdc977-6027-44f3-abb3-d3e7842aadd0" />

After:

<img width="664" height="808" alt="Skærmbillede 2026-03-10 kl  15 34 34" src="https://github.com/user-attachments/assets/14f005ca-1bc4-4932-9eec-3492474c831b" />

Might pair well with #76361. 

## Why?

This change is mainly a taxonomical one, to simplify the scannability of the sidebar. A side effect is that it can contain information about deprecations that isn't just _components_. I'd like to think we don't deprecate often, but as 76361 also delves into, Storybook isn't just about component docs.

## Testing Instructions

npm run storybook:dev