### PR TITLE
Tabs: Disable anchor support on Tab Menu Item

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1059,7 +1059,8 @@ A single tab button in the tabs menu. ([Source](https://github.com/WordPress/gut
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/tabs-menu
--	**Supports:** anchor, color (background, text), layout (~~allowEditing~~), spacing (padding), typography (fontSize, textAlign), ~~html~~, ~~lock~~, ~~reusable~~
+-	**Supports:** color (background, text), layout (~~allowEditing~~), spacing (padding), typography (fontSize, textAlign), ~~html~~, ~~lock~~, ~~reusable~~
+-	**Attributes:** anchor
 
 ## Tag Cloud
 

--- a/packages/block-library/src/tabs-menu-item/block.json
+++ b/packages/block-library/src/tabs-menu-item/block.json
@@ -17,10 +17,14 @@
 		"core/tabs-menu-item-id",
 		"core/tabs-menu-item-label"
 	],
-	"attributes": {},
+	"attributes": {
+		"anchor": {
+			"type": "string",
+			"default": ""
+		}
+	},
 	"supports": {
 		"html": false,
-		"anchor": true,
 		"reusable": false,
 		"lock": false,
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/75954

<!-- In a few words, what is the PR actually doing? -->

Disables the "HTML Anchor" field in the Advanced panel for the Tab Menu Item block to prevent users from editing or removing the auto-generated anchor value.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Editing the `anchor` on the Tab Menu Item block breaks the sync between the tab panel and its label. The Tab Menu Item block uses the anchor attribute (e.g., tab-1-button) to identify which tab panel it controls. This value is set automatically when the Tabs block is inserted. Because `"anchor": true` was set in the block's supports, an editable "HTML Anchor" field appeared in the Advanced inspector panel. Editing or clearing this value breaks the connection between the menu item and its corresponding tab panel.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removed `"anchor": true` from the block's supports in block.json, which removes the editable "HTML Anchor" UI control. The `anchor` attribute is now declared explicitly under attributes instead, so the value continues to be stored and used internally to match menu items to tab panels; it just can no longer be edited by the user.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new post or page
2. Insert a Tabs block
3. Select one of the Tab Menu Item blocks
4. Open the Advanced panel in the block inspector on the right
5. Confirm there is no "HTML Anchor" field present
6. Verify the tabs still function as expected
