### PR TITLE
[RTC] Fix performance regression on post save

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -396,28 +396,43 @@ export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }
 
-export function __unstableSerializeAndClean( blocks ) {
-	// A single unmodified default block is assumed to
-	// be equivalent to an empty post.
-	if ( blocks.length === 1 && isUnmodifiedDefaultBlock( blocks[ 0 ] ) ) {
-		blocks = [];
-	}
+export const __unstableSerializeAndClean = ( () => {
+	const cache = new WeakMap();
 
-	let content = serialize( blocks );
+	return ( blocks ) => {
+		const cached = cache.get( blocks );
+		if ( cached !== undefined ) {
+			return cached;
+		}
 
-	// For compatibility, treat a post consisting of a
-	// single freeform block as legacy content and apply
-	// pre-block-editor removep'd content formatting.
-	if (
-		blocks.length === 1 &&
-		blocks[ 0 ].name === getFreeformContentHandlerName() &&
-		blocks[ 0 ].name === 'core/freeform'
-	) {
-		content = removep( content );
-	}
+		let effectiveBlocks = blocks;
 
-	return content;
-}
+		// A single unmodified default block is assumed to
+		// be equivalent to an empty post.
+		if (
+			effectiveBlocks.length === 1 &&
+			isUnmodifiedDefaultBlock( effectiveBlocks[ 0 ] )
+		) {
+			effectiveBlocks = [];
+		}
+
+		let content = serialize( effectiveBlocks );
+
+		// For compatibility, treat a post consisting of a
+		// single freeform block as legacy content and apply
+		// pre-block-editor removep'd content formatting.
+		if (
+			effectiveBlocks.length === 1 &&
+			effectiveBlocks[ 0 ].name === getFreeformContentHandlerName() &&
+			effectiveBlocks[ 0 ].name === 'core/freeform'
+		) {
+			content = removep( content );
+		}
+
+		cache.set( blocks, content );
+		return content;
+	};
+} )();
 
 /**
  * Takes a block or set of blocks and returns the serialized post content.

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -342,8 +342,9 @@ export function getPostChangesFromCRDTDoc(
 						);
 					}
 
-					// The consumers of blocks have memoization that renders optimization
-					// here unnecessary.
+					// Consumers that serialize blocks (e.g. getEditedPostContent)
+					// must memoize on the blocks reference to avoid redundant calls
+					// to each block's save function.
 					return true;
 				}
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -342,9 +342,6 @@ export function getPostChangesFromCRDTDoc(
 						);
 					}
 
-					// Consumers that serialize blocks (e.g. getEditedPostContent)
-					// must memoize on the blocks reference to avoid redundant calls
-					// to each block's save function.
 					return true;
 				}
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -916,8 +916,10 @@ export const getSuggestedPostFormat = createRegistrySelector(
  *
  * @return {string} Post content.
  */
