### PR TITLE
Sync: Add CRDT document size limiting framework

### DIFF
--- a/packages/editor/src/utils/sync-error-messages.js
+++ b/packages/editor/src/utils/sync-error-messages.js
@@ -31,6 +31,15 @@ const ERROR_MESSAGES = {
 		),
 		canRetry: true,
 	},
+	'document-too-large': {
+		title: __( 'Document too large' ),
+		description: __(
+			'This document has grown too large for real-time collaboration. ' +
+				'Some changes may not be synced. Try removing large content blocks ' +
+				'or contact your site administrator.'
+		),
+		canRetry: false,
+	},
 	'unknown-error': {
 		title: __( 'Connection lost' ),
 		description: __(

--- a/packages/editor/src/utils/test/sync-error-messages.js
+++ b/packages/editor/src/utils/test/sync-error-messages.js
@@ -8,6 +8,7 @@ describe( 'getSyncErrorMessages', () => {
 		'authentication-failed',
 		'connection-expired',
 		'connection-limit-exceeded',
+		'document-too-large',
 		'unknown-error',
 	] )(
 		'should return title, description, and canRetry for "%s"',
@@ -26,6 +27,13 @@ describe( 'getSyncErrorMessages', () => {
 	it( 'should set canRetry to false for authentication-failed', () => {
 		const result = getSyncErrorMessages( {
 			code: 'authentication-failed',
+		} );
+		expect( result.canRetry ).toBe( false );
+	} );
+
+	it( 'should set canRetry to false for document-too-large', () => {
+		const result = getSyncErrorMessages( {
+			code: 'document-too-large',
 		} );
 		expect( result.canRetry ).toBe( false );
 	} );

--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -12,6 +12,7 @@ import type {
 	ConnectionStatus,
 	ProviderCreator,
 	ProviderCreatorResult,
+	SizeLimits,
 } from '../../types';
 import { pollingManager } from './polling-manager';
 
@@ -19,6 +20,7 @@ export interface ProviderOptions {
 	awareness?: Awareness;
 	debug?: boolean;
 	room: string;
+	sizeLimits?: SizeLimits;
 	ydoc: Y.Doc;
 }
 
@@ -60,6 +62,7 @@ class HttpPollingProvider extends ObservableV2< HttpPollingEvents > {
 			log: this.log,
 			onStatusChange: this.emitStatus,
 			onSync: this.onSync,
+			sizeLimits: this.options.sizeLimits,
 		} );
 	}
 
@@ -137,8 +140,13 @@ class HttpPollingProvider extends ObservableV2< HttpPollingEvents > {
 
 /**
  * Create a provider creator function for the HttpPollingProvider
+ *
+ * @param {SizeLimits} sizeLimits - Optional size limits for sync updates and documents.
+ * @return {ProviderCreator} A provider creator function.
  */
-export function createHttpPollingProvider(): ProviderCreator {
+export function createHttpPollingProvider(
+	sizeLimits?: SizeLimits
+): ProviderCreator {
 	return async ( {
 		awareness,
 		objectType,
@@ -151,6 +159,7 @@ export function createHttpPollingProvider(): ProviderCreator {
 			awareness,
 			// debug: true,
 			room,
+			sizeLimits,
 			ydoc,
 		} );
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -11,7 +11,11 @@ import * as syncProtocol from 'y-protocols/sync';
 /**
  * Internal dependencies
  */
-import type { ConnectionStatus } from '../../types';
+import type {
+	ConnectionError,
+	ConnectionStatus,
+	SizeLimits,
+} from '../../types';
 import {
 	type AwarenessState,
 	type LocalAwarenessState,
@@ -24,6 +28,7 @@ import {
 	base64ToUint8Array,
 	createSyncUpdate,
 	createUpdateQueue,
+	estimateUpdateSizeBytes,
 	postSyncUpdate,
 	postSyncUpdateNonBlocking,
 } from './utils';
@@ -51,6 +56,12 @@ interface RegisterRoomOptions {
 	log: LogFunction;
 	onStatusChange: ( status: ConnectionStatus ) => void;
 	onSync: () => void;
+	sizeLimits?: SizeLimits;
+}
+
+interface ResolvedSizeLimits {
+	maxDocumentSizeBytes: number;
+	maxUpdateSizeBytes: number;
 }
 
 interface RoomState {
@@ -62,11 +73,27 @@ interface RoomState {
 	onStatusChange: ( status: ConnectionStatus ) => void;
 	processAwarenessUpdate: ( state: AwarenessState ) => void;
 	processDocUpdate: ( update: SyncUpdate ) => SyncUpdate | void;
+	sizeLimits: ResolvedSizeLimits;
 	unregister: () => void;
 	updateQueue: UpdateQueue;
 }
 
 const roomStates: Map< string, RoomState > = new Map();
+
+/**
+ * Create a connection error for a size limit violation.
+ *
+ * @param kind Whether the limit was hit on a single update or the full document.
+ */
+function createSizeLimitError( kind: 'update' | 'document' ): ConnectionError {
+	const message =
+		kind === 'update'
+			? 'Individual update exceeds the maximum allowed size.'
+			: 'Document state exceeds the maximum allowed size.';
+	const error = new Error( message ) as ConnectionError;
+	error.code = 'document-too-large';
+	return error;
+}
 
 /**
  * Create a compaction update by merging existing updates. This preserves
@@ -393,10 +420,31 @@ function poll(): void {
 				// full document state to replace all prior updates on the server.
 				if ( room.should_compact ) {
 					roomState.log( 'Server requested compaction update' );
-					roomState.updateQueue.clear();
-					roomState.updateQueue.add(
-						roomState.createCompactionUpdate()
-					);
+					const compactionUpdate = roomState.createCompactionUpdate();
+
+					// Check document size before sending compaction.
+					if (
+						estimateUpdateSizeBytes( compactionUpdate ) >
+						roomState.sizeLimits.maxDocumentSizeBytes
+					) {
+						roomState.log(
+							'Document exceeds size limit, cannot compact',
+							{
+								size: estimateUpdateSizeBytes(
+									compactionUpdate
+								),
+								limit: roomState.sizeLimits
+									.maxDocumentSizeBytes,
+							}
+						);
+						roomState.onStatusChange( {
+							status: 'disconnected',
+							error: createSizeLimitError( 'document' ),
+						} );
+					} else {
+						roomState.updateQueue.clear();
+						roomState.updateQueue.add( compactionUpdate );
+					}
 				} else if ( room.compaction_request ) {
 					// Deprecated
 					roomState.log( 'Server requested (old) compaction update' );
@@ -466,10 +514,16 @@ function registerRoom( {
 	log,
 	onSync,
 	onStatusChange,
+	sizeLimits,
 }: RegisterRoomOptions ): void {
 	if ( roomStates.has( room ) ) {
 		return;
 	}
+
+	const resolvedLimits: ResolvedSizeLimits = {
+		maxDocumentSizeBytes: sizeLimits?.maxDocumentSizeBytes ?? Infinity,
+		maxUpdateSizeBytes: sizeLimits?.maxUpdateSizeBytes ?? Infinity,
+	};
 
 	// Note: Queue is initially paused. Call .resume() to unpause.
 	const updateQueue = createUpdateQueue( [ createSyncStep1Update( doc ) ] );
@@ -483,8 +537,25 @@ function registerRoom( {
 			return;
 		}
 
-		// Tag local document changes as 'update' type.
-		updateQueue.add( createSyncUpdate( update, SyncUpdateType.UPDATE ) );
+		const syncUpdate = createSyncUpdate( update, SyncUpdateType.UPDATE );
+
+		// Check individual update size before queuing.
+		if (
+			estimateUpdateSizeBytes( syncUpdate ) >
+			resolvedLimits.maxUpdateSizeBytes
+		) {
+			log( 'Update exceeds size limit, dropping', {
+				size: estimateUpdateSizeBytes( syncUpdate ),
+				limit: resolvedLimits.maxUpdateSizeBytes,
+			} );
+			onStatusChange( {
+				status: 'disconnected',
+				error: createSizeLimitError( 'update' ),
+			} );
+			return;
+		}
+
+		updateQueue.add( syncUpdate );
 	}
 
 	function unregister(): void {
@@ -508,6 +579,7 @@ function registerRoom( {
 			processAwarenessUpdate( state, awareness ),
 		processDocUpdate: ( update: SyncUpdate ) =>
 			processDocUpdate( update, doc, onSync ),
+		sizeLimits: resolvedLimits,
 		unregister,
 		updateQueue,
 	};

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -52,6 +52,9 @@ jest.mock( '../utils', () => ( {
 		resume: jest.fn(),
 		size: jest.fn( () => 0 ),
 	} ) ),
+	estimateUpdateSizeBytes: jest.fn(
+		( update: { data: string } ) => update.data.length
+	),
 	postSyncUpdate: jest.fn(),
 	postSyncUpdateNonBlocking: jest.fn(),
 } ) );
@@ -62,9 +65,14 @@ interface PollingManager {
 		doc: unknown;
 		awareness: unknown;
 		log: () => void;
-		onStatusChange: () => void;
+		onStatusChange: ( status: unknown ) => void;
 		onSync: () => void;
+		sizeLimits?: {
+			maxDocumentSizeBytes?: number;
+			maxUpdateSizeBytes?: number;
+		};
 	} ) => void;
+	retryNow: () => void;
 	unregisterRoom: ( room: string ) => void;
 }
 
@@ -133,6 +141,116 @@ describe( 'polling-manager', () => {
 		Object.defineProperty( document, 'visibilityState', {
 			configurable: true,
 			get: () => 'visible',
+		} );
+	} );
+
+	describe( 'size limits', () => {
+		// Size limit tests need their own isolated modules with custom
+		// createSyncUpdate mocks to control the data size.
+		function setupWithSizeLimits(
+			dataSize: number,
+			sizeLimits?: {
+				maxDocumentSizeBytes?: number;
+				maxUpdateSizeBytes?: number;
+			}
+		) {
+			let mgr!: PollingManager;
+			let mockPost!: jest.Mock;
+
+			jest.isolateModules( () => {
+				// Override createSyncUpdate to return data of a specific size.
+				const utils = require( '../utils' );
+				utils.createSyncUpdate.mockImplementation(
+					( _data: unknown, type: string ) => ( {
+						data: 'x'.repeat( dataSize ),
+						type,
+					} )
+				);
+				utils.postSyncUpdate.mockResolvedValue( syncResponse );
+				mgr = require( '../polling-manager' ).pollingManager;
+				mockPost = utils.postSyncUpdate;
+			} );
+
+			const onStatusChange = jest.fn();
+			const doc = createMockDoc();
+
+			mgr.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange,
+				onSync: jest.fn(),
+				sizeLimits,
+			} );
+
+			// Get the registered updateV2 handler.
+			const onDocUpdate = ( doc.on as jest.Mock ).mock.calls.find(
+				( call: unknown[] ) => call[ 0 ] === 'updateV2'
+			)?.[ 1 ] as
+				| ( ( update: Uint8Array, origin: unknown ) => void )
+				| undefined;
+
+			return { onStatusChange, onDocUpdate, mockPost };
+		}
+
+		it( 'drops updates exceeding maxUpdateSizeBytes and emits disconnected status', () => {
+			const { onStatusChange, onDocUpdate } = setupWithSizeLimits( 200, {
+				maxUpdateSizeBytes: 100,
+			} );
+
+			expect( onDocUpdate ).toBeDefined();
+			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'some-origin' );
+
+			expect( onStatusChange ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					status: 'disconnected',
+					error: expect.objectContaining( {
+						code: 'document-too-large',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'queues updates within maxUpdateSizeBytes normally', () => {
+			const { onStatusChange, onDocUpdate } = setupWithSizeLimits( 50, {
+				maxUpdateSizeBytes: 100,
+			} );
+
+			onDocUpdate( new Uint8Array( [ 1 ] ), 'some-origin' );
+
+			const sizeLimitCalls = onStatusChange.mock.calls.filter(
+				( call: unknown[] ) => {
+					const status = call[ 0 ] as Record< string, unknown >;
+					return (
+						status.status === 'disconnected' &&
+						( status.error as Record< string, unknown > )?.code ===
+							'document-too-large'
+					);
+				}
+			);
+			expect( sizeLimitCalls ).toHaveLength( 0 );
+		} );
+
+		it( 'allows all updates when no size limits are set', () => {
+			const { onStatusChange, onDocUpdate } = setupWithSizeLimits(
+				10000
+				// No sizeLimits — defaults to Infinity
+			);
+
+			onDocUpdate( new Uint8Array( [ 1 ] ), 'some-origin' );
+
+			const sizeLimitCalls = onStatusChange.mock.calls.filter(
+				( call: unknown[] ) => {
+					const status = call[ 0 ] as Record< string, unknown >;
+					return (
+						status.status === 'disconnected' &&
+						( status.error as Record< string, unknown > )?.code ===
+							'document-too-large'
+					);
+				}
+			);
+			expect( sizeLimitCalls ).toHaveLength( 0 );
 		} );
 	} );
 

--- a/packages/sync/src/providers/http-polling/test/utils.test.ts
+++ b/packages/sync/src/providers/http-polling/test/utils.test.ts
@@ -22,6 +22,7 @@ import {
 	base64ToUint8Array,
 	createSyncUpdate,
 	createUpdateQueue,
+	estimateUpdateSizeBytes,
 	postSyncUpdate,
 	uint8ArrayToBase64,
 } from '../utils';
@@ -172,6 +173,41 @@ describe( 'http-polling utils', () => {
 
 			expect( result.type ).toBe( SyncUpdateType.UPDATE );
 			expect( result.data ).toBe( '' );
+		} );
+	} );
+
+	describe( 'estimateUpdateSizeBytes', () => {
+		it( 'returns the length of the base64 data string', () => {
+			const data = new Uint8Array( [ 72, 101, 108, 108, 111 ] );
+			const update = createSyncUpdate( data, SyncUpdateType.UPDATE );
+
+			expect( estimateUpdateSizeBytes( update ) ).toBe(
+				update.data.length
+			);
+		} );
+
+		it( 'returns 0 for empty data', () => {
+			const update = createSyncUpdate(
+				new Uint8Array( [] ),
+				SyncUpdateType.UPDATE
+			);
+
+			expect( estimateUpdateSizeBytes( update ) ).toBe( 0 );
+		} );
+
+		it( 'scales with data size', () => {
+			const small = createSyncUpdate(
+				new Uint8Array( 10 ),
+				SyncUpdateType.UPDATE
+			);
+			const large = createSyncUpdate(
+				new Uint8Array( 1000 ),
+				SyncUpdateType.UPDATE
+			);
+
+			expect( estimateUpdateSizeBytes( large ) ).toBeGreaterThan(
+				estimateUpdateSizeBytes( small )
+			);
 		} );
 	} );
 

--- a/packages/sync/src/providers/http-polling/utils.ts
+++ b/packages/sync/src/providers/http-polling/utils.ts
@@ -45,6 +45,17 @@ export function createSyncUpdate(
 	};
 }
 
+/**
+ * Estimate the byte size of a SyncUpdate's data payload. Base64 characters
+ * are ASCII, so one character equals one byte in the HTTP payload.
+ *
+ * @param update The sync update to measure.
+ * @return The estimated size in bytes.
+ */
+export function estimateUpdateSizeBytes( update: SyncUpdate ): number {
+	return update.data.length;
+}
+
 export function createUpdateQueue(
 	initial: SyncUpdate[] = [],
 	paused = true

--- a/packages/sync/src/providers/index.ts
+++ b/packages/sync/src/providers/index.ts
@@ -18,7 +18,12 @@ let providerCreators: ProviderCreator[] | null = null;
  * @return {ProviderCreator[]} Creator functions for Yjs providers.
  */
 export function getDefaultProviderCreators(): ProviderCreator[] {
-	return [ createHttpPollingProvider() ];
+	return [
+		createHttpPollingProvider( {
+			maxDocumentSizeBytes: 5 * 1024 * 1024, // 5 MB
+			maxUpdateSizeBytes: 1 * 1024 * 1024, // 1 MB
+		} ),
+	];
 }
 
 /**

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -62,7 +62,19 @@ export type ConnectionErrorCode =
 	| 'authentication-error'
 	| 'connection-expired'
 	| 'connection-limit-exceeded'
+	| 'document-too-large'
 	| 'unknown-error';
+
+/**
+ * Size limits for sync providers. Providers can use these to cap the size of
+ * individual updates and full document state payloads.
+ */
+export interface SizeLimits {
+	/** Maximum size in bytes for the full encoded document state (compaction). */
+	maxDocumentSizeBytes?: number;
+	/** Maximum size in bytes for a single update payload (base64-encoded). */
+	maxUpdateSizeBytes?: number;
+}
 
 /**
  * Sync connection error object.


### PR DESCRIPTION
## Summary
Add a framework for sync providers to declare and enforce maximum document and update sizes. Prevents oversized payloads from being transmitted, protecting against HTTP payload failures and timeouts.

## Changes
- Add `SizeLimits` interface and `'document-too-large'` error code to types
- Implement size estimation utility for updates
- Thread size limits through HTTP polling provider and enforce in polling manager
- Set default limits (5MB document, 1MB per update)
- Add user-facing error message and tests

## Testing Instructions
1. Run unit tests: `npm run test:unit packages/sync`
2. Verify error message tests: `npm run test:unit packages/editor`
3. Check formatting: `npm run lint:js`
4. Manual test: Create post with large content to see modal with "Document too large" when limits exceeded (can set very low limits for testing)