### PR TITLE
Storybook: Upgrade to 10.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"eslint-plugin-prettier": "5.0.0",
 				"eslint-plugin-react-compiler": "19.0.0-beta-0dec889-20241115",
 				"eslint-plugin-ssr-friendly": "1.0.6",
-				"eslint-plugin-storybook": "10.1.11",
+				"eslint-plugin-storybook": "10.2.17",
 				"eslint-plugin-testing-library": "6.0.2",
 				"execa": "4.0.2",
 				"fast-glob": "^3.2.7",
@@ -5681,29 +5681,6 @@
 				"@types/node": ">=18"
 			}
 		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -6622,13 +6599,13 @@
 			}
 		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.6.3.tgz",
-			"integrity": "sha512-9TGZuAX+liGkNKkwuo3FYJu7gHWT0vkBcf7GkOe7s7fmC19XwH/4u5u7sDIFrMooe558ORcmuBvBz7Ur5PlbHw==",
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.6.4.tgz",
+			"integrity": "sha512-6PyZBYKnnVNqOSB0YFly+62R7dmov8segT27A+RVTBVd4iAE6kbW9QBJGlyR2yG4D4ohzhZSTIu7BK1UTtmFFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"glob": "^11.1.0",
+				"glob": "^13.0.1",
 				"react-docgen-typescript": "^2.2.2"
 			},
 			"peerDependencies": {
@@ -6641,50 +6618,51 @@
 				}
 			}
 		},
-		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/glob": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"foreground-child": "^3.3.1",
-				"jackspeak": "^4.1.1",
-				"minimatch": "^10.1.1",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^2.0.0"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": "18 || 20 || >=22"
 			}
 		},
-		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/jackspeak": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/brace-expansion": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/lru-cache": {
-			"version": "11.2.4",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-			"integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -6692,35 +6670,35 @@
 			}
 		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/path-scurry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -6728,7 +6706,7 @@
 				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -16695,9 +16673,9 @@
 			}
 		},
 		"node_modules/@storybook/addon-a11y": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.1.11.tgz",
-			"integrity": "sha512-3sr6HmcDgW1+TQAV9QtWBE3HlGyfFXVZY3RECTNLNH6fRC+rYQCItisvQIVxQpyftLSQ8EAMN9JQzs495MjWNg==",
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.2.17.tgz",
+			"integrity": "sha512-J0ogEc4/XFC+Ytz+X1we6TOKreEk/shgUs/mtxdsLa0xJ6bp2n2OQPSjNtQHH/nK4SRBSfHWPm8ztfcXTzeG9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16709,20 +16687,20 @@
 				"url": "https://opencollective.com/storybook"
 			},
 			"peerDependencies": {
-				"storybook": "^10.1.11"
+				"storybook": "^10.2.17"
 			}
 		},
 		"node_modules/@storybook/addon-docs": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.1.11.tgz",
-			"integrity": "sha512-Jwm291Fhim2eVcZIVlkG1B2skb0ZI9oru6nqMbJxceQZlvZmcIa4oxvS1oaMTKw2DJnCv97gLm57P/YvRZ8eUg==",
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.2.17.tgz",
+			"integrity": "sha512-c414xi7rxlaHn92qWOxtEkcOMm0/+cvBui0gUsgiWOZOM8dHChGZ/RjMuf1pPDyOrSsybLsPjZhP0WthsMDkdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@mdx-js/react": "^3.0.0",
-				"@storybook/csf-plugin": "10.1.11",
-				"@storybook/icons": "^2.0.0",
-				"@storybook/react-dom-shim": "10.1.11",
+				"@storybook/csf-plugin": "10.2.17",
+				"@storybook/icons": "^2.0.1",
+				"@storybook/react-dom-shim": "10.2.17",
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 				"ts-dedent": "^2.0.0"
@@ -16732,34 +16710,17 @@
 				"url": "https://opencollective.com/storybook"
 			},
 			"peerDependencies": {
-				"storybook": "^10.1.11"
-			}
-		},
-		"node_modules/@storybook/addon-docs/node_modules/@storybook/react-dom-shim": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.1.11.tgz",
-			"integrity": "sha512-o8WPhRlZbORUWG9lAgDgJP0pi905VHJUFJr1Kp8980gHqtlemtnzjPxKy5vFwj6glNhAlK8SS8OOYzWP7hloTQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/storybook"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"storybook": "^10.1.11"
+				"storybook": "^10.2.17"
 			}
 		},
 		"node_modules/@storybook/builder-vite": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.1.11.tgz",
