### PR TITLE
Fields: Add support for classic themes in `template`

### DIFF
--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -48,10 +48,10 @@ const form = {
 				'password',
 			],
 		},
-		'author',
 		'date',
 		'slug',
-		'parent',
+		'author',
+		'template',
 		{
 			id: 'discussion',
 			label: __( 'Discussion' ),
@@ -63,7 +63,7 @@ const form = {
 				'ping_status',
 			],
 		},
-		'template',
+		'parent',
 		'format',
 	],
 };
@@ -92,6 +92,27 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 		},
 		[ postType, postId ]
 	);
+
+	// Fetch classic theme templates from editor settings.
+	const availableTemplates = useSelect( ( select ) => {
+		if ( select( coreDataStore ).getCurrentTheme()?.is_block_theme ) {
+			return null;
+		}
+		return (
+			select( editorStore ).getEditorSettings().availableTemplates ?? {}
+		);
+	}, [] );
+
+	// Augment record only when needed(not a block theme with available templates).
+	const augmentedRecord = useMemo( () => {
+		if ( ! record || ! availableTemplates ) {
+			return record;
+		}
+		return {
+			...record,
+			available_templates: availableTemplates,
+		};
+	}, [ record, availableTemplates ] );
 
 	const { editEntityRecord } = useDispatch( coreDataStore );
 
@@ -137,7 +158,7 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					onActionPerformed={ onActionPerformed }
 				/>
 				<DataForm
-					data={ record }
+					data={ augmentedRecord }
 					fields={ fields }
 					form={ form }
 					onChange={ onChange }

--- a/packages/fields/src/fields/template/hooks.ts
+++ b/packages/fields/src/fields/template/hooks.ts
@@ -10,6 +10,54 @@ import type { WpTemplate } from '@wordpress/core-data';
  */
 import { getItemTitle } from '../../actions/utils';
 import { unlock } from '../../lock-unlock';
+import type { BasePost } from '../../types';
+
+/**
+ * Hook that determines the template field rendering mode for a post.
+ *
+ * @param record The post record.
+ * @return 'block-theme' | 'classic' | null
+ */
+export function useTemplateFieldMode(
+	record: BasePost
+): 'block-theme' | 'classic' | null {
+	const postType = record.type;
+	const availableTemplates = ( ( record as Record< string, any > )
+		?.available_templates ?? {} ) as Record< string, string >;
+	const hasAvailableTemplates = Object.keys( availableTemplates ).length > 0;
+	return useSelect(
+		( select ) => {
+			const isBlockTheme =
+				!! select( coreStore ).getCurrentTheme()?.is_block_theme;
+			const postTypeObj = select( coreStore ).getPostType( postType );
+			if ( ! postTypeObj?.viewable ) {
+				return null;
+			}
+			const canCreateTemplates =
+				isBlockTheme &&
+				( select( coreStore ).canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} ) ??
+					false );
+			const isVisible = hasAvailableTemplates || canCreateTemplates;
+			const canViewTemplates = isVisible
+				? !! select( coreStore ).canUser( 'read', {
+						kind: 'postType',
+						name: 'wp_template',
+				  } )
+				: false;
+			if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
+				return 'classic';
+			}
+			if ( isBlockTheme && canViewTemplates ) {
+				return 'block-theme';
+			}
+			return null;
+		},
+		[ postType, hasAvailableTemplates ]
+	);
+}
 
 /**
  * Compute the template slug to look up in the template hierarchy.

--- a/packages/fields/src/fields/template/template-edit.tsx
+++ b/packages/fields/src/fields/template/template-edit.tsx
@@ -14,22 +14,73 @@ import { __ } from '@wordpress/i18n';
  */
 import { getItemTitle } from '../../actions/utils';
 import type { BasePost } from '../../types';
-import { useDefaultTemplateLabel } from './hooks';
+import { useDefaultTemplateLabel, useTemplateFieldMode } from './hooks';
 import { unlock } from '../../lock-unlock';
