### PR TITLE
Add `[Package] UI` label to PR labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -236,6 +236,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/token-list/**'
 
+'[Package] UI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/ui/**'
+
 '[Package] Url':
     - changed-files:
           - any-glob-to-any-file: 'packages/url/**'


### PR DESCRIPTION
## What?

Adds a `[Package] UI` entry to the PR auto-labeler so that changes touching `packages/ui/**` get the `[Package] UI` label.

## Why?

The `@wordpress/ui` package was missing from `.github/labeler.yml`, so PRs modifying it weren't getting a package label.

## Testing Instructions

N/A — config-only change. Verify that the YAML is valid and the entry is in alphabetical order.