### PR TITLE
CI: Simplify strategy matrix in Build Gutenberg Plugin Zip workflow

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -179,7 +179,7 @@ jobs:
                   fi
 
     build:
-        name: ${{ matrix.IS_WORDPRESS_CORE && 'Build assets for wordpress-develop' || 'Build Release Artifact' }}
+        name: ${{ matrix.IS_GUTENBERG_PLUGIN && 'Build Release Artifact' || 'Build assets for wordpress-develop' }}
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
@@ -192,12 +192,7 @@ jobs:
             )
         strategy:
             matrix:
-                IS_GUTENBERG_PLUGIN: [true]
-                IS_WORDPRESS_CORE: [false]
-
-                include:
-                    - IS_GUTENBERG_PLUGIN: false
-                      IS_WORDPRESS_CORE: true
+                IS_GUTENBERG_PLUGIN: [true, false]
 
         outputs:
             job_status: ${{ job.status }}
@@ -217,7 +212,7 @@ jobs:
                   check-latest: true
 
             - name: Configure build for wordpress-develop
-              if: ${{ matrix.IS_WORDPRESS_CORE }}
+              if: ${{ ! matrix.IS_GUTENBERG_PLUGIN }}
               run: jq --tab '.wpPlugin.name = "wp"' package.json > package.json.tmp && mv package.json.tmp package.json
 
             - name: Build Gutenberg plugin ZIP file
@@ -225,12 +220,12 @@ jobs:
               env:
                   NO_CHECKS: 'true'
                   IS_GUTENBERG_PLUGIN: ${{ matrix.IS_GUTENBERG_PLUGIN }}
-                  IS_WORDPRESS_CORE: ${{ matrix.IS_WORDPRESS_CORE }}
+                  IS_WORDPRESS_CORE: ${{ ! matrix.IS_GUTENBERG_PLUGIN }}
 
             - name: Upload artifact
               uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
-                  name: gutenberg-${{ matrix.IS_WORDPRESS_CORE && 'wordpress-develop' || 'plugin' }}
+                  name: gutenberg-${{ matrix.IS_GUTENBERG_PLUGIN && 'plugin' || 'wordpress-develop'}}
                   path: ./gutenberg.zip
 
             - name: Build release notes draft

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -225,7 +225,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
-                  name: gutenberg-${{ matrix.IS_GUTENBERG_PLUGIN && 'plugin' || 'wordpress-develop'}}
+                  name: gutenberg-${{ ! matrix.IS_GUTENBERG_PLUGIN && 'wordpress-develop' || 'plugin' }}
                   path: ./gutenberg.zip
 
             - name: Build release notes draft


### PR DESCRIPTION
## What?
Simplify strategy matrix in Build Gutenberg Plugin Zip workflow.

## Why?
The two options, `IS_GUTENBERG_PLUGIN` and `IS_WORDPRESS_CORE`, are mutually exclusive. This was previously implemented as a 2x2 matrix with only one entry: https://github.com/WordPress/gutenberg/blob/6715d9a605ed031402b5ee99f55750b7250d37c6/.github/workflows/build-plugin-zip.yml#L194-L197

... that was then extended via `include` to also cover the opposite case: https://github.com/WordPress/gutenberg/blob/6715d9a605ed031402b5ee99f55750b7250d37c6/.github/workflows/build-plugin-zip.yml#L198-L200

This means our 2x2 matrix only contains 2 elements:

| | `IS_GUTENBERG_PLUGIN === true` | `IS_GUTENBERG_PLUGIN === false` |
|-|-|-|
| `IS_WORDPRESS_CORE === true` | | x |
| `IS_WORDPRESS_CORE === false` | x |

## How?
I find it easier to read to have a 1x2 matrix instead (having only `IS_GUTENBERG_PLUGIN`, but allowing it to be either `true` or `false`), and to define `IS_WORDPRESS_CORE` as its `!` negated value.

|`IS_GUTENBERG_PLUGIN === true` | `IS_GUTENBERG_PLUGIN === false` |
|-|-|
| x | x |

```
IS_WORDPRESS_CORE = ! IS_GUTENBERG_PLUGIN
```

## Testing Instructions
Let's see if this does what it's supposed to do on this PR.
