### PR TITLE
RTC: Add post title awareness

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -882,6 +882,18 @@ _Returns_
 
 -   `string|false`: Block Template Lock
 
+### getTitleSelection
+
+Returns the current user's title selection offsets.
+
+_Parameters_
+
+-   _state_ `Object`: Block editor state.
+
+_Returns_
+
+-   `{ start: number|null, end: number|null }`: Title selection offsets.
+
 ### hasBlockMovingClientId
 
 > **Deprecated**
@@ -1698,6 +1710,19 @@ Action that resets the template validity.
 _Parameters_
 
 -   _isValid_ `boolean`: template validity flag.
+
+_Returns_
+
+-   `Object`: Action object.
+
+### setTitleSelection
+
+Sets the current user's title selection offsets.
+
+_Parameters_
+
+-   _start_ `number|null`: The start offset, or null to clear.
+-   _end_ `number|null`: The end offset, or null to clear.
 
 _Returns_
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -345,6 +345,22 @@ export function clearSelectedBlock() {
 }
 
 /**
+ * Sets the current user's title selection offsets.
+ *
+ * @param {number|null} start The start offset, or null to clear.
+ * @param {number|null} end   The end offset, or null to clear.
+ *
+ * @return {Object} Action object.
+ */
+export function setTitleSelection( start, end ) {
+	return {
+		type: 'SET_TITLE_SELECTION',
+		start,
+		end,
+	};
+}
+
+/**
  * Action that enables or disables block selection.
  *
  * @param {boolean} [isSelectionEnabled=true] Whether block selection should

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2353,6 +2353,28 @@ export function requestedInspectorTab( state = null, action ) {
 	return state;
 }
 
+/**
+ * Reducer tracking the local user's title selection.
+ *
+ * Only one post can be actively edited at a time, so a flat
+ * `{ start, end }` is sufficient.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function titleSelection( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_TITLE_SELECTION':
+			return {
+				start: action.start ?? null,
+				end: action.end ?? null,
+			};
+	}
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2360,6 +2382,7 @@ const combinedReducers = combineReducers( {
 	isBlockInterfaceHidden,
 	draggedBlocks,
 	selection,
+	titleSelection,
 	isMultiSelecting,
 	isSelectionEnabled,
 	initialPosition,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -464,6 +464,17 @@ export function getSelectionEnd( state ) {
 }
 
 /**
+ * Returns the current user's title selection offsets.
+ *
+ * @param {Object} state Block editor state.
+ *
+ * @return {{ start: number|null, end: number|null }} Title selection offsets.
+ */
+export function getTitleSelection( state ) {
+	return state.titleSelection;
+}
+
+/**
  * Returns the current block selection start. This value may be null, and it
  * may represent either a singular block selection or multi-selection start.
  * A selection is singular if its start and end match.

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -9,12 +9,10 @@ import { Y } from '@wordpress/sync';
 import { BaseAwarenessState, baseEqualityFieldChecks } from './base-awareness';
 import { getBlockPathInYdoc, resolveBlockClientIdByPath } from './block-lookup';
 import { AWARENESS_CURSOR_UPDATE_THROTTLE_IN_MS } from './config';
-import {
-	areSelectionsStatesEqual,
-	SelectionType,
-} from '../utils/crdt-user-selections';
+import { areSelectionsStatesEqual } from '../utils/crdt-user-selections';
 import { createSelectionSubscription } from './selection/create-selection-subscription';
 
+import { SelectionType } from '../types';
 import type { ResolvedSelection, SelectionState } from '../types';
 import type { YBlocks } from '../utils/crdt-blocks';
 import type {

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -43,6 +43,11 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	protected onSetUp(): void {
 		super.onSetUp();
 
+		// Clean up any prior subscription before creating a new one.
+		if ( this.selectionSubscription ) {
+			this.selectionSubscription.unsubscribe();
+		}
+
 		this.selectionSubscription = createSelectionSubscription(
 			this.doc,
 			this.kind,

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -1,29 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { dispatch, select, subscribe } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-ignore No exported types for block editor store selectors.
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { BaseAwarenessState, baseEqualityFieldChecks } from './base-awareness';
 import { getBlockPathInYdoc, resolveBlockClientIdByPath } from './block-lookup';
-import {
-	AWARENESS_CURSOR_UPDATE_THROTTLE_IN_MS,
-	LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS,
-} from './config';
-import { STORE_NAME as coreStore } from '../name';
+import { AWARENESS_CURSOR_UPDATE_THROTTLE_IN_MS } from './config';
 import {
 	areSelectionsStatesEqual,
-	getSelectionState,
 	SelectionType,
 } from '../utils/crdt-user-selections';
+import { createSelectionSubscription } from './selection/create-selection-subscription';
 
-import { SelectionDirection } from '../types';
-import type { SelectionState, WPBlockSelection } from '../types';
+import type { ResolvedSelection, SelectionState } from '../types';
 import type { YBlocks } from '../utils/crdt-blocks';
 import type {
 	DebugCollaboratorData,
@@ -39,6 +31,8 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 		editorState: this.areEditorStatesEqual,
 	};
 
+	private selectionSubscription: { unsubscribe: () => void } | null = null;
+
 	public constructor(
 		doc: Y.Doc,
 		private kind: string,
@@ -51,149 +45,18 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	protected onSetUp(): void {
 		super.onSetUp();
 
-		this.subscribeToCollaboratorSelectionChanges();
-	}
-
-	/**
-	 * Subscribe to collaborator selection changes and update the selection state.
-	 */
-	private subscribeToCollaboratorSelectionChanges(): void {
-		const {
-			getSelectionStart,
-			getSelectionEnd,
-			getSelectedBlocksInitialCaretPosition,
-		} = select( blockEditorStore );
-
-		// Keep track of the current selection in the outer scope so we can compare
-		// in the subscription.
-		let selectionStart = getSelectionStart();
-		let selectionEnd = getSelectionEnd();
-		let localCursorTimeout: NodeJS.Timeout | null = null;
-
-		// During rapid selection changes (e.g. undo restoring content and
-		// selection), the debounce discards intermediate events. If we use the
-		// last intermediate state instead of the overall change it can produce
-		// the wrong direction.
-		// Use selectionBeforeDebounce to capture the selection state from
-		// before the debounce window so that direction is computed across the
-		// full window when it fires.
-		let selectionBeforeDebounce: {
-			start: WPBlockSelection;
-			end: WPBlockSelection;
-		} | null = null;
-
-		subscribe( () => {
-			const newSelectionStart = getSelectionStart();
-			const newSelectionEnd = getSelectionEnd();
-
-			if (
-				newSelectionStart === selectionStart &&
-				newSelectionEnd === selectionEnd
-			) {
-				return;
-			}
-
-			// On the first change of a debounce window, snapshot the state
-			// we're moving away from.
-			if ( ! selectionBeforeDebounce ) {
-				selectionBeforeDebounce = {
-					start: selectionStart,
-					end: selectionEnd,
-				};
-			}
-
-			selectionStart = newSelectionStart;
-			selectionEnd = newSelectionEnd;
-
-			// Typically selection position is only persisted after typing in a block, which
-			// can cause selection position to be reset by other users making block updates.
-			// Ensure we update the controlled selection right away, persisting our cursor position locally.
-			const initialPosition = getSelectedBlocksInitialCaretPosition();
-			void this.updateSelectionInEntityRecord(
-				selectionStart,
-				selectionEnd,
-				initialPosition
-			);
-
-			// We receive two selection changes in quick succession
-			// from local selection events:
-			//   { clientId: "123...", attributeKey: "content", offset: undefined }
-			//   { clientId: "123...", attributeKey: "content", offset: 554 }
-			// Add a short debounce to avoid sending the first selection change.
-			if ( localCursorTimeout ) {
-				clearTimeout( localCursorTimeout );
-			}
-
-			localCursorTimeout = setTimeout( () => {
-				// Compute direction across the full debounce window.
-				const selectionStateOptions: {
-					selectionDirection?: SelectionDirection;
-				} = {};
-
-				if ( selectionBeforeDebounce ) {
-					selectionStateOptions.selectionDirection =
-						detectSelectionDirection(
-							selectionBeforeDebounce.start,
-							selectionBeforeDebounce.end,
-							selectionStart,
-							selectionEnd
-						);
-
-					// Reset debounced selection state.
-					selectionBeforeDebounce = null;
-				}
-
-				const selectionState = getSelectionState(
-					selectionStart,
-					selectionEnd,
-					this.doc,
-					selectionStateOptions
-				);
-
+		this.selectionSubscription = createSelectionSubscription(
+			this.doc,
+			this.kind,
+			this.name,
+			this.postId,
+			( selectionState ) => {
 				this.setThrottledLocalStateField(
 					'editorState',
 					{ selection: selectionState },
 					AWARENESS_CURSOR_UPDATE_THROTTLE_IN_MS
 				);
-			}, LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS );
-		} );
-	}
-
-	/**
-	 * Update the entity record with the current collaborator's selection.
-	 *
-	 * @param selectionStart  - The start position of the selection.
-	 * @param selectionEnd    - The end position of the selection.
-	 * @param initialPosition - The initial position of the selection.
-	 */
-	private async updateSelectionInEntityRecord(
-		selectionStart: WPBlockSelection,
-		selectionEnd: WPBlockSelection,
-		initialPosition: number | null
-	): Promise< void > {
-		// Send an entityRecord `selection` update if we have a selection.
-		//
-		// Normally WordPress updates the `selection` property of the post when changes are made to blocks.
-		// In a multi-user setup, block changes can occur from other users. When an entity is updated from another
-		// user's changes, useBlockSync() in Gutenberg will reset the user's selection to the last saved selection.
-		//
-		// Manually adding an edit for each movement ensures that other user's changes to the document will
-		// not cause the local user's selection to reset to the last local change location.
-		const edits = {
-			selection: { selectionStart, selectionEnd, initialPosition },
-		};
-
-		const options = {
-			undoIgnore: true,
-		};
-
-		// @ts-ignore Types are not provided when using store name instead of store instance.
-		dispatch( coreStore ).editEntityRecord(
-			this.kind,
-			this.name,
-			this.postId,
-			edits,
-			options
+			}
 		);
 	}
 
@@ -216,27 +79,48 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	}
 
 	/**
-	 * Resolve a selection state to a text index and block client ID.
+	 * Resolve a SelectionState (which uses Y.RelativePositions) to absolute
+	 * positions that the rendering layer can use.
 	 *
-	 * For text-based selections, navigates up from the resolved Y.Text via
-	 * AbstractType.parent to find the containing block, then resolves the
-	 * local clientId via the block's tree path.
-	 * For WholeBlock selections, resolves the block's relative position and
-	 * then finds the local clientId via tree path.
+	 * - Title selections: resolves to a text index within the title Y.Text.
+	 * - WholeBlock selections: resolves the block's relative position and
+	 *   finds the local clientId via tree path.
+	 * - Text-based selections (Cursor, SelectionInOneBlock,
+	 *   SelectionInMultipleBlocks): navigates up from the resolved Y.Text
+	 *   via AbstractType.parent to find the containing block, then resolves
+	 *   the local clientId via the block's tree path.
 	 *
 	 * Tree-path resolution is used instead of reading the clientId directly
-	 * from the Yjs block because the local block-editor store may use different
-	 * clientIds (e.g. in "Show Template" mode where blocks are cloned).
+	 * from the Yjs block because the local block-editor store may use
+	 * different clientIds (e.g. in "Show Template" mode where blocks are
+	 * cloned).
 	 *
 	 * @param selection - The selection state.
-	 * @return The text index and block client ID, or nulls if not resolvable.
+	 * @return The resolved selection with absolute positions.
 	 */
