### PR TITLE
Content Guidelines: Rename route and use the right `Notice` component

### DIFF
--- a/lib/experimental/content-guidelines/load.php
+++ b/lib/experimental/content-guidelines/load.php
@@ -18,8 +18,8 @@ function gutenberg_register_content_guidelines_settings_submenu() {
 		__( 'Guidelines', 'gutenberg' ),
 		__( 'Guidelines', 'gutenberg' ),
 		'manage_options',
-		'content-guidelines-wp-admin',
-		'gutenberg_content_guidelines_wp_admin_render_page'
+		'guidelines-wp-admin',
+		'gutenberg_guidelines_wp_admin_render_page'
 	);
 }
 
@@ -35,7 +35,7 @@ function gutenberg_content_guidelines_enqueue_block_registry_scripts( $hook_suff
 		return;
 	}
 
-	if ( 'settings_page_content-guidelines-wp-admin' !== $hook_suffix ) {
+	if ( 'settings_page_guidelines-wp-admin' !== $hook_suffix ) {
 		return;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63000,8 +63000,7 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/notices": "file:../../packages/notices",
-				"@wordpress/ui": "file:../../packages/ui"
+				"@wordpress/notices": "file:../../packages/notices"
 			}
 		},
 		"routes/font-list": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 			},
 			"font-library",
 			"options-connectors",
