### PR TITLE
Add/configurable viewport values theme json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -152,6 +152,16 @@ Settings related to position.
 
 ---
 
+### responsive
+
+Settings related to responsive behavior.
+
+| Property | Description | Type | Default |
+| -------- | ----------- | ---- | ------- |
+| viewports | Viewport size overrides for block visibility. Override the size of the mobile and/or tablet breakpoints. Desktop has no size value and cannot be overridden. | `[ { name, slug, size } ]` |  |
+
+---
+
 ### shadow
 
 Settings related to shadows.

--- a/lib/block-supports/block-visibility.php
+++ b/lib/block-supports/block-visibility.php
@@ -67,6 +67,18 @@ function gutenberg_render_block_visibility_support( $block_content, $block ) {
 			),
 		);
 
+		// Allow theme/user-defined viewports to override default size values by slug.
+		$theme_viewports = gutenberg_get_global_settings()['responsive']['viewports'] ?? null;
+		if ( is_array( $theme_viewports ) ) {
+			$theme_sizes = array_column( $theme_viewports, 'size', 'slug' );
+			foreach ( $viewport_sizes as &$viewport ) {
+				if ( isset( $theme_sizes[ $viewport['slug'] ] ) ) {
+					$viewport['size'] = $theme_sizes[ $viewport['slug'] ];
+				}
+			}
+			unset( $viewport );
+		}
+
 		/*
 		 * Build media queries from viewport size definitions using the CSS range syntax.
 		 * Could be absorbed into the style engine,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -446,6 +446,9 @@ class WP_Theme_JSON_Gutenberg {
 			'fixed'  => null,
 			'sticky' => null,
 		),
+		'responsive'                    => array(
+			'viewports' => null,
+		),
 		'spacing'                       => array(
 			'customSpacingSize'   => null,
 			'defaultSpacingSizes' => null,
@@ -880,6 +883,15 @@ class WP_Theme_JSON_Gutenberg {
 			$spacing_scale_sizes  = static::compute_spacing_sizes( $spacing_scale );
 			$merged_spacing_sizes = static::merge_spacing_sizes( $spacing_scale_sizes, $spacing_sizes );
 			_wp_array_set( $this->theme_json, $sizes_path, $merged_spacing_sizes );
+		}
+
+		// Validate theme/user-defined viewports. If invalid, remove so consumers fall back to defaults.
+		if ( in_array( $origin, array( 'theme', 'custom' ), true ) ) {
+			$viewports_path = array( 'settings', 'responsive', 'viewports' );
+			$viewports      = _wp_array_get( $this->theme_json, $viewports_path, null );
+			if ( null !== $viewports && ! static::is_valid_viewports( $viewports ) ) {
+				_wp_array_set( $this->theme_json, $viewports_path, null );
+			}
 		}
 	}
 
@@ -5043,5 +5055,66 @@ class WP_Theme_JSON_Gutenberg {
 		if ( isset( $block_metadata['path'] ) ) {
 			return $block_metadata['path'][2];
 		}
+	}
+
+	/**
+	 * Validates theme-defined viewport definitions.
+	 *
+	 * @since 7.1
+	 *
+	 * @param mixed $viewports Value from settings.responsive.viewports.
+	 * @return bool Whether the viewports are valid.
+	 */
+	protected static function is_valid_viewports( $viewports ): bool {
+		if ( ! is_array( $viewports ) ) {
+			return false;
+		}
+
+		// MVP: only mobile and tablet sizes can be overridden (desktop has no size value).
+		$allowed_slugs = array( 'mobile', 'tablet' );
+		$count         = count( $viewports );
+		if ( $count < 1 || $count > 2 ) {
+			return false;
+		}
+
+		$seen_slugs    = array();
+		$previous_size = 0;
+
+		foreach ( $viewports as $viewport ) {
+			// Required fields.
+			if ( empty( $viewport['slug'] ) || ! is_string( $viewport['slug'] ) ) {
+				return false;
+			}
+
+			// Slug must be mobile or tablet.
+			if ( ! in_array( $viewport['slug'], $allowed_slugs, true ) ) {
+				return false;
+			}
+
+			// No duplicate slugs.
+			if ( in_array( $viewport['slug'], $seen_slugs, true ) ) {
+				return false;
+			}
+			$seen_slugs[] = $viewport['slug'];
+
+			// Size is required for both mobile and tablet.
+			if ( empty( $viewport['size'] ) ) {
+				return false;
+			}
+
+			// Only px values for now.
+			if ( ! preg_match( '/^(\d+)px$/', $viewport['size'], $matches ) ) {
+				return false;
+			}
+
+			// Ascending order (catches mobile >= tablet if both provided).
+			$size = (int) $matches[1];
+			if ( $size <= $previous_size ) {
+				return false;
+			}
+			$previous_size = $size;
+		}
+
+		return true;
 	}
 }

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -230,6 +230,13 @@
 				}
 			]
 		},
