### PR TITLE
Admin UI: Update Page background color

### DIFF
--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -1,7 +1,10 @@
 .admin-ui-page {
 	display: flex;
 	height: 100%;
-	background-color: var(--wpds-color-bg-surface-neutral);
+	// @TODO: Revisit page background color. Consider using
+	// --wpds-color-bg-surface-neutral once existing pages (e.g. Styles)
+	// are updated to handle the contrast change.
+	background-color: var(--wpds-color-bg-surface-neutral-strong);
 	color: var(--wpds-color-fg-content-neutral);
 	position: relative;
 	z-index: 1;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -4,6 +4,7 @@
 	// @TODO: Revisit page background color. Consider using
 	// --wpds-color-bg-surface-neutral once existing pages (e.g. Styles)
 	// are updated to handle the contrast change.
+	// See https://github.com/WordPress/gutenberg/pull/76548
 	background-color: var(--wpds-color-bg-surface-neutral-strong);
 	color: var(--wpds-color-fg-content-neutral);
 	position: relative;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -1,7 +1,7 @@
 .admin-ui-page {
 	display: flex;
 	height: 100%;
-	background-color: var(--wpds-color-bg-surface-neutral-strong);
+	background-color: var(--wpds-color-bg-surface-neutral);
 	color: var(--wpds-color-fg-content-neutral);
 	position: relative;
 	z-index: 1;


### PR DESCRIPTION
See design convo https://github.com/WordPress/gutenberg/issues/76709

Part of https://github.com/WordPress/gutenberg/issues/76448

## What?

Updates the Page component background color from `--wpds-color-bg-surface-neutral-strong` (#ffffff) to `--wpds-color-bg-surface-neutral` (#f8f8f8), giving the page a subtle off-white background instead of pure white.

Before:
<img width="843" height="251" alt="image" src="https://github.com/user-attachments/assets/f5a6c3d4-b985-4150-977b-d221672b18cd" />


After:

<img width="845" height="306" alt="image" src="https://github.com/user-attachments/assets/e20f6c91-bfb8-4dd5-ac7b-5ae29724e2de" />

## Why?

As discussed in https://github.com/WordPress/gutenberg/issues/76448, the page background should not be pure white. The design token currently resolves to `#f8f8f8`; a separate effort to update the token value to `#fcfcfc` is being tracked independently.

## How?

Single token swap in `packages/admin-ui/src/page/style.scss`. The header retains `--wpds-color-bg-surface-neutral-strong` (white) for visual separation.

## Testing Instructions

1. Open any admin page that uses the `Page` component
2. Verify the page background is slightly off-white (#f8f8f8) instead of pure white
3. Verify the header remains white

NOTE: since this PR branches out from #76467 test can be done by running `npm run storybook:dev` and checking the Page component

### Keyboard Testing

No keyboard-specific changes.

---

This PR depends on #76467 for Storybook stories.
Part of #76448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)