### PR TITLE
Real Time Collaboration: Introduce filters for the polling intervals.

### DIFF
--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -19,7 +19,4 @@ export const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = applyFilters(
 
 // Must be less than the server-side AWARENESS_TIMEOUT (30 s) to avoid
 // false disconnects when the tab is in the background.
-export const POLLING_INTERVAL_BACKGROUND_TAB_IN_MS = applyFilters(
-	'sync.pollingManager.pollingIntervalBackgroundTab',
-	25 * 1000 // 25 seconds
-) as number;
+export const POLLING_INTERVAL_BACKGROUND_TAB_IN_MS = 25 * 1000; // 25 seconds

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -1,8 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
 export const DEFAULT_CLIENT_LIMIT_PER_ROOM = 3;
 export const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
-export const POLLING_INTERVAL_IN_MS = 1000; // 1 second or 1000 milliseconds
-export const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = 250; // 250 milliseconds
+
+export const POLLING_INTERVAL_IN_MS = applyFilters(
+	'sync.pollingManager.pollingIntervalNoCollaborators',
+	1000 // 1 second or 1000 milliseconds
+) as number;
+
+export const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = applyFilters(
+	'sync.pollingManager.pollingIntervalWithCollaborators',
+	250 // 250 milliseconds
+) as number;
+
 // Must be less than the server-side AWARENESS_TIMEOUT (30 s) to avoid
 // false disconnects when the tab is in the background.
-export const POLLING_INTERVAL_BACKGROUND_TAB_IN_MS = 25 * 1000; // 25 seconds
+export const POLLING_INTERVAL_BACKGROUND_TAB_IN_MS = applyFilters(
+	'sync.pollingManager.pollingIntervalBackgroundTab',
+	25 * 1000 // 25 seconds
+) as number;

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -8,7 +8,7 @@ export const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 
 export const POLLING_INTERVAL_IN_MS = applyFilters(
-	'sync.pollingManager.pollingIntervalNoCollaborators',
+	'sync.pollingManager.pollingInterval',
 	1000 // 1 second or 1000 milliseconds
 ) as number;
 


### PR DESCRIPTION
## What?

Introduces JavaScript filters to allow third party developers to slow down or speed up polling via the RTC client.

Closes #76517


## Why?

The default settings are quite fast (up to four times per second) and this frequency may end up causing people to DDOS themselves on discount hosting.

## How?

Introduces four filters for the polling intervals in the real time collaboration client:

* `sync.pollingManager.pollingIntervalNoCollaborators` the interval in milliseconds when there are no collaborators in the room
* `sync.pollingManager.pollingIntervalWithCollaborators` the interval in milliseconds when there are collaborators in the room
* `sync.pollingManager.pollingIntervalMaxErrorBackoff` the maximum polling interval in milliseconds when there are network or other errors preventing syncing from taking place
* `sync.pollingManager.pollingIntervalBackgroundTab` the polling interval when the editor is in the background (use is in another tab or screen saver active)


## Testing Instructions

1. Enable Real Time Collaboration
2. Open the post editor for any post
3. Open the developer tools network tab
4. Observe that the connections are being made once per second (no collaborators default)
5. Configure network throttling in dev tools to "offline"
6. Observe that the maximum back off period is 30 seconds when the client is in error state.
7. Turn off throttling in dev tools
8. Activate this plugin (I used it as an mu-plugin):
```php
<?php

/**
 * Plugin Name: #76517 Sync rates filters.
 */

add_action(
	'admin_init',
	function() {
		$filters =<<<EOS
		wp.hooks.addFilter( 'sync.pollingManager.pollingIntervalNoCollaborators', 'pr/testing/interval/no-collabs', function( interval ) {
			console.log( 'sync.pollingManager.pollingIntervalNoCollaborators', interval );
			return 10000;
		} );

		wp.hooks.addFilter( 'sync.pollingManager.pollingIntervalWithCollaborators', 'pr/testing/interval/with-collabs', function( interval ) {
			console.log( 'sync.pollingManager.pollingIntervalWithCollaborators', interval );
			return 2500;
		} );

		wp.hooks.addFilter( 'sync.pollingManager.pollingIntervalMaxErrorBackoff', 'pr/testing/interval/max-error-backoff', function( interval ) {
			console.log( 'sync.pollingManager.pollingIntervalMaxErrorBackoff', interval );
			return 60000;
		} );
EOS;
		wp_add_inline_script( 'wp-sync', $filters, 'before' );
	},
	5
);
```
9. Reload the post editor
10. Observe that connections are being made once every ten seconds (no collaborators, filtered)
11. Configure network throttling in dev tools to "offline"
12. Observe the maxiumum back of period is 60 seconds when the client is in an error state
13. Turn off throttling in dev tools
14. Open the same post for editing in a second browser window/tab
15. Observe the connections are being made once every 2.5 seconds (collaborators, filtered)
16. Remember to deactivate the plugin above to avoid confusion at a later date.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A

## Use of AI Tools

Nil.

(Co-pilot tried to help via VS Code with some type-ahead but it really didn't.