### PR TITLE
Admin UI: Add Storybook stories for Breadcrumbs and Page components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57896,6 +57896,7 @@
 				"@wordpress/components": "file:../components",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",
 				"@wordpress/ui": "file:../ui",
 				"clsx": "^2.1.1"

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -49,6 +49,7 @@
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",
 		"@wordpress/ui": "file:../ui",
 		"clsx": "^2.1.1"

--- a/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
+++ b/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
@@ -19,7 +19,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
  * Internal dependencies
  */
 import Breadcrumbs from '..';
-import '../style.scss';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',

--- a/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
+++ b/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
@@ -2,37 +2,17 @@
  * External dependencies
  */
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import {
-	createMemoryHistory,
-	createRootRoute,
-	createRouter,
-	RouterContextProvider,
-} from '@tanstack/react-router';
 
 /**
  * Internal dependencies
  */
 import Breadcrumbs from '..';
-
-const rootRoute = createRootRoute( {
-	notFoundComponent: () => null,
-} );
-const router = createRouter( {
-	routeTree: rootRoute,
-	history: createMemoryHistory( { initialEntries: [ '/' ] } ),
-	defaultNotFoundComponent: () => null,
-} );
+import { withRouter } from '../../stories/with-router';
 
 const meta: Meta< typeof Breadcrumbs > = {
 	component: Breadcrumbs,
 	title: 'Admin UI/Breadcrumbs',
-	decorators: [
-		( Story ) => (
-			<RouterContextProvider router={ router }>
-				<Story />
-			</RouterContextProvider>
-		),
-	],
+	decorators: [ withRouter ],
 };
 
 export default meta;

--- a/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
+++ b/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
@@ -10,22 +10,9 @@ import {
 } from '@tanstack/react-router';
 
 /**
- * WordPress dependencies
- */
-import { privateApis as themeApis } from '@wordpress/theme';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-
-/**
  * Internal dependencies
  */
 import Breadcrumbs from '..';
-
-const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-	'@wordpress/theme'
-);
-
-const { ThemeProvider } = unlock( themeApis );
 
 const rootRoute = createRootRoute( {
 	notFoundComponent: () => null,
@@ -41,11 +28,9 @@ const meta: Meta< typeof Breadcrumbs > = {
 	title: 'Admin UI/Breadcrumbs',
 	decorators: [
 		( Story ) => (
-			<ThemeProvider isRoot>
-				<RouterContextProvider router={ router }>
-					<Story />
-				</RouterContextProvider>
-			</ThemeProvider>
+			<RouterContextProvider router={ router }>
+				<Story />
+			</RouterContextProvider>
 		),
 	],
 };

--- a/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
+++ b/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRouter,
+	RouterContextProvider,
+} from '@tanstack/react-router';
+
+/**
+ * WordPress dependencies
+ */
+import { privateApis as themeApis } from '@wordpress/theme';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+/**
+ * Internal dependencies
+ */
+import Breadcrumbs from '..';
+import '../style.scss';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/theme'
+);
+
+const { ThemeProvider } = unlock( themeApis );
+
+const rootRoute = createRootRoute( {
+	notFoundComponent: () => null,
+} );
+const router = createRouter( {
+	routeTree: rootRoute,
+	history: createMemoryHistory( { initialEntries: [ '/' ] } ),
+	defaultNotFoundComponent: () => null,
+} );
+
+const meta: Meta< typeof Breadcrumbs > = {
+	component: Breadcrumbs,
+	title: 'Admin UI/Breadcrumbs',
+	decorators: [
+		( Story ) => (
+			<ThemeProvider isRoot>
+				<RouterContextProvider router={ router }>
+					<Story />
+				</RouterContextProvider>
+			</ThemeProvider>
+		),
+	],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const SingleItem: Story = {
+	args: {
+		items: [ { label: 'Root breadcrumb' } ],
+	},
+};
+
+export const TwoLevels: Story = {
+	args: {
+		items: [
+			{ label: 'Root breadcrumb', to: '/settings' },
+			{ label: 'Level 1 breadcrumb' },
+		],
+	},
+};
+
+export const ThreeLevels: Story = {
+	args: {
+		items: [
+			{ label: 'Root breadcrumb', to: '/settings' },
+			{ label: 'Level 1 breadcrumb', to: '/settings/connectors' },
+			{ label: 'Level 2 breadcrumb' },
+		],
+	},
+};

--- a/packages/admin-ui/src/lock-unlock.ts
+++ b/packages/admin-ui/src/lock-unlock.ts
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/admin-ui'
+	);

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -8,7 +8,7 @@ import {
 	createRouter,
 	RouterContextProvider,
 } from '@tanstack/react-router';
