### PR TITLE
Page/Post Content Focus Mode: Fix insertion into Post Content block

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1705,9 +1705,21 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const blockEditingMode = getBlockEditingMode( state, rootClientId ?? '' );
+
+	// Compute section context early so the disabled check below can use it.
+	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
+	const sectionClientId = isParentSectionBlock
+		? rootClientId
+		: getParentSectionBlock( state, rootClientId );
+	const isWithinSection = !! sectionClientId;
+
+	// Disabled containers reject all blocks, with one exception: within a
+	// section, the default block (paragraph) is allowed through so it can
+	// reach the content-insertion logic further down (lines 1748-1772)
+	// which conditionally permits it where a sibling paragraph exists.
 	if (
 		blockEditingMode === 'disabled' &&
-		blockName !== getDefaultBlockName()
+		( ! isWithinSection || blockName !== getDefaultBlockName() )
 	) {
 		return false;
 	}
@@ -1723,11 +1735,6 @@ const canInsertBlockTypeUnmemoized = (
 	// It shouldn't be possible to insert inside a section block unless in
 	// some cases when the block is a content block.
 	const isContentRoleBlock = isContentBlock( blockName );
-	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
-	const sectionClientId = isParentSectionBlock
-		? rootClientId
-		: getParentSectionBlock( state, rootClientId );
-	const isWithinSection = !! sectionClientId;
 	if ( isWithinSection && ! isContentRoleBlock ) {
 		return false;
 	}

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -85,7 +85,9 @@ export default function InserterSidebar() {
 				showMostUsedBlocks={ showMostUsedBlocks }
 				showInserterHelpPanel
 				shouldFocusBlock={ isMobileViewport }
-				rootClientId={ blockSectionRootClientId }
+				rootClientId={
+					blockSectionRootClientId ?? inserter.rootClientId
+				}
 				onSelect={ inserter.onSelect }
 				__experimentalInitialTab={ inserter.tab }
 				__experimentalInitialCategory={ inserter.category }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -88,6 +88,7 @@ export default function InserterSidebar() {
 				rootClientId={
 					blockSectionRootClientId ?? inserter.rootClientId
 				}
+				__experimentalInsertionIndex={ inserter.insertionIndex }
 				onSelect={ inserter.onSelect }
 				__experimentalInitialTab={ inserter.tab }
 				__experimentalInitialCategory={ inserter.category }

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -55,14 +55,36 @@ export const getInserter = createRegistrySelector( ( select ) =>
 			}
 
 			if ( getRenderingMode( state ) === 'template-locked' ) {
+				const {
+					getBlocksByName,
+					getSelectedBlockClientId,
+					getBlockParents,
+					getBlockOrder,
+				} = select( blockEditorStore );
 				const [ postContentClientId ] =
-					select( blockEditorStore ).getBlocksByName(
-						'core/post-content'
-					);
+					getBlocksByName( 'core/post-content' );
 				if ( postContentClientId ) {
+					const selectedBlockClientId = getSelectedBlockClientId();
+
+					// If a block inside Post Content is selected,
+					// let the inserter use its default logic for determining the
+					// insertion position by returning an empty insertion point.
+					if (
+						selectedBlockClientId &&
+						selectedBlockClientId !== postContentClientId &&
+						getBlockParents( selectedBlockClientId ).includes(
+							postContentClientId
+						)
+					) {
+						return EMPTY_INSERTION_POINT;
+					}
+
+					// Otherwise (no selection, or Post Content itself
+					// is selected), insert at the end of Post Content.
 					return {
 						rootClientId: postContentClientId,
-						insertionIndex: undefined,
+						insertionIndex:
+							getBlockOrder( postContentClientId ).length,
 						filterValue: undefined,
 					};
 				}
@@ -71,14 +93,26 @@ export const getInserter = createRegistrySelector( ( select ) =>
 			return EMPTY_INSERTION_POINT;
 		},
 		( state ) => {
+			const {
+				getBlocksByName,
+				getSelectedBlockClientId,
+				getBlockParents,
+				getBlockOrder,
+			} = select( blockEditorStore );
 			const [ postContentClientId ] =
-				select( blockEditorStore ).getBlocksByName(
-					'core/post-content'
-				);
+				getBlocksByName( 'core/post-content' );
+			const selectedBlockClientId = getSelectedBlockClientId();
 			return [
 				state.blockInserterPanel,
 				getRenderingMode( state ),
 				postContentClientId,
+				selectedBlockClientId,
+				selectedBlockClientId
+					? getBlockParents( selectedBlockClientId )
+					: undefined,
+				postContentClientId
+					? getBlockOrder( postContentClientId ).length
+					: undefined,
 			];
 		}
 	)

--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -11,11 +11,93 @@ test.use( {
 
 // Post content focus mode (aka the 'Show template' option when editing a post or page).
 test.describe( 'Post Content focus mode', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'inserts blocks into Post Content from different selection states', async ( {
+		admin,
+		editor,
+		page,
+		postContentFocusMode,
+	} ) => {
+		await admin.createNewPost();
+
+		// Add initial content.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Initial paragraph' },
+		} );
+
+		await postContentFocusMode.enableShowTemplate();
+
+		await test.step( 'No selection: inserts at end of Post Content', async () => {
+			await page.evaluate( () => {
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.clearSelectedBlock();
+			} );
+
+			await postContentFocusMode.insertBlockViaGlobalInserter(
+				'Heading'
+			);
+
+			const info =
+				await postContentFocusMode.getPostContentInsertionInfo();
+			expect( info.postContentChildNames ).toEqual( [
+				'core/paragraph',
+				'core/heading',
+			] );
+		} );
+
+		await test.step( 'Post Content selected: inserts at end of Post Content', async () => {
+			const postContent = editor.canvas.getByRole( 'document', {
+				name: 'Block: Content',
+				exact: true,
+			} );
+			await editor.selectBlocks( postContent );
+
+			await postContentFocusMode.insertBlockViaGlobalInserter(
+				'Heading'
+			);
+
+			const info =
+				await postContentFocusMode.getPostContentInsertionInfo();
+			expect( info.postContentChildNames ).toEqual( [
+				'core/paragraph',
+				'core/heading',
+				'core/heading',
+			] );
+		} );
+
+		await test.step( 'Inner block selected: inserts after selected block', async () => {
+			// Select the first paragraph.
+			const paragraph = editor.canvas.getByText( 'Initial paragraph' );
+			await editor.selectBlocks( paragraph );
+
+			await postContentFocusMode.insertBlockViaGlobalInserter(
+				'Heading'
+			);
+
+			const info =
+				await postContentFocusMode.getPostContentInsertionInfo();
+			// The new heading is inserted after the selected paragraph.
+			expect( info.postContentChildNames ).toEqual( [
+				'core/paragraph',
+				'core/heading',
+				'core/heading',
+				'core/heading',
+			] );
+		} );
+	} );
+
 	// Check for regressions of https://github.com/WordPress/gutenberg/issues/76101.
 	test.describe( 'post content inside a template part', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
-			await requestUtils.activateTheme( 'emptytheme' );
-
 			// Create a template part that contains post-title and post-content.
 			await requestUtils.createTemplate( 'wp_template_part', {
 				slug: 'content-area',
@@ -40,7 +122,6 @@ test.describe( 'Post Content focus mode', () => {
 		test.afterAll( async ( { requestUtils } ) => {
 			await requestUtils.deleteAllTemplates( 'wp_template' );
 			await requestUtils.deleteAllTemplates( 'wp_template_part' );
-			await requestUtils.activateTheme( 'twentytwentyone' );
 		} );
 
 		test( 'post title and content are editable and blocks can be inserted', async ( {
@@ -124,89 +205,6 @@ test.describe( 'Post Content focus mode', () => {
 			} );
 		} );
 
-		// Regression test: when Post Content is selected and a block is
-		// inserted via the inserter, it should end up inside Post Content,
-		// not as a sibling in the template part.
-		test( 'inserting a block while Post Content is selected places it inside Post Content', async ( {
-			admin,
-			editor,
-			page,
-			postContentFocusMode,
-		} ) => {
-			await admin.createNewPost();
-
-			// Add initial content so we can verify the new paragraph
-			// is an additional child of Post Content.
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Existing content' },
-			} );
-
-			await postContentFocusMode.enableShowTemplate();
-
-			// Select the Post Content block itself.
-			const postContent = editor.canvas.getByRole( 'document', {
-				name: 'Block: Content',
-				exact: true,
-			} );
-			await editor.selectBlocks( postContent );
-
-			// Open the global block inserter and insert a Paragraph.
-			await page
-				.getByRole( 'button', {
-					name: 'Block Inserter',
-					exact: true,
-				} )
-				.click();
-
-			const inserterPanel = page.getByRole( 'region', {
-				name: 'Block Library',
-			} );
-			await inserterPanel
-				.getByRole( 'tabpanel', { name: 'Blocks' } )
-				.getByRole( 'option', { name: 'Paragraph', exact: true } )
-				.click();
-
-			// Close the inserter.
-			await page
-				.getByRole( 'button', {
-					name: 'Block Inserter',
-					exact: true,
-				} )
-				.click();
-
-			// The inserted paragraph should be inside Post Content,
-			// not a sibling of it inside the template part.
-			const blocks = await page.evaluate( () => {
-				const { select } = window.wp.data;
-				const {
-					getBlocksByName,
-					getBlockOrder,
-					getBlockName,
-					getBlockRootClientId,
-				} = select( 'core/block-editor' );
-				const [ postContentId ] =
-					getBlocksByName( 'core/post-content' );
-				const templatePartId = getBlockRootClientId( postContentId );
-				return {
-					postContentChildCount:
-						getBlockOrder( postContentId ).length,
-					templatePartChildren: getBlockOrder( templatePartId ).map(
-						( id ) => getBlockName( id )
-					),
-				};
-			} );
-
-			// Post Content started with one paragraph; after insertion
-			// it should have two children.
-			expect( blocks.postContentChildCount ).toBe( 2 );
-			// The paragraph should not have been inserted as a sibling
-			// of Post Content inside the template part.
-			expect( blocks.templatePartChildren ).not.toContain(
-				'core/paragraph'
-			);
-		} );
-
 		test( 'template part blocks outside post content are not editable', async ( {
 			admin,
 			editor,
@@ -227,6 +225,132 @@ test.describe( 'Post Content focus mode', () => {
 			} );
 			await expect( siteTitle ).toHaveAttribute( 'inert', 'true' );
 		} );
+
+		test( 'inserts blocks into Post Content from different selection states', async ( {
+			admin,
+			editor,
+			page,
+			postContentFocusMode,
+		} ) => {
+			await admin.createNewPost();
+
+			// Add initial content.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Initial paragraph' },
+			} );
+
+			await postContentFocusMode.enableShowTemplate();
+
+			// The template part's direct children should remain unchanged
+			// throughout all steps (post-title and post-content only).
+			const expectedTemplatePart = [
+				'core/post-title',
+				'core/post-content',
+			];
+
+			await test.step( 'No selection: inserts at end of Post Content', async () => {
+				await page.evaluate( () => {
+					window.wp.data
+						.dispatch( 'core/block-editor' )
+						.clearSelectedBlock();
+				} );
+
+				await postContentFocusMode.insertBlockViaGlobalInserter(
+					'Heading'
+				);
+
+				const info =
+					await postContentFocusMode.getPostContentInsertionInfo();
+				expect( info.postContentChildNames ).toEqual( [
+					'core/paragraph',
+					'core/heading',
+				] );
+				expect( info.templatePartChildren ).toEqual(
+					expectedTemplatePart
+				);
+			} );
+
+			await test.step( 'Template part selected: inserts into Post Content', async () => {
+				// Select the template part that contains Post Content.
+				await page.evaluate( () => {
+					const { select, dispatch } = window.wp.data;
+					const { getBlocksByName, getBlockRootClientId } =
+						select( 'core/block-editor' );
+					const [ postContentId ] =
+						getBlocksByName( 'core/post-content' );
+					const templatePartId =
+						getBlockRootClientId( postContentId );
+					dispatch( 'core/block-editor' ).selectBlock(
+						templatePartId
+					);
+				} );
+
+				await postContentFocusMode.insertBlockViaGlobalInserter(
+					'Heading'
+				);
+
+				const info =
+					await postContentFocusMode.getPostContentInsertionInfo();
+				expect( info.postContentChildNames ).toEqual( [
+					'core/paragraph',
+					'core/heading',
+					'core/heading',
+				] );
+				expect( info.templatePartChildren ).toEqual(
+					expectedTemplatePart
+				);
+			} );
+
+			await test.step( 'Post Content selected: inserts at end of Post Content', async () => {
+				const postContent = editor.canvas.getByRole( 'document', {
+					name: 'Block: Content',
+					exact: true,
+				} );
+				await editor.selectBlocks( postContent );
+
+				await postContentFocusMode.insertBlockViaGlobalInserter(
+					'Heading'
+				);
+
+				const info =
+					await postContentFocusMode.getPostContentInsertionInfo();
+				expect( info.postContentChildNames ).toEqual( [
+					'core/paragraph',
+					'core/heading',
+					'core/heading',
+					'core/heading',
+				] );
+				expect( info.templatePartChildren ).toEqual(
+					expectedTemplatePart
+				);
+			} );
+
+			await test.step( 'Post content inner block selected: inserts after selected block', async () => {
+				// Select the first paragraph (the initial content).
+				const paragraph =
+					editor.canvas.getByText( 'Initial paragraph' );
+				await editor.selectBlocks( paragraph );
+
+				await postContentFocusMode.insertBlockViaGlobalInserter(
+					'Heading'
+				);
+
+				const info =
+					await postContentFocusMode.getPostContentInsertionInfo();
+				// The new heading is inserted after the selected paragraph.
+				expect( info.postContentChildNames ).toEqual( [
+					'core/paragraph',
+					'core/heading',
+					'core/heading',
+					'core/heading',
+					'core/heading',
+				] );
+				expect( info.templatePartChildren ).toEqual(
+					expectedTemplatePart
+				);
+			} );
+		} );
 	} );
 } );
 
@@ -234,6 +358,81 @@ class PostContentFocusMode {
 	constructor( { editor, page } ) {
 		this.editor = editor;
 		this.page = page;
+	}
+
+	/**
+	 * Opens the global block inserter, inserts a block by name, and closes
+	 * the inserter.
+	 *
+	 * @param {string} blockName The label of the block to insert (e.g. 'Heading').
+	 */
+	async insertBlockViaGlobalInserter( blockName ) {
+		await this.page
+			.getByRole( 'button', {
+				name: 'Block Inserter',
+				exact: true,
+			} )
+			.click();
+
+		const inserterPanel = this.page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
+		const searchBox = inserterPanel.getByRole( 'searchbox', {
+			name: 'Search',
+		} );
+		await searchBox.fill( blockName );
+		await inserterPanel
+			.getByRole( 'tabpanel', { name: 'Blocks' } )
+			.getByRole( 'option', { name: blockName, exact: true } )
+			.click();
+
+		// Close the inserter.
+		await this.page
+			.getByRole( 'button', {
+				name: 'Block Inserter',
+				exact: true,
+			} )
+			.click();
+	}
+
+	/**
+	 * Returns information about the blocks inside Post Content and,
+	 * if Post Content is inside a template part, the template part's
+	 * direct children.
+	 *
+	 * @return {Object} An object with:
+	 *   - postContentChildNames: array of block names inside Post Content
+	 *   - templatePartChildren:  array of block names that are direct
+	 *                            children of the template part (only
+	 *                            present when Post Content is inside one)
+	 */
+	async getPostContentInsertionInfo() {
+		return await this.page.evaluate( () => {
+			const { select } = window.wp.data;
+			const {
+				getBlocksByName,
+				getBlockOrder,
+				getBlockName,
+				getBlockRootClientId,
+			} = select( 'core/block-editor' );
+			const [ postContentId ] = getBlocksByName( 'core/post-content' );
+			const result = {
+				postContentChildNames: getBlockOrder( postContentId ).map(
+					( id ) => getBlockName( id )
+				),
+			};
+			// Include template part children if Post Content is inside one.
+			const parentId = getBlockRootClientId( postContentId );
+			if (
+				parentId &&
+				getBlockName( parentId ) === 'core/template-part'
+			) {
+				result.templatePartChildren = getBlockOrder( parentId ).map(
+					( id ) => getBlockName( id )
+				);
+			}
+			return result;
+		} );
 	}
 
 	/**

--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -46,12 +46,9 @@ test.describe( 'Post Content focus mode', () => {
 				'Heading'
 			);
 
-			const info =
-				await postContentFocusMode.getPostContentInsertionInfo();
-			expect( info.postContentChildNames ).toEqual( [
-				'core/paragraph',
-				'core/heading',
-			] );
+			expect(
+				await postContentFocusMode.getPostContentInnerBlockNames()
+			).toEqual( [ 'core/paragraph', 'core/heading' ] );
 		} );
 
 		await test.step( 'Post Content selected: inserts at end of Post Content', async () => {
@@ -65,13 +62,9 @@ test.describe( 'Post Content focus mode', () => {
 				'Heading'
 			);
 
-			const info =
-				await postContentFocusMode.getPostContentInsertionInfo();
-			expect( info.postContentChildNames ).toEqual( [
-				'core/paragraph',
-				'core/heading',
-				'core/heading',
-			] );
+			expect(
+				await postContentFocusMode.getPostContentInnerBlockNames()
+			).toEqual( [ 'core/paragraph', 'core/heading', 'core/heading' ] );
 		} );
 
 		await test.step( 'Inner block selected: inserts after selected block', async () => {
@@ -83,10 +76,10 @@ test.describe( 'Post Content focus mode', () => {
 				'Heading'
 			);
 
-			const info =
-				await postContentFocusMode.getPostContentInsertionInfo();
 			// The new heading is inserted after the selected paragraph.
-			expect( info.postContentChildNames ).toEqual( [
+			expect(
+				await postContentFocusMode.getPostContentInnerBlockNames()
+			).toEqual( [
 				'core/paragraph',
 				'core/heading',
 				'core/heading',
@@ -260,15 +253,12 @@ test.describe( 'Post Content focus mode', () => {
 					'Heading'
 				);
 
-				const info =
-					await postContentFocusMode.getPostContentInsertionInfo();
-				expect( info.postContentChildNames ).toEqual( [
-					'core/paragraph',
-					'core/heading',
-				] );
-				expect( info.templatePartChildren ).toEqual(
-					expectedTemplatePart
-				);
+				expect(
+					await postContentFocusMode.getPostContentInnerBlockNames()
+				).toEqual( [ 'core/paragraph', 'core/heading' ] );
+				expect(
+					await postContentFocusMode.getTemplatePartInnerBlockNames()
+				).toEqual( expectedTemplatePart );
 			} );
 
 			await test.step( 'Template part selected: inserts into Post Content', async () => {
@@ -290,16 +280,16 @@ test.describe( 'Post Content focus mode', () => {
 					'Heading'
 				);
 
-				const info =
-					await postContentFocusMode.getPostContentInsertionInfo();
-				expect( info.postContentChildNames ).toEqual( [
+				expect(
+					await postContentFocusMode.getPostContentInnerBlockNames()
+				).toEqual( [
 					'core/paragraph',
 					'core/heading',
 					'core/heading',
 				] );
-				expect( info.templatePartChildren ).toEqual(
-					expectedTemplatePart
-				);
+				expect(
+					await postContentFocusMode.getTemplatePartInnerBlockNames()
+				).toEqual( expectedTemplatePart );
 			} );
 
 			await test.step( 'Post Content selected: inserts at end of Post Content', async () => {
@@ -313,17 +303,17 @@ test.describe( 'Post Content focus mode', () => {
 					'Heading'
 				);
 
-				const info =
-					await postContentFocusMode.getPostContentInsertionInfo();
-				expect( info.postContentChildNames ).toEqual( [
+				expect(
+					await postContentFocusMode.getPostContentInnerBlockNames()
+				).toEqual( [
 					'core/paragraph',
 					'core/heading',
 					'core/heading',
 					'core/heading',
 				] );
-				expect( info.templatePartChildren ).toEqual(
-					expectedTemplatePart
-				);
+				expect(
+					await postContentFocusMode.getTemplatePartInnerBlockNames()
+				).toEqual( expectedTemplatePart );
 			} );
 
 			await test.step( 'Post content inner block selected: inserts after selected block', async () => {
@@ -336,19 +326,19 @@ test.describe( 'Post Content focus mode', () => {
 					'Heading'
 				);
 
-				const info =
-					await postContentFocusMode.getPostContentInsertionInfo();
 				// The new heading is inserted after the selected paragraph.
-				expect( info.postContentChildNames ).toEqual( [
+				expect(
+					await postContentFocusMode.getPostContentInnerBlockNames()
+				).toEqual( [
 					'core/paragraph',
 					'core/heading',
 					'core/heading',
 					'core/heading',
 					'core/heading',
 				] );
-				expect( info.templatePartChildren ).toEqual(
-					expectedTemplatePart
-				);
+				expect(
+					await postContentFocusMode.getTemplatePartInnerBlockNames()
+				).toEqual( expectedTemplatePart );
 			} );
 		} );
 	} );
@@ -396,42 +386,40 @@ class PostContentFocusMode {
 	}
 
 	/**
-	 * Returns information about the blocks inside Post Content and,
-	 * if Post Content is inside a template part, the template part's
-	 * direct children.
+	 * Returns the block names of Post Content's inner blocks.
 	 *
-	 * @return {Object} An object with:
-	 *   - postContentChildNames: array of block names inside Post Content
-	 *   - templatePartChildren:  array of block names that are direct
-	 *                            children of the template part (only
-	 *                            present when Post Content is inside one)
+	 * @return {string[]} Array of block names inside Post Content.
 	 */
-	async getPostContentInsertionInfo() {
+	async getPostContentInnerBlockNames() {
 		return await this.page.evaluate( () => {
-			const { select } = window.wp.data;
+			const { getBlocksByName, getBlockOrder, getBlockName } =
+				window.wp.data.select( 'core/block-editor' );
+			const [ postContentId ] = getBlocksByName( 'core/post-content' );
+			return getBlockOrder( postContentId ).map( ( id ) =>
+				getBlockName( id )
+			);
+		} );
+	}
+
+	/**
+	 * Returns the block names of the direct children of the template part
+	 * that contains Post Content.
+	 *
+	 * @return {string[]} Array of block names inside the template part.
+	 */
+	async getTemplatePartInnerBlockNames() {
+		return await this.page.evaluate( () => {
 			const {
 				getBlocksByName,
 				getBlockOrder,
 				getBlockName,
 				getBlockRootClientId,
-			} = select( 'core/block-editor' );
+			} = window.wp.data.select( 'core/block-editor' );
 			const [ postContentId ] = getBlocksByName( 'core/post-content' );
-			const result = {
-				postContentChildNames: getBlockOrder( postContentId ).map(
-					( id ) => getBlockName( id )
-				),
-			};
-			// Include template part children if Post Content is inside one.
-			const parentId = getBlockRootClientId( postContentId );
-			if (
-				parentId &&
-				getBlockName( parentId ) === 'core/template-part'
-			) {
-				result.templatePartChildren = getBlockOrder( parentId ).map(
-					( id ) => getBlockName( id )
-				);
-			}
-			return result;
+			const templatePartId = getBlockRootClientId( postContentId );
+			return getBlockOrder( templatePartId ).map( ( id ) =>
+				getBlockName( id )
+			);
 		} );
 	}
 

--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -124,6 +124,89 @@ test.describe( 'Post Content focus mode', () => {
 			} );
 		} );
 
+		// Regression test: when Post Content is selected and a block is
+		// inserted via the inserter, it should end up inside Post Content,
+		// not as a sibling in the template part.
+		test( 'inserting a block while Post Content is selected places it inside Post Content', async ( {
+			admin,
+			editor,
+			page,
+			postContentFocusMode,
+		} ) => {
+			await admin.createNewPost();
+
+			// Add initial content so we can verify the new paragraph
+			// is an additional child of Post Content.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Existing content' },
+			} );
+
+			await postContentFocusMode.enableShowTemplate();
+
+			// Select the Post Content block itself.
+			const postContent = editor.canvas.getByRole( 'document', {
+				name: 'Block: Content',
+				exact: true,
+			} );
+			await editor.selectBlocks( postContent );
+
+			// Open the global block inserter and insert a Paragraph.
+			await page
+				.getByRole( 'button', {
+					name: 'Block Inserter',
+					exact: true,
+				} )
+				.click();
+
+			const inserterPanel = page.getByRole( 'region', {
+				name: 'Block Library',
+			} );
+			await inserterPanel
+				.getByRole( 'tabpanel', { name: 'Blocks' } )
+				.getByRole( 'option', { name: 'Paragraph', exact: true } )
+				.click();
+
+			// Close the inserter.
+			await page
+				.getByRole( 'button', {
+					name: 'Block Inserter',
+					exact: true,
+				} )
+				.click();
+
+			// The inserted paragraph should be inside Post Content,
+			// not a sibling of it inside the template part.
+			const blocks = await page.evaluate( () => {
+				const { select } = window.wp.data;
+				const {
+					getBlocksByName,
+					getBlockOrder,
+					getBlockName,
+					getBlockRootClientId,
+				} = select( 'core/block-editor' );
+				const [ postContentId ] =
+					getBlocksByName( 'core/post-content' );
+				const templatePartId = getBlockRootClientId( postContentId );
+				return {
+					postContentChildCount:
+						getBlockOrder( postContentId ).length,
+					templatePartChildren: getBlockOrder( templatePartId ).map(
+						( id ) => getBlockName( id )
+					),
+				};
+			} );
+
+			// Post Content started with one paragraph; after insertion
+			// it should have two children.
+			expect( blocks.postContentChildCount ).toBe( 2 );
+			// The paragraph should not have been inserted as a sibling
+			// of Post Content inside the template part.
+			expect( blocks.templatePartChildren ).not.toContain(
+				'core/paragraph'
+			);
+		} );
+
 		test( 'template part blocks outside post content are not editable', async ( {
 			admin,
 			editor,

--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -67,7 +67,7 @@ test.describe( 'Post Content focus mode', () => {
 			).toEqual( [ 'core/paragraph', 'core/heading', 'core/heading' ] );
 		} );
 
-		await test.step( 'Inner block selected: inserts after selected block', async () => {
+		await test.step( 'Post content inner block selected: inserts after selected block', async () => {
 			// Select the first paragraph.
 			const paragraph = editor.canvas.getByText( 'Initial paragraph' );
 			await editor.selectBlocks( paragraph );

--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -17,6 +17,9 @@ test.describe( 'Post Content focus mode', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		// Reset preferences so the persisted "Show template" rendering mode
+		// does not leak into subsequent test files.
+		await requestUtils.resetPreferences();
 	} );
 
 	test( 'inserts blocks into Post Content from different selection states', async ( {
@@ -110,6 +113,12 @@ test.describe( 'Post Content focus mode', () => {
 					'<!-- wp:template-part {"slug":"content-area","theme":"emptytheme"} /-->',
 				].join( '\n' ),
 			} );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			// "Show template" persists the rendering mode in user preferences.
+			// Reset between tests so each test starts in post-only mode.
+			await requestUtils.resetPreferences();
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What?
After #76305 I noticed there were a few oddities around block insertion.

If you have Post Content nested in a Template Part like #76305, then when the Post Content is selected blocks are insertable into the template part.

## Why?
I found this was due to two reasons:
1. Some time ago there was a regression of the behavior introduced in [Page Content Focus: Default insertion point to the Post Content block](https://github.com/WordPress/gutenberg/pull/51773#top). I found the problem is reproducible in 6.9, with a Post Content block selected, the inserter doesn't allow blocks to be added. After #76305, when Post Content is in a template part it's much more noticable. This is due to flaws with how blockEditingModes work, a user can technically insert blocks into the `contentOnly` template part, this ability has been somewhat hidden before through the insertion point wrangling, so it needs to be fixed again as best as possible.
2. Separately #76189 also introduced an issue that's difficult to repro. For this you need to put Post Content in a template part, but also wrap it in a group. When editing from post content focus mode it's possible to insert paragraphs after Post Content within the group. That PR added an `isWithinSection` clause to gate the paragraph insertion logic, but it missed an earlier if statement that also needed `isWithinSection` added to it.

## How?
1. Ensure the `rootClientId` and `insertionIndex` calculated by the editor package's `getInserter` function are passed through to the inserter sidebar. These set the default insertion point, and have some special logic for page content focus mode (`getRenderingMode( state ) === 'template-locked'`). I've had to also make some changes to the `getInserter` selector that derives these values, as since it was implemented block insertion logic has changed. The editor now searches up from the selected block to find an insertion point. If a user has a Post Content block select that doesn't work very well, blocks need to be inserted into post content! 
2. Add the missing `isWithinSection` condition

## Testing Instructions
I've added a bunch of e2e tests to prevent regressions. 

1. Open a post and edit the template (Document sidebar > Template > Edit template)
2. Select the Post content block and wrap it in a group, then wrap the group in a template part ('Create template part' from the block options menu). Save.
3. Go back to the post, add a paragraph with some text.
4. Click Template options → Show template in the post settings sidebar.
5. Select the Post Content block (via List View), then open the global block inserter and insert a Paragraph.
6. Expected: The Paragraph is inserted inside Post Content

In trunk: The paragraph is inserted into the template part after the post content block, and can't be edited.

Smoke test: try inserting blocks with different selections (no blocks selected, the template part selected, an inner block of the post content selected). The blocks should all end up in post content to mimic editing a post/page as described in #51773.

## Screenshots or screencast <!-- if applicable -->
#### Before
The paragraph is inserted into the template part, not into post content

https://github.com/user-attachments/assets/edf46639-5342-4623-91cb-940b67429a04

#### After
The paragraph is inserted into post content

https://github.com/user-attachments/assets/1e5297b8-f96b-49ba-b4ac-2476c94bb109

## Use of AI Tools
OpenCode + Claude Code used extensively, under lots of human direction and review.