### PR TITLE
Try/encode decode custom css

### DIFF
--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -6,6 +6,34 @@
  */
 
 /**
+ * Decodes a CSS attribute value that was base64-encoded by the block editor
+ * to survive wp_kses processing. Returns the value unchanged if it was never
+ * encoded (legacy content, or content saved by users with `unfiltered_html`).
+ *
+ * Migration note: once a proper CSS sanitizer API lands in WordPress core,
+ * remove the encoding call in the JS `onChange` handler. Keep this function
+ * as a read-time shim — it will decode any previously encoded values and
+ * return plain CSS, which will then be stored as plain CSS on the next save
+ * (lazy migration). Remove the shim once all encoded values have been cycled
+ * through a save.
+ *
+ * @since 7.0.0
+ *
+ * @param string $value Stored attribute value.
+ * @return string Decoded CSS string, or the original value if not encoded.
+ */
+function gutenberg_decode_css_attribute( $value ) {
+	$prefix = 'data:text/css;base64,';
+	if ( ! str_starts_with( $value, $prefix ) ) {
+		return $value;
+	}
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+	$decoded = base64_decode( substr( $value, strlen( $prefix ) ), /* strict */ true );
+	// If the decoded string contains characters from outside the base64 alphabet or a null byte, set the CSS to an empty string.
+	return ( false === $decoded || str_contains( $decoded, "\0" ) ) ? '' : $decoded;
+}
+
+/**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
  * @since 7.0.0
@@ -25,6 +53,12 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	if ( empty( $custom_css ) ) {
 		return $parsed_block;
 	}
+
+	// Decode base64-encoded CSS. The JS editor encodes CSS before saving so
+	// that wp_kses cannot corrupt characters like `&`, `>`, or nested selectors.
+	// Plain CSS (saved by users with `unfiltered_html`, or legacy content) is
+	// returned unchanged by this function.
+	$custom_css = gutenberg_decode_css_attribute( $custom_css );
 
 	// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).
 	if ( preg_match( '#</?\w+#', $custom_css ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60853,7 +60853,8 @@
 				"@wordpress/media-fields": "file:../media-fields",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
-				"@wordpress/ui": "file:../ui"
+				"@wordpress/ui": "file:../ui",
+				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60852,7 +60852,8 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/media-fields": "file:../media-fields",
 				"@wordpress/notices": "file:../notices",
-				"@wordpress/private-apis": "file:../private-apis"
+				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/ui": "file:../ui"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -24,6 +24,62 @@ const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 // Stable empty object reference for useSelect.
 const EMPTY_STYLE = {};
 
+/*
+ * CSS is base64-encoded before saving to protect it from wp_kses corruption
+ * (KSES treats the CSS string as HTML and mangles characters like `&`, `>`,
+ * and anything inside angle brackets).
+ *
+ * Migration path once a proper CSS sanitizer API lands in WordPress core:
+ *   - Remove the `encodeCSSAttribute` call in `onChange` — plain CSS can then
+ *     be stored directly.
+ *   - Keep `decodeCSSAttribute` as a read-time shim: if a stored value starts
+ *     with the prefix it was encoded by this code, decode it, sanitize it with
+ *     the new API, and let the next save write it back as plain CSS (lazy
+ *     migration). The shim can be removed once all encoded values have been
+ *     cycled through a save.
+ */
+const CSS_BASE64_PREFIX = 'data:text/css;base64,';
+
+/**
+ * Encodes a CSS string as a base64 data URI so it survives wp_kses intact.
+ *
+ * @param {string} css Raw CSS string.
+ * @return {string} Encoded value.
+ */
+function encodeCSSAttribute( css ) {
+	const bytes = new TextEncoder().encode( css );
+	let binary = '';
+	for ( const byte of bytes ) {
+		binary += String.fromCharCode( byte );
+	}
+	return CSS_BASE64_PREFIX + btoa( binary );
+}
+
+/**
+ * Decodes a value previously encoded by `encodeCSSAttribute`.
+ * Returns the value unchanged if it was never encoded (legacy content or
+ * content saved by users with `unfiltered_html` who bypass KSES).
+ *
+ * @param {string|undefined} value Stored attribute value.
+ * @return {string|undefined} Decoded CSS string, or the original value.
+ */
+function decodeCSSAttribute( value ) {
+	if (
+		typeof value !== 'string' ||
+		! value.startsWith( CSS_BASE64_PREFIX )
+	) {
+		return value;
+	}
+	try {
+		const binary = atob( value.slice( CSS_BASE64_PREFIX.length ) );
+		const bytes = Uint8Array.from( binary, ( c ) => c.charCodeAt( 0 ) );
+		return new TextDecoder().decode( bytes );
+	} catch {
+		// Malformed base64 — treat as plain CSS rather than silently dropping.
+		return value;
+	}
+}
+
 /**
  * Inspector control for custom CSS.
  *
@@ -35,9 +91,18 @@ const EMPTY_STYLE = {};
 function CustomCSSControl( { blockName, setAttributes, style } ) {
 	const blockType = getBlockType( blockName );
 
+	// Decode the stored CSS for display so the user always sees plain CSS,
+	// not the base64-encoded value that is stored to survive wp_kses.
+	const displayStyle = useMemo(
+		() => ( { ...style, css: decodeCSSAttribute( style?.css ) } ),
+		[ style ]
+	);
+
 	function onChange( newStyle ) {
 		// Normalize whitespace-only CSS to undefined so it gets cleaned up.
-		const css = newStyle?.css?.trim() ? newStyle.css : undefined;
+		const rawCSS = newStyle?.css?.trim() ? newStyle.css : undefined;
+		// Encode before storing so wp_kses cannot corrupt the CSS value.
+		const css = rawCSS ? encodeCSSAttribute( rawCSS ) : undefined;
 		setAttributes( {
 			style: cleanEmptyObject( { ...newStyle, css } ),
 		} );
@@ -54,9 +119,9 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	return (
 		<InspectorControls group="advanced">
 			<AdvancedPanel
-				value={ style }
+				value={ displayStyle }
 				onChange={ onChange }
-				inheritedValue={ style }
+				inheritedValue={ displayStyle }
 				help={ cssHelpText }
 			/>
 		</InspectorControls>
@@ -99,7 +164,9 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
  * @return {Object} Block props including className for custom CSS scoping.
  */
 function useBlockProps( { style } ) {
-	const customCSS = style?.css;
+	// Decode before validation and processing — the stored value may be
+	// base64-encoded to survive wp_kses.
+	const customCSS = decodeCSSAttribute( style?.css );
 
 	// Validate CSS is non-empty and passes validation checks.
 	const isValidCSS =

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -60,7 +60,8 @@
 		"@wordpress/media-fields": "file:../media-fields",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
-		"@wordpress/ui": "file:../ui"
+		"@wordpress/ui": "file:../ui",
+		"clsx": "^2.1.1"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -59,7 +59,8 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/media-fields": "file:../media-fields",
 		"@wordpress/notices": "file:../notices",
-		"@wordpress/private-apis": "file:../private-apis"
+		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/ui": "file:../ui"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -182,25 +182,6 @@ export function MediaUploadModal( {
 			: [ String( value ) ];
 	} );
 
-	const {
-		uploadingFiles,
-		registerBatch,
-		dismissError,
-		clearCompleted,
-		allComplete,
-	} = useUploadStatus();
-
-	const isPopoverOpenRef = useRef( false );
-	const handlePopoverOpenChange = useCallback(
-		( open: boolean ) => {
-			isPopoverOpenRef.current = open;
-			if ( ! open ) {
-				clearCompleted();
-			}
-		},
-		[ clearCompleted ]
-	);
-
 	const { createSuccessNotice, removeAllNotices } =
 		useDispatch( noticesStore );
 	const { invalidateResolution } = useDispatch( coreStore );
@@ -271,6 +252,55 @@ export function MediaUploadModal( {
 			...filters,
 		};
 	}, [ view, allowedTypes ] );
