### PR TITLE
Icons Registry: Extend search to include label and keywords fields

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-icons-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-icons-registry.php
@@ -257,19 +257,43 @@ if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 		 * @return array[] Array of arrays containing the registered icon properties.
 		 */
 		public function get_registered_icons( $search = '' ) {
-			$icons = array();
+    $icons = array();
 
-			foreach ( $this->registered_icons as $icon ) {
-				if ( ! empty( $search ) && false === stripos( $icon['name'], $search ) ) {
-					continue;
-				}
+    foreach ( $this->registered_icons as $icon ) {
+        if ( ! empty( $search ) ) {
+            $match = false;
 
-				$icon['content'] = $icon['content'] ?? $this->get_content( $icon['name'] );
-				$icons[]         = $icon;
-			}
+            // Search in 'name' field.
+            if ( false !== stripos( $icon['name'], $search ) ) {
+                $match = true;
+            }
 
-			return $icons;
-		}
+            // Search in 'label' field.
+            if ( ! $match && ! empty( $icon['label'] ) && false !== stripos( $icon['label'], $search ) ) {
+                $match = true;
+            }
+
+            // Search in 'keywords' field.
+            if ( ! $match && ! empty( $icon['keywords'] ) && is_array( $icon['keywords'] ) ) {
+                foreach ( $icon['keywords'] as $keyword ) {
+                    if ( false !== stripos( $keyword, $search ) ) {
+                        $match = true;
+                        break;
+                    }
+                }
+            }
+
+            if ( ! $match ) {
+                continue;
+            }
+        }
+
+        $icon['content'] = $icon['content'] ?? $this->get_content( $icon['name'] );
+        $icons[]         = $icon;
+    }
+
+    return $icons;
+}
 
 		/**
 		 * Checks if an icon is registered.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
 <!-- #ISSUE-NUMBER or URL -->
Extends `get_registered_icons()` in `WP_Icons_Registry` to search 
against `label` and `keywords` fields in addition to `name`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently the search parameter only matches icon names. 
Part of SVG Icon API iteration for WordPress 7.1.

Closes #75715

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated the search logic in `get_registered_icons()` to check 
name, label, and keywords fields using stripos().

## Testing Instructions
Updated the search logic in `get_registered_icons()` to check 
name, label, and keywords fields using stripos().
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
