### PR TITLE
Connectors: Add unregisterConnector and upsert support

### DIFF
--- a/packages/connectors/src/api.ts
+++ b/packages/connectors/src/api.ts
@@ -17,6 +17,8 @@ import type { ConnectorConfig } from './types';
  *
  * @param slug   Unique identifier for the connector.
  * @param config Connector configuration (all fields optional when updating).
+ *               Omit keys you don't want to change — passing `undefined`
+ *               will overwrite the existing value.
  *
  * @example
  * ```js
@@ -26,9 +28,9 @@ import type { ConnectorConfig } from './types';
  *     label: 'OpenAI',
  *     description: 'Text, image, and code generation with GPT.',
  *     icon: <MyOpenAIIcon />,
- *     render: ( { slug, label, description } ) => (
+ *     render: ( { slug, label, description, icon } ) => (
  *         <ConnectorItem
- *             icon={ <MyOpenAIIcon /> }
+ *             icon={ icon }
  *             name={ label }
  *             description={ description }
  *         >

--- a/packages/connectors/src/api.ts
+++ b/packages/connectors/src/api.ts
@@ -12,9 +12,11 @@ import type { ConnectorConfig } from './types';
 
 /**
  * Register a connector that will appear in the Connectors settings page.
+ * If a connector with the given slug already exists, the provided config
+ * fields will be merged into the existing connector (upsert).
  *
  * @param slug   Unique identifier for the connector.
- * @param config Connector configuration.
+ * @param config Connector configuration (all fields optional when updating).
  *
  * @example
  * ```js
@@ -38,7 +40,23 @@ import type { ConnectorConfig } from './types';
  */
 export function registerConnector(
 	slug: string,
-	config: Omit< ConnectorConfig, 'slug' >
+	config: Partial< Omit< ConnectorConfig, 'slug' > >
 ): void {
 	unlock( dispatch( store ) ).registerConnector( slug, config );
+}
+
+/**
+ * Unregister a previously registered connector.
+ *
+ * @param slug Unique identifier of the connector to remove.
+ *
+ * @example
+ * ```js
+ * import { __experimentalUnregisterConnector as unregisterConnector } from '@wordpress/connectors';
+ *
+ * unregisterConnector( 'my-plugin/openai' );
+ * ```
+ */
+export function unregisterConnector( slug: string ): void {
+	unlock( dispatch( store ) ).unregisterConnector( slug );
 }

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,4 +1,7 @@
-export { registerConnector as __experimentalRegisterConnector } from './api';
+export {
+	registerConnector as __experimentalRegisterConnector,
+	unregisterConnector as __experimentalUnregisterConnector,
+} from './api';
 export {
 	ConnectorItem as __experimentalConnectorItem,
 	DefaultConnectorSettings as __experimentalDefaultConnectorSettings,

--- a/packages/connectors/src/store.ts
+++ b/packages/connectors/src/store.ts
@@ -16,16 +16,27 @@ const DEFAULT_STATE: ConnectorsState = {
 };
 
 const actions = {
-	registerConnector( slug: string, config: Omit< ConnectorConfig, 'slug' > ) {
+	registerConnector(
+		slug: string,
+		config: Partial< Omit< ConnectorConfig, 'slug' > >
+	) {
 		return {
 			type: 'REGISTER_CONNECTOR' as const,
 			slug,
 			config,
 		};
 	},
+	unregisterConnector( slug: string ) {
+		return {
+			type: 'UNREGISTER_CONNECTOR' as const,
+			slug,
+		};
+	},
 };
 
-type Action = ReturnType< typeof actions.registerConnector >;
+type Action =
+	| ReturnType< typeof actions.registerConnector >
+	| ReturnType< typeof actions.unregisterConnector >;
 
 function reducer(
 	state: ConnectorsState = DEFAULT_STATE,
@@ -38,11 +49,22 @@ function reducer(
 				connectors: {
 					...state.connectors,
 					[ action.slug ]: {
+						...state.connectors[ action.slug ],
 						slug: action.slug,
 						...action.config,
 					},
 				},
 			};
+		case 'UNREGISTER_CONNECTOR': {
+			if ( ! state.connectors[ action.slug ] ) {
+				return state;
+			}
+			const { [ action.slug ]: _, ...rest } = state.connectors;
+			return {
+				...state,
+				connectors: rest,
+			};
+		}
 		default:
 			return state;
 	}

--- a/packages/connectors/src/test/store.ts
+++ b/packages/connectors/src/test/store.ts
@@ -51,4 +51,112 @@ describe( 'connectors store', () => {
 			} );
 		} );
 	} );