-	public convertSelectionStateToAbsolute( selection: SelectionState ): {
-		textIndex: number | null;
-		localClientId: string | null;
-	} {
+	public convertSelectionStateToAbsolute(
+		selection: SelectionState
+	): ResolvedSelection {
 		if ( selection.type === SelectionType.None ) {
-			return { textIndex: null, localClientId: null };
+			return { type: 'block', textIndex: null, localClientId: null };
+		}
+
+		if ( selection.type === SelectionType.Title ) {
+			const cursorPos = selection.cursorPosition;
+			const absolutePosition =
+				Y.createAbsolutePositionFromRelativePosition(
+					cursorPos.relativePosition,
+					this.doc
+				);
+
+			if ( ! absolutePosition ) {
+				return { type: 'title', textIndex: null };
+			}
+
+			return {
+				type: 'title',
+				textIndex: absolutePosition.index,
+			};
 		}
 
 		if ( selection.type === SelectionType.WholeBlock ) {
@@ -259,7 +143,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 				}
 			}
 
-			return { textIndex: null, localClientId };
+			return { type: 'block', textIndex: null, localClientId };
 		}
 
 		// Text-based selections: resolve cursor position and navigate up.
@@ -274,7 +158,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 		);
 
 		if ( ! absolutePosition ) {
-			return { textIndex: null, localClientId: null };
+			return { type: 'block', textIndex: null, localClientId: null };
 		}
 
 		// Navigate up: Y.Text -> attributes Y.Map -> block Y.Map
@@ -283,7 +167,11 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 			yType instanceof Y.Map ? getBlockPathInYdoc( yType ) : null;
 		const localClientId = path ? resolveBlockClientIdByPath( path ) : null;
 
