### PR TITLE
RTC: Add preference for collaborator notifications

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -73,6 +73,7 @@ export function initializeEditor(
 		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
 		showCollaborationCursor: false,
+		showCollaborationNotifications: true,
 	} );
 
 	if ( window.__clientSideMediaProcessing ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -74,6 +74,7 @@ export function initializeEditor( id, settings ) {
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
 		showCollaborationCursor: false,
+		showCollaborationNotifications: true,
 	} );
 
 	if ( window.__clientSideMediaProcessing ) {

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -19,9 +19,13 @@ const mockCreateNotice = jest.fn();
 let mockOnJoinCallback: Function | null = null;
 let mockOnLeaveCallback: Function | null = null;
 let mockOnPostSaveCallback: Function | null = null;
+let lastJoinPostId: unknown;
+let lastLeavePostId: unknown;
+let lastSavePostId: unknown;
 let mockEditorState = {
 	postStatus: 'draft',
 	isCollaborationEnabled: true,
+	showCollaborationNotifications: true,
 };
 
 jest.mock( '@wordpress/data', () => ( {
@@ -31,6 +35,10 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@wordpress/notices', () => ( {
 	store: 'core/notices',
+} ) );
+
+jest.mock( '@wordpress/preferences', () => ( {
+	store: 'core/preferences',
 } ) );
 
 // Mock the editor store to prevent deep import chain (blocks, rich-text, etc.)
@@ -46,17 +54,20 @@ jest.mock( '@wordpress/core-data', () => ( {
 jest.mock( '../../../lock-unlock', () => ( {
 	unlock: jest.fn( () => ( {
 		useOnCollaboratorJoin: jest.fn(
-			( _postId: unknown, _postType: unknown, callback: Function ) => {
+			( postId: unknown, _postType: unknown, callback: Function ) => {
+				lastJoinPostId = postId;
 				mockOnJoinCallback = callback;
 			}
 		),
 		useOnCollaboratorLeave: jest.fn(
-			( _postId: unknown, _postType: unknown, callback: Function ) => {
+			( postId: unknown, _postType: unknown, callback: Function ) => {
+				lastLeavePostId = postId;
 				mockOnLeaveCallback = callback;
 			}
 		),
 		useOnPostSave: jest.fn(
-			( _postId: unknown, _postType: unknown, callback: Function ) => {
+			( postId: unknown, _postType: unknown, callback: Function ) => {
+				lastSavePostId = postId;
 				mockOnPostSaveCallback = callback;
 			}
 		),
@@ -103,21 +114,40 @@ function makeMe( overrides: Record< string, unknown > = {} ) {
 // --- Setup ---
 
 function buildMockSelect() {
-	return () => ( {
-		getCurrentPostAttribute: ( attr: string ) =>
-			attr === 'status' ? mockEditorState.postStatus : undefined,
-		isCollaborationEnabledForCurrentPost: () =>
-			mockEditorState.isCollaborationEnabled,
-	} );
+	return ( storeKey: string ) => {
+		if ( storeKey === 'core/preferences' ) {
+			return {
+				get: ( scope: string, name: string ) => {
+					if (
+						scope === 'core' &&
+						name === 'showCollaborationNotifications'
+					) {
+						return mockEditorState.showCollaborationNotifications;
+					}
+					return undefined;
+				},
+			};
+		}
+		return {
+			getCurrentPostAttribute: ( attr: string ) =>
+				attr === 'status' ? mockEditorState.postStatus : undefined,
+			isCollaborationEnabledForCurrentPost: () =>
+				mockEditorState.isCollaborationEnabled,
+		};
+	};
 }
 
 beforeEach( () => {
 	mockOnJoinCallback = null;
 	mockOnLeaveCallback = null;
 	mockOnPostSaveCallback = null;
+	lastJoinPostId = undefined;
+	lastLeavePostId = undefined;
+	lastSavePostId = undefined;
 	mockEditorState = {
 		postStatus: 'draft',
 		isCollaborationEnabled: true,
+		showCollaborationNotifications: true,
 	};
 	mockCreateNotice.mockClear();
 	( useSelect as jest.Mock ).mockImplementation( ( selector: Function ) =>
@@ -335,6 +365,32 @@ describe( 'useCollaboratorNotifications', () => {
 			);
 
 			expect( mockCreateNotice ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when notifications are disabled', () => {
+		it( 'passes null postId to hooks when showCollaborationNotifications preference is false', () => {
+			mockEditorState = {
+				...mockEditorState,
+				showCollaborationNotifications: false,
+			};
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			expect( lastJoinPostId ).toBeNull();
+			expect( lastLeavePostId ).toBeNull();
+			expect( lastSavePostId ).toBeNull();
+		} );
+
+		it( 'passes null postId to hooks when collaboration is disabled', () => {
+			mockEditorState = {
+				...mockEditorState,
+				isCollaborationEnabled: false,
+			};
+			renderHook( () => useCollaboratorNotifications( 123, 'post' ) );
+
+			expect( lastJoinPostId ).toBeNull();
+			expect( lastLeavePostId ).toBeNull();
+			expect( lastSavePostId ).toBeNull();
 		} );
 	} );
 } );

--- a/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/use-collaborator-notifications.ts
@@ -10,6 +10,7 @@ import {
 	type PostEditorAwarenessState,
 	type PostSaveEvent,
 } from '@wordpress/core-data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -29,16 +30,6 @@ const NOTIFICATION_TYPE = {
 	COLLAB_USER_ENTERED: 'collab-user-entered',
 	COLLAB_USER_EXITED: 'collab-user-exited',
 } as const;
-
-/**
- * Development kill-switches for each notification type. Flip to `false`
- * to suppress a category during local testing without removing code.
- */
-const NOTIFICATIONS_CONFIG = {
-	userEntered: true,
-	userExited: true,
-	postUpdated: true,
-};
 
 const PUBLISHED_STATUSES = [ 'publish', 'private', 'future' ];
 
@@ -77,23 +68,32 @@ export function useCollaboratorNotifications(
 	postId: number | null,
 	postType: string | null
 ): void {
-	const { postStatus, isCollaborationEnabled } = useSelect( ( select ) => {
-		const editorSel = select( editorStore );
-		return {
-			postStatus: editorSel.getCurrentPostAttribute( 'status' ) as
-				| string
-				| undefined,
-			isCollaborationEnabled:
-				editorSel.isCollaborationEnabledForCurrentPost(),
-		};
-	}, [] );
+	const { postStatus, isCollaborationEnabled, showNotifications } = useSelect(
+		( select ) => {
+			const editorSel = select( editorStore );
+			return {
+				postStatus: editorSel.getCurrentPostAttribute( 'status' ) as
+					| string
+					| undefined,
+				isCollaborationEnabled:
+					editorSel.isCollaborationEnabledForCurrentPost(),
+				showNotifications:
+					select( preferencesStore ).get(
+						'core',
+						'showCollaborationNotifications'
+					) ?? true,
+			};
+		},
+		[]
+	);
 
 	const { createNotice } = useDispatch( noticesStore );
 
-	// Pass null when collaboration is disabled to prevent the hooks
-	// from subscribing to awareness state.
-	const effectivePostId = isCollaborationEnabled ? postId : null;
-	const effectivePostType = isCollaborationEnabled ? postType : null;
+	// Pass null when collaboration is disabled or notifications are
+	// turned off to prevent the hooks from subscribing to awareness state.
+	const shouldSubscribe = isCollaborationEnabled && showNotifications;
+	const effectivePostId = shouldSubscribe ? postId : null;
+	const effectivePostType = shouldSubscribe ? postType : null;
 
 	useOnCollaboratorJoin(
 		effectivePostId,
@@ -103,10 +103,6 @@ export function useCollaboratorNotifications(
 				collaborator: PostEditorAwarenessState,
 				me?: PostEditorAwarenessState
 			) => {
-				if ( ! NOTIFICATIONS_CONFIG.userEntered ) {
-					return;
-				}
-
 				/*
 				 * Skip collaborators who were present before the current user
 				 * joined. Their enteredAt is earlier than ours, meaning we're
@@ -143,10 +139,6 @@ export function useCollaboratorNotifications(
 		effectivePostType,
 		useCallback(
 			( collaborator: PostEditorAwarenessState ) => {
-				if ( ! NOTIFICATIONS_CONFIG.userExited ) {
-					return;
-				}
-
 				void createNotice(
 					'info',
 					sprintf(
@@ -174,7 +166,7 @@ export function useCollaboratorNotifications(
 				saver: PostEditorAwarenessState,
 				prevEvent: PostSaveEvent | null
 			) => {
-				if ( ! NOTIFICATIONS_CONFIG.postUpdated || ! postStatus ) {
+				if ( ! postStatus ) {
 					return;
 				}
 

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -132,7 +132,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									scope="core"
 									featureName="showCollaborationNotifications"
 									help={ __(
-										'Show snackbar notifications when collaborators join, leave, or save the post.'
+										'Show notifications when collaborators join, leave, or save the post.'
 									) }
 									label={ __(
 										'Show collaboration notifications'

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -128,6 +128,16 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									) }
 									label={ __( 'Show avatar in blocks' ) }
 								/>
+								<PreferenceToggleControl
+									scope="core"
+									featureName="showCollaborationNotifications"
+									help={ __(
+										'Show snackbar notifications when collaborators join, leave, or save the post.'
+									) }
+									label={ __(
+										'Show collaboration notifications'
+									) }
+								/>
 							</PreferencesModalSection>
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }


### PR DESCRIPTION
## What?
See #75323
Follow-up to [this comment](https://github.com/WordPress/gutenberg/pull/76358#discussion_r2915549058) by @ingeniumed on #76358.

Add a user-facing preference to toggle collaborator session notifications (join, leave, save/publish).

## Why?

A user preference for notifications was [originally proposed](https://github.com/WordPress/gutenberg/issues/75323#issuecomment-3874245493) in #75323 but wasn't included in the first implementation (#76065). This adds it now, following the `showCollaborationCursor` pattern from #76270.

## How?

- Remove the `NOTIFICATIONS_CONFIG` constant and its three guard clauses from `useCollaboratorNotifications`.
- Add a `showCollaborationNotifications` preference (default: `true`) registered in both `edit-post` and `edit-site`.
- Read the preference via `preferencesStore` in `useCollaboratorNotifications`. When `false`, pass `null` as `postId` to the awareness hooks so they skip subscribing entirely — the same pattern used for `isCollaborationEnabled`.
- Add a `PreferenceToggleControl` in Preferences > General > Interface, placed after the "Show avatar in blocks" toggle.
- Add tests for the preference-disabled path and the existing `isCollaborationEnabled: false` path.

## Testing Instructions

1. Open a post in the editor with collaboration enabled.
2. Open **Preferences** (top-right `⋮` menu > Preferences).
3. Go to **General** tab > **Interface** section.
4. Verify the **"Show collaboration notifications"** toggle is visible and enabled by default.
5. With the toggle on, have a second user join/leave/save the post — confirm snackbar notifications appear.
6. Toggle it off. Repeat step 5 — confirm no notifications appear.
7. Toggle it back on — confirm notifications resume.


## Screenshots or screencast

| <img width="1457" height="858" alt="Screenshot 2026-03-12 at 10 11 05 PM" src="https://github.com/user-attachments/assets/088ba94d-124c-4228-b8d1-79b1ab191ce8" /> |
| :---: |
| New preference "Show collaboration notifications" |

