### PR TITLE
Nav submenu: add support to style current submenu in theme.json

### DIFF
--- a/backport-changelog/7.1/11174.md
+++ b/backport-changelog/7.1/11174.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11174
 
 * https://github.com/WordPress/gutenberg/pull/75736
+* https://github.com/WordPress/gutenberg/pull/76367

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -626,9 +626,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(
-		'core/button'               => array( ':hover', ':focus', ':focus-visible', ':active' ),
-		'core/navigation-link'      => array( ':hover', ':focus', ':focus-visible', ':active' ),
-		'core/navigation-submenu'   => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/button'             => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-link'    => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-submenu' => array( ':hover', ':focus', ':focus-visible', ':active' ),
 	);
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -626,8 +626,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(
-		'core/button'          => array( ':hover', ':focus', ':focus-visible', ':active' ),
-		'core/navigation-link' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/button'               => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-link'      => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-submenu'   => array( ':hover', ':focus', ':focus-visible', ':active' ),
 	);
 
 	/**
@@ -819,7 +820,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_CUSTOM_STATES = array(
-		'core/navigation-link' => array( '-current' ),
+		'core/navigation-link'    => array( '-current' ),
+		'core/navigation-submenu' => array( '-current' ),
 	);
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -610,8 +610,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(
-		'core/button'          => array( ':hover', ':focus', ':focus-visible', ':active' ),
-		'core/navigation-link' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/button'               => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-link'      => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-submenu'   => array( ':hover', ':focus', ':focus-visible', ':active' ),
 	);
 
 	/**
@@ -632,7 +633,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_CUSTOM_STATES = array(
-		'core/navigation-link' => array( '@current' ),
+		'core/navigation-link'    => array( '@current' ),
+		'core/navigation-submenu' => array( '@current' ),
 	);
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -610,9 +610,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(
-		'core/button'               => array( ':hover', ':focus', ':focus-visible', ':active' ),
-		'core/navigation-link'      => array( ':hover', ':focus', ':focus-visible', ':active' ),
-		'core/navigation-submenu'   => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/button'             => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-link'    => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-submenu' => array( ':hover', ':focus', ':focus-visible', ':active' ),
 	);
 
 	/**

--- a/packages/block-library/src/navigation-submenu/README.md
+++ b/packages/block-library/src/navigation-submenu/README.md
@@ -70,6 +70,13 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 
 - `core/isInsideSubmenu` → attribute `isParentSubmenu`
 
+## CSS Selectors
+
+_Defined via the [`selectors`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/) property in block.json._
+
+- **states**:
+  - -current: `.wp-block-navigation .wp-block-navigation-submenu .current-menu-item`
+
 ## Block Markup
 
 This is a [**hybrid block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/). It saves static markup that the server may enhance during rendering.

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -87,6 +87,11 @@
 			"clientNavigation": true
 		}
 	},
+	"selectors": {
+		"states": {
+			"-current": ".wp-block-navigation .wp-block-navigation-submenu .current-menu-item"
+		}
+	},
 	"editorStyle": "wp-block-navigation-submenu-editor",
 	"style": "wp-block-navigation-submenu"
 }

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -80,6 +80,11 @@
 			"clientNavigation": true
 		}
 	},
+	"selectors": {
+		"states": {
+			"@current": ".wp-block-navigation .wp-block-navigation-submenu .current-menu-item"
+		}
+	},
 	"editorStyle": "wp-block-navigation-submenu-editor",
 	"style": "wp-block-navigation-submenu"
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8028,6 +8028,39 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'current-menu-item', $stylesheet_unsupported );
 	}
 
+	/**
+	 * Test that core/navigation-submenu supports -current and its pseudo-selectors
+	 * independently from core/navigation-link, using its own CSS selector.
+	 */
+	public function test_block_custom_states_navigation_submenu() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-submenu' => array(
+							'-current' => array(
+								'color'  => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+								':hover' => array(
+									'color' => array(
+										'text' => 'white',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$expected   = ':root :where(.wp-block-navigation .wp-block-navigation-submenu .current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .wp-block-navigation-submenu .current-menu-item:hover){color: white;}';
+		$this->assertSameCSS( $expected, $stylesheet );
+	}
+
 	public function test_merge_incoming_data_block_level_inherits_global_default_setting() {
 		$defaults = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6915,6 +6915,39 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'current-menu-item', $stylesheet_unsupported );
 	}
 
+	/**
+	 * Test that core/navigation-submenu supports @current and its pseudo-selectors
+	 * independently from core/navigation-link, using its own CSS selector.
+	 */
+	public function test_block_custom_states_navigation_submenu() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-submenu' => array(
+							'@current' => array(
+								'color'  => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+								':hover' => array(
+									'color' => array(
+										'text' => 'white',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$expected   = ':root :where(.wp-block-navigation .wp-block-navigation-submenu .current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .wp-block-navigation-submenu .current-menu-item:hover){color: white;}';
+		$this->assertSameCSS( $expected, $stylesheet );
+	}
+
 	public function test_merge_incoming_data_block_level_inherits_global_default_setting() {
 		$defaults = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2594,7 +2594,17 @@
 					]
 				},
 				"core/navigation-submenu": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksCustomStatesProperties"
+						}
+					]
 				},
 				"core/nextpage": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2216,7 +2216,17 @@
 					]
 				},
 				"core/navigation-submenu": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksCustomStatesProperties"
+						}
+					]
 				},
 				"core/nextpage": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up to https://github.com/WordPress/gutenberg/pull/75736/

Following the discussion on the other PR, we are adding support for `current` state to the submenu block too

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For consistency and to allow users more nunaced control over how they style their navigation blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We are adding support the same we did for the nav link, by adding it to the allowed blocks constant, adding a selector on block.json and modifying the schema andadding tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Add this to your theme.json, before this PR only the nav-link applied, now we can target submenus specifically.
```
"core/navigation-link": {
    "-current": { "color": { "text": "pink" } }
},
"core/navigation-submenu": {
    "-current": { "color": { "text": "green" } }
},
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1026" height="304" alt="Screenshot 2026-03-10 at 17 20 40" src="https://github.com/user-attachments/assets/e0dd7d08-1ac3-484d-b218-db9c12716e84" />|<img width="1071" height="371" alt="Screenshot 2026-03-10 at 17 16 33" src="https://github.com/user-attachments/assets/233f3fbd-088b-4dab-869b-b4d1fe52f856" />|
