### PR TITLE
Collapsible.Card: make contents hidden until found

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -22,6 +22,7 @@
 -   `Card`, `CollapsibleCard`: update padding to match legacy `Card` component ([#76368](https://github.com/WordPress/gutenberg/pull/76368)).
 -   `CollapsibleCard`: move trigger to the header ([#76265](https://github.com/WordPress/gutenberg/pull/76265)).
 -   `CollapsibleCard`: add animations ([#76378](https://github.com/WordPress/gutenberg/pull/76378)).
+-   `CollapsibleCard`: make contents hidden until found ([#76498](https://github.com/WordPress/gutenberg/pull/76498)).
 
 ## 0.8.0 (2026-03-04)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -22,7 +22,7 @@
 -   `Card`, `CollapsibleCard`: update padding to match legacy `Card` component ([#76368](https://github.com/WordPress/gutenberg/pull/76368)).
 -   `CollapsibleCard`: move trigger to the header ([#76265](https://github.com/WordPress/gutenberg/pull/76265)).
 -   `CollapsibleCard`: add animations ([#76378](https://github.com/WordPress/gutenberg/pull/76378)).
--   `CollapsibleCard`: make contents hidden until found ([#76498](https://github.com/WordPress/gutenberg/pull/76498)).
+-   `CollapsibleCard`: allows the browser page search to find and expand the panel contents via the `hiddenUntilFound` prop. ([#76498](https://github.com/WordPress/gutenberg/pull/76498)).
 
 ## 0.8.0 (2026-03-04)
 

--- a/packages/ui/src/collapsible-card/content.tsx
+++ b/packages/ui/src/collapsible-card/content.tsx
@@ -18,6 +18,7 @@ export const Content = forwardRef< HTMLDivElement, ContentProps >(
 			<Collapsible.Panel
 				ref={ ref }
 				className={ clsx( styles.content, className ) }
+				hiddenUntilFound
 				{ ...restProps }
 			>
 				<Card.Content

--- a/packages/ui/src/collapsible-card/content.tsx
+++ b/packages/ui/src/collapsible-card/content.tsx
@@ -11,14 +11,14 @@ import type { ContentProps } from './types';
  */
 export const Content = forwardRef< HTMLDivElement, ContentProps >(
 	function CollapsibleCardContent(
-		{ className, render, children, ...restProps },
+		{ className, render, children, hiddenUntilFound = true, ...restProps },
 		ref
 	) {
 		return (
 			<Collapsible.Panel
 				ref={ ref }
 				className={ clsx( styles.content, className ) }
-				hiddenUntilFound
+				hiddenUntilFound={ hiddenUntilFound }
 				{ ...restProps }
 			>
 				<Card.Content

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -53,9 +53,7 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			expect(
-				screen.queryByText( 'Hidden content' )
-			).not.toBeInTheDocument();
+			expect( screen.getByText( 'Hidden content' ) ).not.toBeVisible();
 		} );
 
 		it( 'shows content when defaultOpen is true', () => {
@@ -87,9 +85,7 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			expect(
-				screen.queryByText( 'Toggle content' )
-			).not.toBeInTheDocument();
+			expect( screen.getByText( 'Toggle content' ) ).not.toBeVisible();
 
 			await user.click(
 				screen.getByRole( 'button', {
@@ -107,9 +103,7 @@ describe( 'CollapsibleCard', () => {
 				} )
 			);
 
-			expect(
-				screen.queryByText( 'Toggle content' )
-			).not.toBeInTheDocument();
+			expect( screen.getByText( 'Toggle content' ) ).not.toBeVisible();
 		} );
 
 		it( 'calls onOpenChange when toggled', async () => {

--- a/packages/ui/src/collapsible-card/types.ts
+++ b/packages/ui/src/collapsible-card/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { PanelProps } from '../collapsible/types';
 import type { ComponentProps } from '../utils/types';
 
 export interface RootProps extends ComponentProps< 'div' > {
@@ -41,4 +42,13 @@ export interface ContentProps extends ComponentProps< 'div' > {
 	 * The content to be rendered inside the collapsible content area.
 	 */
 	children?: ReactNode;
+	/**
+	 * Allows the browser’s built-in page search to find and expand the panel contents.
+	 *
+	 * Overrides the `keepMounted` prop and uses `hidden="until-found"`
+	 * to hide the element without removing it from the DOM.
+	 *
+	 * @default true
+	 */
+	hiddenUntilFound?: PanelProps[ 'hiddenUntilFound' ];
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Makes the `CollapsibleCard.Content` [hidden until found](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#the_hidden_until_found_state)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For better content discovery

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the `hiddenUntilFound` prop on the underling `Collapsible.Panel` component, and updating unit tests to reflect the new behaviour (card content is added to the DOM, even if visually hidden)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load Storybook examples for `CollapsibleCard`
- Verify that the `Content` of the card, while the card is collapsed, are `hidden`
- Search with the browser a string that matches the card content
- Notice how the card expands and the contents are highlighted

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Cursor + Claude Opus 4.6
