### PR TITLE
Reset blockEditingModes on RESET_BLOCKS

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -147,7 +147,7 @@ export const getEnabledClientIdsTree = createRegistrySelector( () =>
 	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
 		state.blocks.order,
 		state.derivedBlockEditingModes,
-		state.blockEditingModes,
+		state.blocks.blockEditingModes,
 	] )
 );
 
@@ -170,7 +170,7 @@ export const getEnabledBlockParents = createSelector(
 	},
 	( state ) => [
 		state.blocks.parents,
-		state.blockEditingModes,
+		state.blocks.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,
 	]

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1283,6 +1283,25 @@ export const blocks = pipe(
 		}
 		return state;
 	},
+
+	blockEditingModes( state = new Map(), action ) {
+		switch ( action.type ) {
+			case 'SET_BLOCK_EDITING_MODE':
+				if ( state.get( action.clientId ) === action.mode ) {
+					return state;
+				}
+				return new Map( state ).set( action.clientId, action.mode );
+			case 'UNSET_BLOCK_EDITING_MODE': {
+				if ( ! state.has( action.clientId ) ) {
+					return state;
+				}
+				const newState = new Map( state );
+				newState.delete( action.clientId );
+				return newState;
+			}
+		}
+		return state;
+	},
 } );
 
 /**
@@ -2128,38 +2147,6 @@ export function editedContentOnlySection( state, action ) {
 }
 
 /**
- * Reducer returning a map of block client IDs to block editing modes.
- *
- * @param {Map}    state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Map} Updated state.
- */
-export function blockEditingModes( state = new Map(), action ) {
-	switch ( action.type ) {
-		case 'SET_BLOCK_EDITING_MODE':
-			if ( state.get( action.clientId ) === action.mode ) {
-				return state;
-			}
-			return new Map( state ).set( action.clientId, action.mode );
-		case 'UNSET_BLOCK_EDITING_MODE': {
-			if ( ! state.has( action.clientId ) ) {
-				return state;
-			}
-			const newState = new Map( state );
-			newState.delete( action.clientId );
-			return newState;
-		}
-		case 'RESET_BLOCKS': {
-			return state.has( '' )
-				? new Map().set( '', state.get( '' ) )
-				: state;
-		}
-	}
-	return state;
-}
-
-/**
  * Reducer returning a map of style IDs to style overrides.
  *
  * @param {Map}    state  Current state.
@@ -2395,7 +2382,6 @@ const combinedReducers = combineReducers( {
 	editedContentOnlySection,
 	blockVisibility,
 	viewportModalClientIds,
-	blockEditingModes,
 	styleOverrides,
 	removalPromptData,
 	blockRemovalRules,
@@ -2526,7 +2512,7 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	// so the default block editing mode is set to disabled.
 	const sectionRootClientId = state.settings?.[ sectionRootClientIdKey ];
 	const sectionClientIds = state.blocks.order.get( sectionRootClientId );
-	const hasDisabledBlocks = Array.from( state.blockEditingModes ).some(
+	const hasDisabledBlocks = Array.from( state.blocks.blockEditingModes ).some(
 		( [ , mode ] ) => mode === 'disabled'
 	);
 	const templatePartClientIds = [];
@@ -2602,7 +2588,7 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 
 		// If the block already has an explicit block editing mode set,
 		// don't override it.
-		if ( state.blockEditingModes.has( clientId ) ) {
+		if ( state.blocks.blockEditingModes.has( clientId ) ) {
 			return;
 		}
 
@@ -2613,12 +2599,12 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 			let ancestorBlockEditingMode;
 			let parent = state.blocks.parents.get( clientId );
 			while ( parent !== undefined ) {
-				if ( state.blockEditingModes.has( parent ) ) {
+				if ( state.blocks.blockEditingModes.has( parent ) ) {
 					// Checking the explicit block editing mode will be slower,
 					// as the block editing mode is more likely to be set on a
 					// distant ancestor.
 					ancestorBlockEditingMode =
-						state.blockEditingModes.get( parent );
+						state.blocks.blockEditingModes.get( parent );
 				}
 				if ( ancestorBlockEditingMode ) {
 					break;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -693,6 +693,16 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			controlledOrder.forEach( preserveTreeEntry );
 		}
 
+		// Preserve block editing modes for blocks that are not removed.
+		const preservedBlockEditingModes =
+			state?.blockEditingModes ?? new Map();
+		for ( const [ clientId, mode ] of preservedBlockEditingModes ) {
+			if ( ! newState.tree.has( clientId ) ) {
+				continue;
+			}
+			newState.blockEditingModes.set( clientId, mode );
+		}
+
 		return newState;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3242,8 +3242,8 @@ export function getBlockEditingMode( state, clientId = '' ) {
 	}
 
 	// In normal mode, consider that an explicitly set editing mode takes over.
-	if ( state.blockEditingModes.has( clientId ) ) {
-		return state.blockEditingModes.get( clientId );
+	if ( state.blocks.blockEditingModes.has( clientId ) ) {
+		return state.blocks.blockEditingModes.get( clientId );
 	}
 
 	return 'default';

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -131,12 +131,12 @@ describe( 'private selectors', () => {
 						'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
 					],
 				] ),
+				blockEditingModes: new Map( [] ),
 			},
 			blockListSettings: {
 				'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337': {},
 				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {},
 			},
-			blockEditingModes: new Map( [] ),
 			derivedBlockEditingModes: new Map( [] ),
 		};
 
@@ -152,7 +152,10 @@ describe( 'private selectors', () => {
 		it( 'should return false when top level block is not disabled', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [] ),
+				},
 				derivedBlockEditingModes: new Map( [] ),
 			};
 			expect(
@@ -166,9 +169,12 @@ describe( 'private selectors', () => {
 		it( 'should return true when top level block is disabled and there are no editing modes within it', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
-				] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
@@ -187,7 +193,10 @@ describe( 'private selectors', () => {
 		it( 'should return true when top level block is disabled via inheritance and there are no editing modes within it', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [ [ '', 'disabled' ] ] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [ [ '', 'disabled' ] ] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
@@ -208,10 +217,13 @@ describe( 'private selectors', () => {
 		it( 'should return true when top level block is disabled and there are disabled editing modes within it', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
-					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
-				] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
@@ -229,10 +241,13 @@ describe( 'private selectors', () => {
 		it( 'should return false when top level block is disabled and there are non-disabled editing modes within it', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
-					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
-				] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [
+						[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
@@ -250,10 +265,13 @@ describe( 'private selectors', () => {
 		it( 'should return false when top level block is disabled via inheritance and there are non-disabled editing modes within it', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ '', 'disabled' ],
-					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
-				] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [
+						[ '', 'disabled' ],
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
@@ -343,7 +361,10 @@ describe( 'private selectors', () => {
 		it( 'should return tree containing only clientId and innerBlocks', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [] ),
+				},
 				derivedBlockEditingModes: new Map( [] ),
 			};
 			expect( getEnabledClientIdsTree( state ) ).toEqual( [
@@ -381,7 +402,10 @@ describe( 'private selectors', () => {
 		it( 'should return a subtree when rootBlockClientId is given', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [] ),
+				},
 				derivedBlockEditingModes: new Map( [] ),
 			};
 			expect(
@@ -413,11 +437,20 @@ describe( 'private selectors', () => {
 		it( 'should filter out disabled blocks', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ '', 'disabled' ],
-					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'contentOnly' ],
-					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'contentOnly' ],
-				] ),
+				blocks: {
+					...baseState.blocks,
+					blockEditingModes: new Map( [
+						[ '', 'disabled' ],
+						[
+							'b26fc763-417d-4f01-b81c-2ec61e14a972',
+							'contentOnly',
+						],
+						[
+							'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+							'contentOnly',
+						],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
@@ -457,8 +490,8 @@ describe( 'private selectors', () => {
 						[ '6cf70164-9097-4460-bcbf-200560546988', [] ],
 						[ '', [ '6cf70164-9097-4460-bcbf-200560546988' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map(),
 			};
 			expect(
@@ -503,11 +536,11 @@ describe( 'private selectors', () => {
 							[ '4c2b7140-fffd-44b4-b2a7-820c670a6514' ],
 						],
 					] ),
+					blockEditingModes: new Map( [
+						[ '', 'disabled' ],
+						[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'default' ],
+					] ),
 				},
-				blockEditingModes: new Map( [
-					[ '', 'disabled' ],
-					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'default' ],
-				] ),
 				derivedBlockEditingModes: new Map( [
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
@@ -556,11 +589,11 @@ describe( 'private selectors', () => {
 							[ '4c2b7140-fffd-44b4-b2a7-820c670a6514' ],
 						],
 					] ),
+					blockEditingModes: new Map( [
+						[ '', 'disabled' ],
+						[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'default' ],
+					] ),
 				},
-				blockEditingModes: new Map( [
-					[ '', 'disabled' ],
-					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'default' ],
-				] ),
 				derivedBlockEditingModes: new Map( [
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 				] ),

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3816,8 +3816,67 @@ describe( 'state', () => {
 			expect( newState.blockEditingModes ).toEqual( new Map() );
 		} );
 
-		it( 'should clear editing modes when blocks are reset', () => {
+		it( 'should preserve editing modes when blocks are reset', () => {
+			// Add a template with two template parts.
 			let state = blocks( undefined, {} );
+			state = blocks( state, {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{
+						name: 'core/template-part',
+						clientId: 'template-part-1',
+						attributes: {},
+						innerBlocks: [],
+					},
+					{
+						name: 'core/template-part',
+						clientId: 'template-part-2',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+
+			// In each of the template parts add a controlled content (a paragraph block).
+			state = blocks( state, {
+				type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+				clientId: 'template-part-1',
+				hasControlledInnerBlocks: true,
+			} );
+			state = blocks( state, {
+				type: 'REPLACE_INNER_BLOCKS',
+				rootClientId: 'template-part-1',
+				blocks: [
+					{
+						name: 'core/paragraph',
+						clientId: 'paragraph-1',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+			state = blocks( state, {
+				type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+				clientId: 'template-part-2',
+				hasControlledInnerBlocks: true,
+			} );
+			state = blocks( state, {
+				type: 'REPLACE_INNER_BLOCKS',
+				rootClientId: 'template-part-2',
+				blocks: [
+					{
+						name: 'core/paragraph',
+						clientId: 'paragraph-2',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+
+			// Set block editing modes, just like `DisableNonPageContentBlocks` would do:
+			// - the root block to 'disabled'
+			// - the template parts to 'contentOnly'
+			// - the template part children to 'disabled'
 			state = blocks( state, {
 				type: 'SET_BLOCK_EDITING_MODE',
 				clientId: '',
@@ -3825,14 +3884,47 @@ describe( 'state', () => {
 			} );
 			state = blocks( state, {
 				type: 'SET_BLOCK_EDITING_MODE',
-				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
+				clientId: 'template-part-1',
 				mode: 'contentOnly',
 			} );
-			const newState = blocks( state, {
-				type: 'RESET_BLOCKS',
-				blocks: [],
+			state = blocks( state, {
+				type: 'SET_BLOCK_EDITING_MODE',
+				clientId: 'template-part-2',
+				mode: 'contentOnly',
 			} );
-			expect( newState.blockEditingModes ).toEqual( new Map() );
+			state = blocks( state, {
+				type: 'SET_BLOCK_EDITING_MODE',
+				clientId: 'paragraph-1',
+				mode: 'disabled',
+			} );
+			state = blocks( state, {
+				type: 'SET_BLOCK_EDITING_MODE',
+				clientId: 'paragraph-2',
+				mode: 'disabled',
+			} );
+
+			// Reset the template, keeping only one of the template parts.
+			state = blocks( state, {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{
+						name: 'core/template-part',
+						clientId: 'template-part-1',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+
+			// Check that the editing modes for valid blocks are preserved, and the
+			// editing modes for removed blocks are cleared.
+			expect( state.blockEditingModes ).toEqual(
+				new Map( [
+					[ '', 'disabled' ],
+					[ 'template-part-1', 'contentOnly' ],
+					[ 'paragraph-1', 'disabled' ],
+				] )
+			);
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -37,7 +37,6 @@ import {
 	settings,
 	lastBlockAttributesChange,
 	lastBlockInserted,
-	blockEditingModes,
 	expandedBlock,
 	zoomLevel,
 	editedContentOnlySection,
@@ -287,6 +286,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 
 				const newChildBlock = createBlock( 'core/test-child-block', {
@@ -345,6 +345,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 				expect( state.tree.get( 'chicken' ) ).not.toBe(
 					existingState.tree.get( 'chicken' )
@@ -387,6 +388,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 
 				const newChildBlock = createBlock( 'core/test-child-block', {
@@ -445,6 +447,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 				expect( state.tree.get( 'chicken' ) ).not.toBe(
 					existingState.tree.get( 'chicken' )
@@ -516,6 +519,7 @@ describe( 'state', () => {
 					),
 					tree: new Map(),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 
 				const newChildBlock1 = createBlock( 'core/test-child-block', {
@@ -610,6 +614,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 
 				expect( state.tree.get( '' ).innerBlocks[ 0 ] ).toBe(
@@ -685,6 +690,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 
 				const newChildBlock = createBlock( 'core/test-block' );
@@ -737,6 +743,7 @@ describe( 'state', () => {
 						} )
 					),
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				} );
 
 				// The block object of the parent should be updated.
@@ -758,6 +765,7 @@ describe( 'state', () => {
 				isIgnoredChange: false,
 				tree: new Map(),
 				controlledInnerBlocks: {},
+				blockEditingModes: new Map(),
 			} );
 		} );
 
@@ -3776,17 +3784,18 @@ describe( 'state', () => {
 
 	describe( 'blockEditingModes', () => {
 		it( 'should return an empty map by default', () => {
-			expect( blockEditingModes( undefined, {} ) ).toEqual( new Map() );
+			const state = blocks( undefined, {} );
+			expect( state.blockEditingModes ).toEqual( new Map() );
 		} );
 
 		it( 'should set the editing mode for a block', () => {
-			const state = new Map();
-			const newState = blockEditingModes( state, {
+			const state = blocks( undefined, {} );
+			const newState = blocks( state, {
 				type: 'SET_BLOCK_EDITING_MODE',
 				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
 				mode: 'default',
 			} );
-			expect( newState ).toEqual(
+			expect( newState.blockEditingModes ).toEqual(
 				new Map( [
 					[ '14501cc2-90a6-4f52-aa36-ab6e896135d1', 'default' ],
 				] )
@@ -3794,30 +3803,36 @@ describe( 'state', () => {
 		} );
 
 		it( 'should clear the editing mode for a block', () => {
-			const state = new Map( [
-				[ '14501cc2-90a6-4f52-aa36-ab6e896135d1', 'default' ],
-			] );
-			const newState = blockEditingModes( state, {
+			let state = blocks( undefined, {} );
+			state = blocks( state, {
+				type: 'SET_BLOCK_EDITING_MODE',
+				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
+				mode: 'default',
+			} );
+			const newState = blocks( state, {
 				type: 'UNSET_BLOCK_EDITING_MODE',
 				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
 			} );
-			expect( newState ).toEqual( new Map() );
+			expect( newState.blockEditingModes ).toEqual( new Map() );
 		} );
 
 		it( 'should clear editing modes when blocks are reset', () => {
-			const state = new Map( [
-				[ '', 'disabled' ],
-				[ '14501cc2-90a6-4f52-aa36-ab6e896135d1', 'default' ],
-			] );
-			const newState = blockEditingModes( state, {
-				type: 'RESET_BLOCKS',
+			let state = blocks( undefined, {} );
+			state = blocks( state, {
+				type: 'SET_BLOCK_EDITING_MODE',
+				clientId: '',
+				mode: 'disabled',
 			} );
-			expect( newState ).toEqual(
-				new Map( [
-					// Root mode should be maintained.
-					[ '', 'disabled' ],
-				] )
-			);
+			state = blocks( state, {
+				type: 'SET_BLOCK_EDITING_MODE',
+				clientId: '14501cc2-90a6-4f52-aa36-ab6e896135d1',
+				mode: 'contentOnly',
+			} );
+			const newState = blocks( state, {
+				type: 'RESET_BLOCKS',
+				blocks: [],
+			} );
+			expect( newState.blockEditingModes ).toEqual( new Map() );
 		} );
 	} );
 
@@ -4001,7 +4016,6 @@ describe( 'state', () => {
 				settings,
 				zoomLevel,
 				blockListSettings,
-				blockEditingModes,
 				editedContentOnlySection,
 			} )
 		);

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2698,10 +2698,10 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					order: new Map(),
 					parents: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/invalid' ) ).toBe( false );
 		} );
@@ -2713,12 +2713,12 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					order: new Map(),
 					parents: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
 					allowedBlockTypes: [],
 				},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				false
@@ -2732,12 +2732,12 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
 					allowedBlockTypes: [ 'core/test-block-a' ],
 				},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				true
@@ -2751,12 +2751,12 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					order: new Map(),
 					parents: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {
 					templateLock: 'all',
 				},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				false
@@ -2770,14 +2770,14 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(
+						Object.entries( {
+							'': 'disabled',
+						} )
+					),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(
-					Object.entries( {
-						'': 'disabled',
-					} )
-				),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				false
@@ -2791,10 +2791,10 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-c' ) ).toBe(
 				false
@@ -2816,10 +2816,10 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2841,12 +2841,12 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2868,12 +2868,12 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -2895,6 +2895,7 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {
@@ -2902,7 +2903,6 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-b', 'block1' )
@@ -2924,6 +2924,7 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {
@@ -2931,7 +2932,6 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-b', 'block1' )
@@ -2953,14 +2953,14 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(
+						Object.entries( {
+							block1: 'disabled',
+						} )
+					),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(
-					Object.entries( {
-						block1: 'disabled',
-					} )
-				),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-b', 'block1' )
@@ -2982,6 +2982,7 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {
@@ -2989,7 +2990,6 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-c', 'block1' )
@@ -3011,10 +3011,10 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/post-content-child', 'block1' )
@@ -3028,10 +3028,10 @@ describe( 'selectors', () => {
 					attributes: new Map(),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/post-content-child' )
@@ -3062,13 +3062,13 @@ describe( 'selectors', () => {
 						[ '', [ 'block1' ] ],
 						[ 'block1', [ 'block2' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 					block2: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3098,12 +3098,12 @@ describe( 'selectors', () => {
 						} )
 					),
 					order: new Map( [ [ '', [ 'block1' ] ] ] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType( state, 'core/test-block-a', 'block1' )
@@ -3138,12 +3138,12 @@ describe( 'selectors', () => {
 						[ '', [ 'parent' ] ],
 						[ 'parent', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					parent: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'parent', 'contentOnly' ],
 				] ),
@@ -3187,6 +3187,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -3195,7 +3196,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -3245,6 +3245,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -3253,7 +3254,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -3295,6 +3295,7 @@ describe( 'selectors', () => {
 						[ 'block1', [ 'block2' ] ],
 						[ 'block2', [ 'block3' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
@@ -3302,7 +3303,6 @@ describe( 'selectors', () => {
 					block3: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3340,6 +3340,7 @@ describe( 'selectors', () => {
 						[ 'block1', [ 'block2' ] ],
 						[ 'block2', [ 'block3' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
@@ -3347,7 +3348,6 @@ describe( 'selectors', () => {
 					block3: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3385,6 +3385,7 @@ describe( 'selectors', () => {
 						[ 'block1', [ 'block2' ] ],
 						[ 'block2', [ 'block3' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
@@ -3392,7 +3393,6 @@ describe( 'selectors', () => {
 					block3: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3426,6 +3426,7 @@ describe( 'selectors', () => {
 						[ 'block2', 'block1' ],
 						[ 'block1', '' ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
@@ -3434,7 +3435,6 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3469,13 +3469,13 @@ describe( 'selectors', () => {
 						[ '', [ 'block1' ] ],
 						[ 'block1', [ 'block2' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					block1: {},
 					block2: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect(
 				canInsertBlockType(
@@ -3507,6 +3507,7 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					1: {
@@ -3517,7 +3518,6 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlocks( state, [ '2' ], '1' ) ).toBe( true );
 		} );
@@ -3541,6 +3541,7 @@ describe( 'selectors', () => {
 					),
 					parents: new Map(),
 					order: new Map(),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					1: {
@@ -3548,7 +3549,6 @@ describe( 'selectors', () => {
 					},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( false );
 		} );
@@ -3820,11 +3820,11 @@ describe( 'selectors', () => {
 					order: new Map(),
 					parents: new Map(),
 					cache: {},
+					blockEditingModes: new Map(),
 				},
 				settings: {},
 				preferences: {},
 				blockListSettings: {},
-				blockEditingModes: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-a' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -3861,11 +3861,11 @@ describe( 'selectors', () => {
 					order: new Map(),
 					parents: new Map(),
 					cache: {},
+					blockEditingModes: new Map(),
 				},
 				settings: {},
 				preferences: {},
 				blockListSettings: {},
-				blockEditingModes: new Map(),
 			};
 			const block = { name: 'core/with-tranforms-a' };
 			const items = getBlockTransformItems( state, block );
@@ -3895,6 +3895,7 @@ describe( 'selectors', () => {
 					),
 					cache: {},
 					controlledInnerBlocks: {},
+					blockEditingModes: new Map(),
 				},
 				settings: {},
 				preferences: {},
@@ -3904,7 +3905,6 @@ describe( 'selectors', () => {
 					},
 					block2: {},
 				},
-				blockEditingModes: new Map(),
 			};
 			const blocks = [
 				{ clientId: 'block2', name: 'core/with-tranforms-a' },
@@ -3946,13 +3946,13 @@ describe( 'selectors', () => {
 					),
 					controlledInnerBlocks: {},
 					parents: new Map(),
+					blockEditingModes: new Map(),
 				},
 				preferences: {
 					insertUsage: {},
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-a' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -3978,6 +3978,7 @@ describe( 'selectors', () => {
 					order: new Map(),
 					parents: new Map(),
 					cache: {},
+					blockEditingModes: new Map(),
 				},
 				preferences: {
 					insertUsage: {
@@ -3986,7 +3987,6 @@ describe( 'selectors', () => {
 				},
 				blockListSettings: {},
 				settings: {},
-				blockEditingModes: new Map(),
 			};
 			const blocks = [ { name: 'core/with-tranforms-c' } ];
 			const items = getBlockTransformItems( state, blocks );
@@ -4476,12 +4476,12 @@ describe( 'selectors', () => {
 						[ '', [ 'parent' ] ],
 						[ 'parent', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					parent: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'parent', 'contentOnly' ],
 				] ),
@@ -4526,6 +4526,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -4534,7 +4535,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -4579,6 +4579,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -4587,7 +4588,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -4641,6 +4641,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [ 'child1', 'child2' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -4649,7 +4650,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -4688,12 +4688,12 @@ describe( 'selectors', () => {
 						[ '', [ 'parent' ] ],
 						[ 'parent', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					parent: {},
 				},
 				settings: {},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'parent', 'contentOnly' ],
 				] ),
@@ -4738,6 +4738,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -4746,7 +4747,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -4791,6 +4791,7 @@ describe( 'selectors', () => {
 						[ 'section', [ 'container' ] ],
 						[ 'container', [ 'child' ] ],
 					] ),
+					blockEditingModes: new Map(),
 				},
 				blockListSettings: {
 					section: {},
@@ -4799,7 +4800,6 @@ describe( 'selectors', () => {
 				settings: {
 					[ sectionRootClientIdKey ]: '',
 				},
-				blockEditingModes: new Map(),
 				derivedBlockEditingModes: new Map( [
 					[ 'container', 'contentOnly' ],
 				] ),
@@ -4972,7 +4972,9 @@ describe( '__unstableGetClientIdsTree', () => {
 
 describe( 'getBlockEditingMode', () => {
 	const baseState = {
-		blockEditingModes: new Map( [] ),
+		blocks: {
+			blockEditingModes: new Map( [] ),
+		},
 		derivedBlockEditingModes: new Map( [] ),
 	};
 
@@ -5001,9 +5003,11 @@ describe( 'getBlockEditingMode', () => {
 	it( 'should return disabled if explicitly set', () => {
 		const state = {
 			...baseState,
-			blockEditingModes: new Map( [
-				[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
-			] ),
+			blocks: {
+				blockEditingModes: new Map( [
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+				] ),
+			},
 		};
 		expect(
 			getBlockEditingMode( state, 'b3247f75-fd94-4fef-97f9-5bfd162cc416' )
@@ -5013,9 +5017,11 @@ describe( 'getBlockEditingMode', () => {
 	it( 'should return contentOnly if explicitly set', () => {
 		const state = {
 			...baseState,
-			blockEditingModes: new Map( [
-				[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'contentOnly' ],
-			] ),
+			blocks: {
+				blockEditingModes: new Map( [
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'contentOnly' ],
+				] ),
+			},
 		};
 		expect(
 			getBlockEditingMode( state, 'b3247f75-fd94-4fef-97f9-5bfd162cc416' )
@@ -5026,9 +5032,14 @@ describe( 'getBlockEditingMode', () => {
 		it( 'should return default if explicitly set', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'contentOnly' ],
-				] ),
+				blocks: {
+					blockEditingModes: new Map( [
+						[
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							'contentOnly',
+						],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
 				] ),
@@ -5044,9 +5055,14 @@ describe( 'getBlockEditingMode', () => {
 		it( 'should return disabled if explicitly set', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'contentOnly' ],
-				] ),
+				blocks: {
+					blockEditingModes: new Map( [
+						[
+							'b3247f75-fd94-4fef-97f9-5bfd162cc416',
+							'contentOnly',
+						],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
 				] ),
@@ -5062,9 +5078,11 @@ describe( 'getBlockEditingMode', () => {
 		it( 'should return contentOnly if explicitly set', () => {
 			const state = {
 				...baseState,
-				blockEditingModes: new Map( [
-					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
-				] ),
+				blocks: {
+					blockEditingModes: new Map( [
+						[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
+					] ),
+				},
 				derivedBlockEditingModes: new Map( [
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'contentOnly' ],
 				] ),


### PR DESCRIPTION
This fixes a part of #76310. Where a newly created page has read-only content and can't be modified. How to reproduce:
- enable template-locked mode, i.e., set "Show template" in the preview menu
- in Site Editor, go to the Pages list and there, select one of existing pages (important!). That renders the page template with a given page's content.
- now click "Add New Page" and create a new page. The new page will render, but within the same template. On `RESET_BLOCKS`, a big part of the block tree will stay the same, and only some of the controlled inner blocks will change. The logic in #75458 will try to preserve the inner blocks.
- the new page's content is read-only, I can't edit the title or content!

This happens because:
- the original page will set block editing mode for root block to `disabled`, and then selectively sets `contentOnly` to some of the child blocks (template parts, `core/post-content`). The `DisableNonPageContentBlocks` component does this.
- then `RESET_BLOCKS` will preserve only the `disabled` flag for the root block, but will remove all the `contentOnly` flags for the child blocks. They all become disabled.
- the effects in `DisableNonPageContentBlocks` will not reconstruct the block editing mode flags.

I'm fixing this by:
- moving the `blockEditingModes` state to `state.blocks.blockEditingModes` so that the `blocks` reducer, wrapped with `withBlockReset`, can modify the state on `RESET_BLOCKS`.
- on `RESET_BLOCKS`, preserve the editing mode of blocks that still exist and have the same client ID. Including controlled inner blocks. Very similar to preservation of `controlledInnerBlocks` in #76591.

This and #76591 together fixes all known causes of #76310, which can be closed after this PR is merged.