### PR TITLE
Connectors: Sync PHP code with WordPress Core

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *
 		 * @see wp_get_connectors()
 		 *
-		 * @return array Connector settings keyed by connector ID.
+		 * @return array<string, array> The array of registered connectors keyed by connector ID.
 		 *
 		 * @phpstan-return array<string, Connector>
 		 */

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -16,17 +16,17 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 	 * @access private
 	 *
 	 * @phpstan-type Connector array{
-	 *     name: string,
-	 *     description: string,
-	 *     logo_url?: string|null,
-	 *     type: string,
+	 *     name: non-empty-string,
+	 *     description: non-empty-string,
+	 *     logo_url?: non-empty-string,
+	 *     type: 'ai_provider',
 	 *     authentication: array{
-	 *         method: string,
-	 *         credentials_url?: string|null,
-	 *         setting_name?: string
+	 *         method: 'api_key'|'none',
+	 *         credentials_url?: non-empty-string,
+	 *         setting_name?: non-empty-string
 	 *     },
 	 *     plugin?: array{
-	 *         slug: string
+	 *         slug: non-empty-string
 	 *     }
 	 * }
 	 */
@@ -62,7 +62,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *
 		 *     @type string $name           Required. The connector's display name.
 		 *     @type string $description    Optional. The connector's description. Default empty string.
-		 *     @type string|null $logo_url  Optional. URL to the connector's logo image. Default null.
+		 *     @type string $logo_url       Optional. URL to the connector's logo image.
 		 *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
 		 *     @type array  $authentication {
 		 *         Required. Authentication configuration.
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *         @type string      $method          Required. The authentication method: 'api_key' or 'none'.
 		 *         @type string|null $credentials_url Optional. URL where users can obtain API credentials.
 		 *     }
