### PR TITLE
Fix "should undo bold" flaky test

### DIFF
--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -177,6 +177,10 @@ test.describe( 'undo', () => {
 		await editor.canvas.locator( '[data-type="core/paragraph"]' ).click();
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
+
+		// Real-time collaboration causes block CRDT content to be updated
+		// asynchronously, and the RTC undo manager relies on up-to-date CRDT
+		// content. Ensure the bold has been applied before trying to undo.
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
@@ -185,6 +189,7 @@ test.describe( 'undo', () => {
 				},
 			},
 		] );
+
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -177,6 +177,14 @@ test.describe( 'undo', () => {
 		await editor.canvas.locator( '[data-type="core/paragraph"]' ).click();
 		await pageUtils.pressKeys( 'primary+a' );
 		await pageUtils.pressKeys( 'primary+b' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '<strong>test</strong>',
+				},
+			},
+		] );
 		await pageUtils.pressKeys( 'primary+z' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/48558.

Roughly since we enabled real-time collaboration to run on tests in https://github.com/WordPress/gutenberg/pull/75699, https://github.com/WordPress/gutenberg/issues/48558 was reopened and showed frequent failures.

This PR fixes the flaky test by waiting for bold to be applied in the text before undoing changes to avoid a race condition.

## Why?

The problem is that there's a `setTimeout(..., 0)` between the action of applying bold and bold getting updated in the CRDT doc, but there's not a delay between sending "CMD+b" and "CMD+z". This is a race condition.

After bold is applied to text in a post, the code in `editEntityRecord` [calls `getSyncManager().update()`](https://github.com/WordPress/gutenberg/blob/2253cc8c48a65e9530b9740ab41d550e0dd3defc/packages/core-data/src/actions.js#L460-L466) with the updated post content. Internally, the `update()` function is [wrapped in a `yieldToEventLoop()`](https://github.com/WordPress/gutenberg/blob/2253cc8c48a65e9530b9740ab41d550e0dd3defc/packages/sync/src/manager.ts#L672), which just does a [`setTimeout()`](https://github.com/WordPress/gutenberg/blob/2253cc8c48a65e9530b9740ab41d550e0dd3defc/packages/sync/src/performance.ts#L47-L49). 

Even though the bold has been applied visually, the CRDT blocks are not updated synchronously. Because the undo manager depends on changes being applied to the YDoc, this creates a race condition. If there's a delay between bold and undo actions, the test works, but if they're too close together the CRDT doc may not receive an update before the undo action.

## How?

This is essentially a test-only problem, because it's difficult and unlikely to fire two chorded keystrokes in the same exact JS event loop with a human-controlled keyboard. As a fix, we can await the bold formatting to be applied to text in `getBlocks()` which happens nearly instantly.

## Testing Instructions

On `trunk`, locally run the test:

```
npm run test:e2e -- --grep="should undo bold"
```

I can usually get it to fail in the first couple of attempts. On this branch `fix/should-undo-bold-flaky` I was able to run the test 30 consecutive times without failure.