+
+	describe( 'registerConnector (upsert)', () => {
+		it( 'should merge config when re-registering an existing slug', () => {
+			const registry = createRegistryWithStore();
+			const { getConnector } = unlock( registry.select( STORE_NAME ) );
+			const { registerConnector } = unlock(
+				registry.dispatch( STORE_NAME )
+			);
+
+			registerConnector( 'test', {
+				label: 'Original',
+				description: 'Original description',
+			} );
+
+			registerConnector( 'test', {
+				label: 'Updated',
+			} );
+
+			const connector = getConnector( 'test' );
+			expect( connector ).toMatchObject( {
+				slug: 'test',
+				label: 'Updated',
+				description: 'Original description',
+			} );
+		} );
+
+		it( 'should allow updating render and icon independently', () => {
+			const registry = createRegistryWithStore();
+			const { getConnector } = unlock( registry.select( STORE_NAME ) );
+			const { registerConnector } = unlock(
+				registry.dispatch( STORE_NAME )
+			);
+
+			const originalRender = () => null;
+			registerConnector( 'test', {
+				label: 'Test',
+				description: 'A test connector',
+				render: originalRender,
+			} );
+
+			const newRender = () => 'updated';
+			registerConnector( 'test', {
+				render: newRender,
+			} );
+
+			const connector = getConnector( 'test' );
+			expect( connector?.render ).toBe( newRender );
+			expect( connector?.label ).toBe( 'Test' );
+			expect( connector?.description ).toBe( 'A test connector' );
+		} );
+	} );
+
+	describe( 'unregisterConnector', () => {
+		it( 'should remove an existing connector', () => {
+			const registry = createRegistryWithStore();
+			const { getConnectors, getConnector } = unlock(
+				registry.select( STORE_NAME )
+			);
+			const { registerConnector, unregisterConnector } = unlock(
+				registry.dispatch( STORE_NAME )
+			);
+
+			registerConnector( 'test', {
+				label: 'Test',
+				description: 'A test connector',
+			} );
+
+			expect( getConnectors() ).toHaveLength( 1 );
+
+			unregisterConnector( 'test' );
+
+			expect( getConnectors() ).toHaveLength( 0 );
+			expect( getConnector( 'test' ) ).toBeUndefined();
+		} );
+
+		it( 'should return a new reference after unregistering', () => {
+			const registry = createRegistryWithStore();
+			const { getConnectors } = unlock( registry.select( STORE_NAME ) );
+			const { registerConnector, unregisterConnector } = unlock(
+				registry.dispatch( STORE_NAME )
+			);
+
+			registerConnector( 'test', {
+				label: 'Test',
+				description: 'A test connector',
+			} );
+
+			const before = getConnectors();
+			unregisterConnector( 'test' );
+			const after = getConnectors();
+
+			expect( before ).not.toBe( after );
+		} );
+
+		it( 'should be a no-op for a non-existent slug', () => {
+			const registry = createRegistryWithStore();
+			const { getConnectors } = unlock( registry.select( STORE_NAME ) );
+			const { unregisterConnector } = unlock(
+				registry.dispatch( STORE_NAME )
+			);
+
+			const before = getConnectors();
+			unregisterConnector( 'non-existent' );
+			const after = getConnectors();
+
+			expect( before ).toBe( after );
+		} );
+	} );
 } );

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -7,6 +7,7 @@ export interface ConnectorRenderProps {
 	slug: string;
 	label: string;
 	description: string;
+	icon?: ReactNode;
 }
 
 export interface ConnectorConfig {

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -105,7 +105,6 @@ interface ApiKeyConnectorConfig {
 	pluginSlug?: string;
 	settingName: string;
 	helpUrl?: string;
-	icon?: React.ReactNode;
 	isInstalled?: boolean;
 	isActivated?: boolean;
 	keySource?: ApiKeySource;
@@ -273,13 +272,13 @@ export function registerDefaultConnectors() {
 		registerConnector( connectorName, {
 			label: data.name,
 			description: data.description,
+			icon: getConnectorLogo( connectorId, data.name, data.logoUrl ),
 			render: ( props ) => (
 				<ApiKeyConnector
 					{ ...props }
 					pluginSlug={ data.plugin?.slug }
 					settingName={ authentication.settingName }
 					helpUrl={ authentication.credentialsUrl ?? undefined }
-					icon={ getConnectorLogo( connectorId, data.logoUrl ) }
 					isInstalled={ data.plugin?.isInstalled }
 					isActivated={ data.plugin?.isActivated }
 					keySource={ authentication.keySource }
@@ -289,3 +288,4 @@ export function registerDefaultConnectors() {
 		} );
 	}
 }
+

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -288,4 +288,3 @@ export function registerDefaultConnectors() {
 		} );
 	}
 }