-		 *     @type array  $plugin {
+		 *     @type array  $plugin         {
 		 *         Optional. Plugin data for install/activate UI.
 		 *
 		 *         @type string $slug The WordPress.org plugin slug.
@@ -158,8 +158,10 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 			}
 
 			if ( 'api_key' === $args['authentication']['method'] ) {
-				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'] ?? null;
-				$connector['authentication']['setting_name']    = "connectors_ai_{$id}_api_key";
+				if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
+					$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
+				}
+				$connector['authentication']['setting_name'] = "connectors_ai_{$id}_api_key";
 			}
 
 			if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {
@@ -206,7 +208,8 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *
 		 * @see wp_get_connectors()
 		 *
-		 * @return array<string, array> The array of registered connectors keyed by connector ID.
+		 * @return array Connector settings keyed by connector ID.
+		 *
 		 * @phpstan-return array<string, Connector>
 		 */
 		public function get_all_registered(): array {

--- a/lib/compat/wordpress-7.0/connectors.php
+++ b/lib/compat/wordpress-7.0/connectors.php
@@ -36,7 +36,41 @@ if ( ! function_exists( 'wp_get_connector' ) ) {
 	 * @see WP_Connector_Registry::get_registered()
 	 *
 	 * @param string $id The connector identifier.
-	 * @return array|null The registered connector data, or null if not registered.
+	 * @return array|null {
+	 *     Connector data, or null if not registered.
+	 *
+	 *     @type string $name           The connector's display name.
+	 *     @type string $description    The connector's description.
+	 *     @type string $logo_url       Optional. URL to the connector's logo image.
+	 *     @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+	 *     @type array  $authentication {
+	 *         Authentication configuration. When method is 'api_key', includes
+	 *         credentials_url and setting_name. When 'none', only method is present.
+	 *
+	 *         @type string $method          The authentication method: 'api_key' or 'none'.
+	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
+	 *         @type string $setting_name    Optional. The setting name for the API key.
+	 *     }
+	 *     @type array  $plugin         {
+	 *         Optional. Plugin data for install/activate UI.
+	 *
+	 *         @type string $slug The WordPress.org plugin slug.
+	 *     }
+	 * }
+	 * @phpstan-return ?array{
+	 *     name: non-empty-string,
+	 *     description: non-empty-string,
+	 *     logo_url?: non-empty-string,
+	 *     type: 'ai_provider',
+	 *     authentication: array{
+	 *         method: 'api_key'|'none',
+	 *         credentials_url?: non-empty-string,
+	 *         setting_name?: non-empty-string
+	 *     },
+	 *     plugin?: array{
+	 *         slug: non-empty-string
+	 *     }
+	 * }
 	 */
 	function wp_get_connector( string $id ): ?array {
 		$registry = WP_Connector_Registry::get_instance();
@@ -56,7 +90,45 @@ if ( ! function_exists( 'wp_get_connectors' ) ) {
 	 *
 	 * @see WP_Connector_Registry::get_all_registered()
 	 *
-	 * @return array[] An array of registered connectors keyed by connector ID.
+	 * @return array {
+	 *     Connector settings keyed by connector ID.
+	 *
+	 *     @type array ...$0 {
+	 *         Data for a single connector.
+	 *
+	 *         @type string      $name           The connector's display name.
+	 *         @type string      $description    The connector's description.
+	 *         @type string      $logo_url       Optional. URL to the connector's logo image.
+	 *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
+	 *         @type array       $authentication {
+	 *             Authentication configuration. When method is 'api_key', includes
+	 *             credentials_url and setting_name. When 'none', only method is present.
+	 *
+	 *             @type string $method          The authentication method: 'api_key' or 'none'.
+	 *             @type string $credentials_url Optional. URL where users can obtain API credentials.
+	 *             @type string $setting_name    Optional. The setting name for the API key.
+	 *         }
+	 *         @type array       $plugin         {
+	 *             Optional. Plugin data for install/activate UI.
+	 *
+	 *             @type string $slug The WordPress.org plugin slug.
+	 *         }
+	 *     }
+	 * }
+	 * @phpstan-return array<string, array{
+	 *     name: non-empty-string,
+	 *     description: non-empty-string,
+	 *     logo_url?: non-empty-string,
+	 *     type: 'ai_provider',
+	 *     authentication: array{
+	 *         method: 'api_key'|'none',
+	 *         credentials_url?: non-empty-string,
+	 *         setting_name?: non-empty-string
+	 *     },
+	 *     plugin?: array{
+	 *         slug: non-empty-string
+	 *     }
+	 * }>
 	 */
 	function wp_get_connectors(): array {
 		$registry = WP_Connector_Registry::get_instance();

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -161,10 +161,11 @@ add_action( 'init', '_gutenberg_connectors_init', 15 );
  *
  * @access private
  *
- * @param string $provider_id The provider ID (e.g., 'openai', 'anthropic', 'google').
+ * @param string $provider_id  The provider ID (e.g., 'openai', 'anthropic', 'google').
+ * @param string $setting_name The option name for the API key (e.g., 'connectors_ai_openai_api_key').
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
-function _gutenberg_get_api_key_source( string $provider_id ): string {
+function _gutenberg_get_api_key_source( string $provider_id, string $setting_name ): string {
 	// Convert provider ID to CONSTANT_CASE for env var name.
 	// e.g., 'openai' -> 'OPENAI', 'anthropic' -> 'ANTHROPIC'.
 	$constant_case_id = strtoupper(
@@ -187,8 +188,7 @@ function _gutenberg_get_api_key_source( string $provider_id ): string {
 	}
 
 	// Check database.
-	$setting_name = "connectors_ai_{$provider_id}_api_key";
-	$db_value     = get_option( $setting_name, '' );
+	$db_value = get_option( $setting_name, '' );
 	if ( '' !== $db_value ) {
 		return 'database';
 	}
@@ -251,41 +251,6 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
 }
 
 /**
- * Gets the registered connector settings.
- *
- * @access private
- *
- * @return array {
- *     Connector settings keyed by connector ID.
- *
- *     @type array ...$0 {
- *         Data for a single connector.
- *
- *         @type string $name           The connector's display name.
- *         @type string $description    The connector's description.
- *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
- *         @type array  $plugin         Optional. Plugin data for install/activate UI.
- *             @type string $slug       The WordPress.org plugin slug.
- *         }
- *         @type string $logo_url       Optional. URL to the connector's logo image.
- *         @type array  $authentication {
- *             Authentication configuration. When method is 'api_key', includes
- *             credentials_url and setting_name. When 'none', only method is present.
- *
- *             @type string      $method          The authentication method: 'api_key' or 'none'.
- *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
- *             @type string      $setting_name    Optional. The setting name for the API key.
- *         }
- *     }
- * }
- */
-function _gutenberg_get_connector_settings(): array {
-	$connectors = wp_get_connectors();
-	ksort( $connectors );
-	return $connectors;
-}
-
-/**
  * Masks and validates connector API keys in REST responses.
  *
  * On every `/wp/v2/settings` response, masks connector API key values so raw
@@ -317,9 +282,9 @@ function _gutenberg_connectors_rest_settings_dispatch( WP_REST_Response $respons
 
 	$is_update = 'POST' === $request->get_method() || 'PUT' === $request->get_method();
 
-	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 
@@ -364,7 +329,7 @@ function _gutenberg_register_default_connector_settings(): void {
 
 	$ai_registry = \WordPress\AiClient\AiClient::defaultRegistry();
 
-	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
 		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
@@ -412,7 +377,7 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 
 	try {
 		$ai_registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+		foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 			if ( 'ai_provider' !== $connector_data['type'] ) {
 				continue;
 			}
@@ -427,7 +392,7 @@ function _gutenberg_pass_default_connector_keys_to_ai_client(): void {
 			}
 
 			// Skip if the key is already provided via env var or constant.
-			$key_source = _gutenberg_get_api_key_source( $connector_id );
+			$key_source = _gutenberg_get_api_key_source( $connector_id, $auth['setting_name'] );
 			if ( 'env' === $key_source || 'constant' === $key_source ) {
 				continue;
 			}
@@ -475,14 +440,14 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 	}
 
 	$connectors = array();
-	foreach ( _gutenberg_get_connector_settings() as $connector_id => $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth     = $connector_data['authentication'];
 		$auth_out = array( 'method' => $auth['method'] );
 
 		if ( 'api_key' === $auth['method'] ) {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
-			$auth_out['keySource']      = _gutenberg_get_api_key_source( $connector_id );
+			$auth_out['keySource']      = _gutenberg_get_api_key_source( $connector_id, $auth['setting_name'] ?? '' );
 			try {
 				$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
 			} catch ( Exception $e ) {
@@ -514,6 +479,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 
 		$connectors[ $connector_id ] = $connector_out;
 	}
+	ksort( $connectors );
 	$data['connectors'] = $connectors;
 	return $data;
 }


### PR DESCRIPTION
## Summary

Aligns the Gutenberg connectors PHP backend with the latest WordPress Core refactors to keep the two codebases in sync.

- Validate `credentials_url` in registry `register()` before setting, matching Core's stricter approach
- Update PHPStan type annotations to use stricter types (`non-empty-string`, `'ai_provider'`, `'api_key'|'none'`)
- Add detailed PHPDoc with `@type` annotations on `wp_get_connector()` and `wp_get_connectors()`
- Add second `$setting_name` parameter to `_gutenberg_get_api_key_source()` matching Core's signature
- Add `ai_provider` type check in REST dispatch filter to skip non-AI connectors
- Remove `_gutenberg_get_connector_settings()` helper; call `wp_get_connectors()` directly and `ksort()` only in the script module data function

## Test plan

- [ ] Verify the Connectors settings page loads correctly at Settings > Connectors
- [ ] Verify API key saving and masking still works via the REST API
- [ ] Verify connector registration and display for default providers (Anthropic, Google, OpenAI)
- [ ] Verify env var / constant API key source detection still works