### PR TITLE
InputControl: Respect prop value if modified during onChange callback

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Revert `word-break: break-word` addition ([#76230](https://github.com/WordPress/gutenberg/pull/76230)).
 -   `VisuallyHidden`: Add `word-break: normal` to prevent text wrapping issues in screen reader content ([#75539](https://github.com/WordPress/gutenberg/pull/75539)).
+-   `InputControl`: Fix issue where prop value may not be accurately reflected into displayed field if value is modified in change handler, when used in combination with `isPressEnterToChange`.
 
 ### Enhancements
 

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -183,15 +183,18 @@ describe( 'InputControl', () => {
 		} );
 
 		it( 'should update value if the parent transforms it on commit', async () => {
+			const onChange = jest.fn();
 			const user = await userEvent.setup();
 			const Example = () => {
 				const [ state, setState ] = useState( '50' );
 				return (
 					<InputControl
 						value={ state }
-						onChange={ ( v ) => {
-							// Simulate a parent that clamps the value.
-							setState( Number( v ) > 60 ? '60' : v );
+						onChange={ ( nextValue ) => {
+							const clampedValue =
+								Number( nextValue ) > 60 ? '60' : nextValue;
+							setState( clampedValue );
+							onChange( clampedValue );
 						} }
 						isPressEnterToChange
 					/>
@@ -204,6 +207,8 @@ describe( 'InputControl', () => {
 			await user.type( input, '99' );
 			await user.keyboard( '{Tab}' );
 
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+			expect( onChange ).toHaveBeenCalledWith( '60' );
 			expect( input ).toHaveValue( '60' );
 		} );
 

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -182,6 +182,31 @@ describe( 'InputControl', () => {
 			expect( spy ).toHaveBeenCalledWith( 'that was then' );
 		} );
 
+		it( 'should update value if the parent transforms it on commit', async () => {
+			const user = await userEvent.setup();
+			const Example = () => {
+				const [ state, setState ] = useState( '50' );
+				return (
+					<InputControl
+						value={ state }
+						onChange={ ( v ) => {
+							// Simulate a parent that clamps the value.
+							setState( Number( v ) > 60 ? '60' : v );
+						} }
+						isPressEnterToChange
+					/>
+				);
+			};
+			render( <Example /> );
+			const input = getInput();
+
+			await user.clear( input );
+			await user.type( input, '99' );
+			await user.keyboard( '{Tab}' );
+
+			expect( input ).toHaveValue( '60' );
+		} );
+
 		it( 'should commit value when blurred if value is invalid', async () => {
 			const user = await userEvent.setup();
 			const spyChange = jest.fn();

--- a/packages/components/src/input-control/utils.ts
+++ b/packages/components/src/input-control/utils.ts
@@ -6,12 +6,7 @@ import type { FocusEventHandler } from 'react';
 /**
  * WordPress dependencies
  */
-import {
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -73,7 +68,6 @@ export function useDraft( props: {
 	onBlur?: FocusEventHandler;
 	onChange: InputChangeCallback;
 } ) {
-	const previousValueRef = useRef( props.value );
 	const [ draft, setDraft ] = useState< {
 		value?: string;
 		isStale?: boolean;
@@ -84,11 +78,9 @@ export function useDraft( props: {
 	// To do so, it tracks the previous value and marks the draft value as stale
 	// after each render.
 	useLayoutEffect( () => {
-		const { current: previousValue } = previousValueRef;
-		previousValueRef.current = props.value;
 		if ( draft.value !== undefined && ! draft.isStale ) {
 			setDraft( { ...draft, isStale: true } );
-		} else if ( draft.isStale && props.value !== previousValue ) {
+		} else if ( draft.isStale && props.value !== draft.value ) {
 			setDraft( {} );
 		}
 	}, [ props.value, draft ] );

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -235,8 +235,7 @@ function UnforwardedNumberControl(
 			required={ required }
 			step={ step }
 			type={ typeProp }
-			// @ts-expect-error TODO: Resolve discrepancy between `value` types in InputControl based components
-			value={ valueProp }
+			value={ valueProp === undefined ? valueProp : String( valueProp ) }
 			__unstableStateReducer={ numberControlStateReducer }
 			size={ size }
 			__shouldNotWarnDeprecated36pxSize

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -102,7 +103,8 @@ describe( 'RangeControl', () => {
 			expect( onChange ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should keep invalid values in number input until loss of focus', () => {
+		it( 'should keep invalid values in number input until loss of focus', async () => {
+			const user = userEvent.setup();
 			const onChange = jest.fn();
 			render(
 				<RangeControl onChange={ onChange } min={ -1 } max={ 1 } />
@@ -111,13 +113,13 @@ describe( 'RangeControl', () => {
 			const rangeInput = getRangeInput();
 			const numberInput = getNumberInput();
 
-			act( () => numberInput.focus() );
-			fireChangeEvent( numberInput, '-1.1' );
+			await user.clear( numberInput );
+			await user.type( numberInput, '-1.1' );
 
 			expect( numberInput.value ).toBe( '-1.1' );
 			expect( rangeInput.value ).toBe( '-1' );
 
-			fireEvent.blur( numberInput );
+			await user.keyboard( '{Tab}' );
 			expect( onChange ).toHaveBeenCalledWith( -1 );
 			expect( numberInput.value ).toBe( '-1' );
 		} );


### PR DESCRIPTION
## What?

Related to: #75530

Fixes an issue where `InputControl` may become stuck in a stale draft state if the controlled input value prop is changed during the `onChange` callback, when used in combination with `isPressEnterToChange`.

## Why?

The `DateTimePicker` component time component uses `InputControl` as a controlled input and [syncs its value to state on change](https://github.com/WordPress/gutenberg/blob/5740956805fc3d1031d5c41a8d2f38a54c872d77/packages/components/src/date-time/time/index.tsx#L178). As of #76400 (and prior to #73887, i.e. WordPress 6.9), this change handler may result in a date that is different than the original value entered in the field. Without these changes, the updated state value (and consequently controlled prop value) would not be accounted for in the change handling, meaning that the displayed value of the field may be out of sync with the the internal value representation.

https://github.com/user-attachments/assets/1010f8d4-f4b8-4ebd-9207-67d9f972c3a7

## How?

From my understanding of how this behavior was introduced in #40518, the idea is to allow an incoming prop value to take precedence over whatever value is "drafted" in the `isPressEnterToChange` mode. The sequence of events when the value is manipulated _during_ a change callback results in a desync that causes the draft to _not_ reset when receiving the new prop value. Instead of comparing to the a copy of the last prop value (which may not be accurate), compare to the latest draft value directly.

## Testing Instructions

Repeat Testing Instructions from #40518

Verify regression tests pass: `npm run test:unit packages/components/src/input-control/test/index.js`

Optionally, rebase this branch on top of `fix/day-picker-invalid-day` and observe that the interaction shown in the screen recording above correctly results in a date selection of February 28, 2026, reflected in both the input field and calendar.
