### PR TITLE
Components: Add allowForms prop to SandBox component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 -   `GradientPicker`: Add `selectedSlug` prop for slug-based selection and pass the selected preset's slug to `onChange`, so two presets sharing a gradient keep their identity ([#80554](https://github.com/WordPress/gutenberg/pull/80554)).
 -   `SandBox`: Add `allowPopups` prop to opt into `allow-popups` in the iframe's sandbox attribute ([#69617](https://github.com/WordPress/gutenberg/pull/69617)).
+-   `SandBox`: Add `allowForms` prop to opt into `allow-forms` in the iframe's sandbox attribute ([#76471](https://github.com/WordPress/gutenberg/pull/76471)).
 -   Validated form controls: Only move focus to the invalid control for trusted `invalid` events (form submission, `reportValidity()`). Consumers can now dispatch a synthetic `invalid` event to reveal a control's error message without disturbing the user's place in the form ([#80685](https://github.com/WordPress/gutenberg/pull/80685)).
 
 ### Bug Fixes

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -268,6 +268,7 @@ function IsolatedSandBox( {
 	onFocus,
 	tabIndex,
 	allowPopups = false,
+	allowForms = false,
 }: SandBoxContentProps ) {
 	const ref = useRef< HTMLIFrameElement >( null );
 	const [ width, setWidth ] = useState( 0 );
@@ -275,6 +276,7 @@ function IsolatedSandBox( {
 
 	const sandbox = clsx( 'allow-scripts', 'allow-presentation', {
 		'allow-popups': allowPopups,
+		'allow-forms': allowForms,
 	} );
 
 	const srcDoc = useMemo(
@@ -393,6 +395,7 @@ function SameOriginSandBox( {
 	onFocus,
 	tabIndex,
 	allowPopups = false,
+	allowForms = false,
 }: SandBoxContentProps ) {
 	const ref = useRef< HTMLIFrameElement >( null );
 	const [ width, setWidth ] = useState( 0 );
@@ -404,6 +407,7 @@ function SameOriginSandBox( {
 		'allow-presentation',
 		{
 			'allow-popups': allowPopups,
+			'allow-forms': allowForms,
 		}
 	);
 

--- a/packages/components/src/sandbox/stories/index.story.tsx
+++ b/packages/components/src/sandbox/stories/index.story.tsx
@@ -36,4 +36,11 @@ const Template: StoryFn< typeof SandBox > = ( args ) => <SandBox { ...args } />;
 export const Default = Template.bind( {} );
 Default.args = {
 	html: '<p>Arbitrary HTML content</p>',
+	allowForms: false,
+};
+
+export const WithForm = Template.bind( {} );
+WithForm.args = {
+	html: '<form action="#"><label for="name">Name</label><input id="name" type="text" /><button type="submit">Submit</button></form>',
+	allowForms: true,
 };

--- a/packages/components/src/sandbox/test/index.tsx
+++ b/packages/components/src/sandbox/test/index.tsx
@@ -70,6 +70,27 @@ describe( 'SandBox', () => {
 		);
 	} );
 
+	it( 'should not include allow-forms by default', () => {
+		render( <SandBox html="<p>Hello</p>" title="No Forms" /> );
+
+		const iframe = screen.getByTitle< HTMLIFrameElement >( 'No Forms' );
+
+		expect( iframe.getAttribute( 'sandbox' ) ).not.toContain(
+			'allow-forms'
+		);
+	} );
+
+	it( 'should include allow-forms when allowForms is set', () => {
+		render( <SandBox html="<p>Hello</p>" title="Forms" allowForms /> );
+
+		const iframe = screen.getByTitle< HTMLIFrameElement >( 'Forms' );
+
+		expect( iframe ).toHaveAttribute(
+			'sandbox',
+			'allow-scripts allow-presentation allow-forms'
+		);
+	} );
+
 	it( 'should set srcdoc with the provided html content', () => {
 		render( <SandBox html="<p>Hello</p>" title="Test Title" /> );
 

--- a/packages/components/src/sandbox/types.ts
+++ b/packages/components/src/sandbox/types.ts
@@ -22,6 +22,16 @@ export type SandBoxProps = {
 	 */
 	allowPopups?: boolean;
 	/**
+	 * Whether to include `allow-forms` in the iframe's sandbox attribute.
+	 * When true, content inside the iframe is allowed to submit forms.
+	 *
+	 * Enable this for previews whose content includes forms that should be
+	 * submittable.
+	 *
+	 * @default false
+	 */
+	allowForms?: boolean;
+	/**
 	 * The HTML to render in the body of the iframe document.
 	 *
 	 * @default ''

--- a/storybook/components-manifest.yml
+++ b/storybook/components-manifest.yml
@@ -803,6 +803,7 @@
       - style
 - name: SandBox
   props:
+      - allowForms
       - allowPopups
       - allowSameOrigin
       - html


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #48942

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently there is no way to allow forms in the Sandbox component, so in cases where that is necessary, like submitting your date of birth to view age-restricted content, the submission is blocked. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding an `allowForms` prop to the SandBox component that includes `allow-forms` to the iframe, making it possible to allow it selectively.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Storybook can be used for that.
1- Run storybook with `npm run storybook:dev`
2 - Go to Components > Utilities > SandBox > With Form
3 - Check that you can submit the form
4 - Disable allowForms and reload
5 - Check that you can't submit the form

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Claude Code was used to generate tests.