### PR TITLE
Navigation Link: fix current-menu-item not applied for custom kind links, legacy blocks, and taxonomy links without explicit kind

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -191,6 +191,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
 	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
 	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	$enable_id_match = 'post-type-archive' !== $link_kind;
 
 	/*
 	 * Entity ID match.
@@ -214,7 +215,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 		? $queried_object instanceof WP_Term
 		: $queried_object instanceof WP_Post;
 
-	if ( $ids_match && $object_type_matches ) {
+	if ( $enable_id_match && $ids_match && $object_type_matches ) {
 		return true;
 	}
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -189,8 +189,9 @@ function block_core_navigation_link_is_active( $attributes ) {
 	$stored_kind    = $attributes['kind'] ?? '';
 	$stored_type    = $attributes['type'] ?? '';
 	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
-	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	$kind_from_type  = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$link_kind       = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	// Archive links match by URL (via is_post_type_archive()), not by entity ID, so skip ID matching.
 	$enable_id_match = 'post-type-archive' !== $link_kind;
 
 	/*

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -174,6 +174,87 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 
 
 /**
+ * Determines whether a navigation link block should be marked as the active/current item
+ * based on the current WordPress query context.
+ *
+ * Mirrors the two ID-based match branches of the classic menu system
+ * (`_wp_menu_item_classes_by_context()` in wp-includes/nav-menu-template.php):
+ *
+ * - Branch B: direct entity ID match, guarded by object-type check to prevent post/term
+ *             ID collisions (posts and terms use independent auto-increment sequences).
+ * - Branch C: post-type archive URL match, regardless of stored ID.
+ *
+ * @since 6.8.0
+ *
+ * @param array $attributes The block attributes.
+ * @return bool Whether the link represents the current page/archive.
+ */
+function block_core_navigation_link_is_active( $attributes ) {
+	/*
+	 * Determine the effective "kind" of this link.
+	 *
+	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
+	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
+	 *
+	 * Backwards compatibility — why `kind` may be absent:
+	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
+	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
+	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
+	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
+	 * post-type links without relying on a stored `kind`.
+	 *
+	 * Backwards compatibility — the "tag" alias:
+	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
+	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
+	 * `taxonomy_exists()` can find the registered taxonomy correctly.
+	 */
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
+	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+
+	/*
+	 * Branch B: direct entity ID match.
+	 *
+	 * Backwards compatibility — numeric id guard:
+	 * Historically, the `id` attribute could be set to a URL string rather than an integer
+	 * in some editor versions. `absint()` converts non-numeric values (including strings
+	 * and null) to 0, ensuring those values never produce a match.
+	 *
+	 * Post/term ID collision guard — mirrors classic menu's _menu_item_type + query-state check:
+	 * `instanceof` confirms the queried object is the correct PHP type before accepting the
+	 * ID match, preventing a taxonomy link from activating on a post page with the same
+	 * integer ID (and vice versa).
+	 */
+	$queried_object      = get_queried_object();
+	$link_id             = absint( $attributes['id'] ?? 0 );
+	$is_taxonomy_link    = 'taxonomy' === $link_kind;
+	$queried_id          = get_queried_object_id();
+	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$object_type_matches = $is_taxonomy_link
+		? $queried_object instanceof WP_Term
+		: $queried_object instanceof WP_Post;
+
+	if ( $ids_match && $object_type_matches ) {
+		return true;
+	}
+
+	/*
+	 * Branch C: post-type archive URL match.
+	 * Active when the current URL matches the archive permalink, regardless of stored ID.
+	 */
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
+		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
+		if ( $attributes['url'] === $queried_archive_link ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Renders the `core/navigation-link` block.
  *
  * @since 5.9.0
@@ -209,68 +290,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$css_classes    = trim( implode( ' ', $classes ) );
-	$queried_object = get_queried_object();
-
-	/*
-	 * Determine the effective "kind" of this link.
-	 *
-	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
-	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
-	 *
-	 * Backwards compatibility — why `kind` may be absent:
-	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
-	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
-	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
-	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
-	 * post-type links without relying on a stored `kind`.
-	 *
-	 * Backwards compatibility — the "tag" alias:
-	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
-	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
-	 * `taxonomy_exists()` can find the registered taxonomy correctly.
-	 */
-	$stored_kind    = $attributes['kind'] ?? '';
-	$stored_type    = $attributes['type'] ?? '';
-	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
-	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
-
-	/*
-	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch B):
-	 * A nav item is "active" when its stored entity ID matches the queried object ID AND
-	 * the object type agrees — posts live in wp_posts, terms in wp_terms/wp_term_taxonomy,
-	 * and both tables use independent auto-increment sequences so the same integer can
-	 * appear in both. The classic system guards against this collision via _menu_item_type
-	 * meta ("post_type" vs "taxonomy") combined with mutually exclusive query-state flags.
-	 * Here we use instanceof checks on the queried object as the equivalent guard.
-	 *
-	 * Backwards compatibility — numeric id guard:
-	 * Historically, the `id` attribute could be set to a URL string rather than an integer
-	 * in some editor versions. `absint()` converts non-numeric values (including strings
-	 * and null) to 0, ensuring those values never produce a match.
-	 */
-	$link_id          = absint( $attributes['id'] ?? 0 );
-	$is_taxonomy_link = 'taxonomy' === $link_kind;
-	$queried_id       = get_queried_object_id();
-	$ids_match        = $link_id > 0 && $queried_id === $link_id;
-	// Post/term ID collision guard — mirrors classic menu's type + query-state check.
-	$object_type_matches = $is_taxonomy_link
-		? $queried_object instanceof WP_Term
-		: $queried_object instanceof WP_Post;
-	$is_active           = $ids_match && $object_type_matches;
-
-	/*
-	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch C):
-	 * Post-type archive links become active when the current URL matches the archive
-	 * permalink, regardless of whether an entity ID is stored on the block.
-	 */
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
-		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
-			$is_active = true;
-		}
-	}
+	$css_classes = trim( implode( ' ', $classes ) );
+	$is_active   = block_core_navigation_link_is_active( $attributes );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -247,10 +247,10 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	 *
 	 * Backwards compatibility — numeric id guard:
 	 * Historically, the `id` attribute could be set to a URL string rather than an integer
-	 * in some editor versions. `is_numeric()` ensures those values never produce a match.
+	 * in some editor versions. `absint()` converts non-numeric values (including strings
+	 * and null) to 0, ensuring those values never produce a match.
 	 */
-	$raw_id           = $attributes['id'] ?? null;
-	$link_id          = is_numeric( $raw_id ) ? (int) $raw_id : 0;
+	$link_id          = absint( $attributes['id'] ?? 0 );
 	$is_taxonomy_link = 'taxonomy' === $link_kind;
 	$queried_id       = get_queried_object_id();
 	$ids_match        = $link_id > 0 && $queried_id === $link_id;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -211,7 +211,13 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes         = trim( implode( ' ', $classes ) );
 	$queried_object      = get_queried_object();
-	$link_kind           = ! empty( $attributes['kind'] ) ? $attributes['kind'] : 'post-type';
+	$stored_kind         = $attributes['kind'] ?? '';
+	$stored_type         = $attributes['type'] ?? '';
+	// JS normalises 'post_tag' → 'tag' before storing. Map it back so taxonomy_exists() works.
+	$resolved_type       = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	// When kind is explicitly stored, trust it. Otherwise infer from type: if the stored
+	// type is a registered taxonomy slug, treat the link as a taxonomy link.
+	$link_kind           = ! empty( $stored_kind ) ? $stored_kind : ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
 	$link_id             = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
 	$is_taxonomy_link    = 'taxonomy' === $link_kind;
 	$queried_id          = get_queried_object_id();

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -177,12 +177,13 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
  * Determines whether a navigation link block should be marked as the active/current item
  * based on the current WordPress query context.
  *
