### PR TITLE
Fix RTL styling on AI plugin callout banner

### DIFF
--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -34,10 +34,16 @@
 		overflow: hidden;
 		border-radius: 8px;
 		padding: 24px;
-		padding-right: 220px;
+		padding-inline-end: 220px;
 		background:
 			linear-gradient(90deg, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0.6) 100%),
 			linear-gradient(90deg, #89dcdc 0%, #c7eb5c 46.15%, #a920c1 100%);
+
+		[dir="rtl"] & {
+			background:
+				linear-gradient(270deg, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0.6) 100%),
+				linear-gradient(270deg, #89dcdc 0%, #c7eb5c 46.15%, #a920c1 100%);
+		}
 
 		&__content {
 			display: flex;
@@ -60,7 +66,7 @@
 
 		&__decoration {
 			position: absolute;
-			right: 8px;
+			inset-inline-end: 8px;
 			top: -15px;
 			width: 248px;
 			height: 248px;
@@ -75,12 +81,12 @@
 	@media (max-width: 680px) {
 		.ai-plugin-callout {
 			padding: 12px;
-			padding-right: 84px;
+			padding-inline-end: 84px;
 
 			&__decoration {
 				width: 134px;
 				height: 134px;
-				right: 4px;
+				inset-inline-end: 4px;
 				top: -8px;
 			}
 		}


### PR DESCRIPTION
## Summary

- Use CSS logical properties (`padding-inline-end`, `inset-inline-end`) instead of physical ones (`padding-right`, `right`) for the callout padding and decoration positioning
- Flip the gradient direction from `90deg` to `270deg` in RTL so the color progression mirrors the layout

## Test plan

- [ ] Visit Settings > Connectors in RTL without AI plugin active/installed.
- [ ] Verify the WP logo decoration appears on the left (start) side
- [ ] Verify the gradient flows right-to-left matching the decoration position
- [ ] Verify text and buttons are properly aligned with no overlap
- [ ] Test responsive breakpoints (680px, 480px) also flip correctly
- [ ] Verify LTR mode is unchanged

## Before
<img width="2698" height="1498" alt="image" src="https://github.com/user-attachments/assets/2d27acc0-d8de-4e88-a777-7ffadd5879a1" />



## After
<img width="1349" height="744" alt="Screenshot 2026-03-13 at 16 44 38" src="https://github.com/user-attachments/assets/332e71d8-84a5-48ca-b22e-1c15d8e8b773" />
