### PR TITLE
RTC: Place sync connection modal in front of popover

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -137,6 +137,7 @@ $z-layers: (
 	".editor-post-template__swap-template-modal": 1000001,
 	".editor-post-template__create-template-modal": 1000001,
 	".edit-site-template-panel__replace-template-modal": 1000001,
+	".editor-sync-connection-modal": 1000001,
 
 	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
 	// because it uses emotion and not sass. We need it to render on top its parent popover.

--- a/packages/editor/src/components/sync-connection-modal/index.js
+++ b/packages/editor/src/components/sync-connection-modal/index.js
@@ -146,7 +146,7 @@ export function SyncConnectionModal() {
 	return (
 		<BlockCanvasCover.Fill>
 			<Modal
-				className="editor-sync-connection-modal"
+				overlayClassName="editor-sync-connection-modal"
 				isDismissible={ false }
 				onRequestClose={ () => {} }
 				shouldCloseOnClickOutside={ false }

--- a/packages/editor/src/components/sync-connection-modal/style.scss
+++ b/packages/editor/src/components/sync-connection-modal/style.scss
@@ -1,4 +1,9 @@
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/z-index" as *;
+
+.editor-sync-connection-modal {
+	z-index: z-index(".editor-sync-connection-modal");
+}
 
 .editor-sync-connection-modal p {
 	margin: 0;


### PR DESCRIPTION
## What?

[Modals are generally expected to be placed behind popovers](https://github.com/WordPress/gutenberg/blob/903cef796600c0f745530e45123cac2178434c0b/packages/base-styles/_z-index.scss#L121), but there are some scenarios where we may want to give the modal priority.

| Before | After |
|--------|--------|
| <img width="678" height="438" alt="image" src="https://github.com/user-attachments/assets/3be51360-f16d-441b-b857-28d154096f9e" />| <img width="679" height="440" alt="image" src="https://github.com/user-attachments/assets/86c67ceb-f6df-42c2-ae1c-3882174f6dd4" />| 

## Testing Instructions

1. Open the block toolbar dropdown.
2. Run the following code via your brouser console. The modal appears after two seconds.
  ```javascript
  const postType = wp.data.select('core/editor').getCurrentPostType();
  const postId = wp.data.select('core/editor').getCurrentPostId();
  wp.data.dispatch('core').setSyncConnectionStatus(
    'postType',
    postType,
    postId,
    {
      status: 'disconnected',
      error: { code: 'connection-expired' },
	  retryInMs: 5000 
    }
  );
  ```
3. Confirm that the sync connection modal is displayed in front of the block toolbar dropdown