### PR TITLE
Core Data: Fix selectors returning stale results for different 'per_page' queries

### DIFF
--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -34,12 +34,8 @@ const queriedItemsCacheByState = new WeakMap();
 function getQueriedItemsUncached( state, query ) {
 	const { stableKey, page, perPage, include, fields, context } =
 		getQueryParts( query );
-	let itemIds;
 
-	if ( state.queries?.[ context ]?.[ stableKey ] ) {
-		itemIds = state.queries[ context ][ stableKey ].itemIds;
-	}
-
+	const itemIds = state.queries?.[ context ]?.[ stableKey ]?.itemIds;
 	if ( ! itemIds ) {
 		return null;
 	}
@@ -49,6 +45,17 @@ function getQueriedItemsUncached( state, query ) {
 		perPage === -1
 			? itemIds.length
 			: Math.min( startOffset + perPage, itemIds.length );
+
+	// If the requested page range exceeds the stored itemIds, the data for
+	// this specific pagination window may not have been fetched yet. Return
+	// null unless totalItems confirms we already have all available items.
+	if ( perPage !== -1 && itemIds.length < startOffset + perPage ) {
+		const totalItems =
+			state.queries[ context ][ stableKey ]?.meta?.totalItems;
+		if ( Number.isFinite( totalItems ) && itemIds.length < totalItems ) {
+			return null;
+		}
+	}
 
 	const items = [];
 	for ( let i = startOffset; i < endOffset; i++ ) {

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -51,7 +51,7 @@ function getQueriedItemsUncached( state, query ) {
 	// null unless totalItems confirms we already have all available items.
 	if ( perPage !== -1 && itemIds.length < startOffset + perPage ) {
 		const totalItems =
-			state.queries[ context ][ stableKey ]?.meta?.totalItems;
+			state.queries[ context ][ stableKey ].meta?.totalItems;
 		if ( Number.isFinite( totalItems ) && itemIds.length < totalItems ) {
 			return null;
 		}

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -239,4 +239,29 @@ describe( 'getQueriedItems', () => {
 
 		expect( result ).toBe( null );
 	} );
+
+	it( 'should return null when per_page exceeds stored itemIds and more items exist', () => {
+		const state = {
+			items: {
+				default: {
+					1: { id: 1 },
+					2: { id: 2 },
+				},
+			},
+			itemIsComplete: {
+				default: { 1: true, 2: true },
+			},
+			queries: {
+				default: {
+					'': {
+						itemIds: [ 1, 2 ],
+						meta: { totalItems: 5 },
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state, { per_page: 3 } );
+		expect( result ).toBe( null );
+	} );
 } );


### PR DESCRIPTION
## What?
Closes #56355.

Queries with different `per_page` values share the same `stableKey`, causing selectors to return cached items from a prior query instead of `null` while the new query resolves. Add a check in `getQueriedItemsUncached` that returns `null` when stored `itemIds` can't satisfy the requested pagination range and `totalItems` confirms more items exist.

Note: The new guardrail might fail when `totalItems` and the query return stale data, but that should be very rare.


## How
Tries to fix the bug without changing the query `cacheKey`.

## Testing Instructions

```js
 // 1. API call, returns null
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 2 } )

 // 2. No API call, returns expected results
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 2 } )

 // 3.  API call, returns null
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 3 } )

 // 4.  No API call, returns expected results
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 3 } )

 // 5.  API call, returns null
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 4 } )

 // 6.  No API call, returns expected results
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 4 } ) 
```

### Testing Instructions for Keyboard
Same.