-		return { textIndex: absolutePosition.index, localClientId };
+		return {
+			type: 'block',
+			textIndex: absolutePosition.index,
+			localClientId,
+		};
 	}
 
 	/**
@@ -365,51 +253,4 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 			collaboratorMap: Object.fromEntries( collaboratorMapData ),
 		};
 	}
-}
-
-/**
- * Detect the direction of a selection change by comparing old and new edges.
- *
- * When the user extends a selection backward (e.g. Shift+Left), the
- * selectionStart edge moves while selectionEnd stays fixed, so the caret
- * is at the start.  The reverse is true for forward extension.
- *
- * @param prevStart - The previous selectionStart.
- * @param prevEnd   - The previous selectionEnd.
- * @param newStart  - The new selectionStart.
- * @param newEnd    - The new selectionEnd.
- * @return The detected direction, defaulting to Forward when indeterminate.
- */
-function detectSelectionDirection(
-	prevStart: WPBlockSelection,
-	prevEnd: WPBlockSelection,
-	newStart: WPBlockSelection,
-	newEnd: WPBlockSelection
-): SelectionDirection {
-	const startMoved = ! areBlockSelectionsEqual( prevStart, newStart );
-	const endMoved = ! areBlockSelectionsEqual( prevEnd, newEnd );
-
-	if ( startMoved && ! endMoved ) {
-		return SelectionDirection.Backward;
-	}
-
-	return SelectionDirection.Forward;
-}
-
-/**
- * Compare two WPBlockSelection objects by value.
- *
- * @param a - First selection.
- * @param b - Second selection.
- * @return True if all fields are equal.
- */
-function areBlockSelectionsEqual(
-	a: WPBlockSelection,
-	b: WPBlockSelection
-): boolean {
-	return (
-		a.clientId === b.clientId &&
-		a.attributeKey === b.attributeKey &&
-		a.offset === b.offset
-	);
 }

