### PR TITLE
Revisions: Show changed block attributes in inspector sidebar

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -29,6 +29,22 @@ import { unlock } from '../../lock-unlock';
 const { parseRawBlock } = unlock( blocksPrivateApis );
 
 /**
+ * Safely stringifies a value for display and comparison.
+ *
+ * @param {*} value The value to stringify.
+ * @return {string} The stringified value.
+ */
+function stringifyValue( value ) {
+	if ( value === null || value === undefined ) {
+		return '';
+	}
+	if ( typeof value === 'object' ) {
+		return JSON.stringify( value, null, 2 );
+	}
+	return String( value );
+}
+
+/**
  * Calculate text similarity using word diff (semantically meaningful).
  * Returns ratio of unchanged words to total words.
  *
@@ -65,7 +81,7 @@ function pairSimilarBlocks( blocks ) {
 
 	// Separate blocks by status, tracking original indices.
 	blocks.forEach( ( block, index ) => {
-		const status = block.__revisionDiffStatus;
+		const status = block.__revisionDiffStatus?.status;
 		if ( status === 'removed' ) {
 			removed.push( { block, index } );
 		} else if ( status === 'added' ) {
@@ -120,7 +136,7 @@ function pairSimilarBlocks( blocks ) {
 			// Create modified block with previous content stored.
 			modifications.set( bestMatch.index, {
 				...bestMatch.block,
-				__revisionDiffStatus: 'modified',
+				__revisionDiffStatus: { status: 'modified' },
 				__previousRawBlock: rem.block,
 			} );
 		}
@@ -176,14 +192,14 @@ function diffRawBlocks( currentRaw, previousRaw ) {
 			for ( let i = 0; i < part.count; i++ ) {
 				result.push( {
 					...currentRaw[ currIdx++ ],
-					__revisionDiffStatus: 'added',
+					__revisionDiffStatus: { status: 'added' },
 				} );
 			}
 		} else if ( part.removed ) {
 			for ( let i = 0; i < part.count; i++ ) {
 				result.push( {
 					...previousRaw[ prevIdx++ ],
-					__revisionDiffStatus: 'removed',
+					__revisionDiffStatus: { status: 'removed' },
 				} );
 			}
 		} else {
@@ -481,26 +497,28 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 }
 
 /**
- * Apply rich text diff to all rich-text attributes of a block.
- * Compares each rich-text attribute between current and previous parsed blocks.
+ * Apply diffs to a modified block's attributes.
+ * - Rich-text attributes: applies inline diff formatting (ins/del marks).
+ * - Other attributes: computes word-level diffs for the sidebar panel.
  *
  * @param {Object} currentBlock  Current parsed block.
  * @param {Object} previousBlock Previous parsed block.
+ * @param {Object} diffStatus    The __revisionDiffStatus object to attach changedAttributes to.
  */
