### PR TITLE
Boot: Remove manual fallbacks from design token usages

### DIFF
--- a/packages/boot/src/components/navigation/navigation-item/style.scss
+++ b/packages/boot/src/components/navigation/navigation-item/style.scss
@@ -2,7 +2,7 @@
 @use "@wordpress/base-styles/mixins";
 
 .boot-navigation-item.components-item {
-	color: var(--wpds-color-fg-interactive-neutral, #1e1e1e);
+	color: var(--wpds-color-fg-interactive-neutral);
 	padding-inline: variables.$grid-unit-05;
 	padding-block: 0;
 	margin-inline: variables.$grid-unit-15;
@@ -19,13 +19,13 @@
 	}
 
 	// Rounded focus ring
-	border-radius: var(--wpds-border-radius-sm, 2px);
+	border-radius: var(--wpds-border-radius-sm);
 
 	&.active,
 	&:hover,
 	&:focus,
 	&[aria-current="true"] {
-		color: var(--wpds-color-fg-interactive-brand-active, #0073aa);
+		color: var(--wpds-color-fg-interactive-brand-active);
 	}
 
 	&.active {
@@ -37,7 +37,7 @@
 	}
 
 	&[aria-current="true"] {
-		color: var(--wpds-color-fg-interactive-brand-active, #0073aa);
+		color: var(--wpds-color-fg-interactive-brand-active);
 		font-weight: variables.$font-weight-medium;
 	}
 

--- a/packages/boot/src/components/navigation/navigation-screen/style.scss
+++ b/packages/boot/src/components/navigation/navigation-screen/style.scss
@@ -6,7 +6,7 @@
 }
 
 .boot-navigation-screen .components-text {
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	color: var(--wpds-color-fg-content-neutral);
 }
 
 .boot-navigation-screen__title-icon {
@@ -24,7 +24,7 @@
 	&#{&},
 	&#{&} .boot-navigation-screen__title {
 		line-height: variables.$font-line-height-x-large;
-		color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+		color: var(--wpds-color-fg-content-neutral);
 	}
 }
 

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -6,9 +6,9 @@
 	width: 100%;
 	display: flex;
 	flex-direction: row;
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	color: var(--wpds-color-fg-content-neutral);
 	isolation: isolate;
-	background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+	background: var(--wpds-color-bg-surface-neutral-weak);
 }
 
 .boot-layout__sidebar-backdrop {
@@ -36,7 +36,7 @@
 		left: 0;
 		width: 300px;
 		max-width: 85vw;
-		background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+		background: var(--wpds-color-bg-surface-neutral-weak);
 		z-index: 100003;
 		box-shadow: 2px 0 8px rgba(0, 0, 0, 0.2);
 	}
@@ -52,9 +52,9 @@
 		top: variables.$admin-bar-height-big;
 	}
 	z-index: 3;
