### PR TITLE
Site Editor: Fix unsupported theme flash on direct URL navigation

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/home.js
+++ b/packages/edit-site/src/components/site-editor-routes/home.js
@@ -30,7 +30,7 @@ export const homeRoute = {
 		},
 		mobile( { siteData } ) {
 			if ( ! isThemeDataLoaded( siteData ) ) {
-				return null;
+				return <></>;
 			}
 			return siteData.currentTheme.is_block_theme ||
 				isClassicThemeWithStyleBookSupport( siteData ) ? (

--- a/packages/edit-site/src/components/site-editor-routes/home.js
+++ b/packages/edit-site/src/components/site-editor-routes/home.js
@@ -4,15 +4,17 @@
 import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import Editor from '../editor';
-import { isClassicThemeWithStyleBookSupport } from './utils';
+import { isClassicThemeWithStyleBookSupport, isThemeDataLoaded } from './utils';
 
 export const homeRoute = {
 	name: 'home',
 	path: '/',
 	areas: {
 		sidebar( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ||
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ||
 				isClassicThemeWithStyleBookSupport( siteData ) ? (
 				<SidebarNavigationScreenMain />
 			) : (
@@ -27,8 +29,10 @@ export const homeRoute = {
 			) : undefined;
 		},
 		mobile( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ||
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ||
 				isClassicThemeWithStyleBookSupport( siteData ) ? (
 				<SidebarNavigationScreenMain />
 			) : (

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -10,6 +10,7 @@ import Editor from '../editor';
 import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import { unlock } from '../../lock-unlock';
+import { isThemeDataLoaded } from './utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -29,24 +30,30 @@ export const navigationItemRoute = {
 	path: '/wp_navigation/:postId',
 	areas: {
 		sidebar( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<SidebarNavigationScreenNavigationMenu backPath="/navigation" />
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
 		preview( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<Editor />
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
 		mobile( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<MobileNavigationItemView />
 			) : (
 				<SidebarNavigationScreenUnsupported />

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -51,7 +51,7 @@ export const navigationItemRoute = {
 		},
 		mobile( { siteData } ) {
 			if ( ! isThemeDataLoaded( siteData ) ) {
-				return null;
+				return <></>;
 			}
 			return siteData.currentTheme.is_block_theme ? (
 				<MobileNavigationItemView />

--- a/packages/edit-site/src/components/site-editor-routes/navigation.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation.js
@@ -10,6 +10,7 @@ import Editor from '../editor';
 import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import { unlock } from '../../lock-unlock';
+import { isThemeDataLoaded } from './utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -29,8 +30,10 @@ export const navigationRoute = {
 	path: '/navigation',
 	areas: {
 		sidebar( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<SidebarNavigationScreenNavigationMenus backPath="/" />
 			) : (
 				<SidebarNavigationScreenUnsupported />
@@ -41,8 +44,10 @@ export const navigationRoute = {
 			return isBlockTheme ? <Editor /> : undefined;
 		},
 		mobile( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<MobileNavigationView />
 			) : (
 				<SidebarNavigationScreenUnsupported />

--- a/packages/edit-site/src/components/site-editor-routes/navigation.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation.js
@@ -45,7 +45,7 @@ export const navigationRoute = {
 		},
 		mobile( { siteData } ) {
 			if ( ! isThemeDataLoaded( siteData ) ) {
-				return null;
+				return <></>;
 			}
 			return siteData.currentTheme.is_block_theme ? (
 				<MobileNavigationView />

--- a/packages/edit-site/src/components/site-editor-routes/page-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/page-item.js
@@ -32,7 +32,7 @@ export const pageItemRoute = {
 		},
 		mobile( { siteData } ) {
 			if ( ! isThemeDataLoaded( siteData ) ) {
-				return null;
+				return <></>;
 			}
 			return siteData.currentTheme.is_block_theme ? (
 				<Editor />

--- a/packages/edit-site/src/components/site-editor-routes/page-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/page-item.js
@@ -10,14 +10,17 @@ import Editor from '../editor';
 import DataViewsSidebarContent from '../sidebar-dataviews';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
+import { isThemeDataLoaded } from './utils';
 
 export const pageItemRoute = {
 	name: 'page-item',
 	path: '/page/:postId',
 	areas: {
 		sidebar( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<SidebarNavigationScreen
 					title={ __( 'Pages' ) }
 					backPath="/"
@@ -28,16 +31,20 @@ export const pageItemRoute = {
 			);
 		},
 		mobile( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<Editor />
 			) : (
 				<SidebarNavigationScreenUnsupported />
 			);
 		},
 		preview( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<Editor />
 			) : (
 				<SidebarNavigationScreenUnsupported />

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -16,6 +16,7 @@ import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-uns
 import DataViewsSidebarContent from '../sidebar-dataviews';
 import PostList from '../post-list';
 import { unlock } from '../../lock-unlock';
+import { isThemeDataLoaded } from './utils';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -51,8 +52,10 @@ export const pagesRoute = {
 	path: '/page',
 	areas: {
 		sidebar( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<SidebarNavigationScreen
 					title={ __( 'Pages' ) }
 					backPath="/"
@@ -75,8 +78,10 @@ export const pagesRoute = {
 			return isList ? <Editor /> : undefined;
 		},
 		mobile( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<MobilePagesView />
 			) : (
 				<SidebarNavigationScreenUnsupported />

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -79,7 +79,7 @@ export const pagesRoute = {
 		},
 		mobile( { siteData } ) {
 			if ( ! isThemeDataLoaded( siteData ) ) {
-				return null;
+				return <></>;
 			}
 			return siteData.currentTheme.is_block_theme ? (
 				<MobilePagesView />

--- a/packages/edit-site/src/components/site-editor-routes/stylebook.js
+++ b/packages/edit-site/src/components/site-editor-routes/stylebook.js
@@ -10,7 +10,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import { unlock } from '../../lock-unlock';
-import { isClassicThemeWithStyleBookSupport } from './utils';
+import { isClassicThemeWithStyleBookSupport, isThemeDataLoaded } from './utils';
 
 const { StyleBookPreview } = unlock( editorPrivateApis );
 
@@ -19,6 +19,9 @@ export const stylebookRoute = {
 	path: '/stylebook',
 	areas: {
 		sidebar( { siteData } ) {
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
 			return isClassicThemeWithStyleBookSupport( siteData ) ? (
 				<SidebarNavigationScreen
 					title={ __( 'Styles' ) }

--- a/packages/edit-site/src/components/site-editor-routes/template-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/template-item.js
@@ -19,7 +19,7 @@ const areas = {
 	},
 	mobile( { siteData } ) {
 		if ( ! isThemeDataLoaded( siteData ) ) {
-			return null;
+			return <></>;
 		}
 		return siteData.currentTheme.is_block_theme ? (
 			<Editor />

--- a/packages/edit-site/src/components/site-editor-routes/template-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/template-item.js
@@ -4,27 +4,34 @@
 import Editor from '../editor';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
+import { isThemeDataLoaded } from './utils';
 
 const areas = {
 	sidebar( { siteData } ) {
-		const isBlockTheme = siteData.currentTheme?.is_block_theme;
-		return isBlockTheme ? (
+		if ( ! isThemeDataLoaded( siteData ) ) {
+			return null;
+		}
+		return siteData.currentTheme.is_block_theme ? (
 			<SidebarNavigationScreenTemplatesBrowse backPath="/" />
 		) : (
 			<SidebarNavigationScreenUnsupported />
 		);
 	},
 	mobile( { siteData } ) {
-		const isBlockTheme = siteData.currentTheme?.is_block_theme;
-		return isBlockTheme ? (
+		if ( ! isThemeDataLoaded( siteData ) ) {
+			return null;
+		}
+		return siteData.currentTheme.is_block_theme ? (
 			<Editor />
 		) : (
 			<SidebarNavigationScreenUnsupported />
 		);
 	},
 	preview( { siteData } ) {
-		const isBlockTheme = siteData.currentTheme?.is_block_theme;
-		return isBlockTheme ? (
+		if ( ! isThemeDataLoaded( siteData ) ) {
+			return null;
+		}
+		return siteData.currentTheme.is_block_theme ? (
 			<Editor />
 		) : (
 			<SidebarNavigationScreenUnsupported />

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -72,7 +72,7 @@ export const templatesRoute = {
 		},
 		mobile( { siteData } ) {
 			if ( ! isThemeDataLoaded( siteData ) ) {
-				return null;
+				return <></>;
 			}
 			if ( ! siteData.currentTheme.is_block_theme ) {
 				return <SidebarNavigationScreenUnsupported />;

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -14,6 +14,7 @@ import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-uns
 import PageTemplates from '../page-templates';
 import PageTemplatesLegacy from '../page-templates/index-legacy';
 import { unlock } from '../../lock-unlock';
+import { isThemeDataLoaded } from './utils';
 
 async function isTemplateListView( query ) {
 	const { activeView = 'active' } = query;
@@ -39,8 +40,10 @@ export const templatesRoute = {
 	path: '/template',
 	areas: {
 		sidebar( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			return isBlockTheme ? (
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			return siteData.currentTheme.is_block_theme ? (
 				<SidebarNavigationScreenTemplatesBrowse backPath="/" />
 			) : (
 				<SidebarNavigationScreenUnsupported />
@@ -68,8 +71,10 @@ export const templatesRoute = {
 			return isListView ? <Editor /> : undefined;
 		},
 		mobile( { siteData } ) {
-			const isBlockTheme = siteData.currentTheme?.is_block_theme;
-			if ( ! isBlockTheme ) {
+			if ( ! isThemeDataLoaded( siteData ) ) {
+				return null;
+			}
+			if ( ! siteData.currentTheme.is_block_theme ) {
 				return <SidebarNavigationScreenUnsupported />;
 			}
 			// Check if the template activation experiment is enabled.

--- a/packages/edit-site/src/components/site-editor-routes/utils.js
+++ b/packages/edit-site/src/components/site-editor-routes/utils.js
@@ -1,4 +1,16 @@
 /**
+ * Check if the current theme data has been loaded from the REST API.
+ *
+ * @param {Object} siteData - The site data provided by the site editor route area resolvers.
+ * @return {boolean} True if the theme data is available, false otherwise.
+ */
+export function isThemeDataLoaded( siteData ) {
+	return (
+		siteData.currentTheme !== undefined && siteData.currentTheme !== null
+	);
+}
+
+/**
  * Check if the classic theme supports the stylebook.
  *
  * @param {Object} siteData - The site data provided by the site editor route area resolvers.


### PR DESCRIPTION
## What?

Fix a brief flash of "The theme you are currently using does not support this screen" when navigating directly to a Site Editor URL with a block theme.

This closes issue #76462

## Why?

When loading a Site Editor URL directly (e.g. `?p=%2Fwp_template%2F...&canvas=edit`), the route area resolvers check `siteData.currentTheme?.is_block_theme` to decide whether to render the actual content or `<SidebarNavigationScreenUnsupported />`. However, `currentTheme` is fetched asynchronously via the REST API and is initially `null`. The optional chaining evaluates to `undefined` (falsy), so the resolvers briefly render the unsupported theme warning before the theme data arrives and the correct UI takes over.

## How?

Add an `isThemeDataLoaded()` helper to `utils.js` that checks whether `currentTheme` has been populated yet. Area resolvers that render `<SidebarNavigationScreenUnsupported />` now return `null` early when theme data is still pending, rendering nothing in those slots until the theme type is actually known. Areas that already returned `undefined` for non-block themes (like `preview` and `content`) are unaffected since they were already safe.

This is an AI-assisted contribution (Claude). All code has been reviewed and tested by the author.

## Testing Instructions

1. Start `wp-env` with a block theme active (e.g. Twenty Twenty-Five).
2. Navigate directly to a Site Editor template URL, e.g.: `/wp-admin/site-editor.php?p=%2Fwp_template%2Fpub%2Ftwentytwentyfive%2F%2Findex&canvas=edit`
3. Verify the "The theme you are currently using does not support this screen" warning does **not** flash in the sidebar.
4. To make the race condition a bit more visible, use DevTools Network throttling; with this fix the screen should remain empty until the correct content loads.
5. Switch to a classic theme and visit `/wp-admin/site-editor.php`. Verify the unsupported theme warning still appears and persists as expected.

Screen | Before | After
----|---|------
Navigation | https://github.com/user-attachments/assets/fc791c75-75e5-4d83-8f91-9c0fceccead5 | https://github.com/user-attachments/assets/0e74af1b-5275-444c-8439-9d082d494943
Page list | https://github.com/user-attachments/assets/da59ca7f-ec83-4a99-823b-24a37cd4c37d | https://github.com/user-attachments/assets/bd881171-ba9d-4c66-9481-def4a55aa523
Page | https://github.com/user-attachments/assets/b2087400-a838-434b-b54f-c1315f8671e8 | https://github.com/user-attachments/assets/b7e40ece-cf06-4e13-b1de-d506ba83b181
Template library | https://github.com/user-attachments/assets/58730437-aef4-4218-87ef-d9842e4ba7af | https://github.com/user-attachments/assets/20fefd33-a1f6-4379-8934-126526374ee8


### Testing Instructions for Keyboard

No UI interaction changes — this only affects the timing of what renders in existing layout areas.









