### PR TITLE
Infra: Use devEngines and simplify CI caching

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -9,6 +9,8 @@ inputs:
 runs:
     using: 'composite'
     steps:
+        # Configure the desired version of node with caching.
+        # Note: the node_modules directory is intentionally not cached.
         - name: Use desired version of Node.js
           uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
           with:
@@ -16,13 +18,11 @@ runs:
               node-version: ${{ inputs.node-version }}
               check-latest: true
               # Caching for npm dependencies is automatically enabled when package.json contains devEngines.packageManager field set to npm
+              # cache: npm
               cache-dependency-path: |
                   package-lock.json
                   patches/**
 
-        # We don't explicitly cache node_modules, we rely on actions/setup-node's `cache: npm` (above)
-        # to cache ~/.npm (the download cache), so cache can be reused between different Node.js versions.
-        # This skips network downloads while npm ci rebuilds the local node_modules.
         - name: Install npm dependencies
           run: |
               npm ci

--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -15,40 +15,22 @@ runs:
               node-version-file: ${{ inputs.node-version == '' && '.nvmrc' || '' }}
               node-version: ${{ inputs.node-version }}
               check-latest: true
-              cache: npm
+              # Caching for npm dependencies is automatically enabled when package.json contains devEngines.packageManager field set to npm
+              cache-dependency-path: |
+                  package-lock.json
+                  patches/**
 
-        - name: Get Node.js and npm version
-          id: node-version
-          run: |
-              echo "NODE_VERSION=$(node -v)" >> "$GITHUB_OUTPUT"
-          shell: bash
-
-        - name: Cache node_modules
-          id: cache-node_modules
-          uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-          with:
-              path: '**/node_modules'
-              key: node_modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('package-lock.json', 'patches/**') }}
-
+        # We don't explicitly cache node_modules, we rely on actions/setup-node's `cache: npm` (above)
+        # to cache ~/.npm (the download cache), so cache can be reused between different Node.js versions.
+        # This skips network downloads while npm ci rebuilds the local node_modules.
         - name: Install npm dependencies
-          if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}
           run: |
               npm ci
           shell: bash
+
         - name: Upload npm logs as an artifact on failure
           uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
           if: failure()
           with:
               name: npm-logs
               path: C:\npm\cache\_logs
-
-        # On cache hit, we run the post-install script to match the native `npm ci` behavior.
-        # An example of this is to patch `node_modules` using patch-package.
-        - name: Post-install
-          if: ${{ steps.cache-node_modules.outputs.cache-hit == 'true' }}
-          run: |
-              # Run the post-install script for the root project.
-              npm run postinstall
-              # Run the post-install scripts for workspaces.
-              npx lerna run postinstall
-          shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,10 +103,6 @@
 				"uuid": "9.0.1",
 				"vite": "7.3.0",
 				"wait-on": "8.0.1"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,15 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"engines": {
-		"node": ">=20.10.0",
-		"npm": ">=10.2.3"
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": ">=20.10.0"
+		},
+		"packageManager": {
+			"name": "npm",
+			"version": ">=10.2.3"
+		}
 	},
 	"wpPlugin": {
 		"name": "gutenberg",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

As pointed out in https://github.com/WordPress/gutenberg/pull/75814#discussion_r2899963443 by Michael Garvin, a maintainer of npm CLI, we should be using [`devEngines`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#devengines) in root package.json instead of `engines`. 

`devEngines` also lets some related tools make assumptions about project setup, like the `actions/setup-node` GitHub Action will use it to infer the cache policy: https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data

## Why?

`engines` is meant for the published packages. For development packages like this monorepo root, `devEngines` is the standard.

## How?

- Replace `engines` with `devEngines` in root package.json
- Simplify caching by letting `actions/setup-node` handle it for us.

We don't explicitly cache node_modules, we rely on `actions/setup-node`'s `cache: npm` to cache `~/.npm` (the download cache), so cache can be reused between different Node.js versions. This skips network downloads while npm ci rebuilds the local node_modules.

## Testing Instructions

- Try setting the `devEngines.runtime.version` to some higher node version than your system and run `npm install`
- Confirm that you see the nice error message
- Do the same for `devEngines.pakageManager.version`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1013" height="447" alt="image" src="https://github.com/user-attachments/assets/4f49bf61-8d08-4d17-8e56-76e970cf64c5" />