### PR TITLE
 Block Custom CSS: encode values to prevent wp_kses mangling

### DIFF
--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -53,10 +53,12 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 		return $parsed_block;
 	}
 
-	// Decode base64-encoded CSS. The JS editor encodes CSS before saving so
-	// that wp_kses cannot corrupt characters like `&`, `>`, or nested selectors.
-	// Plain CSS (saved by users with `unfiltered_html`, or legacy content) is
-	// returned unchanged by this function.
+	/*
+	 * Decode base64-encoded CSS. The JS editor encodes CSS before saving so
+	 * that wp_kses cannot corrupt characters like `&`, `>`, or nested selectors.
+	 * Plain CSS (saved by users with `unfiltered_html`, or legacy content) is
+	 * returned unchanged by this function.
+	 */
 	$custom_css = gutenberg_decode_custom_css_attribute_for_display( $custom_css );
 
 	// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -22,15 +22,14 @@
  * @param string $value Stored attribute value.
  * @return string Decoded CSS string, or the original value if not encoded.
  */
-function gutenberg_decode_css_attribute( $value ) {
+function gutenberg_decode_custom_css_attribute_for_display( $value ) {
 	$prefix = 'data:text/css;base64,';
 	if ( ! str_starts_with( $value, $prefix ) ) {
 		return $value;
 	}
 	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 	$decoded = base64_decode( substr( $value, strlen( $prefix ) ), /* strict */ true );
-	// If the decoded string contains characters from outside the base64 alphabet or a null byte, set the CSS to an empty string.
-	return ( false === $decoded || str_contains( $decoded, "\0" ) ) ? '' : $decoded;
+	return false !== $decoded ? $decoded : '';
 }
 
 /**
@@ -58,7 +57,7 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	// that wp_kses cannot corrupt characters like `&`, `>`, or nested selectors.
 	// Plain CSS (saved by users with `unfiltered_html`, or legacy content) is
 	// returned unchanged by this function.
-	$custom_css = gutenberg_decode_css_attribute( $custom_css );
+	$custom_css = gutenberg_decode_custom_css_attribute_for_display( $custom_css );
 
 	// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).
 	if ( preg_match( '#</?\w+#', $custom_css ) ) {

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -6,6 +6,34 @@
  */
 
 /**
+ * Decodes a CSS attribute value that was base64-encoded by the block editor
+ * to survive wp_kses processing. Returns the value unchanged if it was never
+ * encoded (legacy content, or content saved by users with `unfiltered_html`).
+ *
+ * Migration note: once a proper CSS sanitizer API lands in WordPress core,
+ * remove the encoding call in the JS `onChange` handler. Keep this function
+ * as a read-time shim — it will decode any previously encoded values and
+ * return plain CSS, which will then be stored as plain CSS on the next save
+ * (lazy migration). Remove the shim once all encoded values have been cycled
+ * through a save.
+ *
+ * @since 7.0.0
+ *
+ * @param string $value Stored attribute value.
+ * @return string Decoded CSS string, or the original value if not encoded.
+ */
+function gutenberg_decode_css_attribute( $value ) {
+	$prefix = 'data:text/css;base64,';
+	if ( ! str_starts_with( $value, $prefix ) ) {
+		return $value;
+	}
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+	$decoded = base64_decode( substr( $value, strlen( $prefix ) ), /* strict */ true );
+	// If the decoded string contains characters from outside the base64 alphabet or a null byte, set the CSS to an empty string.
+	return ( false === $decoded || str_contains( $decoded, "\0" ) ) ? '' : $decoded;
+}
+
+/**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
  * @since 7.0.0
@@ -25,6 +53,12 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 	if ( empty( $custom_css ) ) {
 		return $parsed_block;
 	}
+
+	// Decode base64-encoded CSS. The JS editor encodes CSS before saving so
+	// that wp_kses cannot corrupt characters like `&`, `>`, or nested selectors.
+	// Plain CSS (saved by users with `unfiltered_html`, or legacy content) is
+	// returned unchanged by this function.
+	$custom_css = gutenberg_decode_css_attribute( $custom_css );
 
 	// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).
 	if ( preg_match( '#</?\w+#', $custom_css ) ) {

--- a/lib/compat/wordpress-7.0/kses.php
+++ b/lib/compat/wordpress-7.0/kses.php
@@ -20,3 +20,63 @@ function gutenberg_add_display_to_safe_style_css( $attr ) {
 	return $attr;
 }
 add_filter( 'safe_style_css', 'gutenberg_add_display_to_safe_style_css' );
+
+/**
+ * Encodes the custom CSS attribute of a single block, recursing into innerBlocks.
+ *
+ * All CSS values are base64-encoded so they survive wp_kses processing
+ * unchanged. Already-encoded values are left untouched.
+ *
+ * Migration note: once a proper CSS sanitizer API lands in WordPress core, remove this function
+ * and `gutenberg_encode_custom_css_for_kses` together with the `encodeCSSAttribute`
+ * call in the JS `onChange` handler. Both encode steps must be removed in the
+ * same release to avoid a mixed storage state. Keep the decode shims
+ * (`gutenberg_decode_custom_css_attribute_for_display` and JS
+ * `decodeCSSAttribute`) as read-time shims for backward compatibility.
+ *
+ * @since 7.0.0
+ *
+ * @param array $block Parsed block (may contain innerBlocks).
+ * @return array Block with custom CSS attribute encoded.
+ */
+function gutenberg_encode_block_custom_css( $block ) {
+	if ( ! empty( $block['innerBlocks'] ) ) {
+		$block['innerBlocks'] = array_map( 'gutenberg_encode_block_custom_css', $block['innerBlocks'] );
+	}
+
+	$css = $block['attrs']['style']['css'] ?? null;
+	if ( $css && ! str_starts_with( $css, 'data:text/css;base64,' ) ) {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$block['attrs']['style']['css'] = 'data:text/css;base64,' . base64_encode( $css );
+	}
+
+	return $block;
+}
+
+/**
+ * Encodes custom CSS block attributes before wp_kses can corrupt them.
+ *
+ * Hooks into `pre_kses` at priority 9 (before `wp_pre_kses_block_attributes`
+ * at priority 10). Parses the block tree, base64-encodes all custom CSS
+ * attribute values, then re-serializes — the same parse → mutate → serialize
+ * pattern that `wp_pre_kses_block_attributes` itself uses, so no block
+ * validation issues arise.
+ *
+ * Covers all save paths (REST API, WP-CLI, programmatic `wp_insert_post`)
+ * regardless of whether the JS editor encoded the value first.
+ *
+ * Migration note: see `gutenberg_encode_block_custom_css`.
+ *
+ * @since 7.0.0
+ *
+ * @param string $content Post content about to be processed by wp_kses.
+ * @return string Content with custom CSS attributes encoded.
+ */
+function gutenberg_encode_custom_css_for_kses( $content ) {
+	if ( ! has_blocks( $content ) ) {
+		return $content;
+	}
+	$blocks = array_map( 'gutenberg_encode_block_custom_css', parse_blocks( $content ) );
+	return serialize_blocks( $blocks );
+}
+add_filter( 'pre_kses', 'gutenberg_encode_custom_css_for_kses', 9 );

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -24,6 +24,62 @@ const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 // Stable empty object reference for useSelect.
 const EMPTY_STYLE = {};
 
+/*
+ * CSS is base64-encoded before saving to protect it from wp_kses corruption
+ * (KSES treats the CSS string as HTML and mangles characters like `&`, `>`,
+ * and anything inside angle brackets).
+ *
+ * Migration path once a proper CSS sanitizer API lands in WordPress core:
+ *   - Remove the `encodeCSSAttribute` call in `onChange` — plain CSS can then
+ *     be stored directly.
+ *   - Keep `decodeCSSAttribute` as a read-time shim: if a stored value starts
+ *     with the prefix it was encoded by this code, decode it, sanitize it with
+ *     the new API, and let the next save write it back as plain CSS (lazy
+ *     migration). The shim can be removed once all encoded values have been
+ *     cycled through a save.
+ */
+const CSS_BASE64_PREFIX = 'data:text/css;base64,';
+
+/**
+ * Encodes a CSS string as a base64 data URI so it survives wp_kses intact.
+ *
+ * @param {string} css Raw CSS string.
+ * @return {string} Encoded value.
+ */
+function encodeCSSAttribute( css ) {
+	const bytes = new TextEncoder().encode( css );
+	let binary = '';
+	for ( const byte of bytes ) {
+		binary += String.fromCharCode( byte );
+	}
+	return CSS_BASE64_PREFIX + btoa( binary );
+}
+
+/**
+ * Decodes a value previously encoded by `encodeCSSAttribute`.
+ * Returns the value unchanged if it was never encoded (legacy content or
+ * content saved by users with `unfiltered_html` who bypass KSES).
+ *
+ * @param {string|undefined} value Stored attribute value.
+ * @return {string|undefined} Decoded CSS string, or the original value.
+ */
+function decodeCSSAttribute( value ) {
+	if (
+		typeof value !== 'string' ||
+		! value.startsWith( CSS_BASE64_PREFIX )
+	) {
+		return value;
+	}
+	try {
+		const binary = atob( value.slice( CSS_BASE64_PREFIX.length ) );
+		const bytes = Uint8Array.from( binary, ( c ) => c.charCodeAt( 0 ) );
+		return new TextDecoder().decode( bytes );
+	} catch {
+		// Malformed base64 — treat as plain CSS rather than silently dropping.
+		return value;
+	}
+}
+
 /**
  * Inspector control for custom CSS.
  *
@@ -35,9 +91,18 @@ const EMPTY_STYLE = {};
 function CustomCSSControl( { blockName, setAttributes, style } ) {
 	const blockType = getBlockType( blockName );
 
+	// Decode the stored CSS for display so the user always sees plain CSS,
+	// not the base64-encoded value that is stored to survive wp_kses.
+	const displayStyle = useMemo(
+		() => ( { ...style, css: decodeCSSAttribute( style?.css ) } ),
+		[ style ]
+	);
+
 	function onChange( newStyle ) {
 		// Normalize whitespace-only CSS to undefined so it gets cleaned up.
-		const css = newStyle?.css?.trim() ? newStyle.css : undefined;
+		const rawCSS = newStyle?.css?.trim() ? newStyle.css : undefined;
+		// Encode before storing so wp_kses cannot corrupt the CSS value.
+		const css = rawCSS ? encodeCSSAttribute( rawCSS ) : undefined;
 		setAttributes( {
 			style: cleanEmptyObject( { ...newStyle, css } ),
 		} );
@@ -54,9 +119,9 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	return (
 		<InspectorControls group="advanced">
 			<AdvancedPanel
-				value={ style }
+				value={ displayStyle }
 				onChange={ onChange }
-				inheritedValue={ style }
+				inheritedValue={ displayStyle }
 				help={ cssHelpText }
 			/>
 		</InspectorControls>
@@ -99,7 +164,9 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
  * @return {Object} Block props including className for custom CSS scoping.
  */
 function useBlockProps( { style } ) {
-	const customCSS = style?.css;
+	// Decode before validation and processing — the stored value may be
+	// base64-encoded to survive wp_kses.
+	const customCSS = decodeCSSAttribute( style?.css );
 
 	// Validate CSS is non-empty and passes validation checks.
 	const isValidCSS =

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -42,6 +42,7 @@ const CSS_BASE64_PREFIX = 'data:text/css;base64,';
 
 /**
  * Encodes a CSS string as a base64 data URI so it survives wp_kses intact.
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa.
  *
  * @param {string} css Raw CSS string.
  * @return {string} Encoded value.

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -568,4 +568,116 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not render when decoded CSS contains HTML markup.' );
 	}
+
+	// Tests for gutenberg_encode_custom_css_for_kses().
+
+	/**
+	 * Tests that content without blocks is returned unchanged.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 */
+	public function test_encode_for_kses_ignores_non_block_content() {
+		$content = '<p>Hello world</p>';
+		$this->assertSame( $content, gutenberg_encode_custom_css_for_kses( $content ) );
+	}
+
+	/**
+	 * Tests that CSS without KSES-sensitive characters is still encoded.
+	 * All CSS is encoded uniformly regardless of content, for consistent storage.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 */
+	public function test_encode_for_kses_encodes_safe_css() {
+		$css     = 'color: red; font-size: 16px;';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
+		$result  = gutenberg_encode_custom_css_for_kses( $content );
+		$this->assertStringContainsString(
+			json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+			$result,
+			'All CSS should be encoded, including values with no KSES-sensitive characters.'
+		);
+	}
+
+	/**
+	 * Tests that CSS with `&` is encoded before KSES can corrupt it.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 */
+	public function test_encode_for_kses_encodes_css_with_ampersand() {
+		$css     = '& > p { color: red; }';
+		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
+		$result  = gutenberg_encode_custom_css_for_kses( $content );
+		$this->assertStringNotContainsString( $css, $result, 'Original CSS should be replaced.' );
+		$this->assertStringContainsString( 'data:text/css;base64,', $result, 'Result should contain base64-encoded CSS.' );
+	}
+
+	/**
+	 * Tests the primary bug scenario: nested CSS selectors survive encoding for KSES.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 */
+	public function test_encode_for_kses_encodes_nested_css_selectors() {
+		$css     = 'background: green; & p { color: yellow; padding: 20px; }';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
+		$result  = gutenberg_encode_custom_css_for_kses( $content );
+		$this->assertStringContainsString(
+			json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+			$result,
+			'CSS should be base64-encoded in the block comment.'
+		);
+	}
+
+	/**
+	 * Tests that already-encoded CSS is not double-encoded.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 */
+	public function test_encode_for_kses_does_not_double_encode() {
+		$css     = '& > p { color: red; }';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
+		$result  = gutenberg_encode_custom_css_for_kses( $content );
+		$this->assertSame( $content, $result, 'Already-encoded CSS should not be modified.' );
+	}
+
+	/**
+	 * Tests that CSS in inner blocks is also encoded.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 * @covers ::gutenberg_collect_custom_css_values_for_encoding
+	 */
+	public function test_encode_for_kses_encodes_inner_block_css() {
+		$inner_css = '& > span { color: blue; }';
+		$encoded   = 'data:text/css;base64,' . base64_encode( $inner_css );
+		// Simulate a group block with an inner paragraph that has custom CSS.
+		$content = '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph {"style":{"css":' . json_encode( $inner_css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+		$result  = gutenberg_encode_custom_css_for_kses( $content );
+		$this->assertStringContainsString(
+			json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+			$result,
+			'CSS in inner blocks should be base64-encoded.'
+		);
+	}
+
+	/**
+	 * Tests that encoded CSS round-trips correctly: encode_for_kses + decode_for_display
+	 * restores the original CSS.
+	 *
+	 * @covers ::gutenberg_encode_custom_css_for_kses
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
+	 */
+	public function test_encode_for_kses_round_trips_with_decode() {
+		$css     = 'background: green; & p { color: yellow; }';
+		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
+		$encoded_content = gutenberg_encode_custom_css_for_kses( $content );
+
+		// Extract the encoded CSS value from the result.
+		$blocks      = parse_blocks( $encoded_content );
+		$stored_css  = $blocks[0]['attrs']['style']['css'];
+		$decoded_css = gutenberg_decode_custom_css_attribute_for_display( $stored_css );
+
+		$this->assertSame( $css, $decoded_css, 'CSS should survive the encode → store → decode round-trip.' );
+	}
 }

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -658,8 +658,8 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_encode_for_kses_round_trips_with_decode() {
-		$css     = 'background: green; & p { color: yellow; }';
-		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
+		$css             = 'background: green; & p { color: yellow; }';
+		$content         = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
 		$encoded_content = gutenberg_encode_custom_css_for_kses( $content );
 
 		// Extract the encoded CSS value from the result.

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -438,4 +438,144 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added for valid CSS.' );
 	}
+
+	// Tests for gutenberg_decode_css_attribute().
+
+	/**
+	 * Tests that plain CSS (no prefix) is returned unchanged.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_returns_plain_css_unchanged() {
+		$css = 'color: red; font-size: 16px;';
+		$this->assertSame( $css, gutenberg_decode_css_attribute( $css ) );
+	}
+
+	/**
+	 * Tests that a base64-encoded value is decoded correctly.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_decodes_encoded_value() {
+		$css     = 'color: red;';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+	}
+
+	/**
+	 * Tests that nested CSS selectors survive the encode/decode round-trip.
+	 * This is the primary bug being fixed: wp_kses corrupts `&` and `>` in CSS.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_decodes_nested_css() {
+		$css     = 'background: green; & p { color: yellow; padding: 20px; }';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+	}
+
+	/**
+	 * Tests that CSS with characters wp_kses would corrupt (`&`, `>`) round-trips correctly.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_decodes_kses_sensitive_characters() {
+		$css     = '& > p { color: red; }';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+	}
+
+	/**
+	 * Tests that non-ASCII characters (e.g. Unicode in content values) survive decoding.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_decodes_unicode_characters() {
+		$css     = 'content: "→";';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+	}
+
+	/**
+	 * Tests that an invalid base64 payload returns an empty string.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_returns_empty_for_invalid_base64() {
+		$invalid = 'data:text/css;base64,!!!not-valid-base64!!!';
+		$this->assertSame( '', gutenberg_decode_css_attribute( $invalid ) );
+	}
+
+	/**
+	 * Tests that a payload containing a null byte after decoding returns an empty string.
+	 *
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_decode_css_attribute_returns_empty_for_null_byte_in_decoded_value() {
+		$encoded = 'data:text/css;base64,' . base64_encode( "color: red;\0" );
+		$this->assertSame( '', gutenberg_decode_css_attribute( $encoded ) );
+	}
+
+	// Integration tests: encode/decode through the full render path.
+
+	/**
+	 * Tests that base64-encoded CSS is decoded and applied correctly during render.
+	 * Verifies the primary bug fix: a block saved by a user without unfiltered_html
+	 * should render with the correct CSS, including nested selectors.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_render_decodes_and_applies_base64_encoded_css() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-encoded',
+			array( 'customCSS' => true )
+		);
+
+		$css     = 'background: green; & p { color: yellow; }';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-encoded',
+			'attrs'     => array(
+				'style' => array(
+					'css' => $encoded,
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added for encoded CSS.' );
+	}
+
+	/**
+	 * Tests that a base64-encoded HTML injection payload is rejected after decoding.
+	 * Encoding must not be used to bypass the HTML markup check.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 * @covers ::gutenberg_decode_css_attribute
+	 */
+	public function test_render_rejects_base64_encoded_html_injection() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-encoded-html',
+			array( 'customCSS' => true )
+		);
+
+		// Encode an HTML injection payload — should be caught after decoding.
+		$encoded = 'data:text/css;base64,' . base64_encode( 'color: red;</style><script>alert(1)</script>' );
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-encoded-html',
+			'attrs'     => array(
+				'style' => array(
+					'css' => $encoded,
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayNotHasKey( 'className', $result['attrs'], 'Block should not render when decoded CSS contains HTML markup.' );
+	}
 }

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -439,81 +439,71 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added for valid CSS.' );
 	}
 
