### PR TITLE
E2E Tests: Fix flaky autocomplete and mentions test

### DIFF
--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -71,10 +71,6 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		await admin.createNewPost();
 	} );
 
-	test.afterEach( async ( { editor } ) => {
-		await editor.publishPost();
-	} );
-
 	[
 		[ 'User Mention', 'mention' ],
 		[ 'Custom Completer', 'option' ],


### PR DESCRIPTION
## What?
PR tries to fix some flaky `autocomplete-and-mentions.spec.js`, which for some reason fails on `test.afterEach`. I wasn't able to find why this step and post publishing as added, but it's not needed to run assertions.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
```