### PR TITLE
Update Node version to v24 for flaky test reporter

### DIFF
--- a/packages/report-flaky-tests/action.yml
+++ b/packages/report-flaky-tests/action.yml
@@ -13,5 +13,5 @@ inputs:
         required: true
         default: 'flaky-tests'
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'build/index.cjs'


### PR DESCRIPTION
## What?
This is similar to #62401.

PR updates the Node version for the flaky test reporter action.

## Why?
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: ./packages/report-flaky-tests. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Testing Instructions
It shouldn't generate a notice in the e2e tests summary after the PR is merged.