### PR TITLE
ThemeProvider: Fix tags in Storybook

### DIFF
--- a/packages/theme/src/color-ramps/stories/index.story.tsx
+++ b/packages/theme/src/color-ramps/stories/index.story.tsx
@@ -36,7 +36,6 @@ const meta: Meta< typeof ColorGen > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
-	tags: [ 'status-experimental' ],
 };
 export default meta;
 

--- a/packages/theme/src/stories/index.story.tsx
+++ b/packages/theme/src/stories/index.story.tsx
@@ -34,7 +34,7 @@ const meta: Meta< typeof ThemeProvider > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-private' ],
 };
 export default meta;
 


### PR DESCRIPTION
## What?

Fixes the Storybook tags on `ThemeProvider`. 

## Why?

It's actually private, not experimental.

## Testing Instructions

See Storybook.