-export const getEditedPostContent = createRegistrySelector(
-	( select ) => ( state ) => {
+export const getEditedPostContent = createRegistrySelector( ( select ) => {
+	const serializationCache = new WeakMap();
+
+	return ( state ) => {
 		const postId = getCurrentPostId( state );
 		const postType = getCurrentPostType( state );
 		const record = select( coreStore ).getEditedEntityRecord(
@@ -929,14 +931,20 @@ export const getEditedPostContent = createRegistrySelector(
 			if ( typeof record.content === 'function' ) {
 				return record.content( record );
 			} else if ( record.blocks ) {
-				return __unstableSerializeAndClean( record.blocks );
+				let content = serializationCache.get( record.blocks );
+				if ( content === undefined ) {
+					content =
+						__unstableSerializeAndClean( record.blocks ) || '';
+					serializationCache.set( record.blocks, content );
+				}
+				return content;
 			} else if ( record.content ) {
 				return record.content;
 			}
 		}
 		return '';
-	}
-);
+	};
+} );
 
 /**
  * Returns true if the post is being published, or false otherwise.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -916,35 +916,39 @@ export const getSuggestedPostFormat = createRegistrySelector(
  *
  * @return {string} Post content.
  */
-export const getEditedPostContent = createRegistrySelector( ( select ) => {
-	const serializationCache = new WeakMap();
-
-	return ( state ) => {
-		const postId = getCurrentPostId( state );
-		const postType = getCurrentPostType( state );
-		const record = select( coreStore ).getEditedEntityRecord(
-			'postType',
-			postType,
-			postId
-		);
-		if ( record ) {
-			if ( typeof record.content === 'function' ) {
-				return record.content( record );
-			} else if ( record.blocks ) {
-				let content = serializationCache.get( record.blocks );
-				if ( content === undefined ) {
-					content =
-						__unstableSerializeAndClean( record.blocks ) || '';
-					serializationCache.set( record.blocks, content );
+export const getEditedPostContent = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state ) => {
+			const postId = getCurrentPostId( state );
+			const postType = getCurrentPostType( state );
+			const record = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			if ( record ) {
+				if ( typeof record.content === 'function' ) {
+					return record.content( record );
+				} else if ( record.blocks ) {
+					return __unstableSerializeAndClean( record.blocks );
+				} else if ( record.content ) {
+					return record.content;
 				}
-				return content;
-			} else if ( record.content ) {
-				return record.content;
 			}
+			return '';
+		},
+		( state ) => {
+			const postId = getCurrentPostId( state );
+			const postType = getCurrentPostType( state );
+			const record = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			return [ record?.content, record?.blocks ];
 		}
-		return '';
-	};
-} );
+	)
+);
 
 /**
  * Returns true if the post is being published, or false otherwise.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -929,7 +929,7 @@ export const getEditedPostContent = createRegistrySelector(
 			if ( typeof record.content === 'function' ) {
 				return record.content( record );
 			} else if ( record.blocks ) {
-				return __unstableSerializeAndClean( record.blocks ) || '';
+				return __unstableSerializeAndClean( record.blocks );
 			} else if ( record.content ) {
 				return record.content;
 			}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -916,10 +916,8 @@ export const getSuggestedPostFormat = createRegistrySelector(
  *
  * @return {string} Post content.
  */
-export const getEditedPostContent = createRegistrySelector( ( select ) => {
-	const serializationCache = new WeakMap();
-
-	return ( state ) => {
+export const getEditedPostContent = createRegistrySelector(
+	( select ) => ( state ) => {
 		const postId = getCurrentPostId( state );
 		const postType = getCurrentPostType( state );
 		const record = select( coreStore ).getEditedEntityRecord(
@@ -931,20 +929,14 @@ export const getEditedPostContent = createRegistrySelector( ( select ) => {
 			if ( typeof record.content === 'function' ) {
 				return record.content( record );
 			} else if ( record.blocks ) {
-				let content = serializationCache.get( record.blocks );
-				if ( content === undefined ) {
-					content =
-						__unstableSerializeAndClean( record.blocks ) || '';
-					serializationCache.set( record.blocks, content );
-				}
-				return content;
+				return __unstableSerializeAndClean( record.blocks ) || '';
 			} else if ( record.content ) {
 				return record.content;
 			}
 		}
 		return '';
-	};
-} );
+	}
+);
 
 /**
  * Returns true if the post is being published, or false otherwise.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -916,39 +916,35 @@ export const getSuggestedPostFormat = createRegistrySelector(
  *
  * @return {string} Post content.
  */
-export const getEditedPostContent = createRegistrySelector( ( select ) =>
-	createSelector(
-		( state ) => {
-			const postId = getCurrentPostId( state );
-			const postType = getCurrentPostType( state );
-			const record = select( coreStore ).getEditedEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			if ( record ) {
-				if ( typeof record.content === 'function' ) {
-					return record.content( record );
-				} else if ( record.blocks ) {
-					return __unstableSerializeAndClean( record.blocks );
-				} else if ( record.content ) {
-					return record.content;
+export const getEditedPostContent = createRegistrySelector( ( select ) => {
+	const serializationCache = new WeakMap();
+
+	return ( state ) => {
+		const postId = getCurrentPostId( state );
+		const postType = getCurrentPostType( state );
+		const record = select( coreStore ).getEditedEntityRecord(
+			'postType',
+			postType,
+			postId
+		);
+		if ( record ) {
+			if ( typeof record.content === 'function' ) {
+				return record.content( record );
+			} else if ( record.blocks ) {
+				let content = serializationCache.get( record.blocks );
+				if ( content === undefined ) {
+					content =
+						__unstableSerializeAndClean( record.blocks ) || '';
+					serializationCache.set( record.blocks, content );
 				}
+				return content;
+			} else if ( record.content ) {
+				return record.content;
 			}
-			return '';
-		},
-		( state ) => {
-			const postId = getCurrentPostId( state );
-			const postType = getCurrentPostType( state );
-			const record = select( coreStore ).getEditedEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			return [ record?.content, record?.blocks ];
 		}
-	)
-);
+		return '';
+	};
+} );
 
 /**
  * Returns true if the post is being published, or false otherwise.


### PR DESCRIPTION
## What?

Fixes #76352 

## Why?

The CRDT sync system always includes blocks in the changes it dispatches to the entity store on initialization, even when the blocks haven't changed. This is by design — the comment in getPostChangesFromCRDTDoc notes that "consumers of blocks have memoization that renders optimization here unnecessary."

However, the `getEditedPostContent` selector — one such consumer — had no memoization. It's a createRegistrySelector that calls `__unstableSerializeAndClean(record.blocks)` on every access, which invokes each block's save function. Before collaboration, this code path was rarely hit because blocks was never set directly in entity edits (it was derived from content via the transient read callback). With collaboration enabled, the sync system sets blocks in entity edits on load, causing this branch to run on every selector access across all subscribed components.

## How?

Wraps `getEditedPostContent` with `createSelector`, using `[record?.content, record?.blocks]` as dependants. The expensive serialization now runs once per unique blocks/content reference and returns the cached result for all subsequent accesses within the same state.

## Testing Instructions

Follow the reproduction steps from the linked issue. There is a simple plugin that registers a block that will `console.log` every time the `save` function is called. Before this fix you will see it fire many times on post save, and then much fewer after this fix.