### PR TITLE
Allow adding new items to Site Editor v2 Navigation List View

### DIFF
--- a/packages/lazy-editor/src/hooks/use-block-library-private-apis.tsx
+++ b/packages/lazy-editor/src/hooks/use-block-library-private-apis.tsx
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useEditorAssets } from './use-editor-assets';
+import { unlock } from '../lock-unlock';
+
+/**
+ * Returns the unlocked private APIs from @wordpress/block-library
+ * after editor assets have been dynamically loaded.
+ *
+ * block-library is loaded at runtime via useEditorAssets, so it cannot
+ * be statically imported. This hook encapsulates the dynamic access.
+ *
+ * @return The unlocked block-library private APIs, or null if assets are not yet loaded.
+ */
+export function useBlockLibraryPrivateApis() {
+	const { isReady } = useEditorAssets();
+
+	return useMemo( () => {
+		if ( ! isReady ) {
+			return null;
+		}
+		const blockLibrary = (
+			window as Window & {
+				wp?: {
+					blockLibrary?: {
+						privateApis: Parameters< typeof unlock >[ 0 ];
+					};
+				};
+			}
+		).wp?.blockLibrary;
+		if ( ! blockLibrary ) {
+			return null;
+		}
+		return unlock( blockLibrary.privateApis );
+	}, [ isReady ] );
+}

