### PR TITLE
`CollapsibleCard`: add animations

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
 -   `Card`, `CollapsibleCard`: update padding to match legacy `Card` component ([#76368](https://github.com/WordPress/gutenberg/pull/76368)).
 -   `CollapsibleCard`: move trigger to the header ([#76265](https://github.com/WordPress/gutenberg/pull/76265)).
+-   `CollapsibleCard`: add animations ([#76378](https://github.com/WordPress/gutenberg/pull/76378)).
 
 ## 0.8.0 (2026-03-04)
 

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -4,6 +4,7 @@
 	.root {
 		--wp-ui-card-padding: var(--wpds-dimension-padding-2xl);
 		--wp-ui-card-header-content-gap: var(--wpds-dimension-gap-xl);
+		--wp-ui-card-header-content-margin: calc(var(--wp-ui-card-header-content-gap) - var(--wp-ui-card-padding));
 
 		display: flex;
 		flex-direction: column;
@@ -28,7 +29,7 @@
 	/* Custom vertical gap between header and content */
 	.header + .content {
 		padding-block-start: 0;
-		margin-block-start: calc(var(--wp-ui-card-header-content-gap) - var(--wp-ui-card-padding));
+		margin-block-start: var(--wp-ui-card-header-content-margin);
 	}
 
 	.fullbleed {

--- a/packages/ui/src/collapsible-card/content.tsx
+++ b/packages/ui/src/collapsible-card/content.tsx
@@ -11,16 +11,22 @@ import type { ContentProps } from './types';
  */
 export const Content = forwardRef< HTMLDivElement, ContentProps >(
 	function CollapsibleCardContent(
-		{ className, render, ...restProps },
+		{ className, render, children, ...restProps },
 		ref
 	) {
 		return (
 			<Collapsible.Panel
 				ref={ ref }
 				className={ clsx( styles.content, className ) }
-				render={ <Card.Content render={ render } /> }
 				{ ...restProps }
-			/>
+			>
+				<Card.Content
+					className={ styles[ 'content-inner' ] }
+					render={ render }
+				>
+					{ children }
+				</Card.Content>
+			</Collapsible.Panel>
 		);
 	}
 );

--- a/packages/ui/src/collapsible-card/content.tsx
+++ b/packages/ui/src/collapsible-card/content.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from '@wordpress/element';
+import clsx from 'clsx';
 import * as Card from '../card';
 import * as Collapsible from '../collapsible';
+import styles from './style.module.css';
 import type { ContentProps } from './types';
 
 /**
@@ -8,10 +10,14 @@ import type { ContentProps } from './types';
  * visible when expanded.
  */
 export const Content = forwardRef< HTMLDivElement, ContentProps >(
-	function CollapsibleCardContent( { render, ...restProps }, ref ) {
+	function CollapsibleCardContent(
+		{ className, render, ...restProps },
+		ref
+	) {
 		return (
 			<Collapsible.Panel
 				ref={ ref }
+				className={ clsx( styles.content, className ) }
 				render={ <Card.Content render={ render } /> }
 				{ ...restProps }
 			/>

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -106,6 +106,57 @@ export const Disabled: Story = {
 };
 
 /**
+ * Multiple collapsible cards stacked vertically, simulating a typical
+ * settings-panel or FAQ-style layout.
+ */
+export const Stacked: Story = {
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div
+			style={ {
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 'var(--wpds-dimension-gap-lg)',
+			} }
+		>
+			{ [
+				'General',
+				'Advanced',
+				'Accessibility',
+				'Performance',
+				'Privacy',
+				'Notifications',
+			].map( ( title ) => (
+				<CollapsibleCard.Root key={ title }>
+					<CollapsibleCard.Header>
+						<Card.Title>{ title }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<Text>
+							Configure all { title.toLowerCase() } settings for
+							your site. Changes here affect how your site behaves
+							across all pages and posts.
+						</Text>
+						<Text>
+							Review each option carefully before saving. Some
+							changes may require a page reload to take effect.
+							Hover over individual options for more details about
+							what they control.
+						</Text>
+						<Text>
+							If you&apos;re unsure about a setting, you can
+							always reset to defaults using the button at the
+							bottom of this section. Your previous configuration
+							will be saved as a backup.
+						</Text>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			) ) }
+		</div>
+	),
+};
+
+/**
  * Visual comparison: a `CollapsibleCard` (open) next to a regular `Card`
  * to verify identical spacing and layout.
  */

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -39,16 +39,26 @@
 	}
 
 	.content {
-		&[data-starting-style] {
-			opacity: 0;
-			transform: translateY(-4px);
+		height: var(--collapsible-panel-height);
+		overflow: hidden;
+		margin-block-start: var(--wp-ui-card-header-content-margin);
+
+		&[hidden]:not([hidden="until-found"]) {
+			display: none;
+		}
+
+		&[data-starting-style],
+		&[data-ending-style] {
+			height: 0;
 		}
 
 		@media not (prefers-reduced-motion) {
-			&[data-open] {
-				transition: opacity 0.15s ease 0.05s, transform 0.15s ease 0.05s;
-			}
+			transition: all 150ms ease-out;
 		}
+	}
+
+	.content-inner {
+		padding-block-start: 0;
 	}
 }
 

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -57,12 +57,13 @@
 		}
 	}
 
-	.content-inner {
-		padding-block-start: 0;
-	}
 }
 
 @layer wp-ui-compositions {
+	.content-inner {
+		padding-block-start: 0;
+	}
+
 	.header {
 		display: flex;
 		flex-direction: row;

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -39,13 +39,14 @@
 	}
 
 	.content {
-		@media not (prefers-reduced-motion) {
-			transition: opacity 0.15s ease, transform 0.15s ease;
+		&[data-starting-style] {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
 
-			&[data-starting-style],
-			&[data-ending-style] {
-				opacity: 0;
-				transform: translateY(-4px);
+		@media not (prefers-reduced-motion) {
+			&[data-open] {
+				transition: opacity 0.15s ease 0.05s, transform 0.15s ease 0.05s;
 			}
 		}
 	}

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -37,6 +37,18 @@
 	.header[data-disabled] .header-trigger {
 		color: var(--wpds-color-fg-interactive-neutral-disabled);
 	}
+
+	.content {
+		@media not (prefers-reduced-motion) {
+			transition: opacity 0.15s ease, transform 0.15s ease;
+
+			&[data-starting-style],
+			&[data-ending-style] {
+				opacity: 0;
+				transform: translateY(-4px);
+			}
+		}
+	}
 }
 
 @layer wp-ui-compositions {

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -23,6 +23,10 @@
 
 		/* For an outline that looks like `IconButton`'s */
 		border-radius: var(--wpds-border-radius-sm);
+
+		@media not (prefers-reduced-motion) {
+			transition: rotate 0.15s ease-out;
+		}
 	}
 
 	.header[data-panel-open] .header-trigger {


### PR DESCRIPTION
## What

Add open/close animations to the `CollapsibleCard` component in `@wordpress/ui`.

## Why

Add visual polish

## How

- The "content" container's height is animated
- The chevron icon rotates

Animations are disabled when reduced motion id preferred.


## Testing Instructions

1. `npm start`
2. Open Storybook
3. Navigate to **Design System / Components / CollapsibleCard**
4. Check the animation as described above, when expanding / collapsing the card
5. Enable "Reduce motion" in your OS accessibility settings (or browser dev tools), make sure the card doesn't animate when expanded / collapsed

## Screen capture





https://github.com/user-attachments/assets/abc6ff05-b017-46cb-9ef6-5bc0f6e68978