+		"responsive": {
+			"viewports": [
+				{ "name": "Mobile", "slug": "mobile", "size": "480px" },
+				{ "name": "Tablet", "slug": "tablet", "size": "782px" },
+				{ "name": "Desktop", "slug": "desktop" }
+			]
+		},
 		"shadow": {
 			"defaultPresets": true,
 			"presets": [

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility-viewports.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility-viewports.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockVisibilityViewports } from '../use-block-visibility-viewports';
+import { BLOCK_VISIBILITY_VIEWPORTS } from '../constants';
+
+jest.mock( '../../use-settings', () => ( {
+	useSettings: jest.fn(),
+} ) );
+
+import { useSettings } from '../../use-settings';
+
+describe( 'useBlockVisibilityViewports', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns the default viewports when no theme viewports are defined', () => {
+		useSettings.mockReturnValue( [ undefined ] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		expect( result.current ).toBe( BLOCK_VISIBILITY_VIEWPORTS );
+	} );
+
+	it( 'returns the default viewports when theme viewports is an empty array', () => {
+		useSettings.mockReturnValue( [ [] ] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		expect( result.current ).toBe( BLOCK_VISIBILITY_VIEWPORTS );
+	} );
+
+	it( 'merges a mobile size override into the defaults', () => {
+		useSettings.mockReturnValue( [
+			[ { slug: 'mobile', size: '600px' } ],
+		] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		expect( result.current.mobile.size ).toBe( '600px' );
+		expect( result.current.tablet ).toBe(
+			BLOCK_VISIBILITY_VIEWPORTS.tablet
+		);
+		expect( result.current.desktop ).toBe(
+			BLOCK_VISIBILITY_VIEWPORTS.desktop
+		);
+	} );
+
+	it( 'merges a tablet size override into the defaults', () => {
+		useSettings.mockReturnValue( [
+			[ { slug: 'tablet', size: '900px' } ],
+		] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		expect( result.current.tablet.size ).toBe( '900px' );
+		expect( result.current.mobile ).toBe(
+			BLOCK_VISIBILITY_VIEWPORTS.mobile
+		);
+	} );
+
+	it( 'merges both mobile and tablet size overrides', () => {
+		useSettings.mockReturnValue( [
+			[
+				{ slug: 'mobile', size: '600px' },
+				{ slug: 'tablet', size: '900px' },
+			],
+		] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		expect( result.current.mobile.size ).toBe( '600px' );
+		expect( result.current.tablet.size ).toBe( '900px' );
+	} );
+
+	it( 'preserves label and icon from defaults when overriding size', () => {
+		useSettings.mockReturnValue( [
+			[ { slug: 'mobile', size: '600px' } ],
+		] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		expect( result.current.mobile.label ).toBe(
+			BLOCK_VISIBILITY_VIEWPORTS.mobile.label
+		);
+		expect( result.current.mobile.icon ).toBe(
+			BLOCK_VISIBILITY_VIEWPORTS.mobile.icon
+		);
+	} );
+
+	it( 'ignores unknown slugs in theme viewports', () => {
+		useSettings.mockReturnValue( [
+			[ { slug: 'desktop', size: '1200px' } ],
+		] );
+
+		const { result } = renderHook( () => useBlockVisibilityViewports() );
+
+		// desktop has no size in defaults and the hook should not add one
+		expect( result.current.desktop.size ).toBeUndefined();
+	} );
+} );

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -6,30 +6,38 @@ import { renderHook } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
-import { useViewportMatch } from '@wordpress/compose';
+import { useMediaQuery } from '@wordpress/compose';
 
-// Mock WordPress dependencies before importing the hook
 jest.mock( '@wordpress/compose', () => ( {
-	useViewportMatch: jest.fn(),
+	useMediaQuery: jest.fn(),
+} ) );
+
+jest.mock( '../use-block-visibility-viewports', () => ( {
+	useBlockVisibilityViewports: jest.fn(),
 } ) );
 
 /**
  * Internal dependencies
  */
 import useBlockVisibility from '../use-block-visibility';
+import { useBlockVisibilityViewports } from '../use-block-visibility-viewports';
+import { BLOCK_VISIBILITY_VIEWPORTS } from '../constants';
 
 describe( 'useBlockVisibility', () => {
 	// Helper function to set up viewport matches
 	const setupViewport = ( { isMobileOrLarger, isMediumOrLarger } ) => {
+		useBlockVisibilityViewports.mockReturnValue(
+			BLOCK_VISIBILITY_VIEWPORTS
+		);
 		if (
 			isMobileOrLarger !== undefined &&
 			isMediumOrLarger !== undefined
 		) {
-			useViewportMatch
+			useMediaQuery
 				.mockReturnValueOnce( isMobileOrLarger )
 				.mockReturnValueOnce( isMediumOrLarger );
 		} else {
-			useViewportMatch.mockReturnValue(
+			useMediaQuery.mockReturnValue(
 				isMobileOrLarger ?? isMediumOrLarger ?? true
 			);
 		}
@@ -312,6 +320,48 @@ describe( 'useBlockVisibility', () => {
 				} )
 			);
 
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+	} );
+
+	describe( 'Theme breakpoint overrides', () => {
+		it( 'uses theme-defined mobile size for viewport detection', () => {
+			useBlockVisibilityViewports.mockReturnValue( {
+				...BLOCK_VISIBILITY_VIEWPORTS,
+				mobile: { ...BLOCK_VISIBILITY_VIEWPORTS.mobile, size: '600px' },
+			} );
+			useMediaQuery
+				.mockReturnValueOnce( false ) // not larger than mobile
+				.mockReturnValueOnce( false ); // not larger than tablet
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( {
+					blockVisibility: { viewport: { mobile: false } },
+					deviceType: 'desktop',
+				} )
+			);
+
+			expect( result.current.currentViewport ).toBe( 'mobile' );
+			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
+		} );
+
+		it( 'uses theme-defined tablet size for viewport detection', () => {
+			useBlockVisibilityViewports.mockReturnValue( {
+				...BLOCK_VISIBILITY_VIEWPORTS,
+				tablet: { ...BLOCK_VISIBILITY_VIEWPORTS.tablet, size: '900px' },
+			} );
+			useMediaQuery
+				.mockReturnValueOnce( true ) // larger than mobile
+				.mockReturnValueOnce( false ); // not larger than tablet
+
+			const { result } = renderHook( () =>
+				useBlockVisibility( {
+					blockVisibility: { viewport: { tablet: false } },
+					deviceType: 'desktop',
+				} )
+			);
+
+			expect( result.current.currentViewport ).toBe( 'tablet' );
 			expect( result.current.isBlockCurrentlyHidden ).toBe( true );
 		} );
 	} );

--- a/packages/block-editor/src/components/block-visibility/use-block-visibility-viewports.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility-viewports.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { useSettings } from '../use-settings';
+import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
+
+/**
+ * Returns the resolved viewport definitions for block visibility, merging
+ * any theme-defined size overrides into the defaults.
+ *
+ * Themes can override the `size` of the `mobile` and/or `tablet` viewports
+ * via `settings.responsive.viewports` in theme.json. The `desktop` viewport
+ * has no size value and cannot be overridden.
+ *
+ * @return {Object} Viewport definitions keyed by slug.
+ */
+export function useBlockVisibilityViewports() {
+	const [ themeViewports ] = useSettings( 'responsive.viewports' );
+
+	if ( ! themeViewports?.length ) {
+		return BLOCK_VISIBILITY_VIEWPORTS;
+	}
+
+	const OVERRIDABLE_SLUGS = [ 'mobile', 'tablet' ];
+	const merged = { ...BLOCK_VISIBILITY_VIEWPORTS };
+	themeViewports.forEach( ( { slug, size } ) => {
+		if ( OVERRIDABLE_SLUGS.includes( slug ) ) {
+			merged[ slug ] = { ...merged[ slug ], size };
+		}
+	} );
+	return merged;
+}

--- a/packages/block-editor/src/components/block-visibility/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/use-block-visibility.js
@@ -1,12 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useViewportMatch } from '@wordpress/compose';
+import { useMediaQuery } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
+import { useBlockVisibilityViewports } from './use-block-visibility-viewports';
 
 /**
  * Returns information about the current block visibility state.
@@ -22,8 +23,15 @@ export default function useBlockVisibility( options = {} ) {
 		deviceType = BLOCK_VISIBILITY_VIEWPORTS.desktop.key,
 	} = options;
 
-	const isLargerThanMobile = useViewportMatch( 'mobile', '>=' ); // >= 480px
-	const isLargerThanTablet = useViewportMatch( 'medium', '>=' ); // >= 782px
+	const viewports = useBlockVisibilityViewports();
+	// @todo Consolidate default breakpoint values into a single source of truth
+	// shared between constants.js, use-block-visibility.js, and lib/theme.json.
+	// See https://github.com/WordPress/gutenberg/issues/75707.
+	const mobileSize = viewports.mobile.size ?? '480px';
+	const tabletSize = viewports.tablet.size ?? '782px';
+
+	const isLargerThanMobile = useMediaQuery( `(min-width: ${ mobileSize })` );
+	const isLargerThanTablet = useMediaQuery( `(min-width: ${ tabletSize })` );
 
 	/*
 	 * Priority:

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7257,4 +7257,154 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( 'string-value', $settings['appearanceTools'] );
 		$this->assertSame( array( 'nested' => 'value' ), $settings['custom'] );
 	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::is_valid_viewports
+	 */
+	public function test_theme_viewports_valid_mobile_override() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'mobile', 'size' => '600px' ),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNotNull( $viewports, 'Valid mobile viewport override should be preserved.' );
+		$this->assertSame( '600px', $viewports[0]['size'] );
+	}
+
+	public function test_theme_viewports_valid_both_overrides() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'mobile', 'size' => '600px' ),
+							array( 'slug' => 'tablet', 'size' => '900px' ),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNotNull( $viewports );
+		$this->assertCount( 2, $viewports );
+	}
+
+	public function test_theme_viewports_invalid_unknown_slug_is_rejected() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'widescreen', 'size' => '1400px' ),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNull( $viewports, 'Unknown slug should cause viewports to be rejected.' );
+	}
+
+	public function test_theme_viewports_invalid_non_px_size_is_rejected() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'mobile', 'size' => '30rem' ),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNull( $viewports, 'Non-px size should cause viewports to be rejected.' );
+	}
+
+	public function test_theme_viewports_invalid_descending_order_is_rejected() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'mobile', 'size' => '900px' ),
+							array( 'slug' => 'tablet', 'size' => '480px' ),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNull( $viewports, 'Descending sizes should cause viewports to be rejected.' );
+	}
+
+	public function test_theme_viewports_invalid_duplicate_slug_is_rejected() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'mobile', 'size' => '480px' ),
+							array( 'slug' => 'mobile', 'size' => '600px' ),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNull( $viewports, 'Duplicate slugs should cause viewports to be rejected.' );
+	}
+
+	public function test_default_origin_viewports_are_not_validated() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'responsive' => array(
+						'viewports' => array(
+							array( 'slug' => 'mobile', 'size' => '480px' ),
+							array( 'slug' => 'tablet', 'size' => '782px' ),
+							array( 'slug' => 'desktop' ),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$settings  = $theme_json->get_settings();
+		$viewports = $settings['responsive']['viewports'] ?? null;
+		$this->assertNotNull( $viewports, 'Default origin viewports should not be validated or removed.' );
+	}
 }

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -395,6 +395,45 @@
 				}
 			}
 		},
