### PR TITLE
Dependency Extraction Webpack Plugin: Externalize script modules as import() and emit module_dependencies

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added detection of dynamic imports of script modules
+
 ## 6.49.0 (2026-06-24)
 
 ## 6.48.1 (2026-06-16)

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -88,9 +88,19 @@ class DependencyExtractionWebpackPlugin {
 				typeof externalRequest === 'undefined' &&
 				this.options.useDefaults
 			) {
-				externalRequest = this.useModules
-					? defaultRequestToExternalModule( request )
-					: defaultRequestToExternal( request );
+				if ( this.useModules ) {
+					externalRequest = defaultRequestToExternalModule( request );
+				} else {
+					try {
+						externalRequest =
+							defaultRequestToExternalModule( request );
+					} catch {
+						// Not a script module, fall through.
+					}
+					if ( typeof externalRequest === 'undefined' ) {
+						externalRequest = defaultRequestToExternal( request );
+					}
+				}
 			}
 		} catch ( err ) {
 			return callback( err );
@@ -289,6 +299,10 @@ class DependencyExtractionWebpackPlugin {
 			const chunkStaticDeps = new Set();
 			/** @type {Set<string>} */
 			const chunkDynamicDeps = new Set();
+			/** @type {Set<string>} */
+			const chunkScriptModuleStaticDeps = new Set();
+			/** @type {Set<string>} */
+			const chunkScriptModuleDynamicDeps = new Set();
 
 			if ( injectPolyfill ) {
 				chunkStaticDeps.add( 'wp-polyfill' );
@@ -310,6 +324,17 @@ class DependencyExtractionWebpackPlugin {
 						( isStatic ? chunkStaticDeps : chunkDynamicDeps ).add(
 							m.request
 						);
+					} else if ( m.externalType === 'import' ) {
+						const isStatic =
+							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
+								compilation,
+								m
+							);
+
+						( isStatic
+							? chunkScriptModuleStaticDeps
+							: chunkScriptModuleDynamicDeps
+						).add( userRequest );
 					} else {
 						chunkStaticDeps.add(
 							this.mapRequestToDependency( userRequest )
@@ -382,6 +407,18 @@ class DependencyExtractionWebpackPlugin {
 				],
 				version: contentHash,
 			};
+
+			if (
+				chunkScriptModuleStaticDeps.size ||
+				chunkScriptModuleDynamicDeps.size
+			) {
+				assetData.module_dependencies = [
+					...Array.from( chunkScriptModuleStaticDeps ).sort(),
+					...Array.from( chunkScriptModuleDynamicDeps )
+						.sort()
+						.map( ( id ) => ( { id, import: 'dynamic' } ) ),
+				];
+			}
 
 			if ( this.useModules ) {
 				assetData.type = 'module';

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -304,6 +304,9 @@ class DependencyExtractionWebpackPlugin {
 			/** @type {Set<string>} */
 			const chunkScriptModuleDynamicDeps = new Set();
 
+			const staticDepsCurrent = new WeakSet();
+			const staticDepsCache = new WeakMap();
+
 			if ( injectPolyfill ) {
 				chunkStaticDeps.add( 'wp-polyfill' );
 			}
@@ -317,6 +320,8 @@ class DependencyExtractionWebpackPlugin {
 					if ( this.useModules ) {
 						const isStatic =
 							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
+								staticDepsCache,
+								staticDepsCurrent,
 								compilation,
 								m
 							);
@@ -324,21 +329,45 @@ class DependencyExtractionWebpackPlugin {
 						( isStatic ? chunkStaticDeps : chunkDynamicDeps ).add(
 							m.request
 						);
-					} else if ( m.externalType === 'import' ) {
+					} else if ( m.externalType === 'import' || m.externalType === 'module') {
 						const isStatic =
 							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
+								staticDepsCache,
+								staticDepsCurrent,
 								compilation,
 								m
 							);
 
-						( isStatic
-							? chunkScriptModuleStaticDeps
-							: chunkScriptModuleDynamicDeps
-						).add( userRequest );
+						(isStatic ? chunkScriptModuleStaticDeps : chunkScriptModuleDynamicDeps)
+							.add(userRequest);
 					} else {
 						chunkStaticDeps.add(
 							this.mapRequestToDependency( userRequest )
 						);
+					}
+				}
+				if (m.blocks) {
+					for (const block of m.blocks) {
+						if (block.constructor.name !== AsyncDependenciesBlock.name && block.constructor.name !== DependenciesBlock.name) {
+							continue;
+						}
+						for (const dep of block.dependencies) {
+							if (this.externalizedDeps.has(dep.userRequest)) {
+								if (block.constructor.name === AsyncDependenciesBlock.name) {
+									if (this.useModules) {
+										chunkDynamicDeps.add(dep.request);
+									} else {
+										chunkScriptModuleDynamicDeps.add(dep.userRequest)
+									}
+								} else {
+									if (this.useModules) {
+										chunkStaticDeps.add(dep.request);
+									} else {
+										chunkScriptModuleStaticDeps.add(dep.userRequest)
+									}
+								}
+							}
+						}
 					}
 				}
 			};
@@ -481,9 +510,6 @@ class DependencyExtractionWebpackPlugin {
 		}
 	}
 
-	static #staticDepsCurrent = new WeakSet();
-	static #staticDepsCache = new WeakMap();
-
 	/**
 	 * Can we trace a line of static dependencies from an entry to a module
 	 *
@@ -492,20 +518,20 @@ class DependencyExtractionWebpackPlugin {
 	 *
 	 * @return {boolean} True if there is a static import path to the root
 	 */
-	static hasStaticDependencyPathToRoot( compilation, block ) {
-		if ( DependencyExtractionWebpackPlugin.#staticDepsCache.has( block ) ) {
-			return DependencyExtractionWebpackPlugin.#staticDepsCache.get(
+	static hasStaticDependencyPathToRoot( staticDepsCache, staticDepsCurrent, compilation, block ) {
+		if ( staticDepsCache.has( block ) ) {
+			return staticDepsCache.get(
 				block
 			);
 		}
 
 		if (
-			DependencyExtractionWebpackPlugin.#staticDepsCurrent.has( block )
+			staticDepsCurrent.has( block )
 		) {
 			return false;
 		}
 
-		DependencyExtractionWebpackPlugin.#staticDepsCurrent.add( block );
+		staticDepsCurrent.add( block );
 
 		const incomingConnections = [
 			...compilation.moduleGraph.getIncomingConnections( block ),
@@ -520,11 +546,11 @@ class DependencyExtractionWebpackPlugin {
 		// If we don't have non-entry, non-library incoming connections,
 		// we've reached a root of
 		if ( ! incomingConnections.length ) {
-			DependencyExtractionWebpackPlugin.#staticDepsCache.set(
+			staticDepsCache.set(
 				block,
 				true
 			);
-			DependencyExtractionWebpackPlugin.#staticDepsCurrent.delete(
+			staticDepsCurrent.delete(
 				block
 			);
 			return true;
@@ -545,11 +571,11 @@ class DependencyExtractionWebpackPlugin {
 
 		// All the dependencies were Async, the module was reached via a dynamic import
 		if ( ! staticDependentModules.length ) {
-			DependencyExtractionWebpackPlugin.#staticDepsCache.set(
+			staticDepsCache.set(
 				block,
 				false
 			);
-			DependencyExtractionWebpackPlugin.#staticDepsCurrent.delete(
+			staticDepsCurrent.delete(
 				block
 			);
 			return false;
@@ -559,13 +585,14 @@ class DependencyExtractionWebpackPlugin {
 		const result = staticDependentModules.some(
 			( parentStaticDependentModule ) =>
 				DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
+					staticDepsCache, staticDepsCurrent,
 					compilation,
 					parentStaticDependentModule
 				)
 		);
 
-		DependencyExtractionWebpackPlugin.#staticDepsCache.set( block, result );
-		DependencyExtractionWebpackPlugin.#staticDepsCurrent.delete( block );
+		staticDepsCache.set( block, result );
+		staticDepsCurrent.delete( block );
 		return result;
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -329,7 +329,10 @@ class DependencyExtractionWebpackPlugin {
 						( isStatic ? chunkStaticDeps : chunkDynamicDeps ).add(
 							m.request
 						);
-					} else if ( m.externalType === 'import' || m.externalType === 'module') {
+					} else if (
+						m.externalType === 'import' ||
+						m.externalType === 'module'
+					) {
 						const isStatic =
 							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
 								staticDepsCache,
@@ -338,32 +341,47 @@ class DependencyExtractionWebpackPlugin {
 								m
 							);
 
-						(isStatic ? chunkScriptModuleStaticDeps : chunkScriptModuleDynamicDeps)
-							.add(userRequest);
+						( isStatic
+							? chunkScriptModuleStaticDeps
+							: chunkScriptModuleDynamicDeps
+						).add( userRequest );
 					} else {
 						chunkStaticDeps.add(
 							this.mapRequestToDependency( userRequest )
 						);
 					}
 				}
-				if (m.blocks) {
-					for (const block of m.blocks) {
-						if (block.constructor.name !== AsyncDependenciesBlock.name && block.constructor.name !== DependenciesBlock.name) {
+				if ( m.blocks ) {
+					for ( const block of m.blocks ) {
+						if (
+							block.constructor.name !==
+								AsyncDependenciesBlock.name &&
+							block.constructor.name !== DependenciesBlock.name
+						) {
 							continue;
 						}
-						for (const dep of block.dependencies) {
-							if (this.externalizedDeps.has(dep.userRequest)) {
-								if (block.constructor.name === AsyncDependenciesBlock.name) {
-									if (this.useModules) {
-										chunkDynamicDeps.add(dep.request);
+						for ( const dep of block.dependencies ) {
+							if (
+								this.externalizedDeps.has( dep.userRequest )
+							) {
+								if (
+									block.constructor.name ===
+									AsyncDependenciesBlock.name
+								) {
+									if ( this.useModules ) {
+										chunkDynamicDeps.add( dep.request );
 									} else {
-										chunkScriptModuleDynamicDeps.add(dep.userRequest)
+										chunkScriptModuleDynamicDeps.add(
+											dep.userRequest
+										);
 									}
 								} else {
-									if (this.useModules) {
-										chunkStaticDeps.add(dep.request);
+									if ( this.useModules ) {
+										chunkStaticDeps.add( dep.request );
 									} else {
-										chunkScriptModuleStaticDeps.add(dep.userRequest)
+										chunkScriptModuleStaticDeps.add(
+											dep.userRequest
+										);
 									}
 								}
 							}
@@ -518,16 +536,17 @@ class DependencyExtractionWebpackPlugin {
 	 *
 	 * @return {boolean} True if there is a static import path to the root
 	 */
-	static hasStaticDependencyPathToRoot( staticDepsCache, staticDepsCurrent, compilation, block ) {
+	static hasStaticDependencyPathToRoot(
+		staticDepsCache,
+		staticDepsCurrent,
+		compilation,
+		block
+	) {
 		if ( staticDepsCache.has( block ) ) {
-			return staticDepsCache.get(
-				block
-			);
+			return staticDepsCache.get( block );
 		}
 
-		if (
-			staticDepsCurrent.has( block )
-		) {
+		if ( staticDepsCurrent.has( block ) ) {
 			return false;
 		}
 
@@ -546,13 +565,8 @@ class DependencyExtractionWebpackPlugin {
 		// If we don't have non-entry, non-library incoming connections,
 		// we've reached a root of
 		if ( ! incomingConnections.length ) {
-			staticDepsCache.set(
-				block,
-				true
-			);
-			staticDepsCurrent.delete(
-				block
-			);
+			staticDepsCache.set( block, true );
+			staticDepsCurrent.delete( block );
 			return true;
 		}
 
@@ -571,13 +585,8 @@ class DependencyExtractionWebpackPlugin {
 
 		// All the dependencies were Async, the module was reached via a dynamic import
 		if ( ! staticDependentModules.length ) {
-			staticDepsCache.set(
-				block,
-				false
-			);
-			staticDepsCurrent.delete(
-				block
-			);
+			staticDepsCache.set( block, false );
+			staticDepsCurrent.delete( block );
 			return false;
 		}
 
@@ -585,7 +594,8 @@ class DependencyExtractionWebpackPlugin {
 		const result = staticDependentModules.some(
 			( parentStaticDependentModule ) =>
 				DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
-					staticDepsCache, staticDepsCurrent,
+					staticDepsCache,
+					staticDepsCurrent,
 					compilation,
 					parentStaticDependentModule
 				)

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -95,6 +95,8 @@ function defaultRequestToExternalModule( request ) {
 	switch ( request ) {
 		case '@wordpress/interactivity-router':
 		case '@wordpress/a11y':
+		case '@wordpress/abilities':
+		case '@wordpress/core-abilities':
 			return `import ${ request }`;
 	}
 

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -92,6 +92,8 @@ function defaultRequestToExternalModule( request ) {
 	switch ( request ) {
 		case '@wordpress/interactivity-router':
 		case '@wordpress/a11y':
+		case '@wordpress/abilities':
+		case '@wordpress/core-abilities':
 			return `import ${ request }`;
 	}
 


### PR DESCRIPTION
## Summary
FIxes: https://github.com/WordPress/gutenberg/issues/75196

Packages like `@wordpress/abilities` and `@wordpress/core-abilities` are script modules (registered via `wpScriptModuleExports`) that don't expose `window` globals. The webpack dependency extraction plugin currently treats all `@wordpress/*` packages as window-global scripts, which causes:

1. Wrong externalization as `window.wp.abilities` (doesn't exist at runtime)
2. Listed as `wp-abilities` in `dependencies` instead of `module_dependencies` in the asset file

This PR adds these packages to the existing `defaultRequestToExternalModule` switch (alongside `@wordpress/a11y` and `@wordpress/interactivity-router`) and makes non-module (IIFE) builds also consult that function. Script module externals are detected in `processModule` via `m.externalType === 'import'` and emitted as `module_dependencies` in the asset file, matching the format WordPress PHP expects.

### Changes

**`util.js`** — 2 lines: add `@wordpress/abilities` and `@wordpress/core-abilities` to the existing `defaultRequestToExternalModule` switch

**`index.js`** — 3 changes:
- Bridge call: for non-module builds, try `defaultRequestToExternalModule` first (try-catch), fall through to `defaultRequestToExternal` for regular scripts
- `processModule`: detect import-type externals via `m.externalType === 'import'`, route to separate `chunkScriptModuleStaticDeps`/`chunkScriptModuleDynamicDeps` sets
- Asset output: emit `module_dependencies` array with static/dynamic entries

## Test plan

- [ ] Checkout this branch, do `npm install && npm run build`. Check out https://github.com/jonathanbossenger/wp-ai-client-demo/tree/debug-wp-build-2 (branch debug-wp-build-2 ).
- [ ] Run on the wp-ai-client-demo folder "npm install && rm -rf node_modules/webpack && node /Users/user/storage/repos/gutenberg/gutenberg-1/packages/scripts/bin/wp-scripts.js build" replace the gutenberg path
- [ ] Go to wp-admin/tools.php?page=wp-ai-client-demo-tools. Verify on the browser console that abilities api module is logged and an array of abilities is also logged.