+
+	// Per-batch completion handler: auto-select uploaded items and refresh the grid.
+	const handleBatchComplete = useCallback(
+		( attachments: Partial< Attachment >[] ) => {
+			const uploadedIds = attachments
+				.map( ( attachment ) => String( attachment.id ) )
+				.filter( Boolean );
+
+			if ( multiple ) {
+				setSelection( ( prev ) => {
+					const existing = new Set( prev );
+					const newIds = uploadedIds.filter(
+						( id ) => ! existing.has( id )
+					);
+					return [ ...prev, ...newIds ];
+				} );
+			} else {
+				setSelection( uploadedIds.slice( 0, 1 ) );
+			}
+
+			// Invalidate immediately so newly uploaded files appear in the grid.
+			// The server has already returned 201 responses at this point.
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'attachment',
+				queryArgs,
+			] );
+		},
+		[ multiple, invalidateResolution, queryArgs ]
+	);
+
+	const {
+		uploadingFiles,
+		registerBatch,
+		dismissError,
+		clearCompleted,
+		allComplete,
+	} = useUploadStatus( { onBatchComplete: handleBatchComplete } );
+
+	const isPopoverOpenRef = useRef( false );
+	const handlePopoverOpenChange = useCallback(
+		( open: boolean ) => {
+			isPopoverOpenRef.current = open;
+			if ( ! open ) {
+				clearCompleted();
+			}
+		},
+		[ clearCompleted ]
+	);
 
 	// Fetch all media attachments using WordPress core data with permissions
 	const {
@@ -362,42 +392,12 @@ export function MediaUploadModal( {
 	// Use onUpload if provided, otherwise fall back to uploadMedia
 	const handleUpload = onUpload || uploadMedia;
 
-	// Per-batch completion handler: auto-select uploaded items and refresh the grid.
-	const handleBatchComplete = useCallback(
-		( attachments: Partial< Attachment >[] ) => {
-			const uploadedIds = attachments
-				.map( ( attachment ) => String( attachment.id ) )
-				.filter( Boolean );
-
-			if ( multiple ) {
-				setSelection( ( prev ) => {
-					const existing = new Set( prev );
-					const newIds = uploadedIds.filter(
-						( id ) => ! existing.has( id )
-					);
-					return [ ...prev, ...newIds ];
-				} );
-			} else {
-				setSelection( uploadedIds.slice( 0, 1 ) );
-			}
-
-			// Invalidate immediately so newly uploaded files appear in the grid.
-			// The server has already returned 201 responses at this point.
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				'attachment',
-				queryArgs,
-			] );
-		},
-		[ multiple, invalidateResolution, queryArgs ]
-	);
-
 	// Show success notice and auto-clear completed entries when all batches finish.
 	const prevAllCompleteRef = useRef( false );
 	useEffect( () => {
 		if ( allComplete && ! prevAllCompleteRef.current ) {
 			const completeCount = uploadingFiles.filter(
-				( f ) => f.status === 'uploaded'
+				( file ) => file.status === 'uploaded'
 			).length;
 			if ( completeCount > 0 ) {
 				createSuccessNotice(
@@ -432,9 +432,7 @@ export function MediaUploadModal( {
 			const files = event.target.files;
 			if ( files && files.length > 0 ) {
 				const filesArray = Array.from( files );
-				const { onFileChange, onError } = registerBatch( filesArray, {
-					onBatchComplete: handleBatchComplete,
-				} );
+				const { onFileChange, onError } = registerBatch( filesArray );
 
 				handleUpload( {
 					allowedTypes,
@@ -444,7 +442,7 @@ export function MediaUploadModal( {
 				} );
 			}
 		},
-		[ allowedTypes, handleUpload, registerBatch, handleBatchComplete ]
+		[ allowedTypes, handleUpload, registerBatch ]
 	);
 
 	const paginationInfo = useMemo(
@@ -531,10 +529,8 @@ export function MediaUploadModal( {
 						);
 					}
 					if ( filteredFiles.length > 0 ) {
-						const { onFileChange, onError } = registerBatch(
-							filteredFiles,
-							{ onBatchComplete: handleBatchComplete }
-						);
+						const { onFileChange, onError } =
+							registerBatch( filteredFiles );
 
 						handleUpload( {
 							allowedTypes,

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -638,11 +643,9 @@ export function MediaUploadModal( {
 				<DataViewsPicker.FiltersToggled className="dataviews-filters__container" />
 				<DataViewsPicker.Layout />
 				<div
-					className={
-						uploadingFiles.length > 0
-							? 'media-upload-modal__footer is-uploading'
-							: 'media-upload-modal__footer'
-					}
+					className={ clsx( 'media-upload-modal__footer', {
+						'is-uploading': uploadingFiles.length > 0,
+					} ) }
 				>
 					<UploadStatusPopover
 						uploadingFiles={ uploadingFiles }

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -214,7 +214,8 @@ export function MediaUploadModal( {
 		}
 	}, [] );
 
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, removeAllNotices } =
+		useDispatch( noticesStore );
 	const { invalidateResolution } = useDispatch( coreStore );
 
 	// DataViews configuration - allow view updates
@@ -366,8 +367,9 @@ export function MediaUploadModal( {
 	);
 
 	const handleModalClose = useCallback( () => {
+		removeAllNotices( 'snackbar', NOTICES_CONTEXT );
 		onClose?.();
-	}, [ onClose ] );
+	}, [ removeAllNotices, onClose ] );
 
 	// Use onUpload if provided, otherwise fall back to uploadMedia
 	const handleUpload = onUpload || uploadMedia;

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -316,7 +316,7 @@ export function MediaUploadModal( {
 		() => [
 			{
 				id: 'select',
-				label: multiple ? __( 'Select' ) : __( 'Select' ),
+				label: __( 'Select' ),
 				isPrimary: true,
 				supportsBulk: multiple,
 				async callback() {

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -57,6 +57,7 @@ import {
 
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 
+// Module-level counter for generating unique IDs for upload status entries.
 let uploadIdCounter = 0;
 
 // Layout constants - matching the picker layout types

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -6,6 +6,8 @@ import {
 	useState,
 	useCallback,
 	useMemo,
+	useRef,
+	useEffect,
 } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import {
@@ -17,6 +19,7 @@ import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
 import type { View, Field, ActionButton } from '@wordpress/dataviews';
+import { Stack } from '@wordpress/ui';
 import {
 	altTextField,
 	attachedToField,
@@ -40,9 +43,16 @@ import { isBlobURL } from '@wordpress/blob';
 import type { Attachment, RestAttachment } from '../../utils/types';
 import { transformAttachment } from '../../utils/transform-attachment';
 import { uploadMedia } from '../../utils/upload-media';
+import { UploadError } from '../../utils/upload-error';
 import { unlock } from '../../lock-unlock';
+import {
+	UploadStatusPopover,
+	type UploadingFile,
+} from './upload-status-popover';
 
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+
+let uploadIdCounter = 0;
 
 // Layout constants - matching the picker layout types
 const LAYOUT_PICKER_GRID = 'pickerGrid';
@@ -173,8 +183,32 @@ export function MediaUploadModal( {
 			: [ String( value ) ];
 	} );
 
-	const { createSuccessNotice, createErrorNotice, createInfoNotice } =
-		useDispatch( noticesStore );
+	const [ uploadingFiles, setUploadingFiles ] = useState< UploadingFile[] >(
+		[]
+	);
+	const completionTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
+	const isPopoverOpenRef = useRef( false );
+
+	// Clear timeout on unmount.
+	useEffect( () => {
+		return () => {
+			if ( completionTimeoutRef.current ) {
+				clearTimeout( completionTimeoutRef.current );
+			}
+		};
+	}, [] );
+
+	const handlePopoverOpenChange = useCallback( ( open: boolean ) => {
+		isPopoverOpenRef.current = open;
+		// When the popover closes, clear completed files.
+		if ( ! open ) {
+			setUploadingFiles( ( prev ) =>
+				prev.filter( ( f ) => f.status !== 'complete' )
+			);
+		}
+	}, [] );
+
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { invalidateResolution } = useDispatch( coreStore );
 
 	// DataViews configuration - allow view updates
@@ -344,7 +378,26 @@ export function MediaUploadModal( {
 			);
 
 			if ( allComplete && attachments.length > 0 ) {
-				// Show success notice (replaces progress notice via ID)
+				// Mark uploading files as complete
+				setUploadingFiles( ( prev ) =>
+					prev.map( ( f ) =>
+						f.status === 'uploading'
+							? { ...f, status: 'complete' as const }
+							: f
+					)
+				);
+
+				// Clear completed entries after a delay, but only if the
+				// popover isn't open. If it is, they'll be cleared on close.
+				completionTimeoutRef.current = setTimeout( () => {
+					if ( ! isPopoverOpenRef.current ) {
+						setUploadingFiles( ( prev ) =>
+							prev.filter( ( f ) => f.status !== 'complete' )
+						);
+					}
+				}, 2000 );
+
+				// Show success notice
 				createSuccessNotice(
 					sprintf(
 						// translators: %s: number of files
@@ -387,17 +440,30 @@ export function MediaUploadModal( {
 	);
 
 	// Shared upload error handler
-	const handleUploadError = useCallback(
-		( error: Error ) => {
-			// Show error notice (replaces progress notice via ID)
-			createErrorNotice( error.message, {
-				type: 'snackbar',
-				context: NOTICES_CONTEXT,
-				id: NOTICE_ID_UPLOAD_PROGRESS,
+	const handleUploadError = useCallback( ( error: Error ) => {
+		const fileName =
+			error instanceof UploadError ? error.file.name : undefined;
+
+		setUploadingFiles( ( prev ) => {
+			let matched = false;
+			return prev.map( ( f ) => {
+				if (
+					! matched &&
+					fileName &&
+					f.name === fileName &&
+					f.status === 'uploading'
+				) {
+					matched = true;
+					return {
+						...f,
+						status: 'error' as const,
+						error: error.message,
+					};
+				}
+				return f;
 			} );
-		},
-		[ createErrorNotice ]
-	);
+		} );
+	}, [] );
 
 	const handleFileSelect = useCallback(
 		( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -405,24 +471,15 @@ export function MediaUploadModal( {
 			if ( files && files.length > 0 ) {
 				const filesArray = Array.from( files );
 
-				// Show upload start notice
-				createInfoNotice(
-					sprintf(
-						// translators: %s: number of files
-						_n(
-							'Uploading %s file',
-							'Uploading %s files',
-							filesArray.length
-						),
-						filesArray.length.toLocaleString()
-					),
-					{
-						type: 'snackbar',
-						context: NOTICES_CONTEXT,
-						id: NOTICE_ID_UPLOAD_PROGRESS,
-						explicitDismiss: true,
-					}
+				// Track uploading files in popover
+				const newEntries: UploadingFile[] = filesArray.map(
+					( file ) => ( {
+						id: String( ++uploadIdCounter ),
+						name: file.name,
+						status: 'uploading' as const,
+					} )
 				);
+				setUploadingFiles( ( prev ) => [ ...prev, ...newEntries ] );
 
 				handleUpload( {
 					allowedTypes,
@@ -432,13 +489,7 @@ export function MediaUploadModal( {
 				} );
 			}
 		},
-		[
-			allowedTypes,
-			handleUpload,
-			createInfoNotice,
-			handleUploadComplete,
-			handleUploadError,
-		]
+		[ allowedTypes, handleUpload, handleUploadComplete, handleUploadError ]
 	);
 
 	const paginationInfo = useMemo(
@@ -525,24 +576,18 @@ export function MediaUploadModal( {
 						);
 					}
 					if ( filteredFiles.length > 0 ) {
-						// Show upload start notice
-						createInfoNotice(
-							sprintf(
-								// translators: %s: number of files
-								_n(
-									'Uploading %s file',
-									'Uploading %s files',
-									filteredFiles.length
-								),
-								filteredFiles.length.toLocaleString()
-							),
-							{
-								type: 'snackbar',
-								context: NOTICES_CONTEXT,
-								id: NOTICE_ID_UPLOAD_PROGRESS,
-								explicitDismiss: true,
-							}
+						// Track uploading files in popover
+						const newEntries: UploadingFile[] = filteredFiles.map(
+							( file ) => ( {
+								id: String( ++uploadIdCounter ),
+								name: file.name,
+								status: 'uploading' as const,
+							} )
 						);
+						setUploadingFiles( ( prev ) => [
+							...prev,
+							...newEntries,
+						] );
 
 						handleUpload( {
 							allowedTypes,
@@ -566,10 +611,51 @@ export function MediaUploadModal( {
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
 				getItemId={ ( item: RestAttachment ) => String( item.id ) }
-				search={ search }
-				searchLabel={ searchLabel }
 				itemListLabel={ __( 'Media items' ) }
-			/>
+			>
+				<Stack
+					direction="row"
+					align="top"
+					justify="space-between"
+					className="dataviews__view-actions"
+					gap="xs"
+				>
+					<Stack
+						direction="row"
+						gap="sm"
+						justify="start"
+						className="dataviews__search"
+					>
+						{ search && (
+							<DataViewsPicker.Search label={ searchLabel } />
+						) }
+						<DataViewsPicker.FiltersToggle />
+					</Stack>
+					<Stack direction="row" gap="xs" style={ { flexShrink: 0 } }>
+						<DataViewsPicker.ViewConfig />
+					</Stack>
+				</Stack>
+				<DataViewsPicker.FiltersToggled className="dataviews-filters__container" />
+				<DataViewsPicker.Layout />
+				<div
+					className={
+						uploadingFiles.length > 0
+							? 'media-upload-modal__footer is-uploading'
+							: 'media-upload-modal__footer'
+					}
+				>
+					<UploadStatusPopover
+						uploadingFiles={ uploadingFiles }
+						onDismissError={ ( fileId ) => {
+							setUploadingFiles( ( prev ) =>
+								prev.filter( ( f ) => f.id !== fileId )
+							);
+						} }
+						onOpenChange={ handlePopoverOpenChange }
+					/>
+					<DataViewsPicker.BulkActionToolbar />
+				</div>
+			</DataViewsPicker>
 			{ createPortal(
 				<SnackbarNotices
 					className="media-upload-modal__snackbar"

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -579,6 +579,7 @@ export function MediaUploadModal( {
 						<DataViewsPicker.FiltersToggle />
 					</Stack>
 					<Stack direction="row" gap="xs" style={ { flexShrink: 0 } }>
+						<DataViewsPicker.LayoutSwitcher />
 						<DataViewsPicker.ViewConfig />
 					</Stack>
 				</Stack>

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -40,7 +40,6 @@ import {
 	mimeTypeField,
 } from '@wordpress/media-fields';
 import { store as noticesStore, SnackbarNotices } from '@wordpress/notices';
-import { isBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -48,17 +47,11 @@ import { isBlobURL } from '@wordpress/blob';
 import type { Attachment, RestAttachment } from '../../utils/types';
 import { transformAttachment } from '../../utils/transform-attachment';
 import { uploadMedia } from '../../utils/upload-media';
-import { UploadError } from '../../utils/upload-error';
 import { unlock } from '../../lock-unlock';
-import {
-	UploadStatusPopover,
-	type UploadingFile,
-} from './upload-status-popover';
+import { UploadStatusPopover } from './upload-status-popover';
+import { useUploadStatus } from './use-upload-status';
 
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
-
-// Module-level counter for generating unique IDs for upload status entries.
-let uploadIdCounter = 0;
 
 // Layout constants - matching the picker layout types
 const LAYOUT_PICKER_GRID = 'pickerGrid';
@@ -189,30 +182,24 @@ export function MediaUploadModal( {
 			: [ String( value ) ];
 	} );
 
-	const [ uploadingFiles, setUploadingFiles ] = useState< UploadingFile[] >(
-		[]
-	);
-	const completionTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
+	const {
+		uploadingFiles,
+		registerBatch,
+		dismissError,
+		clearCompleted,
+		allComplete,
+	} = useUploadStatus();
+
 	const isPopoverOpenRef = useRef( false );
-
-	// Clear timeout on unmount.
-	useEffect( () => {
-		return () => {
-			if ( completionTimeoutRef.current ) {
-				clearTimeout( completionTimeoutRef.current );
+	const handlePopoverOpenChange = useCallback(
+		( open: boolean ) => {
+			isPopoverOpenRef.current = open;
+			if ( ! open ) {
+				clearCompleted();
 			}
-		};
-	}, [] );
-
-	const handlePopoverOpenChange = useCallback( ( open: boolean ) => {
-		isPopoverOpenRef.current = open;
-		// When the popover closes, clear completed files.
-		if ( ! open ) {
-			setUploadingFiles( ( prev ) =>
-				prev.filter( ( f ) => f.status !== 'complete' )
-			);
-		}
-	}, [] );
+		},
+		[ clearCompleted ]
+	);
 
 	const { createSuccessNotice, removeAllNotices } =
 		useDispatch( noticesStore );
@@ -359,11 +346,12 @@ export function MediaUploadModal( {
 						? transformedPosts
 						: transformedPosts?.[ 0 ];
 
+					removeAllNotices( 'snackbar', NOTICES_CONTEXT );
 					onSelect( selectedItems );
 				},
 			},
 		],
-		[ multiple, onSelect, selection ]
+		[ multiple, onSelect, selection, removeAllNotices ]
 	);
 
 	const handleModalClose = useCallback( () => {
@@ -374,47 +362,53 @@ export function MediaUploadModal( {
 	// Use onUpload if provided, otherwise fall back to uploadMedia
 	const handleUpload = onUpload || uploadMedia;
 
-	// Shared upload success handler
-	const handleUploadComplete = useCallback(
+	// Per-batch completion handler: auto-select uploaded items and refresh the grid.
+	const handleBatchComplete = useCallback(
 		( attachments: Partial< Attachment >[] ) => {
-			// Check if all uploads are complete (no blob URLs)
-			const allComplete = attachments.every(
-				( attachment ) =>
-					attachment.id &&
-					attachment.url &&
-					! isBlobURL( attachment.url )
-			);
+			const uploadedIds = attachments
+				.map( ( attachment ) => String( attachment.id ) )
+				.filter( Boolean );
 
-			if ( allComplete && attachments.length > 0 ) {
-				// Mark uploading files as complete
-				setUploadingFiles( ( prev ) =>
-					prev.map( ( f ) =>
-						f.status === 'uploading'
-							? { ...f, status: 'complete' as const }
-							: f
-					)
-				);
+			if ( multiple ) {
+				setSelection( ( prev ) => {
+					const existing = new Set( prev );
+					const newIds = uploadedIds.filter(
+						( id ) => ! existing.has( id )
+					);
+					return [ ...prev, ...newIds ];
+				} );
+			} else {
+				setSelection( uploadedIds.slice( 0, 1 ) );
+			}
 
-				// Clear completed entries after a delay, but only if the
-				// popover isn't open. If it is, they'll be cleared on close.
-				completionTimeoutRef.current = setTimeout( () => {
-					if ( ! isPopoverOpenRef.current ) {
-						setUploadingFiles( ( prev ) =>
-							prev.filter( ( f ) => f.status !== 'complete' )
-						);
-					}
-				}, 2000 );
+			// Invalidate immediately so newly uploaded files appear in the grid.
+			// The server has already returned 201 responses at this point.
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'attachment',
+				queryArgs,
+			] );
+		},
+		[ multiple, invalidateResolution, queryArgs ]
+	);
 
-				// Show success notice
+	// Show success notice and auto-clear completed entries when all batches finish.
+	const prevAllCompleteRef = useRef( false );
+	useEffect( () => {
+		if ( allComplete && ! prevAllCompleteRef.current ) {
+			const completeCount = uploadingFiles.filter(
+				( f ) => f.status === 'uploaded'
+			).length;
+			if ( completeCount > 0 ) {
 				createSuccessNotice(
 					sprintf(
 						// translators: %s: number of files
 						_n(
 							'Uploaded %s file',
 							'Uploaded %s files',
-							attachments.length
+							completeCount
 						),
-						attachments.length.toLocaleString()
+						completeCount.toLocaleString()
 					),
 					{
 						type: 'snackbar',
@@ -422,82 +416,35 @@ export function MediaUploadModal( {
 						id: NOTICE_ID_UPLOAD_PROGRESS,
 					}
 				);
-
-				// Auto-select the newly uploaded items
-				const uploadedIds = attachments
-					.map( ( attachment ) => String( attachment.id ) )
-					.filter( Boolean );
-
-				if ( multiple ) {
-					// In multiple mode, add to existing selection
-					setSelection( ( prev ) => [ ...prev, ...uploadedIds ] );
-				} else {
-					// In single mode, replace selection with the first uploaded item
-					setSelection( uploadedIds.slice( 0, 1 ) );
-				}
-
-				// Invalidate the entity records resolution to refresh the view
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					'attachment',
-					queryArgs,
-				] );
 			}
-		},
-		[ createSuccessNotice, invalidateResolution, queryArgs, multiple ]
-	);
 
-	// Shared upload error handler
-	const handleUploadError = useCallback( ( error: Error ) => {
-		const fileName =
-			error instanceof UploadError ? error.file.name : undefined;
-
-		setUploadingFiles( ( prev ) => {
-			let matched = false;
-			return prev.map( ( f ) => {
-				if (
-					! matched &&
-					fileName &&
-					f.name === fileName &&
-					f.status === 'uploading'
-				) {
-					matched = true;
-					return {
-						...f,
-						status: 'error' as const,
-						error: error.message,
-					};
-				}
-				return f;
-			} );
-		} );
-	}, [] );
+			// Auto-clear completed entries, unless the popover is
+			// open — in that case, they'll be cleared on close.
+			if ( ! isPopoverOpenRef.current ) {
+				clearCompleted();
+			}
+		}
+		prevAllCompleteRef.current = allComplete;
+	}, [ allComplete, uploadingFiles, createSuccessNotice, clearCompleted ] );
 
 	const handleFileSelect = useCallback(
 		( event: React.ChangeEvent< HTMLInputElement > ) => {
 			const files = event.target.files;
 			if ( files && files.length > 0 ) {
 				const filesArray = Array.from( files );
-
-				// Track uploading files in popover
-				const newEntries: UploadingFile[] = filesArray.map(
-					( file ) => ( {
-						id: String( ++uploadIdCounter ),
-						name: file.name,
-						status: 'uploading' as const,
-					} )
-				);
-				setUploadingFiles( ( prev ) => [ ...prev, ...newEntries ] );
+				const { onFileChange, onError } = registerBatch( filesArray, {
+					onBatchComplete: handleBatchComplete,
+				} );
 
 				handleUpload( {
 					allowedTypes,
 					filesList: filesArray,
-					onFileChange: handleUploadComplete,
-					onError: handleUploadError,
+					onFileChange,
+					onError,
 				} );
 			}
 		},
-		[ allowedTypes, handleUpload, handleUploadComplete, handleUploadError ]
+		[ allowedTypes, handleUpload, registerBatch, handleBatchComplete ]
 	);
 
 	const paginationInfo = useMemo(
@@ -584,24 +531,16 @@ export function MediaUploadModal( {
 						);
 					}
 					if ( filteredFiles.length > 0 ) {
-						// Track uploading files in popover
-						const newEntries: UploadingFile[] = filteredFiles.map(
-							( file ) => ( {
-								id: String( ++uploadIdCounter ),
-								name: file.name,
-								status: 'uploading' as const,
-							} )
+						const { onFileChange, onError } = registerBatch(
+							filteredFiles,
+							{ onBatchComplete: handleBatchComplete }
 						);
-						setUploadingFiles( ( prev ) => [
-							...prev,
-							...newEntries,
-						] );
 
 						handleUpload( {
 							allowedTypes,
 							filesList: filteredFiles,
-							onFileChange: handleUploadComplete,
-							onError: handleUploadError,
+							onFileChange,
+							onError,
 						} );
 					}
 				} }
@@ -652,11 +591,7 @@ export function MediaUploadModal( {
 				>
 					<UploadStatusPopover
 						uploadingFiles={ uploadingFiles }
-						onDismissError={ ( fileId ) => {
-							setUploadingFiles( ( prev ) =>
-								prev.filter( ( f ) => f.id !== fileId )
-							);
-						} }
+						onDismissError={ dismissError }
 						onOpenChange={ handlePopoverOpenChange }
 					/>
 					<DataViewsPicker.BulkActionToolbar />

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -123,12 +123,4 @@
 		font-size: 12px;
 	}
 
-	.media-upload-modal__upload-status__error {
-		color: $alert-red;
-		font-size: 12px;
-		flex-shrink: 0;
-		display: flex;
-		align-items: center;
-		gap: $grid-unit-05;
-	}
 }

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -45,17 +45,12 @@
 		position: absolute;
 		display: flex;
 		align-items: center;
+		gap: $grid-unit-10;
 		// Match the footer's padding so the trigger aligns with the item count.
 		left: $grid-unit-30;
 		top: 0;
 		bottom: 0;
 		z-index: 1;
-	}
-
-	.media-upload-modal__upload-status__trigger {
-		display: flex;
-		align-items: center;
-		gap: $grid-unit-10;
 
 		.components-spinner {
 			width: $grid-unit-20;

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -122,5 +122,4 @@
 		flex: 1;
 		font-size: 12px;
 	}
-
 }

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -30,7 +30,7 @@
 		// Match the z-index the footer normally has, since we take over sticky.
 		z-index: 2;
 
-		&.is-uploading .dataviews-bulk-actions-footer__item-count {
+		&.is-uploading .dataviews-picker-footer__bulk-selection {
 			visibility: hidden;
 		}
 

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -42,6 +42,7 @@
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-10;
+		background-color: var(--wp-dataviews-color-background, $white);
 		// Match the footer's padding so the trigger aligns with the item count.
 		left: $grid-unit-30;
 		top: 0;

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	.components-modal__frame.is-full-screen .components-modal__content {
-		margin-bottom: $grid-unit-20;
+		margin-bottom: 0;
 	}
 
 	.components-modal__content {
@@ -17,10 +17,6 @@
 
 	.dataviews-picker-wrapper > .dataviews__view-actions {
 		padding-top: $grid-unit-10;
-	}
-
-	.dataviews-footer {
-		padding-bottom: $grid-unit-10;
 	}
 
 	.media-upload-modal__footer {

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -22,22 +22,6 @@
 	.dataviews-footer {
 		padding-bottom: $grid-unit-10;
 	}
-}
-
-.media-upload-modal__snackbar {
-	@include snackbar-container();
-	z-index: 200000;
-
-	// Override the transform and transform-origin applied by the Snackbar component
-	// to prevent the snackbar from shifting position when its content changes while
-	// the media upload modal is open. This is an edge case particular to the media
-	// upload modal when instantiated from a popover, such as the Replace control in
-	// the Image Block. In that case, the Framer Motion transform appears to get
-	// confused by the Snackbars being a child of the popover.
-	> div {
-		transform: none !important;
-		transform-origin: 0 !important;
-	}
 
 	.media-upload-modal__footer {
 		position: sticky;
@@ -76,13 +60,30 @@
 		.components-spinner {
 			width: $grid-unit-20;
 			height: $grid-unit-20;
+			margin: 0;
 		}
 	}
+}
 
-	.media-upload-modal__upload-status__popover {
-		.components-popover__content {
-			width: 320px;
-		}
+.media-upload-modal__snackbar {
+	@include snackbar-container();
+	z-index: 200000;
+
+	// Override the transform and transform-origin applied by the Snackbar component
+	// to prevent the snackbar from shifting position when its content changes while
+	// the media upload modal is open. This is an edge case particular to the media
+	// upload modal when instantiated from a popover, such as the Replace control in
+	// the Image Block. In that case, the Framer Motion transform appears to get
+	// confused by the Snackbars being a child of the popover.
+	> div {
+		transform: none !important;
+		transform-origin: 0 !important;
+	}
+}
+
+.media-upload-modal__upload-status__popover {
+	.components-popover__content {
+		width: 320px;
 	}
 
 	.media-upload-modal__upload-status__header {
@@ -90,12 +91,10 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: $grid-unit-15 $grid-unit-20;
-		border-bottom: 1px solid $gray-300;
-
 		h3 {
 			margin: 0;
 			font-size: 13px;
-			font-weight: 600;
+			font-weight: $font-weight-medium;
 		}
 	}
 
@@ -103,26 +102,23 @@
 		max-height: 200px;
 		overflow-y: auto;
 		margin: 0;
-		padding: 0;
+		padding: 0 0 $grid-unit-05;
 		list-style: none;
 	}
 
 	.media-upload-modal__upload-status__item {
 		display: flex;
 		align-items: flex-start;
+		margin-bottom: 0;
 		justify-content: space-between;
 		gap: $grid-unit-10;
 		padding: $grid-unit-10 $grid-unit-20;
-		border-bottom: 1px solid $gray-100;
-
-		&:last-child {
-			border-bottom: none;
-		}
 
 		.components-spinner {
 			flex-shrink: 0;
 			width: $grid-unit-20;
 			height: $grid-unit-20;
+			margin: 0;
 		}
 	}
 

--- a/packages/media-utils/src/components/media-upload-modal/style.scss
+++ b/packages/media-utils/src/components/media-upload-modal/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/mixins" as *;
 
 .media-upload-modal {
@@ -36,5 +37,110 @@
 	> div {
 		transform: none !important;
 		transform-origin: 0 !important;
+	}
+
+	.media-upload-modal__footer {
+		position: sticky;
+		bottom: 0;
+		background-color: inherit;
+		// Match the z-index the footer normally has, since we take over sticky.
+		z-index: 2;
+
+		&.is-uploading .dataviews-bulk-actions-footer__item-count {
+			visibility: hidden;
+		}
+
+		// The inner footer no longer needs sticky/z-index since the wrapper handles it.
+		.dataviews-footer {
+			position: static;
+			z-index: auto;
+		}
+	}
+
+	.media-upload-modal__upload-status {
+		position: absolute;
+		display: flex;
+		align-items: center;
+		// Match the footer's padding so the trigger aligns with the item count.
+		left: $grid-unit-30;
+		top: 0;
+		bottom: 0;
+		z-index: 1;
+	}
+
+	.media-upload-modal__upload-status__trigger {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+
+		.components-spinner {
+			width: $grid-unit-20;
+			height: $grid-unit-20;
+		}
+	}
+
+	.media-upload-modal__upload-status__popover {
+		.components-popover__content {
+			width: 320px;
+		}
+	}
+
+	.media-upload-modal__upload-status__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: $grid-unit-15 $grid-unit-20;
+		border-bottom: 1px solid $gray-300;
+
+		h3 {
+			margin: 0;
+			font-size: 13px;
+			font-weight: 600;
+		}
+	}
+
+	.media-upload-modal__upload-status__list {
+		max-height: 200px;
+		overflow-y: auto;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.media-upload-modal__upload-status__item {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: $grid-unit-10;
+		padding: $grid-unit-10 $grid-unit-20;
+		border-bottom: 1px solid $gray-100;
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		.components-spinner {
+			flex-shrink: 0;
+			width: $grid-unit-20;
+			height: $grid-unit-20;
+		}
+	}
+
+	.media-upload-modal__upload-status__filename {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		min-width: 0;
+		flex: 1;
+		font-size: 12px;
+	}
+
+	.media-upload-modal__upload-status__error {
+		color: $alert-red;
+		font-size: 12px;
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
 	}
 }

--- a/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
+++ b/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
@@ -1,0 +1,647 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useUploadStatus } from '../use-upload-status';
+import { UploadError } from '../../../utils/upload-error';
+
+function createFile( name: string ): File {
+	return new File( [ 'content' ], name, { type: 'image/png' } );
+}
+
+function createAttachment( id: number, name: string ) {
+	return { id, url: `https://example.com/${ name }` };
+}
+
+function createBlobAttachment( name: string ) {
+	return { url: `blob:https://example.com/${ name }` };
+}
+
+// isBlobURL from @wordpress/blob checks for the "blob:" prefix.
+jest.mock( '@wordpress/blob', () => ( {
+	isBlobURL: ( url: string ) => url.startsWith( 'blob:' ),
+} ) );
+
+describe( 'useUploadStatus', () => {
+	it( 'should start with empty state', () => {
+		const { result } = renderHook( () => useUploadStatus() );
+
+		expect( result.current.uploadingFiles ).toEqual( [] );
+		expect( result.current.allComplete ).toBe( false );
+	} );
+
+	describe( 'registerBatch', () => {
+		it( 'should add files with uploading status', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+
+			act( () => {
+				result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] );
+			} );
+
+			expect( result.current.uploadingFiles ).toHaveLength( 2 );
+			expect( result.current.uploadingFiles[ 0 ].name ).toBe( 'a.png' );
+			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
+				'uploading'
+			);
+			expect( result.current.uploadingFiles[ 1 ].name ).toBe( 'b.png' );
+			expect( result.current.allComplete ).toBe( false );
+		} );
+
+		it( 'should assign the same batchId to files in a batch', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+
+			act( () => {
+				result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] );
+			} );
+
+			const batchId = result.current.uploadingFiles[ 0 ].batchId;
+			expect( batchId ).toBeTruthy();
+			expect( result.current.uploadingFiles[ 1 ].batchId ).toBe(
+				batchId
+			);
+		} );
+
+		it( 'should assign different batchIds to separate batches', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+
+			act( () => {
+				result.current.registerBatch( [ createFile( 'a.png' ) ] );
+				result.current.registerBatch( [ createFile( 'b.png' ) ] );
+			} );
+
+			expect( result.current.uploadingFiles[ 0 ].batchId ).not.toBe(
+				result.current.uploadingFiles[ 1 ].batchId
+			);
+		} );
+	} );
+
+	describe( 'onFileChange (batch completion)', () => {
+		it( 'should ignore calls with blob URLs', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+
+			act( () => {
+				( { onFileChange } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+				] ) );
+			} );
+
+			act( () => {
+				onFileChange( [ createBlobAttachment( 'a.png' ) ] );
+			} );
+
+			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
+				'uploading'
+			);
+			expect( result.current.allComplete ).toBe( false );
+		} );
+
+		it( 'should mark batch as uploaded when all attachments have real URLs', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+
+			act( () => {
+				( { onFileChange } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] ) );
+			} );
+
+			act( () => {
+				onFileChange( [
+					createAttachment( 1, 'a.png' ),
+					createAttachment( 2, 'b.png' ),
+				] );
+			} );
+
+			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
+				'uploaded'
+			);
+			expect( result.current.uploadingFiles[ 1 ].status ).toBe(
+				'uploaded'
+			);
+			expect( result.current.allComplete ).toBe( true );
+		} );
+
+		it( 'should only mark its own batch as uploaded, not other batches', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onFileChangeA: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+			let onFileChangeB: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+
+			act( () => {
+				( { onFileChange: onFileChangeA } =
+					result.current.registerBatch( [ createFile( 'a.png' ) ] ) );
+				( { onFileChange: onFileChangeB } =
+					result.current.registerBatch( [ createFile( 'b.png' ) ] ) );
+			} );
+
+			// Complete batch A only.
+			act( () => {
+				onFileChangeA( [ createAttachment( 1, 'a.png' ) ] );
+			} );
+
+			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
+				'uploaded'
+			);
+			expect( result.current.uploadingFiles[ 1 ].status ).toBe(
+				'uploading'
+			);
+			expect( result.current.allComplete ).toBe( false );
+
+			// Now complete batch B.
+			act( () => {
+				onFileChangeB( [ createAttachment( 2, 'b.png' ) ] );
+			} );
+
+			expect( result.current.allComplete ).toBe( true );
+		} );
+
+		it( 'should call onBatchComplete exactly once even if onFileChange fires multiple times', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			const onBatchComplete = jest.fn();
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+
+			act( () => {
+				( { onFileChange } = result.current.registerBatch(
+					[ createFile( 'a.png' ) ],
+					{ onBatchComplete }
+				) );
+			} );
+
+			const attachment = createAttachment( 1, 'a.png' );
+
+			act( () => {
+				onFileChange( [ attachment ] );
+				onFileChange( [ attachment ] );
+				onFileChange( [ attachment ] );
+			} );
+
+			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
+			expect( onBatchComplete ).toHaveBeenCalledWith( [ attachment ] );
+		} );
+
+		it( 'should handle onFileChange with growing arrays (no blob URLs)', () => {
+			// When window.__clientSideMediaProcessing is true, blob URLs
+			// are not created. onFileChange is called with a growing array
+			// as each file completes: [att1], [att1, att2], [att1, att2, att3].
+			// The success count must not double-count overlapping entries.
+			const { result } = renderHook( () => useUploadStatus() );
+			const onBatchComplete = jest.fn();
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+
+			act( () => {
+				( { onFileChange } = result.current.registerBatch(
+					[
+						createFile( 'a.png' ),
+						createFile( 'b.png' ),
+						createFile( 'c.png' ),
+					],
+					{ onBatchComplete }
+				) );
+			} );
+
+			const att1 = createAttachment( 1, 'a.png' );
+			const att2 = createAttachment( 2, 'b.png' );
+			const att3 = createAttachment( 3, 'c.png' );
+
+			// File 1 completes.
+			act( () => {
+				onFileChange( [ att1 ] );
+			} );
+
+			expect( onBatchComplete ).not.toHaveBeenCalled();
+			expect( result.current.allComplete ).toBe( false );
+
+			// File 2 completes.
+			act( () => {
+				onFileChange( [ att1, att2 ] );
+			} );
+
+			expect( onBatchComplete ).not.toHaveBeenCalled();
+			expect( result.current.allComplete ).toBe( false );
+
+			// File 3 completes — batch should now be done.
+			act( () => {
+				onFileChange( [ att1, att2, att3 ] );
+			} );
+
+			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
+			expect( onBatchComplete ).toHaveBeenCalledWith( [
+				att1,
+				att2,
+				att3,
+			] );
+			expect( result.current.allComplete ).toBe( true );
+		} );
+	} );
+
+	describe( 'onError', () => {
+		it( 'should mark the matching file in the batch as errored', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onError: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onError } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] ) );
+			} );
+
+			act( () => {
+				const file = createFile( 'a.png' );
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'Upload failed',
+						file,
+					} )
+				);
+			} );
+
+			expect( result.current.uploadingFiles[ 0 ].status ).toBe( 'error' );
+			expect( result.current.uploadingFiles[ 0 ].error ).toBe(
+				'Upload failed'
+			);
+			expect( result.current.uploadingFiles[ 1 ].status ).toBe(
+				'uploading'
+			);
+		} );
+
+		it( 'should only mark one file per error even with duplicate names in the same batch', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onError: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onError } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'a.png' ),
+				] ) );
+			} );
+
+			act( () => {
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'Upload failed',
+						file: createFile( 'a.png' ),
+					} )
+				);
+			} );
+
+			const statuses = result.current.uploadingFiles.map(
+				( f ) => f.status
+			);
+			expect( statuses ).toEqual( [ 'error', 'uploading' ] );
+		} );
+
+		it( 'should not affect files in a different batch', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onErrorB: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				result.current.registerBatch( [ createFile( 'a.png' ) ] );
+				( { onError: onErrorB } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+				] ) );
+			} );
+
+			// Error targets batch B's file, not batch A's.
+			act( () => {
+				onErrorB(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'Upload failed',
+						file: createFile( 'a.png' ),
+					} )
+				);
+			} );
+
+			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
+				'uploading'
+			);
+			expect( result.current.uploadingFiles[ 1 ].status ).toBe( 'error' );
+		} );
+	} );
+
+	describe( 'allComplete', () => {
+		it( 'should be false when there are no files', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			expect( result.current.allComplete ).toBe( false );
+		} );
+
+		it( 'should be false when some files are still uploading', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onFileChangeA: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+
+			act( () => {
+				( { onFileChange: onFileChangeA } =
+					result.current.registerBatch( [ createFile( 'a.png' ) ] ) );
+				result.current.registerBatch( [ createFile( 'b.png' ) ] );
+			} );
+
+			act( () => {
+				onFileChangeA( [ createAttachment( 1, 'a.png' ) ] );
+			} );
+
+			expect( result.current.allComplete ).toBe( false );
+		} );
+
+		it( 'should be true when all files are uploaded or errored', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+			let onError: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onFileChange, onError } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] ) );
+			} );
+
+			act( () => {
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'fail',
+						file: createFile( 'a.png' ),
+					} )
+				);
+			} );
+
+			// One errored, one still uploading.
+			expect( result.current.allComplete ).toBe( false );
+
+			// Complete the remaining file — onFileChange fires with just
+			// the successful attachment (failed ones are filtered as null
+			// by uploadMedia).
+			act( () => {
+				onFileChange( [ createAttachment( 2, 'b.png' ) ] );
+			} );
+
+			expect( result.current.allComplete ).toBe( true );
+		} );
+	} );
+
+	describe( 'mixed success and error (uploadMedia race condition)', () => {
+		it( 'should handle onFileChange firing before onError for a failed file', () => {
+			// Simulates the uploadMedia flow for 3 files where c.png fails:
+			// 1. Blob URLs created for all 3 (ignored by hook)
+			// 2. a.png succeeds: onFileChange([a, blob:b, blob:c]) — has blobs, ignored
+			// 3. b.png succeeds: onFileChange([a, b, blob:c]) — has blobs, ignored
+			// 4. c.png fails: setAndUpdateFiles(2, null) triggers
+			//    onFileChange([a, b]) — 2 real URLs, resolvedCount += 2
+			// 5. onError(c.png) — marks c.png as error, resolvedCount += 1
+			// 6. resolvedCount (3) >= batchSize (3) — batch complete
+			const { result } = renderHook( () => useUploadStatus() );
+			const onBatchComplete = jest.fn();
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+			let onError: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onFileChange, onError } = result.current.registerBatch(
+					[
+						createFile( 'a.png' ),
+						createFile( 'b.png' ),
+						createFile( 'c.png' ),
+					],
+					{ onBatchComplete }
+				) );
+			} );
+
+			// Steps 1-3: blob URL calls and partial completions (ignored).
+			act( () => {
+				onFileChange( [
+					createBlobAttachment( 'a' ),
+					createBlobAttachment( 'b' ),
+					createBlobAttachment( 'c' ),
+				] );
+				onFileChange( [
+					createAttachment( 1, 'a.png' ),
+					createBlobAttachment( 'b' ),
+					createBlobAttachment( 'c' ),
+				] );
+				onFileChange( [
+					createAttachment( 1, 'a.png' ),
+					createAttachment( 2, 'b.png' ),
+					createBlobAttachment( 'c' ),
+				] );
+			} );
+
+			expect( onBatchComplete ).not.toHaveBeenCalled();
+
+			// Step 4: c.png fails — onFileChange fires with nulls filtered
+			// (only the 2 successful attachments).
+			act( () => {
+				onFileChange( [
+					createAttachment( 1, 'a.png' ),
+					createAttachment( 2, 'b.png' ),
+				] );
+			} );
+
+			// resolvedCount is 2, batchSize is 3 — not done yet.
+			expect( onBatchComplete ).not.toHaveBeenCalled();
+
+			// Step 5: onError fires for c.png.
+			act( () => {
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'Upload failed',
+						file: createFile( 'c.png' ),
+					} )
+				);
+			} );
+
+			// Now resolvedCount is 3 — batch complete.
+			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
+			expect( onBatchComplete ).toHaveBeenCalledWith( [
+				createAttachment( 1, 'a.png' ),
+				createAttachment( 2, 'b.png' ),
+			] );
+
+			// c.png should be errored, a.png and b.png should be uploaded.
+			const statuses = result.current.uploadingFiles.map( ( f ) => [
+				f.name,
+				f.status,
+			] );
+			expect( statuses ).toEqual( [
+				[ 'a.png', 'uploaded' ],
+				[ 'b.png', 'uploaded' ],
+				[ 'c.png', 'error' ],
+			] );
+			expect( result.current.allComplete ).toBe( true );
+		} );
+
+		it( 'should handle all files erroring', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			const onBatchComplete = jest.fn();
+			let onFileChange: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+			let onError: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onFileChange, onError } = result.current.registerBatch(
+					[ createFile( 'a.png' ), createFile( 'b.png' ) ],
+					{ onBatchComplete }
+				) );
+			} );
+
+			// Both fail: onFileChange fires with empty array (all nulls
+			// filtered out), then onError fires for each.
+			act( () => {
+				onFileChange( [] );
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'fail a',
+						file: createFile( 'a.png' ),
+					} )
+				);
+				onFileChange( [] );
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'fail b',
+						file: createFile( 'b.png' ),
+					} )
+				);
+			} );
+
+			// onBatchComplete should still fire (with empty attachments).
+			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
+			expect( onBatchComplete ).toHaveBeenCalledWith( [] );
+
+			const statuses = result.current.uploadingFiles.map(
+				( f ) => f.status
+			);
+			expect( statuses ).toEqual( [ 'error', 'error' ] );
+			expect( result.current.allComplete ).toBe( true );
+		} );
+	} );
+
+	describe( 'dismissError', () => {
+		it( 'should remove the errored file from the list', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onError: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onError } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] ) );
+			} );
+
+			act( () => {
+				onError(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'fail',
+						file: createFile( 'a.png' ),
+					} )
+				);
+			} );
+
+			const erroredFile = result.current.uploadingFiles.find(
+				( f ) => f.status === 'error'
+			)!;
+
+			act( () => {
+				result.current.dismissError( erroredFile.id );
+			} );
+
+			expect( result.current.uploadingFiles ).toHaveLength( 1 );
+			expect( result.current.uploadingFiles[ 0 ].name ).toBe( 'b.png' );
+		} );
+	} );
+
+	describe( 'clearCompleted', () => {
+		it( 'should remove uploaded entries but keep uploading and errored ones', () => {
+			const { result } = renderHook( () => useUploadStatus() );
+			let onFileChangeA: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onFileChange' ];
+			let onErrorB: ReturnType<
+				typeof result.current.registerBatch
+			>[ 'onError' ];
+
+			act( () => {
+				( { onFileChange: onFileChangeA } =
+					result.current.registerBatch( [ createFile( 'a.png' ) ] ) );
+				( { onError: onErrorB } = result.current.registerBatch( [
+					createFile( 'b.png' ),
+				] ) );
+				result.current.registerBatch( [ createFile( 'c.png' ) ] );
+			} );
+
+			// Complete batch A, error batch B, leave batch C uploading.
+			act( () => {
+				onFileChangeA( [ createAttachment( 1, 'a.png' ) ] );
+				onErrorB(
+					new UploadError( {
+						code: 'GENERAL',
+						message: 'fail',
+						file: createFile( 'b.png' ),
+					} )
+				);
+			} );
+
+			act( () => {
+				result.current.clearCompleted();
+			} );
+
+			const remaining = result.current.uploadingFiles;
+			expect( remaining ).toHaveLength( 2 );
+			expect( remaining.map( ( f ) => f.status ) ).toEqual( [
+				'error',
+				'uploading',
+			] );
+		} );
+	} );
+} );