--- a/packages/core-data/src/awareness/selection/create-block-selection-subscription.ts
+++ b/packages/core-data/src/awareness/selection/create-block-selection-subscription.ts
@@ -1,0 +1,236 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch, select, subscribe } from '@wordpress/data';
+// @ts-ignore No exported types for block editor store selectors.
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import type { Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import { LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS } from '../config';
+import { STORE_NAME as coreStore } from '../../name';
+import { getSelectionState } from '../../utils/crdt-user-selections';
+
+import { SelectionDirection } from '../../types';
+import type { SelectionState, WPBlockSelection } from '../../types';
+
+/**
+ * Creates a subscription to block-editor store selection changes.
+ *
+ * Subscribes to getSelectionStart / getSelectionEnd, debounces rapid
+ * selection events, computes a SelectionState via getSe	lectionState(),
+ * and persists the selection to the entity record to prevent remote resets.
+ *
+ * @param doc               - The Yjs document for creating relative positions.
+ * @param kind              - Entity kind (e.g. 'postType').
+ * @param name              - Entity name (e.g. 'post').
+ * @param postId            - The post ID.
+ * @param onSelectionChange - Callback invoked with the new SelectionState after debounce.
+ * @return An object with an unsubscribe method to tear down the subscription.
+ */
+export function createBlockSelectionSubscription(
+	doc: Y.Doc,
+	kind: string,
+	name: string,
+	postId: number,
+	onSelectionChange: ( selectionState: SelectionState ) => void
+): { unsubscribe: () => void } {
+	const {
+		getSelectionStart,
+		getSelectionEnd,
+		getSelectedBlocksInitialCaretPosition,
+	} = select( blockEditorStore );
+
+	let selectionStart = getSelectionStart();
+	let selectionEnd = getSelectionEnd();
+
+	// During rapid selection changes (e.g. undo restoring content and
+	// selection), the debounce discards intermediate events. If we use the
+	// last intermediate state instead of the overall change it can produce
+	// the wrong direction.
+	// Use selectionBeforeDebounce to capture the selection state from
+	// before the debounce window so that direction is computed across the
+	// full window when it fires.
+	let selectionBeforeDebounce: {
+		start: WPBlockSelection;
+		end: WPBlockSelection;
+	} | null = null;
+
+	let localCursorTimeout: NodeJS.Timeout | null = null;
+
+	const unsubscribeFromStore = subscribe( () => {
+		const newSelectionStart = getSelectionStart();
+		const newSelectionEnd = getSelectionEnd();
+
+		if (
+			newSelectionStart === selectionStart &&
+			newSelectionEnd === selectionEnd
+		) {
+			return;
+		}
+
+		// On the first change of a debounce window, snapshot the state
+		// we're moving away from.
+		if ( ! selectionBeforeDebounce ) {
+			selectionBeforeDebounce = {
+				start: selectionStart,
+				end: selectionEnd,
+			};
+		}
+
+		selectionStart = newSelectionStart;
+		selectionEnd = newSelectionEnd;
+
+		// Persist our cursor position locally right away so that other
+		// users' block updates don't reset our selection.
+		const initialPosition = getSelectedBlocksInitialCaretPosition();
+		updateSelectionInEntityRecord(
+			kind,
+			name,
+			postId,
+			selectionStart,
+			selectionEnd,
+			initialPosition
+		);
+
+		// We receive two selection changes in quick succession
+		// from local selection events:
+		//   { clientId: "123...", attributeKey: "content", offset: undefined }
+		//   { clientId: "123...", attributeKey: "content", offset: 554 }
+		// Add a short debounce to avoid sending the first selection change.
+		if ( localCursorTimeout ) {
+			clearTimeout( localCursorTimeout );
+		}
+
+		localCursorTimeout = setTimeout( () => {
+			// Compute direction across the full debounce window.
+			const selectionStateOptions: {
+				selectionDirection?: SelectionDirection;
+			} = {};
+
+			if ( selectionBeforeDebounce ) {
+				selectionStateOptions.selectionDirection =
+					detectSelectionDirection(
+						selectionBeforeDebounce.start,
+						selectionBeforeDebounce.end,
+						selectionStart,
+						selectionEnd
+					);
+
+				// Reset debounced selection state.
+				selectionBeforeDebounce = null;
+			}
+
+			const selectionState = getSelectionState(
+				selectionStart,
+				selectionEnd,
+				doc,
+				selectionStateOptions
+			);
+
+			onSelectionChange( selectionState );
+		}, LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS );
+	} );
+
+	return {
+		unsubscribe: () => {
+			unsubscribeFromStore();
+			if ( localCursorTimeout ) {
+				clearTimeout( localCursorTimeout );
+				localCursorTimeout = null;
+			}
+		},
+	};
+}
+
+/**
+ * Update the entity record with the current collaborator's selection.
+ *
+ * Normally WordPress updates the `selection` property of the post when changes
+ * are made to blocks. In a multi-user setup, block changes can occur from other
+ * users. When an entity is updated from another user's changes, useBlockSync()
+ * in Gutenberg will reset the user's selection to the last saved selection.
+ *
+ * Manually adding an edit for each movement ensures that other user's changes
+ * to the document will not cause the local user's selection to reset.
+ * @param kind
+ * @param name
+ * @param postId
+ * @param selectionStart
+ * @param selectionEnd
+ * @param initialPosition
+ */
+function updateSelectionInEntityRecord(
+	kind: string,
+	name: string,
+	postId: number,
+	selectionStart: WPBlockSelection,
+	selectionEnd: WPBlockSelection,
+	initialPosition: number | null
+): void {
+	const edits = {
+		selection: { selectionStart, selectionEnd, initialPosition },
+	};
+
+	const options = {
+		undoIgnore: true,
+	};
+
+	// @ts-ignore Types are not provided when using store name instead of store instance.
+	dispatch( coreStore ).editEntityRecord(
+		kind,
+		name,
+		postId,
+		edits,
+		options
+	);
+}
+
+/**
+ * Detect the direction of a selection change by comparing old and new edges.
+ *
+ * When the user extends a selection backward (e.g. Shift+Left), the
+ * selectionStart edge moves while selectionEnd stays fixed, so the caret
+ * is at the start.  The reverse is true for forward extension.
+ *
+ * @param prevStart - The previous selectionStart.
+ * @param prevEnd   - The previous selectionEnd.
+ * @param newStart  - The new selectionStart.
+ * @param newEnd    - The new selectionEnd.
+ * @return The detected direction, defaulting to Forward when indeterminate.
+ */
+function detectSelectionDirection(
+	prevStart: WPBlockSelection,
+	prevEnd: WPBlockSelection,
+	newStart: WPBlockSelection,
+	newEnd: WPBlockSelection
+): SelectionDirection {
+	const startMoved = ! areBlockSelectionsEqual( prevStart, newStart );
+	const endMoved = ! areBlockSelectionsEqual( prevEnd, newEnd );
+
+	if ( startMoved && ! endMoved ) {
+		return SelectionDirection.Backward;
+	}
+
+	return SelectionDirection.Forward;
+}
+
+/**
+ * Compare two WPBlockSelection objects by value.
+ *
+ * @param a - First selection.
+ * @param b - Second selection.
+ * @return True if all fields are equal.
+ */
+function areBlockSelectionsEqual(
+	a: WPBlockSelection,
+	b: WPBlockSelection
+): boolean {
+	return (
+		a.clientId === b.clientId &&
+		a.attributeKey === b.attributeKey &&
+		a.offset === b.offset
+	);
+}

--- a/packages/core-data/src/awareness/selection/create-selection-subscription.ts
+++ b/packages/core-data/src/awareness/selection/create-selection-subscription.ts
@@ -8,6 +8,7 @@ import type { Y } from '@wordpress/sync';
  */
 import { createBlockSelectionSubscription } from './create-block-selection-subscription';
 import { createTitleSelectionSubscription } from './create-title-selection-subscription';
+import { SelectionType } from '../../utils/crdt-user-selections';
 import type { SelectionState } from '../../types';
 
 /**
@@ -28,15 +29,37 @@ export function createSelectionSubscription(
 	postId: number,
 	onSelectionChange: ( selectionState: SelectionState ) => void
 ): { unsubscribe: () => void } {
+	// Coordinates the two sources so that a block "none" event (which fires
+	// when the block editor clears its selection) does not overwrite an active
+	// title selection. When clicking from a block into the title, the sequence
+	// is: title fires -> block clears to "none". Without this guard the
+	// trailing "none" would clobber the title cursor.
+	let titleIsActive = false;
+
 	const blockSub = createBlockSelectionSubscription(
 		doc,
 		kind,
 		name,
 		postId,
-		onSelectionChange
+		( selectionState ) => {
+			if ( selectionState.type === SelectionType.None && titleIsActive ) {
+				// The block editor cleared its selection after the title
+				// became active. Ignore this so the title cursor persists.
+				return;
+			}
+
+			titleIsActive = false;
+			onSelectionChange( selectionState );
+		}
 	);
 
-	const titleSub = createTitleSelectionSubscription( doc, onSelectionChange );
+	const titleSub = createTitleSelectionSubscription(
+		doc,
+		( selectionState ) => {
+			titleIsActive = true;
+			onSelectionChange( selectionState );
+		}
+	);
 
 	return {
 		unsubscribe: () => {

--- a/packages/core-data/src/awareness/selection/create-selection-subscription.ts
+++ b/packages/core-data/src/awareness/selection/create-selection-subscription.ts
@@ -8,7 +8,7 @@ import type { Y } from '@wordpress/sync';
  */
 import { createBlockSelectionSubscription } from './create-block-selection-subscription';
 import { createTitleSelectionSubscription } from './create-title-selection-subscription';
-import { SelectionType } from '../../utils/crdt-user-selections';
+import { SelectionType } from '../../types';
 import type { SelectionState } from '../../types';
 
 /**

--- a/packages/core-data/src/awareness/selection/create-selection-subscription.ts
+++ b/packages/core-data/src/awareness/selection/create-selection-subscription.ts
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import type { Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import { createBlockSelectionSubscription } from './create-block-selection-subscription';
+import { createTitleSelectionSubscription } from './create-title-selection-subscription';
+import type { SelectionState } from '../../types';
+
+/**
+ * Creates a combined subscription that observes both block and title selection
+ * changes and forwards the latest SelectionState to a single callback.
+ *
+ * @param doc               - The Yjs document.
+ * @param kind              - Entity kind (e.g. 'postType').
+ * @param name              - Entity name (e.g. 'post').
+ * @param postId            - The post ID.
+ * @param onSelectionChange - Single callback for any selection change.
+ * @return An object with an unsubscribe method to tear down both subscriptions.
+ */
+export function createSelectionSubscription(
+	doc: Y.Doc,
+	kind: string,
+	name: string,
+	postId: number,
+	onSelectionChange: ( selectionState: SelectionState ) => void
+): { unsubscribe: () => void } {
+	const blockSub = createBlockSelectionSubscription(
+		doc,
+		kind,
+		name,
+		postId,
+		onSelectionChange
+	);
+
+	const titleSub = createTitleSelectionSubscription( doc, onSelectionChange );
+
+	return {
+		unsubscribe: () => {
+			blockSub.unsubscribe();
+			titleSub.unsubscribe();
+		},
+	};
+}

--- a/packages/core-data/src/awareness/selection/create-title-selection-subscription.ts
+++ b/packages/core-data/src/awareness/selection/create-title-selection-subscription.ts
@@ -1,0 +1,169 @@
+/**
+ * WordPress dependencies
+ */
+import { select, subscribe } from '@wordpress/data';
+import { Y } from '@wordpress/sync';
+// @ts-ignore No exported types for block editor store selectors.
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS } from '../config';
+import { CRDT_RECORD_MAP_KEY } from '../../sync';
+import { SelectionType } from '../../utils/crdt-user-selections';
+import { getRootMap } from '../../utils/crdt-utils';
+
+import { SelectionDirection } from '../../types';
+import type { SelectionState } from '../../types';
+import type { YPostRecord } from '../../utils/crdt';
+
+/**
+ * Creates a subscription to title selection changes from the block-editor store.
+ *
+ * Debounces before creating Y.RelativePositions so that the Y.Text has time
+ * to reflect the corresponding content change (which propagates via
+ * mergeRichTextUpdate slightly after the selection change).
+ *
+ * @param doc               - The Yjs document for creating relative positions.
+ * @param onSelectionChange - Callback invoked with the new SelectionState after debounce.
+ * @return An object with an unsubscribe method to tear down the subscription.
+ */
+export function createTitleSelectionSubscription(
+	doc: Y.Doc,
+	onSelectionChange: ( selectionState: SelectionState ) => void
+): { unsubscribe: () => void } {
+	let prevTitleSelection: {
+		start: number | null;
+		end: number | null;
+	} | null = null;
+
+	let localCursorTimeout: NodeJS.Timeout | null = null;
+
+	const unsubscribeFromStore = subscribe( () => {
+		const { getTitleSelection } = select( blockEditorStore );
+		const titleSelection = getTitleSelection();
+
+		if ( titleSelection === prevTitleSelection ) {
+			return;
+		}
+		const prev = prevTitleSelection;
+		prevTitleSelection = titleSelection ?? null;
+
+		// Cancel any pending debounce to prevent it from overwriting
+		// this title selection.
+		if ( localCursorTimeout ) {
+			clearTimeout( localCursorTimeout );
+			localCursorTimeout = null;
+		}
+
+		if (
+			! titleSelection ||
+			titleSelection.start === null ||
+			typeof titleSelection.start !== 'number'
+		) {
+			// Title selection cleared or invalid — the block subscription
+			// will pick up any new block selection, so do nothing here.
+			return;
+		}
+
+		// Debounce: when the user types, the selection change fires
+		// before the Y.Text content update (which goes through
+		// mergeRichTextUpdate). Creating a Y.RelativePosition against
+		// stale text produces an off-by-one. The short delay lets the
+		// Y.Text update settle first.
+		localCursorTimeout = setTimeout( () => {
+			const ymap = getRootMap< YPostRecord >( doc, CRDT_RECORD_MAP_KEY );
+			const titleYText = ymap.get( 'title' );
+
+			if ( ! ( titleYText instanceof Y.Text ) ) {
+				return;
+			}
+
+			const { start, end } = titleSelection;
+
+			let selectionState: SelectionState;
+
+			if ( end === null || start === end ) {
+				// Cursor only.
+				const relativePosition = Y.createRelativePositionFromTypeIndex(
+					titleYText,
+					start
+				);
+				selectionState = {
+					type: SelectionType.Title,
+					cursorPosition: {
+						relativePosition,
+						absoluteOffset: start,
+					},
+				};
+			} else {
+				// Text selection in title.
+				const startRelPos = Y.createRelativePositionFromTypeIndex(
+					titleYText,
+					start
+				);
+				const endRelPos = Y.createRelativePositionFromTypeIndex(
+					titleYText,
+					end
+				);
+
+				const selectionDirection = detectTitleSelectionDirection(
+					prev,
+					titleSelection
+				);
+
+				selectionState = {
+					type: SelectionType.Title,
+					cursorPosition: {
+						relativePosition: startRelPos,
+						absoluteOffset: start,
+					},
+					cursorEndPosition: {
+						relativePosition: endRelPos,
+						absoluteOffset: end,
+					},
+					selectionDirection,
+				};
+			}
+
+			onSelectionChange( selectionState );
+		}, LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS );
+	} );
+
+	return {
+		unsubscribe: () => {
+			unsubscribeFromStore();
+			if ( localCursorTimeout ) {
+				clearTimeout( localCursorTimeout );
+				localCursorTimeout = null;
+			}
+		},
+	};
+}
+
+/**
+ * Detect the direction of a title selection change by comparing which edge
+ * moved relative to the previous selection.
+ *
+ * @param prev       - The previous title selection offsets, or null.
+ * @param next       - The new title selection offsets.
+ * @param next.start
+ * @param next.end
+ * @return The detected direction, defaulting to Forward when indeterminate.
+ */
+function detectTitleSelectionDirection(
+	prev: { start: number | null; end: number | null } | null,
+	next: { start: number | null; end: number | null }
+): SelectionDirection {
+	if ( prev && prev.start !== null && prev.end !== null ) {
+		const startMoved = prev.start !== next.start;
+		const endMoved = prev.end !== next.end;
+
+		if ( startMoved && ! endMoved ) {
+			return SelectionDirection.Backward;
+		}
+	}
+
+	return SelectionDirection.Forward;
+}

