### PR TITLE
Correct input of setIsLoading

### DIFF
--- a/packages/list-reusable-blocks/src/components/import-form/index.js
+++ b/packages/list-reusable-blocks/src/components/import-form/index.js
@@ -29,7 +29,7 @@ function ImportForm( { instanceId, onUpload } ) {
 		if ( ! file ) {
 			return;
 		}
-		setIsLoading( { isLoading: true } );
+		setIsLoading( true );
 		importReusableBlock( file )
 			.then( ( reusableBlock ) => {
 				if ( ! formRef ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
I think isLoading's type was supposed to be a simple boolean. The code however, used `false` for false and then the object `{isLoading: true}` for true. While you get the same result when you're doing a boolean comparison on isLoading, I don't think it's really correct. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
While the current code functions the same, it's kind of confusing and messy to use a `false` for false and `{isLoading: true}` for true.  Additionally, if someone did a strict comparison with `true` at some point this code would fail unexpectedly.

## How?
<!-- How is your PR addressng the issue at hand? What are the implementation details? -->
Replaced `{isLoading: true}` with `true` in `packages/list-reusable-blocks/src/components/import-form/index.js`