-	// Tests for gutenberg_decode_css_attribute().
+	// Tests for gutenberg_decode_custom_css_attribute_for_display().
 
 	/**
 	 * Tests that plain CSS (no prefix) is returned unchanged.
 	 *
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_decode_css_attribute_returns_plain_css_unchanged() {
 		$css = 'color: red; font-size: 16px;';
-		$this->assertSame( $css, gutenberg_decode_css_attribute( $css ) );
+		$this->assertSame( $css, gutenberg_decode_custom_css_attribute_for_display( $css ) );
 	}
 
 	/**
 	 * Tests that a base64-encoded value is decoded correctly.
 	 *
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_decode_css_attribute_decodes_encoded_value() {
 		$css     = 'color: red;';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
-		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+		$this->assertSame( $css, gutenberg_decode_custom_css_attribute_for_display( $encoded ) );
 	}
 
 	/**
 	 * Tests that nested CSS selectors survive the encode/decode round-trip.
 	 * This is the primary bug being fixed: wp_kses corrupts `&` and `>` in CSS.
 	 *
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_decode_css_attribute_decodes_nested_css() {
 		$css     = 'background: green; & p { color: yellow; padding: 20px; }';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
-		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+		$this->assertSame( $css, gutenberg_decode_custom_css_attribute_for_display( $encoded ) );
 	}
 
 	/**
 	 * Tests that CSS with characters wp_kses would corrupt (`&`, `>`) round-trips correctly.
 	 *
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_decode_css_attribute_decodes_kses_sensitive_characters() {
 		$css     = '& > p { color: red; }';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
-		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+		$this->assertSame( $css, gutenberg_decode_custom_css_attribute_for_display( $encoded ) );
 	}
 
 	/**
 	 * Tests that non-ASCII characters (e.g. Unicode in content values) survive decoding.
 	 *
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_decode_css_attribute_decodes_unicode_characters() {
 		$css     = 'content: "→";';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
-		$this->assertSame( $css, gutenberg_decode_css_attribute( $encoded ) );
+		$this->assertSame( $css, gutenberg_decode_custom_css_attribute_for_display( $encoded ) );
 	}
 
 	/**
 	 * Tests that an invalid base64 payload returns an empty string.
 	 *
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_decode_css_attribute_returns_empty_for_invalid_base64() {
 		$invalid = 'data:text/css;base64,!!!not-valid-base64!!!';
-		$this->assertSame( '', gutenberg_decode_css_attribute( $invalid ) );
-	}
-
-	/**
-	 * Tests that a payload containing a null byte after decoding returns an empty string.
-	 *
-	 * @covers ::gutenberg_decode_css_attribute
-	 */
-	public function test_decode_css_attribute_returns_empty_for_null_byte_in_decoded_value() {
-		$encoded = 'data:text/css;base64,' . base64_encode( "color: red;\0" );
-		$this->assertSame( '', gutenberg_decode_css_attribute( $encoded ) );
+		$this->assertSame( '', gutenberg_decode_custom_css_attribute_for_display( $invalid ) );
 	}
 
 	// Integration tests: encode/decode through the full render path.
