### PR TITLE
Tab Block: Remove anchor from save function

### DIFF
--- a/packages/block-library/src/tab/save.js
+++ b/packages/block-library/src/tab/save.js
@@ -3,15 +3,11 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
-	const { anchor } = attributes;
-
-	const tabPanelId = anchor;
-
+export default function save() {
 	const blockProps = useBlockProps.save( {
 		role: 'tabpanel',
 	} );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 
-	return <section { ...innerBlocksProps } id={ tabPanelId } />;
+	return <section { ...innerBlocksProps } />;
 }

--- a/packages/block-library/src/tabs/save.js
+++ b/packages/block-library/src/tabs/save.js
@@ -3,13 +3,9 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
-	const { anchor } = attributes;
-
-	const tabsId = anchor;
-
+export default function save() {
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 
-	return <div { ...innerBlocksProps } id={ tabsId } />;
+	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Anchor is saved with block supports.


Therefore, it will work even if removed from the save function.

https://github.com/WordPress/gutenberg/blob/1079391c508cbb79b808499b4ee73e22d0a61b3b/packages/block-editor/src/hooks/anchor.js#L118-L124

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a tab block.
3. Anchor support is functioning as it did before.