+		"settingsResponsiveProperties": {
+			"type": "object",
+			"properties": {
+				"responsive": {
+					"description": "Settings related to responsive behavior.",
+					"type": "object",
+					"properties": {
+						"viewports": {
+							"description": "Viewport size overrides for block visibility. Override the size of the mobile and/or tablet breakpoints. Desktop has no size value and cannot be overridden.",
+							"type": "array",
+							"minItems": 1,
+							"maxItems": 2,
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Human-readable label for the viewport.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Identifier for the viewport to override. Must be mobile or tablet.",
+										"type": "string",
+										"enum": [ "mobile", "tablet" ]
+									},
+									"size": {
+										"description": "Max width for the viewport in px (e.g. 480px).",
+										"type": "string",
+										"pattern": "^\\d+px$"
+									}
+								},
+								"required": [ "slug", "size" ],
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
 		"settingsShadowProperties": {
 			"type": "object",
 			"properties": {
@@ -867,6 +906,7 @@
 				{ "$ref": "#/definitions/settingsLayoutProperties" },
 				{ "$ref": "#/definitions/settingsLightboxProperties" },
 				{ "$ref": "#/definitions/settingsPositionProperties" },
+				{ "$ref": "#/definitions/settingsResponsiveProperties" },
 				{ "$ref": "#/definitions/settingsShadowProperties" },
 				{ "$ref": "#/definitions/settingsSpacingProperties" },
 				{ "$ref": "#/definitions/settingsTypographyProperties" },
@@ -883,6 +923,7 @@
 				"layout",
 				"lightbox",
 				"position",
+				"responsive",
 				"shadow",
 				"spacing",
 				"typography",
@@ -1288,8 +1329,12 @@
 						"backgroundPosition": {
 							"description": "Sets the `background-position` CSS property.",
 							"oneOf": [
-								{ "type": "string" },
-								{ "$ref": "#/definitions/refComplete" }
+								{
+									"type": "string"
+								},
+								{
+									"$ref": "#/definitions/refComplete"
+								}
 							]
 						},
 						"backgroundRepeat": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1329,12 +1329,8 @@
 						"backgroundPosition": {
 							"description": "Sets the `background-position` CSS property.",
 							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/definitions/refComplete"
-								}
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
 							]
 						},
 						"backgroundRepeat": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allows themes to override the default mobile (480px) and tablet (782px) breakpoint sizes via `settings.responsive.viewports` in `theme.json`. 

The three viewport slugs (`mobile`, `tablet`, `desktop`) remain fixed; only the pixel values can change. Desktop has no size value and cannot be overridden.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Add some custom sizes for mobile and tablet and check if they work in the editor and frontend:

Example theme.json:


```json
{
	"settings": {
	  "responsive": {
	    "viewports": [
	      { "slug": "mobile", "size": "100px" },
	      { "slug": "tablet", "size": "1000px" }
	    ]
	  }
}
```

1. Set a block to hidden on mobile. Confirm the generated CSS uses width <= 100px instead of width <= 480px
2. Set a block to hidden on tablet. Confirm 100px < width <= 1000px
3. Resize the editor window below 100px — block should show as hidden in the editor
4. Remove viewports from theme.json — defaults (480px, 782px) should restore
5. Set an invalid value (e.g. "size": "30rem") — defaults should be used silently
