### PR TITLE
Navigation: Update close button size.

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/style.scss
+++ b/packages/block-library/src/navigation-overlay-close/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	justify-content: center;
 	gap: 0.5em;
-	padding: 0.5em;
+	padding: 0;
 	border: none;
 	background: transparent;
 	cursor: pointer;
@@ -14,8 +14,8 @@
 	}
 
 	svg {
-		width: 1.5em;
-		height: 1.5em;
+		width: 24px;
+		height: 24px;
 		fill: currentColor;
 		display: block;
 		flex-shrink: 0;


### PR DESCRIPTION
## What?

This PR updates the default close button icon size in the new Nav Overlay menu to 24x24 with no inner button padding.

This is important because it matches the burger icon default metrics:

<img width="332" height="136" alt="Skærmbillede 2026-03-13 kl  10 24 32" src="https://github.com/user-attachments/assets/e7005265-6e4b-476e-889d-1bdc2d7c5508" />

This is important, and I'm marking it as a bug in the hopes that it can be in a 7.0 RC release, so we avoid having to change styles in overlays at a future time. The main reason it's important is so that you can ensure the burger menu and close icons are in exactly the same places between closed and open. 

It is also relatively limited CSS, safe, and looks good with the changes applied:

<img width="600" height="365" alt="Skærmbillede 2026-03-13 kl  10 24 58" src="https://github.com/user-attachments/assets/a3e47973-8767-4b27-bca2-b4ca437494a6" />

Many sites animate a single icon—the burger icon consisting of a two lines, `=`, transforming into the two lines of an `x`. This is a goal of the work here as well, even if it will be tricky. But it requires that we think of the burger button and the close buttons as siblings that need to share dimensions perfectly accurately. If they don't the icons will shift between states.

## Testing Instructions

Create a navigation overlay with a close button, observe that it's 24x24 with no inner padding on the wrapping `button` element.