@@ -524,7 +514,7 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	 * should render with the correct CSS, including nested selectors.
 	 *
 	 * @covers ::gutenberg_render_custom_css_support_styles
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_render_decodes_and_applies_base64_encoded_css() {
 		$this->register_custom_css_block_with_support(
@@ -554,7 +544,7 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	 * Encoding must not be used to bypass the HTML markup check.
 	 *
 	 * @covers ::gutenberg_render_custom_css_support_styles
-	 * @covers ::gutenberg_decode_css_attribute
+	 * @covers ::gutenberg_decode_custom_css_attribute_for_display
 	 */
 	public function test_render_rejects_base64_encoded_html_injection() {
 		$this->register_custom_css_block_with_support(

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -591,12 +591,8 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 		$css     = 'color: red; font-size: 16px;';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
 		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
-		$result  = gutenberg_encode_custom_css_for_kses( $content );
-		$this->assertStringContainsString(
-			json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-			$result,
-			'All CSS should be encoded, including values with no KSES-sensitive characters.'
-		);
+		$result  = parse_blocks( gutenberg_encode_custom_css_for_kses( $content ) );
+		$this->assertSame( $encoded, $result[0]['attrs']['style']['css'], 'All CSS should be encoded, including values with no KSES-sensitive characters.' );
 	}
 
 	/**
@@ -606,10 +602,10 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	 */
 	public function test_encode_for_kses_encodes_css_with_ampersand() {
 		$css     = '& > p { color: red; }';
+		$encoded = 'data:text/css;base64,' . base64_encode( $css );
 		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
-		$result  = gutenberg_encode_custom_css_for_kses( $content );
-		$this->assertStringNotContainsString( $css, $result, 'Original CSS should be replaced.' );
-		$this->assertStringContainsString( 'data:text/css;base64,', $result, 'Result should contain base64-encoded CSS.' );
+		$result  = parse_blocks( gutenberg_encode_custom_css_for_kses( $content ) );
+		$this->assertSame( $encoded, $result[0]['attrs']['style']['css'], 'CSS with ampersand should be base64-encoded.' );
 	}
 
 	/**
@@ -621,12 +617,8 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 		$css     = 'background: green; & p { color: yellow; padding: 20px; }';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
 		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
-		$result  = gutenberg_encode_custom_css_for_kses( $content );
-		$this->assertStringContainsString(
-			json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-			$result,
-			'CSS should be base64-encoded in the block comment.'
-		);
+		$result  = parse_blocks( gutenberg_encode_custom_css_for_kses( $content ) );
+		$this->assertSame( $encoded, $result[0]['attrs']['style']['css'], 'Nested CSS selectors should be base64-encoded.' );
 	}
 
 	/**
@@ -638,27 +630,24 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 		$css     = '& > p { color: red; }';
 		$encoded = 'data:text/css;base64,' . base64_encode( $css );
 		$content = '<!-- wp:paragraph {"style":{"css":' . json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph -->';
-		$result  = gutenberg_encode_custom_css_for_kses( $content );
-		$this->assertSame( $content, $result, 'Already-encoded CSS should not be modified.' );
+		$result  = parse_blocks( gutenberg_encode_custom_css_for_kses( $content ) );
+		$this->assertSame( $encoded, $result[0]['attrs']['style']['css'], 'Already-encoded CSS should not be modified.' );
 	}
 
 	/**
 	 * Tests that CSS in inner blocks is also encoded.
 	 *
 	 * @covers ::gutenberg_encode_custom_css_for_kses
-	 * @covers ::gutenberg_collect_custom_css_values_for_encoding
+	 * @covers ::gutenberg_encode_block_custom_css
 	 */
 	public function test_encode_for_kses_encodes_inner_block_css() {
 		$inner_css = '& > span { color: blue; }';
 		$encoded   = 'data:text/css;base64,' . base64_encode( $inner_css );
 		// Simulate a group block with an inner paragraph that has custom CSS.
-		$content = '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph {"style":{"css":' . json_encode( $inner_css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
-		$result  = gutenberg_encode_custom_css_for_kses( $content );
-		$this->assertStringContainsString(
-			json_encode( $encoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-			$result,
-			'CSS in inner blocks should be base64-encoded.'
-		);
+		$content     = '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph {"style":{"css":' . json_encode( $inner_css, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '}} --><p>Test</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+		$result      = parse_blocks( gutenberg_encode_custom_css_for_kses( $content ) );
+		$inner_block = $result[0]['innerBlocks'][0];
+		$this->assertSame( $encoded, $inner_block['attrs']['style']['css'], 'CSS in inner blocks should be base64-encoded.' );
 	}
 
 	/**


### PR DESCRIPTION
### What

When a user without `unfiltered_html` (e.g. an Editor role) saves a post, WordPress runs `wp_kses` on the post content. 

wp_kses` treats block attribute string values as HTML, so it mangles CSS containing characters like `&`, `>`, or nested selectors — `& p { color: red }` becomes `&amp; p { color: red }`, and the rendered selector becomes `.wp-custom-css-xxxamp; p {}`.

### How

Before saving, the JS `onChange` handler base64-encodes the CSS value as a `data:text/css;base64,…` URI. `wp_kses` passes base64 characters through untouched. On read, the value is decoded back to plain CSS in three places:

- **`CustomCSSControl`** — decodes into `displayStyle` before passing to `AdvancedPanel`, so the user always sees readable CSS in the panel
- **`useBlockProps`** — decodes before `validateCSS` and `processCSSNesting`, so the editor preview works correctly
- **`gutenberg_render_custom_css_support_styles`** — decodes before `process_blocks_custom_css`, so the frontend renders the correct CSS

Values that don't start with the prefix (legacy content, or content saved by admins who bypass KSES entirely) are returned unchanged.

### Migration path

This encoding is intentionally temporary. When `WP_CSS_Token_Processor` or a proper CSS sanitizer API lands in WordPress core:

1. Remove the `encodeCSSAttribute` call in `onChange` — plain CSS can then be stored directly
2. Keep `decodeCSSAttribute` and `gutenberg_decode_css_attribute` as read-time shims — they decode any previously encoded values, and the next save will write plain CSS, so migration is lazy with no batch script required
3. Remove the shims once all sites have cycled through at least one save

### Notes

- **Existing corrupted content** (`&amp;` already in the DB) is not auto-repaired — the user must re-edit and re-save the affected block
- Encoding is currently tied to the CSS control's `onChange`. It only fires when someone edits CSS. It doesn't fire for passive saves where the CSS attribute is just carried along.

### Testing

1. As an Editor (any role without `unfiltered_html`), add a block and open **Advanced → Additional CSS**
2. Enter CSS with nested selectors: `background: green; & p { color: yellow; padding: 20px; }`
3. Save the post
4. Verify the frontend renders both rules correctly with the nested selector applied
5. Reload the editor — verify the CSS panel shows the original unencoded CSS, not the base64 value

```html
<!-- wp:group {"style":{"css":"data:text/css;base64,YmFja2dyb3VuZDogZ3JlZW47ICYgcCB7Y29sb3I6IHllbGxvdztwYWRkaW5nOjIwcHg7fQ=="},"layout":{"type":"constrained"}} -->
<div class="wp-block-group has-custom-css"><!-- wp:paragraph -->
<p>Test!!</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

```

```css
background: green; & p {color: yellow;padding:20px;}
```