-			"integrity": "sha512-MMD09Ap7FyzDfWG961pkIMv/w684XXe1bBEi+wCEpHxvrgAd3j3A9w/Rqp9Am2uRDPCEdi1QgSzS3SGW3aGThQ==",
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.2.17.tgz",
+			"integrity": "sha512-m/OBveTLm5ds/tUgHmmbKzgSi/oeCpQwm5rZa49vP2BpAd41Q7ER6TzkOoISzPoNNMAcbVmVc5vn7k6hdbPSHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@storybook/csf-plugin": "10.1.11",
-				"@vitest/mocker": "3.2.4",
+				"@storybook/csf-plugin": "10.2.17",
 				"ts-dedent": "^2.0.0"
 			},
 			"funding": {
@@ -16767,14 +16728,14 @@
 				"url": "https://opencollective.com/storybook"
 			},
 			"peerDependencies": {
-				"storybook": "^10.1.11",
+				"storybook": "^10.2.17",
 				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
 		"node_modules/@storybook/csf-plugin": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.1.11.tgz",
-			"integrity": "sha512-Ant0NhgqHKzQsseeVTSetZCuDHHs0W2HRkHt51Kg/sUl0T/sDtfVA+fWZT8nGzGZqYSFkxqYPWjauPmIhPtaRw==",
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.2.17.tgz",
+			"integrity": "sha512-crHH8i/4mwzeXpWRPgwvwX2vjytW42zyzTRySUax5dTU8o9sjk4y+Z9hkGx3Nmu1TvqseS8v1Z20saZr/tQcWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16787,7 +16748,7 @@
 			"peerDependencies": {
 				"esbuild": "*",
 				"rollup": "*",
-				"storybook": "^10.1.11",
+				"storybook": "^10.2.17",
 				"vite": "*",
 				"webpack": "*"
 			},
@@ -16823,17 +16784,60 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@storybook/react-vite": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.1.11.tgz",
-			"integrity": "sha512-qh1BCD25nIoiDfqwha+qBkl7pcG4WuzM+c8tsE63YEm8AFIbNKg5K8lVUoclF+4CpFz7IwBpWe61YUTDfp+91w==",
+		"node_modules/@storybook/react": {
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.2.17.tgz",
+			"integrity": "sha512-875AVMYil2X9Civil6GFZ8koIzlKxcXbl2eJ7+/GPbhIonTNmwx0qbWPHttjZXUvFuQ4RRtb9KkBwy4TCb/LeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.3",
+				"@storybook/global": "^5.0.0",
+				"@storybook/react-dom-shim": "10.2.17",
+				"react-docgen": "^8.0.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"storybook": "^10.2.17",
+				"typescript": ">= 4.9.x"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@storybook/react-dom-shim": {
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.2.17.tgz",
+			"integrity": "sha512-x9Kb7eUSZ1zGsEw/TtWrvs1LwWIdNp8qoOQCgPEjdB07reSJcE8R3+ASWHJThmd4eZf66ZALPJyerejake4Osw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"storybook": "^10.2.17"
+			}
+		},
+		"node_modules/@storybook/react-vite": {
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.2.17.tgz",
+			"integrity": "sha512-E/1hNmxVsjy9l3TuaNufSqkdz8saTJUGEs8GRCjKlF7be2wljIwewUxjAT3efk+bxOCw76ZmqGHk6MnRa3y7Gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.4",
 				"@rollup/pluginutils": "^5.0.2",
-				"@storybook/builder-vite": "10.1.11",
-				"@storybook/react": "10.1.11",
+				"@storybook/builder-vite": "10.2.17",
+				"@storybook/react": "10.2.17",
 				"empathic": "^2.0.0",
 				"magic-string": "^0.30.0",
 				"react-docgen": "^8.0.0",
@@ -16847,153 +16851,8 @@
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"storybook": "^10.1.11",
+				"storybook": "^10.2.17",
 				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/@babel/core": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/generator": "^7.28.6",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/@babel/traverse": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-			"integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/generator": "^7.28.6",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.6",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6",
-				"debug": "^4.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/@storybook/react": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.1.11.tgz",
-			"integrity": "sha512-rmMGmEwBaM2YpB8oDk2moM0MNjNMqtwyoPPZxjyruY9WVhYca8EDPGKEdRzUlb4qZJsTgLi7VU4eqg6LD/mL3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@storybook/global": "^5.0.0",
-				"@storybook/react-dom-shim": "10.1.11",
-				"react-docgen": "^8.0.2"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/storybook"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"storybook": "^10.1.11",
-				"typescript": ">= 4.9.x"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/@storybook/react-dom-shim": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.1.11.tgz",
-			"integrity": "sha512-o8WPhRlZbORUWG9lAgDgJP0pi905VHJUFJr1Kp8980gHqtlemtnzjPxKy5vFwj6glNhAlK8SS8OOYzWP7hloTQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/storybook"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"storybook": "^10.1.11"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/convert-source-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@storybook/react-vite/node_modules/doctrine": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/react-docgen": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.2.tgz",
-			"integrity": "sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.28.0",
-				"@babel/traverse": "^7.28.0",
-				"@babel/types": "^7.28.2",
-				"@types/babel__core": "^7.20.5",
-				"@types/babel__traverse": "^7.20.7",
-				"@types/doctrine": "^0.0.9",
-				"@types/resolve": "^1.20.2",
-				"doctrine": "^3.0.0",
-				"resolve": "^1.22.1",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": "^20.9.0 || >=22"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@storybook/react-vite/node_modules/strip-bom": {
@@ -17004,19 +16863,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/@storybook/react-vite/node_modules/strip-indent": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
-			"integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@storybook/react-vite/node_modules/tsconfig-paths": {
@@ -19704,43 +19550,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/mocker": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "3.2.4",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.17"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/mocker/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
@@ -31541,17 +31350,17 @@
 			}
 		},
 		"node_modules/eslint-plugin-storybook": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.1.11.tgz",
-			"integrity": "sha512-mbq2r2kK5+AcLl0XDJ3to91JOgzCbHOqj+J3n+FRw6drk+M1boRqMShSoMMm0HdzXPLmlr7iur+qJ5ZuhH6ayQ==",
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.2.17.tgz",
+			"integrity": "sha512-LtzVBHcq+RbrhTnF1rFNpc5bmg/kmdDsw/6bIKOnyDY4r0g5ldZSNN3R/fxLrhFOL2DhmmDywN9lcFNqHCP3vQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "^8.8.1"
+				"@typescript-eslint/utils": "^8.48.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=8",
-				"storybook": "^10.1.11"
+				"storybook": "^10.2.17"
 			}
 		},
 		"node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/scope-manager": {
@@ -47742,6 +47551,28 @@
 				"ws": "^7"
 			}
 		},