--- a/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
+++ b/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
@@ -179,17 +179,18 @@ describe( 'useUploadStatus', () => {
 		} );
 
 		it( 'should call onBatchComplete exactly once even if onFileChange fires multiple times', () => {
-			const { result } = renderHook( () => useUploadStatus() );
 			const onBatchComplete = jest.fn();
+			const { result } = renderHook( () =>
+				useUploadStatus( { onBatchComplete } )
+			);
 			let onFileChange: ReturnType<
 				typeof result.current.registerBatch
 			>[ 'onFileChange' ];
 
 			act( () => {
-				( { onFileChange } = result.current.registerBatch(
-					[ createFile( 'a.png' ) ],
-					{ onBatchComplete }
-				) );
+				( { onFileChange } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+				] ) );
 			} );
 
 			const attachment = createAttachment( 1, 'a.png' );
@@ -209,21 +210,20 @@ describe( 'useUploadStatus', () => {
 			// are not created. onFileChange is called with a growing array
 			// as each file completes: [att1], [att1, att2], [att1, att2, att3].
 			// The success count must not double-count overlapping entries.
-			const { result } = renderHook( () => useUploadStatus() );
 			const onBatchComplete = jest.fn();
+			const { result } = renderHook( () =>
+				useUploadStatus( { onBatchComplete } )
+			);
 			let onFileChange: ReturnType<
 				typeof result.current.registerBatch
 			>[ 'onFileChange' ];
 
 			act( () => {
-				( { onFileChange } = result.current.registerBatch(
-					[
-						createFile( 'a.png' ),
-						createFile( 'b.png' ),
-						createFile( 'c.png' ),
-					],
-					{ onBatchComplete }
-				) );
+				( { onFileChange } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+					createFile( 'c.png' ),
+				] ) );
 			} );
 
 			const att1 = createAttachment( 1, 'a.png' );
