### PR TITLE
Media: Enable AVIF support for client-side uploads

### DIFF
--- a/backport-changelog/7.0/11218.md
+++ b/backport-changelog/7.0/11218.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11218
+
+* https://github.com/WordPress/gutenberg/pull/76371

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -76,7 +76,9 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 
 		$result = parent::create_item_permissions_check( $request );
 
-		remove_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
+		if ( ! $request['generate_sub_sizes'] ) {
+			remove_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
+		}
 
 		return $result;
 	}

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -76,7 +76,7 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 
 		$result = parent::create_item_permissions_check( $request );
 
-		if ( ! $request['generate_sub_sizes'] ) {
+		if ( false === $request['generate_sub_sizes'] ) {
 			remove_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
 		}
 

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -70,7 +70,7 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
 	public function create_item_permissions_check( $request ) {
-		if ( ! $request['generate_sub_sizes'] ) {
+		if ( false === $request['generate_sub_sizes'] ) {
 			add_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
 		}
 

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -70,7 +70,7 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
 	public function create_item_permissions_check( $request ) {
-		if ( isset( $request['generate_sub_sizes'] ) && ! $request['generate_sub_sizes'] ) {
+		if ( ! $request['generate_sub_sizes'] ) {
 			add_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
 		}
 

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -61,6 +61,27 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	}
 
 	/**
+	 * Checks if a given request has access to create an attachment.
+	 *
+	 * Skips the server-side image type support check when the client
+	 * will handle image processing (generate_sub_sizes is false).
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( isset( $request['generate_sub_sizes'] ) && ! $request['generate_sub_sizes'] ) {
+			add_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
+		}
+
+		$result = parent::create_item_permissions_check( $request );
+
+		remove_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
+
+		return $result;
+	}
+
+	/**
 	 * Retrieves an array of endpoint arguments from the item schema for the controller.
 	 *
 	 * @param string $method Optional. HTTP method of the request. The arguments for `CREATABLE` requests are

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -9,6 +9,9 @@ import VipsModule from 'wasm-vips/vips.wasm';
 // @ts-expect-error - WASM files are inlined as base64 data URLs at build time
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
+// @ts-expect-error - WASM files are inlined as base64 data URLs at build time
+import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
+
 /**
  * Internal dependencies
  */
@@ -41,9 +44,9 @@ async function getVips(): Promise< typeof Vips > {
 	}
 
 	vipsInstance = await Vips( {
-		// Only load JXL module, skip HEIF due to trademark issues.
+		// Load JXL and HEIF dynamic modules for full format support.
 		// wasm-vips defaults to ["vips-jxl.wasm", "vips-heif.wasm"].
-		dynamicLibraries: [ 'vips-jxl.wasm' ],
+		dynamicLibraries: [ 'vips-jxl.wasm', 'vips-heif.wasm' ],
 		locateFile: ( fileName: string ) => {
 			// WASM files are inlined as base64 data URLs at build time,
 			// eliminating the need for separate file downloads and avoiding
@@ -52,6 +55,8 @@ async function getVips(): Promise< typeof Vips > {
 				return VipsModule;
 			} else if ( fileName.endsWith( 'vips-jxl.wasm' ) ) {
 				return VipsJxlModule;
+			} else if ( fileName.endsWith( 'vips-heif.wasm' ) ) {
+				return VipsHeifModule;
 			}
 			return fileName;
 		},

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -86,8 +86,8 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	public function test_create_item_skips_image_editor_support_check_when_not_generating_sub_sizes() {
 		wp_set_current_user( self::$admin_id );
 
-		// Force the image editor support check to reject the mime type.
-		add_filter( 'wp_image_editor_supports', '__return_false' );
+		// Remove all image editors so wp_image_editor_supports() returns false.
+		add_filter( 'wp_image_editors', '__return_empty_array' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_file_params(
@@ -106,7 +106,7 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
 		$result     = $controller->create_item_permissions_check( $request );
 
-		remove_filter( 'wp_image_editor_supports', '__return_false' );
+		remove_filter( 'wp_image_editors', '__return_empty_array' );
 
 		// Should pass because the bypass filter was applied (client handles processing).
 		$this->assertTrue( $result );
@@ -124,8 +124,8 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	public function test_create_item_enforces_image_editor_support_check_when_generating_sub_sizes() {
 		wp_set_current_user( self::$admin_id );
 
-		// Force the image editor support check to reject the mime type.
-		add_filter( 'wp_image_editor_supports', '__return_false' );
+		// Remove all image editors so wp_image_editor_supports() returns false.
+		add_filter( 'wp_image_editors', '__return_empty_array' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_file_params(
@@ -144,7 +144,7 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
 		$result     = $controller->create_item_permissions_check( $request );
 
-		remove_filter( 'wp_image_editor_supports', '__return_false' );
+		remove_filter( 'wp_image_editors', '__return_empty_array' );
 
 		// Should fail because the server needs to generate sub-sizes but can't.
 		$this->assertWPError( $result );

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -75,8 +75,11 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	}
 
 	/**
-	 * Verifies that uploading an image type not supported by the server's image editor
-	 * succeeds when generate_sub_sizes is false (client handles processing).
+	 * Verifies that the permissions check bypasses the image editor support check
+	 * when generate_sub_sizes is false (client handles processing).
+	 *
+	 * Tests the permissions check directly with file params set, since the core
+	 * check uses get_file_params() which is only populated for multipart uploads.
 	 *
 	 * @covers ::create_item_permissions_check
 	 */
@@ -87,23 +90,34 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		add_filter( 'wp_image_editor_supports', '__return_false' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
-		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_file_params(
+			array(
+				'file' => array(
+					'name'     => 'canola.jpg',
+					'type'     => 'image/jpeg',
+					'tmp_name' => DIR_TESTDATA . '/images/canola.jpg',
+					'error'    => 0,
+					'size'     => filesize( DIR_TESTDATA . '/images/canola.jpg' ),
+				),
+			)
+		);
 		$request->set_param( 'generate_sub_sizes', false );
 
-		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
+		$result     = $controller->create_item_permissions_check( $request );
 
 		remove_filter( 'wp_image_editor_supports', '__return_false' );
 
-		// Should succeed even though the server doesn't support the image type,
-		// because the client will handle all image processing.
-		$this->assertSame( 201, $response->get_status() );
+		// Should pass because the bypass filter was applied (client handles processing).
+		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Verifies that the image editor support check is still enforced
+	 * Verifies that the permissions check still enforces the image editor support check
 	 * when generate_sub_sizes is true (server handles processing).
+	 *
+	 * Tests the permissions check directly with file params set, since the core
+	 * check uses get_file_params() which is only populated for multipart uploads.
 	 *
 	 * @covers ::create_item_permissions_check
 	 */
@@ -114,18 +128,27 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		add_filter( 'wp_image_editor_supports', '__return_false' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
-		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_file_params(
+			array(
+				'file' => array(
+					'name'     => 'canola.jpg',
+					'type'     => 'image/jpeg',
+					'tmp_name' => DIR_TESTDATA . '/images/canola.jpg',
+					'error'    => 0,
+					'size'     => filesize( DIR_TESTDATA . '/images/canola.jpg' ),
+				),
+			)
+		);
 		$request->set_param( 'generate_sub_sizes', true );
 
-		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
-		$response = rest_get_server()->dispatch( $request );
+		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
+		$result     = $controller->create_item_permissions_check( $request );
 
 		remove_filter( 'wp_image_editor_supports', '__return_false' );
 
 		// Should fail because the server needs to generate sub-sizes but can't.
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame( 'rest_upload_image_type_not_supported', $response->get_data()['code'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_upload_image_type_not_supported', $result->get_error_code() );
 	}
 
 	/**

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -75,6 +75,60 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	}
 
 	/**
+	 * Verifies that uploading an image type not supported by the server's image editor
+	 * succeeds when generate_sub_sizes is false (client handles processing).
+	 *
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_create_item_skips_image_editor_support_check_when_not_generating_sub_sizes() {
+		wp_set_current_user( self::$admin_id );
+
+		// Force the image editor support check to reject the mime type.
+		add_filter( 'wp_image_editor_supports', '__return_false' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'wp_image_editor_supports', '__return_false' );
+
+		// Should succeed even though the server doesn't support the image type,
+		// because the client will handle all image processing.
+		$this->assertSame( 201, $response->get_status() );
+	}
+
+	/**
+	 * Verifies that the image editor support check is still enforced
+	 * when generate_sub_sizes is true (server handles processing).
+	 *
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_create_item_enforces_image_editor_support_check_when_generating_sub_sizes() {
+		wp_set_current_user( self::$admin_id );
+
+		// Force the image editor support check to reject the mime type.
+		add_filter( 'wp_image_editor_supports', '__return_false' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_param( 'generate_sub_sizes', true );
+
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'wp_image_editor_supports', '__return_false' );
+
+		// Should fail because the server needs to generate sub-sizes but can't.
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_upload_image_type_not_supported', $response->get_data()['code'] );
+	}
+
+	/**
 	 * Verifies that skipping sub-size generation works.
 	 *
 	 * @covers ::create_item

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -137,6 +137,9 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 				),
 			)
 		);
+		// Explicitly set generate_sub_sizes since defaults aren't applied outside REST dispatch.
+		$request->set_param( 'generate_sub_sizes', true );
+
 		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
 		$result     = $controller->create_item_permissions_check( $request );
 

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -106,8 +106,6 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
 		$result     = $controller->create_item_permissions_check( $request );
 
-		remove_filter( 'wp_image_editors', '__return_empty_array' );
-
 		// Should pass because the bypass filter was applied (client handles processing).
 		$this->assertTrue( $result );
 	}
@@ -139,12 +137,8 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 				),
 			)
 		);
-		$request->set_param( 'generate_sub_sizes', true );
-
 		$controller = new Gutenberg_REST_Attachments_Controller( 'attachment' );
 		$result     = $controller->create_item_permissions_check( $request );
-
-		remove_filter( 'wp_image_editors', '__return_empty_array' );
 
 		// Should fail because the server needs to generate sub-sizes but can't.
 		$this->assertWPError( $result );
@@ -199,8 +193,6 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 
 		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
 		$response = rest_get_server()->dispatch( $request );
-
-		remove_filter( 'wp_generate_attachment_metadata', '__return_empty_array', 1 );
 
 		$this->assertSame( 201, $response->get_status() );
 
@@ -916,8 +908,6 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 		$request_server = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request_server->set_header( 'Content-Type', 'image/jpeg' );
 		$request_server->set_header( 'Content-Disposition', 'attachment; filename=server-side-upload.jpg' );
-		$request_server->set_param( 'generate_sub_sizes', true );
-
 		$request_server->set_body( file_get_contents( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' ) );
 		$response_server = rest_get_server()->dispatch( $request_server );
 		$data_server     = $response_server->get_data();


### PR DESCRIPTION
## Summary

Fixes #76369.

Enables end-to-end client-side AVIF upload support with two changes:

### 1. Skip server image support check for client-side uploads

When client-side media processing is enabled (`generate_sub_sizes=false`), the server doesn't need to process the image — the browser handles everything via WASM/vips. However, WordPress core's `create_item_permissions_check()` rejects uploads for image formats the server's image editor doesn't support (e.g. AVIF on servers without AVIF support), returning `rest_upload_image_type_not_supported` before `create_item()` even runs.

- Overrides `create_item_permissions_check()` in `Gutenberg_REST_Attachments_Controller` to bypass the server support check via the `wp_prevent_unsupported_mime_type_uploads` filter when `generate_sub_sizes` is `false`
- Adds two tests: one verifying the check is skipped for client-side uploads, one verifying it's still enforced for server-side uploads

### 2. Load HEIF module in wasm-vips for AVIF decoding

The HEIF dynamic library (`vips-heif.wasm`) was previously excluded due to trademark concerns around HEIF (Nokia patents). However, AVIF uses the royalty-free AV1 codec from the Alliance for Open Media. Without this module, vips cannot decode AVIF buffers, causing uploads to fail with "buffer is not in a known format".

- Adds `vips-heif.wasm` to `dynamicLibraries` and `locateFile` in the vips worker
- The WASM module (~4.4 MB) is inlined at build time and only loads when client-side media processing is active

## Test plan

- [ ] Upload an AVIF image on a server that does **not** support AVIF in its image editor — upload should succeed with no errors
- [ ] Verify sideload API calls appear in the network panel (one per sub-size)
- [ ] Upload an AVIF with client-side media disabled on a server without image editor support — should still be rejected with `rest_upload_image_type_not_supported`
- [ ] Verify AVIF images are processed client-side (sub-sizes generated via vips, no server-side processing needed)