### PR TITLE
WP Admin: Update Connectors screen footer text for consistency.

### DIFF
--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -98,7 +98,7 @@ function ConnectorsPage() {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'Find more connectors in <a>the plugin directory</a>'
+								'If the connector you need is not listed, <a>search the plugin directory</a> to see if a connector is available.'
 							),
 							{
 								a: (

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -103,7 +103,7 @@ function ConnectorsPage() {
 							{
 								a: (
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									<a href="plugin-install.php" />
+									<a href="plugin-install.php?s=connector&tab=search&type=tag" />
 								),
 							}
 						) }

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -69,9 +69,12 @@ test.describe( 'Connectors', () => {
 		// Verify the plugin directory search link is present.
 		await expect(
 			page.getByRole( 'link', {
-				name: 'the plugin directory',
+				name: 'search the plugin directory',
 			} )
-		).toHaveAttribute( 'href', 'plugin-install.php' );
+		).toHaveAttribute(
+			'href',
+			'plugin-install.php?s=connector&tab=search&type=tag'
+		);
 	} );
 
 	test.describe( 'Test provider setup flow', () => {
@@ -295,7 +298,7 @@ test.describe( 'Connectors', () => {
 				// Plugin directory link should be hidden.
 				await expect(
 					page.getByRole( 'link', {
-						name: 'the plugin directory',
+						name: 'search the plugin directory',
 					} )
 				).toBeHidden();
 			} );


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76374
Updates the footer text on the Connectors screen.

## Why?
To ensure consistency and standardization with the messaging used on the Tools → Import screen.

## How?
Updates the footer copy and links it to the plugin directory filtered by the connector tag.

## Testing Instructions

1. Navigate to the Connectors screen.
2. Check the footer text.
3. Click the link and confirm it opens the Add Plugins screen filtered by the connector tag.


## Screenshot 

<img width="1462" height="760" alt="image" src="https://github.com/user-attachments/assets/e6d60a4d-47e9-4913-8f14-9438710a16e9" />