-

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -272,7 +272,7 @@ export function registerDefaultConnectors() {
 		registerConnector( connectorName, {
 			label: data.name,
 			description: data.description,
-			icon: getConnectorLogo( connectorId, data.name, data.logoUrl ),
+			icon: getConnectorLogo( connectorId, data.logoUrl ),
 			render: ( props ) => (
 				<ApiKeyConnector
 					{ ...props }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -88,6 +88,7 @@ function ConnectorsPage() {
 										slug={ connector.slug }
 										label={ connector.label }
 										description={ connector.description }
+										icon={ connector.icon }
 									/>
 								);
 							}


### PR DESCRIPTION
## Summary

- Add `unregisterConnector` API to remove a connector by slug
- Update `registerConnector` to support upsert — re-registering an existing slug merges the new config with the existing one, enabling partial updates (e.g. updating only `render` or `label`)
- Add unit tests for both behaviors

## Test plan

- [x] Unit tests pass (`npm run test:unit -- -- packages/connectors/src/test/store.ts`)
- [x] Lint passes
- [ ] Paste the following on the browser console:
```
const connectors = (await import( '@wordpress/connectors' ) );
const registerConnector = connectors.__experimentalRegisterConnector;
const ConnectorItem = connectors.__experimentalConnectorItem;
const { useState, createElement } = wp.element;
const { Button } = wp.components;

// Hello World connector render component
function HelloWorldConnector( { label, description, icon } ) {
	const [ isExpanded, setIsExpanded ] = useState( false );

	return createElement(
		ConnectorItem,
		{
			name: label,
			description,
            icon,
			actionArea: createElement(
				Button,
				{
					variant: 'secondary',
					size: 'compact',
					onClick: () => setIsExpanded( ! isExpanded ),
					'aria-expanded': isExpanded,
				},
				isExpanded ? 'Close' : 'Configure'
			),
		},
		isExpanded &&
			createElement( 'p', null, 'Hello World settings would go here!' )
	);
}

// Register the Hello World connector
registerConnector( 'example/hello-world', {
	label: 'Hello World',
	description: 'A simple example connector registered via script module.',
	render: HelloWorldConnector,
} );
```
- [ ]  Verify a connector got registered.
- [ ] Paste `connectors.__experimentalRegisterConnector('ai-provider/anthropic', {render: HelloWorldConnector } );` verify the anthropic connector UI got updated.
- [ ] Paste `connectors.__experimentalUnregisterConnector('ai-provider/openai')`, verify the open ai connector got unregistered.