### PR TITLE
Experimental: Add `template` panel to include the existing template actions

### DIFF
--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -210,11 +210,6 @@ export const getPostsPageId = createRegistrySelector( ( select ) => () => {
 export const getTemplateId = createRegistrySelector(
 	( select ) => ( state, postType, postId ) => {
 		const homepage = unlock( select( STORE_NAME ) ).getHomePage();
-
-		if ( ! homepage ) {
-			return;
-		}
-
 		// For the front page, we always use the front page template if existing.
 		if (
 			postType === 'page' &&

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -210,6 +210,11 @@ export const getPostsPageId = createRegistrySelector( ( select ) => () => {
 export const getTemplateId = createRegistrySelector(
 	( select ) => ( state, postType, postId ) => {
 		const homepage = unlock( select( STORE_NAME ) ).getHomePage();
+
+		if ( ! homepage ) {
+			return;
+		}
+
 		// For the front page, we always use the front page template if existing.
 		if (
 			postType === 'page' &&

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -3,7 +3,8 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,20 +65,75 @@ function useTemplates( postType ) {
 	);
 }
 
-export function useAvailableTemplates( postType ) {
+export function useAvailableTemplates() {
+	const { postType, postId } = useEditedPostContext();
+	const [ postSlug ] = useEntityProp( 'postType', postType, 'slug', postId );
 	const currentTemplateSlug = useCurrentTemplateSlug();
 	const allowSwitchingTemplate = useAllowSwitchingTemplates();
 	const templates = useTemplates( postType );
+	// Add the default template to the available ones. We don't care about
+	// possible assignment to postspage/homepage because it's guarded by
+	// `allowSwitchingTemplate` above.
+	const defaultTemplate = useSelect(
+		( select ) => {
+			// Only append the default template if the experiment is enabled.
+			if ( ! window?.__experimentalDataFormInspector ) {
+				return null;
+			}
+			// If the default template is already assigned, no need
+			// to add it to the available templates.
+			if ( ! currentTemplateSlug ) {
+				return null;
+			}
+			const { getDefaultTemplateId, getEntityRecord } =
+				select( coreStore );
+			let slug;
+			if ( postSlug ) {
+				slug =
+					postType === 'page'
+						? `${ postType }-${ postSlug }`
+						: `single-${ postType }-${ postSlug }`;
+			} else {
+				slug = postType === 'page' ? 'page' : `single-${ postType }`;
+			}
+			const templateId = getDefaultTemplateId( { slug } );
+			if ( ! templateId ) {
+				return null;
+			}
+			return getEntityRecord( 'postType', 'wp_template', templateId );
+		},
+		[ currentTemplateSlug, postSlug, postType ]
+	);
 	return useMemo(
 		() =>
 			allowSwitchingTemplate &&
-			templates?.filter(
-				( template ) =>
-					template.is_custom &&
-					template.slug !== currentTemplateSlug &&
-					!! template.content.raw // Skip empty templates.
-			),
-		[ templates, currentTemplateSlug, allowSwitchingTemplate ]
+			[
+				...( templates || [] ).filter(
+					( template ) =>
+						template.is_custom &&
+						template.slug !== currentTemplateSlug &&
+						!! template.content.raw // Skip empty templates.
+				),
+				defaultTemplate && {
+					...defaultTemplate,
+					title: {
+						rendered: sprintf(
+							// translators: %s: Template name
+							__( '%s (default)' ),
+							defaultTemplate.title.rendered
+						),
+					},
+					// That's extra custom prop in order to update to an empty template
+					// when we select the default template.
+					isDefault: true,
+				},
+			].filter( Boolean ),
+		[
+			templates,
+			defaultTemplate,
+			currentTemplateSlug,
+			allowSwitchingTemplate,
+		]
 	);
 }
 

--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -16,12 +16,9 @@ import { parse } from '@wordpress/blocks';
 import { useAvailableTemplates, useEditedPostContext } from './hooks';
 import { searchTemplates } from '../../utils/search-templates';
 
-export default function SwapTemplateButton( { onClick } ) {
-	const [ showModal, setShowModal ] = useState( false );
+export function SwapTemplateModal( { onRequestClose, onSelect } ) {
 	const { postType, postId } = useEditedPostContext();
-	const availableTemplates = useAvailableTemplates( postType );
 	const { editEntityRecord } = useDispatch( coreStore );
-
 	const onTemplateSelect = async ( template ) => {
 		editEntityRecord(
 			'postType',
@@ -30,9 +27,31 @@ export default function SwapTemplateButton( { onClick } ) {
 			{ template: template.name },
 			{ undoIgnore: true }
 		);
-		setShowModal( false ); // Close the template suggestions modal first.
-		onClick();
+		onRequestClose();
+		onSelect?.();
 	};
+	return (
+		<Modal
+			title={ __( 'Choose a template' ) }
+			onRequestClose={ onRequestClose }
+			overlayClassName="editor-post-template__swap-template-modal"
+			isFullScreen
+		>
+			<div className="editor-post-template__swap-template-modal-content">
+				<TemplatesList
+					postType={ postType }
+					onSelect={ onTemplateSelect }
+				/>
+			</div>
+		</Modal>
+	);
+}
+
+export default function SwapTemplateButton( { onClick } ) {
+	const [ showModal, setShowModal ] = useState( false );
+	const { postType } = useEditedPostContext();
+	const availableTemplates = useAvailableTemplates( postType );
+
 	return (
 		<>
 			<MenuItem
@@ -43,19 +62,10 @@ export default function SwapTemplateButton( { onClick } ) {
 				{ __( 'Change template' ) }
 			</MenuItem>
 			{ showModal && (
-				<Modal
-					title={ __( 'Choose a template' ) }
+				<SwapTemplateModal
 					onRequestClose={ () => setShowModal( false ) }
-					overlayClassName="editor-post-template__swap-template-modal"
-					isFullScreen
-				>
-					<div className="editor-post-template__swap-template-modal-content">
-						<TemplatesList
-							postType={ postType }
-							onSelect={ onTemplateSelect }
-						/>
-					</div>
-				</Modal>
+					onSelect={ onClick }
+				/>
 			) }
 		</>
 	);

--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -24,7 +24,9 @@ export function SwapTemplateModal( { onRequestClose, onSelect } ) {
 			'postType',
 			postType,
 			postId,
-			{ template: template.name },
+			// Since we append the default template we need to properly
+			// update to an empty string.
+			{ template: template.isDefault ? '' : template.name },
 			{ undoIgnore: true }
 		);
 		onRequestClose();
@@ -38,10 +40,7 @@ export function SwapTemplateModal( { onRequestClose, onSelect } ) {
 			isFullScreen
 		>
 			<div className="editor-post-template__swap-template-modal-content">
-				<TemplatesList
-					postType={ postType }
-					onSelect={ onTemplateSelect }
-				/>
+				<TemplatesList onSelect={ onTemplateSelect } />
 			</div>
 		</Modal>
 	);
@@ -49,8 +48,7 @@ export function SwapTemplateModal( { onRequestClose, onSelect } ) {
 
 export default function SwapTemplateButton( { onClick } ) {
 	const [ showModal, setShowModal ] = useState( false );
-	const { postType } = useEditedPostContext();
-	const availableTemplates = useAvailableTemplates( postType );
+	const availableTemplates = useAvailableTemplates();
 
 	return (
 		<>
@@ -71,9 +69,9 @@ export default function SwapTemplateButton( { onClick } ) {
 	);
 }
 
-function TemplatesList( { postType, onSelect } ) {
+function TemplatesList( { onSelect } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
-	const availableTemplates = useAvailableTemplates( postType );
+	const availableTemplates = useAvailableTemplates();
 	const templatesAsPatterns = useMemo(
 		() =>
 			availableTemplates.map( ( template ) => ( {
@@ -81,6 +79,7 @@ function TemplatesList( { postType, onSelect } ) {
 				blocks: parse( template.content.raw ),
 				title: decodeEntities( template.title.rendered ),
 				id: template.id,
+				isDefault: template.isDefault,
 			} ) ),
 		[ availableTemplates ]
 	);

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -30,6 +30,7 @@ import PostTaxonomiesPanel from '../post-taxonomies/panel';
 import RevisionFieldsDiffPanel from '../revision-fields-diff';
 import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
+import TemplateActionsPanel from '../template-actions-panel';
 import TemplateContentPanel from '../template-content-panel';
 import TemplatePartContentPanel from '../template-part-content-panel';
 import { MediaMetadataPanel } from '../media';
@@ -134,6 +135,7 @@ const SidebarContent = ( {
 								<>
 									<PluginDocumentSettingPanel.Slot />
 									<TemplateContentPanel />
+									<TemplateActionsPanel />
 									<TemplatePartContentPanel />
 									<PostTransformPanel />
 									<PostTaxonomiesPanel />

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -135,7 +135,9 @@ const SidebarContent = ( {
 								<>
 									<PluginDocumentSettingPanel.Slot />
 									<TemplateContentPanel />
-									<TemplateActionsPanel />
+									{ window?.__experimentalDataFormInspector && (
+										<TemplateActionsPanel />
+									) }
 									<TemplatePartContentPanel />
 									<PostTransformPanel />
 									<PostTaxonomiesPanel />

--- a/packages/editor/src/components/template-actions-panel/block-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/block-theme-content.js
@@ -29,7 +29,11 @@ import CreateNewTemplateModal from '../post-template/create-new-template-modal';
 import { SwapTemplateModal } from '../post-template/swap-template-button';
 import { useAvailableTemplates } from '../post-template/hooks';
 
-export default function TemplateActionsPanelContent( { templateId } ) {
+export default function TemplateActionsPanelContent() {
+	const templateId = useSelect(
+		( select ) => select( editorStore ).getCurrentTemplateId(),
+		[]
+	);
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
 	const [ isSwapModalOpen, setIsSwapModalOpen ] = useState( false );
 

--- a/packages/editor/src/components/template-actions-panel/block-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/block-theme-content.js
@@ -27,17 +27,13 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '../../store';
 import CreateNewTemplateModal from '../post-template/create-new-template-modal';
 import { SwapTemplateModal } from '../post-template/swap-template-button';
-import {
-	useAvailableTemplates,
-	useEditedPostContext,
-} from '../post-template/hooks';
+import { useAvailableTemplates } from '../post-template/hooks';
 
 export default function TemplateActionsPanelContent( { templateId } ) {
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
 	const [ isSwapModalOpen, setIsSwapModalOpen ] = useState( false );
 
-	const { postType } = useEditedPostContext();
-	const availableTemplates = useAvailableTemplates( postType );
+	const availableTemplates = useAvailableTemplates();
 	const hasSwapTargets = !! availableTemplates?.length;
 
 	const {

--- a/packages/editor/src/components/template-actions-panel/block-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/block-theme-content.js
@@ -1,0 +1,196 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useEntityRecord,
+	useEntityBlockEditor,
+	store as coreStore,
+} from '@wordpress/core-data';
+import { BlockPreview } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	Button,
+	Tooltip,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import CreateNewTemplateModal from '../post-template/create-new-template-modal';
+import { SwapTemplateModal } from '../post-template/swap-template-button';
+import {
+	useAvailableTemplates,
+	useEditedPostContext,
+} from '../post-template/hooks';
+
+export default function TemplateActionsPanelContent( { templateId } ) {
+	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
+	const [ isSwapModalOpen, setIsSwapModalOpen ] = useState( false );
+
+	const { postType } = useEditedPostContext();
+	const availableTemplates = useAvailableTemplates( postType );
+	const hasSwapTargets = !! availableTemplates?.length;
+
+	const {
+		onNavigateToEntityRecord,
+		canCreateTemplate,
+		hasGoBack,
+		getEditorSettings,
+	} = useSelect( ( select ) => {
+		const { getEditorSettings: _getEditorSettings } = select( editorStore );
+		const editorSettings = _getEditorSettings();
+		return {
+			onNavigateToEntityRecord: editorSettings.onNavigateToEntityRecord,
+			canCreateTemplate: !! select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
+			hasGoBack: editorSettings.hasOwnProperty(
+				'onNavigateToPreviousEntityRecord'
+			),
+			getEditorSettings: _getEditorSettings,
+		};
+	}, [] );
+
+	const { get: getPreference } = useSelect( preferencesStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	const { editedRecord: template, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_template',
+		templateId
+	);
+
+	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_template', {
+		id: templateId,
+	} );
+
+	if ( ! hasResolved ) {
+		return null;
+	}
+
+	// The site editor does not have a `onNavigateToPreviousEntityRecord` setting as it uses its own routing
+	// and assigns its own backlink to focusMode pages.
+	const notificationAction = hasGoBack
+		? [
+				{
+					label: __( 'Go back' ),
+					onClick: () =>
+						getEditorSettings().onNavigateToPreviousEntityRecord(),
+				},
+		  ]
+		: undefined;
+
+	const mayShowTemplateEditNotice = () => {
+		if ( ! getPreference( 'core/edit-site', 'welcomeGuideTemplate' ) ) {
+			createSuccessNotice(
+				__(
+					'Editing template. Changes made here affect all posts and pages that use the template.'
+				),
+				{ type: 'snackbar', actions: notificationAction }
+			);
+		}
+	};
+
+	const templateName = decodeEntities( template.title );
+
+	const previewContent = !! blocks?.length && (
+		<BlockPreview.Async>
+			<BlockPreview blocks={ blocks } />
+		</BlockPreview.Async>
+	);
+
+	const renderPreview = () => {
+		if ( ! previewContent ) {
+			return null;
+		}
+
+		if ( hasSwapTargets ) {
+			const tooltipText = __( 'Change template' );
+			return (
+				<Tooltip text={ tooltipText }>
+					<div
+						className="editor-template-actions-panel__preview"
+						role="button"
+						tabIndex={ 0 }
+						aria-label={ tooltipText }
+						onClick={ () => setIsSwapModalOpen( true ) }
+						onKeyPress={ () => setIsSwapModalOpen( true ) }
+					>
+						{ previewContent }
+					</div>
+				</Tooltip>
+			);
+		}
+
+		return (
+			<div className="editor-template-actions-panel__preview">
+				{ previewContent }
+			</div>
+		);
+	};
+
+	return (
+		<>
+			<PanelBody
+				title={ sprintf(
+					/* translators: %s: template name */
+					__( 'Template: %s' ),
+					templateName
+				) }
+				initialOpen={ false }
+			>
+				<VStack>
+					{ renderPreview() }
+					<HStack>
+						{ onNavigateToEntityRecord && (
+							<Button
+								className="editor-template-actions-panel__action"
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ () => {
+									onNavigateToEntityRecord( {
+										postId: template.id,
+										postType: 'wp_template',
+									} );
+									mayShowTemplateEditNotice();
+								} }
+							>
+								{ __( 'Edit' ) }
+							</Button>
+						) }
+						{ canCreateTemplate && (
+							<Button
+								className="editor-template-actions-panel__action"
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ () => setIsCreateModalOpen( true ) }
+							>
+								{ __( 'Create new' ) }
+							</Button>
+						) }
+					</HStack>
+				</VStack>
+			</PanelBody>
+			{ isCreateModalOpen && (
+				<CreateNewTemplateModal
+					onClose={ () => setIsCreateModalOpen( false ) }
+				/>
+			) }
+			{ isSwapModalOpen && (
+				<SwapTemplateModal
+					onRequestClose={ () => setIsSwapModalOpen( false ) }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/editor/src/components/template-actions-panel/classic-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/classic-theme-content.js
@@ -77,7 +77,9 @@ export default function ClassicThemeContent( { templateId } ) {
 				<PanelBody title={ __( 'Template' ) } initialOpen={ false }>
 					<VStack>
 						<Text>
-							{ __( 'This page uses a classic template.' ) }
+							{ __(
+								'This page uses a classic template. To edit this template with blocks, create a block template.'
+							) }
 						</Text>
 						<HStack>
 							<Button
@@ -86,7 +88,7 @@ export default function ClassicThemeContent( { templateId } ) {
 								variant="secondary"
 								onClick={ () => setIsCreateModalOpen( true ) }
 							>
-								{ __( 'Create new' ) }
+								{ __( 'Create block template' ) }
 							</Button>
 						</HStack>
 					</VStack>

--- a/packages/editor/src/components/template-actions-panel/classic-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/classic-theme-content.js
@@ -29,7 +29,6 @@ import CreateNewTemplateModal from '../post-template/create-new-template-modal';
 
 export default function ClassicThemeContent( { templateId } ) {
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
-
 	const {
 		onNavigateToEntityRecord,
 		canCreateTemplate,
@@ -51,58 +50,19 @@ export default function ClassicThemeContent( { templateId } ) {
 			getEditorSettings: _getEditorSettings,
 		};
 	}, [] );
-
 	const { get: getPreference } = useSelect( preferencesStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
-
 	const { editedRecord: template } = useEntityRecord(
 		'postType',
 		'wp_template',
 		templateId
 	);
-
 	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_template', {
 		id: templateId,
 	} );
 
 	// Path A: No block template and cannot create templates.
 	if ( ! templateId && ! canCreateTemplate ) {
-		return null;
-	}
-
-	// Path B: No block template but can create templates.
-	if ( ! templateId ) {
-		return (
-			<>
-				<PanelBody title={ __( 'Template' ) } initialOpen={ false }>
-					<VStack>
-						<Text>
-							{ __(
-								'This page uses a classic template. To edit this template with blocks, create a block template.'
-							) }
-						</Text>
-						<HStack>
-							<Button
-								className="editor-template-actions-panel__action"
-								__next40pxDefaultSize
-								variant="secondary"
-								onClick={ () => setIsCreateModalOpen( true ) }
-							>
-								{ __( 'Create block template' ) }
-							</Button>
-						</HStack>
-					</VStack>
-				</PanelBody>
-				{ isCreateModalOpen && (
-					<CreateNewTemplateModal
-						onClose={ () => setIsCreateModalOpen( false ) }
-					/>
-				) }
-			</>
-		);
-	}
-
-	if ( ! template ) {
 		return null;
 	}
 
@@ -127,7 +87,9 @@ export default function ClassicThemeContent( { templateId } ) {
 		}
 	};
 
-	const templateName = decodeEntities( template.title );
+	const templateName = template
+		? decodeEntities( template.title )
+		: undefined;
 
 	const previewContent = !! blocks?.length && (
 		<BlockPreview.Async>
@@ -138,21 +100,32 @@ export default function ClassicThemeContent( { templateId } ) {
 	return (
 		<>
 			<PanelBody
-				title={ sprintf(
-					/* translators: %s: template name */
-					__( 'Template: %s' ),
-					templateName
-				) }
+				title={
+					template
+						? sprintf(
+								/* translators: %s: template name */
+								__( 'Template: %s' ),
+								templateName
+						  )
+						: __( 'Template' )
+				}
 				initialOpen={ false }
 			>
 				<VStack>
-					{ previewContent && (
+					{ ! templateId && (
+						<Text>
+							{ __(
+								'This page uses a classic template. To edit this template with blocks, create a block template.'
+							) }
+						</Text>
+					) }
+					{ template && previewContent && (
 						<div className="editor-template-actions-panel__preview">
 							{ previewContent }
 						</div>
 					) }
 					<HStack>
-						{ onNavigateToEntityRecord && (
+						{ template && onNavigateToEntityRecord && (
 							<Button
 								className="editor-template-actions-panel__action"
 								__next40pxDefaultSize
@@ -175,7 +148,9 @@ export default function ClassicThemeContent( { templateId } ) {
 								variant="secondary"
 								onClick={ () => setIsCreateModalOpen( true ) }
 							>
-								{ __( 'Create new' ) }
+								{ ! templateId
+									? __( 'Create block template' )
+									: __( 'Create new' ) }
 							</Button>
 						) }
 					</HStack>

--- a/packages/editor/src/components/template-actions-panel/classic-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/classic-theme-content.js
@@ -1,0 +1,189 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useEntityRecord,
+	useEntityBlockEditor,
+	store as coreStore,
+} from '@wordpress/core-data';
+import { BlockPreview } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import CreateNewTemplateModal from '../post-template/create-new-template-modal';
+
+export default function ClassicThemeContent( { templateId } ) {
+	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
+
+	const {
+		onNavigateToEntityRecord,
+		canCreateTemplate,
+		hasGoBack,
+		getEditorSettings,
+	} = useSelect( ( select ) => {
+		const { getEditorSettings: _getEditorSettings } = select( editorStore );
+		const editorSettings = _getEditorSettings();
+		return {
+			onNavigateToEntityRecord: editorSettings.onNavigateToEntityRecord,
+			canCreateTemplate:
+				!! select( coreStore ).canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} ) && editorSettings.supportsTemplateMode,
+			hasGoBack: editorSettings.hasOwnProperty(
+				'onNavigateToPreviousEntityRecord'
+			),
+			getEditorSettings: _getEditorSettings,
+		};
+	}, [] );
+
+	const { get: getPreference } = useSelect( preferencesStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	const { editedRecord: template } = useEntityRecord(
+		'postType',
+		'wp_template',
+		templateId
+	);
+
+	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_template', {
+		id: templateId,
+	} );
+
+	// Path A: No block template and cannot create templates.
+	if ( ! templateId && ! canCreateTemplate ) {
+		return null;
+	}
+
+	// Path B: No block template but can create templates.
+	if ( ! templateId ) {
+		return (
+			<>
+				<PanelBody title={ __( 'Template' ) } initialOpen={ false }>
+					<VStack>
+						<Text>
+							{ __( 'This page uses a classic template.' ) }
+						</Text>
+						<HStack>
+							<Button
+								className="editor-template-actions-panel__action"
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ () => setIsCreateModalOpen( true ) }
+							>
+								{ __( 'Create new' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</PanelBody>
+				{ isCreateModalOpen && (
+					<CreateNewTemplateModal
+						onClose={ () => setIsCreateModalOpen( false ) }
+					/>
+				) }
+			</>
+		);
+	}
+
+	if ( ! template ) {
+		return null;
+	}
+
+	const notificationAction = hasGoBack
+		? [
+				{
+					label: __( 'Go back' ),
+					onClick: () =>
+						getEditorSettings().onNavigateToPreviousEntityRecord(),
+				},
+		  ]
+		: undefined;
+
+	const mayShowTemplateEditNotice = () => {
+		if ( ! getPreference( 'core/edit-site', 'welcomeGuideTemplate' ) ) {
+			createSuccessNotice(
+				__(
+					'Editing template. Changes made here affect all posts and pages that use the template.'
+				),
+				{ type: 'snackbar', actions: notificationAction }
+			);
+		}
+	};
+
+	const templateName = decodeEntities( template.title );
+
+	const previewContent = !! blocks?.length && (
+		<BlockPreview.Async>
+			<BlockPreview blocks={ blocks } />
+		</BlockPreview.Async>
+	);
+
+	return (
+		<>
+			<PanelBody
+				title={ sprintf(
+					/* translators: %s: template name */
+					__( 'Template: %s' ),
+					templateName
+				) }
+				initialOpen={ false }
+			>
+				<VStack>
+					{ previewContent && (
+						<div className="editor-template-actions-panel__preview">
+							{ previewContent }
+						</div>
+					) }
+					<HStack>
+						{ onNavigateToEntityRecord && (
+							<Button
+								className="editor-template-actions-panel__action"
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ () => {
+									onNavigateToEntityRecord( {
+										postId: template.id,
+										postType: 'wp_template',
+									} );
+									mayShowTemplateEditNotice();
+								} }
+							>
+								{ __( 'Edit' ) }
+							</Button>
+						) }
+						{ canCreateTemplate && (
+							<Button
+								className="editor-template-actions-panel__action"
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ () => setIsCreateModalOpen( true ) }
+							>
+								{ __( 'Create new' ) }
+							</Button>
+						) }
+					</HStack>
+				</VStack>
+			</PanelBody>
+			{ isCreateModalOpen && (
+				<CreateNewTemplateModal
+					onClose={ () => setIsCreateModalOpen( false ) }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/editor/src/components/template-actions-panel/classic-theme-content.js
+++ b/packages/editor/src/components/template-actions-panel/classic-theme-content.js
@@ -27,7 +27,11 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '../../store';
 import CreateNewTemplateModal from '../post-template/create-new-template-modal';
 
-export default function ClassicThemeContent( { templateId } ) {
+export default function ClassicThemeContent() {
+	const templateId = useSelect(
+		( select ) => select( editorStore ).getCurrentTemplateId(),
+		[]
+	);
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
 	const {
 		onNavigateToEntityRecord,

--- a/packages/editor/src/components/template-actions-panel/index.js
+++ b/packages/editor/src/components/template-actions-panel/index.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import BlockThemeContent from './block-theme-content';
+import ClassicThemeContent from './classic-theme-content';
+
+export default function TemplateActionsPanel() {
+	const { templateId, isBlockTheme, isVisible } = useSelect( ( select ) => {
+		if ( ! window?.__experimentalDataFormInspector ) {
+			return { isVisible: false };
+		}
+
+		const { getCurrentTemplateId, getEditorSettings, getCurrentPostType } =
+			select( editorStore );
+		const postType = getCurrentPostType();
+
+		if ( postType !== 'page' && postType !== 'post' ) {
+			return { isVisible: false };
+		}
+
+		const settings = getEditorSettings();
+		const _isBlockTheme = settings.__unstableIsBlockBasedTheme;
+		const hasTemplates =
+			!! settings.availableTemplates &&
+			Object.keys( settings.availableTemplates ).length > 0;
+
+		if (
+			! _isBlockTheme &&
+			! settings.supportsTemplateMode &&
+			! hasTemplates
+		) {
+			return { isVisible: false };
+		}
+
+		return {
+			templateId: getCurrentTemplateId(),
+			isBlockTheme: _isBlockTheme,
+			isVisible: true,
+		};
+	}, [] );
+
+	const canViewTemplates = useSelect(
+		( select ) => {
+			return isVisible
+				? select( coreStore ).canUser( 'read', {
+						kind: 'postType',
+						name: 'wp_template',
+				  } )
+				: false;
+		},
+		[ isVisible ]
+	);
+
+	// Classic themes without template support should not render the panel at all.
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	if ( ! isBlockTheme || ! canViewTemplates ) {
+		return <ClassicThemeContent templateId={ templateId } />;
+	}
+
+	if ( isBlockTheme && templateId ) {
+		return <BlockThemeContent templateId={ templateId } />;
+	}
+
+	return null;
+}

--- a/packages/editor/src/components/template-actions-panel/index.js
+++ b/packages/editor/src/components/template-actions-panel/index.js
@@ -2,70 +2,31 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { usePostTemplatePanelMode } from '../post-template/hooks';
 import BlockThemeContent from './block-theme-content';
 import ClassicThemeContent from './classic-theme-content';
 
 export default function TemplateActionsPanel() {
-	const { templateId, isBlockTheme, isVisible } = useSelect( ( select ) => {
-		const { getCurrentTemplateId, getEditorSettings, getCurrentPostType } =
-			select( editorStore );
-		const postType = getCurrentPostType();
-
-		if ( postType !== 'page' && postType !== 'post' ) {
-			return { isVisible: false };
-		}
-
-		const settings = getEditorSettings();
-		const _isBlockTheme = settings.__unstableIsBlockBasedTheme;
-		const hasTemplates =
-			!! settings.availableTemplates &&
-			Object.keys( settings.availableTemplates ).length > 0;
-
-		if (
-			! _isBlockTheme &&
-			! settings.supportsTemplateMode &&
-			! hasTemplates
-		) {
-			return { isVisible: false };
-		}
-
-		return {
-			templateId: getCurrentTemplateId(),
-			isBlockTheme: _isBlockTheme,
-			isVisible: true,
-		};
-	}, [] );
-
-	const canViewTemplates = useSelect(
-		( select ) => {
-			return isVisible
-				? select( coreStore ).canUser( 'read', {
-						kind: 'postType',
-						name: 'wp_template',
-				  } )
-				: false;
-		},
-		[ isVisible ]
+	const postType = useSelect(
+		( select ) => select( editorStore ).getCurrentPostType(),
+		[]
 	);
-
-	// Classic themes without template support should not render the panel at all.
-	if ( ! isVisible ) {
+	const mode = usePostTemplatePanelMode();
+	// This check is because the experiment is gated for these post
+	// types for now. Later we should use `postType.viewable`.
+	if ( ! [ 'page', 'post' ].includes( postType ) ) {
 		return null;
 	}
-
-	if ( ! isBlockTheme || ! canViewTemplates ) {
-		return <ClassicThemeContent templateId={ templateId } />;
+	if ( mode === 'classic' ) {
+		return <ClassicThemeContent />;
 	}
-
-	if ( isBlockTheme && templateId ) {
-		return <BlockThemeContent templateId={ templateId } />;
+	if ( mode === 'block-theme' ) {
+		return <BlockThemeContent />;
 	}
-
 	return null;
 }

--- a/packages/editor/src/components/template-actions-panel/index.js
+++ b/packages/editor/src/components/template-actions-panel/index.js
@@ -13,10 +13,6 @@ import ClassicThemeContent from './classic-theme-content';
 
 export default function TemplateActionsPanel() {
 	const { templateId, isBlockTheme, isVisible } = useSelect( ( select ) => {
-		if ( ! window?.__experimentalDataFormInspector ) {
-			return { isVisible: false };
-		}
-
 		const { getCurrentTemplateId, getEditorSettings, getCurrentPostType } =
 			select( editorStore );
 		const postType = getCurrentPostType();

--- a/packages/editor/src/components/template-actions-panel/style.scss
+++ b/packages/editor/src/components/template-actions-panel/style.scss
@@ -1,0 +1,39 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
+.editor-template-actions-panel__preview {
+	.block-editor-block-preview__container {
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+		border-radius: $radius-medium;
+
+		&::after {
+			outline: $border-width solid rgba($black, 0.1);
+			outline-offset: -$border-width;
+			border-radius: $radius-medium;
+			@media not (prefers-reduced-motion) {
+				transition: outline 0.1s linear;
+			}
+		}
+	}
+
+	&[role="button"] {
+		cursor: pointer;
+
+		&:hover .block-editor-block-preview__container::after {
+			outline-color: rgba($black, 0.3);
+		}
+
+		&:focus-visible .block-editor-block-preview__container::after {
+			outline-color: var(--wp-admin-theme-color);
+			outline-width: var(--wp-admin-border-width-focus);
+			outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+		}
+	}
+}
+
+.editor-template-actions-panel__action {
+	flex: 1;
+	justify-content: center;
+}

--- a/packages/editor/src/components/template-actions-panel/style.scss
+++ b/packages/editor/src/components/template-actions-panel/style.scss
@@ -4,7 +4,7 @@
 .editor-template-actions-panel__preview {
 	.block-editor-block-preview__container {
 		display: flex;
-		align-items: center;
+		aspect-ratio: 4/3;
 		overflow: hidden;
 		border-radius: $radius-medium;
 

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -48,6 +48,7 @@
 @use "./components/post-taxonomies/style.scss" as *;
 @use "./components/sync-connection-error-modal/style.scss" as *;
 @use "./components/post-template/style.scss" as *;
+@use "./components/template-actions-panel/style.scss" as *;
 @use "./components/post-text-editor/style.scss" as *;
 @use "./components/post-title/style.scss" as *;
 @use "./components/post-url/style.scss" as *;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76104
Which is part of the bigger: https://github.com/WordPress/gutenberg/issues/76076
Alternative of: https://github.com/WordPress/gutenberg/pull/76251

The discussions in the alternative PR led to some new designs about where the template actions should live.

Block themes:
<img width="1200" height="1695" alt="Image" src="https://github.com/user-attachments/assets/d1e0ed03-1e37-439e-a27e-8a4ba74a4f7f" />

Classic themes (with and without template support)
<img width="1224" height="481" alt="Image" src="https://github.com/user-attachments/assets/1ed91ba3-59a9-437d-baf1-58f476aa8132" />

### Notes
The replacement of `change` template in both template field (DataForm) and this panel is going to be handled separately because we first need to create the new `radio-card` component.

This PR is WIP and aims to validate the suggested approach and  clarify the remaining  UX/UI issues.
1. In the template panel I've added the old `change template` modal only for block themes for now, which is available if you click the preview. Hybrid themes can have php templates without preview, so they should render a select control. Should this `select` control render in a modal in this case?
2. In block themes when there are no available templates we need a way (possibly) in the template panel to `use the default template). Right now you can't from the panel. 

## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment
2. Test with a block theme by editing pages and changing templates
3. Test with a classic theme (no template support) -> The panel shouldn't render
4. Test with a hybrid theme (I use `2014` and add template support). The panel should show the `create new` button and only show the `edit` and the template preview if a block template is selected.

### Snippet for adding template support:
```
add_action( 'after_setup_theme', 'mytheme_setup' );
function mytheme_setup() {
    add_theme_support( 'block-templates' );
    add_theme_support( 'block-template-parts' );
}
```

#### Block theme (2025)


https://github.com/user-attachments/assets/fcb11f31-f759-488f-a827-b869c8ddabc3


#### Hybrid theme

https://github.com/user-attachments/assets/2d75ec24-ccc6-403b-8737-a3300cee2505



