### PR TITLE
Fix RTL styling on Connectors, Font Library, and boot-based admin pages

### DIFF
--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -33,7 +33,7 @@
 		position: fixed;
 		top: 0;
 		bottom: 0;
-		left: 0;
+		inset-inline-start: 0;
 		width: 300px;
 		max-width: 85vw;
 		background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
@@ -76,7 +76,7 @@
 
 		.boot-layout--single-page & {
 			margin-top: 0;
-			margin-left: 0;
+			margin-inline-start: 0;
 		}
 	}
 }

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -231,7 +231,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 
 		/* Reset wp-admin padding */
 		#wpcontent {
-			padding-left: 0;
+			padding-inline-start: 0;
 		}
 		#wpbody-content {
 			padding-bottom: 0;
@@ -247,14 +247,14 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 
 		/* Accessibility regions */
 		.a11y-speak-region {
-			left: -1px;
+			inset-inline-start: -1px;
 			top: -1px;
 		}
 
 		/* Admin menu indicators */
 		ul#adminmenu a.wp-has-current-submenu::after,
 		ul#adminmenu > li.current > a.current::after {
-			border-right-color: #fff;
+			border-inline-end-color: #fff;
 		}
 
 		/* Media frame fix */


### PR DESCRIPTION
## Summary

- Replace physical CSS directional properties with logical properties in the shared `page-wp-admin.php` template and boot layout styles
- Fixes the double arrow on the active admin menu item and the unexpected spacing between the sidebar and content in RTL languages
- Affects all boot-based admin pages: Connectors, Font Library, Content Guidelines, etc.

## Test plan

- [ ] Switch WordPress to an RTL language (e.g. Arabic or Hebrew or use RTL tester plugin.)
- [ ] Navigate to Settings > Connectors and Settings > Font Library
- [ ] Verify no double arrow on the active menu item
- [ ] Verify no spacing gap between the sidebar and content
- [ ] Switch back to LTR and verify no regression


## Before
<img width="1498" height="763" alt="Screenshot 2026-03-13 at 16 07 24" src="https://github.com/user-attachments/assets/771b20be-3158-4ab3-8ae7-ef749ac12083" />
<img width="1511" height="776" alt="Screenshot 2026-03-13 at 15 50 46" src="https://github.com/user-attachments/assets/ef69a0aa-7d4c-4438-81a1-8eb4a26468a2" />



## After
<img width="1505" height="769" alt="Screenshot 2026-03-13 at 16 25 44" src="https://github.com/user-attachments/assets/98916ebf-37bf-4d64-90cc-0e3cda8768bf" />
<img width="1500" height="772" alt="Screenshot 2026-03-13 at 16 25 33" src="https://github.com/user-attachments/assets/19080829-0cbe-438d-b3ad-fdc6e7a303ec" />

