### PR TITLE
ui/Card: increase padding, align with legacy Card

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `Badge`: Add border, update text color, and apply `neutral-strong` background to `none` intent for better contrast against neutral surfaces ([#76356](https://github.com/WordPress/gutenberg/pull/76356)).
 -   `Notice`: Improve narrow layout by letting description and actions span the icon column when a title is present ([#76202](https://github.com/WordPress/gutenberg/pull/76202)).
 -   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
+-   `Card`, `CollapsibleCard`: update padding to match legacy `Card` component ([#76368](https://github.com/WordPress/gutenberg/pull/76368)).
 
 ## 0.8.0 (2026-03-04)
 

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -2,8 +2,8 @@
 
 @layer wp-ui-components {
 	.root {
-		--wp-ui-card-padding: var(--wpds-dimension-padding-xl);
-		--wp-ui-card-header-content-gap: var(--wpds-dimension-gap-lg);
+		--wp-ui-card-padding: var(--wpds-dimension-padding-2xl);
+		--wp-ui-card-header-content-gap: var(--wpds-dimension-gap-xl);
 
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Splitting off https://github.com/WordPress/gutenberg/pull/76282

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Tweak the `@wordpress/ui` `Card` component to have the same padding (`24px`) as the legacy `Card` from `@wordpress/components`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistency, especially as we refactor parts of the UI from `@wordpress/components` to `@wordpress/ui` ([example](https://github.com/WordPress/gutenberg/pull/76282))

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tweak tokens

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load Storybook example

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Scenario |Before|After|
|-|-|-|
| `Card` | ![Screenshot 2026-03-10 at 17 19 52](https://github.com/user-attachments/assets/88d7e209-5b49-42b3-98ee-fac9cc58360f) | ![Screenshot 2026-03-10 at 17 18 56](https://github.com/user-attachments/assets/4638b8b5-7307-4d39-8ffd-4cab8522a426) |
| `CollapsibleCard` (closed) |  ![Screenshot 2026-03-10 at 17 20 00](https://github.com/user-attachments/assets/4d53cf3b-d869-42f3-9e16-0824a6dff680) | ![Screenshot 2026-03-10 at 17 19 05](https://github.com/user-attachments/assets/0a49632c-124f-4a56-aef0-36ad865d51de) |
| `CollapsibleCard` (opened) |  ![Screenshot 2026-03-10 at 17 20 07](https://github.com/user-attachments/assets/5605f968-18d7-4b1a-8728-3bf5cc2a57f9) | ![Screenshot 2026-03-10 at 17 19 16](https://github.com/user-attachments/assets/af3c13e9-6ed9-44dd-b40f-ac7ddc0c7268) |
