### PR TITLE
Cherry-pick: CI: Simplify strategy matrix in Build Gutenberg Plugin Zip workflow

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -179,7 +179,7 @@ jobs:
                   fi
 
     build:
-        name: ${{ matrix.IS_WORDPRESS_CORE && 'Build assets for wordpress-develop' || 'Build Release Artifact' }}
+        name: ${{ matrix.IS_GUTENBERG_PLUGIN && 'Build Release Artifact' || 'Build assets for wordpress-develop' }}
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
@@ -192,12 +192,7 @@ jobs:
             )
         strategy:
             matrix:
-                IS_GUTENBERG_PLUGIN: [true]
-                IS_WORDPRESS_CORE: [false]
-
-                include:
-                    - IS_GUTENBERG_PLUGIN: false
-                      IS_WORDPRESS_CORE: true
+                IS_GUTENBERG_PLUGIN: [true, false]
 
         outputs:
             job_status: ${{ job.status }}
@@ -217,7 +212,7 @@ jobs:
                   check-latest: true
 
             - name: Configure build for wordpress-develop
-              if: ${{ matrix.IS_WORDPRESS_CORE }}
+              if: ${{ ! matrix.IS_GUTENBERG_PLUGIN }}
               run: jq --tab '.wpPlugin.name = "wp"' package.json > package.json.tmp && mv package.json.tmp package.json
 
             - name: Build Gutenberg plugin ZIP file
@@ -225,12 +220,12 @@ jobs:
               env:
                   NO_CHECKS: 'true'
                   IS_GUTENBERG_PLUGIN: ${{ matrix.IS_GUTENBERG_PLUGIN }}
-                  IS_WORDPRESS_CORE: ${{ matrix.IS_WORDPRESS_CORE }}
+                  IS_WORDPRESS_CORE: ${{ ! matrix.IS_GUTENBERG_PLUGIN }}
 
             - name: Upload artifact
               uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
               with:
-                  name: gutenberg-${{ matrix.IS_WORDPRESS_CORE && 'wordpress-develop' || 'plugin' }}
+                  name: gutenberg-${{ ! matrix.IS_GUTENBERG_PLUGIN && 'wordpress-develop' || 'plugin' }}
                   path: ./gutenberg.zip
 
             - name: Build release notes draft


### PR DESCRIPTION
## What?
This performs a `git cherry-pick` on 684ad23205876b8c527471a243f3183257027b25 from `trunk`, which is failing to be done by the workflow for a reason that is unclear. I've opened #76537 to investigate this, but this PR performs a manual cherry-pick of the changes in #76435 for the time being.

## Use of AI Tools
No AI was used.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