--- a/packages/lazy-editor/src/index.tsx
+++ b/packages/lazy-editor/src/index.tsx
@@ -1,7 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+export { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
+
+/**
  * Internal dependencies
  */
 export { Editor } from './components/editor';
 export { Preview } from './components/preview';
+export { useBlockLibraryPrivateApis } from './hooks/use-block-library-private-apis';
 export { useEditorAssets, loadEditorAssets } from './hooks/use-editor-assets';
 export { useEditorSettings } from './hooks/use-editor-settings';

--- a/packages/lazy-editor/src/index.tsx
+++ b/packages/lazy-editor/src/index.tsx
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-export { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
-
-/**
  * Internal dependencies
  */
 export { Editor } from './components/editor';

--- a/routes/navigation-edit/editor/content.tsx
+++ b/routes/navigation-edit/editor/content.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { useBlockLibraryPrivateApis } from '@wordpress/lazy-editor';
 
 /**
  * Internal dependencies
@@ -26,24 +27,6 @@ type Block = {
 };
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
-
-// block-library is loaded dynamically via useEditorAssets before this component renders.
-// Access NavigationLinkUI from its private-apis at runtime rather than via static import.
-function getNavigationLinkUI() {
-	const blockLibrary = (
-		window as Window & {
-			wp: {
-				blockLibrary: { privateApis: Parameters< typeof unlock >[ 0 ] };
-			};
-		}
-	 ).wp?.blockLibrary;
-	if ( ! blockLibrary ) {
-		return null;
-	}
-	const { NavigationLinkUI } = unlock( blockLibrary.privateApis );
-
-	return NavigationLinkUI as any;
-}
 
 // Needs to be kept in sync with the query used at packages/block-library/src/page-list/edit.js.
 const MAX_PAGE_COUNT = 100;
@@ -123,7 +106,8 @@ export default function NavigationMenuContent( {
 		[ __unstableMarkNextChangeAsNotPersistent, replaceBlock ]
 	);
 
-	const NavigationLinkUI = getNavigationLinkUI();
+	const blockLibraryPrivateApis = useBlockLibraryPrivateApis();
+	const NavigationLinkUI = blockLibraryPrivateApis?.NavigationLinkUI;
 
 	// The hidden block is needed because it makes block edit side effects trigger.
 	// For example a navigation page list load its items has an effect on edit to load its items.

--- a/routes/navigation-edit/editor/content.tsx
+++ b/routes/navigation-edit/editor/content.tsx
@@ -7,10 +7,7 @@ import {
 	BlockList,
 	// @ts-expect-error - No type declarations available for @wordpress/block-editor
 } from '@wordpress/block-editor';
-import { useDispatch, useSelect } from '@wordpress/data';
-// @ts-expect-error - No type declarations available for @wordpress/blocks
-import { createBlock } from '@wordpress/blocks';
-import { useCallback } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -19,13 +16,25 @@ import { store as coreStore } from '@wordpress/core-data';
 import { unlock } from '../../lock-unlock';
 import LeafMoreMenu from './leaf-more-menu';
 
-type Block = {
-	clientId: string;
-	name: string;
-	attributes: Record< string, unknown >;
-};
-
 const { PrivateListView } = unlock( blockEditorPrivateApis );
+
+// block-library is loaded dynamically via useEditorAssets before this component renders.
+// Access NavigationLinkUI from its private-apis at runtime rather than via static import.
+function getNavigationLinkUI() {
+	const blockLibrary = (
+		window as Window & {
+			wp: {
+				blockLibrary: { privateApis: Parameters< typeof unlock >[ 0 ] };
+			};
+		}
+	 ).wp?.blockLibrary;
+	if ( ! blockLibrary ) {
+		return null;
+	}
+	const { NavigationLinkUI } = unlock( blockLibrary.privateApis );
+
+	return NavigationLinkUI as any;
+}
 
 // Needs to be kept in sync with the query used at packages/block-library/src/page-list/edit.js.
 const MAX_PAGE_COUNT = 100;
@@ -85,24 +94,8 @@ export default function NavigationMenuContent( {
 		},
 		[ rootClientId ]
 	);
-	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
 
-	const offCanvasOnselect = useCallback(
-		( block: Block ) => {
-			if (
-				block.name === 'core/navigation-link' &&
-				! block.attributes.url
-			) {
-				__unstableMarkNextChangeAsNotPersistent();
-				replaceBlock(
-					block.clientId,
-					createBlock( 'core/navigation-link', block.attributes )
-				);
-			}
-		},
-		[ __unstableMarkNextChangeAsNotPersistent, replaceBlock ]
-	);
+	const NavigationLinkUI = getNavigationLinkUI();
 
 	// The hidden block is needed because it makes block edit side effects trigger.
 	// For example a navigation page list load its items has an effect on edit to load its items.
@@ -111,9 +104,9 @@ export default function NavigationMenuContent( {
 			{ ! isLoading && (
 				<PrivateListView
 					rootClientId={ listViewRootClientId }
-					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }
-					showAppender={ false }
+					additionalBlockContent={ NavigationLinkUI }
+					showAppender
 					isExpanded
 				/>
 			) }

--- a/routes/navigation-edit/editor/content.tsx
+++ b/routes/navigation-edit/editor/content.tsx
@@ -7,7 +7,10 @@ import {
 	BlockList,
 	// @ts-expect-error - No type declarations available for @wordpress/block-editor
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+// @ts-expect-error - No type declarations available for @wordpress/blocks
+import { createBlock } from '@wordpress/blocks';
+import { useCallback } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -15,6 +18,12 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { unlock } from '../../lock-unlock';
 import LeafMoreMenu from './leaf-more-menu';
+
+type Block = {
+	clientId: string;
+	name: string;
+	attributes: Record< string, unknown >;
+};
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
 
@@ -95,6 +104,25 @@ export default function NavigationMenuContent( {
 		[ rootClientId ]
 	);
 
+	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	const offCanvasOnselect = useCallback(
+		( block: Block ) => {
+			if (
+				block.name === 'core/navigation-link' &&
+				! block.attributes.url
+			) {
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceBlock(
+					block.clientId,
+					createBlock( 'core/navigation-link', block.attributes )
+				);
+			}
+		},
+		[ __unstableMarkNextChangeAsNotPersistent, replaceBlock ]
+	);
+
 	const NavigationLinkUI = getNavigationLinkUI();
 
 	// The hidden block is needed because it makes block edit side effects trigger.
@@ -104,6 +132,7 @@ export default function NavigationMenuContent( {
 			{ ! isLoading && (
 				<PrivateListView
 					rootClientId={ listViewRootClientId }
+					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }
 					additionalBlockContent={ NavigationLinkUI }
 					showAppender

--- a/routes/navigation-edit/editor/index.tsx
+++ b/routes/navigation-edit/editor/index.tsx
@@ -8,6 +8,10 @@ import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
 import { useEditorAssets } from '@wordpress/lazy-editor';
+import {
+	// @ts-expect-error - No type declarations available for this export
+	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+} from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -28,6 +32,16 @@ export default function NavigationMenuEditor( { id }: { id: number } ) {
 		return [ createBlock( 'core/navigation', { ref: id } ) ];
 	}, [ assetsReady, id ] );
 
+	const settings = useMemo(
+		() => ( {
+			__experimentalFetchLinkSuggestions: (
+				search: string,
+				searchOptions: Record< string, unknown >
+			) => fetchLinkSuggestions( search, searchOptions, {} ),
+		} ),
+		[]
+	);
+
 	if ( ! assetsReady || ! blocks.length ) {
 		return (
 			<div
@@ -45,7 +59,7 @@ export default function NavigationMenuEditor( { id }: { id: number } ) {
 
 	return (
 		<BlockEditorProvider
-			settings={ {} }
+			settings={ settings }
 			value={ blocks }
 			onChange={ noop }
 			onInput={ noop }

--- a/routes/navigation-edit/editor/index.tsx
+++ b/routes/navigation-edit/editor/index.tsx
@@ -8,9 +8,10 @@ import { BlockEditorProvider } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
 import {
-	fetchLinkSuggestions,
-	useEditorAssets,
-} from '@wordpress/lazy-editor';
+	// @ts-expect-error - No type declarations available for this export
+	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+} from '@wordpress/core-data';
+import { useEditorAssets } from '@wordpress/lazy-editor';
 
 /**
  * Internal dependencies

--- a/routes/navigation-edit/editor/index.tsx
+++ b/routes/navigation-edit/editor/index.tsx
@@ -7,11 +7,10 @@ import { BlockEditorProvider } from '@wordpress/block-editor';
 // @ts-expect-error - No type declarations available for @wordpress/blocks
 import { createBlock } from '@wordpress/blocks';
 import { Spinner } from '@wordpress/components';
-import { useEditorAssets } from '@wordpress/lazy-editor';
 import {
-	// @ts-expect-error - No type declarations available for this export
-	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
-} from '@wordpress/core-data';
+	fetchLinkSuggestions,
+	useEditorAssets,
+} from '@wordpress/lazy-editor';
 
 /**
  * Internal dependencies

--- a/test/e2e/specs/site-editor/navigation-extensible-editor-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-extensible-editor-list-view.spec.js
@@ -1,0 +1,180 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Navigation extensible editor - list view editing', () => {
+	const navMenuFixture = {
+		title: 'Test Navigation Menu',
+		content:
+			'<!-- wp:navigation-link {"label":"Existing Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+	};
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-extensible-site-editor',
+		] );
+		await requestUtils.createPage( {
+			title: 'Test Page 1',
+			status: 'publish',
+		} );
+		await requestUtils.createPage( {
+			title: 'Test Page 2',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPages(),
+			requestUtils.setGutenbergExperiments( [] ),
+			requestUtils.activateTheme( 'twentytwentyone' ),
+		] );
+	} );
+
+	test.use( {
+		linkControl: async ( { page }, use ) => {
+			await use( new LinkControl( { page } ) );
+		},
+	} );
+
+	test( 'can use appender in extensible editor list view', async ( {
+		admin,
+		page,
+		requestUtils,
+		linkControl,
+	} ) => {
+		const createdMenu =
+			await requestUtils.createNavigationMenu( navMenuFixture );
+
+		await admin.visitAdminPage(
+			'admin.php',
+			`page=site-editor-v2&p=/navigation/edit/${ createdMenu.id }`
+		);
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect( listView ).toBeVisible();
+
+		// Verify the existing item is shown in the list view.
+		await expect(
+			listView.getByRole( 'link', { name: 'Existing Item' } )
+		).toBeVisible();
+
+		// The appender button should be present to allow adding new items.
+		const appender = listView.getByRole( 'button', { name: 'Add page' } );
+		await expect( appender ).toBeVisible();
+
+		const linkControlSearch = linkControl.getLinkControlSearch();
+
+		await test.step( 'can add new menu items', async () => {
+			await appender.click();
+
+			// The LinkUI popover should open and immediately focus the search input.
+			await expect( linkControlSearch ).toBeFocused();
+
+			// Search for and select the page.
+			await linkControl.useLinkControlSearch( 'Test Page 2' );
+
+			// The new item should be appended after the existing item.
+			await expect(
+				listView.getByRole( 'link', { name: 'Test Page 2' } )
+			).toBeVisible();
+		} );
+
+		await test.step( 'can open and close the Link UI without losing focus', async () => {
+			await page.keyboard.press( 'ArrowDown' );
+			await expect( appender ).toBeFocused();
+			await page.keyboard.press( 'Enter' );
+			await expect( linkControlSearch ).toBeFocused();
+			await page.keyboard.press( 'Escape' );
+			await expect( linkControlSearch ).toBeHidden();
+		} );
+
+		await test.step( 'can create a new page', async () => {
+			await appender.click();
+
+			// The search input should be focused immediately.
+			await expect( linkControl.getLinkControlSearch() ).toBeFocused();
+
+			// Type a new page title that doesn't exist yet.
+			await page.keyboard.type( 'Brand New Page', { delay: 50 } );
+
+			// Tab twice to reach the "Create page" button.
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+
+			const createPageButton = page.getByRole( 'button', {
+				name: 'Create page',
+			} );
+			await expect( createPageButton ).toBeVisible();
+			await expect( createPageButton ).toBeFocused();
+
+			// Open the page creation form.
+			await page.keyboard.press( 'Enter' );
+
+			// The title field should be pre-populated with the typed text.
+			const titleField = page.getByRole( 'textbox', { name: 'Title' } );
+			await expect( titleField ).toHaveValue( 'Brand New Page' );
+
+			// The Back button should be focused after entering the creation form.
+			const backButton = page.locator( '.link-ui-page-creator__back' );
+			await expect( backButton ).toBeFocused();
+
+			// Tab to the title field.
+			await page.keyboard.press( 'Tab' );
+			await expect( titleField ).toBeFocused();
+
+			// Tab to the Publish checkbox (on by default).
+			await page.keyboard.press( 'Tab' );
+			const publishCheckbox = page.getByRole( 'checkbox', {
+				name: 'Publish',
+			} );
+			await expect( publishCheckbox ).toBeFocused();
+			await expect( publishCheckbox ).toBeChecked();
+
+			// Tab twice more to reach the Create page button.
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+			await expect( createPageButton ).toBeFocused();
+			await page.keyboard.press( 'Enter' );
+
+			// The newly created page should appear as a new item in the list view.
+			await expect(
+				listView.getByRole( 'link', { name: 'Brand New Page' } )
+			).toBeVisible();
+		} );
+	} );
+} );
+
+class LinkControl {
+	constructor( { page } ) {
+		this.page = page;
+	}
+
+	getLinkControlSearch() {
+		return this.page.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+	}
+
+	async useLinkControlSearch( searchTerm ) {
+		await expect( this.getLinkControlSearch() ).toBeFocused();
+
+		await this.page.keyboard.type( searchTerm, { delay: 50 } );
+
+		await expect(
+			this.page.getByRole( 'listbox', { name: 'Search results' } )
+		).toBeVisible();
+
+		await this.page.keyboard.press( 'ArrowDown' );
+		await this.page.keyboard.press( 'Enter' );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/77070

Brings the extensible site editor v2 (extensible site editor) navigation list view to feature parity with the v1 sidebar list view.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The v1 site editor sidebar shows the appender for adding new menu items. The v2 extensible editor's list view was missing this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- **`NavigationLinkUI` as `additionalBlockContent`**: The LinkUI popover (used when adding/editing navigation links) is now passed to `PrivateListView` via `additionalBlockContent`. Because `@wordpress/block-library` is loaded dynamically via `useEditorAssets`, it can't be statically imported — instead, `NavigationLinkUI` is accessed at runtime from `window.wp.blockLibrary.privateApis`.
- change `showAppender` to `true`
- **E2E tests**: Added `navigation-extensible-editor-list-view.spec.js` mirroring the sidebar's `navigation-sidebar-list-view.spec.js`, covering the appender, link picker focus, search, Escape handling, and new page creation.



I wanted to have both Site Editor v1 and v2 share the same Navigation List View component, but that seems like it'll be more work and make it more difficult to move forwards. I think it's better to keep them separate for now.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the **Extensible Site Editor** experiment (Gutenberg → Experiments)
2. **Appearance → Editor**
3. Go to **Navigation** and edit a navigation menu 
4. Verify the list view shows existing items
5. Click **+** appender — the LinkUI popover should open and focus the search input
6. 🟢 Search for a page and select it — the new item should appear in the list
7. Click **+** appender — the LinkUI popover should open and focus the search input
8. Press Escape from the LinkUI 
9. 🟢 Focus should return to appender
10. Click **+** appender — the LinkUI popover should open and focus the search input
11. Use the appender to create a new page via the page creator form
12. 🟢 Newly created page should show in the navigation


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="825" height="720" alt="Appender showing in navigation edit screen" src="https://github.com/user-attachments/assets/55c52335-7513-4c6f-a806-7b61c1162f1e" />
