### PR TITLE
Add isNavigationPostEditorKey symbol to fix menu display context

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -48,6 +48,7 @@ import {
 	deviceTypeKey,
 	isIsolatedEditorKey,
 	isNavigationOverlayContextKey,
+	isNavigationPostEditorKey,
 	mediaUploadOnSuccessKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
@@ -130,6 +131,7 @@ lock( privateApis, {
 	deviceTypeKey,
 	isIsolatedEditorKey,
 	isNavigationOverlayContextKey,
+	isNavigationPostEditorKey,
 	mediaUploadOnSuccessKey,
 	useBlockElement,
 	useBlockElementRef,

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -10,4 +10,5 @@ export const deviceTypeKey = Symbol( 'deviceTypeKey' );
 export const isNavigationOverlayContextKey = Symbol(
 	'isNavigationOverlayContext'
 );
+export const isNavigationPostEditorKey = Symbol( 'isNavigationPostEditor' );
 export const mediaUploadOnSuccessKey = Symbol( 'mediaUploadOnSuccess' );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -86,7 +86,7 @@ import {
 	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
 } from '../constants';
 
-const { isIsolatedEditorKey } = unlock( blockEditorPrivateApis );
+const { isNavigationPostEditorKey } = unlock( blockEditorPrivateApis );
 
 /**
  * Component that renders the Add page button for the Navigation block.
@@ -330,15 +330,17 @@ function Navigation( {
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const settings = getSettings();
+
 		return {
 			isPreviewMode: settings.isPreviewMode,
 			onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
 			// Needed to construct the template part ID for the overlay preview.
 			currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
-			// In preview mode or isolated editor, always show navigation expanded (no hamburger)
-			// so users can see and interact with all menu items.
+			// When editing a navigation post directly in an isolated editor,
+			// always show navigation expanded (no hamburger) so users can see
+			// and interact with all menu items.
 			editorDisabledResponsive:
-				settings.isPreviewMode || !! settings?.[ isIsolatedEditorKey ],
+				!! settings?.[ isNavigationPostEditorKey ],
 		};
 	}, [] );
 	const hasAlreadyRendered = isPreviewMode ? false : recursionDetected;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -104,6 +104,7 @@ const {
 	isIsolatedEditorKey,
 	deviceTypeKey,
 	isNavigationOverlayContextKey,
+	isNavigationPostEditorKey,
 	mediaUploadOnSuccessKey,
 } = unlock( privateApis );
 
@@ -391,6 +392,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				'wp_block',
 				'wp_navigation',
 			].includes( postType ),
+			[ isNavigationPostEditorKey ]: postType === 'wp_navigation',
 			// When in template-locked mode (e.g., "Show Template" in the post editor),
 			// don't treat template parts as contentOnly sections.
 			disableContentOnlyForTemplateParts:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76439

When editing a template part that contains a navigation block (e.g. a header with `focusMode=true`), the navigation block's responsive overlay/hamburger menu was incorrectly suppressed — the same as when editing a navigation post directly.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `editorDisabledResponsive` flag relied on `isIsolatedEditorKey`, which is `true` for *any* isolated editor context: `wp_template_part`, `wp_block`, and `wp_navigation`. Only the `wp_navigation` case should disable responsive mode (so the full menu is always visible when editing a nav entity directly).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a new private block-editor setting key `isNavigationPostEditorKey`, set to `true` only when `postType === 'wp_navigation'` in `use-block-editor-settings`. The navigation block uses this narrower key instead of `isIsolatedEditorKey`.

Also removes an unrelated `isPreviewMode` condition from the same check, as it was not needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the site editor on a template, find or add a navigation block in a header template part
- Edit the navigation in the Inspector Sidebar set Overlay Visibility to Always
- The navigation should always show the hamburger menu
- Click through to edit this template part in an isolated editor
- The navigation should still show the hamburger menu
- Go to the Site Editor navigation sidebar
- Find this navigation
- Edit it in the isolated editor
- It should display the full navigation, NOT the hamburger menu
- Shrink the canvas area
- The full navigation should still show and not collapse to a hamburger menu

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


https://github.com/user-attachments/assets/88556341-16db-4c4a-8dda-8632330b8099