+		"node_modules/react-docgen": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.2.tgz",
+			"integrity": "sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.28.0",
+				"@babel/traverse": "^7.28.0",
+				"@babel/types": "^7.28.2",
+				"@types/babel__core": "^7.20.5",
+				"@types/babel__traverse": "^7.20.7",
+				"@types/doctrine": "^0.0.9",
+				"@types/resolve": "^1.20.2",
+				"doctrine": "^3.0.0",
+				"resolve": "^1.22.1",
+				"strip-indent": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.9.0 || >=22"
+			}
+		},
 		"node_modules/react-docgen-typescript": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
@@ -47750,6 +47581,161 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"typescript": ">= 4.3.x"
+			}
+		},
+		"node_modules/react-docgen/node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/react-docgen/node_modules/@babel/core": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/react-docgen/node_modules/@babel/generator": {
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/react-docgen/node_modules/@babel/parser": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/react-docgen/node_modules/@babel/traverse": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/react-docgen/node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/react-docgen/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/react-docgen/node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/react-docgen/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/react-docgen/node_modules/strip-indent": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+			"integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/react-dom": {
@@ -51709,14 +51695,14 @@
 			}
 		},
 		"node_modules/storybook": {
-			"version": "10.1.11",
-			"resolved": "https://registry.npmjs.org/storybook/-/storybook-10.1.11.tgz",
-			"integrity": "sha512-pKP5jXJYM4OjvNklGuHKO53wOCAwfx79KvZyOWHoi9zXUH5WVMFUe/ZfWyxXG/GTcj0maRgHGUjq/0I43r0dDQ==",
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.17.tgz",
+			"integrity": "sha512-yueTpl5YJqLzQqs3CanxNdAAfFU23iP0j+JVJURE4ghfEtRmWfWoZWLGkVcyjmgum7UmjwAlqRuOjQDNvH89kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@storybook/global": "^5.0.0",
-				"@storybook/icons": "^2.0.0",
+				"@storybook/icons": "^2.0.1",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/user-event": "^14.6.1",
 				"@vitest/expect": "3.2.4",
@@ -51724,7 +51710,7 @@
 				"esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
 				"open": "^10.2.0",
 				"recast": "^0.23.5",
-				"semver": "^7.6.2",
+				"semver": "^7.7.3",
 				"use-sync-external-store": "^1.5.0",
 				"ws": "^8.18.0"
 			},
