### PR TITLE
[Command Palette]: Add "Log Out" command

### DIFF
--- a/lib/compat/wordpress-6.9/command-palette.php
+++ b/lib/compat/wordpress-6.9/command-palette.php
@@ -10,6 +10,7 @@ function gutenberg_enqueue_command_palette_assets() {
 
 	$command_palette_settings = array(
 		'is_network_admin' => is_network_admin(),
+		'logout_url'       => wp_logout_url(),
 	);
 
 	/**

--- a/packages/core-commands/src/admin-commands.js
+++ b/packages/core-commands/src/admin-commands.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useCommands } from '@wordpress/commands';
+import { __ } from '@wordpress/i18n';
+import { login } from '@wordpress/icons';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Registers global admin commands for the Command Palette.
+ *
+ * @param {string} logoutUrl The URL to log the user out.
+ */
+export function useAdminCommands( logoutUrl ) {
+	const commands = useMemo( () => {
+		if ( ! logoutUrl ) {
+			return [];
+		}
+
+		return [
+			{
+				name: 'core/log-out',
+				label: __( 'Log Out' ),
+				icon: login,
+				callback: ( { close } ) => {
+					close();
+					document.location.href = logoutUrl;
+				},
+			},
+		];
+	}, [ logoutUrl ] );
+
+	useCommands( commands );
+}

--- a/packages/core-commands/src/index.js
+++ b/packages/core-commands/src/index.js
@@ -9,6 +9,7 @@ import { CommandMenu } from '@wordpress/commands';
  * Internal dependencies
  */
 import { useAdminNavigationCommands } from './admin-navigation-commands';
+import { useAdminCommands } from './admin-commands';
 import { useSiteEditorNavigationCommands } from './site-editor-navigation-commands';
 import { unlock } from './lock-unlock';
 export { privateApis } from './private-apis';
@@ -17,10 +18,14 @@ const { RouterProvider } = unlock( routerPrivateApis );
 
 // Register core commands and render the Command Palette.
 function CommandPalette( { settings } ) {
-	const { menu_commands: menuCommands, is_network_admin: isNetworkAdmin } =
-		settings;
+	const {
+		menu_commands: menuCommands,
+		is_network_admin: isNetworkAdmin,
+		logout_url: logoutUrl,
+	} = settings;
 	useAdminNavigationCommands( menuCommands );
 	useSiteEditorNavigationCommands( isNetworkAdmin );
+	useAdminCommands( logoutUrl );
 	return (
 		<RouterProvider pathArg="p">
 			<CommandMenu />

--- a/packages/core-commands/src/private-apis.js
+++ b/packages/core-commands/src/private-apis.js
@@ -2,12 +2,14 @@
  * Internal dependencies
  */
 import { useAdminNavigationCommands } from './admin-navigation-commands';
+import { useAdminCommands } from './admin-commands';
 import { useSiteEditorNavigationCommands } from './site-editor-navigation-commands';
 import { lock } from './lock-unlock';
 
 function useCommands() {
 	useAdminNavigationCommands();
 	useSiteEditorNavigationCommands();
+	useAdminCommands();
 }
 
 export const privateApis = {};


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Open Questions Before I mark it ready.
- Do you think the PHP changes need to go in 6.9 or 7.0 (duplicated again)? Is there any documentation for the same?
- Would it be better to register them in Site Navigation or separately? ( I think separate would be good)

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76457

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Command Palette currently lacks a log out command. Users relying on keyboard-driven workflows must leave the editor context to log out — typically navigating to the admin bar or a separate screen. This breaks flow for power users and is inconsistent with the Command Palette's goal of surfacing common admin actions.

As the Command Palette expands beyond block editors into broader wp-admin (tracked in #58218), user-account actions like logging out are a natural fit. Log Out is already accessible via the admin bar — a core navigation element — and other keyboard-centric tools (VS Code, Linear, Notion) treat session management as a first-class palette command.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
PHP (lib/compat/wordpress-6.9/command-palette.php):

- Added logout_url to the command palette settings via wp_logout_url(), consistent with how other admin URLs are passed to the JS runtime.

JS (packages/core-commands/src/):

- New file admin-commands.js — registers a core/log-out command using the useCommands hook. Uses the login icon from @wordpress/icons.
- Modified index.js — destructures logout_url from settings and calls useAdminCommands( logoutUrl ).
- Modified private-apis.js — adds useAdminCommands() to the private API code path.

## Testing Instructions

1. Open any wp-admin page
2. Open the Command Palette (Cmd+K / Ctrl+K)
3. Type "log out" — verify the Log Out command appears
4. Select it — verify you are redirected to the login screen

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/379fcf4e-42ff-4836-9851-ad9946e43973

