### PR TITLE
Include AI tools disclosure in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,3 +29,9 @@ Closes <!-- #ISSUE-NUMBER or URL -->
 |Before|After|
 |-|-|
 |<!-- Before screenshot here -->|<!-- After screenshot here -->|
+
+## Use of AI Tools
+
+<!--
+You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
+-->


### PR DESCRIPTION
Closes #76002.

See Core-64587.

Copied from [the equivalent section](https://github.com/WordPress/wordpress-develop/blob/cc19ca7567e9e4c0769759cb9ae7c2214c52b57d/.github/pull_request_template.md?plain=1#L22-L26) in the WordPress core pull request template introduced in:

- https://github.com/WordPress/wordpress-develop/pull/10850