-
+import { __experimentalText as Text } from '@wordpress/components';
 /**
  * WordPress dependencies
  */
@@ -66,7 +66,7 @@ export const Default: Story = {
 		title: 'Page title',
 		showSidebarToggle: false,
 		children: (
-			<div style={ { padding: '24px 24px' } }>Page content here</div>
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
 		),
 	},
 };
@@ -77,7 +77,7 @@ export const WithSubtitle: Story = {
 		subTitle: 'All of the subtitle text you need goes here.',
 		showSidebarToggle: false,
 		children: (
-			<div style={ { padding: '24px 24px' } }>Page content here</div>
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
 		),
 	},
 };
@@ -94,10 +94,11 @@ export const WithBreadcrumbs: Story = {
 			/>
 		),
 		children: (
-			<div style={ { padding: '24px 24px' } }>Page content here</div>
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
 		),
 	},
 };
+
 export const WithBreadcrumbsAndSubtitle: Story = {
 	args: {
 		showSidebarToggle: false,
@@ -111,7 +112,7 @@ export const WithBreadcrumbsAndSubtitle: Story = {
 			/>
 		),
 		children: (
-			<div style={ { padding: '24px 24px' } }>Page content here</div>
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
 		),
 	},
 };

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -2,12 +2,6 @@
  * External dependencies
  */
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import {
-	createMemoryHistory,
-	createRootRoute,
-	createRouter,
-	RouterContextProvider,
-} from '@tanstack/react-router';
 import { __experimentalText as Text } from '@wordpress/components';
 
 /**
@@ -15,15 +9,7 @@ import { __experimentalText as Text } from '@wordpress/components';
  */
 import Page from '..';
 import Breadcrumbs from '../../breadcrumbs';