@@ -54480,9 +54466,9 @@
 			}
 		},
 		"node_modules/unplugin/node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -58624,13 +58610,13 @@
 			},
 			"devDependencies": {
 				"@ariakit/test": "^0.4.13",
-				"@storybook/addon-docs": "^10.1.11",
-				"@storybook/react-vite": "^10.1.11",
+				"@storybook/addon-docs": "^10.2.8",
+				"@storybook/react-vite": "^10.2.8",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@types/jest": "^29.5.14",
 				"@wordpress/jest-console": "file:../jest-console",
 				"snapshot-diff": "^0.10.0",
-				"storybook": "^10.1.11",
+				"storybook": "^10.2.8",
 				"timezone-mock": "^1.3.6"
 			},
 			"engines": {
@@ -59756,12 +59742,12 @@
 				"remove-accents": "^0.5.0"
 			},
 			"devDependencies": {
-				"@storybook/addon-docs": "^10.1.11",
-				"@storybook/react-vite": "^10.1.11",
+				"@storybook/addon-docs": "^10.2.8",
+				"@storybook/react-vite": "^10.2.8",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@types/jest": "^29.5.14",
 				"esbuild": "^0.27.2",
-				"storybook": "^10.1.11"
+				"storybook": "^10.2.8"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -62639,7 +62625,7 @@
 				"memize": "^2.1.0"
 			},
 			"devDependencies": {
-				"@storybook/react-vite": "^10.1.11",
+				"@storybook/react-vite": "^10.2.8",
 				"@terrazzo/cli": "^0.10.2",
 				"@terrazzo/plugin-css": "^0.10.2",
 				"@terrazzo/token-tools": "^0.10.2",
@@ -62648,7 +62634,7 @@
 				"@types/node": "^20.17.10",
 				"esbuild": "^0.27.2",
 				"esbuild-esm-loader": "^0.3.3",
-				"storybook": "^10.1.11"
+				"storybook": "^10.2.8"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -62702,12 +62688,12 @@
 				"clsx": "^2.1.1"
 			},
 			"devDependencies": {
-				"@storybook/addon-docs": "^10.1.11",
-				"@storybook/react-vite": "^10.1.11",
+				"@storybook/addon-docs": "^10.2.8",
+				"@storybook/react-vite": "^10.2.8",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.17.10",
-				"storybook": "^10.1.11"
+				"storybook": "^10.2.8"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -63272,12 +63258,12 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@storybook/addon-a11y": "^10.1.11",
-				"@storybook/addon-docs": "^10.1.11",
+				"@storybook/addon-a11y": "^10.2.8",
+				"@storybook/addon-docs": "^10.2.8",
 				"@storybook/icons": "^2.0.1",
-				"@storybook/react-vite": "^10.1.11",
+				"@storybook/react-vite": "^10.2.8",
 				"@wordpress/theme": "file:../packages/theme",
-				"storybook": "^10.1.11",
+				"storybook": "^10.2.8",
 				"storybook-addon-tag-badges": "^3.0.4",
 				"terser": "^5.37.0"
 			}

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"eslint-plugin-prettier": "5.0.0",
 		"eslint-plugin-react-compiler": "19.0.0-beta-0dec889-20241115",
 		"eslint-plugin-ssr-friendly": "1.0.6",
