### PR TITLE
`Select.Popup`, `Input`: Expose `anchor` and `rootRef` props

### DIFF
--- a/packages/ui/src/form/primitives/input/input.tsx
+++ b/packages/ui/src/form/primitives/input/input.tsx
@@ -7,11 +7,20 @@ import type { InputProps } from './types';
 import { InputLayout } from '../input-layout';
 
 export const Input = forwardRef< HTMLElement, InputProps >( function Input(
-	{ className, size = 'default', prefix, suffix, style, ...restProps },
+	{
+		className,
+		size = 'default',
+		prefix,
+		suffix,
+		style,
+		rootRef,
+		...restProps
+	},
 	ref
 ) {
 	return (
 		<InputLayout
+			ref={ rootRef }
 			className={ clsx(
 				focusStyles[ 'outset-ring--focus-within' ],
 				className

--- a/packages/ui/src/form/primitives/input/types.ts
+++ b/packages/ui/src/form/primitives/input/types.ts
@@ -11,6 +11,12 @@ export type InputProps = Omit<
 		 * Whether the field is disabled.
 		 */
 		disabled?: boolean;
+		/**
+		 * Ref to the root element. Useful for anchoring popups to the
+		 * full input container (including prefix/suffix) rather than
+		 * the inner `<input>`.
+		 */
+		rootRef?: React.Ref< HTMLDivElement >;
 	} & {
 		/**
 		 * The type of the input element.

--- a/packages/ui/src/form/primitives/select/popup.tsx
+++ b/packages/ui/src/form/primitives/select/popup.tsx
@@ -16,11 +16,15 @@ const ThemeProvider: typeof ThemeProviderType =
 	unlock( themePrivateApis ).ThemeProvider;
 
 export const Popup = forwardRef< HTMLDivElement, SelectPopupProps >(
-	function Popup( { className, children, style, ...restProps }, ref ) {
+	function Popup(
+		{ anchor, className, children, style, ...restProps },
+		ref
+	) {
 		return (
 			<_Select.Portal>
 				<_Select.Positioner
 					{ ...ITEM_POPUP_POSITIONER_PROPS }
+					anchor={ anchor }
 					alignItemWithTrigger={ false }
 					style={ style }
 					className={ clsx(

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -27,7 +27,13 @@ export type SelectTriggerProps = Omit< _Select.Trigger.Props, 'children' > & {
 	children?: _Select.Value.Props[ 'children' ];
 };
 
-export type SelectPopupProps = _Select.Popup.Props;
+export type SelectPopupProps = _Select.Popup.Props & {
+	/**
+	 * An element to position the popup against.
+	 * By default, the popup is positioned against the trigger.
+	 */
+	anchor?: _Select.Positioner.Props[ 'anchor' ];
+};
 
 export type SelectItemProps = Omit<
 	_Select.Item.Props,


### PR DESCRIPTION
## What?

Expose an `anchor` prop on `Select.Popup` and a `rootRef` prop on `Input`, allowing popup positioning against the full input container rather than the inner element.

## Why?

Base UI's `Positioner` anchors to the trigger/input element by default. When an `Input` has prefix or suffix slots, the inner `<input>` is narrower than the outer `InputLayout` container, so any popup positioned against it will be misaligned and too narrow.

`Select.Popup` wraps the Base UI `Positioner` but doesn't expose its `anchor` prop, so there's currently no way to override the default anchor. Similarly, `Input` forwards its `ref` to the inner `<input>` element, giving consumers no way to reference the outer `InputLayout` wrapper for use as an anchor.

## How?

- `Select.Popup`: Accept an `anchor` prop and forward it to `_Select.Positioner`. This matches the existing Base UI `Positioner` API.
- `Input`: Add a `rootRef` prop forwarded to the root `InputLayout` element. The existing `ref` continues to target the inner `<input>`.

## Testing Instructions

No visual changes — these are new opt-in props with no effect when unused.