-
-const rootRoute = createRootRoute( {
-	notFoundComponent: () => null,
-} );
-const router = createRouter( {
-	routeTree: rootRoute,
-	history: createMemoryHistory( { initialEntries: [ '/' ] } ),
-	defaultNotFoundComponent: () => null,
-} );
+import { withRouter } from '../../stories/with-router';
 
 const meta: Meta< typeof Page > = {
 	component: Page,
@@ -31,15 +17,7 @@ const meta: Meta< typeof Page > = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	decorators: [
-		( Story ) => (
-			<RouterContextProvider router={ router }>
-				<div style={ { height: '400px' } }>
-					<Story />
-				</div>
-			</RouterContextProvider>
-		),
-	],
+	decorators: [ withRouter ],
 };
 
 export default meta;

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRouter,
+	RouterContextProvider,
+} from '@tanstack/react-router';
+
+/**
+ * WordPress dependencies
+ */
+import { privateApis as themeApis } from '@wordpress/theme';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+/**
+ * Internal dependencies
+ */
+import Page from '..';
+import Breadcrumbs from '../../breadcrumbs';
+import '../../style.scss';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/theme'
+);
+
+const { ThemeProvider } = unlock( themeApis );
+
+const rootRoute = createRootRoute( {
+	notFoundComponent: () => null,
+} );
+const router = createRouter( {
+	routeTree: rootRoute,
+	history: createMemoryHistory( { initialEntries: [ '/' ] } ),
+	defaultNotFoundComponent: () => null,
+} );
+
+const meta: Meta< typeof Page > = {
+	component: Page,
+	title: 'Admin UI/Page',
+	parameters: {
+		layout: 'fullscreen',
+	},
+	decorators: [
+		( Story ) => (
+			<ThemeProvider isRoot>
+				<RouterContextProvider router={ router }>
+					<div style={ { height: '400px' } }>
+						<Story />
+					</div>
+				</RouterContextProvider>
+			</ThemeProvider>
+		),
+	],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const Default: Story = {
+	args: {
+		title: 'Page title',
+		showSidebarToggle: false,
+		children: (
+			<div style={ { padding: '24px 24px' } }>Page content here</div>
+		),
+	},
+};
+
+export const WithSubtitle: Story = {
+	args: {
+		title: 'Page title',
+		subTitle: 'All of the subtitle text you need goes here.',
+		showSidebarToggle: false,
+		children: (
+			<div style={ { padding: '24px 24px' } }>Page content here</div>
+		),
+	},
+};
+
+export const WithBreadcrumbs: Story = {
+	args: {
+		showSidebarToggle: false,
+		breadcrumbs: (
+			<Breadcrumbs
+				items={ [
+					{ label: 'Root breadcrumb', to: '/connectors' },
+					{ label: 'Level 1 breadcrumb' },
+				] }
+			/>
+		),
+		children: (
+			<div style={ { padding: '24px 24px' } }>Page content here</div>
+		),
+	},
+};
+export const WithBreadcrumbsAndSubtitle: Story = {
+	args: {
+		showSidebarToggle: false,
+		subTitle: 'All of the subtitle text you need goes here.',
+		breadcrumbs: (
+			<Breadcrumbs
+				items={ [
+					{ label: 'Root breadcrumb', to: '/connectors' },
+					{ label: 'Level 1 breadcrumb' },
+				] }
+			/>
+		),
+		children: (
+			<div style={ { padding: '24px 24px' } }>Page content here</div>
+		),
+	},
+};

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -20,7 +20,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
  */
 import Page from '..';
 import Breadcrumbs from '../../breadcrumbs';
-import '../../style.scss';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -9,24 +9,12 @@ import {
 	RouterContextProvider,
 } from '@tanstack/react-router';
 import { __experimentalText as Text } from '@wordpress/components';
-/**
- * WordPress dependencies
- */
-import { privateApis as themeApis } from '@wordpress/theme';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 /**
  * Internal dependencies
  */
 import Page from '..';
 import Breadcrumbs from '../../breadcrumbs';
-
-const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-	'@wordpress/theme'
-);
-
-const { ThemeProvider } = unlock( themeApis );
 
 const rootRoute = createRootRoute( {
 	notFoundComponent: () => null,
@@ -45,13 +33,11 @@ const meta: Meta< typeof Page > = {
 	},
 	decorators: [
 		( Story ) => (
-			<ThemeProvider isRoot>
-				<RouterContextProvider router={ router }>
-					<div style={ { height: '400px' } }>
-						<Story />
-					</div>
-				</RouterContextProvider>
-			</ThemeProvider>
+			<RouterContextProvider router={ router }>
+				<div style={ { height: '400px' } }>
+					<Story />
+				</div>
+			</RouterContextProvider>
 		),
 	],
 };

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -17,7 +17,14 @@ const meta: Meta< typeof Page > = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	decorators: [ withRouter ],
+	decorators: [
+		( Story ) => (
+			<div style={ { minHeight: '400px' } }>
+				<Story />
+			</div>
+		),
+		withRouter,
+	],
 };
 
 export default meta;

--- a/packages/admin-ui/src/stories/with-router.tsx
+++ b/packages/admin-ui/src/stories/with-router.tsx
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as routePrivateApis } from '@wordpress/route';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { createMemoryHistory, createRootRoute, createRouter, RouterProvider } =
+	unlock( routePrivateApis );
+
+/**
+ * Storybook decorator that provides a router context.
+ *
+ * Wraps stories in a minimal tanstack router (via @wordpress/route private
+ * APIs) so that components consuming `Link` from `@wordpress/route` can
+ * render without errors.
+ */
+export function withRouter( Story: React.ComponentType ) {
+	const rootRoute = createRootRoute( { component: Story } );
+	const router = createRouter( {
+		routeTree: rootRoute,
+		history: createMemoryHistory( { initialEntries: [ '/' ] } ),
+		defaultNotFoundComponent: () => null,
+	} );
+	return <RouterProvider router={ router } />;
+}

--- a/packages/admin-ui/tsconfig.json
+++ b/packages/admin-ui/tsconfig.json
@@ -5,6 +5,7 @@
 		{ "path": "../components" },
 		{ "path": "../element" },
 		{ "path": "../i18n" },
