### PR TITLE
Remove redundant onNavigateToEntityRecord handling

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -314,12 +314,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	return useMemo( () => {
 		const blockEditorSettings = {
 			...Object.fromEntries(
-				Object.entries( settings )
-					.filter( ( [ key ] ) =>
-						BLOCK_EDITOR_SETTINGS.includes( key )
-					)
-					// Exclude onNavigateToEntityRecord since we're wrapping it
-					.filter( ( [ key ] ) => key !== 'onNavigateToEntityRecord' )
+				Object.entries( settings ).filter( ( [ key ] ) =>
+					BLOCK_EDITOR_SETTINGS.includes( key )
+				)
 			),
 			[ globalStylesDataKey ]: globalStylesData,
 			[ globalStylesLinksDataKey ]: globalStylesLinksData,
@@ -331,7 +328,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			hasFixedToolbar,
 			isDistractionFree,
 			keepCaretInsideBlock,
-			onNavigateToEntityRecord: settings.onNavigateToEntityRecord,
 			[ getMediaSelectKey ]: ( select, attachmentId ) => {
 				return select( coreStore ).getEntityRecord(
 					'postType',


### PR DESCRIPTION
## What?
Removes the now-unnecessary filter and explicit re-assignment of `onNavigateToEntityRecord` from `useBlockEditorSettings`. Addresses https://github.com/WordPress/gutenberg/pull/75371#discussion_r2936784755

## Why?
After PR #75371 removed the wrapping logic for `onNavigateToEntityRecord`, the setting now passes through directly. Since `onNavigateToEntityRecord` is already in the `BLOCK_EDITOR_SETTINGS` allowlist, the filter excluding it and the explicit re-assignment are redundant.

## How?
Removed the `.filter( ( [ key ] ) => key !== 'onNavigateToEntityRecord' )` and its comment, along with the explicit `onNavigateToEntityRecord: settings.onNavigateToEntityRecord` assignment. The setting is now handled purely through the `Object.fromEntries` spread of allowed keys.