### PR TITLE
InputLayout.Slot: Forward className prop

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+-   `InputLayout.Slot`: Forward the incoming `className` prop instead of letting it be silently overwritten by the rest spread ([#76459](https://github.com/WordPress/gutenberg/pull/76459)).
 -   `VisuallyHidden`: Add `word-break: normal` to prevent text wrapping issues in screen reader content ([#75539](https://github.com/WordPress/gutenberg/pull/75539)).
 
 ### Enhancements

--- a/packages/ui/src/form/primitives/input-layout/slot.tsx
+++ b/packages/ui/src/form/primitives/input-layout/slot.tsx
@@ -9,13 +9,17 @@ import type { InputLayoutSlotProps } from './types';
 export const InputLayoutSlot = forwardRef<
 	HTMLDivElement,
 	InputLayoutSlotProps
->( function InputLayoutSlot( { padding = 'default', ...restProps }, ref ) {
+>( function InputLayoutSlot(
+	{ padding = 'default', className, ...restProps },
+	ref
+) {
 	return (
 		<div
 			ref={ ref }
 			className={ clsx(
 				styles[ 'input-layout-slot' ],
-				styles[ `is-padding-${ padding }` ]
+				styles[ `is-padding-${ padding }` ],
+				className
 			) }
 			{ ...restProps }
 		/>


### PR DESCRIPTION
## What?

Destructure and merge the incoming `className` prop in `InputLayout.Slot` instead of letting it fall through in the rest spread.

## Why?

`InputLayoutSlotProps` extends `React.HTMLAttributes<HTMLDivElement>`, so consumers can pass `className`. But since it wasn't destructured, it ended up in `restProps` and the spread after the explicit `className` silently overwrote the internal styles.

## How?

Destructure `className` from props and include it in the `clsx()` call, consistent with how `InputLayout` already handles it.

I've also proposed a preventative lint rule in #76458.

## Testing Instructions

No visual changes. Existing Storybook stories for `InputLayout` should render identically.