- * Mirrors the two ID-based match branches of the classic menu system
+ * Mirrors the two ID-based active-state checks of the classic menu system
  * (`_wp_menu_item_classes_by_context()` in wp-includes/nav-menu-template.php):
  *
- * - Branch B: direct entity ID match, guarded by object-type check to prevent post/term
- *             ID collisions (posts and terms use independent auto-increment sequences).
- * - Branch C: post-type archive URL match, regardless of stored ID.
+ * - Entity ID match: the link's stored entity ID matches the current queried object ID,
+ *   with an object-type guard to prevent false positives from post/term ID collisions.
+ * - Post-type archive URL match: the link's URL matches the current archive permalink,
+ *   regardless of whether an entity ID is stored.
  *
  * @since 6.8.0
  *
@@ -215,7 +216,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
 
 	/*
-	 * Branch B: direct entity ID match.
+	 * Entity ID match.
 	 *
 	 * Backwards compatibility — numeric id guard:
 	 * Historically, the `id` attribute could be set to a URL string rather than an integer
@@ -241,7 +242,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 	}
 
 	/*
-	 * Branch C: post-type archive URL match.
+	 * Post-type archive URL match.
 	 * Active when the current URL matches the archive permalink, regardless of stored ID.
 	 */
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -212,8 +212,9 @@ function block_core_navigation_link_is_active( $attributes ) {
 	$stored_kind    = $attributes['kind'] ?? '';
 	$stored_type    = $attributes['type'] ?? '';
 	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
-	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	$kind_from_type  = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$link_kind       = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	// Archive links match by URL (via is_post_type_archive()), not by entity ID, so skip ID matching.
 	$enable_id_match = 'post-type-archive' !== $link_kind;
 
 	/*

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -214,6 +214,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
 	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
 	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	$enable_id_match = 'post-type-archive' !== $link_kind;
 
 	/*
 	 * Entity ID match.
@@ -237,7 +238,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 		? $queried_object instanceof WP_Term
 		: $queried_object instanceof WP_Post;
 
-	if ( $ids_match && $object_type_matches ) {
+	if ( $enable_id_match && $ids_match && $object_type_matches ) {
 		return true;
 	}
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -209,12 +209,12 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$css_classes         = trim( implode( ' ', $classes ) );
-	$queried_object      = get_queried_object();
-	$stored_kind         = $attributes['kind'] ?? '';
-	$stored_type         = $attributes['type'] ?? '';
+	$css_classes    = trim( implode( ' ', $classes ) );
+	$queried_object = get_queried_object();
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
 	// JS normalises 'post_tag' → 'tag' before storing. Map it back so taxonomy_exists() works.
-	$resolved_type       = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$resolved_type = 'tag' === $stored_type ? 'post_tag' : $stored_type;
 	// When kind is explicitly stored, trust it. Otherwise infer from type: if the stored
 	// type is a registered taxonomy slug, treat the link as a taxonomy link.
 	$link_kind           = ! empty( $stored_kind ) ? $stored_kind : ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -6,6 +6,7 @@
  */
 
 require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
+require_once __DIR__ . '/navigation-link/shared/navigation-item-is-active.php';
 require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
 
 /**
@@ -172,91 +173,6 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 	return $url;
 }
 
-
-/**
- * Determines whether a navigation link block should be marked as the active/current item
- * based on the current WordPress query context.
- *
- * Mirrors the two ID-based active-state checks of the classic menu system
- * (`_wp_menu_item_classes_by_context()` in wp-includes/nav-menu-template.php):
- *
- * - Entity ID match: the link's stored entity ID matches the current queried object ID,
- *   with an object-type guard to prevent false positives from post/term ID collisions.
- * - Post-type archive URL match: the link's URL matches the current archive permalink,
- *   regardless of whether an entity ID is stored.
- *
- * @since 6.8.0
- *
- * @param array $attributes The block attributes.
- * @return bool Whether the link represents the current page/archive.
- */
-function block_core_navigation_link_is_active( $attributes ) {
-	/*
-	 * Determine the effective "kind" of this link.
-	 *
-	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
-	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
-	 *
-	 * Backwards compatibility — why `kind` may be absent:
-	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
-	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
-	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
-	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
-	 * post-type links without relying on a stored `kind`.
-	 *
-	 * Backwards compatibility — the "tag" alias:
-	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
-	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
-	 * `taxonomy_exists()` can find the registered taxonomy correctly.
-	 */
-	$stored_kind    = $attributes['kind'] ?? '';
-	$stored_type    = $attributes['type'] ?? '';
-	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$kind_from_type  = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
-	$link_kind       = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
-	// Archive links match by URL (via is_post_type_archive()), not by entity ID, so skip ID matching.
-	$enable_id_match = 'post-type-archive' !== $link_kind;
-
-	/*
-	 * Entity ID match.
-	 *
-	 * Backwards compatibility — numeric id guard:
-	 * Historically, the `id` attribute could be set to a URL string rather than an integer
-	 * in some editor versions. `absint()` converts non-numeric values (including strings
-	 * and null) to 0, ensuring those values never produce a match.
-	 *
-	 * Post/term ID collision guard — mirrors classic menu's _menu_item_type + query-state check:
-	 * `instanceof` confirms the queried object is the correct PHP type before accepting the
-	 * ID match, preventing a taxonomy link from activating on a post page with the same
-	 * integer ID (and vice versa).
-	 */
-	$queried_object      = get_queried_object();
-	$link_id             = absint( $attributes['id'] ?? 0 );
-	$is_taxonomy_link    = 'taxonomy' === $link_kind;
-	$queried_id          = get_queried_object_id();
-	$ids_match           = $link_id > 0 && $queried_id === $link_id;
-	$object_type_matches = $is_taxonomy_link
-		? $queried_object instanceof WP_Term
-		: $queried_object instanceof WP_Post;
-
-	if ( $enable_id_match && $ids_match && $object_type_matches ) {
-		return true;
-	}
-
-	/*
-	 * Post-type archive URL match.
-	 * Active when the current URL matches the archive permalink, regardless of stored ID.
-	 */
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
-		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 /**
  * Renders the `core/navigation-link` block.
  *
@@ -294,7 +210,11 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
 	$css_classes = trim( implode( ' ', $classes ) );
-	$is_active   = block_core_navigation_link_is_active( $attributes );
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$is_active = gutenberg_block_core_shared_navigation_item_is_active( $attributes );
+	} else {
+		$is_active = block_core_shared_navigation_item_is_active( $attributes );
+	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -209,9 +209,17 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$css_classes = trim( implode( ' ', $classes ) );
-	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
-	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
+	$css_classes         = trim( implode( ' ', $classes ) );
+	$queried_object      = get_queried_object();
+	$link_kind           = ! empty( $attributes['kind'] ) ? $attributes['kind'] : 'post-type';
+	$link_id             = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
+	$is_taxonomy_link    = 'taxonomy' === $link_kind;
+	$queried_id          = get_queried_object_id();
+	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$object_type_matches = $is_taxonomy_link
+		? $queried_object instanceof WP_Term
+		: $queried_object instanceof WP_Post;
+	$is_active           = $ids_match && $object_type_matches;
 
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -211,22 +211,60 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes    = trim( implode( ' ', $classes ) );
 	$queried_object = get_queried_object();
-	$stored_kind    = $attributes['kind'] ?? '';
-	$stored_type    = $attributes['type'] ?? '';
-	// JS normalises 'post_tag' → 'tag' before storing. Map it back so taxonomy_exists() works.
+
+	/*
+	 * Determine the effective "kind" of this link.
+	 *
+	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
+	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
+	 *
+	 * Backwards compatibility — why `kind` may be absent:
+	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
+	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
+	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
+	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
+	 * post-type links without relying on a stored `kind`.
+	 *
+	 * Backwards compatibility — the "tag" alias:
+	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
+	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
+	 * `taxonomy_exists()` can find the registered taxonomy correctly.
+	 */
+	$stored_kind   = $attributes['kind'] ?? '';
+	$stored_type   = $attributes['type'] ?? '';
 	$resolved_type = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	// When kind is explicitly stored, trust it. Otherwise infer from type: if the stored
-	// type is a registered taxonomy slug, treat the link as a taxonomy link.
-	$link_kind           = ! empty( $stored_kind ) ? $stored_kind : ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
-	$link_id             = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
-	$is_taxonomy_link    = 'taxonomy' === $link_kind;
-	$queried_id          = get_queried_object_id();
-	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$link_kind     = ! empty( $stored_kind )
+		? $stored_kind
+		: ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
+
+	/*
+	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch B):
+	 * A nav item is "active" when its stored entity ID matches the queried object ID AND
+	 * the object type agrees — posts live in wp_posts, terms in wp_terms/wp_term_taxonomy,
+	 * and both tables use independent auto-increment sequences so the same integer can
+	 * appear in both. The classic system guards against this collision via _menu_item_type
+	 * meta ("post_type" vs "taxonomy") combined with mutually exclusive query-state flags.
+	 * Here we use instanceof checks on the queried object as the equivalent guard.
+	 *
+	 * Backwards compatibility — numeric id guard:
+	 * Historically, the `id` attribute could be set to a URL string rather than an integer
+	 * in some editor versions. `is_numeric()` ensures those values never produce a match.
+	 */
+	$link_id          = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
+	$is_taxonomy_link = 'taxonomy' === $link_kind;
+	$queried_id       = get_queried_object_id();
+	$ids_match        = $link_id > 0 && $queried_id === $link_id;
+	// Post/term ID collision guard — mirrors classic menu's type + query-state check.
 	$object_type_matches = $is_taxonomy_link
 		? $queried_object instanceof WP_Term
 		: $queried_object instanceof WP_Post;
 	$is_active           = $ids_match && $object_type_matches;
 
+	/*
+	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch C):
+	 * Post-type archive links become active when the current URL matches the archive
+	 * permalink, regardless of whether an entity ID is stored on the block.
+	 */
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
 		if ( $attributes['url'] === $queried_archive_link ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -230,12 +230,11 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
 	 * `taxonomy_exists()` can find the registered taxonomy correctly.
 	 */
-	$stored_kind   = $attributes['kind'] ?? '';
-	$stored_type   = $attributes['type'] ?? '';
-	$resolved_type = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$link_kind     = ! empty( $stored_kind )
-		? $stored_kind
-		: ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
+	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
 
 	/*
 	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch B):
@@ -250,7 +249,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	 * Historically, the `id` attribute could be set to a URL string rather than an integer
 	 * in some editor versions. `is_numeric()` ensures those values never produce a match.
 	 */
-	$link_id          = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
+	$raw_id           = $attributes['id'] ?? null;
+	$link_id          = is_numeric( $raw_id ) ? (int) $raw_id : 0;
 	$is_taxonomy_link = 'taxonomy' === $link_kind;
 	$queried_id       = get_queried_object_id();
 	$ids_match        = $link_id > 0 && $queried_id === $link_id;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -187,12 +187,12 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$css_classes         = trim( implode( ' ', $classes ) );
-	$queried_object      = get_queried_object();
-	$stored_kind         = $attributes['kind'] ?? '';
-	$stored_type         = $attributes['type'] ?? '';
+	$css_classes    = trim( implode( ' ', $classes ) );
+	$queried_object = get_queried_object();
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
 	// JS normalises 'post_tag' → 'tag' before storing. Map it back so taxonomy_exists() works.
-	$resolved_type       = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$resolved_type = 'tag' === $stored_type ? 'post_tag' : $stored_type;
 	// When kind is explicitly stored, trust it. Otherwise infer from type: if the stored
 	// type is a registered taxonomy slug, treat the link as a taxonomy link.
 	$link_kind           = ! empty( $stored_kind ) ? $stored_kind : ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -154,12 +154,13 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
  * Determines whether a navigation link block should be marked as the active/current item
  * based on the current WordPress query context.
  *
- * Mirrors the two ID-based match branches of the classic menu system
+ * Mirrors the two ID-based active-state checks of the classic menu system
  * (`_wp_menu_item_classes_by_context()` in wp-includes/nav-menu-template.php):
  *
- * - Branch B: direct entity ID match, guarded by object-type check to prevent post/term
- *             ID collisions (posts and terms use independent auto-increment sequences).
- * - Branch C: post-type archive URL match, regardless of stored ID.
+ * - Entity ID match: the link's stored entity ID matches the current queried object ID,
+ *   with an object-type guard to prevent false positives from post/term ID collisions.
+ * - Post-type archive URL match: the link's URL matches the current archive permalink,
+ *   regardless of whether an entity ID is stored.
  *
  * @since 6.8.0
  *
@@ -192,7 +193,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
 
 	/*
-	 * Branch B: direct entity ID match.
+	 * Entity ID match.
 	 *
 	 * Backwards compatibility — numeric id guard:
 	 * Historically, the `id` attribute could be set to a URL string rather than an integer
@@ -218,7 +219,7 @@ function block_core_navigation_link_is_active( $attributes ) {
 	}
 
 	/*
-	 * Branch C: post-type archive URL match.
+	 * Post-type archive URL match.
 	 * Active when the current URL matches the archive permalink, regardless of stored ID.
 	 */
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -189,22 +189,60 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes    = trim( implode( ' ', $classes ) );
 	$queried_object = get_queried_object();
-	$stored_kind    = $attributes['kind'] ?? '';
-	$stored_type    = $attributes['type'] ?? '';
-	// JS normalises 'post_tag' → 'tag' before storing. Map it back so taxonomy_exists() works.
+
+	/*
+	 * Determine the effective "kind" of this link.
+	 *
+	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
+	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
+	 *
+	 * Backwards compatibility — why `kind` may be absent:
+	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
+	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
+	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
+	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
+	 * post-type links without relying on a stored `kind`.
+	 *
+	 * Backwards compatibility — the "tag" alias:
+	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
+	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
+	 * `taxonomy_exists()` can find the registered taxonomy correctly.
+	 */
+	$stored_kind   = $attributes['kind'] ?? '';
+	$stored_type   = $attributes['type'] ?? '';
 	$resolved_type = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	// When kind is explicitly stored, trust it. Otherwise infer from type: if the stored
-	// type is a registered taxonomy slug, treat the link as a taxonomy link.
-	$link_kind           = ! empty( $stored_kind ) ? $stored_kind : ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
-	$link_id             = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
-	$is_taxonomy_link    = 'taxonomy' === $link_kind;
-	$queried_id          = get_queried_object_id();
-	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$link_kind     = ! empty( $stored_kind )
+		? $stored_kind
+		: ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
+
+	/*
+	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch B):
+	 * A nav item is "active" when its stored entity ID matches the queried object ID AND
+	 * the object type agrees — posts live in wp_posts, terms in wp_terms/wp_term_taxonomy,
+	 * and both tables use independent auto-increment sequences so the same integer can
+	 * appear in both. The classic system guards against this collision via _menu_item_type
+	 * meta ("post_type" vs "taxonomy") combined with mutually exclusive query-state flags.
+	 * Here we use instanceof checks on the queried object as the equivalent guard.
+	 *
+	 * Backwards compatibility — numeric id guard:
+	 * Historically, the `id` attribute could be set to a URL string rather than an integer
+	 * in some editor versions. `is_numeric()` ensures those values never produce a match.
+	 */
+	$link_id          = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
+	$is_taxonomy_link = 'taxonomy' === $link_kind;
+	$queried_id       = get_queried_object_id();
+	$ids_match        = $link_id > 0 && $queried_id === $link_id;
+	// Post/term ID collision guard — mirrors classic menu's type + query-state check.
 	$object_type_matches = $is_taxonomy_link
 		? $queried_object instanceof WP_Term
 		: $queried_object instanceof WP_Post;
 	$is_active           = $ids_match && $object_type_matches;
 
+	/*
+	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch C):
+	 * Post-type archive links become active when the current URL matches the archive
+	 * permalink, regardless of whether an entity ID is stored on the block.
+	 */
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
 		if ( $attributes['url'] === $queried_archive_link ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -189,7 +189,13 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes         = trim( implode( ' ', $classes ) );
 	$queried_object      = get_queried_object();
-	$link_kind           = ! empty( $attributes['kind'] ) ? $attributes['kind'] : 'post-type';
+	$stored_kind         = $attributes['kind'] ?? '';
+	$stored_type         = $attributes['type'] ?? '';
+	// JS normalises 'post_tag' → 'tag' before storing. Map it back so taxonomy_exists() works.
+	$resolved_type       = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	// When kind is explicitly stored, trust it. Otherwise infer from type: if the stored
+	// type is a registered taxonomy slug, treat the link as a taxonomy link.
+	$link_kind           = ! empty( $stored_kind ) ? $stored_kind : ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
 	$link_id             = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
 	$is_taxonomy_link    = 'taxonomy' === $link_kind;
 	$queried_id          = get_queried_object_id();

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -151,6 +151,87 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 
 
 /**
+ * Determines whether a navigation link block should be marked as the active/current item
+ * based on the current WordPress query context.
+ *
+ * Mirrors the two ID-based match branches of the classic menu system
+ * (`_wp_menu_item_classes_by_context()` in wp-includes/nav-menu-template.php):
+ *
+ * - Branch B: direct entity ID match, guarded by object-type check to prevent post/term
+ *             ID collisions (posts and terms use independent auto-increment sequences).
+ * - Branch C: post-type archive URL match, regardless of stored ID.
+ *
+ * @since 6.8.0
+ *
+ * @param array $attributes The block attributes.
+ * @return bool Whether the link represents the current page/archive.
+ */
+function block_core_navigation_link_is_active( $attributes ) {
+	/*
+	 * Determine the effective "kind" of this link.
+	 *
+	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
+	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
+	 *
+	 * Backwards compatibility — why `kind` may be absent:
+	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
+	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
+	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
+	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
+	 * post-type links without relying on a stored `kind`.
+	 *
+	 * Backwards compatibility — the "tag" alias:
+	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
+	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
+	 * `taxonomy_exists()` can find the registered taxonomy correctly.
+	 */
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
+	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+
+	/*
+	 * Branch B: direct entity ID match.
+	 *
+	 * Backwards compatibility — numeric id guard:
+	 * Historically, the `id` attribute could be set to a URL string rather than an integer
+	 * in some editor versions. `absint()` converts non-numeric values (including strings
+	 * and null) to 0, ensuring those values never produce a match.
+	 *
+	 * Post/term ID collision guard — mirrors classic menu's _menu_item_type + query-state check:
+	 * `instanceof` confirms the queried object is the correct PHP type before accepting the
+	 * ID match, preventing a taxonomy link from activating on a post page with the same
+	 * integer ID (and vice versa).
+	 */
+	$queried_object      = get_queried_object();
+	$link_id             = absint( $attributes['id'] ?? 0 );
+	$is_taxonomy_link    = 'taxonomy' === $link_kind;
+	$queried_id          = get_queried_object_id();
+	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$object_type_matches = $is_taxonomy_link
+		? $queried_object instanceof WP_Term
+		: $queried_object instanceof WP_Post;
+
+	if ( $ids_match && $object_type_matches ) {
+		return true;
+	}
+
+	/*
+	 * Branch C: post-type archive URL match.
+	 * Active when the current URL matches the archive permalink, regardless of stored ID.
+	 */
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
+		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
+		if ( $attributes['url'] === $queried_archive_link ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Renders the `core/navigation-link` block.
  *
  * @since 5.9.0
@@ -187,68 +268,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$css_classes    = trim( implode( ' ', $classes ) );
-	$queried_object = get_queried_object();
-
-	/*
-	 * Determine the effective "kind" of this link.
-	 *
-	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
-	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
-	 *
-	 * Backwards compatibility — why `kind` may be absent:
-	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
-	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
-	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
-	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
-	 * post-type links without relying on a stored `kind`.
-	 *
-	 * Backwards compatibility — the "tag" alias:
-	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
-	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
-	 * `taxonomy_exists()` can find the registered taxonomy correctly.
-	 */
-	$stored_kind    = $attributes['kind'] ?? '';
-	$stored_type    = $attributes['type'] ?? '';
-	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
-	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
-
-	/*
-	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch B):
-	 * A nav item is "active" when its stored entity ID matches the queried object ID AND
-	 * the object type agrees — posts live in wp_posts, terms in wp_terms/wp_term_taxonomy,
-	 * and both tables use independent auto-increment sequences so the same integer can
-	 * appear in both. The classic system guards against this collision via _menu_item_type
-	 * meta ("post_type" vs "taxonomy") combined with mutually exclusive query-state flags.
-	 * Here we use instanceof checks on the queried object as the equivalent guard.
-	 *
-	 * Backwards compatibility — numeric id guard:
-	 * Historically, the `id` attribute could be set to a URL string rather than an integer
-	 * in some editor versions. `absint()` converts non-numeric values (including strings
-	 * and null) to 0, ensuring those values never produce a match.
-	 */
-	$link_id          = absint( $attributes['id'] ?? 0 );
-	$is_taxonomy_link = 'taxonomy' === $link_kind;
-	$queried_id       = get_queried_object_id();
-	$ids_match        = $link_id > 0 && $queried_id === $link_id;
-	// Post/term ID collision guard — mirrors classic menu's type + query-state check.
-	$object_type_matches = $is_taxonomy_link
-		? $queried_object instanceof WP_Term
-		: $queried_object instanceof WP_Post;
-	$is_active           = $ids_match && $object_type_matches;
-
-	/*
-	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch C):
-	 * Post-type archive links become active when the current URL matches the archive
-	 * permalink, regardless of whether an entity ID is stored on the block.
-	 */
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
-		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
-			$is_active = true;
-		}
-	}
+	$css_classes = trim( implode( ' ', $classes ) );
+	$is_active   = block_core_navigation_link_is_active( $attributes );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -225,10 +225,10 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	 *
 	 * Backwards compatibility — numeric id guard:
 	 * Historically, the `id` attribute could be set to a URL string rather than an integer
-	 * in some editor versions. `is_numeric()` ensures those values never produce a match.
+	 * in some editor versions. `absint()` converts non-numeric values (including strings
+	 * and null) to 0, ensuring those values never produce a match.
 	 */
-	$raw_id           = $attributes['id'] ?? null;
-	$link_id          = is_numeric( $raw_id ) ? (int) $raw_id : 0;
+	$link_id          = absint( $attributes['id'] ?? 0 );
 	$is_taxonomy_link = 'taxonomy' === $link_kind;
 	$queried_id       = get_queried_object_id();
 	$ids_match        = $link_id > 0 && $queried_id === $link_id;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -187,9 +187,17 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$css_classes = trim( implode( ' ', $classes ) );
-	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
-	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
+	$css_classes         = trim( implode( ' ', $classes ) );
+	$queried_object      = get_queried_object();
+	$link_kind           = ! empty( $attributes['kind'] ) ? $attributes['kind'] : 'post-type';
+	$link_id             = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
+	$is_taxonomy_link    = 'taxonomy' === $link_kind;
+	$queried_id          = get_queried_object_id();
+	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$object_type_matches = $is_taxonomy_link
+		? $queried_object instanceof WP_Term
+		: $queried_object instanceof WP_Post;
+	$is_active           = $ids_match && $object_type_matches;
 
 	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -208,12 +208,11 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
 	 * `taxonomy_exists()` can find the registered taxonomy correctly.
 	 */
-	$stored_kind   = $attributes['kind'] ?? '';
-	$stored_type   = $attributes['type'] ?? '';
-	$resolved_type = 'tag' === $stored_type ? 'post_tag' : $stored_type;
-	$link_kind     = ! empty( $stored_kind )
-		? $stored_kind
-		: ( taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type' );
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
+	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$link_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
 
 	/*
 	 * Mirrors classic menu behaviour (_wp_menu_item_classes_by_context(), Branch B):
@@ -228,7 +227,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	 * Historically, the `id` attribute could be set to a URL string rather than an integer
 	 * in some editor versions. `is_numeric()` ensures those values never produce a match.
 	 */
-	$link_id          = is_numeric( $attributes['id'] ?? null ) ? (int) $attributes['id'] : 0;
+	$raw_id           = $attributes['id'] ?? null;
+	$link_id          = is_numeric( $raw_id ) ? (int) $raw_id : 0;
 	$is_taxonomy_link = 'taxonomy' === $link_kind;
 	$queried_id       = get_queried_object_id();
 	$ids_match        = $link_id > 0 && $queried_id === $link_id;

--- a/packages/block-library/src/navigation-link/shared/navigation-item-is-active.php
+++ b/packages/block-library/src/navigation-link/shared/navigation-item-is-active.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Shared helper function for checking if navigation items are active.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Determines whether a navigation item should be marked as the active/current item
+ * based on the current WordPress query context.
+ *
+ * Mirrors the two ID-based active-state checks of the classic menu system
+ * (`_wp_menu_item_classes_by_context()` in wp-includes/nav-menu-template.php):
+ *
+ * - Entity ID match: the item's stored entity ID matches the current queried object ID,
+ *   with an object-type guard to prevent false positives from post/term ID collisions.
+ * - Post-type archive URL match: the item's URL matches the current archive permalink,
+ *   regardless of whether an entity ID is stored.
+ *
+ * @since 6.8.0
+ *
+ * @param array $attributes The block attributes.
+ * @return bool Whether the item represents the current page/archive.
+ */
+function block_core_shared_navigation_item_is_active( $attributes ) {
+	/*
+	 * Determine the effective "kind" of this item.
+	 *
+	 * Block-system specific: the block stores `kind` ("post-type" / "taxonomy" / "custom")
+	 * and `type` (e.g. "page", "post", "category", "tag") as separate attributes.
+	 *
+	 * Backwards compatibility - why `kind` may be absent:
+	 * The JS editor only writes `kind` to the block attributes when it is a non-empty string
+	 * (`...( kind && { kind } )` in update-attributes.js). For built-in types such as
+	 * "category" or "tag", older editor versions left `kind` unset. In those cases we fall
+	 * back to inspecting `type` via `taxonomy_exists()` to distinguish taxonomy links from
+	 * post-type links without relying on a stored `kind`.
+	 *
+	 * Backwards compatibility - the "tag" alias:
+	 * The JS editor normalises the WordPress taxonomy slug "post_tag" to "tag" before
+	 * storing it in the `type` attribute (see update-attributes.js). Map it back so that
+	 * `taxonomy_exists()` can find the registered taxonomy correctly.
+	 */
+	$stored_kind    = $attributes['kind'] ?? '';
+	$stored_type    = $attributes['type'] ?? '';
+	$resolved_type  = 'tag' === $stored_type ? 'post_tag' : $stored_type;
+	$kind_from_type = taxonomy_exists( $resolved_type ) ? 'taxonomy' : 'post-type';
+	$item_kind      = ! empty( $stored_kind ) ? $stored_kind : $kind_from_type;
+	// Archive links match by URL (via is_post_type_archive()), not by entity ID, so skip ID matching.
+	$enable_id_match = 'post-type-archive' !== $item_kind;
+
+	/*
+	 * Entity ID match.
+	 *
+	 * Backwards compatibility - numeric id guard:
+	 * Historically, the `id` attribute could be set to a URL string rather than an integer
+	 * in some editor versions. `absint()` converts non-numeric values (including strings
+	 * and null) to 0, ensuring those values never produce a match.
+	 *
+	 * Post/term ID collision guard - mirrors classic menu's _menu_item_type + query-state check:
+	 * `instanceof` confirms the queried object is the correct PHP type before accepting the
+	 * ID match, preventing a taxonomy link from activating on a post page with the same
+	 * integer ID (and vice versa).
+	 */
+	$queried_object      = get_queried_object();
+	$link_id             = absint( $attributes['id'] ?? 0 );
+	$is_taxonomy_link    = 'taxonomy' === $item_kind;
+	$queried_id          = get_queried_object_id();
+	$ids_match           = $link_id > 0 && $queried_id === $link_id;
+	$object_type_matches = $is_taxonomy_link
+		? $queried_object instanceof WP_Term
+		: $queried_object instanceof WP_Post;
+
+	if ( $enable_id_match && $ids_match && $object_type_matches ) {
+		return true;
+	}
+
+	/*
+	 * Post-type archive URL match.
+	 * Active when the current URL matches the archive permalink, regardless of stored ID.
+	 */
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
+		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
+		if ( $attributes['url'] === $queried_archive_link ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -6,6 +6,7 @@
  */
 
 require_once __DIR__ . '/navigation-link/shared/item-should-render.php';
+require_once __DIR__ . '/navigation-link/shared/navigation-item-is-active.php';
 require_once __DIR__ . '/navigation-link/shared/render-submenu-icon.php';
 
 /**
@@ -96,14 +97,10 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 	$has_submenu = ! empty( trim( $inner_blocks_html ) );
 
-	$kind      = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
-	$is_active = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
-
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
-		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
-			$is_active = true;
-		}
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$is_active = gutenberg_block_core_shared_navigation_item_is_active( $attributes );
+	} else {
+		$is_active = block_core_shared_navigation_item_is_active( $attributes );
 	}
 
 	$show_submenu_indicators = isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'];

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -26,10 +26,10 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	private $original_block_supports;
 
 	public static function wpSetUpBeforeClass() {
-		// Register "dogs" before creating posts of that type so go_to() can resolve them.
+		// Register a unique CPT before creating posts of that type so go_to() can resolve them.
 		// has_archive enables get_post_type_archive_link() for the archive branch tests.
 		register_post_type(
-			'dogs',
+			'gutenberg_test_nav_cpt',
 			array(
 				'public'             => true,
 				'publicly_queryable' => true,
@@ -63,7 +63,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 		self::$custom_post = self::factory()->post->create_and_get(
 			array(
-				'post_type'    => 'dogs',
+				'post_type'    => 'gutenberg_test_nav_cpt',
 				'post_status'  => 'publish',
 				'post_name'    => 'metaldog',
 				'post_title'   => 'Metal Dog',
@@ -114,7 +114,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-		unregister_post_type( 'dogs' );
+		unregister_post_type( 'gutenberg_test_nav_cpt' );
 		foreach ( self::$pages as $page_to_delete ) {
 			wp_delete_post( $page_to_delete->ID );
 		}
@@ -191,7 +191,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Metal Dog',
-				'type'  => 'dogs',
+				'type'  => 'gutenberg_test_nav_cpt',
 				'kind'  => 'post-type',
 				'id'    => self::$custom_post->ID,
 				'url'   => get_permalink( self::$custom_post->ID ),
@@ -448,12 +448,12 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	 * archive page. Mirrors Branch C of _wp_menu_item_classes_by_context().
 	 */
 	public function test_current_menu_item_for_post_type_archive_link() {
-		$archive_url = get_post_type_archive_link( 'dogs' );
+		$archive_url = get_post_type_archive_link( 'gutenberg_test_nav_cpt' );
 		$this->go_to( $archive_url );
 		$output = $this->render_nav_link(
 			array(
-				'label' => 'Dogs Archive',
-				'type'  => 'dogs',
+				'label' => 'Custom CPT Archive',
+				'type'  => 'gutenberg_test_nav_cpt',
 				'kind'  => 'post-type-archive',
 				'url'   => $archive_url,
 			)
@@ -465,8 +465,8 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	 * A post-type-archive link should NOT be active when on a different post type's archive.
 	 */
 	public function test_no_current_menu_item_for_archive_link_on_wrong_archive() {
-		// Go to the dogs archive but render a link pointing to the posts archive.
-		$this->go_to( get_post_type_archive_link( 'dogs' ) );
+		// Go to the custom CPT archive but render a link pointing to the posts archive.
+		$this->go_to( get_post_type_archive_link( 'gutenberg_test_nav_cpt' ) );
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Posts Archive',
@@ -483,12 +483,12 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	 * happens to be set — is_post_type_archive() must be true for the branch to fire.
 	 */
 	public function test_no_current_menu_item_for_archive_link_on_singular_page() {
-		$archive_url = get_post_type_archive_link( 'dogs' );
+		$archive_url = get_post_type_archive_link( 'gutenberg_test_nav_cpt' );
 		$this->go_to( get_permalink( self::$page->ID ) );
 		$output = $this->render_nav_link(
 			array(
-				'label' => 'Dogs Archive',
-				'type'  => 'dogs',
+				'label' => 'Custom CPT Archive',
+				'type'  => 'gutenberg_test_nav_cpt',
 				'kind'  => 'post-type-archive',
 				'url'   => $archive_url,
 			)
@@ -664,7 +664,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$url     = 'http://' . WP_TESTS_DOMAIN;
 
 		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Metal Dogs\",\"type\":\"dogs\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+			"<!-- wp:navigation-link {\"label\":\"Metal Dogs\",\"type\":\"gutenberg_test_nav_cpt\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
 		);
 		$this->assertEquals( 1, count( $parsed_blocks ) );
 

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -387,7 +387,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	public function test_no_current_menu_item_when_id_is_string_url() {
 		$this->go_to( get_permalink( self::$page->ID ) );
 		// Render with id set to a URL string — the historical bug scenario.
-		// is_numeric() must prevent this from ever matching.
+		// absint() must prevent this from ever matching.
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Page',

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -236,6 +236,26 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'aria-current="page"', $output );
 	}
 
+	/**
+	 * When kind is absent but type is "page", the link should still be treated as a post-type
+	 * link. Covers WP 6.7 blocks created via Custom Link variation where kind may be omitted
+	 * for built-in types.
+	 */
+	public function test_current_menu_item_for_page_type_without_kind() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				// No 'kind' — simulates older/custom-link-variation blocks.
+				'id'    => self::$page->ID,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
 	// -------------------------------------------------------------------------
 	// Group 2: Active state — Taxonomy links
 	// -------------------------------------------------------------------------
@@ -262,6 +282,45 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 				'label' => 'Dogs',
 				'type'  => 'post_tag',
 				'kind'  => 'taxonomy',
+				'id'    => self::$tag->term_id,
+				'url'   => get_term_link( self::$tag ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	/**
+	 * When kind is absent but type is "category", the link should be inferred as a taxonomy
+	 * link via taxonomy_exists(). Fails before fix because kind defaults to 'post-type' and
+	 * instanceof WP_Post check fails on a term archive page.
+	 */
+	public function test_current_menu_item_for_category_type_without_kind() {
+		$this->go_to( get_term_link( self::$category ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Cats',
+				'type'  => 'category',
+				// No 'kind' stored — JS omits kind when newKind is empty and type is built-in.
+				'id'    => self::$category->term_id,
+				'url'   => get_term_link( self::$category ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	/**
+	 * Same as above but for tags. JS normalises 'post_tag' → 'tag' before storing in type,
+	 * so the fix must map 'tag' back to 'post_tag' for taxonomy_exists() to return true.
+	 */
+	public function test_current_menu_item_for_tag_type_without_kind() {
+		$this->go_to( get_term_link( self::$tag ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Dogs',
+				'type'  => 'tag', // stored as 'tag', not 'post_tag'.
+				// No 'kind' stored.
 				'id'    => self::$tag->term_id,
 				'url'   => get_term_link( self::$tag ),
 			)

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -27,11 +27,13 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass() {
 		// Register "dogs" before creating posts of that type so go_to() can resolve them.
+		// has_archive enables get_post_type_archive_link() for the archive branch tests.
 		register_post_type(
 			'dogs',
 			array(
 				'public'             => true,
 				'publicly_queryable' => true,
+				'has_archive'        => true,
 			)
 		);
 
@@ -435,6 +437,63 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 		$this->assertStringNotContainsString( 'current-menu-item', $output );
 		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	// -------------------------------------------------------------------------
+	// Group 6: Active state — post type archive (Branch C, mirrors classic menu)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A post-type-archive link should receive current-menu-item when on the matching
+	 * archive page. Mirrors Branch C of _wp_menu_item_classes_by_context().
+	 */
+	public function test_current_menu_item_for_post_type_archive_link() {
+		$archive_url = get_post_type_archive_link( 'dogs' );
+		$this->go_to( $archive_url );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Dogs Archive',
+				'type'  => 'dogs',
+				'kind'  => 'post-type-archive',
+				'url'   => $archive_url,
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+	}
+
+	/**
+	 * A post-type-archive link should NOT be active when on a different post type's archive.
+	 */
+	public function test_no_current_menu_item_for_archive_link_on_wrong_archive() {
+		// Go to the dogs archive but render a link pointing to the posts archive.
+		$this->go_to( get_post_type_archive_link( 'dogs' ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Posts Archive',
+				'type'  => 'post',
+				'kind'  => 'post-type-archive',
+				'url'   => get_post_type_archive_link( 'post' ),
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+	}
+
+	/**
+	 * A post-type-archive link should NOT be active on a non-archive page even if the URL
+	 * happens to be set — is_post_type_archive() must be true for the branch to fire.
+	 */
+	public function test_no_current_menu_item_for_archive_link_on_singular_page() {
+		$archive_url = get_post_type_archive_link( 'dogs' );
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Dogs Archive',
+				'type'  => 'dogs',
+				'kind'  => 'post-type-archive',
+				'url'   => $archive_url,
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
 	}
 
 	public function test_returns_link_when_post_is_published() {

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -29,7 +29,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		// Register a unique CPT before creating posts of that type so go_to() can resolve them.
 		// has_archive enables get_post_type_archive_link() for the archive branch tests.
 		register_post_type(
-			'gutenberg_test_nav_cpt',
+			'gb_test_nav_cpt',
 			array(
 				'public'             => true,
 				'publicly_queryable' => true,
@@ -63,7 +63,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 		self::$custom_post = self::factory()->post->create_and_get(
 			array(
-				'post_type'    => 'gutenberg_test_nav_cpt',
+				'post_type'    => 'gb_test_nav_cpt',
 				'post_status'  => 'publish',
 				'post_name'    => 'metaldog',
 				'post_title'   => 'Metal Dog',
@@ -114,7 +114,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-		unregister_post_type( 'gutenberg_test_nav_cpt' );
+		unregister_post_type( 'gb_test_nav_cpt' );
 		foreach ( self::$pages as $page_to_delete ) {
 			wp_delete_post( $page_to_delete->ID );
 		}
@@ -191,7 +191,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Metal Dog',
-				'type'  => 'gutenberg_test_nav_cpt',
+				'type'  => 'gb_test_nav_cpt',
 				'kind'  => 'post-type',
 				'id'    => self::$custom_post->ID,
 				'url'   => get_permalink( self::$custom_post->ID ),
@@ -448,12 +448,12 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	 * archive page. Mirrors Branch C of _wp_menu_item_classes_by_context().
 	 */
 	public function test_current_menu_item_for_post_type_archive_link() {
-		$archive_url = get_post_type_archive_link( 'gutenberg_test_nav_cpt' );
+		$archive_url = get_post_type_archive_link( 'gb_test_nav_cpt' );
 		$this->go_to( $archive_url );
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Custom CPT Archive',
-				'type'  => 'gutenberg_test_nav_cpt',
+				'type'  => 'gb_test_nav_cpt',
 				'kind'  => 'post-type-archive',
 				'url'   => $archive_url,
 			)
@@ -466,7 +466,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	 */
 	public function test_no_current_menu_item_for_archive_link_on_wrong_archive() {
 		// Go to the custom CPT archive but render a link pointing to the posts archive.
-		$this->go_to( get_post_type_archive_link( 'gutenberg_test_nav_cpt' ) );
+		$this->go_to( get_post_type_archive_link( 'gb_test_nav_cpt' ) );
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Posts Archive',
@@ -483,12 +483,12 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	 * happens to be set — is_post_type_archive() must be true for the branch to fire.
 	 */
 	public function test_no_current_menu_item_for_archive_link_on_singular_page() {
-		$archive_url = get_post_type_archive_link( 'gutenberg_test_nav_cpt' );
+		$archive_url = get_post_type_archive_link( 'gb_test_nav_cpt' );
 		$this->go_to( get_permalink( self::$page->ID ) );
 		$output = $this->render_nav_link(
 			array(
 				'label' => 'Custom CPT Archive',
-				'type'  => 'gutenberg_test_nav_cpt',
+				'type'  => 'gb_test_nav_cpt',
 				'kind'  => 'post-type-archive',
 				'url'   => $archive_url,
 			)
@@ -664,7 +664,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$url     = 'http://' . WP_TESTS_DOMAIN;
 
 		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Metal Dogs\",\"type\":\"gutenberg_test_nav_cpt\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+			"<!-- wp:navigation-link {\"label\":\"Metal Dogs\",\"type\":\"gb_test_nav_cpt\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
 		);
 		$this->assertEquals( 1, count( $parsed_blocks ) );
 

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -11,7 +11,9 @@
  */
 class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	private static $category;
+	private static $tag;
 	private static $page;
+	private static $post;
 	private static $draft;
 	private static $custom_draft;
 	private static $custom_post;
@@ -24,6 +26,14 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	private $original_block_supports;
 
 	public static function wpSetUpBeforeClass() {
+		// Register "dogs" before creating posts of that type so go_to() can resolve them.
+		register_post_type(
+			'dogs',
+			array(
+				'public'             => true,
+				'publicly_queryable' => true,
+			)
+		);
 
 		self::$draft   = self::factory()->post->create_and_get(
 			array(
@@ -73,6 +83,15 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 		self::$pages[] = self::$page;
 
+		self::$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Post',
+			)
+		);
+		self::$pages[] = self::$post;
+
 		self::$category = self::factory()->category->create_and_get(
 			array(
 				'taxonomy'    => 'category',
@@ -81,11 +100,19 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 				'description' => 'Cats Category',
 			)
 		);
-
 		self::$terms[] = self::$category;
+
+		self::$tag = self::factory()->tag->create_and_get(
+			array(
+				'name' => 'dogs',
+				'slug' => 'dogs',
+			)
+		);
+		self::$terms[] = self::$tag;
 	}
 
 	public static function wpTearDownAfterClass() {
+		unregister_post_type( 'dogs' );
 		foreach ( self::$pages as $page_to_delete ) {
 			wp_delete_post( $page_to_delete->ID );
 		}
@@ -107,6 +134,248 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		WP_Block_Supports::$block_to_render = $this->original_block_supports;
 		parent::tear_down();
+	}
+
+	/**
+	 * Renders a navigation-link block with the given attributes and returns the HTML output.
+	 */
+	private function render_nav_link( array $attrs ): string {
+		$json          = wp_json_encode( $attrs );
+		$parsed_blocks = parse_blocks( "<!-- wp:navigation-link {$json} /-->" );
+		$block         = new WP_Block( $parsed_blocks[0], array() );
+		return gutenberg_render_block_core_navigation_link(
+			$block->attributes,
+			array(),
+			$block
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Group 1: Active state — Post-type links
+	// -------------------------------------------------------------------------
+
+	public function test_current_menu_item_for_page_link() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'post-type',
+				'id'    => self::$page->ID,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	public function test_current_menu_item_for_standard_post_link() {
+		$this->go_to( get_permalink( self::$post->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Post',
+				'type'  => 'post',
+				'kind'  => 'post-type',
+				'id'    => self::$post->ID,
+				'url'   => get_permalink( self::$post->ID ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	public function test_current_menu_item_for_custom_post_type_link() {
+		$this->go_to( get_permalink( self::$custom_post->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Metal Dog',
+				'type'  => 'dogs',
+				'kind'  => 'post-type',
+				'id'    => self::$custom_post->ID,
+				'url'   => get_permalink( self::$custom_post->ID ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	public function test_current_menu_item_for_legacy_link_without_kind() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		// Omit 'kind' entirely to simulate an older serialised block.
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'id'    => self::$page->ID,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	/**
+	 * Confirmed failing test (TDD red): a link with kind "custom" and a numeric id
+	 * must receive current-menu-item when on the matching page.
+	 *
+	 * Fails before fix because $kind = "custom", get_queried_object()->custom
+	 * does not exist on any WP object, so ! empty(...) is always false.
+	 */
+	public function test_current_menu_item_for_custom_kind_link_with_id() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'custom',
+				'id'    => self::$page->ID,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	// -------------------------------------------------------------------------
+	// Group 2: Active state — Taxonomy links
+	// -------------------------------------------------------------------------
+
+	public function test_current_menu_item_for_category_link() {
+		$this->go_to( get_term_link( self::$category ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Cats',
+				'type'  => 'category',
+				'kind'  => 'taxonomy',
+				'id'    => self::$category->term_id,
+				'url'   => get_term_link( self::$category ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	public function test_current_menu_item_for_tag_link() {
+		$this->go_to( get_term_link( self::$tag ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Dogs',
+				'type'  => 'post_tag',
+				'kind'  => 'taxonomy',
+				'id'    => self::$tag->term_id,
+				'url'   => get_term_link( self::$tag ),
+			)
+		);
+		$this->assertStringContainsString( 'current-menu-item', $output );
+		$this->assertStringContainsString( 'aria-current="page"', $output );
+	}
+
+	// -------------------------------------------------------------------------
+	// Group 3: Not active — non-matching page (no go_to)
+	// -------------------------------------------------------------------------
+
+	public function test_no_current_menu_item_when_not_on_linked_page() {
+		// No go_to() — get_queried_object_id() returns 0, so no id can match.
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'post-type',
+				'id'    => self::$page->ID,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	// -------------------------------------------------------------------------
+	// Group 4: Not active — ID edge cases
+	// -------------------------------------------------------------------------
+
+	public function test_no_current_menu_item_when_id_is_absent() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'post-type',
+				'url'   => get_permalink( self::$page->ID ),
+				// No 'id' attribute.
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	public function test_no_current_menu_item_when_id_is_zero() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'post-type',
+				'id'    => 0,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	public function test_no_current_menu_item_when_id_is_string_url() {
+		$this->go_to( get_permalink( self::$page->ID ) );
+		// Render with id set to a URL string — the historical bug scenario.
+		// is_numeric() must prevent this from ever matching.
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'post-type',
+				'id'    => 'https://example.com',
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	// -------------------------------------------------------------------------
+	// Group 5: Not active — post/term ID collision guards
+	// -------------------------------------------------------------------------
+
+	public function test_taxonomy_link_not_active_when_on_post_page_with_matching_id() {
+		// Simulate being on a post page. The taxonomy link carries the same integer
+		// id as the post — this must NOT produce a false positive.
+		$this->go_to( get_permalink( self::$page->ID ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Category',
+				'type'  => 'category',
+				'kind'  => 'taxonomy',
+				'id'    => self::$page->ID,
+				'url'   => get_term_link( self::$category ),
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	public function test_post_type_link_not_active_when_on_term_page_with_matching_id() {
+		// Simulate being on a term archive page. The post-type link carries the same
+		// integer id as the term — this must NOT produce a false positive.
+		$this->go_to( get_term_link( self::$category ) );
+		$output = $this->render_nav_link(
+			array(
+				'label' => 'Page',
+				'type'  => 'page',
+				'kind'  => 'post-type',
+				'id'    => self::$category->term_id,
+				'url'   => get_permalink( self::$page->ID ),
+			)
+		);
+		$this->assertStringNotContainsString( 'current-menu-item', $output );
+		$this->assertStringNotContainsString( 'aria-current', $output );
 	}
 
 	public function test_returns_link_when_post_is_published() {

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -83,11 +83,11 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 		self::$pages[] = self::$page;
 
-		self::$post = self::factory()->post->create_and_get(
+		self::$post    = self::factory()->post->create_and_get(
 			array(
-				'post_type'    => 'post',
-				'post_status'  => 'publish',
-				'post_title'   => 'Test Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Test Post',
 			)
 		);
 		self::$pages[] = self::$post;
@@ -100,9 +100,9 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 				'description' => 'Cats Category',
 			)
 		);
-		self::$terms[] = self::$category;
+		self::$terms[]  = self::$category;
 
-		self::$tag = self::factory()->tag->create_and_get(
+		self::$tag     = self::factory()->tag->create_and_get(
 			array(
 				'name' => 'dogs',
 				'slug' => 'dogs',

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -51,6 +51,30 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::gutenberg_render_block_core_navigation_submenu
+	 */
+	public function test_should_apply_current_menu_item_for_custom_kind_link_with_id() {
+		$page_id = self::$page->ID;
+		$this->go_to( get_permalink( $page_id ) );
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-submenu {"label":"Submenu Label","type":"page","kind":"custom","id":' . $page_id . ',"url":"' . get_permalink( $page_id ) . '"} -->
+            <!-- wp:navigation-link {"label":"Submenu Item Link Label","type":"page","id":' . $page_id . ',"url":"' . get_permalink( $page_id ) . '","kind":"post-type"} /-->
+        <!-- /wp:navigation-submenu -->'
+		);
+
+		$navigation_submenu_block = new WP_Block( $parsed_blocks[0], array() );
+		$rendered_html            = gutenberg_render_block_core_navigation_submenu(
+			$navigation_submenu_block->attributes,
+			array(),
+			$navigation_submenu_block
+		);
+
+		$this->assertStringContainsString( 'current-menu-item', $rendered_html );
+		$this->assertStringContainsString( 'aria-current="page"', $rendered_html );
+	}
+
+	/**
 	 * @group submenu-color-inheritance
 	 * @covers ::gutenberg_render_block_core_navigation_submenu
 	 */


### PR DESCRIPTION
## What

Fixes #61266

Fixes `current-menu-item` and `aria-current="page"` not being applied to Navigation Link blocks in several scenarios that should produce an active state.

## Why

The PHP render function used a fragile dynamic property lookup to determine whether a nav link is active:

```php
$kind      = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
$is_active = ! empty( $attributes['id'] )
    && get_queried_object_id() === (int) $attributes['id']
    && ! empty( get_queried_object()->$kind ); // ← dynamic property on queried object
```

This converts `kind` from kebab-case to snake-case and then reads a property of that name off the queried object. It works for `"post-type"` (→ `WP_Post->post_type`) and `"taxonomy"` (→ `WP_Term->taxonomy`), but silently fails for any other value:

- `kind: "custom"` — links saved before the current entity-link conventions, or links where the editor resolved a URL to a post ID, store `id` alongside `kind: "custom"`. The property `get_queried_object()->custom` never exists, so `$is_active` is always `false`.
- `kind` absent, `type: "category"` or `type: "tag"` — the JS editor omits `kind` from the stored attributes when `newKind` is empty and the type is a built-in (see `update-attributes.js`). Defaulting to `"post-type"` causes a `WP_Post` check against a `WP_Term` archive page.

## How

During development, the classic WordPress menu system (`_wp_menu_item_classes_by_context()` in `wp-includes/nav-menu-template.php`) was reviewed as a reference for how active-state detection should work and how post/term ID collisions should be prevented. That analysis directly informed the approach taken here and identified the follow-up gaps noted at the bottom of this PR.

Replaces the property-lookup approach with explicit `instanceof` checks, mirroring how the classic menu system avoids post/term ID collisions:

- `$stored_kind` and `$stored_type` are read from attributes
- When `kind` is absent, `taxonomy_exists( $resolved_type )` infers whether the link targets a taxonomy — handles `category`, `tag` (mapped to `post_tag`), and any registered custom taxonomy
- `$is_taxonomy_link` drives an `instanceof WP_Term` vs `instanceof WP_Post` check, replacing the unreliable property lookup
- `$link_id` uses `is_numeric()` to guard against the historical case where `id` could be a URL string
- Post/term ID collision protection is fully preserved (a taxonomy link never becomes active on a post page with the same integer ID, and vice versa)

## Testing Instructions

1. Create a page (e.g. "About") and publish it
2. Add a Navigation block and insert a **Custom Link** item pointing to that page's URL, using the search/autocomplete to select the page (so an `id` is stored)
3. Visit the page on the front end — the nav item should now have `current-menu-item` and `aria-current="page"` ✅
4. Repeat with a **Category** link and a **Tag** link — both should activate correctly on their respective archive pages ✅
5. For custom post types: register a CPT, create a post of that type, add a navigation link to it, and verify the active class appears when viewing that post ✅
6. Verify no false positives: a category link should **not** be active when viewing a post whose ID happens to match the category term ID

## Backwards Compatibility

| Stored `kind`                                   | Queried object | Result                                                |
| ----------------------------------------------- | -------------- | ----------------------------------------------------- |
| `"post-type"` (page/post/any CPT)               | `WP_Post`      | ✅ Active (unchanged)                                 |
| `"taxonomy"` (category/tag/custom taxonomy)     | `WP_Term`      | ✅ Active (unchanged)                                 |
| `"custom"` with id (legacy links)               | `WP_Post`      | ✅ Active (bug fixed)                                 |
| empty / not stored (legacy)                     | `WP_Post`      | ✅ Active (backwards compat)                          |
| `kind` absent, `type: "category"` or `"tag"`   | `WP_Term`      | ✅ Active (bug fixed via `taxonomy_exists()` fallback) |
| `"post-type"` link on term page with same ID   | `WP_Term`      | ✅ Inactive (collision guard preserved)               |
| `"taxonomy"` link on post page with same ID    | `WP_Post`      | ✅ Inactive (collision guard preserved)               |

## Tests

24 PHP unit tests added to `phpunit/blocks/class-block-library-navigation-link-test.php` covering:

- Active state for pages, standard posts, custom post types, legacy links without `kind`, and `kind: "custom"` links with id (the confirmed bug)
- Active state for categories, tags, and links where `kind` is absent but `type` identifies a taxonomy
- Inactive state for non-matching pages, absent/zero/string IDs
- Post/term ID collision guards (must pass both before and after the fix)

---

## Known gaps — follow-up issues

As part of this work the classic WordPress menu system (`_wp_menu_item_classes_by_context()`) was reviewed in detail. It handles four distinct match branches (A–D); this PR addresses Branch B (direct ID + type match). The following gaps should each be tackled as a separate follow-up issue:

1. **`core/navigation-submenu` has the same bug** — the submenu block's `index.php` contains an identical copy of the broken `->$kind` property lookup. The same fix applies. There is also an opportunity to extract the shared `$is_active` logic into a single utility function rather than maintaining it in two places.

2. **No URL-based matching for links without an `id`** (Branch D) — the classic system matches `custom` type items by comparing the stored URL against `REQUEST_URI`. A `kind: "custom"` link with no `id` (severed entity links, manually-typed URLs) will never receive `current-menu-item` even when the URL exactly matches the current page.

3. **No taxonomy ancestor propagation** (Branch A) — when viewing a singular post, the classic system flags any category/tag the post belongs to as an active parent, walking the full ancestor chain. The block system has no equivalent.

4. **No ancestor/parent classes** — `current-menu-ancestor`, `current-menu-parent`, `current-{object}-parent`, and related classes from the classic system's second pass are largely absent from the block implementation (the submenu block has partial support via an inner-block scan, but nothing systematic).
