### PR TITLE
Guidelines: Refactor components and improve TypeScript typing

### DIFF
--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -10,9 +10,8 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './store';
+import { store as coreContentGuidelinesStore } from './store';
 import type {
-	Categories,
 	RestGuidelinesResponse,
 	GuidelinesImportData,
 	ContentGuidelinesRevision,
@@ -34,9 +33,7 @@ function isValidGuidelinesImport(
 }
 
 export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse > {
-	const { setFromResponse } = dispatch( STORE_NAME ) as {
-		setFromResponse: ( response: RestGuidelinesResponse ) => void;
-	};
+	const { setFromResponse } = dispatch( coreContentGuidelinesStore );
 
 	const response = ( await apiFetch( {
 		path: '/wp/v2/content-guidelines?context=edit',
@@ -49,15 +46,9 @@ export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse 
 
 export async function saveContentGuidelines(): Promise< RestGuidelinesResponse > {
 	// @ts-ignore
-	const { setFromResponse } = dispatch( STORE_NAME );
+	const { setFromResponse } = dispatch( coreContentGuidelinesStore );
 
-	const guidelinesStore = select( STORE_NAME ) as unknown as {
-		getId: () => number | null;
-		getStatus: () => string | null;
-		getAllGuidelines: () => Categories;
-		getBlockGuidelines: () => Record< string, string >;
-		getGuideline: ( category: string ) => string | Record< string, string >;
-	};
+	const guidelinesStore = select( coreContentGuidelinesStore );
 
 	const id = guidelinesStore.getId();
 	const status = guidelinesStore.getStatus() || 'draft';
@@ -113,7 +104,9 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
  */
 export async function importContentGuidelines( file: File ): Promise< void > {
 	// @ts-ignore
-	const { setGuideline, setBlockGuideline } = dispatch( STORE_NAME );
+	const { setGuideline, setBlockGuideline } = dispatch(
+		coreContentGuidelinesStore
+	);
 	const { createSuccessNotice } = dispatch( noticesStore );
 
 	const parsed: unknown = JSON.parse( await file.text() );
@@ -126,10 +119,7 @@ export async function importContentGuidelines( file: File ): Promise< void > {
 		);
 	}
 
-	const guidelinesStore = select( STORE_NAME ) as unknown as {
-		getAllGuidelines: () => Categories;
-		getBlockGuidelines: () => Record< string, string >;
-	};
+	const guidelinesStore = select( coreContentGuidelinesStore );
 	const previousCategories = guidelinesStore.getAllGuidelines();
 	const previousBlocks = { ...guidelinesStore.getBlockGuidelines() };
 
@@ -180,10 +170,7 @@ export async function importContentGuidelines( file: File ): Promise< void > {
 export function exportContentGuidelines(): void {
 	const { createSuccessNotice } = dispatch( noticesStore );
 
-	const guidelinesStore = select( STORE_NAME ) as unknown as {
-		getAllGuidelines: () => Categories;
-		getBlockGuidelines: () => Record< string, string >;
-	};
+	const guidelinesStore = select( coreContentGuidelinesStore );
 	const contentGuidelinesCategories = guidelinesStore.getAllGuidelines();
 	const blockGuidelines = guidelinesStore.getBlockGuidelines();
 

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -45,7 +45,6 @@ export async function fetchContentGuidelines(): Promise< RestGuidelinesResponse 
 }
 
 export async function saveContentGuidelines(): Promise< RestGuidelinesResponse > {
-	// @ts-ignore
 	const { setFromResponse } = dispatch( coreContentGuidelinesStore );
 
 	const guidelinesStore = select( coreContentGuidelinesStore );
@@ -103,7 +102,6 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
  * @param file Content Guidelines JSON file
  */
 export async function importContentGuidelines( file: File ): Promise< void > {
-	// @ts-ignore
 	const { setGuideline, setBlockGuideline } = dispatch(
 		coreContentGuidelinesStore
 	);

--- a/routes/content-guidelines/components/action-item.tsx
+++ b/routes/content-guidelines/components/action-item.tsx
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHeading as Heading,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+interface ActionProps {
+	slug: string;
+	title: string;
+	description: string;
+	buttonLabel: string;
+	ariaLabel: string;
+	onClick: () => void;
+	disabled?: boolean;
+	isBusy?: boolean;
+}
+export default function ActionItem( {
+	slug,
+	title,
+	description,
+	buttonLabel,
+	ariaLabel,
+	onClick,
+	disabled,
+	isBusy,
+}: ActionProps ) {
+	const descriptionId = `content-guidelines-action-${ slug }-description`;
+
+	return (
+		<li className="content-guidelines__action-list-item">
+			<HStack
+				justify="space-between"
+				className="content-guidelines__action-row"
+			>
+				<VStack spacing={ 1 }>
+					<Heading
+						level={ 3 }
+						size={ 13 }
+						weight={ 400 }
+						className="content-guidelines__action-title"
+					>
+						{ title }
+					</Heading>
+					<Text
+						id={ descriptionId }
+						size={ 13 }
+						weight={ 400 }
+						variant="muted"
+						className="content-guidelines__action-description"
+					>
+						{ description }
+					</Text>
+				</VStack>
+				<Button
+					size="compact"
+					variant="secondary"
+					className="content-guidelines__action-button"
+					aria-label={ ariaLabel }
+					aria-describedby={ descriptionId }
+					onClick={ onClick }
+					isBusy={ isBusy }
+					disabled={ disabled }
+				>
+					{ buttonLabel }
+				</Button>
+			</HStack>
+		</li>
+	);
+}

--- a/routes/content-guidelines/components/actions-section.tsx
+++ b/routes/content-guidelines/components/actions-section.tsx
@@ -27,7 +27,7 @@ function getErrorMessage( error: unknown ): string {
 	if ( error instanceof Error ) {
 		return error.message;
 	}
-	
+
 	if ( typeof error === 'object' && error !== null && 'message' in error ) {
 		return String( ( error as { message: unknown } ).message );
 	}
@@ -93,6 +93,35 @@ export default function ActionsSection() {
 		}
 	}
 
+	const ACTIONS = [
+		{
+			slug: 'import',
+			title: __( 'Import' ),
+			description: __( 'Upload a JSON file to import your guidelines.' ),
+			buttonLabel: __( 'Upload' ),
+			ariaLabel: __( 'Import guidelines' ),
+			onClick: handleImportClick,
+			isBusy: isImporting,
+			disabled: isImporting || !! pendingImport,
+		},
+		{
+			slug: 'export',
+			title: __( 'Export' ),
+			description: __( 'Export your guidelines to a JSON file.' ),
+			buttonLabel: __( 'Download' ),
+			ariaLabel: __( 'Export guidelines' ),
+			onClick: handleExportClick,
+		},
+		{
+			slug: 'revert',
+			title: __( 'Revert' ),
+			description: __( 'Use a previous version of your guidelines.' ),
+			buttonLabel: __( 'View history' ),
+			ariaLabel: __( 'View history of guidelines' ),
+			onClick: () => goTo( '/revision-history' ),
+		},
+	];
+
 	return (
 		<VStack spacing={ 4 } className="content-guidelines__actions">
 			<Heading level={ 3 } size={ 15 } weight={ 500 }>
@@ -121,38 +150,9 @@ export default function ActionsSection() {
 				 */
 				/* eslint-disable jsx-a11y/no-redundant-roles */ }
 				<ul role="list" className="content-guidelines__actions-list">
-					<ActionItem
-						slug="import"
-						title={ __( 'Import' ) }
-						description={ __(
-							'Upload a JSON file to import your guidelines.'
-						) }
-						buttonLabel={ __( 'Upload' ) }
-						ariaLabel={ __( 'Import guidelines' ) }
-						onClick={ handleImportClick }
-						isBusy={ isImporting }
-						disabled={ isImporting || !! pendingImport }
-					/>
-					<ActionItem
-						slug="export"
-						title={ __( 'Export' ) }
-						description={ __(
-							'Export your guidelines to a JSON file.'
-						) }
-						buttonLabel={ __( 'Download' ) }
-						ariaLabel={ __( 'Export guidelines' ) }
-						onClick={ handleExportClick }
-					/>
-					<ActionItem
-						slug="revert"
-						title={ __( 'Revert' ) }
-						description={ __(
-							'Use a previous version of your guidelines.'
-						) }
-						buttonLabel={ __( 'View history' ) }
-						ariaLabel={ __( 'View history of guidelines' ) }
-						onClick={ () => goTo( '/revision-history' ) }
-					/>
+					{ ACTIONS.map( ( action ) => (
+						<ActionItem key={ action.slug } { ...action } />
+					) ) }
 				</ul>
 				{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
 			</Card>

--- a/routes/content-guidelines/components/actions-section.tsx
+++ b/routes/content-guidelines/components/actions-section.tsx
@@ -21,43 +21,22 @@ import { useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { importContentGuidelines, exportContentGuidelines } from '../api';
+import ActionItem from './action-item';
 
 function getErrorMessage( error: unknown ): string {
 	if ( error instanceof Error ) {
 		return error.message;
 	}
+	
 	if ( typeof error === 'object' && error !== null && 'message' in error ) {
 		return String( ( error as { message: unknown } ).message );
 	}
 	return __( 'Unknown error.' );
 }
 
-const ACTIONS = [
-	{
-		slug: 'import',
-		title: __( 'Import' ),
-		description: __( 'Upload a JSON file to import your guidelines.' ),
-		buttonLabel: __( 'Upload' ),
-		ariaLabel: __( 'Import guidelines' ),
-	},
-	{
-		slug: 'export',
-		title: __( 'Export' ),
-		description: __( 'Export your guidelines to a JSON file.' ),
-		buttonLabel: __( 'Download' ),
-		ariaLabel: __( 'Export guidelines' ),
-	},
-	{
-		slug: 'revert',
-		title: __( 'Revert' ),
-		description: __( 'Use a previous version of your guidelines.' ),
-		buttonLabel: __( 'View history' ),
-		ariaLabel: __( 'View history of guidelines' ),
-	},
-];
-
 export default function ActionsSection() {
 	const { goTo } = useNavigator();
+
 	const fileInputRef = useRef< HTMLInputElement >( null );
 	const [ isImporting, setIsImporting ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
@@ -114,25 +93,6 @@ export default function ActionsSection() {
 		}
 	}
 
-	const buttonProps: Partial<
-		Record<
-			string,
-			{
-				onClick: () => void | Promise< void >;
-				isBusy?: boolean;
-				disabled?: boolean;
-			}
-		>
-	> = {
-		import: {
-			onClick: handleImportClick,
-			isBusy: isImporting,
-			disabled: isImporting || !! pendingImport,
-		},
-		export: { onClick: handleExportClick },
-		revert: { onClick: () => goTo( '/revision-history' ) },
-	};
-
 	return (
 		<VStack spacing={ 4 } className="content-guidelines__actions">
 			<Heading level={ 3 } size={ 15 } weight={ 500 }>
@@ -161,51 +121,38 @@ export default function ActionsSection() {
 				 */
 				/* eslint-disable jsx-a11y/no-redundant-roles */ }
 				<ul role="list" className="content-guidelines__actions-list">
-					{ ACTIONS.map( ( action ) => {
-						const descriptionId = `content-guidelines-action-${ action.slug }-description`;
-						return (
-							<li
-								key={ action.slug }
-								className="content-guidelines__action-list-item"
-							>
-								<HStack
-									justify="space-between"
-									className="content-guidelines__action-row"
-								>
-									<VStack spacing={ 1 }>
-										<Heading
-											level={ 3 }
-											size={ 13 }
-											weight={ 400 }
-											className="content-guidelines__action-title"
-										>
-											{ action.title }
-										</Heading>
-										<Text
-											id={ descriptionId }
-											size={ 13 }
-											weight={ 400 }
-											variant="muted"
-											className="content-guidelines__action-description"
-										>
-											{ action.description }
-										</Text>
-									</VStack>
-									<Button
-										size="compact"
-										variant="secondary"
-										className="content-guidelines__action-button"
-										aria-label={ action.ariaLabel }
-										aria-describedby={ descriptionId }
-										{ ...( buttonProps[ action.slug ] ??
-											{} ) }
-									>
-										{ action.buttonLabel }
-									</Button>
-								</HStack>
-							</li>
-						);
-					} ) }
+					<ActionItem
+						slug="import"
+						title={ __( 'Import' ) }
+						description={ __(
+							'Upload a JSON file to import your guidelines.'
+						) }
+						buttonLabel={ __( 'Upload' ) }
+						ariaLabel={ __( 'Import guidelines' ) }
+						onClick={ handleImportClick }
+						isBusy={ isImporting }
+						disabled={ isImporting || !! pendingImport }
+					/>
+					<ActionItem
+						slug="export"
+						title={ __( 'Export' ) }
+						description={ __(
+							'Export your guidelines to a JSON file.'
+						) }
+						buttonLabel={ __( 'Download' ) }
+						ariaLabel={ __( 'Export guidelines' ) }
+						onClick={ handleExportClick }
+					/>
+					<ActionItem
+						slug="revert"
+						title={ __( 'Revert' ) }
+						description={ __(
+							'Use a previous version of your guidelines.'
+						) }
+						buttonLabel={ __( 'View history' ) }
+						ariaLabel={ __( 'View history of guidelines' ) }
+						onClick={ () => goTo( '/revision-history' ) }
+					/>
 				</ul>
 				{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
 			</Card>

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -27,7 +27,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { saveContentGuidelines } from '../api';
-import { STORE_NAME } from '../store';
+import { store as coreContentGuidelinesStore } from '../store';
 import { unlock } from '../../lock-unlock';
 import './block-guideline-modal.scss';
 
@@ -52,8 +52,7 @@ export default function BlockGuidelineModal( {
 		useState( false );
 
 	const blockGuidelines = useSelect(
-		// @ts-ignore
-		( select ) => select( STORE_NAME ).getBlockGuidelines(),
+		( select ) => select( coreContentGuidelinesStore ).getBlockGuidelines(),
 		[]
 	);
 
@@ -95,7 +94,7 @@ export default function BlockGuidelineModal( {
 		[ blockOptions, selectedBlock ]
 	);
 
-	const { setBlockGuideline } = useDispatch( STORE_NAME );
+	const { setBlockGuideline } = useDispatch( coreContentGuidelinesStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const handleSave = ( value: string ) => {

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -28,7 +28,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import BlockGuidelineModal from './block-guideline-modal';
 import { saveContentGuidelines } from '../api';
-import { STORE_NAME } from '../store';
+import { store as coreContentGuidelinesStore } from '../store';
 import './block-guidelines.scss';
 
 const PER_PAGE = 5;
@@ -85,8 +85,7 @@ export default function BlockGuidelines() {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const blockGuidelines = useSelect(
-		// @ts-ignore
-		( select ) => select( STORE_NAME ).getBlockGuidelines(),
+		( select ) => select( coreContentGuidelinesStore ).getBlockGuidelines(),
 		[]
 	);
 
@@ -109,7 +108,7 @@ export default function BlockGuidelines() {
 		[ blockGuidelines, blockTypes ]
 	);
 
-	const { setBlockGuideline } = useDispatch( STORE_NAME );
+	const { setBlockGuideline } = useDispatch( coreContentGuidelinesStore );
 
 	const handleRowClick = ( id: string ) => {
 		setSelectedItem( id );

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -30,7 +30,6 @@ export default function GuidelineAccordionForm( {
 	headingId,
 	descriptionId,
 }: GuidelineAccordionFormProps ) {
-	// @ts-ignore
 	const { setGuideline } = useDispatch( coreContentGuidelinesStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ loading, setLoading ] = useState( false );
@@ -40,7 +39,6 @@ export default function GuidelineAccordionForm( {
 
 	const { value } = useSelect(
 		( select ) => ( {
-			// @ts-ignore
 			value: select( coreContentGuidelinesStore ).getGuideline( slug ),
 		} ),
 		[ slug ]

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -20,7 +20,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from '../store';
+import { store as coreContentGuidelinesStore } from '../store';
 import { saveContentGuidelines } from '../api';
 import type { GuidelineAccordionFormProps } from '../types';
 
@@ -31,7 +31,7 @@ export default function GuidelineAccordionForm( {
 	descriptionId,
 }: GuidelineAccordionFormProps ) {
 	// @ts-ignore
-	const { setGuideline } = useDispatch( STORE_NAME );
+	const { setGuideline } = useDispatch( coreContentGuidelinesStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ loading, setLoading ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
@@ -41,7 +41,7 @@ export default function GuidelineAccordionForm( {
 	const { value } = useSelect(
 		( select ) => ( {
 			// @ts-ignore
-			value: select( STORE_NAME ).getGuideline( slug ) as string,
+			value: select( coreContentGuidelinesStore ).getGuideline( slug ),
 		} ),
 		[ slug ]
 	);

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -21,7 +21,7 @@ import type { View, Field, Action } from '@wordpress/dataviews';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from '../store';
+import { store as coreContentGuidelinesStore } from '../store';
 import {
 	fetchContentGuidelinesRevisions,
 	restoreContentGuidelinesRevision,
@@ -57,12 +57,7 @@ export default function RevisionHistory() {
 		useDispatch( noticesStore );
 
 	const guidelinesId = useSelect(
-		( select ) =>
-			(
-				select( STORE_NAME ) as unknown as {
-					getId: () => number | null;
-				}
-			 ).getId(),
+		( select ) => select( coreContentGuidelinesStore ).getId(),
 		[]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76387

Refactors parts of the Content Guidelines implementation to improve component structure and TypeScript typing.


## Why?
During the review of #76155 a few code quality improvements were identified, mainly around component readability and stronger typing.


## How?
- Decompose `actions-section` into smaller components for better readability.
- Refactor guideline TypeScript types and use the exported store object instead of `STORE_NAME` to avoid `as unknown` casts and improve type inference.


## Testing Instructions
1. Open the **Content Guidelines** screen.
2. Verify that all actions and guideline content behave as expected.
3. Confirm there are no regressions in functionality.

