### PR TITLE
Core Data: Fix the list of properties persisted in autosaves

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -730,9 +730,12 @@ export const saveEntityRecord =
 							( acc, key ) => {
 								// These properties are persisted in autosaves.
 								if (
-									[ 'title', 'excerpt', 'content' ].includes(
-										key
-									)
+									[
+										'title',
+										'excerpt',
+										'content',
+										'meta',
+									].includes( key )
 								) {
 									acc[ key ] = newRecord[ key ];
 								} else if ( key === 'status' ) {


### PR DESCRIPTION
## What?
This is a follow-up to #53072.

PR updates the list of persisted properties in autosaves when it's handled as a normal save. The list should include `meta` after #53072.

## Why?
Just a small code quality fix.

## Testing Instructions
This just affects what data is synced back to the store. I couldn't find any bugs. Our e2e test coverage should suffice.