--- a/packages/core-data/src/awareness/selection/create-title-selection-subscription.ts
+++ b/packages/core-data/src/awareness/selection/create-title-selection-subscription.ts
@@ -11,10 +11,8 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 import { LOCAL_CURSOR_UPDATE_DEBOUNCE_IN_MS } from '../config';
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
-import { SelectionType } from '../../utils/crdt-user-selections';
 import { getRootMap } from '../../utils/crdt-utils';
-
-import { SelectionDirection } from '../../types';
+import { SelectionDirection, SelectionType } from '../../types';
 import type { SelectionState } from '../../types';
 import type { YPostRecord } from '../../utils/crdt';
 

--- a/packages/core-data/src/awareness/test/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/test/post-editor-awareness.ts
@@ -8,7 +8,7 @@ import { dispatch, select, subscribe, resolveSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { PostEditorAwareness } from '../post-editor-awareness';
-import { SelectionType } from '../../utils/crdt-user-selections';
+import { SelectionType } from '../../types';
 import type {
 	SelectionNone,
 	SelectionCursor,

--- a/packages/core-data/src/awareness/test/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/test/post-editor-awareness.ts
@@ -13,6 +13,7 @@ import type {
 	SelectionNone,
 	SelectionCursor,
 	SelectionWholeBlock,
+	ResolvedBlockSelection,
 } from '../../types';
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
 import type { CollaboratorInfo } from '../types';
@@ -88,7 +89,7 @@ function mockBlockEditorStore( overrides: MockBlockEditorOverrides = {} ) {
 		overrides.getBlocks ??
 		jest.fn().mockReturnValue( overrides.blocks ?? defaultBlocks );
 
-	( select as jest.Mock ).mockReturnValue( {
+	const blockEditorSelectors = {
 		getSelectionStart:
 			overrides.getSelectionStart ?? jest.fn().mockReturnValue( {} ),
 		getSelectionEnd:
@@ -102,7 +103,10 @@ function mockBlockEditorStore( overrides: MockBlockEditorOverrides = {} ) {
 			.fn()
 			.mockReturnValue( overrides.getBlockName ?? 'core/paragraph' ),
 		getBlocks,
-	} );
+		getTitleSelection: jest.fn().mockReturnValue( undefined ),
+	};
+
+	( select as jest.Mock ).mockReturnValue( blockEditorSelectors );
 
 	return { getBlocks };
 }
@@ -168,6 +172,7 @@ function createTestDocWithBlocks( blocks?: Y.Map< any >[] ) {
 describe( 'PostEditorAwareness', () => {
 	let doc: Y.Doc;
 	let subscribeCallback: ( () => void ) | null = null;
+	let subscribeCallbacks: ( () => void )[] = [];
 	let mockEditEntityRecord: jest.Mock;
 
 	beforeEach( () => {
@@ -182,9 +187,15 @@ describe( 'PostEditorAwareness', () => {
 
 		mockBlockEditorStore();
 
-		// Mock subscribe to capture the callback
+		// Mock subscribe to capture callbacks.
+		// The first subscription is for block selections, the second for title.
+		subscribeCallbacks = [];
 		( subscribe as jest.Mock ).mockImplementation( ( callback ) => {
-			subscribeCallback = callback;
+			subscribeCallbacks.push( callback );
+			// Keep subscribeCallback pointing to the first (block) subscription.
+			if ( ! subscribeCallback ) {
+				subscribeCallback = callback;
+			}
 			return jest.fn(); // unsubscribe
 		} );
 
@@ -204,6 +215,7 @@ describe( 'PostEditorAwareness', () => {
 		jest.useRealTimers();
 		jest.restoreAllMocks();
 		subscribeCallback = null;
+		subscribeCallbacks = [];
 		doc.destroy();
 	} );
 
@@ -241,8 +253,9 @@ describe( 'PostEditorAwareness', () => {
 			awareness.setUp();
 			awareness.setUp();
 
-			// Subscribe should only be called once
-			expect( subscribe ).toHaveBeenCalledTimes( 1 );
+			// Subscribe should only be called once per subscription
+			// (block selection + title selection = 2 subscriptions)
+			expect( subscribe ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		test( 'should subscribe to selection changes', () => {
@@ -457,7 +470,9 @@ describe( 'PostEditorAwareness', () => {
 
 			// Should return nulls when the relative position's type cannot be found
 			expect( result.textIndex ).toBeNull();
-			expect( result.localClientId ).toBeNull();
+			expect(
+				( result as ResolvedBlockSelection ).localClientId
+			).toBeNull();
 		} );
 
 		test( 'should return text index and block client ID for valid cursor selection', () => {
@@ -495,7 +510,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBe( 5 );
-			expect( result.localClientId ).toBe( 'block-1' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'block-1'
+			);
 		} );
 
 		test( 'should resolve WholeBlock selection to block client ID', () => {
@@ -527,7 +544,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBeNull();
-			expect( result.localClientId ).toBe( 'block-1' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'block-1'
+			);
 		} );
 	} );
 
@@ -733,7 +752,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBe( 2 );
-			expect( result.localClientId ).toBe( 'local-2' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-2'
+			);
 
 			nestedDoc.destroy();
 		} );
@@ -806,7 +827,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBe( 5 );
-			expect( result.localClientId ).toBe( 'local-inner-1' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-inner-1'
+			);
 
 			nestedDoc.destroy();
 		} );
@@ -861,7 +884,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBeNull();
-			expect( result.localClientId ).toBe( 'local-img' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-img'
+			);
 
 			nestedDoc.destroy();
 		} );
@@ -955,7 +980,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBe( 7 );
-			expect( result.localClientId ).toBe( 'local-deep-1' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-deep-1'
+			);
 
 			nestedDoc.destroy();
 		} );
@@ -1057,7 +1084,9 @@ describe( 'PostEditorAwareness', () => {
 
 			expect( result.textIndex ).toBe( 4 );
 			// Should resolve to the post-content inner block, not a template block
-			expect( result.localClientId ).toBe( 'local-para-1' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-para-1'
+			);
 			// Verify getBlocks was called with the post-content clientId
 			expect( mockGetBlocks ).toHaveBeenCalledWith( postContentClientId );
 
@@ -1128,7 +1157,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBeNull();
-			expect( result.localClientId ).toBe( 'local-img' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-img'
+			);
 
 			templateDoc.destroy();
 		} );
@@ -1177,7 +1208,9 @@ describe( 'PostEditorAwareness', () => {
 				awareness.convertSelectionStateToAbsolute( selection );
 
 			expect( result.textIndex ).toBe( 3 );
-			expect( result.localClientId ).toBe( 'local-para' );
+			expect( ( result as ResolvedBlockSelection ).localClientId ).toBe(
+				'local-para'
+			);
 
 			normalDoc.destroy();
 		} );

--- a/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
@@ -16,7 +16,7 @@ import {
 	useOnPostSave,
 } from '../use-post-editor-awareness-state';
 import { getSyncManager } from '../../sync';
-import { SelectionType } from '../../utils/crdt-user-selections';
+import { SelectionType } from '../../types';
 import type {
 	PostEditorAwarenessState,
 	YDocDebugData,

--- a/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
@@ -293,6 +293,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 			};
 
 			expect( result.current( mockSelection ) ).toEqual( {
+				type: 'block',
 				textIndex: null,
 				localClientId: null,
 			} );
@@ -307,6 +308,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 				},
 			};
 			mockAwareness.convertSelectionStateToAbsolute.mockReturnValue( {
+				type: 'block',
 				textIndex: 10,
 				localClientId: 'block-1',
 			} );
@@ -321,6 +323,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 				mockAwareness.convertSelectionStateToAbsolute
 			).toHaveBeenCalledWith( mockSelection );
 			expect( position ).toEqual( {
+				type: 'block',
 				textIndex: 10,
 				localClientId: 'block-1',
 			} );

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -25,6 +25,7 @@ interface AwarenessState {
 }
 
 const defaultResolvedSelection: ResolvedSelection = {
+	type: 'block',
 	textIndex: null,
 	localClientId: null,
 };

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -137,8 +137,7 @@ register( store ); // Register store after unlocking private selectors to allow 
  * Enums cannot be exported private without losing the ability to narrow types
  * based on their values (they blur to string type).
  */
-export { SelectionType } from './utils/crdt-user-selections';
-export { SelectionDirection } from './types';
+export { SelectionType, SelectionDirection } from './types';
 
 export { default as EntityProvider } from './entity-provider';
 export * from './entity-provider';

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -119,14 +119,33 @@ export type SelectionWholeBlock = {
 	blockPosition: Y.RelativePosition;
 };
 
+export type SelectionInTitle = {
+	// The user has a cursor or text selection in the post title.
+	// The title Y.Text lives directly on the root YPostRecord map,
+	// not inside a block's attributes map.
+	type: SelectionType.Title;
+	cursorPosition: CursorPosition;
+	cursorEndPosition?: CursorPosition;
+	selectionDirection?: SelectionDirection;
+};
+
 export type SelectionState =
 	| SelectionNone
 	| SelectionCursor
 	| SelectionInOneBlock
 	| SelectionInMultipleBlocks
-	| SelectionWholeBlock;
+	| SelectionWholeBlock
+	| SelectionInTitle;
 
-export interface ResolvedSelection {
+export interface ResolvedBlockSelection {
+	type: 'block';
 	textIndex: number | null;
 	localClientId: string | null;
 }
+
+export interface ResolvedTitleSelection {
+	type: 'title';
+	textIndex: number | null;
+}
+
+export type ResolvedSelection = ResolvedBlockSelection | ResolvedTitleSelection;

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -3,11 +3,6 @@
  */
 import type { Y } from '@wordpress/sync';
 
-/**
- * Internal dependencies
- */
-import type { SelectionType } from './utils/crdt-user-selections';
-
 export interface AnyFunction {
 	( ...args: any[] ): any;
 }
@@ -74,6 +69,18 @@ export enum SelectionDirection {
 	Forward = 'f',
 	/** The caret is at the start of the selection (right-to-left). */
 	Backward = 'b',
+}
+
+/**
+ * The type of selection.
+ */
+export enum SelectionType {
+	None = 'none',
+	Cursor = 'cursor',
+	SelectionInOneBlock = 'selection-in-one-block',
+	SelectionInMultipleBlocks = 'selection-in-multiple-blocks',
+	WholeBlock = 'whole-block',
+	Title = 'title',
 }
 
 export type SelectionNone = {

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -23,6 +23,7 @@ import {
 	type SelectionInOneBlock,
 	type SelectionInMultipleBlocks,
 	type SelectionWholeBlock,
+	type SelectionInTitle,
 	type CursorPosition,
 } from '../types';
 
@@ -35,6 +36,7 @@ export enum SelectionType {
 	SelectionInOneBlock = 'selection-in-one-block',
 	SelectionInMultipleBlocks = 'selection-in-multiple-blocks',
 	WholeBlock = 'whole-block',
+	Title = 'title',
 }
 
 /**
@@ -348,6 +350,30 @@ export function areSelectionsStatesEqual(
 				selection1.blockPosition,
 				( selection2 as SelectionWholeBlock ).blockPosition
 			);
+
+		case SelectionType.Title: {
+			const sel2Title = selection2 as SelectionInTitle;
+			const cursorEqual = areCursorPositionsEqual(
+				selection1.cursorPosition,
+				sel2Title.cursorPosition
+			);
+			if ( ! cursorEqual ) {
+				return false;
+			}
+			if ( selection1.cursorEndPosition && sel2Title.cursorEndPosition ) {
+				return (
+					areCursorPositionsEqual(
+						selection1.cursorEndPosition,
+						sel2Title.cursorEndPosition
+					) &&
+					selection1.selectionDirection ===
+						sel2Title.selectionDirection
+				);
+			}
+			return (
+				! selection1.cursorEndPosition && ! sel2Title.cursorEndPosition
+			);
+		}
 
 		default:
 			return false;

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -13,31 +13,20 @@ import { CRDT_RECORD_MAP_KEY } from '../sync';
 import type { YPostRecord } from './crdt';
 import type { YBlock, YBlocks } from './crdt-blocks';
 import { getRootMap } from './crdt-utils';
-import type { SelectionDirection } from '../types';
 import {
+	SelectionType,
 	type AbsoluteBlockIndexPath,
-	type WPBlockSelection,
-	type SelectionState,
-	type SelectionNone,
-	type SelectionCursor,
-	type SelectionInOneBlock,
-	type SelectionInMultipleBlocks,
-	type SelectionWholeBlock,
-	type SelectionInTitle,
 	type CursorPosition,
+	type SelectionCursor,
+	type SelectionDirection,
+	type SelectionInMultipleBlocks,
+	type SelectionInOneBlock,
+	type SelectionInTitle,
+	type SelectionNone,
+	type SelectionState,
+	type SelectionWholeBlock,
+	type WPBlockSelection,
 } from '../types';
-
-/**
- * The type of selection.
- */
-export enum SelectionType {
-	None = 'none',
-	Cursor = 'cursor',
-	SelectionInOneBlock = 'selection-in-one-block',
-	SelectionInMultipleBlocks = 'selection-in-multiple-blocks',
-	WholeBlock = 'whole-block',
-	Title = 'title',
-}
 
 /**
  * Converts WordPress block editor selection to a SelectionState.

--- a/packages/core-data/src/utils/test/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/test/crdt-user-selections.ts
@@ -10,8 +10,8 @@ import { select } from '@wordpress/data';
 import {
 	areSelectionsStatesEqual,
 	getSelectionState,
-	SelectionType,
 } from '../crdt-user-selections';
+import { SelectionType } from '../../types';
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
 
 jest.mock( '@wordpress/data', () => ( {

--- a/packages/editor/src/components/collaborators-overlay/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/compute-selection.ts
@@ -2,6 +2,7 @@ import { SelectionDirection, SelectionType } from '@wordpress/core-data';
 import type {
 	ResolvedSelection,
 	ResolvedBlockSelection,
+	SelectionInTitle,
 } from '@wordpress/core-data';
 
 import {
@@ -154,7 +155,7 @@ function computeTitleCursorOnly(
  * @param overlayContext
  */
 function computeTitleTextSelection(
-	selection: any,
+	selection: SelectionInTitle,
 	start: ResolvedSelection,
 	end: ResolvedSelection,
 	overlayContext: OverlayContext

--- a/packages/editor/src/components/collaborators-overlay/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/compute-selection.ts
@@ -1,5 +1,8 @@
 import { SelectionDirection, SelectionType } from '@wordpress/core-data';
-import type { ResolvedSelection } from '@wordpress/core-data';
+import type {
+	ResolvedSelection,
+	ResolvedBlockSelection,
+} from '@wordpress/core-data';
 
 import {
 	getCursorPosition,
@@ -58,6 +61,20 @@ export function computeSelectionVisual(
 		return {};
 	}
 
+	if ( selection.type === SelectionType.Title ) {
+		if ( ! end ) {
+			// Cursor only in title.
+			return computeTitleCursorOnly( start, overlayContext );
+		}
+		// Text selection in title.
+		return computeTitleTextSelection(
+			selection,
+			start,
+			end,
+			overlayContext
+		);
+	}
+
 	if ( selection.type === SelectionType.Cursor ) {
 		return computeCursorOnly( start, overlayContext );
 	}
@@ -80,7 +97,7 @@ function computeCursorOnly(
 	start: ResolvedSelection,
 	overlayContext: OverlayContext
 ): SelectionVisual {
-	if ( ! start.localClientId ) {
+	if ( start.type !== 'block' || ! start.localClientId ) {
 		return {};
 	}
 	const blockElement =
@@ -91,6 +108,95 @@ function computeCursorOnly(
 		coords: getCursorPosition(
 			start.textIndex,
 			blockElement,
+			overlayContext.editorDocument,
+			overlayContext.overlayRect
+		),
+	};
+}
+
+/**
+ * Find the title DOM element in the editor document.
+ * @param overlayContext
+ */
+function findTitleElement(
+	overlayContext: OverlayContext
+): HTMLElement | null {
+	return overlayContext.editorDocument.querySelector< HTMLElement >(
+		'[data-post-title]'
+	);
+}
+
+/**
+ * Compute cursor coordinates for a cursor in the post title.
+ * @param start
+ * @param overlayContext
+ */
+function computeTitleCursorOnly(
+	start: ResolvedSelection,
+	overlayContext: OverlayContext
+): SelectionVisual {
+	const titleElement = findTitleElement( overlayContext );
+	return {
+		coords: getCursorPosition(
+			start.textIndex,
+			titleElement,
+			overlayContext.editorDocument,
+			overlayContext.overlayRect
+		),
+	};
+}
+
+/**
+ * Compute cursor coordinates and selection rects for a text selection in the title.
+ * @param selection
+ * @param start
+ * @param end
+ * @param overlayContext
+ */
+function computeTitleTextSelection(
+	selection: any,
+	start: ResolvedSelection,
+	end: ResolvedSelection,
+	overlayContext: OverlayContext
+): SelectionVisual {
+	if ( start.textIndex === null || end.textIndex === null ) {
+		return {};
+	}
+
+	const titleElement = findTitleElement( overlayContext );
+	if ( ! titleElement ) {
+		return {};
+	}
+
+	const isReverse =
+		selection.selectionDirection === SelectionDirection.Backward;
+	const activeEnd = isReverse ? start : end;
+
+	const rects =
+		getSelectionRects(
+			titleElement,
+			start.textIndex,
+			end.textIndex,
+			overlayContext.editorDocument,
+			overlayContext.overlayRect
+		) ?? [];
+
+	if ( rects.length > 0 ) {
+		return {
+			coords: getCursorPosition(
+				activeEnd.textIndex,
+				titleElement,
+				overlayContext.editorDocument,
+				overlayContext.overlayRect
+			),
+			selectionRects: rects,
+		};
+	}
+
+	return {
+		coords: getCursorPosition(
+			start.textIndex,
+			titleElement,
 			overlayContext.editorDocument,
 			overlayContext.overlayRect
 		),
@@ -114,6 +220,8 @@ function computeTextSelection(
 	overlayContext: OverlayContext
 ): SelectionVisual {
 	if (
+		start.type !== 'block' ||
+		end.type !== 'block' ||
 		! start.localClientId ||
 		! end.localClientId ||
 		start.textIndex === null ||
@@ -181,8 +289,8 @@ function computeTextSelection(
  * @return Array of selection rectangles.
  */
 function computeSingleBlockRects(
-	start: ResolvedSelection,
-	end: ResolvedSelection,
+	start: ResolvedBlockSelection,
+	end: ResolvedBlockSelection,
 	overlayContext: OverlayContext
 ): SingleBlockResult {
 	const blockElement =
@@ -221,8 +329,8 @@ function computeSingleBlockRects(
  * @return Array of selection rectangles.
  */
 function computeMultiBlockRects(
-	start: ResolvedSelection,
-	end: ResolvedSelection,
+	start: ResolvedBlockSelection,
+	end: ResolvedBlockSelection,
 	overlayContext: OverlayContext
 ): MultiBlockResult {
 	let docFirst = start;

--- a/packages/editor/src/components/collaborators-overlay/use-block-highlighting.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-block-highlighting.ts
@@ -90,11 +90,14 @@ export function useBlockHighlighting(
 				return ! userState.isMe && isWholeBlockSelected;
 			} )
 			.map( ( userState ) => {
-				let localClientId;
+				let localClientId: string | null = null;
 				try {
-					( { localClientId } = resolveSelection(
+					const resolved = resolveSelection(
 						userState.editorState?.selection
-					) );
+					);
+					if ( resolved.type === 'block' ) {
+						localClientId = resolved.localClientId;
+					}
 				} catch {
 					return null;
 				}

--- a/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
@@ -102,12 +102,26 @@ export function useRenderCursors(
 			};
 
 			let start: ResolvedSelection = {
+				type: 'block',
 				textIndex: null,
 				localClientId: null,
 			};
 			let end: ResolvedSelection | undefined;
 
-			if ( selection.type === SelectionType.Cursor ) {
+			if ( selection.type === SelectionType.Title ) {
+				try {
+					start = resolveSelection( selection );
+					if ( selection.cursorEndPosition ) {
+						end = resolveSelection( {
+							type: SelectionType.Title,
+							cursorPosition: selection.cursorEndPosition,
+						} );
+					}
+				} catch {
+					// Selection may reference a stale Yjs position.
+					return;
+				}
+			} else if ( selection.type === SelectionType.Cursor ) {
 				try {
 					start = resolveSelection( selection );
 				} catch {

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -57,8 +57,12 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 
 	const [ selection, setSelection ] = useState( {} );
 
-	const { clearSelectedBlock, insertBlocks, insertDefaultBlock } =
-		useDispatch( blockEditorStore );
+	const {
+		clearSelectedBlock,
+		insertBlocks,
+		insertDefaultBlock,
+		setTitleSelection,
+	} = useDispatch( blockEditorStore );
 
 	const decodedPlaceholder =
 		decodeEntities( placeholder ) || __( 'Add title' );
@@ -86,6 +90,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 					end: newEnd,
 				};
 			} );
+			setTitleSelection( newStart, newEnd );
 		},
 		__unstableDisableFormats: false,
 	} );
@@ -102,6 +107,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 	function onUnselect() {
 		setIsSelected( false );
 		setSelection( {} );
+		setTitleSelection( null, null );
 	}
 
 	function onEnterPress() {
@@ -189,6 +195,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 			aria-label={ decodedPlaceholder }
 			role="textbox"
 			aria-multiline="true"
+			data-post-title=""
 			onFocus={ onSelect }
 			onBlur={ onUnselect }
 			onKeyDown={ onKeyDown }


### PR DESCRIPTION
## What?

Closes #75304.

Adds post title awareness in real-time collaboration. Previously, collaborator cursors were only shown when editing blocks and hidden in the title. Now when a collaborator clicks into or selects text in the post title, other users can see their cursor position and text selection:

https://github.com/user-attachments/assets/49668bae-799f-4536-9e53-194d9158c61a

## Why?

The existing awareness system only tracked block selections. The post title lives outside the block tree, so it was invisible to the typical `getSelection` methods. This meant collaborators couldn't see when others were working in the title.

## How?

To start, this PR introduces a new `titleSelection` selection type in the block-editor store. `getSelectionStart()`/`getSelectionEnd()` are exposed in the block-editor store, but there's no similar subscription available for selection changes in the post title, as it's stored separately in the `<PostTitle>` component.

This is probably the change that should be scrutinized most. "Post Title" may not be a block editor concern, but we already have block selections in the same API so it seems strange to put it elsewhere. This could have been exposed through private APIs, but I think it makes sense as a public pairing to block selection. I'd also be interested in the idea of combining them, although post title selections don't have the same shape as a `WPBlockSelection` due to lack of `attributeKey` and `clientId` unless we use magic string values.

---

The complex block selection subscribe/debounce/announce in `PostEditorAwareness` was refactored. Now, `createSelectionSubscription()` composes both block selections and title selections and `PostEditorAwareness` is in charge of announcements on change.

Added some additional types for the new selection (`SelectionInTitle` and `ResolvedTitleSelection`), as title selections are a different shape without block client IDs and attributes. `computeSelectionVisual()` in the drawing code now also handles title cursors. The `[data-post-title]` attribute was purposefully added to the `<PostTitle>` component to help with cursor positioning for drawing the cursor and highlights, since we no longer have a block `clientId`.

## Testing Instructions

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
1. Open a post in two tabs.
2. As User 1, click into the post title.
3. Confirm that User 2 sees User 1's cursor in the title at the correct position.
4. As User 1, select a portion of the title text.
5. Verify that User 2 sees the selection highlight in the title, as well as the cursor on the correct side of the selection.
6. As User 1, click into a block in the post body.
7. Verify that the title selection disappears and the block cursor appears instead.
8. As User 1, click back into the title and verify the cursor reappears in the title.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Coding the feature. Manually reviewed and guided.