### PR TITLE
Content Guidelines: Use `Notice` from `@wordpress/components` instead of `@wordpress/ui`

### DIFF
--- a/routes/content-guidelines/components/actions-section.tsx
+++ b/routes/content-guidelines/components/actions-section.tsx
@@ -10,10 +10,10 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	Notice,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
-import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -144,15 +144,13 @@ export default function ActionsSection() {
 				style={ { display: 'none' } }
 			/>
 			{ error && (
-				<Notice.Root
-					intent="warning"
-					className="content-guidelines__actions-notice"
+				<Notice
+					isDismissible
+					status="warning"
+					onRemove={ () => setError( null ) }
 				>
-					<Notice.Title className="content-guidelines__actions-notice-title">
-						{ error }
-					</Notice.Title>
-					<Notice.CloseIcon onClick={ () => setError( null ) } />
-				</Notice.Root>
+					{ error }
+				</Notice>
 			) }
 			<Card className="content-guidelines__actions-card">
 				{ /*

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -11,9 +11,9 @@ import {
 	TextareaControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	Notice,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Notice } from '@wordpress/ui';
 import { createElement, useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -172,15 +172,13 @@ export default function BlockGuidelineModal( {
 					rows={ 6 }
 				/>
 				{ error && (
-					<Notice.Root intent="error">
-						<Notice.Title>
-							{ sprintf(
-								/* translators: %s: Error message. */
-								__( 'Error: %s' ),
-								error
-							) }
-						</Notice.Title>
-					</Notice.Root>
+					<Notice status="error" isDismissible={ false }>
+						{ sprintf(
+							/* translators: %s: Error message. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</Notice>
 				) }
 				<HStack
 					justify="flex-end"

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -10,8 +10,8 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
+	Notice,
 } from '@wordpress/components';
-import { Notice } from '@wordpress/ui';
 import {
 	DataViews,
 	filterSortAndPaginate,
@@ -205,15 +205,13 @@ export default function BlockGuidelines() {
 	return (
 		<VStack spacing={ 4 } className="block-guidelines">
 			{ error && (
-				<Notice.Root intent="error">
-					<Notice.Title>
-						{ sprintf(
-							/* translators: %s: Error message. */
-							__( 'Error: %s' ),
-							error
-						) }
-					</Notice.Title>
-				</Notice.Root>
+				<Notice status="error" isDismissible={ false }>
+					{ sprintf(
+						/* translators: %s: Error message. */
+						__( 'Error: %s' ),
+						error
+					) }
+				</Notice>
 			) }
 			{ rows.length > 0 && (
 				<DataViews

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -3,10 +3,13 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	Notice,
+} from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
-import { Notice } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	createElement,
@@ -106,15 +109,13 @@ export default function GuidelineAccordionForm( {
 					}
 				/>
 				{ error && (
-					<Notice.Root intent="error">
-						<Notice.Title>
-							{ sprintf(
-								/* translators: %s: Error message. */
-								__( 'Error saving guidelines: %s' ),
-								error
-							) }
-						</Notice.Title>
-					</Notice.Root>
+					<Notice isDismissible={ false } status="error">
+						{ sprintf(
+							/* translators: %s: Error message. */
+							__( 'Error saving guidelines: %s' ),
+							error
+						) }
+					</Notice>
 				) }
 				<Button
 					variant="primary"

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -10,8 +10,8 @@ import {
 	Spinner,
 	Navigator,
 	__experimentalVStack as VStack,
+	Notice,
 } from '@wordpress/components';
-import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -85,20 +85,20 @@ function ContentGuidelinesPage() {
 		>
 			{ error && (
 				<div className="content-guidelines__content">
-					<Notice.Root intent="error">
-						<Notice.Title>
+					<Notice status="error" isDismissible={ false }>
+						<p>
 							{ sprintf(
 								/* translators: %s: Error message. */
 								__( 'Error loading guidelines: %s' ),
 								error
 							) }
-						</Notice.Title>
-						<Notice.Description>
+						</p>
+						<p>
 							{ __(
 								'Please try again. If the problem persists, contact support.'
 							) }
-						</Notice.Description>
-					</Notice.Root>
+						</p>
+					</Notice>
 				</div>
 			) }
 			{ loading ? (

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -29,17 +29,6 @@
 	margin-top: $grid-unit-20;
 }
 
-.content-guidelines__actions-notice {
-	border: none;
-	border-left: 4px solid $alert-yellow;
-	background-color: color.adjust($alert-yellow, $lightness: +35%);
-	border-radius: 0;
-}
-
-.content-guidelines__actions-notice-title {
-	font-size: 13px;
-	font-weight: 400;
-}
 
 .content-guidelines__actions {
 	width: min(680px, 100%);


### PR DESCRIPTION

## What, Why, How?
Closes https://github.com/WordPress/gutenberg/issues/76389

Replaces the `Notice` component usage in the Content Guidelines page to use `@wordpress/components` instead of the under-development `@wordpress/ui` package.

## Testing Instructions
1. Navigate to the Content Guidelines page.
2. Simulate an error (e.g., disconnect network/Use a JSON that does not follow the expected format of the content guidelines.) to trigger the error Notice. (Or can be tested by deliberately throwing errors in the respective files, which is how I tested this.)
3. Verify the error notice displays correctly with both the error message and the help text.

## Screenshots
Figma [Reference](https://www.figma.com/design/XNQJ1XkLyn5YfvZlbIzCj2/Content-guidelines?node-id=5639-7879&t=hszJKeQZANO0d4bM-0)

### Warning 

The notice in trunk uses extra CSS to achieve what it currently does [reference](https://github.com/WordPress/gutenberg/blob/5d06c68c0ae397f8e7ea2d6c322e5716084a65ad/routes/content-guidelines/style.scss#L32-L42)
|Trunk|Figma|this PR|
|-|-|-|
|<img width="688" height="341" alt="image" src="https://github.com/user-attachments/assets/4ebd8825-6043-465d-8de8-52acc4d4559d" />|<img width="688" height="341" alt="image" src="https://github.com/user-attachments/assets/9d538ac9-4169-4406-a548-239b75277f11" />|<img width="688" height="341" alt="image" src="https://github.com/user-attachments/assets/96c1d354-ebed-4c6e-9ee6-784b8e5f2536" />|




### Error 
|Trunk|Figma|this PR|
|-|-|-|
|<img width="688" height="333" alt="image" src="https://github.com/user-attachments/assets/f164eca4-3be3-4a5d-a6f5-bb3f6e62fd23" />|<img width="688" height="333" alt="image" src="https://github.com/user-attachments/assets/75182c36-524a-4df5-a211-880e3bbfcaf7" />|<img width="688" height="333" alt="image" src="https://github.com/user-attachments/assets/b0dae5f4-e9fc-4a89-ae40-fc4419ebdac6" />|

P.S. The final visuals don't go hand in hand with the Figma designs. The Notice component from the components package has limited functionality—for example, it doesn't support icons, and the background color defaults to red for errors(different from what is expected in Figma). The overall design of the error notice also differs from what's shown in the Figma mockups. 

In this instance, using "warning" status would have been perfectly fine visually. That said, the issue only referenced changing the Notice import source, but I went a step further and removed all usage of the `Notice` from the `content-guidelines/` folder, which I believe aligns with the intended issue. 