### PR TITLE
Admin UI: Add visual prop to Page header component

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   `Page`: Add `visual` prop to render an icon or image alongside the header title or breadcrumbs, outside the `h2` tag. [#76469](https://github.com/WordPress/gutenberg/pull/76469)
+-   `Page`: Add `visual` prop to render a decorative-only icon or image alongside the header title or breadcrumbs. [#76469](https://github.com/WordPress/gutenberg/pull/76469)
 
 ## 1.12.0 (2026-04-15)
 

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   `Page`: Add `visual` prop to render an icon or image alongside the header title or breadcrumbs, outside the `h2` tag. [#76469](https://github.com/WordPress/gutenberg/pull/76469)
+
 ## 1.12.0 (2026-04-15)
 
 ### Enhancements

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -12,7 +12,7 @@ export default function Header( {
 	headingLevel = 2,
 	breadcrumbs,
 	badges,
-	logo,
+	icon,
 	title,
 	subTitle,
 	actions,
@@ -21,7 +21,7 @@ export default function Header( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
-	logo?: React.ReactNode;
+	icon?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle: React.ReactNode;
 	actions?: React.ReactNode;
@@ -42,9 +42,9 @@ export default function Header( {
 							className="admin-ui-page__sidebar-toggle-slot"
 						/>
 					) }
-					{ logo && (
-						<div className="admin-ui-page__header-logo">
-							{ logo }
+					{ icon && (
+						<div className="admin-ui-page__header-icon">
+							{ icon }
 						</div>
 					) }
 					{ title && (

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -12,6 +12,7 @@ export default function Header( {
 	headingLevel = 2,
 	breadcrumbs,
 	badges,
+	logo,
 	title,
 	subTitle,
 	actions,
@@ -20,6 +21,7 @@ export default function Header( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
+	logo?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle: React.ReactNode;
 	actions?: React.ReactNode;
@@ -39,6 +41,11 @@ export default function Header( {
 							bubblesVirtually
 							className="admin-ui-page__sidebar-toggle-slot"
 						/>
+					) }
+					{ logo && (
+						<div className="admin-ui-page__header-logo">
+							{ logo }
+						</div>
 					) }
 					{ title && (
 						<HeadingTag className="admin-ui-page__header-title">

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -12,7 +12,7 @@ export default function Header( {
 	headingLevel = 2,
 	breadcrumbs,
 	badges,
-	icon,
+	visual,
 	title,
 	subTitle,
 	actions,
@@ -21,7 +21,7 @@ export default function Header( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
-	icon?: React.ReactNode;
+	visual?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle: React.ReactNode;
 	actions?: React.ReactNode;
@@ -42,9 +42,9 @@ export default function Header( {
 							className="admin-ui-page__sidebar-toggle-slot"
 						/>
 					) }
-					{ icon && (
-						<div className="admin-ui-page__header-icon">
-							{ icon }
+					{ visual && (
+						<div className="admin-ui-page__header-visual">
+							{ visual }
 						</div>
 					) }
 					{ title && (

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -43,7 +43,10 @@ export default function Header( {
 						/>
 					) }
 					{ visual && (
-						<div className="admin-ui-page__header-visual">
+						<div
+							className="admin-ui-page__header-visual"
+							aria-hidden="true"
+						>
 							{ visual }
 						</div>
 					) }

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -14,7 +14,7 @@ function Page( {
 	headingLevel,
 	breadcrumbs,
 	badges,
-	logo,
+	icon,
 	title,
 	subTitle,
 	children,
@@ -27,7 +27,7 @@ function Page( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
-	logo?: React.ReactNode;
+	icon?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle?: React.ReactNode;
 	children: React.ReactNode;
@@ -43,12 +43,12 @@ function Page( {
 
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ effectiveAriaLabel }>
-			{ ( title || breadcrumbs || badges || actions || logo ) && (
+			{ ( title || breadcrumbs || badges || actions || icon ) && (
 				<Header
 					headingLevel={ headingLevel }
 					breadcrumbs={ breadcrumbs }
 					badges={ badges }
-					logo={ logo }
+					icon={ icon }
 					title={ title }
 					subTitle={ subTitle }
 					actions={ actions }

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -27,6 +27,17 @@ function Page( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
+	/**
+	 * Optional visual mark (icon, image, etc.) shown before the page title or breadcrumbs.
+	 *
+	 * The visual is rendered outside the page heading element and is treated as purely
+	 * decorative in the accessibility tree (the wrapper uses `aria-hidden`). Do not pass
+	 * interactive content (links, buttons, tooltips) or non-redundant text here.
+	 *
+	 * When passing an `<img>`, use `alt=""` if the image does not add meaning beyond what is
+	 * already available in the visible title, breadcrumbs, or surrounding copy. Meaningful
+	 * images should not rely on this slot for their accessible name.
+	 */
 	visual?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle?: React.ReactNode;

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -14,6 +14,7 @@ function Page( {
 	headingLevel,
 	breadcrumbs,
 	badges,
+	logo,
 	title,
 	subTitle,
 	children,
@@ -26,6 +27,7 @@ function Page( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
+	logo?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle?: React.ReactNode;
 	children: React.ReactNode;
@@ -41,11 +43,12 @@ function Page( {
 
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ effectiveAriaLabel }>
-			{ ( title || breadcrumbs || badges || actions ) && (
+			{ ( title || breadcrumbs || badges || actions || logo ) && (
 				<Header
 					headingLevel={ headingLevel }
 					breadcrumbs={ breadcrumbs }
 					badges={ badges }
+					logo={ logo }
 					title={ title }
 					subTitle={ subTitle }
 					actions={ actions }

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -14,7 +14,7 @@ function Page( {
 	headingLevel,
 	breadcrumbs,
 	badges,
-	icon,
+	visual,
 	title,
 	subTitle,
 	children,
@@ -27,7 +27,7 @@ function Page( {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
-	icon?: React.ReactNode;
+	visual?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle?: React.ReactNode;
 	children: React.ReactNode;
@@ -43,12 +43,12 @@ function Page( {
 
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ effectiveAriaLabel }>
-			{ ( title || breadcrumbs || badges || actions || icon ) && (
+			{ ( title || breadcrumbs || badges || actions || visual ) && (
 				<Header
 					headingLevel={ headingLevel }
 					breadcrumbs={ breadcrumbs }
 					badges={ badges }
-					icon={ icon }
+					visual={ visual }
 					title={ title }
 					subTitle={ subTitle }
 					actions={ actions }

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -95,6 +95,12 @@ export const WithVisualAndBreadcrumbs: Story = {
 	},
 };
 
+/**
+ * Demonstrates that large images are constrained by the header visual styles.
+ *
+ * The `img` uses an empty `alt` because the visual region is hidden from assistive
+ * technologies and the page title carries the accessible name.
+ */
 export const WithImageVisual: Story = {
 	args: {
 		title: 'Page title',

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -13,30 +13,6 @@ import Page from '..';
 import Breadcrumbs from '../../breadcrumbs';
 import { withRouter } from '../../stories/with-router';
 
-const JetpackLogo = ( {
-	height = 32,
-	width = 32,
-}: {
-	height?: number;
-	width?: number;
-} ) => (
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		x="0px"
-		y="0px"
-		viewBox="0 0 32 32"
-		height={ height }
-		width={ width }
-		// role="img" is required to prevent VoiceOver on Safari reading the content of the SVG
-		role="img"
-	>
-		<path
-			fill="#069e08"
-			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
-		/>
-	</svg>
-);
-
 const meta: Meta< typeof Page > = {
 	component: Page,
 	title: 'Admin UI/Page',
@@ -92,20 +68,19 @@ export const WithBreadcrumbs: Story = {
 	},
 };
 
-export const WithLogo: Story = {
+export const WithIcon: Story = {
 	args: {
 		title: 'Page title',
-		logo: <Icon icon={ wordpress } size={ 24 } />,
+		icon: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
 	},
 };
 
-export const WithLogoAndBreadcrumbs: Story = {
+export const WithIconAndBreadcrumbs: Story = {
 	args: {
-		logo: <Icon icon={ wordpress } size={ 24 } />,
+		icon: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
 		breadcrumbs: (
 			<Breadcrumbs
@@ -115,38 +90,8 @@ export const WithLogoAndBreadcrumbs: Story = {
 				] }
 			/>
 		),
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
-	},
-};
-
-export const WithJetpackLogo: Story = {
-	args: {
-		title: 'Jetpack',
-		logo: <JetpackLogo width={ 20 } />,
-		showSidebarToggle: false,
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
-	},
-};
-
-export const WithJetpackLogoAndBreadcrumbs: Story = {
-	args: {
-		logo: <JetpackLogo width={ 20 } />,
-		showSidebarToggle: false,
-		breadcrumbs: (
-			<Breadcrumbs
-				items={ [
-					{ label: 'Root breadcrumb', to: '/connectors' },
-					{ label: 'Level 1 breadcrumb' },
-				] }
-			/>
-		),
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
 	},
 };
 

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -100,7 +100,7 @@ export const WithImageVisual: Story = {
 		title: 'Page title',
 		visual: (
 			<img
-				src="https://s.w.org/about/images/logos/wordpress-logo-notext-rgb.png"
+				src="https://secure.gravatar.com/avatar/c0ccdd53794779bcc07fcae7b79c4d80?s=48&r=g&d=mm"
 				alt="Page visual"
 			/>
 		),

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -95,6 +95,21 @@ export const WithIconAndBreadcrumbs: Story = {
 	},
 };
 
+export const WithImageIcon: Story = {
+	args: {
+		title: 'Page title',
+		icon: (
+			<img
+				src="https://s.w.org/about/images/logos/wordpress-logo-notext-rgb.png"
+				alt="Page icon"
+			/>
+		),
+		showSidebarToggle: false,
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
+	},
+};
+
 export const WithBreadcrumbsAndSubtitle: Story = {
 	args: {
 		showSidebarToggle: false,

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -4,6 +4,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 // eslint-disable-next-line @wordpress/use-recommended-components -- admin-ui is a bundled package that depends on @wordpress/ui
 import { Badge, Button, Text } from '@wordpress/ui';
+import { Icon, wordpress } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -33,18 +34,6 @@ const JetpackLogo = ( {
 			fill="#069e08"
 			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
 		/>
-	</svg>
-);
-
-const GlobeLogo = () => (
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 24 24"
-		fill="currentColor"
-		width={ 24 }
-		height={ 24 }
-	>
-		<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
 	</svg>
 );
 
@@ -106,7 +95,7 @@ export const WithBreadcrumbs: Story = {
 export const WithLogo: Story = {
 	args: {
 		title: 'Page title',
-		logo: <GlobeLogo />,
+		logo: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
 		children: (
 			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
@@ -116,7 +105,7 @@ export const WithLogo: Story = {
 
 export const WithLogoAndBreadcrumbs: Story = {
 	args: {
-		logo: <GlobeLogo />,
+		logo: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
 		breadcrumbs: (
 			<Breadcrumbs

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -101,7 +101,7 @@ export const WithImageVisual: Story = {
 		visual: (
 			<img
 				src="https://secure.gravatar.com/avatar/c0ccdd53794779bcc07fcae7b79c4d80?s=48&r=g&d=mm"
-				alt="Page visual"
+				alt=""
 			/>
 		),
 		showSidebarToggle: false,

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -12,6 +12,42 @@ import Page from '..';
 import Breadcrumbs from '../../breadcrumbs';
 import { withRouter } from '../../stories/with-router';
 
+const JetpackLogo = ( {
+	height = 32,
+	width = 32,
+}: {
+	height?: number;
+	width?: number;
+} ) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		x="0px"
+		y="0px"
+		viewBox="0 0 32 32"
+		height={ height }
+		width={ width }
+		// role="img" is required to prevent VoiceOver on Safari reading the content of the SVG
+		role="img"
+	>
+		<path
+			fill="#069e08"
+			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
+		/>
+	</svg>
+);
+
+const GlobeLogo = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="currentColor"
+		width={ 24 }
+		height={ 24 }
+	>
+		<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+	</svg>
+);
+
 const meta: Meta< typeof Page > = {
 	component: Page,
 	title: 'Admin UI/Page',
@@ -64,6 +100,64 @@ export const WithBreadcrumbs: Story = {
 		),
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
+	},
+};
+
+export const WithLogo: Story = {
+	args: {
+		title: 'Page title',
+		logo: <GlobeLogo />,
+		showSidebarToggle: false,
+		children: (
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
+		),
+	},
+};
+
+export const WithLogoAndBreadcrumbs: Story = {
+	args: {
+		logo: <GlobeLogo />,
+		showSidebarToggle: false,
+		breadcrumbs: (
+			<Breadcrumbs
+				items={ [
+					{ label: 'Root breadcrumb', to: '/connectors' },
+					{ label: 'Level 1 breadcrumb' },
+				] }
+			/>
+		),
+		children: (
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
+		),
+	},
+};
+
+export const WithJetpackLogo: Story = {
+	args: {
+		title: 'Jetpack',
+		logo: <JetpackLogo width={ 20 } />,
+		showSidebarToggle: false,
+		children: (
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
+		),
+	},
+};
+
+export const WithJetpackLogoAndBreadcrumbs: Story = {
+	args: {
+		logo: <JetpackLogo width={ 20 } />,
+		showSidebarToggle: false,
+		breadcrumbs: (
+			<Breadcrumbs
+				items={ [
+					{ label: 'Root breadcrumb', to: '/connectors' },
+					{ label: 'Level 1 breadcrumb' },
+				] }
+			/>
+		),
+		children: (
+			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
+		),
 	},
 };
 

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -68,19 +68,19 @@ export const WithBreadcrumbs: Story = {
 	},
 };
 
-export const WithIcon: Story = {
+export const WithVisual: Story = {
 	args: {
 		title: 'Page title',
-		icon: <Icon icon={ wordpress } size={ 24 } />,
+		visual: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
 	},
 };
 
-export const WithIconAndBreadcrumbs: Story = {
+export const WithVisualAndBreadcrumbs: Story = {
 	args: {
-		icon: <Icon icon={ wordpress } size={ 24 } />,
+		visual: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
 		breadcrumbs: (
 			<Breadcrumbs
@@ -95,13 +95,13 @@ export const WithIconAndBreadcrumbs: Story = {
 	},
 };
 
-export const WithImageIcon: Story = {
+export const WithImageVisual: Story = {
 	args: {
 		title: 'Page title',
-		icon: (
+		visual: (
 			<img
 				src="https://s.w.org/about/images/logos/wordpress-logo-notext-rgb.png"
-				alt="Page icon"
+				alt="Page visual"
 			/>
 		),
 		showSidebarToggle: false,
@@ -183,6 +183,7 @@ export const WithActions: Story = {
 
 export const FullHeader: Story = {
 	args: {
+		visual: <Icon icon={ wordpress } size={ 24 } />,
 		subTitle: 'All of the subtitle text you need goes here.',
 		breadcrumbs: (
 			<Breadcrumbs

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -30,7 +30,7 @@
 	white-space: nowrap;
 }
 
-.admin-ui-page__header-logo {
+.admin-ui-page__header-icon {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -34,6 +34,7 @@
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
+	// TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-sm.
 	width: 24px;
 	height: 24px;
 

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -41,9 +41,9 @@
 	img,
 	svg {
 		display: block;
-		width: 24px;
-		height: 24px;
-		object-fit: contain;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
 	}
 }
 

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -30,6 +30,18 @@
 	white-space: nowrap;
 }
 
+.admin-ui-page__header-logo {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+
+	img,
+	svg {
+		display: block;
+		object-fit: contain;
+	}
+}
+
 .admin-ui-page__sidebar-toggle-slot:empty {
 	display: none;
 }

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -34,10 +34,14 @@
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
+	width: 24px;
+	height: 24px;
 
 	img,
 	svg {
 		display: block;
+		width: 24px;
+		height: 24px;
 		object-fit: contain;
 	}
 }

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -30,7 +30,7 @@
 	white-space: nowrap;
 }
 
-.admin-ui-page__header-icon {
+.admin-ui-page__header-visual {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -31,19 +31,19 @@
 }
 
 .admin-ui-page__header-visual {
-	display: flex;
-	align-items: center;
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-template-rows: 1fr;
 	flex-shrink: 0;
 	// TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-sm.
 	width: 24px;
 	height: 24px;
 
-	img,
-	svg {
-		display: block;
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
+	> * {
+		grid-column: 1 / -1;
+		grid-row: 1 / -1;
+		max-width: 100%;
+		max-height: 100%;
 	}
 }
 


### PR DESCRIPTION
See design convo https://github.com/WordPress/gutenberg/issues/76709

## What?

Adds a `visual` prop to the Page component's header, allowing consumers to display a logo or symbol alongside the title or breadcrumbs.

See https://github.com/WordPress/gutenberg/issues/76448

> **Note:** This PR depends on #76467 (Storybook stories for admin-ui). The story files in this diff include both the base stories from that PR and the new logo stories. The implementation changes are in `header.tsx`, `index.tsx`, and `style.scss`.

<img width="631" height="271" alt="image" src="https://github.com/user-attachments/assets/ed4a1adb-088f-483c-a846-3aca8b87a8ee" />

<img width="595" height="264" alt="image" src="https://github.com/user-attachments/assets/b3f72012-65c2-4601-8b18-680eca60543d" />


## Why?

As described in https://github.com/WordPress/gutenberg/issues/76448, consumers currently pass logos inside the `title` prop, which places them inside the `h2` tag. This is fragile and creates accessibility issues — when the title contains non-text content, a separate `ariaLabel` must be passed to maintain good semantics (see https://github.com/WordPress/gutenberg/issues/75898).

An officially supported `visual` prop renders the logo **outside** the `h2` tag, ensuring:
- Consistent logo placement across consumers
- Proper semantic structure (visual is not part of the heading tag)
- No need for a separate `ariaLabel` if the only difference is the visual between `title` and `ariaLabel`.

## How?

- Added `visual?: React.ReactNode` prop to `Page` (`index.tsx`) and `Header` (`header.tsx`)
- Logo renders before the title/breadcrumbs in the header row, wrapped in a `div.admin-ui-page__header-logo`
- Added CSS for the logo container: flex-centered, non-shrinking, with `object-fit: contain` for img/svg children
- Added Storybook stories demonstrating the logo with title, with breadcrumbs, and with a Jetpack logo

## Testing Instructions

1. Run `npm run storybook:dev`
2. Navigate to **Admin UI > Page** in the sidebar
3. Check the following stories:
   - `With Logo`: globe icon + "Page title" heading
   - `With Jetpack Logo`: Jetpack icon + "Jetpack" heading
   - `With Logo And Breadcrumbs`: globe icon + breadcrumb navigation
   - `With Jetpack Logo And Breadcrumbs`: Jetpack icon + breadcrumb navigation
4. Verify the logo appears to the left of the title/breadcrumbs
5. Inspect the DOM — the logo should be **outside** the `h2` element

## Testing Instructions for Keyboard

1. Tab through the stories — the logo container should not be focusable (it's decorative
2. The heading and breadcrumb links should remain keyboard accessible
EOF
)