-			"content-guidelines"
+			"guidelines"
 		]
 	},
 	"config": {

--- a/routes/content-guidelines/components/actions-section.tsx
+++ b/routes/content-guidelines/components/actions-section.tsx
@@ -1,3 +1,5 @@
+/* @jsx createElement */
+
 /**
  * WordPress dependencies
  */
@@ -5,6 +7,7 @@ import {
 	Button,
 	Card,
 	Modal,
+	Notice,
 	useNavigator,
 	__experimentalText as Text,
 	__experimentalHeading as Heading,
@@ -12,10 +15,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useRef, useState } from '@wordpress/element';
-// TODO: Revert to the `Notice` in `@wordpress/components` for now.
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Notice } from '@wordpress/ui';
+import { createElement, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -146,15 +146,13 @@ export default function ActionsSection() {
 				style={ { display: 'none' } }
 			/>
 			{ error && (
-				<Notice.Root
-					intent="warning"
-					className="content-guidelines__actions-notice"
+				<Notice
+					status="error"
+					onRemove={ () => setError( null ) }
+					isDismissible
 				>
-					<Notice.Title className="content-guidelines__actions-notice-title">
-						{ error }
-					</Notice.Title>
-					<Notice.CloseIcon onClick={ () => setError( null ) } />
-				</Notice.Root>
+					{ error }
+				</Notice>
 			) }
 			<Card className="content-guidelines__actions-card">
 				{ /*

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -172,7 +172,7 @@ export default function BlockGuidelineModal( {
 					rows={ 6 }
 				/>
 				{ error && (
-					<Notice status="error" onDismiss={ () => setError( null ) }>
+					<Notice status="error" onRemove={ () => setError( null ) }>
 						{ sprintf(
 							/* translators: %s: Error message. */
 							__( 'Error: %s' ),

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -7,15 +7,13 @@ import {
 	Button,
 	ComboboxControl,
 	Modal,
+	Notice,
 	TextControl,
 	TextareaControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-// TODO: Revert to the `Notice` in `@wordpress/components` for now.
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Notice } from '@wordpress/ui';
 import { createElement, useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -174,15 +172,13 @@ export default function BlockGuidelineModal( {
 					rows={ 6 }
 				/>
 				{ error && (
-					<Notice.Root intent="error">
-						<Notice.Title>
-							{ sprintf(
-								/* translators: %s: Error message. */
-								__( 'Error: %s' ),
-								error
-							) }
-						</Notice.Title>
-					</Notice.Root>
+					<Notice status="error" onDismiss={ () => setError( null ) }>
+						{ sprintf(
+							/* translators: %s: Error message. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</Notice>
 				) }
 				<HStack
 					justify="flex-end"

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -7,13 +7,11 @@ import {
 	Button,
 	Icon,
 	Modal,
+	Notice,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-// TODO: Revert to the `Notice` in `@wordpress/components` for now.
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Notice } from '@wordpress/ui';
 import {
 	DataViews,
 	filterSortAndPaginate,
@@ -207,15 +205,13 @@ export default function BlockGuidelines() {
 	return (
 		<VStack spacing={ 4 } className="block-guidelines">
 			{ error && (
-				<Notice.Root intent="error">
-					<Notice.Title>
-						{ sprintf(
-							/* translators: %s: Error message. */
-							__( 'Error: %s' ),
-							error
-						) }
-					</Notice.Title>
-				</Notice.Root>
+				<Notice status="error" onDismiss={ () => setError( null ) }>
+					{ sprintf(
+						/* translators: %s: Error message. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</Notice>
 			) }
 			{ rows.length > 0 && (
 				<DataViews

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -205,7 +205,7 @@ export default function BlockGuidelines() {
 	return (
 		<VStack spacing={ 4 } className="block-guidelines">
 			{ error && (
-				<Notice status="error" onDismiss={ () => setError( null ) }>
+				<Notice status="error" onRemove={ () => setError( null ) }>
 					{ sprintf(
 						/* translators: %s: Error message. */
 						__( 'Error: %s' ),

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -109,7 +109,7 @@ export default function GuidelineAccordionForm( {
 					}
 				/>
 				{ error && (
-					<Notice status="error" onDismiss={ () => setError( null ) }>
+					<Notice status="error" onRemove={ () => setError( null ) }>
 						{ sprintf(
 							/* translators: %s: Error message. */
 							__( 'Error saving guidelines: %s' ),

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -3,12 +3,13 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Button,
+	Notice,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
-// TODO: Revert to the `Notice` in `@wordpress/components` for now.
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Notice } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	createElement,
@@ -108,15 +109,13 @@ export default function GuidelineAccordionForm( {
 					}
 				/>
 				{ error && (
-					<Notice.Root intent="error">
-						<Notice.Title>
-							{ sprintf(
-								/* translators: %s: Error message. */
-								__( 'Error saving guidelines: %s' ),
-								error
-							) }
-						</Notice.Title>
-					</Notice.Root>
+					<Notice status="error" onDismiss={ () => setError( null ) }>
+						{ sprintf(
+							/* translators: %s: Error message. */
+							__( 'Error saving guidelines: %s' ),
+							error
+						) }
+					</Notice>
 				) }
 				<Button
 					variant="primary"

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -21,7 +21,6 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/notices": "file:../../packages/notices",
-		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/block-library": "file:../../packages/block-library",
 		"@wordpress/blocks": "file:../../packages/blocks"
 	}

--- a/routes/content-guidelines/package.json
+++ b/routes/content-guidelines/package.json
@@ -5,7 +5,7 @@
 	"route": {
 		"path": "/",
 		"page": [
-			"content-guidelines"
+			"guidelines"
 		]
 	},
 	"dependencies": {

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -86,17 +86,18 @@ function ContentGuidelinesPage() {
 			{ error && (
 				<div className="content-guidelines__content">
 					<Notice status="error" isDismissible={ false }>
-						<b>
+						<strong>
 							{ sprintf(
 								/* translators: %s: Error message. */
 								__( 'Error loading guidelines: %s' ),
 								error
 							) }
-						</b>
-						<br />
-						{ __(
-							'Please try again. If the problem persists, contact support.'
-						) }
+						</strong>
+						<p className="content-guidelines__error-description">
+							{ __(
+								'Please try again. If the problem persists, contact support.'
+							) }
+						</p>
 					</Notice>
 				</div>
 			) }

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -9,11 +9,9 @@ import { createElement, useEffect, useState } from '@wordpress/element';
 import {
 	Spinner,
 	Navigator,
+	Notice,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-// TODO: Revert to the `Notice` in `@wordpress/components` for now.
-// eslint-disable-next-line @wordpress/use-recommended-components
-import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -87,20 +85,19 @@ function ContentGuidelinesPage() {
 		>
 			{ error && (
 				<div className="content-guidelines__content">
-					<Notice.Root intent="error">
-						<Notice.Title>
+					<Notice status="error" isDismissible={ false }>
+						<b>
 							{ sprintf(
 								/* translators: %s: Error message. */
 								__( 'Error loading guidelines: %s' ),
 								error
 							) }
-						</Notice.Title>
-						<Notice.Description>
-							{ __(
-								'Please try again. If the problem persists, contact support.'
-							) }
-						</Notice.Description>
-					</Notice.Root>
+						</b>
+						<br />
+						{ __(
+							'Please try again. If the problem persists, contact support.'
+						) }
+					</Notice>
 				</div>
 			) }
 			{ loading ? (

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -29,18 +29,6 @@
 	margin-top: $grid-unit-20;
 }
 
-.content-guidelines__actions-notice {
-	border: none;
-	border-left: 4px solid $alert-yellow;
-	background-color: color.adjust($alert-yellow, $lightness: +35%);
-	border-radius: 0;
-}
-
-.content-guidelines__actions-notice-title {
-	font-size: 13px;
-	font-weight: 400;
-}
-
 .content-guidelines__actions {
 	width: min(680px, 100%);
 	margin: $grid-unit-20 auto 0;

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -119,6 +119,11 @@
 	color: $gray-900;
 }
 
+.content-guidelines__error-description {
+	margin: 0;
+	margin-top: $grid-unit-10;
+}
+
 .content-guidelines__revision-description {
 	padding-left: $grid-unit-10;
 }


### PR DESCRIPTION
## What?

Related issue: https://github.com/WordPress/gutenberg/issues/76389

- Updates the Content Guidelines REST route used by the client API to the renamed endpoint.
- - We were using /wp-admin/options-general.php?page=content-guidelines-wp-admin, but now we are dropping the `content` prefix.
- Uses the `Notice` component from `@wordpress/components` in the Content Guidelines UI.

## Why?
- Keeps the Content Guidelines UI working after the REST route rename.
- Standardizes notices on the shared `@wordpress/components` implementation for consistency and maintainability.


## Testing Instructions
_You may need to do `npm install && npm build` first_

First, ensure that the content guidelines page loads on the http://localhost:8888/wp-admin/options-general.php?page=guidelines-wp-admin route

Now, ensure that we are using the `Notice` component from the `@wordpress/components` library. Here is how you can reproduce the errors:
1. Apply this patch:
```diff
diff --git a/routes/content-guidelines/api.ts b/routes/content-guidelines/api.ts
index 6e2b97af99..bac2128686 100644
--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -92,7 +92,7 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 	};
 
 	const path = id
-		? `/wp/v2/content-guidelines/${ id }`
+		? `/wp/v2/content-guidelines-test/${ id }`
 		: '/wp/v2/content-guidelines';
 	const method = id ? 'PUT' : 'POST';
 
@@ -263,7 +263,7 @@ export async function restoreContentGuidelinesRevision(
 	revisionId: number
 ): Promise< RestGuidelinesResponse > {
 	return ( await apiFetch( {
-		path: `/wp/v2/content-guidelines/${ guidelinesId }/revisions/${ revisionId }/restore`,
+		path: `/wp/v2/content-guidelines/${ guidelinesId }/revisions/${ revisionId }/restore-test`,
 		method: 'POST',
 	} ) ) as RestGuidelinesResponse;
 }
```
2. Try to save a simple-guideline. You should see an error (match with the sample error screenshot attached at the bottom of this PR description)
3. Try to save a block guideline. You should see the error.
4. Try to remove a block guideline from the table. You should see the error.
5. Click on a block-guideline to open the block-guideline modal. Now click `Remove` to delete that guideline. You should see the error.
6. Try to import guidelines by clicking on an import and selecting a json file. You should see the error.


## Screenshots

Before | After
--- | ---
<img width="699" height="145" alt="Screenshot 2026-03-12 at 12 39 28 PM" src="https://github.com/user-attachments/assets/df7716fa-95e4-4d92-914a-cd34b4f6d787" /> | <img width="699" height="145" alt="Screenshot 2026-03-12 at 12 34 41 PM" src="https://github.com/user-attachments/assets/f5fb055c-67ab-48c9-b63f-6820231daa55" />
<img width="660" height="40" alt="Screenshot 2026-03-12 at 12 40 24 PM" src="https://github.com/user-attachments/assets/f82a6808-6f99-4057-aeea-33a6203efb1b" /> | <img width="660" height="40" alt="Screenshot 2026-03-12 at 12 40 30 PM" src="https://github.com/user-attachments/assets/5df1091e-54e5-4f1e-a975-828860310046" />
