### PR TITLE
DataViews: Add spinner in `DataViewsLayout` in initial load of data

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - DataViews: Fix last column classname in table layout. [#76133](https://github.com/WordPress/gutenberg/pull/76133)
+- DataViews: Add spinner in DataViewsLayout in initial load of data. [#76486](https://github.com/WordPress/gutenberg/pull/76486)
 - DataForm: Properly handle dates in datetime control. [#76193](https://github.com/WordPress/gutenberg/pull/76193)
 
 ### Enhancements

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -7,6 +7,7 @@ import type { ComponentType } from 'react';
  * WordPress dependencies
  */
 import { useContext } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import DataViewsContext from '../dataviews-context';
 import { VIEW_LAYOUTS } from '../dataviews-layouts';
+import { useDelayedLoading } from '../../hooks/use-delayed-loading';
 import type { ViewBaseProps } from '../../types';
 
 type DataViewsLayoutProps = {
@@ -41,8 +43,20 @@ export default function DataViewsLayout( { className }: DataViewsLayoutProps ) {
 		empty = <p>{ __( 'No results' ) }</p>,
 	} = useContext( DataViewsContext );
 
+	const isDelayedInitialLoading = useDelayedLoading( ! hasInitiallyLoaded, {
+		delay: 200,
+	} );
 	if ( ! hasInitiallyLoaded ) {
-		return null;
+		if ( ! isDelayedInitialLoading ) {
+			return null;
+		}
+		return (
+			<div className="dataviews-loading">
+				<p>
+					<Spinner />
+				</p>
+			</div>
+		);
 	}
 
 	const ViewComponent = VIEW_LAYOUTS.find(

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -46,10 +46,15 @@ export default function DataViewsLayout( { className }: DataViewsLayoutProps ) {
 	const isDelayedInitialLoading = useDelayedLoading( ! hasInitiallyLoaded, {
 		delay: 200,
 	} );
+	// Until the initial data load completes, show a spinner (or nothing if fast).
+	// After that, render the layout component which preserves previous data
+	// while loading subsequent requests.
 	if ( ! hasInitiallyLoaded ) {
+		// If the initial data load is fast, don't show the loading state at all.
 		if ( ! isDelayedInitialLoading ) {
 			return null;
 		}
+		// If the initial data load takes more than 200ms, show the loading state.
 		return (
 			<div className="dataviews-loading">
 				<p>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/74572

The above PR removed the `spinners` from layouts (not for infinite scrolling) and didn't render the ViewLayout component during initial rendering to handle the `empty` component easily in each layout without having to duplicate that logic in each one. 

That though regressed the UX during the initial load. This PR adds a spinner with the same styles as before (inside layouts) during initial load.

The difference now though is that during the initial loading of data only the spinner is shown and not the layout. This is better than before since it avoids layout shifts, like for example in `table` headers.




## Testing Instructions
1. In site editor go to any page that uses DataViews and hard refresh 
2. Observe that a spinner is shown during the initial loading of data
3. Everything else should work as before