+
+type TemplateEditComponentProps = Omit<
+	DataFormControlProps< BasePost >,
+	'onChange'
+> & {
+	onChange: ( value: string ) => void;
+};
 
 const EMPTY_ARRAY: [] = [];
 
-export const TemplateEdit = ( {
+function ClassicTemplateEdit( {
 	data,
 	field,
 	onChange,
-}: DataFormControlProps< BasePost > ) => {
-	const { id } = field;
+}: TemplateEditComponentProps ) {
+	const postId =
+		typeof data.id === 'number' ? data.id : parseInt( data.id, 10 );
+	const value = field.getValue( { item: data } );
+	const options = useMemo(
+		() =>
+			Object.entries(
+				( ( data as Record< string, any > )?.available_templates ??
+					{} ) as Record< string, string >
+			).map( ( [ templateSlug, title ] ) => ( {
+				label: title,
+				value: templateSlug,
+			} ) ),
+		[ data ]
+	);
+	const canSwitchTemplate = useSelect(
+		( select ) => {
+			const { getHomePage, getPostsPageId } = unlock(
+				select( coreStore )
+			);
+			const singlePostId = String( postId );
+			const isPostsPage = getPostsPageId() === singlePostId;
+			const isFrontPage =
+				data.type === 'page' && getHomePage()?.postId === singlePostId;
+
+			return ! isPostsPage && ! isFrontPage;
+		},
+		[ postId, data.type ]
+	);
+	return (
+		<SelectControl
+			__next40pxDefaultSize
+			label={ __( 'Template' ) }
+			hideLabelFromVision
+			value={ value }
+			options={ options }
+			onChange={ onChange }
+			disabled={ ! canSwitchTemplate }
+		/>
+	);
+}
+
+function BlockThemeTemplateEdit( {
+	data,
+	field,
+	onChange,
+}: TemplateEditComponentProps ) {
 	const postType = data.type;
 	const postId =
 		typeof data.id === 'number' ? data.id : parseInt( data.id, 10 );
 	const slug = data.slug;
-
 	const { templates, canSwitchTemplate } = useSelect(
 		( select ) => {
 			const allTemplates =
@@ -46,12 +97,9 @@ export const TemplateEdit = ( {
 				select( coreStore )
 			);
 			const singlePostId = String( postId );
-			const isPostsPage =
-				singlePostId !== undefined && getPostsPageId() === singlePostId;
+			const isPostsPage = getPostsPageId() === singlePostId;
 			const isFrontPage =
-				singlePostId !== undefined &&
-				postType === 'page' &&
-				getHomePage()?.postId === singlePostId;
+				postType === 'page' && getHomePage()?.postId === singlePostId;
 
 			return {
 				templates: allTemplates,
@@ -60,23 +108,12 @@ export const TemplateEdit = ( {
 		},
 		[ postId, postType ]
 	);
-
 	const defaultTemplateLabel = useDefaultTemplateLabel(
 		postType,
 		postId,
 		slug
 	);
-
 	const value = field.getValue( { item: data } );
-
-	const onChangeControl = useCallback(
-		( newValue: string ) =>
-			onChange( {
-				[ id ]: newValue,
-			} ),
-		[ id, onChange ]
-	);
-
 	const options = useMemo( () => {
 		const templateOptions = templates.map( ( template ) => ( {
 			label: getItemTitle( template ),
@@ -87,7 +124,6 @@ export const TemplateEdit = ( {
 			...templateOptions,
 		];
 	}, [ templates, defaultTemplateLabel ] );
-
 	return (
 		<SelectControl
 			__next40pxDefaultSize
@@ -95,8 +131,29 @@ export const TemplateEdit = ( {
 			hideLabelFromVision
 			value={ value }
 			options={ options }
-			onChange={ onChangeControl }
+			onChange={ onChange }
 			disabled={ ! canSwitchTemplate }
 		/>
 	);
+}
+
+export const TemplateEdit = ( {
+	data,
+	field,
+	onChange,
+}: DataFormControlProps< BasePost > ) => {
+	const onChangeControl = useCallback(
+		( newValue: string ) =>
+			onChange( {
+				[ field.id ]: newValue,
+			} ),
+		[ field.id, onChange ]
+	);
+	const mode = useTemplateFieldMode( data );
+	if ( ! mode || ! [ 'block-theme', 'classic' ].includes( mode ) ) {
+		return null;
+	}
+	const Edit =
+		mode === 'classic' ? ClassicTemplateEdit : BlockThemeTemplateEdit;
+	return <Edit data={ data } field={ field } onChange={ onChangeControl } />;
 };

--- a/packages/fields/src/fields/template/template-view.tsx
+++ b/packages/fields/src/fields/template/template-view.tsx
@@ -5,18 +5,35 @@ import { useSelect } from '@wordpress/data';
 import type { WpTemplate } from '@wordpress/core-data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { getItemTitle } from '../../actions/utils';
 import type { BasePost } from '../../types';
-import { useDefaultTemplateLabel } from './hooks';
+import { useDefaultTemplateLabel, useTemplateFieldMode } from './hooks';
 
-export const TemplateView = ( {
+function ClassicTemplateView( {
 	item,
 	field,
-}: DataViewRenderFieldProps< BasePost > ) => {
+}: DataViewRenderFieldProps< BasePost > ) {
+	const templateSlug = field.getValue( { item } );
+	const availableTemplates = ( ( item as Record< string, any > )
+		?.available_templates ?? {} ) as Record< string, string >;
+
+	const classicLabel =
+		templateSlug && availableTemplates[ templateSlug ]
+			? availableTemplates[ templateSlug ]
+			: __( 'Default template' );
+
+	return <>{ classicLabel }</>;
+}
+
+function BlockThemeTemplateView( {
+	item,
+	field,
+}: DataViewRenderFieldProps< BasePost > ) {
 	const postType = item.type;
 	const slug = item.slug;
 	const postId = item.id;
@@ -49,4 +66,17 @@ export const TemplateView = ( {
 	);
 
 	return <>{ templateLabel ?? defaultTemplateLabel }</>;
+}
+
+export const TemplateView = ( {
+	item,
+	field,
+}: DataViewRenderFieldProps< BasePost > ) => {
+	const mode = useTemplateFieldMode( item );
+	if ( ! mode || ! [ 'block-theme', 'classic' ].includes( mode ) ) {
+		return null;
+	}
+	const View =
+		mode === 'classic' ? ClassicTemplateView : BlockThemeTemplateView;
+	return <View item={ item } field={ field } />;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76104
Which is part of the bigger: https://github.com/WordPress/gutenberg/issues/76076
Extracted from: https://github.com/WordPress/gutenberg/pull/76251

In this [exploration](https://github.com/WordPress/gutenberg/pull/76251) the discussions led to:
1. `template` field as part of the `quick edit/post summary` should be only about changing a template
2. remaining actions (e.g. create, edit, etc..) should be in a different place (probably a new panel in inspector controls)

This PR handles part of the first point above by making the `template` field to work properly (only change template) in the context of quick edit and post summary with DataForm. Right now the `template` field is broken for classic themes (with and without template support).

There will be a follow up to update the actual UI for changing a template based on the designs for all the types of themes.




## Testing Instructions 
1. In Gutenberg experiments enable `Editor Inspector: Use DataForm`
2. Observe that there is no regression either in site editor quick edit or the post summary with DataForm
3. Switch to a classic theme which has templates but no initial `template support` like `2014`. Noting that classic themes don't have access to the site editor and therefore the quick edit there.
4. Go to a page and test the `template` field with the experiment **enabled**.
5. Check the same page with the experiment **disabled**.
6. Template options should be identical and work well
7. Now add the snippet (provided below) to add `template support`
8. Go to a page with the experiment **disabled** and create a new template (there is plus icon in the dialog).
9. Repeat steps: `4, 5, 6` 

### Snippet to add template support
```
add_action( 'after_setup_theme', 'mytheme_setup' );
function mytheme_setup() {
    add_theme_support( 'block-templates' );
    add_theme_support( 'block-template-parts' );
}

```