+		{ "path": "../private-apis" },
 		{ "path": "../route" },
 		{ "path": "../ui" }
 	]

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -10,6 +10,7 @@
  * The list of core modules allowed to opt-in to the private APIs.
  */
 const CORE_MODULES_USING_PRIVATE_APIS = [
+	'@wordpress/admin-ui',
 	'@wordpress/block-directory',
 	'@wordpress/block-editor',
 	'@wordpress/block-library',

--- a/packages/route/src/private-apis.ts
+++ b/packages/route/src/private-apis.ts
@@ -6,6 +6,7 @@ import {
 	createBrowserHistory,
 	createLazyRoute,
 	createLink,
+	createMemoryHistory,
 	createRootRoute,
 	createRoute,
 	createRouter,
@@ -38,6 +39,7 @@ lock( privateApis, {
 	// Router creation and setup
 	createBrowserHistory,
 	createLazyRoute,
+	createMemoryHistory,
 	createRouter,
 	createRootRoute,
 	createRoute,

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -33,6 +33,7 @@ const stories = [
 	'../packages/theme/src/**/stories/*.story.@(tsx|mdx)',
 	'../packages/ui/src/**/stories/*.mdx',
 	'../packages/ui/src/**/stories/*.story.@(ts|tsx)',
+	'../packages/admin-ui/src/**/stories/*.story.@(ts|tsx)',
 ].filter( Boolean );
 
 const config: StorybookConfig = {

--- a/storybook/package-styles/admin-ui-ltr.lazy.scss
+++ b/storybook/package-styles/admin-ui-ltr.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/admin-ui/build-style/style.css";

--- a/storybook/package-styles/admin-ui-rtl.lazy.scss
+++ b/storybook/package-styles/admin-ui-rtl.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/admin-ui/build-style/style-rtl.css";

--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -17,6 +17,8 @@ import fieldsLtr from '../package-styles/fields-ltr.lazy.scss?inline';
 import fieldsRtl from '../package-styles/fields-rtl.lazy.scss?inline';
 import mediaFieldsLtr from '../package-styles/media-fields-ltr.lazy.scss?inline';
 import mediaFieldsRtl from '../package-styles/media-fields-rtl.lazy.scss?inline';
+import adminUiLtr from '../package-styles/admin-ui-ltr.lazy.scss?inline';
+import adminUiRtl from '../package-styles/admin-ui-rtl.lazy.scss?inline';
 import designTokens from '../package-styles/design-tokens.lazy.scss?inline';
 
 /**
@@ -72,6 +74,11 @@ const CONFIG = [
 		componentIdMatcher: /^fields-/,
 		ltr: [ componentsLtr, dataviewsLtr, fieldsLtr, mediaFieldsLtr ],
 		rtl: [ componentsRtl, dataviewsRtl, fieldsRtl, mediaFieldsRtl ],
+	},
+	{
+		componentIdMatcher: /^admin-ui-/,
+		ltr: [ designTokens, componentsLtr, adminUiLtr ],
+		rtl: [ designTokens, componentsRtl, adminUiRtl ],
 	},
 	{
 		componentIdMatcher: /^design-system-/,


### PR DESCRIPTION
## What?

Adds Storybook stories for the `Breadcrumbs` and `Page` components in the `@wordpress/admin-ui` package.

See #76448

<img width="312" height="341" alt="image" src="https://github.com/user-attachments/assets/5eb84087-39bc-49f6-86d8-ccca56541b31" />


## Why?

The admin-ui package currently has no Storybook coverage for its components. Adding stories enables visual development, design review, and documentation for these components as work continues on the Admin UI visual tweaks tracked in #76448.

## How?

- Added a stories glob for `packages/admin-ui` in `storybook/main.ts`
- Created Breadcrumbs stories: `SingleItem`, `TwoLevels`, `ThreeLevels` — demonstrating breadcrumb links and heading levels
- Created Page stories: `Default`, `WithSubtitle`, `WithBreadcrumbs`, `WithBreadcrumbsAndSubtitle` — demonstrating the Page layout with various header configurations
- Stories are wrapped with `ThemeProvider` (from `@wordpress/theme`) and `RouterContextProvider` (from `@tanstack/react-router`) to match the runtime environment

## Testing Instructions

1. Run `npm run storybook:dev`
2. Navigate to the **Admin UI** section in the sidebar
3. Verify **Breadcrumbs** stories render correctly:
   - `SingleItem`: single breadcrumb, no separator
   - `TwoLevels`: first item is a link, second is a heading, separated by `/`
   - `ThreeLevels`: first two items are links, last is a heading, separated by `/`
4. Verify **Page** stories render correctly:
   - `Default`: page with title
   - `WithSubtitle`: page with title and subtitle
   - `WithBreadcrumbs`: page with breadcrumb navigation (first breadcrumb is a link)
   - `WithBreadcrumbsAndSubtitle`: page with breadcrumbs and subtitle together

## Testing Instructions for Keyboard

1. Tab through the Breadcrumbs stories — linked breadcrumb items should be focusable and navigable via keyboard
2. Verify the `nav` element has an appropriate `aria-label` ("Breadcrumbs")