-		"eslint-plugin-storybook": "10.1.11",
+		"eslint-plugin-storybook": "10.2.17",
 		"eslint-plugin-testing-library": "6.0.2",
 		"execa": "4.0.2",
 		"fast-glob": "^3.2.7",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -103,13 +103,13 @@
 	},
 	"devDependencies": {
 		"@ariakit/test": "^0.4.13",
-		"@storybook/addon-docs": "^10.1.11",
-		"@storybook/react-vite": "^10.1.11",
+		"@storybook/addon-docs": "^10.2.8",
+		"@storybook/react-vite": "^10.2.8",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@types/jest": "^29.5.14",
 		"@wordpress/jest-console": "file:../jest-console",
 		"snapshot-diff": "^0.10.0",
-		"storybook": "^10.1.11",
+		"storybook": "^10.2.8",
 		"timezone-mock": "^1.3.6"
 	},
 	"peerDependencies": {

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -75,12 +75,12 @@
 		"remove-accents": "^0.5.0"
 	},
 	"devDependencies": {
-		"@storybook/addon-docs": "^10.1.11",
-		"@storybook/react-vite": "^10.1.11",
+		"@storybook/addon-docs": "^10.2.8",
+		"@storybook/react-vite": "^10.2.8",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@types/jest": "^29.5.14",
 		"esbuild": "^0.27.2",
-		"storybook": "^10.1.11"
+		"storybook": "^10.2.8"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -85,7 +85,7 @@
 		"memize": "^2.1.0"
 	},
 	"devDependencies": {
-		"@storybook/react-vite": "^10.1.11",
+		"@storybook/react-vite": "^10.2.8",
 		"@terrazzo/cli": "^0.10.2",
 		"@terrazzo/plugin-css": "^0.10.2",
 		"@terrazzo/token-tools": "^0.10.2",
@@ -94,7 +94,7 @@
 		"@types/node": "^20.17.10",
 		"esbuild": "^0.27.2",
 		"esbuild-esm-loader": "^0.3.3",
-		"storybook": "^10.1.11"
+		"storybook": "^10.2.8"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,12 +56,12 @@
 		"clsx": "^2.1.1"
 	},
 	"devDependencies": {
-		"@storybook/addon-docs": "^10.1.11",
-		"@storybook/react-vite": "^10.1.11",
+		"@storybook/addon-docs": "^10.2.8",
+		"@storybook/react-vite": "^10.2.8",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^20.17.10",
-		"storybook": "^10.1.11"
+		"storybook": "^10.2.8"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -20,12 +20,12 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@storybook/addon-a11y": "^10.1.11",
-		"@storybook/addon-docs": "^10.1.11",
+		"@storybook/addon-a11y": "^10.2.8",
+		"@storybook/addon-docs": "^10.2.8",
 		"@storybook/icons": "^2.0.1",
-		"@storybook/react-vite": "^10.1.11",
+		"@storybook/react-vite": "^10.2.8",
 		"@wordpress/theme": "file:../packages/theme",
-		"storybook": "^10.1.11",
+		"storybook": "^10.2.8",
 		"storybook-addon-tag-badges": "^3.0.4",
 		"terser": "^5.37.0"
 	},


### PR DESCRIPTION
## What?

Upgrades all Storybook packages from `^10.1.11` to `^10.2.8`.

## Why?

10.2 includes [storybookjs/storybook#33276](https://github.com/storybookjs/storybook/pull/33276), which [fixes](https://github.com/WordPress/gutenberg/pull/76205#issuecomment-4006653286) the "Reset selection" crash in global toolbar dropdowns. The fix makes the reset option only appear when a `resetItem` is explicitly configured, and uses `undefined` instead of the `_reset` sentinel string. This should make #76205 unnecessary.

## How?

Bumped version specifiers for all `@storybook/*`, `storybook`, and `eslint-plugin-storybook` packages across:

- `package.json` (`eslint-plugin-storybook`: `10.1.11` → `10.2.17`)
- `storybook/package.json`
- `packages/components/package.json`
- `packages/dataviews/package.json`
- `packages/theme/package.json`
- `packages/ui/package.json`

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Navigate to any component story.
3. Open the "Text direction" or "CSS" toolbar dropdown.
4. Confirm there is no "Reset selection" option (the upstream fix hides it when no reset item is configured).

The changelog looks safe, but in any case there should be no disruptive changes to the Storybook.