-function applyRichTextDiffToBlock( currentBlock, previousBlock ) {
+function applyDiffToBlock( currentBlock, previousBlock, diffStatus ) {
 	const blockType = getBlockType( currentBlock.name );
 	if ( ! blockType ) {
 		return;
 	}
 
-	// Find rich-text attributes and compare
+	const changedAttributes = {};
+
 	for ( const [ attrName, attrDef ] of Object.entries(
 		blockType.attributes
 	) ) {
 		if ( attrDef.source === 'rich-text' ) {
 			const currentRichText = currentBlock.attributes[ attrName ];
 			const previousRichText = previousBlock.attributes[ attrName ];
-
 			if (
 				currentRichText instanceof RichTextData &&
 				previousRichText instanceof RichTextData
@@ -510,7 +528,21 @@ function applyRichTextDiffToBlock( currentBlock, previousBlock ) {
 					previousRichText
 				);
 			}
+		} else {
+			const currStr = stringifyValue(
+				currentBlock.attributes[ attrName ]
+			);
+			const prevStr = stringifyValue(
+				previousBlock.attributes[ attrName ]
+			);
+			if ( currStr !== prevStr ) {
+				changedAttributes[ attrName ] = diffWords( prevStr, currStr );
+			}
 		}
+	}
+
+	if ( Object.keys( changedAttributes ).length > 0 ) {
+		diffStatus.changedAttributes = changedAttributes;
 	}
 }
 
@@ -525,31 +557,25 @@ function applyRichTextDiffToBlock( currentBlock, previousBlock ) {
 function applyDiffRecursively( parsedBlock, rawBlock ) {
 	// Copy diff status from raw block to parsed block.
 	if ( rawBlock.__revisionDiffStatus ) {
-		parsedBlock.__revisionDiffStatus = rawBlock.__revisionDiffStatus;
-		// Store in attributes (as a new object to avoid frozen-object issues)
-		// so it survives store normalization and is accessible via
-		// getSelectedBlock() in the sidebar.
-		parsedBlock.attributes = {
-			...parsedBlock.attributes,
-			__revisionDiffStatus: rawBlock.__revisionDiffStatus,
-		};
-	}
-
-	// Apply rich text diff if this block is modified and has a previous raw block.
-	if (
-		rawBlock.__revisionDiffStatus === 'modified' &&
-		rawBlock.__previousRawBlock
-	) {
-		const previousParsed = parseRawBlock( rawBlock.__previousRawBlock );
-		if ( previousParsed ) {
-			applyRichTextDiffToBlock( parsedBlock, previousParsed );
-			// Store previous attributes (as a new object) so they survive
-			// store normalization and are accessible via getSelectedBlock().
-			parsedBlock.attributes = {
-				...parsedBlock.attributes,
-				__previousAttributes: previousParsed.attributes,
-			};
+		// Apply diffs if this block is modified and has a previous raw block.
+		if (
+			rawBlock.__revisionDiffStatus.status === 'modified' &&
+			rawBlock.__previousRawBlock
+		) {
+			const previousParsed = parseRawBlock( rawBlock.__previousRawBlock );
+			if ( previousParsed ) {
+				applyDiffToBlock(
+					parsedBlock,
+					previousParsed,
+					rawBlock.__revisionDiffStatus
+				);
+			}
 		}
+
+		parsedBlock.__revisionDiffStatus = rawBlock.__revisionDiffStatus;
+		// Also store in attributes so it survives block-editor store normalization.
+		parsedBlock.attributes.__revisionDiffStatus =
+			rawBlock.__revisionDiffStatus;
 	}
 
 	// Recursively process inner blocks.

--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -526,6 +526,13 @@ function applyDiffRecursively( parsedBlock, rawBlock ) {
 	// Copy diff status from raw block to parsed block.
 	if ( rawBlock.__revisionDiffStatus ) {
 		parsedBlock.__revisionDiffStatus = rawBlock.__revisionDiffStatus;
+		// Store in attributes (as a new object to avoid frozen-object issues)
+		// so it survives store normalization and is accessible via
+		// getSelectedBlock() in the sidebar.
+		parsedBlock.attributes = {
+			...parsedBlock.attributes,
+			__revisionDiffStatus: rawBlock.__revisionDiffStatus,
+		};
 	}
 
 	// Apply rich text diff if this block is modified and has a previous raw block.
@@ -536,6 +543,12 @@ function applyDiffRecursively( parsedBlock, rawBlock ) {
 		const previousParsed = parseRawBlock( rawBlock.__previousRawBlock );
 		if ( previousParsed ) {
 			applyRichTextDiffToBlock( parsedBlock, previousParsed );
+			// Store previous attributes (as a new object) so they survive
+			// store normalization and are accessible via getSelectedBlock().
+			parsedBlock.attributes = {
+				...parsedBlock.attributes,
+				__previousAttributes: previousParsed.attributes,
+			};
 		}
 	}
 

--- a/packages/editor/src/components/post-revisions-preview/diff-markers.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-markers.js
@@ -32,10 +32,10 @@ const { useBlockElementRef } = unlock( blockEditorPrivateApis );
 function collectDiffBlocks( blocks ) {
 	const result = [];
 	for ( const block of blocks ) {
-		if ( block.__revisionDiffStatus ) {
+		if ( block.__revisionDiffStatus?.status ) {
 			result.push( {
 				clientId: block.clientId,
-				status: block.__revisionDiffStatus,
+				status: block.__revisionDiffStatus.status,
 			} );
 		}
 		if ( block.innerBlocks?.length ) {

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -95,7 +95,7 @@ const REVISION_DIFF_STYLES = `
 function withRevisionDiffClasses( BlockListBlock ) {
 	return ( props ) => {
 		const { block, className } = props;
-		const diffStatus = block?.__revisionDiffStatus;
+		const diffStatus = block?.__revisionDiffStatus?.status;
 
 		const enhancedClassName = clsx( className, {
 			'is-revision-added': diffStatus === 'added',

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -91,7 +91,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content: 'Hello',
-					__revisionDiffStatus: 'added',
+					__revisionDiffStatus: { status: 'added' },
 				},
 			},
 		] );
@@ -108,7 +108,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content: 'Hello',
-					__revisionDiffStatus: 'removed',
+					__revisionDiffStatus: { status: 'removed' },
 				},
 			},
 		] );
@@ -144,7 +144,9 @@ describe( 'diffRevisionContent', () => {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					__revisionDiffStatus: 'modified',
+					__revisionDiffStatus: {
+						status: 'modified',
+					},
 				},
 			},
 		] );
@@ -167,7 +169,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content: 'NEW',
-					__revisionDiffStatus: 'added',
+					__revisionDiffStatus: { status: 'added' },
 				},
 			},
 			{
@@ -211,14 +213,14 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content: 'First new block',
-					__revisionDiffStatus: 'added',
+					__revisionDiffStatus: { status: 'added' },
 				},
 			},
 			{
 				name: 'core/paragraph',
 				attributes: {
 					content: 'Second new block',
-					__revisionDiffStatus: 'added',
+					__revisionDiffStatus: { status: 'added' },
 				},
 			},
 			{
@@ -227,7 +229,9 @@ describe( 'diffRevisionContent', () => {
 					// Inline diff: "existing" → "modified"
 					content:
 						'This is some <del title="Removed" class="revision-diff-removed">existing</del><ins title="Added" class="revision-diff-added">modified</ins> content',
-					__revisionDiffStatus: 'modified',
+					__revisionDiffStatus: {
+						status: 'modified',
+					},
 				},
 			},
 		] );
@@ -265,7 +269,7 @@ describe( 'diffRevisionContent', () => {
 						name: 'core/paragraph',
 						attributes: {
 							content: 'B',
-							__revisionDiffStatus: 'added',
+							__revisionDiffStatus: { status: 'added' },
 						},
 					},
 				],
@@ -305,7 +309,7 @@ describe( 'diffRevisionContent', () => {
 						name: 'core/paragraph',
 						attributes: {
 							content: 'B',
-							__revisionDiffStatus: 'removed',
+							__revisionDiffStatus: { status: 'removed' },
 						},
 					},
 				],
@@ -342,7 +346,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content: 'Second block content',
-					__revisionDiffStatus: 'added',
+					__revisionDiffStatus: { status: 'added' },
 				},
 			},
 			{
@@ -356,7 +360,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content: 'Second block content',
-					__revisionDiffStatus: 'removed',
+					__revisionDiffStatus: { status: 'removed' },
 				},
 			},
 		] );
@@ -381,7 +385,17 @@ describe( 'diffRevisionContent', () => {
 				attributes: {
 					content: 'Same content',
 					className: 'new-class',
-					__revisionDiffStatus: 'modified',
+					__revisionDiffStatus: {
+						status: 'modified',
+						changedAttributes: {
+							className: [
+								{
+									added: true,
+									value: 'new-class',
+								},
+							],
+						},
+					},
 				},
 			},
 		] );
@@ -410,7 +424,9 @@ describe( 'diffRevisionContent', () => {
 				attributes: {
 					content:
 						'Second block content<ins title="Added" class="revision-diff-added"> modified</ins>',
-					__revisionDiffStatus: 'modified',
+					__revisionDiffStatus: {
+						status: 'modified',
+					},
 				},
 			},
 			{
@@ -466,7 +482,9 @@ describe( 'diffRevisionContent', () => {
 									name: 'core/paragraph',
 									attributes: {
 										content: 'New',
-										__revisionDiffStatus: 'added',
+										__revisionDiffStatus: {
+											status: 'added',
+										},
 									},
 								},
 							],
@@ -490,7 +508,7 @@ describe( 'diffRevisionContent', () => {
 				{
 					name: 'core/group',
 					attributes: {
-						__revisionDiffStatus: 'added',
+						__revisionDiffStatus: { status: 'added' },
 					},
 					innerBlocks: [
 						{
@@ -526,7 +544,7 @@ describe( 'diffRevisionContent', () => {
 				{
 					name: 'core/group',
 					attributes: {
-						__revisionDiffStatus: 'removed',
+						__revisionDiffStatus: { status: 'removed' },
 					},
 					innerBlocks: [
 						{
@@ -577,7 +595,7 @@ describe( 'diffRevisionContent', () => {
 							name: 'core/paragraph',
 							attributes: {
 								content: 'NEW',
-								__revisionDiffStatus: 'added',
+								__revisionDiffStatus: { status: 'added' },
 							},
 						},
 						{
@@ -629,7 +647,9 @@ describe( 'diffRevisionContent', () => {
 						{
 							name: 'core/paragraph',
 							attributes: {
-								__revisionDiffStatus: 'modified',
+								__revisionDiffStatus: {
+									status: 'modified',
+								},
 							},
 						},
 					],
@@ -673,7 +693,7 @@ describe( 'diffRevisionContent', () => {
 							name: 'core/paragraph',
 							attributes: {
 								content: 'C',
-								__revisionDiffStatus: 'removed',
+								__revisionDiffStatus: { status: 'removed' },
 							},
 						},
 						{
@@ -682,7 +702,9 @@ describe( 'diffRevisionContent', () => {
 								// B→D modification with inline diff
 								content:
 									'<del title="Removed" class="revision-diff-removed">B</del><ins title="Added" class="revision-diff-added">D</ins>',
-								__revisionDiffStatus: 'modified',
+								__revisionDiffStatus: {
+									status: 'modified',
+								},
 							},
 						},
 					],
@@ -739,7 +761,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								content:
 									'The quick brown fox jumps over the lazy dog near the riverbank',
-								__revisionDiffStatus: 'removed',
+								__revisionDiffStatus: { status: 'removed' },
 							},
 						},
 						{
@@ -747,7 +769,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								content:
 									'Third paragraph also removed from this post',
-								__revisionDiffStatus: 'removed',
+								__revisionDiffStatus: { status: 'removed' },
 							},
 						},
 						{
@@ -755,7 +777,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								content:
 									'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod',
-								__revisionDiffStatus: 'added',
+								__revisionDiffStatus: { status: 'added' },
 							},
 						},
 					],
@@ -803,7 +825,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'Hello <strong><span title="1 format added" class="revision-diff-format-added">world</span></strong>',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -829,7 +853,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'Hello <strong><del title="Removed" class="revision-diff-removed">world</del><ins title="Added" class="revision-diff-added">everyone</ins></strong>',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -879,7 +905,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'Visit <a href="https://new-site.com"><span title="1 format changed" class="revision-diff-format-changed">our site</span></a> today',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -907,7 +935,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'Visit <a href="https://example.com"><del title="Removed" class="revision-diff-removed">our</del><ins title="Added" class="revision-diff-added">the</ins> <del title="Removed" class="revision-diff-removed">site</del><ins title="Added" class="revision-diff-added">website</ins></a> today',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -955,7 +985,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'<span title="1 format removed" class="revision-diff-format-removed">Bold</span> and <span title="1 format removed" class="revision-diff-format-removed">italic</span> text',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -981,7 +1013,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'Hello <em><span title="1 format added, 1 format removed" class="revision-diff-format-changed">world</span></em>',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -1026,7 +1060,9 @@ describe( 'diffRevisionContent', () => {
 					attributes: {
 						content:
 							'<del title="Removed" class="revision-diff-removed">Hello</del><ins title="Added" class="revision-diff-added">Goodbye</ins> <strong>world</strong>!',
-						__revisionDiffStatus: 'modified',
+						__revisionDiffStatus: {
+							status: 'modified',
+						},
 					},
 				},
 			] );
@@ -1062,7 +1098,9 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								content:
 									'<del title="Removed" class="revision-diff-removed">Hello</del><ins title="Added" class="revision-diff-added">Goodbye</ins> <strong><del title="Removed" class="revision-diff-removed">world</del><ins title="Added" class="revision-diff-added">everyone</ins></strong>',
-								__revisionDiffStatus: 'modified',
+								__revisionDiffStatus: {
+									status: 'modified',
+								},
 							},
 						},
 					],

--- a/packages/editor/src/components/revision-block-diff/index.js
+++ b/packages/editor/src/components/revision-block-diff/index.js
@@ -1,0 +1,187 @@
+/**
+ * External dependencies
+ */
+import { diffWords } from 'diff/lib/diff/word';
+
+/**
+ * WordPress dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { getBlockType } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { RichTextData } from '@wordpress/rich-text';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import PostPanelRow from '../post-panel-row';
+
+// Internal attribute keys injected by the diff pipeline.
+const INTERNAL_KEYS = new Set( [
+	'__revisionDiffStatus',
+	'__previousAttributes',
+] );
+
+/**
+ * Safely stringifies a value for display and comparison.
+ *
+ * @param {*} value The value to stringify.
+ * @return {string} The stringified value.
+ */
+function stringifyValue( value ) {
+	if ( value === null || value === undefined ) {
+		return '';
+	}
+	if ( value instanceof RichTextData ) {
+		return value.toHTMLString();
+	}
+	if ( typeof value === 'string' ) {
+		return value;
+	}
+	return JSON.stringify( value, null, 2 );
+}
+
+/**
+ * Renders a word-level diff between two strings using <ins> and <del> elements.
+ *
+ * @param {Object} props
+ * @param {string} props.from The previous string value.
+ * @param {string} props.to   The current string value.
+ */
+function StringDiff( { from, to } ) {
+	const changes = diffWords( from, to );
+
+	return (
+		<span className="editor-revision-fields-diff__value">
+			{ changes.map( ( part, index ) => {
+				if ( part.added ) {
+					return (
+						<ins
+							key={ index }
+							className="editor-revision-fields-diff__added"
+						>
+							{ part.value }
+						</ins>
+					);
+				}
+				if ( part.removed ) {
+					return (
+						<del
+							key={ index }
+							className="editor-revision-fields-diff__removed"
+						>
+							{ part.value }
+						</del>
+					);
+				}
+				return <span key={ index }>{ part.value }</span>;
+			} ) }
+		</span>
+	);
+}
+
+/**
+ * Returns the set of attribute keys that have `source: 'rich-text'` for a
+ * given block type. These are already diffed inline in the canvas.
+ *
+ * @param {Object|undefined} blockType Block type definition.
+ * @return {Set<string>} Rich-text attribute keys.
+ */
+function getRichTextKeys( blockType ) {
+	const keys = new Set();
+	if ( ! blockType?.attributes ) {
+		return keys;
+	}
+	for ( const [ key, def ] of Object.entries( blockType.attributes ) ) {
+		if ( def.source === 'rich-text' ) {
+			keys.add( key );
+		}
+	}
+	return keys;
+}
+
+/**
+ * Panel that shows changed block attributes for the selected block
+ * when viewing revisions.
+ */
+export default function RevisionBlockDiffPanel() {
+	const { block } = useSelect( ( select ) => {
+		const { getSelectedBlock } = select( blockEditorStore );
+		return {
+			block: getSelectedBlock(),
+		};
+	}, [] );
+
+	if ( ! block ) {
+		return null;
+	}
+
+	const blockType = getBlockType( block.name );
+	const diffStatus = block.attributes?.__revisionDiffStatus;
+	const previousAttrs = block.attributes?.__previousAttributes ?? {};
+	const currentAttrs = block.attributes ?? {};
+	const richTextKeys = getRichTextKeys( blockType );
+
+	// Collect all attribute keys from both sides.
+	const allKeys = new Set( [
+		...Object.keys( currentAttrs ),
+		...Object.keys( previousAttrs ),
+	] );
+
+	const fields = [];
+
+	for ( const key of allKeys ) {
+		// Skip internal diff keys and rich-text attributes (already diffed in canvas).
+		if ( INTERNAL_KEYS.has( key ) || richTextKeys.has( key ) ) {
+			continue;
+		}
+
+		const currStr = stringifyValue( currentAttrs[ key ] );
+		const prevStr = stringifyValue( previousAttrs[ key ] );
+
+		// Only show attributes that actually changed.
+		if ( currStr === prevStr ) {
+			continue;
+		}
+
+		if ( diffStatus === 'added' && currStr ) {
+			fields.push(
+				<PostPanelRow key={ key } label={ key }>
+					<span className="editor-revision-fields-diff__value">
+						<ins className="editor-revision-fields-diff__added">
+							{ currStr }
+						</ins>
+					</span>
+				</PostPanelRow>
+			);
+		} else if ( diffStatus === 'removed' && prevStr ) {
+			fields.push(
+				<PostPanelRow key={ key } label={ key }>
+					<span className="editor-revision-fields-diff__value">
+						<del className="editor-revision-fields-diff__removed">
+							{ prevStr }
+						</del>
+					</span>
+				</PostPanelRow>
+			);
+		} else if ( diffStatus === 'modified' ) {
+			fields.push(
+				<PostPanelRow key={ key } label={ key }>
+					<StringDiff from={ prevStr } to={ currStr } />
+				</PostPanelRow>
+			);
+		}
+	}
+
+	if ( fields.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<PanelBody title={ __( 'Changed attributes' ) } initialOpen>
+			{ fields }
+		</PanelBody>
+	);
+}

--- a/packages/editor/src/components/revision-block-diff/index.js
+++ b/packages/editor/src/components/revision-block-diff/index.js
@@ -1,106 +1,15 @@
 /**
- * External dependencies
- */
-import { diffWords } from 'diff/lib/diff/word';
-
-/**
  * WordPress dependencies
  */
 import { PanelBody } from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { RichTextData } from '@wordpress/rich-text';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import PostPanelRow from '../post-panel-row';
-
-// Internal attribute keys injected by the diff pipeline.
-const INTERNAL_KEYS = new Set( [
-	'__revisionDiffStatus',
-	'__previousAttributes',
-] );
-
-/**
- * Safely stringifies a value for display and comparison.
- *
- * @param {*} value The value to stringify.
- * @return {string} The stringified value.
- */
-function stringifyValue( value ) {
-	if ( value === null || value === undefined ) {
-		return '';
-	}
-	if ( value instanceof RichTextData ) {
-		return value.toHTMLString();
-	}
-	if ( typeof value === 'string' ) {
-		return value;
-	}
-	return JSON.stringify( value, null, 2 );
-}
-
-/**
- * Renders a word-level diff between two strings using <ins> and <del> elements.
- *
- * @param {Object} props
- * @param {string} props.from The previous string value.
- * @param {string} props.to   The current string value.
- */
-function StringDiff( { from, to } ) {
-	const changes = diffWords( from, to );
-
-	return (
-		<span className="editor-revision-fields-diff__value">
-			{ changes.map( ( part, index ) => {
-				if ( part.added ) {
-					return (
-						<ins
-							key={ index }
-							className="editor-revision-fields-diff__added"
-						>
-							{ part.value }
-						</ins>
-					);
-				}
-				if ( part.removed ) {
-					return (
-						<del
-							key={ index }
-							className="editor-revision-fields-diff__removed"
-						>
-							{ part.value }
-						</del>
-					);
-				}
-				return <span key={ index }>{ part.value }</span>;
-			} ) }
-		</span>
-	);
-}
-
-/**
- * Returns the set of attribute keys that have `source: 'rich-text'` for a
- * given block type. These are already diffed inline in the canvas.
- *
- * @param {Object|undefined} blockType Block type definition.
- * @return {Set<string>} Rich-text attribute keys.
- */
-function getRichTextKeys( blockType ) {
-	const keys = new Set();
-	if ( ! blockType?.attributes ) {
-		return keys;
-	}
-	for ( const [ key, def ] of Object.entries( blockType.attributes ) ) {
-		if ( def.source === 'rich-text' ) {
-			keys.add( key );
-		}
-	}
-	return keys;
-}
 
 /**
  * Panel that shows changed block attributes for the selected block
@@ -118,62 +27,44 @@ export default function RevisionBlockDiffPanel() {
 		return null;
 	}
 
-	const blockType = getBlockType( block.name );
-	const diffStatus = block.attributes?.__revisionDiffStatus;
-	const previousAttrs = block.attributes?.__previousAttributes ?? {};
-	const currentAttrs = block.attributes ?? {};
-	const richTextKeys = getRichTextKeys( blockType );
+	const diffInfo = block.attributes?.__revisionDiffStatus;
+	const changedAttributes = diffInfo?.changedAttributes;
 
-	// Collect all attribute keys from both sides.
-	const allKeys = new Set( [
-		...Object.keys( currentAttrs ),
-		...Object.keys( previousAttrs ),
-	] );
-
-	const fields = [];
-
-	for ( const key of allKeys ) {
-		// Skip internal diff keys and rich-text attributes (already diffed in canvas).
-		if ( INTERNAL_KEYS.has( key ) || richTextKeys.has( key ) ) {
-			continue;
-		}
-
-		const currStr = stringifyValue( currentAttrs[ key ] );
-		const prevStr = stringifyValue( previousAttrs[ key ] );
-
-		// Only show attributes that actually changed.
-		if ( currStr === prevStr ) {
-			continue;
-		}
-
-		if ( diffStatus === 'added' && currStr ) {
-			fields.push(
-				<PostPanelRow key={ key } label={ key }>
-					<span className="editor-revision-fields-diff__value">
-						<ins className="editor-revision-fields-diff__added">
-							{ currStr }
-						</ins>
-					</span>
-				</PostPanelRow>
-			);
-		} else if ( diffStatus === 'removed' && prevStr ) {
-			fields.push(
-				<PostPanelRow key={ key } label={ key }>
-					<span className="editor-revision-fields-diff__value">
-						<del className="editor-revision-fields-diff__removed">
-							{ prevStr }
-						</del>
-					</span>
-				</PostPanelRow>
-			);
-		} else if ( diffStatus === 'modified' ) {
-			fields.push(
-				<PostPanelRow key={ key } label={ key }>
-					<StringDiff from={ prevStr } to={ currStr } />
-				</PostPanelRow>
-			);
-		}
+	if ( ! changedAttributes ) {
+		return null;
 	}
+
+	const fields = Object.entries( changedAttributes ).map(
+		( [ key, parts ] ) => (
+			<PostPanelRow key={ key } label={ key }>
+				<span className="editor-revision-fields-diff__value">
+					{ parts.map( ( part, index ) => {
+						if ( part.added ) {
+							return (
+								<ins
+									key={ index }
+									className="editor-revision-fields-diff__added"
+								>
+									{ part.value }
+								</ins>
+							);
+						}
+						if ( part.removed ) {
+							return (
+								<del
+									key={ index }
+									className="editor-revision-fields-diff__removed"
+								>
+									{ part.value }
+								</del>
+							);
+						}
+						return <span key={ index }>{ part.value }</span>;
+					} ) }
+				</span>
+			</PostPanelRow>
+		)
+	);
 
 	if ( fields.length === 0 ) {
 		return null;

--- a/packages/editor/src/components/revision-block-diff/index.js
+++ b/packages/editor/src/components/revision-block-diff/index.js
@@ -66,10 +66,6 @@ export default function RevisionBlockDiffPanel() {
 		)
 	);
 
-	if ( fields.length === 0 ) {
-		return null;
-	}
-
 	return (
 		<PanelBody title={ __( 'Changed attributes' ) } initialOpen>
 			{ fields }

--- a/packages/editor/src/components/revision-block-diff/style.scss
+++ b/packages/editor/src/components/revision-block-diff/style.scss
@@ -1,0 +1,13 @@
+.editor-revision-fields-diff__value {
+	word-break: break-word;
+}
+
+.editor-revision-fields-diff__added {
+	background-color: color-mix(in srgb, currentColor 5%, #00a32a 15%);
+	text-decoration: none;
+}
+
+.editor-revision-fields-diff__removed {
+	text-decoration: line-through;
+	color: #d63638;
+}

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -32,6 +32,7 @@ import SidebarHeader from './header';
 import TemplateContentPanel from '../template-content-panel';
 import TemplatePartContentPanel from '../template-part-content-panel';
 import { MediaMetadataPanel } from '../media';
+import RevisionBlockDiffPanel from '../revision-block-diff';
 import useAutoSwitchEditorSidebars from '../provider/use-auto-switch-editor-sidebars';
 import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
@@ -144,6 +145,7 @@ const SidebarContent = ( {
 				{ ! isAttachment && (
 					<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
 						<BlockInspector />
+						{ isRevisionsMode && <RevisionBlockDiffPanel /> }
 					</Tabs.TabPanel>
 				) }
 			</Tabs.Context.Provider>

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -39,6 +39,7 @@
 @use "./components/post-panel-section/style.scss" as *;
 @use "./components/post-publish-panel/style.scss" as *;
 @use "./components/post-revisions-preview/style.scss" as *;
+@use "./components/revision-block-diff/style.scss" as *;
 @use "./components/post-saved-state/style.scss" as *;
 @use "./components/post-schedule/style.scss" as *;
 @use "./components/post-status/style.scss" as *;

--- a/test/e2e/specs/editor/various/revision-block-diff.spec.js
+++ b/test/e2e/specs/editor/various/revision-block-diff.spec.js
@@ -1,0 +1,151 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Revision Block Diff Panel', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should show changed attributes when alignment changes', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a paragraph with left alignment.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Test paragraph',
+				align: 'left',
+			},
+		} );
+
+		// Save draft to create first revision.
+		await editor.saveDraft();
+
+		// Change alignment to wide.
+		await page.evaluate( () => {
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.updateBlockAttributes( blocks[ 0 ].clientId, {
+					align: 'wide',
+				} );
+		} );
+
+		// Save draft again to create second revision.
+		await editor.saveDraft();
+
+		// Open revisions.
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', { name: '2', exact: true } )
+			.click();
+
+		// Wait for revisions mode.
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// Click on the paragraph block in the revision canvas.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+
+		// Switch to the Block tab in the sidebar.
+		const sidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await sidebar.getByRole( 'tab', { name: 'Block' } ).click();
+
+		// Verify the Changed attributes panel is visible with the align attribute.
+		const panelToggle = sidebar.getByRole( 'button', {
+			name: 'Changed attributes',
+		} );
+		await expect( panelToggle ).toBeVisible();
+		const attributesPanel = panelToggle.locator(
+			'xpath=ancestor::div[contains(@class,"components-panel__body")]'
+		);
+		await expect( attributesPanel.getByText( 'align' ) ).toBeVisible();
+	} );
+
+	test( 'should not show rich-text attributes in the diff panel', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a paragraph.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Original text', dropCap: false },
+		} );
+
+		// Save draft to create first revision.
+		await editor.saveDraft();
+
+		// Change the content and dropCap.
+		await page.evaluate( () => {
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.updateBlockAttributes( blocks[ 0 ].clientId, {
+					content: 'Updated text',
+					dropCap: true,
+				} );
+		} );
+
+		// Save draft again.
+		await editor.saveDraft();
+
+		// Open revisions.
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', { name: '2', exact: true } )
+			.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// Click on the paragraph block.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+
+		// Switch to Block tab.
+		const sidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await sidebar.getByRole( 'tab', { name: 'Block' } ).click();
+
+		// The Changed attributes panel should show dropCap but not content.
+		const panelToggle = sidebar.getByRole( 'button', {
+			name: 'Changed attributes',
+		} );
+		await expect( panelToggle ).toBeVisible();
+		const attributesPanel = panelToggle.locator(
+			'xpath=ancestor::div[contains(@class,"components-panel__body")]'
+		);
+		await expect( attributesPanel.getByText( 'dropCap' ) ).toBeVisible();
+
+		// The "content" rich-text attribute should NOT have its own row label.
+		// PostPanelRow renders the label in a span, so check there's no row for it.
+		await expect(
+			attributesPanel.locator(
+				'.editor-post-panel__row-label:text-is("content")'
+			)
+		).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
## What?

Closes #76359.

<img width="1464" height="960" alt="image" src="https://github.com/user-attachments/assets/3dfd85d3-7a6a-4679-b756-c04b2bd88f01" />


Adds a "Changed attributes" panel to the Block tab in the sidebar when viewing revisions.

## Why?

Rich-text content changes are already diffed inline in the canvas, but non-rich-text attribute changes (e.g. alignment, drop cap, class name) are invisible. This gives users visibility into what block attributes changed between revisions.

## How?

- Refactors `__revisionDiffStatus` from a string to an object `{ status, changedAttributes? }`, where `changedAttributes` contains pre-computed word-level diffs for changed non-rich-text attributes.
- Adds a `RevisionBlockDiffPanel` component wired into the Block tab sidebar in revisions mode.

## Testing Instructions

1. Create a new post, add a paragraph block with some text, save as draft.
2. Change a non-rich-text attribute (e.g. enable drop cap, or change alignment), save again.
3. Open the Revisions panel in the Post tab sidebar, click revision "2".
4. Click a block in the revision canvas, switch to the Block tab in the sidebar.
5. Verify the "Changed attributes" panel appears showing the changed attribute with an inline diff.
6. Verify rich-text attributes (e.g. `content`) do NOT appear in the panel.

### Testing Instructions for Keyboard

1. Follow the same steps above using keyboard navigation.
2. Tab to the revision canvas, use arrow keys to select a block.
3. Tab to the sidebar, use arrow keys to switch to the Block tab.
4. Verify the "Changed attributes" panel is reachable and its content is accessible.

## Use of AI Tools

This PR was authored with assistance from Claude Code (Claude Opus 4.6). All code was reviewed and tested by the contributor.