### PR TITLE
ESLint: Modernize eslint-plugin rule APIs for v10 compatibility

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/no-i18n-in-save.js
+++ b/packages/eslint-plugin/rules/__tests__/no-i18n-in-save.js
@@ -90,7 +90,6 @@ function render() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -103,7 +102,6 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -116,7 +114,6 @@ const save = () => {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -129,7 +126,6 @@ const save = function() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -142,7 +138,6 @@ export default function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -157,7 +152,6 @@ const settings = {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -170,7 +164,6 @@ const settings = {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -183,7 +176,6 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -197,7 +189,6 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -211,7 +202,6 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -228,7 +218,6 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -243,11 +232,9 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},
@@ -262,7 +249,6 @@ function save() {
 			errors: [
 				{
 					messageId: 'noI18nInSave',
-					type: 'CallExpression',
 				},
 			],
 		},

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
@@ -64,7 +64,6 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 				{
 					message: `Usage of \`__experimentalUnsafe\` from \`@wordpress/package\` is not allowed.
 See https://developer.wordpress.org/block-editor/contributors/develop/coding-guidelines/#experimental-and-unstable-apis for details.`,
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -75,7 +74,6 @@ See https://developer.wordpress.org/block-editor/contributors/develop/coding-gui
 				{
 					message: `Usage of \`__experimentalSafe\` from \`@wordpress/unsafe\` is not allowed.
 See https://developer.wordpress.org/block-editor/contributors/develop/coding-guidelines/#experimental-and-unstable-apis for details.`,
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -86,7 +84,6 @@ See https://developer.wordpress.org/block-editor/contributors/develop/coding-gui
 				{
 					message: `Usage of \`__experimentalSafe\` from \`@wordpress/unsafe\` is not allowed.
 See https://developer.wordpress.org/block-editor/contributors/develop/coding-guidelines/#experimental-and-unstable-apis for details.`,
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -97,7 +94,6 @@ See https://developer.wordpress.org/block-editor/contributors/develop/coding-gui
 				{
 					message: `Usage of \`__experimentalUnsafe\` from \`@wordpress/package\` is not allowed.
 See https://developer.wordpress.org/block-editor/contributors/develop/coding-guidelines/#experimental-and-unstable-apis for details.`,
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -108,7 +104,6 @@ See https://developer.wordpress.org/block-editor/contributors/develop/coding-gui
 				{
 					message: `Usage of \`__unstableFeature\` from \`@wordpress/package\` is not allowed.
 See https://developer.wordpress.org/block-editor/contributors/develop/coding-guidelines/#experimental-and-unstable-apis for details.`,
-					type: 'ImportSpecifier',
 				},
 			],
 		},

--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -41,7 +41,6 @@ ruleTester.run( 'use-recommended-components', rule, {
 				{
 					message:
 						'`SomeComponent` from `@wordpress/ui` is not yet recommended for use in a WordPress environment.',
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -51,12 +50,10 @@ ruleTester.run( 'use-recommended-components', rule, {
 				{
 					message:
 						'`Foo` from `@wordpress/ui` is not yet recommended for use in a WordPress environment.',
-					type: 'ImportSpecifier',
 				},
 				{
 					message:
 						'`Bar` from `@wordpress/ui` is not yet recommended for use in a WordPress environment.',
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -67,7 +64,6 @@ ruleTester.run( 'use-recommended-components', rule, {
 				{
 					message:
 						'__experimentalZStack is planned for deprecation. Write your own CSS instead.',
-					type: 'ImportSpecifier',
 				},
 			],
 		},
@@ -77,7 +73,6 @@ ruleTester.run( 'use-recommended-components', rule, {
 				{
 					message:
 						'__experimentalZStack is planned for deprecation. Write your own CSS instead.',
-					type: 'ImportSpecifier',
 				},
 			],
 		},

--- a/packages/eslint-plugin/rules/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/data-no-store-string-literals.js
@@ -31,7 +31,7 @@ function arrayLast( array ) {
 function getReferences( context, specifiers ) {
 	const variables = specifiers.reduce(
 		( acc, specifier ) =>
-			acc.concat( context.getDeclaredVariables( specifier ) ),
+			acc.concat( context.sourceCode.getDeclaredVariables( specifier ) ),
 		[]
 	);
 	const references = variables.reduce(
@@ -58,7 +58,9 @@ function collectAllNodesFromCallbackFunctions( context, node ) {
 		( acc, { identifier: { parent } } ) =>
 			parent && parent.arguments && parent.arguments.length > 0
 				? acc.concat(
-						context.getDeclaredVariables( parent.arguments[ 0 ] )
+						context.sourceCode.getDeclaredVariables(
+							parent.arguments[ 0 ]
+						)
 				  )
 				: acc,
 		[]
@@ -153,9 +155,10 @@ function getFixes( fixer, context, callNode ) {
 		fixer.replaceText( callNode.arguments[ 0 ], variableName ),
 	];
 
-	const imports = context
-		.getAncestors()[ 0 ]
-		.body.filter( ( node ) => node.type === 'ImportDeclaration' );
+	const ancestors = context.sourceCode.getAncestors( callNode );
+	const imports = ancestors[ 0 ].body.filter(
+		( node ) => node.type === 'ImportDeclaration'
+	);
 	const packageImports = imports.filter(
 		( node ) => node.source.value === importName
 	);

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -22,7 +22,8 @@ module.exports = {
 	},
 	create( context ) {
 		const mode = context.options[ 0 ] || 'always';
-		const comments = context.getSourceCode().getAllComments();
+		const sourceCode = context.sourceCode;
+		const comments = sourceCode.getAllComments();
 
 		/**
 		 * Locality classification of an import, one of "External",
@@ -194,9 +195,7 @@ module.exports = {
 										return null;
 									}
 
-									const text = context
-										.getSourceCode()
-										.getText();
+									const text = sourceCode.getText();
 
 									// Trim preceding and trailing newlines.
 									let [ start, end ] = comment.range;

--- a/packages/eslint-plugin/rules/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/i18n-translator-comments.js
@@ -61,6 +61,7 @@ function extractTranslatorKeys( commentText ) {
 module.exports = {
 	meta: {
 		type: 'problem',
+		schema: [],
 		messages: {
 			missing:
 				'Translation function with placeholders is missing preceding translator comment',
@@ -71,6 +72,7 @@ module.exports = {
 		},
 	},
 	create( context ) {
+		const sourceCode = context.sourceCode;
 		return {
 			CallExpression( node ) {
 				const {
@@ -107,7 +109,7 @@ module.exports = {
 					return;
 				}
 
-				const comments = context.getCommentsBefore( node ).slice();
+				const comments = sourceCode.getCommentsBefore( node ).slice();
 
 				let parentNode = parent;
 
@@ -123,7 +125,9 @@ module.exports = {
 					parentNode.type !== 'Program' &&
 					Math.abs( parentNode.loc.start.line - currentLine ) <= 1
 				) {
-					comments.push( ...context.getCommentsBefore( parentNode ) );
+					comments.push(
+						...sourceCode.getCommentsBefore( parentNode )
+					);
 					parentNode = parentNode.parent;
 				}
 

--- a/packages/eslint-plugin/rules/no-i18n-in-save.js
+++ b/packages/eslint-plugin/rules/no-i18n-in-save.js
@@ -22,7 +22,7 @@ module.exports = {
 	},
 	create( context ) {
 		let saveFunctionDepth = 0;
-		const filename = context.getFilename();
+		const filename = context.filename;
 
 		// Skip deprecated files as they preserve old behavior including translation functions
 		const normalizedFilename = filename.replace( /\\/g, '/' );

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -11,15 +11,16 @@
 const FUNCTION_SCOPE_JSX_IDENTIFIERS = new WeakMap();
 
 /**
- * Returns the closest function scope for the current ESLint context object, or
- * undefined if it cannot be determined.
+ * Returns the closest function scope for the given node, or undefined if it
+ * cannot be determined.
  *
  * @param {ESLintRuleContext} context ESLint context object.
+ * @param {ESTreeNode}        node    Current AST node.
  *
  * @return {ESLintScope|undefined} Function scope, if known.
  */
-function getClosestFunctionScope( context ) {
-	let functionScope = context.getScope();
+function getClosestFunctionScope( context, node ) {
+	let functionScope = context.sourceCode.getScope( node );
 	while ( functionScope.type !== 'function' && functionScope.upper ) {
 		functionScope = functionScope.upper;
 	}
@@ -73,7 +74,7 @@ module.exports = /** @type {import('eslint').Rule} */ ( {
 				// identifiers. Account for this by visiting JSX identifiers
 				// first, and tracking them in a map per function scope, which
 				// is later merged with the known variable references.
-				const functionScope = getClosestFunctionScope( context );
+				const functionScope = getClosestFunctionScope( context, node );
 				if ( ! functionScope ) {
 					return;
 				}
@@ -88,7 +89,7 @@ module.exports = /** @type {import('eslint').Rule} */ ( {
 				FUNCTION_SCOPE_JSX_IDENTIFIERS.get( functionScope ).add( node );
 			},
 			'ReturnStatement:exit'( node ) {
-				const functionScope = getClosestFunctionScope( context );
+				const functionScope = getClosestFunctionScope( context, node );
 				if ( ! functionScope ) {
 					return;
 				}

--- a/packages/eslint-plugin/rules/react-no-unsafe-timeout.js
+++ b/packages/eslint-plugin/rules/react-no-unsafe-timeout.js
@@ -71,7 +71,7 @@ module.exports = {
 				// Consider whether `setTimeout` is a reference to the global
 				// by checking references to see if `setTimeout` resolves to a
 				// variable in scope.
-				const { references } = context.getScope();
+				const { references } = context.sourceCode.getScope( node );
 				const hasResolvedReference = references.some(
 					( reference ) =>
 						reference.identifier.name === 'setTimeout' &&


### PR DESCRIPTION
## What?

Update all custom ESLint rules in `@wordpress/eslint-plugin` to use modern APIs and remove deprecated patterns from tests.

Part of the ESLint v10 upgrade effort — see #76506.

## Why?

ESLint v10 removes 18+ deprecated `context.*` methods that our custom rules currently rely on. The replacement APIs have been available since ESLint v8.40+, so updating them now is fully backward-compatible and can land on trunk independently. This reduces the diff in the main ESLint v10 upgrade PR.

Similarly, v10's `RuleTester` removes the `type` property from error assertions. Since `type` is optional in v8, removing it now is safe.

## How?

**Rule API updates** (6 rules modified):

| Old (removed in v10) | New | Rules affected |
|---|---|---|
| `context.getScope()` | `context.sourceCode.getScope(node)` | `react-no-unsafe-timeout`, `no-unused-vars-before-return` |
| `context.getFilename()` | `context.filename` | `no-i18n-in-save` |
| `context.getSourceCode()` | `context.sourceCode` | `dependency-group` |
| `context.getDeclaredVariables()` | `context.sourceCode.getDeclaredVariables()` | `data-no-store-string-literals` |
| `context.getAncestors()` | `context.sourceCode.getAncestors(node)` | `data-no-store-string-literals` |
| `context.getCommentsBefore()` | `sourceCode.getCommentsBefore()` | `i18n-translator-comments` |

**Other changes:**
- Added missing `meta.schema: []` to `i18n-translator-comments` rule (required in v10 for rules with options)
- Removed `type:` from error assertions in 3 test files:
  - `no-i18n-in-save.js` (14 occurrences)
  - `no-unsafe-wp-apis.js` (5 occurrences)
  - `use-recommended-components.js` (5 occurrences)

## Testing Instructions

1. On `trunk`, run `npm run test:unit -- packages/eslint-plugin` and notice the deprecation warnings about `context.getScope()`, `context.getSourceCode()`, etc.
2. On this branch, run the same command — all tests pass with zero deprecation warnings.
3. Run `npm run lint:js` — output should be unchanged from trunk.

## Screenshots or screencast

N/A — no UI changes.

## Use of AI Tools

This PR was authored with [Claude Code](https://claude.ai/claude-code), used for auditing all 28 custom rules for deprecated API usage and making the updates.