@@ -319,7 +319,7 @@ describe( 'useUploadStatus', () => {
 			} );
 
 			const statuses = result.current.uploadingFiles.map(
-				( f ) => f.status
+				( item ) => item.status
 			);
 			expect( statuses ).toEqual( [ 'error', 'uploading' ] );
 		} );
@@ -430,8 +430,10 @@ describe( 'useUploadStatus', () => {
 			//    onFileChange([a, b]) — 2 real URLs, resolvedCount += 2
 			// 5. onError(c.png) — marks c.png as error, resolvedCount += 1
 			// 6. resolvedCount (3) >= batchSize (3) — batch complete
-			const { result } = renderHook( () => useUploadStatus() );
 			const onBatchComplete = jest.fn();
+			const { result } = renderHook( () =>
+				useUploadStatus( { onBatchComplete } )
+			);
 			let onFileChange: ReturnType<
 				typeof result.current.registerBatch
 			>[ 'onFileChange' ];
@@ -440,14 +442,11 @@ describe( 'useUploadStatus', () => {
 			>[ 'onError' ];
 
 			act( () => {
-				( { onFileChange, onError } = result.current.registerBatch(
-					[
-						createFile( 'a.png' ),
-						createFile( 'b.png' ),
-						createFile( 'c.png' ),
-					],
-					{ onBatchComplete }
-				) );
+				( { onFileChange, onError } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+					createFile( 'c.png' ),
+				] ) );
 			} );
 
 			// Steps 1-3: blob URL calls and partial completions (ignored).
@@ -502,9 +501,9 @@ describe( 'useUploadStatus', () => {
 			] );
 
 			// c.png should be errored, a.png and b.png should be uploaded.
-			const statuses = result.current.uploadingFiles.map( ( f ) => [
-				f.name,
-				f.status,
+			const statuses = result.current.uploadingFiles.map( ( item ) => [
+				item.name,
+				item.status,
 			] );
 			expect( statuses ).toEqual( [
 				[ 'a.png', 'uploaded' ],
@@ -515,8 +514,10 @@ describe( 'useUploadStatus', () => {
 		} );
 
 		it( 'should handle all files erroring', () => {
-			const { result } = renderHook( () => useUploadStatus() );
 			const onBatchComplete = jest.fn();
+			const { result } = renderHook( () =>
+				useUploadStatus( { onBatchComplete } )
+			);
 			let onFileChange: ReturnType<
 				typeof result.current.registerBatch
 			>[ 'onFileChange' ];
@@ -525,10 +526,10 @@ describe( 'useUploadStatus', () => {
 			>[ 'onError' ];
 
 			act( () => {
-				( { onFileChange, onError } = result.current.registerBatch(
-					[ createFile( 'a.png' ), createFile( 'b.png' ) ],
-					{ onBatchComplete }
-				) );
+				( { onFileChange, onError } = result.current.registerBatch( [
+					createFile( 'a.png' ),
+					createFile( 'b.png' ),
+				] ) );
 			} );
 
 			// Both fail: onFileChange fires with empty array (all nulls
@@ -557,7 +558,7 @@ describe( 'useUploadStatus', () => {
 			expect( onBatchComplete ).toHaveBeenCalledWith( [] );
 
 			const statuses = result.current.uploadingFiles.map(
-				( f ) => f.status
+				( item ) => item.status
 			);
 			expect( statuses ).toEqual( [ 'error', 'error' ] );
 			expect( result.current.allComplete ).toBe( true );
@@ -589,7 +590,7 @@ describe( 'useUploadStatus', () => {
 			} );
 
 			const erroredFile = result.current.uploadingFiles.find(
-				( f ) => f.status === 'error'
+				( item ) => item.status === 'error'
 			)!;
 
 			act( () => {
@@ -638,7 +639,7 @@ describe( 'useUploadStatus', () => {
 
 			const remaining = result.current.uploadingFiles;
 			expect( remaining ).toHaveLength( 2 );
-			expect( remaining.map( ( f ) => f.status ) ).toEqual( [
+			expect( remaining.map( ( item ) => item.status ) ).toEqual( [
 				'error',
 				'uploading',
 			] );

--- a/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
+++ b/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
@@ -25,6 +25,22 @@ function createBlobAttachment( name: string ) {
 	return { url: `blob:https://example.com/${ name }` };
 }
 
+function createUploadError( name: string, message = 'Upload failed' ) {
+	return new UploadError( {
+		code: 'GENERAL',
+		message,
+		file: createFile( name ),
+	} );
+}
+
+function statuses( result: ReturnType< typeof useUploadStatus > ): string[] {
+	return result.uploadingFiles.map( ( item ) => item.status );
+}
+
+type BatchCallbacks = ReturnType<
+	ReturnType< typeof useUploadStatus >[ 'registerBatch' ]
+>;
+
 // isBlobURL from @wordpress/blob checks for the "blob:" prefix.
 jest.mock( '@wordpress/blob', () => ( {
 	isBlobURL: ( url: string ) => url.startsWith( 'blob:' ),
@@ -51,10 +67,10 @@ describe( 'useUploadStatus', () => {
 
 			expect( result.current.uploadingFiles ).toHaveLength( 2 );
 			expect( result.current.uploadingFiles[ 0 ].name ).toBe( 'a.png' );
-			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
-				'uploading'
-			);
-			expect( result.current.uploadingFiles[ 1 ].name ).toBe( 'b.png' );
+			expect( statuses( result.current ) ).toEqual( [
+				'uploading',
+				'uploading',
+			] );
 			expect( result.current.allComplete ).toBe( false );
 		} );
 
@@ -68,10 +84,10 @@ describe( 'useUploadStatus', () => {
 				] );
 			} );
 
-			const batchId = result.current.uploadingFiles[ 0 ].batchId;
-			expect( batchId ).toBeTruthy();
-			expect( result.current.uploadingFiles[ 1 ].batchId ).toBe(
-				batchId
+			const { uploadingFiles } = result.current;
+			expect( uploadingFiles[ 0 ].batchId ).toBeTruthy();
+			expect( uploadingFiles[ 0 ].batchId ).toBe(
+				uploadingFiles[ 1 ].batchId
 			);
 		} );
 
@@ -92,9 +108,7 @@ describe( 'useUploadStatus', () => {
 	describe( 'onFileChange (batch completion)', () => {
 		it( 'should ignore calls with blob URLs', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
 
 			act( () => {
 				( { onFileChange } = result.current.registerBatch( [
@@ -102,21 +116,15 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			act( () => {
-				onFileChange( [ createBlobAttachment( 'a.png' ) ] );
-			} );
+			act( () => onFileChange( [ createBlobAttachment( 'a.png' ) ] ) );
 
-			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
-				'uploading'
-			);
+			expect( statuses( result.current ) ).toEqual( [ 'uploading' ] );
 			expect( result.current.allComplete ).toBe( false );
 		} );
 
 		it( 'should mark batch as uploaded when all attachments have real URLs', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
 
 			act( () => {
 				( { onFileChange } = result.current.registerBatch( [
@@ -125,30 +133,24 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			act( () => {
+			act( () =>
 				onFileChange( [
 					createAttachment( 1, 'a.png' ),
 					createAttachment( 2, 'b.png' ),
-				] );
-			} );
+				] )
+			);
 
-			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
-				'uploaded'
-			);
-			expect( result.current.uploadingFiles[ 1 ].status ).toBe(
-				'uploaded'
-			);
+			expect( statuses( result.current ) ).toEqual( [
+				'uploaded',
+				'uploaded',
+			] );
 			expect( result.current.allComplete ).toBe( true );
 		} );
 
 		it( 'should only mark its own batch as uploaded, not other batches', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onFileChangeA: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
-			let onFileChangeB: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
+			let onFileChangeA!: BatchCallbacks[ 'onFileChange' ];
+			let onFileChangeB!: BatchCallbacks[ 'onFileChange' ];
 
 			act( () => {
 				( { onFileChange: onFileChangeA } =
@@ -157,23 +159,15 @@ describe( 'useUploadStatus', () => {
 					result.current.registerBatch( [ createFile( 'b.png' ) ] ) );
 			} );
 
-			// Complete batch A only.
-			act( () => {
-				onFileChangeA( [ createAttachment( 1, 'a.png' ) ] );
-			} );
+			act( () => onFileChangeA( [ createAttachment( 1, 'a.png' ) ] ) );
 
-			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
-				'uploaded'
-			);
-			expect( result.current.uploadingFiles[ 1 ].status ).toBe(
-				'uploading'
-			);
+			expect( statuses( result.current ) ).toEqual( [
+				'uploaded',
+				'uploading',
+			] );
 			expect( result.current.allComplete ).toBe( false );
 
-			// Now complete batch B.
-			act( () => {
-				onFileChangeB( [ createAttachment( 2, 'b.png' ) ] );
-			} );
+			act( () => onFileChangeB( [ createAttachment( 2, 'b.png' ) ] ) );
 
 			expect( result.current.allComplete ).toBe( true );
 		} );
@@ -183,9 +177,7 @@ describe( 'useUploadStatus', () => {
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
 
 			act( () => {
 				( { onFileChange } = result.current.registerBatch( [
@@ -206,17 +198,14 @@ describe( 'useUploadStatus', () => {
 		} );
 
 		it( 'should handle onFileChange with growing arrays (no blob URLs)', () => {
-			// When window.__clientSideMediaProcessing is true, blob URLs
-			// are not created. onFileChange is called with a growing array
-			// as each file completes: [att1], [att1, att2], [att1, att2, att3].
-			// The success count must not double-count overlapping entries.
+			// When __clientSideMediaProcessing is true, blob URLs are not
+			// created. onFileChange is called with a growing array as each
+			// file completes: [att1], [att1, att2], [att1, att2, att3].
 			const onBatchComplete = jest.fn();
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
 
 			act( () => {
 				( { onFileChange } = result.current.registerBatch( [
@@ -230,27 +219,13 @@ describe( 'useUploadStatus', () => {
 			const att2 = createAttachment( 2, 'b.png' );
 			const att3 = createAttachment( 3, 'c.png' );
 
-			// File 1 completes.
-			act( () => {
-				onFileChange( [ att1 ] );
-			} );
-
+			act( () => onFileChange( [ att1 ] ) );
 			expect( onBatchComplete ).not.toHaveBeenCalled();
-			expect( result.current.allComplete ).toBe( false );
 
-			// File 2 completes.
-			act( () => {
-				onFileChange( [ att1, att2 ] );
-			} );
-
+			act( () => onFileChange( [ att1, att2 ] ) );
 			expect( onBatchComplete ).not.toHaveBeenCalled();
-			expect( result.current.allComplete ).toBe( false );
 
-			// File 3 completes — batch should now be done.
-			act( () => {
-				onFileChange( [ att1, att2, att3 ] );
-			} );
-
+			act( () => onFileChange( [ att1, att2, att3 ] ) );
 			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
 			expect( onBatchComplete ).toHaveBeenCalledWith( [
 				att1,
@@ -264,9 +239,7 @@ describe( 'useUploadStatus', () => {
 	describe( 'onError', () => {
 		it( 'should mark the matching file in the batch as errored', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onError: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onError!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onError } = result.current.registerBatch( [
@@ -275,16 +248,7 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			act( () => {
-				const file = createFile( 'a.png' );
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'Upload failed',
-						file,
-					} )
-				);
-			} );
+			act( () => onError( createUploadError( 'a.png' ) ) );
 
 			expect( result.current.uploadingFiles[ 0 ].status ).toBe( 'error' );
 			expect( result.current.uploadingFiles[ 0 ].error ).toBe(
@@ -295,11 +259,9 @@ describe( 'useUploadStatus', () => {
 			);
 		} );
 
-		it( 'should only mark one file per error even with duplicate names in the same batch', () => {
+		it( 'should only mark one file per error even with duplicate names', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onError: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onError!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onError } = result.current.registerBatch( [
@@ -308,27 +270,17 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			act( () => {
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'Upload failed',
-						file: createFile( 'a.png' ),
-					} )
-				);
-			} );
+			act( () => onError( createUploadError( 'a.png' ) ) );
 
-			const statuses = result.current.uploadingFiles.map(
-				( item ) => item.status
-			);
-			expect( statuses ).toEqual( [ 'error', 'uploading' ] );
+			expect( statuses( result.current ) ).toEqual( [
+				'error',
+				'uploading',
+			] );
 		} );
 
 		it( 'should not affect files in a different batch', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onErrorB: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onErrorB!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				result.current.registerBatch( [ createFile( 'a.png' ) ] );
@@ -337,21 +289,12 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			// Error targets batch B's file, not batch A's.
-			act( () => {
-				onErrorB(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'Upload failed',
-						file: createFile( 'a.png' ),
-					} )
-				);
-			} );
+			act( () => onErrorB( createUploadError( 'a.png' ) ) );
 
-			expect( result.current.uploadingFiles[ 0 ].status ).toBe(
-				'uploading'
-			);
-			expect( result.current.uploadingFiles[ 1 ].status ).toBe( 'error' );
+			expect( statuses( result.current ) ).toEqual( [
+				'uploading',
+				'error',
+			] );
 		} );
 	} );
 
@@ -363,9 +306,7 @@ describe( 'useUploadStatus', () => {
 
 		it( 'should be false when some files are still uploading', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onFileChangeA: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
+			let onFileChangeA!: BatchCallbacks[ 'onFileChange' ];
 
 			act( () => {
 				( { onFileChange: onFileChangeA } =
@@ -373,21 +314,15 @@ describe( 'useUploadStatus', () => {
 				result.current.registerBatch( [ createFile( 'b.png' ) ] );
 			} );
 
-			act( () => {
-				onFileChangeA( [ createAttachment( 1, 'a.png' ) ] );
-			} );
+			act( () => onFileChangeA( [ createAttachment( 1, 'a.png' ) ] ) );
 
 			expect( result.current.allComplete ).toBe( false );
 		} );
 
 		it( 'should be true when all files are uploaded or errored', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
-			let onError: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
+			let onError!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onFileChange, onError } = result.current.registerBatch( [
@@ -396,26 +331,12 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			act( () => {
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'fail',
-						file: createFile( 'a.png' ),
-					} )
-				);
-			} );
-
-			// One errored, one still uploading.
+			act( () => onError( createUploadError( 'a.png', 'fail' ) ) );
 			expect( result.current.allComplete ).toBe( false );
 
 			// Complete the remaining file — onFileChange fires with just
-			// the successful attachment (failed ones are filtered as null
-			// by uploadMedia).
-			act( () => {
-				onFileChange( [ createAttachment( 2, 'b.png' ) ] );
-			} );
-
+			// the successful attachment.
+			act( () => onFileChange( [ createAttachment( 2, 'b.png' ) ] ) );
 			expect( result.current.allComplete ).toBe( true );
 		} );
 	} );
@@ -424,22 +345,15 @@ describe( 'useUploadStatus', () => {
 		it( 'should handle onFileChange firing before onError for a failed file', () => {
 			// Simulates the uploadMedia flow for 3 files where c.png fails:
 			// 1. Blob URLs created for all 3 (ignored by hook)
-			// 2. a.png succeeds: onFileChange([a, blob:b, blob:c]) — has blobs, ignored
-			// 3. b.png succeeds: onFileChange([a, b, blob:c]) — has blobs, ignored
-			// 4. c.png fails: setAndUpdateFiles(2, null) triggers
-			//    onFileChange([a, b]) — 2 real URLs, resolvedCount += 2
-			// 5. onError(c.png) — marks c.png as error, resolvedCount += 1
-			// 6. resolvedCount (3) >= batchSize (3) — batch complete
+			// 2-3. Partial completions with blobs (ignored)
+			// 4. c.png fails → onFileChange([a, b]), successCount = 2
+			// 5. onError(c.png) → errorCount = 1, total = 3 = batchSize
 			const onBatchComplete = jest.fn();
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
-			let onError: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
+			let onError!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onFileChange, onError } = result.current.registerBatch( [
@@ -449,7 +363,7 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			// Steps 1-3: blob URL calls and partial completions (ignored).
+			// Blob URL calls and partial completions (all ignored).
 			act( () => {
 				onFileChange( [
 					createBlobAttachment( 'a' ),
@@ -467,45 +381,30 @@ describe( 'useUploadStatus', () => {
 					createBlobAttachment( 'c' ),
 				] );
 			} );
-
 			expect( onBatchComplete ).not.toHaveBeenCalled();
 
-			// Step 4: c.png fails — onFileChange fires with nulls filtered
-			// (only the 2 successful attachments).
-			act( () => {
+			// c.png fails — onFileChange with only successful attachments.
+			act( () =>
 				onFileChange( [
 					createAttachment( 1, 'a.png' ),
 					createAttachment( 2, 'b.png' ),
-				] );
-			} );
-
-			// resolvedCount is 2, batchSize is 3 — not done yet.
+				] )
+			);
 			expect( onBatchComplete ).not.toHaveBeenCalled();
 
-			// Step 5: onError fires for c.png.
-			act( () => {
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'Upload failed',
-						file: createFile( 'c.png' ),
-					} )
-				);
-			} );
+			// onError fires for c.png — batch now complete.
+			act( () => onError( createUploadError( 'c.png' ) ) );
 
-			// Now resolvedCount is 3 — batch complete.
 			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
 			expect( onBatchComplete ).toHaveBeenCalledWith( [
 				createAttachment( 1, 'a.png' ),
 				createAttachment( 2, 'b.png' ),
 			] );
 
-			// c.png should be errored, a.png and b.png should be uploaded.
-			const statuses = result.current.uploadingFiles.map( ( item ) => [
-				item.name,
-				item.status,
-			] );
-			expect( statuses ).toEqual( [
+			const fileStatuses = result.current.uploadingFiles.map(
+				( item ) => [ item.name, item.status ]
+			);
+			expect( fileStatuses ).toEqual( [
 				[ 'a.png', 'uploaded' ],
 				[ 'b.png', 'uploaded' ],
 				[ 'c.png', 'error' ],
@@ -518,12 +417,8 @@ describe( 'useUploadStatus', () => {
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
-			let onFileChange: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
-			let onError: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onFileChange!: BatchCallbacks[ 'onFileChange' ];
+			let onError!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onFileChange, onError } = result.current.registerBatch( [
@@ -532,35 +427,19 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			// Both fail: onFileChange fires with empty array (all nulls
-			// filtered out), then onError fires for each.
 			act( () => {
 				onFileChange( [] );
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'fail a',
-						file: createFile( 'a.png' ),
-					} )
-				);
+				onError( createUploadError( 'a.png', 'fail a' ) );
 				onFileChange( [] );
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'fail b',
-						file: createFile( 'b.png' ),
-					} )
-				);
+				onError( createUploadError( 'b.png', 'fail b' ) );
 			} );
 
-			// onBatchComplete should still fire (with empty attachments).
 			expect( onBatchComplete ).toHaveBeenCalledTimes( 1 );
 			expect( onBatchComplete ).toHaveBeenCalledWith( [] );
-
-			const statuses = result.current.uploadingFiles.map(
-				( item ) => item.status
-			);
-			expect( statuses ).toEqual( [ 'error', 'error' ] );
+			expect( statuses( result.current ) ).toEqual( [
+				'error',
+				'error',
+			] );
 			expect( result.current.allComplete ).toBe( true );
 		} );
 	} );
@@ -568,9 +447,7 @@ describe( 'useUploadStatus', () => {
 	describe( 'dismissError', () => {
 		it( 'should remove the errored file from the list', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onError: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onError!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onError } = result.current.registerBatch( [
@@ -579,23 +456,13 @@ describe( 'useUploadStatus', () => {
 				] ) );
 			} );
 
-			act( () => {
-				onError(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'fail',
-						file: createFile( 'a.png' ),
-					} )
-				);
-			} );
+			act( () => onError( createUploadError( 'a.png', 'fail' ) ) );
 
 			const erroredFile = result.current.uploadingFiles.find(
 				( item ) => item.status === 'error'
 			)!;
 
-			act( () => {
-				result.current.dismissError( erroredFile.id );
-			} );
+			act( () => result.current.dismissError( erroredFile.id ) );
 
 			expect( result.current.uploadingFiles ).toHaveLength( 1 );
 			expect( result.current.uploadingFiles[ 0 ].name ).toBe( 'b.png' );
@@ -605,12 +472,8 @@ describe( 'useUploadStatus', () => {
 	describe( 'clearCompleted', () => {
 		it( 'should remove uploaded entries but keep uploading and errored ones', () => {
 			const { result } = renderHook( () => useUploadStatus() );
-			let onFileChangeA: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onFileChange' ];
-			let onErrorB: ReturnType<
-				typeof result.current.registerBatch
-			>[ 'onError' ];
+			let onFileChangeA!: BatchCallbacks[ 'onFileChange' ];
+			let onErrorB!: BatchCallbacks[ 'onError' ];
 
 			act( () => {
 				( { onFileChange: onFileChangeA } =
@@ -624,22 +487,12 @@ describe( 'useUploadStatus', () => {
 			// Complete batch A, error batch B, leave batch C uploading.
 			act( () => {
 				onFileChangeA( [ createAttachment( 1, 'a.png' ) ] );
-				onErrorB(
-					new UploadError( {
-						code: 'GENERAL',
-						message: 'fail',
-						file: createFile( 'b.png' ),
-					} )
-				);
+				onErrorB( createUploadError( 'b.png', 'fail' ) );
 			} );
 
-			act( () => {
-				result.current.clearCompleted();
-			} );
+			act( () => result.current.clearCompleted() );
 
-			const remaining = result.current.uploadingFiles;
-			expect( remaining ).toHaveLength( 2 );
-			expect( remaining.map( ( item ) => item.status ) ).toEqual( [
+			expect( statuses( result.current ) ).toEqual( [
 				'error',
 				'uploading',
 			] );

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -90,6 +90,7 @@ export function UploadStatusPopover( {
 				<Popover
 					className="media-upload-modal__upload-status__popover"
 					placement="top-start"
+					offset={ 8 }
 					anchor={ triggerRef.current }
 					onClose={ () => {
 						// Let the button's onClick handle toggling when

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -75,7 +75,7 @@ export function UploadStatusPopover( {
 
 	return (
 		<div className="media-upload-modal__upload-status">
-			{ isUploading && <Spinner /> }
+			<Spinner />
 			<Button
 				className="media-upload-modal__upload-status__trigger"
 				size="compact"

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -38,9 +38,11 @@ export function UploadStatusPopover( {
 	);
 
 	const activeFiles = uploadingFiles.filter(
-		( f ) => f.status === 'uploading'
+		( file ) => file.status === 'uploading'
 	);
-	const errorFiles = uploadingFiles.filter( ( f ) => f.status === 'error' );
+	const errorFiles = uploadingFiles.filter(
+		( file ) => file.status === 'error'
+	);
 	const hasErrors = errorFiles.length > 0;
 	const isUploading = activeFiles.length > 0;
 

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Button, Popover, Spinner } from '@wordpress/components';
-import { chevronDown } from '@wordpress/icons';
+import { Button, Icon, Notice, Popover, Spinner } from '@wordpress/components';
+import { check, chevronDown } from '@wordpress/icons';
 
 export interface UploadingFile {
 	id: string;
@@ -26,6 +26,7 @@ export function UploadStatusPopover( {
 }: UploadStatusPopoverProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ prevHadErrors, setPrevHadErrors ] = useState( false );
+	const triggerRef = useRef< HTMLButtonElement >( null );
 
 	const updateIsOpen = useCallback(
 		( open: boolean ) => {
@@ -77,18 +78,31 @@ export function UploadStatusPopover( {
 				className="media-upload-modal__upload-status__trigger"
 				variant="tertiary"
 				size="compact"
-				icon={ chevronDown }
-				iconPosition="right"
 				onClick={ () => updateIsOpen( ! isOpen ) }
+				aria-expanded={ isOpen }
+				ref={ triggerRef }
 			>
 				{ isUploading && <Spinner /> }
 				{ buttonLabel }
+				<Icon icon={ chevronDown } size={ 24 } />
 			</Button>
 			{ isOpen && (
 				<Popover
 					className="media-upload-modal__upload-status__popover"
 					placement="top-start"
-					onClose={ () => updateIsOpen( false ) }
+					anchor={ triggerRef.current }
+					onClose={ () => {
+						// Let the button's onClick handle toggling when
+						// the close was triggered by clicking the trigger.
+						if (
+							triggerRef.current?.contains(
+								triggerRef.current.ownerDocument.activeElement
+							)
+						) {
+							return;
+						}
+						updateIsOpen( false );
+					} }
 				>
 					<div className="media-upload-modal__upload-status__header">
 						<h3>{ __( 'Uploading' ) }</h3>
@@ -99,26 +113,29 @@ export function UploadStatusPopover( {
 								key={ file.id }
 								className="media-upload-modal__upload-status__item"
 							>
-								<span className="media-upload-modal__upload-status__filename">
-									{ file.name }
-								</span>
 								{ file.status === 'uploading' && <Spinner /> }
-								{ file.status === 'error' && (
-									<span className="media-upload-modal__upload-status__error">
-										{ file.error }
-										{ onDismissError && (
-											<Button
-												size="compact"
-												variant="link"
-												isDestructive
-												onClick={ () =>
-													onDismissError( file.id )
-												}
-											>
-												{ __( 'Dismiss' ) }
-											</Button>
-										) }
+								{ file.status === 'complete' && (
+									<Icon icon={ check } size={ 16 } />
+								) }
+								{ ( file.status === 'uploading' ||
+									file.status === 'complete' ) && (
+									<span
+										className="media-upload-modal__upload-status__filename"
+										title={ file.name }
+									>
+										{ file.name }
 									</span>
+								) }
+								{ file.status === 'error' && (
+									<Notice
+										status="error"
+										isDismissible={ !! onDismissError }
+										onRemove={ () =>
+											onDismissError?.( file.id )
+										}
+									>
+										{ file.name }: { file.error }
+									</Notice>
 								) }
 							</li>
 						) ) }

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -8,8 +8,9 @@ import { check, chevronDown } from '@wordpress/icons';
 
 export interface UploadingFile {
 	id: string;
+	batchId: string;
 	name: string;
-	status: 'uploading' | 'complete' | 'error';
+	status: 'uploading' | 'uploaded' | 'error';
 	error?: string;
 }
 
@@ -116,11 +117,11 @@ export function UploadStatusPopover( {
 								className="media-upload-modal__upload-status__item"
 							>
 								{ file.status === 'uploading' && <Spinner /> }
-								{ file.status === 'complete' && (
+								{ file.status === 'uploaded' && (
 									<Icon icon={ check } size={ 16 } />
 								) }
 								{ ( file.status === 'uploading' ||
-									file.status === 'complete' ) && (
+									file.status === 'uploaded' ) && (
 									<span
 										className="media-upload-modal__upload-status__filename"
 										title={ file.name }

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { Button, Popover, Spinner } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
+
+export interface UploadingFile {
+	id: string;
+	name: string;
+	status: 'uploading' | 'complete' | 'error';
+	error?: string;
+}
+
+interface UploadStatusPopoverProps {
+	uploadingFiles: UploadingFile[];
+	onDismissError?: ( fileId: string ) => void;
+	onOpenChange?: ( open: boolean ) => void;
+}
+
+export function UploadStatusPopover( {
+	uploadingFiles,
+	onDismissError,
+	onOpenChange,
+}: UploadStatusPopoverProps ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ prevHadErrors, setPrevHadErrors ] = useState( false );
+
+	const updateIsOpen = useCallback(
+		( open: boolean ) => {
+			setIsOpen( open );
+			onOpenChange?.( open );
+		},
+		[ onOpenChange ]
+	);
+
+	const activeFiles = uploadingFiles.filter(
+		( f ) => f.status === 'uploading'
+	);
+	const errorFiles = uploadingFiles.filter( ( f ) => f.status === 'error' );
+	const hasErrors = errorFiles.length > 0;
+	const isUploading = activeFiles.length > 0;
+
+	// Auto-expand when an error occurs.
+	useEffect( () => {
+		if ( hasErrors && ! prevHadErrors ) {
+			updateIsOpen( true );
+		}
+		setPrevHadErrors( hasErrors );
+	}, [ hasErrors, prevHadErrors, updateIsOpen ] );
+
+	if ( uploadingFiles.length === 0 ) {
+		return null;
+	}
+
+	let buttonLabel: string;
+	if ( isUploading ) {
+		buttonLabel = sprintf(
+			// translators: %s: number of files being uploaded
+			_n( 'Uploading %s file', 'Uploading %s files', activeFiles.length ),
+			activeFiles.length.toLocaleString()
+		);
+	} else if ( hasErrors ) {
+		buttonLabel = sprintf(
+			// translators: %s: number of upload errors
+			_n( '%s upload error', '%s upload errors', errorFiles.length ),
+			errorFiles.length.toLocaleString()
+		);
+	} else {
+		buttonLabel = __( 'Upload complete' );
+	}
+
+	return (
+		<div className="media-upload-modal__upload-status">
+			<Button
+				className="media-upload-modal__upload-status__trigger"
+				variant="tertiary"
+				size="compact"
+				icon={ chevronDown }
+				iconPosition="right"
+				onClick={ () => updateIsOpen( ! isOpen ) }
+			>
+				{ isUploading && <Spinner /> }
+				{ buttonLabel }
+			</Button>
+			{ isOpen && (
+				<Popover
+					className="media-upload-modal__upload-status__popover"
+					placement="top-start"
+					onClose={ () => updateIsOpen( false ) }
+				>
+					<div className="media-upload-modal__upload-status__header">
+						<h3>{ __( 'Uploading' ) }</h3>
+					</div>
+					<ul className="media-upload-modal__upload-status__list">
+						{ uploadingFiles.map( ( file ) => (
+							<li
+								key={ file.id }
+								className="media-upload-modal__upload-status__item"
+							>
+								<span className="media-upload-modal__upload-status__filename">
+									{ file.name }
+								</span>
+								{ file.status === 'uploading' && <Spinner /> }
+								{ file.status === 'error' && (
+									<span className="media-upload-modal__upload-status__error">
+										{ file.error }
+										{ onDismissError && (
+											<Button
+												size="compact"
+												variant="link"
+												isDestructive
+												onClick={ () =>
+													onDismissError( file.id )
+												}
+											>
+												{ __( 'Dismiss' ) }
+											</Button>
+										) }
+									</span>
+								) }
+							</li>
+						) ) }
+					</ul>
+				</Popover>
+			) }
+		</div>
+	);
+}

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -74,17 +74,17 @@ export function UploadStatusPopover( {
 
 	return (
 		<div className="media-upload-modal__upload-status">
+			{ isUploading && <Spinner /> }
 			<Button
 				className="media-upload-modal__upload-status__trigger"
-				variant="tertiary"
 				size="compact"
+				icon={ chevronDown }
+				iconPosition="right"
 				onClick={ () => updateIsOpen( ! isOpen ) }
 				aria-expanded={ isOpen }
 				ref={ triggerRef }
 			>
-				{ isUploading && <Spinner /> }
 				{ buttonLabel }
-				<Icon icon={ chevronDown } size={ 24 } />
 			</Button>
 			{ isOpen && (
 				<Popover

--- a/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/upload-status-popover.tsx
@@ -92,6 +92,7 @@ export function UploadStatusPopover( {
 					placement="top-start"
 					offset={ 8 }
 					anchor={ triggerRef.current }
+					focusOnMount
 					onClose={ () => {
 						// Let the button's onClick handle toggling when
 						// the close was triggered by clicking the trigger.

--- a/packages/media-utils/src/components/media-upload-modal/use-upload-status.ts
+++ b/packages/media-utils/src/components/media-upload-modal/use-upload-status.ts
@@ -1,0 +1,196 @@
+/**
+ * Hook for tracking media upload status with batch-scoped callbacks.
+ *
+ * This is a transitional layer that manually tracks upload progress using
+ * local state. The @wordpress/upload-media package provides a Redux-based
+ * store with richer capabilities (per-file progress, pause/resume, retry,
+ * concurrency control, client-side processing). When the media upload modal
+ * adopts @wordpress/upload-media, this hook can be replaced by selectors
+ * from that store (getItems, isBatchUploaded, getItemProgress, etc.) while
+ * keeping the same return interface.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import type { Attachment } from '../../utils/types';
+import { UploadError } from '../../utils/upload-error';
+import type { UploadingFile } from './upload-status-popover';
+
+let idCounter = 0;
+let batchIdCounter = 0;
+
+interface RegisterBatchOptions {
+	onBatchComplete?: ( attachments: Partial< Attachment >[] ) => void;
+}
+
+interface RegisterBatchResult {
+	onFileChange: ( attachments: Partial< Attachment >[] ) => void;
+	onError: ( error: Error ) => void;
+}
+
+interface UseUploadStatusReturn {
+	/** Current list of all tracked files. */
+	uploadingFiles: UploadingFile[];
+	/**
+	 * Register a new batch of files for tracking.
+	 * Returns batch-scoped onFileChange and onError callbacks.
+	 */
+	registerBatch: (
+		files: File[],
+		options?: RegisterBatchOptions
+	) => RegisterBatchResult;
+	/** Remove a single error entry by file id. */
+	dismissError: ( fileId: string ) => void;
+	/** Remove all uploaded (completed) entries from the list. */
+	clearCompleted: () => void;
+	/** True when tracked entries exist but none are still uploading. */
+	allComplete: boolean;
+}
+
+export function useUploadStatus(): UseUploadStatusReturn {
+	const [ uploadingFiles, setUploadingFiles ] = useState< UploadingFile[] >(
+		[]
+	);
+
+	const clearCompleted = useCallback( () => {
+		setUploadingFiles( ( prev ) =>
+			prev.filter( ( f ) => f.status !== 'uploaded' )
+		);
+	}, [] );
+
+	const dismissError = useCallback( ( fileId: string ) => {
+		setUploadingFiles( ( prev ) =>
+			prev.filter( ( f ) => f.id !== fileId )
+		);
+	}, [] );
+
+	const registerBatch = useCallback(
+		(
+			files: File[],
+			options?: RegisterBatchOptions
+		): RegisterBatchResult => {
+			const batchId = String( ++batchIdCounter );
+			const batchSize = files.length;
+
+			const newEntries: UploadingFile[] = files.map( ( file ) => ( {
+				id: String( ++idCounter ),
+				batchId,
+				name: file.name,
+				status: 'uploading' as const,
+			} ) );
+
+			setUploadingFiles( ( prev ) => [ ...prev, ...newEntries ] );
+
+			// Track successes and errors separately. onFileChange receives
+			// the full current array each time (not incremental), so we
+			// store the latest count rather than accumulating. The batch
+			// is complete when successCount + errorCount >= batchSize.
+			let successCount = 0;
+			let errorCount = 0;
+			let batchDone = false;
+			let successAttachments: Partial< Attachment >[] = [];
+
+			const completeBatchIfDone = () => {
+				if ( batchDone || successCount + errorCount < batchSize ) {
+					return;
+				}
+
+				batchDone = true;
+
+				// Mark any remaining 'uploading' entries in this batch
+				// as 'uploaded' (these are the successful ones).
+				setUploadingFiles( ( prev ) =>
+					prev.map( ( f ) =>
+						f.batchId === batchId && f.status === 'uploading'
+							? {
+									...f,
+									status: 'uploaded' as const,
+							  }
+							: f
+					)
+				);
+
+				options?.onBatchComplete?.( successAttachments );
+			};
+
+			const onFileChange = ( attachments: Partial< Attachment >[] ) => {
+				if ( batchDone ) {
+					return;
+				}
+
+				// Ignore intermediate calls where some files still have
+				// blob URLs (not yet uploaded to the server).
+				const allReal = attachments.every(
+					( attachment ) =>
+						attachment.id &&
+						attachment.url &&
+						! isBlobURL( attachment.url )
+				);
+
+				if ( ! allReal ) {
+					return;
+				}
+
+				// Store the latest success count and attachments.
+				// onFileChange receives the full array each time, so
+				// we replace rather than accumulate.
+				successCount = attachments.length;
+				successAttachments = attachments;
+
+				completeBatchIfDone();
+			};
+
+			const onError = ( error: Error ) => {
+				const fileName =
+					error instanceof UploadError ? error.file.name : undefined;
+
+				setUploadingFiles( ( prev ) => {
+					let matched = false;
+					return prev.map( ( f ) => {
+						if (
+							! matched &&
+							f.batchId === batchId &&
+							fileName &&
+							f.name === fileName &&
+							f.status === 'uploading'
+						) {
+							matched = true;
+							return {
+								...f,
+								status: 'error' as const,
+								error: error.message,
+							};
+						}
+						return f;
+					} );
+				} );
+
+				errorCount++;
+
+				completeBatchIfDone();
+			};
+
+			return { onFileChange, onError };
+		},
+		[]
+	);
+
+	const allComplete =
+		uploadingFiles.length > 0 &&
+		uploadingFiles.every( ( f ) => f.status !== 'uploading' );
+
+	return {
+		uploadingFiles,
+		registerBatch,
+		dismissError,
+		clearCompleted,
+		allComplete,
+	};
+}

--- a/packages/media-utils/src/components/media-upload-modal/use-upload-status.ts
+++ b/packages/media-utils/src/components/media-upload-modal/use-upload-status.ts
@@ -26,7 +26,7 @@ import type { UploadingFile } from './upload-status-popover';
 let idCounter = 0;
 let batchIdCounter = 0;
 
-interface RegisterBatchOptions {
+interface UseUploadStatusOptions {
 	onBatchComplete?: ( attachments: Partial< Attachment >[] ) => void;
 }
 
@@ -42,10 +42,7 @@ interface UseUploadStatusReturn {
 	 * Register a new batch of files for tracking.
 	 * Returns batch-scoped onFileChange and onError callbacks.
 	 */
-	registerBatch: (
-		files: File[],
-		options?: RegisterBatchOptions
-	) => RegisterBatchResult;
+	registerBatch: ( files: File[] ) => RegisterBatchResult;
 	/** Remove a single error entry by file id. */
 	dismissError: ( fileId: string ) => void;
 	/** Remove all uploaded (completed) entries from the list. */
@@ -54,28 +51,27 @@ interface UseUploadStatusReturn {
 	allComplete: boolean;
 }
 
-export function useUploadStatus(): UseUploadStatusReturn {
+export function useUploadStatus( {
+	onBatchComplete,
+}: UseUploadStatusOptions = {} ): UseUploadStatusReturn {
 	const [ uploadingFiles, setUploadingFiles ] = useState< UploadingFile[] >(
 		[]
 	);
 
 	const clearCompleted = useCallback( () => {
 		setUploadingFiles( ( prev ) =>
-			prev.filter( ( f ) => f.status !== 'uploaded' )
+			prev.filter( ( item ) => item.status !== 'uploaded' )
 		);
 	}, [] );
 
 	const dismissError = useCallback( ( fileId: string ) => {
 		setUploadingFiles( ( prev ) =>
-			prev.filter( ( f ) => f.id !== fileId )
+			prev.filter( ( item ) => item.id !== fileId )
 		);
 	}, [] );
 
 	const registerBatch = useCallback(
-		(
-			files: File[],
-			options?: RegisterBatchOptions
-		): RegisterBatchResult => {
+		( files: File[] ): RegisterBatchResult => {
 			const batchId = String( ++batchIdCounter );
 			const batchSize = files.length;
 
@@ -107,17 +103,17 @@ export function useUploadStatus(): UseUploadStatusReturn {
 				// Mark any remaining 'uploading' entries in this batch
 				// as 'uploaded' (these are the successful ones).
 				setUploadingFiles( ( prev ) =>
-					prev.map( ( f ) =>
-						f.batchId === batchId && f.status === 'uploading'
+					prev.map( ( item ) =>
+						item.batchId === batchId && item.status === 'uploading'
 							? {
-									...f,
+									...item,
 									status: 'uploaded' as const,
 							  }
-							: f
+							: item
 					)
 				);
 
-				options?.onBatchComplete?.( successAttachments );
+				onBatchComplete?.( successAttachments );
 			};
 
 			const onFileChange = ( attachments: Partial< Attachment >[] ) => {
@@ -148,27 +144,38 @@ export function useUploadStatus(): UseUploadStatusReturn {
 			};
 
 			const onError = ( error: Error ) => {
+				// uploadMedia always wraps errors in UploadError, which
+				// carries the originating File so we can match it back to
+				// the correct item. A custom onUpload prop could pass a
+				// plain Error instead — in that case fileName is undefined
+				// and no entry will be visually marked as errored, but the
+				// batch will still complete correctly via errorCount.
 				const fileName =
 					error instanceof UploadError ? error.file.name : undefined;
 
+				// Find the first still-uploading entry in this batch whose
+				// name matches the failed file and mark it as errored.
+				// Falls back to the first uploading entry in the batch
+				// when no filename is available. The `matched` flag
+				// ensures only one entry is updated even when duplicate
+				// filenames exist in the same batch.
 				setUploadingFiles( ( prev ) => {
 					let matched = false;
-					return prev.map( ( f ) => {
+					return prev.map( ( item ) => {
 						if (
 							! matched &&
-							f.batchId === batchId &&
-							fileName &&
-							f.name === fileName &&
-							f.status === 'uploading'
+							item.batchId === batchId &&
+							item.status === 'uploading' &&
+							( ! fileName || item.name === fileName )
 						) {
 							matched = true;
 							return {
-								...f,
+								...item,
 								status: 'error' as const,
 								error: error.message,
 							};
 						}
-						return f;
+						return item;
 					} );
 				} );
 
@@ -179,12 +186,12 @@ export function useUploadStatus(): UseUploadStatusReturn {
 
 			return { onFileChange, onError };
 		},
-		[]
+		[ onBatchComplete ]
 	);
 
 	const allComplete =
 		uploadingFiles.length > 0 &&
-		uploadingFiles.every( ( f ) => f.status !== 'uploading' );
+		uploadingFiles.every( ( item ) => item.status !== 'uploading' );
 
 	return {
 		uploadingFiles,

--- a/packages/media-utils/tsconfig.json
+++ b/packages/media-utils/tsconfig.json
@@ -17,6 +17,7 @@
 		{ "path": "../icons" },
 		{ "path": "../media-fields" },
 		{ "path": "../notices" },
-		{ "path": "../private-apis" }
+		{ "path": "../private-apis" },
+		{ "path": "../ui" }
 	]
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Tests to come. This is a POC


### What

When a user without `unfiltered_html` (e.g. an Editor role) saves a post, WordPress runs `wp_kses` on the post content. `wp_kses` treats block attribute string values as HTML, so it mangles CSS containing characters like `&`, `>`, or nested selectors — `& p { color: red }` becomes `&amp; p { color: red }`, and the rendered selector becomes `.wp-custom-css-xxxamp; p {}`.

### How

Before saving, the JS `onChange` handler base64-encodes the CSS value as a `data:text/css;base64,…` URI. `wp_kses` passes base64 characters through untouched. On read, the value is decoded back to plain CSS in three places:

- **`CustomCSSControl`** — decodes into `displayStyle` before passing to `AdvancedPanel`, so the user always sees readable CSS in the panel
- **`useBlockProps`** — decodes before `validateCSS` and `processCSSNesting`, so the editor preview works correctly
- **`gutenberg_render_custom_css_support_styles`** — decodes before `process_blocks_custom_css`, so the frontend renders the correct CSS

Both decode paths are safe-by-default: values that don't start with the prefix (legacy content, or content saved by admins who bypass KSES entirely) are returned unchanged.

### Migration path

This encoding is intentionally temporary. When `WP_CSS_Token_Processor` or a proper CSS sanitizer API lands in WordPress core:

1. Remove the `encodeCSSAttribute` call in `onChange` — plain CSS can then be stored directly
2. Keep `decodeCSSAttribute` and `gutenberg_decode_css_attribute` as read-time shims — they decode any previously encoded values, and the next save will write plain CSS, so migration is lazy with no batch script required
3. Remove the shims once all sites have cycled through at least one save

### Notes

- **Existing corrupted content** (`&amp;` already in the DB) is not auto-repaired — the user must re-edit and re-save the affected block
- **Admins** (`unfiltered_html`) bypass KSES; their CSS is stored plain and the decode is a no-op
- `TextEncoder`/`TextDecoder` are used instead of raw `btoa`/`atob` to correctly handle non-ASCII characters in CSS (e.g. `content: "→"`)
- The null-byte check in `gutenberg_decode_css_attribute` rejects crafted payloads that might otherwise survive base64 decoding

### Testing

1. As an Editor (any role without `unfiltered_html`), add a block and open **Advanced → Additional CSS**
2. Enter CSS with nested selectors: `background: green; & p { color: yellow; padding: 20px; }`
3. Save the post
4. Verify the frontend renders both rules correctly with the nested selector applied
5. Reload the editor — verify the CSS panel shows the original unencoded CSS, not the base64 value
