### PR TITLE
Core Data: Add 'supportsPagination' flag for Font Collection entity

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -226,6 +226,7 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'view' },
 		plural: 'fontCollections',
 		key: 'slug',
+		supportsPagination: true,
 	},
 	{
 		label: __( 'Icons' ),


### PR DESCRIPTION
## What?
PR adds the missing `supportsPagination` flag to the Font Collection entity; without this flag, pagination-related metadata won't be generated.

Font Collections controller supports pagination - https://github.com/WordPress/wordpress-develop/blob/876044bec69252bf7831211ded6857bb0df29f6a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-collections-controller.php#L78-L81.

## Testing Instructions
None. Just a minor config update.
