### PR TITLE
Fix: Interactivity API: Native anchor links (#) trigger full page reload due to wpInteractivityId mismatch

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -164,6 +164,9 @@
 	</p>
 </div>
 
+<a data-testid="hash-link" href="#hash-link-target">Go to anchor</a>
+<div id="hash-link-target" data-testid="hash-link-target"></div>
+
 <div id="regions-with-attach-to" data-testid="regions-with-attach-to">
 	<?php
 	/*

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Fix `sessionId` generation crashing in non-secure (non-HTTPS) contexts. ([#76151](https://github.com/WordPress/gutenberg/pull/76151))
 -   Add `initialVdomPromise` synchronization promise to ensure the router waits for hydration to complete before initializing, fixing dead DOM on Safari and Firefox. ([#76053](https://github.com/WordPress/gutenberg/pull/76053))
+-   Fix unexpected full page reload on anchor links. ([#76520](https://github.com/WordPress/gutenberg/pull/76520))
 
 ## 6.41.0 (2026-03-04)
 

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -125,8 +125,16 @@ window.history.replaceState(
 // server can render the correct content. Without this, the URL would change but
 // the page content would remain stale because the interactivity router — which
 // handles client-side navigations — might not be loaded yet.
+//
+// Entries with `null` state are from anchor/fragment navigations (e.g.,
+// clicking `<a href="#section">`), which some browsers (Chrome) also dispatch
+// `popstate` for. These are same-document navigations and must NOT trigger a
+// reload — the browser should just scroll to the target element as normal.
 window.addEventListener( 'popstate', ( event ) => {
-	if ( event.state?.wpInteractivityId !== sessionId ) {
+	if (
+		event.state !== null &&
+		event.state?.wpInteractivityId !== sessionId
+	) {
 		window.location.reload();
 	}
 } );

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -126,10 +126,10 @@ window.history.replaceState(
 // the page content would remain stale because the interactivity router — which
 // handles client-side navigations — might not be loaded yet.
 //
-// Entries with `null` state are from anchor/fragment navigations (e.g.,
-// clicking `<a href="#section">`), which some browsers (Chrome) also dispatch
-// `popstate` for. These are same-document navigations and must NOT trigger a
-// reload — the browser should just scroll to the target element as normal.
+// Some `popstate` events (e.g., anchor/fragment navigations like
+// clicking `<a href="#section">`) have `null` state. These are
+// same-document navigations and must NOT trigger a reload — the browser
+// should just scroll to the target element as normal.
 window.addEventListener( 'popstate', ( event ) => {
 	if (
 		event.state !== null &&

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -710,6 +710,36 @@ test.describe( 'Router regions', () => {
 		}
 	} );
 
+	// Regression test for https://github.com/WordPress/gutenberg/issues/76447.
+	test( 'should not reload the page when clicking a hash anchor link', async ( {
+		page,
+	} ) => {
+		const counter = page.getByTestId( 'state-counter' );
+
+		// Accumulate some in-memory state so a reload would be detectable.
+		await counter.click( { clickCount: 3, delay: 50 } );
+		await expect( counter ).toHaveText( '3' );
+
+		// Set up a listener for the `load` event before clicking. A full-page
+		// reload fires `load`; a same-document hash navigation does not.
+		const loadPromise = page
+			.waitForEvent( 'load', { timeout: 1000 } )
+			.then( () => 'reloaded' )
+			.catch( () => 'no-reload' );
+
+		// Click a plain hash anchor — this fires `popstate` with `state: null`.
+		await page.getByTestId( 'hash-link' ).click();
+
+		// The URL should now include the fragment.
+		await expect( page ).toHaveURL( /#hash-link-target$/ );
+
+		// A full-page reload should not have been triggered.
+		expect( await loadPromise ).toBe( 'no-reload' );
+
+		// In-memory state must be preserved.
+		await expect( counter ).toHaveText( '3' );
+	} );
+
 	// Regression test for https://github.com/WordPress/gutenberg/issues/70500.
 	test( 'should update content on back/forward navigation after a page reload', async ( {
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76447 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR fixes the issue added in PR #75927 
- Fixes the page reload on clicking the anchor/fragment navigation links eg: `(#footer)`. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a check for event.state if that is not null, then only do a reload, else do not.
- PR also tested with the resolution for this PR - https://github.com/WordPress/gutenberg/pull/75927, it do work as expected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### Step-by-step reproduction instructions

1. Use a WordPress site with Gutenberg 22.7.0 enabled
2. Create a page with long content and a standard HTML anchor link: `<a href="#footer">Go to Footer</a>`.
3. Ensure the page also has some block that requires interactivity (Ex: a core/navigation block)
4. Click the Go to Footer link.
5. Observed behavior: The page reloads entirely instead of simply scrolling to the ID.
6. Expected behavior: The browser should navigate to the fragment identifier without a page refresh.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/bd79244b-b8af-4877-894a-24ff9ccecc95

### After

https://github.com/user-attachments/assets/182ad0d2-b324-46d8-bfbc-7f82732b5ffc

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- None
