### PR TITLE
Fix resizable frame jankiness

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -27,6 +27,20 @@ import { store as blockEditorStore } from '../../store';
 
 const ViewportWidthProvider = useViewportMatch.__experimentalWidthProvider;
 
+// Keep simulated viewport width stable at the same ranges as block visibility:
+// mobile < 480, tablet < 782, desktop => 782.
+const DEVICE_BREAKPOINTS = [ 480, 782 ]; // mobile, tablet, desktop
+
+function getBucketedViewportWidth( width ) {
+	for ( let i = 0; i < DEVICE_BREAKPOINTS.length; i++ ) {
+		if ( width < DEVICE_BREAKPOINTS[ i ] ) {
+			return DEVICE_BREAKPOINTS[ i ] - 1;
+		}
+	}
+
+	return DEVICE_BREAKPOINTS[ DEVICE_BREAKPOINTS.length - 1 ];
+}
+
 function bubbleEvent( event, Constructor, frame ) {
 	const init = {};
 
@@ -271,7 +285,6 @@ function Iframe( {
 	const {
 		contentResizeListener,
 		containerResizeListener,
-		containerWidth,
 		isZoomedOut,
 		scaleContainerWidth,
 	} = useScaleCanvas( {
@@ -279,7 +292,7 @@ function Iframe( {
 		frameSize: parseInt( frameSize ),
 		iframeDocument,
 	} );
-
+	const viewportMatchWidth = getBucketedViewportWidth( scaleContainerWidth );
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 
 	const unguardedBodyRef = useMergeRefs( [
@@ -368,7 +381,9 @@ function Iframe( {
 						>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>
-								<ViewportWidthProvider value={ containerWidth }>
+								<ViewportWidthProvider
+									value={ viewportMatchWidth }
+								>
 									{ children }
 								</ViewportWidthProvider>
 							</StyleProvider>

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -484,7 +484,6 @@ export function useScaleCanvas( {
 	return {
 		isZoomedOut,
 		scaleContainerWidth,
-		containerWidth,
 		contentResizeListener,
 		containerResizeListener,
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes issue described in [this comment](https://github.com/WordPress/gutenberg/pull/75156#issuecomment-4039259962).

#75156 added a ViewportWidthProvider to the editor Iframe and passed it the current frame width value, so that anything inside the editor canvas can have access to the frame width via `useViewportMatch`. The problem is that value updates repeatedly when the frame is resizing, causing the choppiness that @jasmussen spotted.

This PR updates the value passed to ViewportWidthProvider to only change when certain breakpoints are reached (currently matching the breakpoints used for [block visibility](https://github.com/WordPress/gutenberg/blob/trunk/lib/block-supports/block-visibility.php#L47), which in the future may be extended to accept theme-defined breakpoints - when that happens we should adjust this logic accordingly)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Follow the steps in #75156 to check the original issue is still fixed.
2. The editor should now resize smoothly:


https://github.com/user-attachments/assets/06350f53-eb3e-46d1-9fa2-3f5c2ced76fe

