### PR TITLE
Dependency Extraction Webpack Plugin: Externalize script modules as import() and emit module_dependencies

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -13,6 +13,8 @@ const {
 	defaultRequestToExternal,
 	defaultRequestToExternalModule,
 	defaultRequestToHandle,
+	getPackageInfo,
+	isScriptModuleImport,
 } = require( './util' );
 
 const { RawSource } = webpack.sources;
@@ -47,6 +49,16 @@ class DependencyExtractionWebpackPlugin {
 		this.externalizedDeps = new Set();
 
 		/**
+		 * Track requests that are script module externals.
+		 *
+		 * Script modules are externalized with `import` type instead of `window`
+		 * and emitted as `module_dependencies` in the asset file.
+		 *
+		 * @type {Set<string>}
+		 */
+		this.scriptModuleDeps = new Set();
+
+		/**
 		 * Should we use modules. This will be set later to match webpack's
 		 * output.module option.
 		 *
@@ -59,7 +71,7 @@ class DependencyExtractionWebpackPlugin {
 	 * @param {webpack.ExternalItemFunctionData}                             data
 	 * @param { ( err?: null | Error, result?: string | string[] ) => void } callback
 	 */
-	externalizeWpDeps( { request }, callback ) {
+	externalizeWpDeps( { request, context }, callback ) {
 		let externalRequest;
 
 		try {
@@ -88,9 +100,23 @@ class DependencyExtractionWebpackPlugin {
 				typeof externalRequest === 'undefined' &&
 				this.options.useDefaults
 			) {
-				externalRequest = this.useModules
-					? defaultRequestToExternalModule( request )
-					: defaultRequestToExternal( request );
+				if ( this.useModules ) {
+					externalRequest =
+						defaultRequestToExternalModule( request );
+				} else {
+					// Check if this is a script module package before
+					// treating it as a regular window-global script.
+					if ( this.isScriptModuleRequest( request, context ) ) {
+						this.externalizedDeps.add( request );
+						this.scriptModuleDeps.add( request );
+						return callback(
+							null,
+							`import ${ request }`
+						);
+					}
+
+					externalRequest = defaultRequestToExternal( request );
+				}
 			}
 		} catch ( err ) {
 			return callback( err );
@@ -103,6 +129,44 @@ class DependencyExtractionWebpackPlugin {
 		}
 
 		return callback();
+	}
+
+	/**
+	 * Check if a request maps to a script-module-only package.
+	 *
+	 * Resolves the package's package.json and checks for wpScriptModuleExports.
+	 * If the package is both a script and a script module, returns false so it
+	 * can be handled as a regular script in non-module builds.
+	 *
+	 * @param {string} request The module request.
+	 * @param {string} context The directory of the importing file.
+	 * @return {boolean} True if the request is a script module that should not
+	 *   be externalized as a window global.
+	 */
+	isScriptModuleRequest( request, context ) {
+		if ( ! request.startsWith( '@wordpress/' ) ) {
+			return false;
+		}
+
+		const parts = request.split( '/' );
+		const packageName = parts.slice( 0, 2 ).join( '/' );
+		const subpath = parts.length > 2 ? parts.slice( 2 ).join( '/' ) : null;
+
+		const packageJson = getPackageInfo( packageName, context );
+		if ( ! packageJson ) {
+			return false;
+		}
+
+		const isScriptModule = isScriptModuleImport( packageJson, subpath );
+		const isScript = !! packageJson.wpScript;
+
+		// If the package is both a script and a script module, treat it as a
+		// regular script in non-module builds (matching esbuild plugin logic).
+		if ( isScriptModule && isScript ) {
+			return false;
+		}
+
+		return isScriptModule;
 	}
 
 	/**
@@ -289,6 +353,10 @@ class DependencyExtractionWebpackPlugin {
 			const chunkStaticDeps = new Set();
 			/** @type {Set<string>} */
 			const chunkDynamicDeps = new Set();
+			/** @type {Set<string>} */
+			const chunkScriptModuleStaticDeps = new Set();
+			/** @type {Set<string>} */
+			const chunkScriptModuleDynamicDeps = new Set();
 
 			if ( injectPolyfill ) {
 				chunkStaticDeps.add( 'wp-polyfill' );
@@ -300,7 +368,19 @@ class DependencyExtractionWebpackPlugin {
 			const processModule = ( m ) => {
 				const { userRequest } = m;
 				if ( this.externalizedDeps.has( userRequest ) ) {
-					if ( this.useModules ) {
+					if ( this.scriptModuleDeps.has( userRequest ) ) {
+						const isStatic =
+							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
+								compilation,
+								m
+							);
+
+						(
+							isStatic
+								? chunkScriptModuleStaticDeps
+								: chunkScriptModuleDynamicDeps
+						).add( userRequest );
+					} else if ( this.useModules ) {
 						const isStatic =
 							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
 								compilation,
@@ -382,6 +462,18 @@ class DependencyExtractionWebpackPlugin {
 				],
 				version: contentHash,
 			};
+
+			if (
+				chunkScriptModuleStaticDeps.size ||
+				chunkScriptModuleDynamicDeps.size
+			) {
+				assetData.module_dependencies = [
+					...Array.from( chunkScriptModuleStaticDeps ).sort(),
+					...Array.from( chunkScriptModuleDynamicDeps )
+						.sort()
+						.map( ( id ) => ( { id, import: 'dynamic' } ) ),
+				];
+			}
 
 			if ( this.useModules ) {
 				assetData.type = 'module';

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -1,3 +1,7 @@
+const { readFileSync } = require( 'fs' );
+const { createRequire } = require( 'module' );
+const path = require( 'path' );
+
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [
 	'@wordpress/admin-ui',
@@ -155,9 +159,97 @@ function camelCaseDash( string ) {
 	return string.replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
 }
 
+/**
+ * Cache for resolved package.json objects.
+ *
+ * @type {Map<string, Object|null>}
+ */
+const packageJsonCache = new Map();
+
+/**
+ * Resolve and read a package's package.json using Node's module resolution.
+ *
+ * @param {string} packageName Full package name (e.g., '@wordpress/abilities').
+ * @param {string} contextDir  Directory to resolve from (the importing file's directory).
+ * @return {Object|null} Parsed package.json object or null if not found.
+ */
+function getPackageInfo( packageName, contextDir ) {
+	const cacheKey = `${ packageName }@${ contextDir }`;
+	if ( packageJsonCache.has( cacheKey ) ) {
+		return packageJsonCache.get( cacheKey );
+	}
+
+	const resolveDirs = [ contextDir, __dirname ];
+	for ( const dir of resolveDirs ) {
+		try {
+			const dirRequire = createRequire(
+				path.join( dir, 'package.json' )
+			);
+			const packageJsonPath = dirRequire.resolve(
+				`${ packageName }/package.json`
+			);
+			const result = JSON.parse(
+				readFileSync( packageJsonPath, 'utf8' )
+			);
+			packageJsonCache.set( cacheKey, result );
+			return result;
+		} catch {
+			// Try next resolution path.
+		}
+	}
+
+	packageJsonCache.set( cacheKey, null );
+	return null;
+}
+
+/**
+ * Check if a package import is a script module.
+ * A package is considered a script module if it has wpScriptModuleExports
+ * and the specific import path (root or subpath) is declared in wpScriptModuleExports.
+ *
+ * Ported from packages/wp-build/lib/wordpress-externals-plugin.mjs.
+ *
+ * @param {Object}      packageJson Package.json object.
+ * @param {string|null} subpath     Subpath after package name, or null for root import.
+ * @return {boolean} True if the import is a script module.
+ */
+function isScriptModuleImport( packageJson, subpath ) {
+	const { wpScriptModuleExports } = packageJson;
+
+	if ( ! wpScriptModuleExports ) {
+		return false;
+	}
+
+	// Root import: @wordpress/package-name
+	if ( ! subpath ) {
+		if ( typeof wpScriptModuleExports === 'string' ) {
+			return true;
+		}
+		if (
+			typeof wpScriptModuleExports === 'object' &&
+			wpScriptModuleExports[ '.' ]
+		) {
+			return true;
+		}
+		return false;
+	}
+
+	// Subpath import: @wordpress/package-name/subpath
+	if (
+		typeof wpScriptModuleExports === 'object' &&
+		wpScriptModuleExports[ `./${ subpath }` ]
+	) {
+		return true;
+	}
+
+	return false;
+}
+
 module.exports = {
 	camelCaseDash,
 	defaultRequestToExternal,
 	defaultRequestToExternalModule,
 	defaultRequestToHandle,
+	getPackageInfo,
+	isScriptModuleImport,
 };

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -1,3 +1,7 @@
+const { readFileSync } = require( 'fs' );
+const { createRequire } = require( 'module' );
+const path = require( 'path' );
+
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [
 	'@wordpress/admin-ui',
@@ -149,9 +153,97 @@ function camelCaseDash( string ) {
 	return string.replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
 }
 
+/**
+ * Cache for resolved package.json objects.
+ *
+ * @type {Map<string, Object|null>}
+ */
+const packageJsonCache = new Map();
+
+/**
+ * Resolve and read a package's package.json using Node's module resolution.
+ *
+ * @param {string} packageName Full package name (e.g., '@wordpress/abilities').
+ * @param {string} contextDir  Directory to resolve from (the importing file's directory).
+ * @return {Object|null} Parsed package.json object or null if not found.
+ */
+function getPackageInfo( packageName, contextDir ) {
+	const cacheKey = `${ packageName }@${ contextDir }`;
+	if ( packageJsonCache.has( cacheKey ) ) {
+		return packageJsonCache.get( cacheKey );
+	}
+
+	const resolveDirs = [ contextDir, __dirname ];
+	for ( const dir of resolveDirs ) {
+		try {
+			const dirRequire = createRequire(
+				path.join( dir, 'package.json' )
+			);
+			const packageJsonPath = dirRequire.resolve(
+				`${ packageName }/package.json`
+			);
+			const result = JSON.parse(
+				readFileSync( packageJsonPath, 'utf8' )
+			);
+			packageJsonCache.set( cacheKey, result );
+			return result;
+		} catch {
+			// Try next resolution path.
+		}
+	}
+
+	packageJsonCache.set( cacheKey, null );
+	return null;
+}
+
+/**
+ * Check if a package import is a script module.
+ * A package is considered a script module if it has wpScriptModuleExports
+ * and the specific import path (root or subpath) is declared in wpScriptModuleExports.
+ *
+ * Ported from packages/wp-build/lib/wordpress-externals-plugin.mjs.
+ *
+ * @param {Object}      packageJson Package.json object.
+ * @param {string|null} subpath     Subpath after package name, or null for root import.
+ * @return {boolean} True if the import is a script module.
+ */
+function isScriptModuleImport( packageJson, subpath ) {
+	const { wpScriptModuleExports } = packageJson;
+
+	if ( ! wpScriptModuleExports ) {
+		return false;
+	}
+
+	// Root import: @wordpress/package-name
+	if ( ! subpath ) {
+		if ( typeof wpScriptModuleExports === 'string' ) {
+			return true;
+		}
+		if (
+			typeof wpScriptModuleExports === 'object' &&
+			wpScriptModuleExports[ '.' ]
+		) {
+			return true;
+		}
+		return false;
+	}
+
+	// Subpath import: @wordpress/package-name/subpath
+	if (
+		typeof wpScriptModuleExports === 'object' &&
+		wpScriptModuleExports[ `./${ subpath }` ]
+	) {
+		return true;
+	}
+
+	return false;
+}
+
 module.exports = {
 	camelCaseDash,
 	defaultRequestToExternal,
 	defaultRequestToExternalModule,
 	defaultRequestToHandle,
+	getPackageInfo,
+	isScriptModuleImport,
 };


### PR DESCRIPTION
## Summary
FIxes: https://github.com/WordPress/gutenberg/issues/75196

WordPress packages that declare `wpScriptModuleExports` in their `package.json` (e.g., `@wordpress/abilities`) are script modules — they don't register `window` globals. The `@wordpress/dependency-extraction-webpack-plugin` currently treats all `@wordpress/*` packages as window-global scripts, which causes two problems:

1. The package gets externalized as `window.wp.abilities` (which doesn't exist at runtime). During the build the dynamic import is not respected.
2. It gets listed as `wp-abilities` in `dependencies` instead of `module_dependencies` in the asset file

This PR fixes the webpack plugin to match the behavior already implemented in the esbuild-based `wp-build` plugin:

- Detects script module packages by reading their `package.json` and checking `wpScriptModuleExports`
- Externalizes them with `import` type (generating `import()` at runtime) instead of `window` global
- Emits them in `module_dependencies` in the asset file, matching the format WordPress PHP expects (`script-loader.php`, `class-wp-scripts.php`)
- Packages that are both a script and a script module (`wpScript` + `wpScriptModuleExports`) are treated as regular scripts in non-module builds

This solution has a drawback packages need to be published on npm so the build can get their package.json. On https://github.com/WordPress/gutenberg/pull/76397 we address that, but it is a hardcoded list.

cc: @youknowriad, @sirreal, @jonathanbossenger 



### Changes

**`util.js`:**
- Added `getPackageInfo()` — resolves and reads a package's `package.json` using Node's module resolution (with caching)
- Added `isScriptModuleImport()` — checks if a package/subpath import is a script module (ported from `wp-build`'s `wordpress-externals-plugin.mjs`)

**`index.js`:**
- Added `isScriptModuleRequest()` method that combines package resolution with script module detection
- Modified `externalizeWpDeps()` to externalize script module requests with `import` type prefix
- Modified `addAssets()` to track script module dependencies separately and emit them as `module_dependencies`

## Test plan

- [ ] Checkout this branch, do `npm install && npm run build`. Check out https://github.com/jonathanbossenger/wp-ai-client-demo/tree/debug-wp-build (branch debug-wp-build ).
- [ ] Run on the wp-ai-client-demo folder "npm install && rm -rf node_modules/webpack && node /Users/user/storage/repos/gutenberg/gutenberg-1/packages/scripts/bin/wp-scripts.js build" replace the gutenberg path
- [ ] Go to wp-admin/tools.php?page=wp-ai-client-demo-tools. Verify on the browser console that abilities api module is logged and an array of abilities is also logged.

On this plugin it should probably use routes and we would not face that problem, but a solution is still needed for scripts using wp-build that consume script modules but are not a wp-module.