### PR TITLE
CI: Don't build release notes during plugin build workflow for WP Core sync

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -234,7 +234,7 @@ jobs:
                   path: ./gutenberg.zip
 
             - name: Build release notes draft
-              if: ${{ needs.bump-version.outputs.new_version }}
+              if: ${{ matrix.IS_GUTENBERG_PLUGIN && needs.bump-version.outputs.new_version }}
               env:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               run: |
@@ -250,7 +250,7 @@ jobs:
                   fi
 
             - name: Upload release notes artifact
-              if: ${{ needs.bump-version.outputs.new_version }}
+              if: ${{ matrix.IS_GUTENBERG_PLUGIN && needs.bump-version.outputs.new_version }}
               uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
                   name: release-notes


### PR DESCRIPTION
## What?
Fixes a bug in the "Build Gutenberg Plugin Zip" GHA workflow.

## Why?
When manually running the "Build Gutenberg Plugin Zip" GHA workflow to publish version 22.7.0 RC 3 of the plugin, it [failed with the following error](https://github.com/WordPress/gutenberg/actions/runs/22948854578):

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

Reported here: https://github.com/WordPress/gutenberg/pull/75844#issuecomment-4038641891.

## How?

_tl;dr_ By only generating and uploading the release notes artifact if run for the `IS_GUTENBERG_PLUGIN` case (and skipping otherwise).

For a more detailed explanation, refer to https://github.com/WordPress/gutenberg/pull/75844#issuecomment-4039661432.

## Testing Instructions
Gotta manually run the "Build Gutenberg Plugin Zip" GHA workflow to find out 😬 
(Should cherry-pick this PR to the `release/22.7` before attempting.)

## Follow-up

There's some more opportunity for cleanup/optimization of that workflow (but not critical to unblock the GB 22.7.0 release). I'll file another PR in the near future.