-	background: var(--wpds-color-bg-surface-neutral, #fff);
+	background: var(--wpds-color-bg-surface-neutral);
 	padding: variables.$grid-unit-20;
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
@@ -85,8 +85,8 @@
 .boot-layout__inspector {
 	flex: 1;
 	overflow-y: auto;
-	background: var(--wpds-color-bg-surface-neutral, #fff);
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	background: var(--wpds-color-bg-surface-neutral);
+	color: var(--wpds-color-fg-content-neutral);
 	position: relative;
 
 	// Mobile-first: surfaces take full screen with fixed positioning
@@ -134,10 +134,10 @@
 .boot-layout__canvas {
 	flex: 1;
 	overflow-y: auto;
-	background: var(--wpds-color-bg-surface-neutral, #fff);
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	background: var(--wpds-color-bg-surface-neutral);
+	color: var(--wpds-color-fg-content-neutral);
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #ddd);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	position: relative;
 
 	// Mobile-first: full screen with lowest priority

--- a/packages/boot/src/components/site-hub/style.scss
+++ b/packages/boot/src/components/site-hub/style.scss
@@ -3,7 +3,7 @@
 .boot-site-hub {
 	position: sticky;
 	top: 0;
-	background-color: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
 	z-index: 1;
 	display: grid;
 	grid-template-columns: 60px 1fr auto;
@@ -45,14 +45,14 @@
 
 	&:focus:not(:active) {
 		outline:
-			var(--wpds-border-width-focus, 2px) solid
-			var(--wpds-color-stroke-focus-brand, #0073aa);
-		outline-offset: calc(-1 * var(--wpds-border-width-focus, 2px));
+			var(--wpds-border-width-focus) solid
+			var(--wpds-color-stroke-focus-brand);
+		outline-offset: calc(-1 * var(--wpds-border-width-focus));
 	}
 }
 
 .boot-site-hub__title-text {
-	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	color: var(--wpds-color-fg-content-neutral);
 	font-size: variables.$font-size-medium;
 	font-weight: variables.$font-weight-medium;
 	overflow: hidden;
@@ -61,7 +61,7 @@
 }
 
 .boot-site-hub__url {
-	color: var(--wpds-color-fg-content-neutral-weak, #757575);
+	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: variables.$font-size-small;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/boot/src/components/site-icon-link/style.scss
+++ b/packages/boot/src/components/site-icon-link/style.scss
@@ -8,7 +8,7 @@ $header-height: variables.$header-height;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+	background: var(--wpds-color-bg-surface-neutral-weak);
 	text-decoration: none;
 
 	@media not (prefers-reduced-motion) {
@@ -17,8 +17,8 @@ $header-height: variables.$header-height;
 
 	&:focus:not(:active) {
 		outline:
-			var(--wpds-border-width-focus, 2px) solid
-			var(--wpds-color-stroke-focus-brand, #0073aa);
-		outline-offset: calc(-1 * var(--wpds-border-width-focus, 2px));
+			var(--wpds-border-width-focus) solid
+			var(--wpds-color-stroke-focus-brand);
+		outline-offset: calc(-1 * var(--wpds-border-width-focus));
 	}
 }

--- a/packages/boot/src/components/site-icon/style.scss
+++ b/packages/boot/src/components/site-icon/style.scss
@@ -7,7 +7,7 @@
 .boot-site-icon__icon {
 	width: variables.$grid-unit-40;
 	height: variables.$grid-unit-40;
-	fill: var(--wpds-color-fg-content-neutral, #1e1e1e);
+	fill: var(--wpds-color-fg-content-neutral);
 }
 
 .boot-site-icon__image {
@@ -15,5 +15,5 @@
 	height: variables.$grid-unit-40;
 	object-fit: cover;
 	aspect-ratio: 1 / 1;
-	border-radius: var(--wpds-border-radius-md, 4px);
+	border-radius: var(--wpds-border-radius-md);
 }


### PR DESCRIPTION
## What?

Removes hardcoded fallback values from `var(--wpds-*)` usages in `@wordpress/boot` component styles.

## Why?

Design token fallbacks are injected automatically at build time by the [PostCSS plugin](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/src/postcss-plugins/add-fallback-to-var.ts) in `@wordpress/theme`. Having manual fallbacks in source is redundant and can drift out of sync with the token definitions.

This is a preparatory step for adding a **stylelint rule** (#76415) that disallows manual fallbacks for `--wpds-*` tokens.

## How?

Straightforward removal of the second argument from `var()` calls, e.g.:

```diff
- background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
+ background: var(--wpds-color-bg-surface-neutral-weak);
```

## Testing Instructions

1. `npm run build && npm run wp-env start`
2. Enable **"Extensible Site Editor"** in **Tools > Gutenberg Experiments**.
3. Go to **Appearance > Editor** (`admin.php?page=site-editor-v2`).
4. Check for visual regressions (or that the automatic fallbacks are working) in some of the affected elements:
   - The overall page background and text colors (**root layout**)
   - The sticky header at the top of the sidebar showing the site name and URL (**site hub**)
   - The site icon/logo inside the sidebar header (**site icon**, **site icon link**)
   - The menu entries in the sidebar, including hover/focus/active states (**navigation item**)
   - The section titles in the sidebar navigation (**navigation screen**)

The build step should inject the same fallback values that were previously hardcoded, so there should be no visible difference.