### PR TITLE
wp-build: Add RTL support for inline styles

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -208,13 +208,22 @@ function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 			from: filePath,
 			map: false,
 		} );
-
-		let cssModule = `if (typeof document !== 'undefined' && process.env.NODE_ENV !== 'test' && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
-	const style = document.createElement("style");
-	style.setAttribute("data-wp-hash", "${ hash }");
-	style.appendChild(document.createTextNode(${ JSON.stringify( css ) }));
-	document.head.appendChild(style);
-}
+		const rtlResult = await postcss( [ rtlcss() ] ).process( css, {
+			from: undefined,
+		} );
+		let cssModule = `(function() {
+	var isRTL = (typeof window !== 'undefined' && window.wp?.i18n?.isRTL?.()) ||
+		(typeof document !== 'undefined' && document.documentElement?.getAttribute?.('dir') === 'rtl');
+	var css = isRTL
+		? ${ JSON.stringify( rtlResult.css ) }
+		: ${ JSON.stringify( css ) };
+	if (typeof document !== 'undefined' && process.env.NODE_ENV !== 'test' && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
+		var style = document.createElement("style");
+		style.setAttribute("data-wp-hash", "${ hash }");
+		style.appendChild(document.createTextNode(css));
+		document.head.appendChild(style);
+	}
+})();
 `;
 
 		// The CSS modules transform produces an `exports` object with class name mappings.
@@ -1641,7 +1650,7 @@ async function buildRoute( routeName ) {
 					wordpressExternalsPlugin(
 						'content.min',
 						'esm',
-						[],
+						[ 'wp-i18n' ],
 						true // Generate asset file for minified build
 					),
 					...createStyleBundlingPlugins( routeDir ),
@@ -1659,7 +1668,7 @@ async function buildRoute( routeName ) {
 					wordpressExternalsPlugin(
 						'content.min',
 						'esm',
-						[],
+						[ 'wp-i18n' ],
 						false // Skip asset file for non-minified build
 					),
 					...createStyleBundlingPlugins( routeDir ),


### PR DESCRIPTION
Alternatives to:

- https://github.com/WordPress/gutenberg/pull/76497
- https://github.com/WordPress/gutenberg/pull/76496

## What?

This PR adds RTL support for inline CSS injected by the wp-build package.

## Why?

Otherwise, in RTL languages, physical properties will not be properly inverted, and the layout will break.

## Testing Instructions

Switch the language to RTL and observe the visual changes in the Connectors page.

http://localhost:8888/wp-admin/options-general.php?page=options-connectors-wp-admin

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1214" height="601" alt="image" src="https://github.com/user-attachments/assets/c02550b2-c8c0-4f53-90ce-85ff87983ac1" />

### After

<img width="1222" height="613" alt="image" src="https://github.com/user-attachments/assets/2d4c003d-d5ba-4e0d-bd7c-5ba0d16a6891" />
