### PR TITLE
E2E Tests: Add coverage for AI plugin callout banner

### DIFF
--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -74,6 +74,29 @@ test.describe( 'Connectors', () => {
 		).toHaveAttribute( 'href', 'plugin-install.php' );
 	} );
 
+	test( 'should display the AI plugin callout banner with install button', async ( {
+		page,
+		admin,
+	} ) => {
+		await admin.visitAdminPage( SETTINGS_PAGE_PATH, CONNECTORS_PAGE_QUERY );
+
+		const banner = page.locator( '.ai-plugin-callout' );
+		await expect( banner ).toBeVisible();
+
+		// Verify the banner message mentions the AI plugin.
+		await expect( banner.getByText( 'AI plugin' ) ).toBeVisible();
+
+		// Verify the Install button is present.
+		await expect(
+			banner.getByRole( 'button', { name: 'Install AI Experiments' } )
+		).toBeVisible();
+
+		// Verify the Learn more link is present.
+		await expect(
+			banner.getByRole( 'link', { name: 'Learn more' } )
+		).toBeVisible();
+	} );
+
 	test.describe( 'Empty state', () => {
 		const PLUGIN_SLUG = 'gutenberg-test-connectors-empty-state';
 
@@ -115,6 +138,9 @@ test.describe( 'Connectors', () => {
 				'href',
 				'plugin-install.php'
 			);
+
+			// Verify the AI plugin callout banner is not shown.
+			await expect( page.locator( '.ai-plugin-callout' ) ).toBeHidden();
 
 			// Verify none of the default connector cards are shown.
 			for ( const { slug } of CONNECTORS ) {
@@ -164,6 +190,11 @@ test.describe( 'Connectors', () => {
 					SETTINGS_PAGE_PATH,
 					CONNECTORS_PAGE_QUERY
 				);
+
+				// AI plugin callout banner should be hidden when user lacks permissions.
+				await expect(
+					page.locator( '.ai-plugin-callout' )
+				).toBeHidden();
 
 				for ( const { slug } of CONNECTORS ) {
 					const card = page.locator( `.connector-item--${ slug }` );


### PR DESCRIPTION
## Summary

Follow-up to #76379.

- Adds a new E2E test verifying the AI plugin callout banner displays with the "Install AI Experiments" button and "Learn more" link when the plugin is not installed.
- Extends the empty state test to verify the banner is hidden when no connectors are registered.
- Extends the capability restriction tests to verify the banner is hidden when the user lacks install/activate permissions.

## Test plan

- [x] All 8 connectors E2E tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)