### PR TITLE
Fix HEIC upload error handling and sub-size format

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -122,7 +122,7 @@ function mediaUpload(
 		},
 		onBatchSuccess,
 		onError: ( error ) =>
-			onError( typeof error === 'string' ? error : ( error?.message ?? '' ) ),
+			onError( typeof error === 'string' ? error : error?.message ?? '' ),
 		additionalData,
 		allowedTypes,
 	} );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -122,7 +122,7 @@ function mediaUpload(
 		},
 		onBatchSuccess,
 		onError: ( error ) =>
-			onError( typeof error === 'string' ? error : error?.message ),
+			onError( typeof error === 'string' ? error : ( error?.message ?? '' ) ),
 		additionalData,
 		allowedTypes,
 	} );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -121,7 +121,8 @@ function mediaUpload(
 			onSuccess?.( attachments );
 		},
 		onBatchSuccess,
-		onError: ( { message } ) => onError( message ),
+		onError: ( error ) =>
+			onError( typeof error === 'string' ? error : error?.message ),
 		additionalData,
 		allowedTypes,
 	} );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -121,8 +121,7 @@ function mediaUpload(
 			onSuccess?.( attachments );
 		},
 		onBatchSuccess,
-		onError: ( error ) =>
-			onError( typeof error === 'string' ? error : error?.message ),
+		onError: ( { message } ) => onError( message ),
 		additionalData,
 		allowedTypes,
 	} );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -166,6 +166,7 @@ export function ImageEdit( {
 			url: undefined,
 			blob: undefined,
 		} );
+		setTemporaryURL();
 	}
 
 	function onFilesPreUpload( files ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -166,8 +166,6 @@ export function ImageEdit( {
 			url: undefined,
 			blob: undefined,
 		} );
-		// Clear the temporary blob URL so the spinner is removed.
-		setTemporaryURL();
 	}
 
 	function onFilesPreUpload( files ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -166,7 +166,6 @@ export function ImageEdit( {
 			url: undefined,
 			blob: undefined,
 		} );
-		setTemporaryURL();
 	}
 
 	function onFilesPreUpload( files ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -166,6 +166,7 @@ export function ImageEdit( {
 			url: undefined,
 			blob: undefined,
 		} );
+		// Clear the temporary blob URL so the spinner is removed.
 		setTemporaryURL();
 	}
 

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -781,7 +781,7 @@ export function uploadItem( id: QueueItemId ) {
 			additionalData: item.additionalData,
 			signal: item.abortController?.signal,
 			onFileChange: ( [ attachment ] ) => {
-				if ( ! isBlobURL( attachment.url ) ) {
+				if ( attachment && ! isBlobURL( attachment.url ) ) {
 					dispatch.finishOperation( id, {
 						attachment,
 					} );

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -755,6 +755,7 @@ export function prepareItem( id: QueueItemId ) {
 						additionalData: {
 							...item.additionalData,
 							generate_sub_sizes: true,
+							convert_format: true,
 						},
 				  }
 				: {};

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -224,6 +224,8 @@ describe( 'actions', () => {
 			expect( updatedItem.additionalData.generate_sub_sizes ).toBe(
 				true
 			);
+			// Server should convert formats (e.g. HEIC to JPEG).
+			expect( updatedItem.additionalData.convert_format ).toBe( true );
 		} );
 
 		it( 'should add only Upload for unsupported image types like SVG', async () => {
@@ -257,6 +259,7 @@ describe( 'actions', () => {
 			expect( updatedItem.additionalData.generate_sub_sizes ).toBe(
 				true
 			);
+			expect( updatedItem.additionalData.convert_format ).toBe( true );
 		} );
 
 		it( 'should add only Upload for unsupported image types like BMP', async () => {
@@ -290,6 +293,7 @@ describe( 'actions', () => {
 			expect( updatedItem.additionalData.generate_sub_sizes ).toBe(
 				true
 			);
+			expect( updatedItem.additionalData.convert_format ).toBe( true );
 		} );
 
 		it( 'should add only Upload for PDF files', async () => {
@@ -323,6 +327,7 @@ describe( 'actions', () => {
 			expect( updatedItem.additionalData.generate_sub_sizes ).toBe(
 				true
 			);
+			expect( updatedItem.additionalData.convert_format ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary
- Enable server-side format conversion when delegating sub-size generation for non-vips-supported file types (like HEIC)
- Fix server upload errors (e.g. HEIC rejection) not surfacing to the user
- Clear the image block spinner when an upload error occurs

## What

### HEIC sub-size format conversion
When uploading HEIC files, the client-side processing pipeline correctly delegates sub-size generation to the server (`generate_sub_sizes: true`) since HEIC is not supported by the browser-based vips. However, `convert_format` remained `false` (the default for client-side processed images), which told the server to skip format conversion. This caused all sub-sized images to be output as HEIC instead of being converted to JPEG as WordPress core does by default.

The fix sets `convert_format: true` alongside `generate_sub_sizes: true` so the server applies the `image_editor_output_format` filter during sub-size generation.

### Upload error handling
When the server returned a 400 error for an unsupported image type, three issues prevented the error from reaching the user:

1. `uploadItem`'s `onFileChange` callback crashed when `uploadMedia` called it with an empty array on failure (accessing `undefined.url`), which prevented `onError` from ever being called.
2. The block editor provider's `onError` wrapper assumed errors were always objects with a `.message` property, but received plain strings from the editor's `mediaUpload` wrapper.
3. The image block's `onUploadError` didn't clear the `temporaryURL` state, leaving the upload spinner visible after an error.

Fixes #76513

## Test plan
- [ ] Upload a HEIC file on a server that supports HEIC (Imagick with HEIC support)
- [ ] Verify sub-sized images are output as JPEG (not HEIC)
- [ ] Upload a HEIC file on a server without HEIC support
- [ ] Verify the upload fails with a clear error message (snackbar notification)
- [ ] Verify the image block spinner is cleared after the error
- [ ] Verify normal image uploads (JPEG, PNG, WebP) still work correctly with client-side processing

🤖 Generated with [Claude Code](https://claude.ai/code)