### PR TITLE
Guidelines: Improve guideline revision UX

### DIFF
--- a/routes/content-guidelines/components/guideline-actions-section.tsx
+++ b/routes/content-guidelines/components/guideline-actions-section.tsx
@@ -84,6 +84,16 @@ export default function GuidelineActionsSection() {
 		}
 	}
 
+	function navigateToRevisionHistory() {
+		if ( window?.location?.href ) {
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'view', 'revision-history' );
+			window.history.replaceState( {}, '', url.toString() );
+		}
+
+		goTo( '/revision-history' );
+	}
+
 	const ACTIONS = [
 		{
 			slug: 'import',
@@ -109,7 +119,7 @@ export default function GuidelineActionsSection() {
 			description: __( 'Use a previous version of your guidelines.' ),
 			buttonLabel: __( 'View history' ),
 			ariaLabel: __( 'View history of guidelines' ),
-			onClick: () => goTo( '/revision-history' ),
+			onClick: navigateToRevisionHistory,
 		},
 	];
 

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -1,4 +1,4 @@
-/* @jsx createElement */
+/* @jsxRuntime automatic */
 
 /**
  * WordPress dependencies
@@ -14,13 +14,7 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
-import {
-	createElement,
-	useEffect,
-	useMemo,
-	useCallback,
-	useState,
-} from '@wordpress/element';
+import { useEffect, useMemo, useCallback, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
@@ -53,8 +47,6 @@ export default function RevisionHistory() {
 	const [ revisions, setRevisions ] = useState< ContentGuidelinesRevision[] >(
 		[]
 	);
-	const [ totalItems, setTotalItems ] = useState( 0 );
-	const [ totalPages, setTotalPages ] = useState( 0 );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ revisionToRestore, setRevisionToRestore ] =
 		useState< ContentGuidelinesRevision | null >( null );
@@ -75,14 +67,15 @@ export default function RevisionHistory() {
 
 		setIsLoading( true );
 		try {
+			// Fetch all revisions at once so client-side filtering works
+			// across the full dataset. Server-side pagination + filtering
+			// will be done together in a follow-up.
 			const result = await fetchContentGuidelinesRevisions( {
 				guidelinesId: guidelinesId!,
-				page: view.page,
-				perPage: view.perPage,
+				page: 1,
+				perPage: 100,
 			} );
 			setRevisions( result.revisions );
-			setTotalItems( result.total );
-			setTotalPages( result.totalPages );
 		} catch {
 			createErrorNotice(
 				__( 'Could not load revision history. Please try again.' ),
@@ -91,7 +84,7 @@ export default function RevisionHistory() {
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ guidelinesId, view.page, view.perPage, createErrorNotice ] );
+	}, [ guidelinesId, createErrorNotice ] );
 
 	useEffect( () => {
 		loadRevisions();
@@ -162,20 +155,13 @@ export default function RevisionHistory() {
 		[ setRevisionToRestore ]
 	);
 
-	const hasActiveFilters = view.filters && view.filters.length > 0;
-
-	const { data: filteredRevisions, paginationInfo: filteredPaginationInfo } =
+	// Client-side pagination and filtering on the full dataset.
+	// TODO: Move both pagination and filtering to the API side together.
+	const { data: displayedRevisions, paginationInfo: paginationToShow } =
 		useMemo(
 			() => filterSortAndPaginate( revisions, view, fields ),
 			[ revisions, view, fields ]
 		);
-
-	const displayedRevisions = hasActiveFilters ? filteredRevisions : revisions;
-
-	// Todo: move filtering to the api level
-	const paginationToShow = hasActiveFilters
-		? filteredPaginationInfo
-		: { totalItems, totalPages };
 
 	async function handleRestore() {
 		if ( ! guidelinesId || ! revisionToRestore ) {

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -43,9 +43,6 @@ const DEFAULT_VIEW: View = {
 	perPage: 10,
 	layout: {
 		enableMoving: false,
-		styles: {
-			author: { align: 'end' },
-		},
 	},
 };
 
@@ -208,12 +205,7 @@ export default function RevisionHistory() {
 				{ __( 'Revision history' ) }
 			</Navigator.BackButton>
 
-			<Text
-				size={ 13 }
-				weight={ 400 }
-				variant="muted"
-				className="content-guidelines__revision-description"
-			>
+			<Text size={ 13 } weight={ 400 } variant="muted">
 				{ __( 'Use a previous version of your guidelines.' ) }
 			</Text>
 

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -1,3 +1,5 @@
+/* @jsx createElement */
+
 /**
  * WordPress dependencies
  */
@@ -11,7 +13,12 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	createElement,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
@@ -183,11 +190,20 @@ export default function RevisionHistory() {
 		}
 	}
 
+	const navigateToGuidelines = () => {
+		if ( window?.location?.href ) {
+			const url = new URL( window.location.href );
+			url.searchParams.delete( 'view' );
+			window.history.replaceState( {}, '', url.toString() );
+		}
+	};
+
 	return (
 		<div className="content-guidelines__revision-history">
 			<Navigator.BackButton
 				icon={ isRTL() ? chevronRight : chevronLeft }
 				className="content-guidelines__revision-history-back"
+				onClick={ navigateToGuidelines }
 			>
 				{ __( 'Revision history' ) }
 			</Navigator.BackButton>

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -7,6 +7,7 @@ import {
 	Button,
 	Modal,
 	Navigator,
+	Spinner,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -17,6 +18,7 @@ import {
 	createElement,
 	useEffect,
 	useMemo,
+	useCallback,
 	useState,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -51,11 +53,12 @@ export default function RevisionHistory() {
 	const [ revisions, setRevisions ] = useState< ContentGuidelinesRevision[] >(
 		[]
 	);
+	const [ totalItems, setTotalItems ] = useState( 0 );
+	const [ totalPages, setTotalPages ] = useState( 0 );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ revisionToRestore, setRevisionToRestore ] =
 		useState< ContentGuidelinesRevision | null >( null );
 	const [ isRestoring, setIsRestoring ] = useState( false );
-	const [ refetchKey, setRefetchKey ] = useState( 0 );
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -65,31 +68,34 @@ export default function RevisionHistory() {
 		[]
 	);
 
-	useEffect( () => {
+	const loadRevisions = useCallback( async () => {
 		if ( ! guidelinesId ) {
 			return;
 		}
 
-		async function loadRevisions() {
-			setIsLoading( true );
-			try {
-				const result = await fetchContentGuidelinesRevisions( {
-					guidelinesId: guidelinesId!,
-					perPage: 100,
-				} );
-				setRevisions( result.revisions );
-			} catch {
-				createErrorNotice(
-					__( 'Could not load revision history. Please try again.' ),
-					{ type: 'snackbar' }
-				);
-			} finally {
-				setIsLoading( false );
-			}
+		setIsLoading( true );
+		try {
+			const result = await fetchContentGuidelinesRevisions( {
+				guidelinesId: guidelinesId!,
+				page: view.page,
+				perPage: view.perPage,
+			} );
+			setRevisions( result.revisions );
+			setTotalItems( result.total );
+			setTotalPages( result.totalPages );
+		} catch {
+			createErrorNotice(
+				__( 'Could not load revision history. Please try again.' ),
+				{ type: 'snackbar' }
+			);
+		} finally {
+			setIsLoading( false );
 		}
+	}, [ guidelinesId, view.page, view.perPage, createErrorNotice ] );
 
+	useEffect( () => {
 		loadRevisions();
-	}, [ guidelinesId, refetchKey, createErrorNotice ] );
+	}, [ loadRevisions ] );
 
 	const authorElements = useMemo( () => {
 		return [
@@ -145,11 +151,6 @@ export default function RevisionHistory() {
 		[ authorElements ]
 	);
 
-	const { data: displayedRevisions, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( revisions, view, fields ),
-		[ revisions, view, fields ]
-	);
-
 	const actions = useMemo< Action< ContentGuidelinesRevision >[] >(
 		() => [
 			{
@@ -160,6 +161,21 @@ export default function RevisionHistory() {
 		],
 		[ setRevisionToRestore ]
 	);
+
+	const hasActiveFilters = view.filters && view.filters.length > 0;
+
+	const { data: filteredRevisions, paginationInfo: filteredPaginationInfo } =
+		useMemo(
+			() => filterSortAndPaginate( revisions, view, fields ),
+			[ revisions, view, fields ]
+		);
+
+	const displayedRevisions = hasActiveFilters ? filteredRevisions : revisions;
+
+	// Todo: move filtering to the api level
+	const paginationToShow = hasActiveFilters
+		? filteredPaginationInfo
+		: { totalItems, totalPages };
 
 	async function handleRestore() {
 		if ( ! guidelinesId || ! revisionToRestore ) {
@@ -173,7 +189,7 @@ export default function RevisionHistory() {
 			);
 			await fetchContentGuidelines();
 			setRevisionToRestore( null );
-			setRefetchKey( ( k ) => k + 1 );
+			await loadRevisions();
 			createSuccessNotice( __( 'Revision restored.' ), {
 				type: 'snackbar',
 			} );
@@ -216,9 +232,16 @@ export default function RevisionHistory() {
 				onChangeView={ setView }
 				actions={ actions }
 				isLoading={ isLoading }
-				paginationInfo={ paginationInfo }
+				paginationInfo={ paginationToShow }
 				defaultLayouts={ { table: {} } }
 				getItemId={ ( item ) => String( item.id ) }
+				empty={
+					isLoading && displayedRevisions.length === 0 ? (
+						<Spinner />
+					) : (
+						__( 'No revisions found.' )
+					)
+				}
 			/>
 
 			{ revisionToRestore && (

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -63,15 +63,18 @@ const GUIDELINE_ITEMS = [
 	},
 ];
 
-function getInitialNavigatorPath() {
-	let view = '';
+const KNOWN_VIEWS = [ 'revision-history' ];
 
+function getInitialNavigatorPath() {
 	if ( window?.location?.href ) {
 		const url = new URL( window.location.href );
-		view = url.searchParams.get( 'view' ) ?? '';
+		const view = url.searchParams.get( 'view' ) ?? '';
+		if ( KNOWN_VIEWS.includes( view ) ) {
+			return `/${ view }`;
+		}
 	}
 
-	return `/${ view }`;
+	return '/';
 }
 
 function ContentGuidelinesPage() {

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -58,8 +58,7 @@ const GUIDELINE_ITEMS = [
 	},
 	{
 		title: __( 'Additional' ),
-		description: __( 'Add additional guidelines for your team.' ),
-
+		description: __( 'Add additional guidelines.' ),
 		slug: 'additional',
 	},
 ];

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -64,6 +64,17 @@ const GUIDELINE_ITEMS = [
 	},
 ];
 
+function getInitialNavigatorPath() {
+	let view = '';
+
+	if ( window?.location?.href ) {
+		const url = new URL( window.location.href );
+		view = url.searchParams.get( 'view' ) ?? '';
+	}
+
+	return `/${ view }`;
+}
+
 function ContentGuidelinesPage() {
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState< string | null >( null );
@@ -107,7 +118,7 @@ function ContentGuidelinesPage() {
 				</div>
 			) : (
 				! error && (
-					<Navigator initialPath="/">
+					<Navigator initialPath={ getInitialNavigatorPath() }>
 						<Navigator.Screen path="/">
 							<VStack className="content-guidelines__content">
 								{ /*

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -34,34 +34,16 @@
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-20;
-	.dataviews__view-actions,
-	.dataviews-filters__container {
-		padding-left: $grid-unit-10;
-		padding-right: $grid-unit-10;
-	}
 
-	.dataviews-view-table {
-		td:first-child {
-			padding-left: $grid-unit-10;
-		}
-
-		td {
-			padding: $grid-unit-20 $grid-unit-10;
-		}
-
-		thead th:has(.dataviews-view-table-header-button):first-child {
-			padding-left: 0;
-		}
-
-		.dataviews-view-table__cell-content-wrapper {
-			max-width: 100%;
-		}
+	.dataviews-wrapper {
+		margin-right: -$grid-unit-30;
+		margin-left: -$grid-unit-30;
 	}
 }
 
 .content-guidelines__revision-history-back {
 	align-self: flex-start;
-	margin-left: -$grid-unit-10;
+	margin-left: -$grid-unit-20;
 	font-weight: 500;
 	color: $gray-900;
 }
@@ -75,7 +57,7 @@
 	padding-left: $grid-unit-10;
 }
 
-.content-guidelines__restore-modal-actions {
+.content-guidelines__restore-modal-actions,
+.content-guidelines__import-modal-actions {
 	margin-top: $grid-unit-30;
 }
-

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -57,7 +57,6 @@
 	padding-left: $grid-unit-10;
 }
 
-.content-guidelines__restore-modal-actions,
-.content-guidelines__import-modal-actions {
+.content-guidelines__restore-modal-actions {
 	margin-top: $grid-unit-30;
 }


### PR DESCRIPTION

## What?
Related issue: https://github.com/WordPress/gutenberg/issues/76384

Improves the Content Guidelines revision history UX: revision list is now server-side paginated via the API, the revision-history screen persists in the URL so it survives page refresh, and a column alignment regression is fixed while removing fragile CSS overrides.

## Why?
Revision history previously loaded all revisions in one request, which does not scale. Navigation to revision history was not reflected in the URL, so refreshing the page would lose the current screen. Column alignment in the revision table had regressed and was being patched with brittle CSS overrides.

## How?
- **Pagination**: `RevisionHistory` calls `fetchContentGuidelinesRevisions` with `page` and `perPage` from the current DataViews view. The API response’s `total` and `totalPages` are passed as `paginationInfo` to `DataViews` so the table shows correct pagination and fetches only the current page. When filters are active, client-side `filterSortAndPaginate` is still used and its pagination is shown.
- **URL persistence**: The Navigator’s `initialPath` in `stage.tsx` is derived from the `view` URL search param (e.g. `?view=revision-history`). When opening revision history, `actions-section` sets `view=revision-history` via `history.replaceState` before `goTo('/revision-history')`. When leaving revision history, the back button clears the `view` param. Refreshing with `?view=revision-history` keeps the user on the revision history screen.
- **Column alignment**: Revision history layout and DataViews wrapper styles in `style.scss` are adjusted so column alignment is correct without fragile overrides; redundant or problematic CSS is removed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Content Guidelines page (e.g. from the relevant admin entry point).
2. In the Actions section, click **View history** to open Revision history.
3. Confirm the URL includes `?view=revision-history` and the revision table loads with pagination (if there are enough revisions).
4. Change page in the table and confirm the list updates (API is called for the new page).
5. Refresh the page and confirm you remain on the Revision history screen.
6. Click the **Revision history** back link and confirm the URL no longer has `view=revision-history` and you are back on the main guidelines view.
7. Confirm the Date and User columns in the revision table are aligned correctly and the layout looks correct.

## Visual Changes

| State | SS |
|--------|--------|
Before | <img width="784" height="46" alt="Screenshot 2026-03-17 at 11 18 26 AM" src="https://github.com/user-attachments/assets/3dd90d52-8a50-49e0-90f2-4b659ce5bc68" />
After | <img width="784" height="46" alt="Screenshot 2026-03-17 at 11 18 21 AM" src="https://github.com/user-attachments/assets/20d3634f-02cc-4582-a4ad-43410fc81d3c" />
Before | <img width="991" height="473" alt="Screenshot 2026-03-17 at 11 19 27 AM" src="https://github.com/user-attachments/assets/d2daa606-0b99-45f9-acc8-5f6e48eba3f8" />
After | <img width="991" height="473" alt="Screenshot 2026-03-17 at 11 19 12 AM" src="https://github.com/user-attachments/assets/f3607f98-8f1c-44a4-b847-df9a3ce608ca" />
Before | <img width="716" height="101" alt="Screenshot 2026-03-17 at 11 30 49 AM" src="https://github.com/user-attachments/assets/e91fd226-5a92-4e20-b339-e743fb8a68d5" />
After | <img width="716" height="101" alt="Screenshot 2026-03-17 at 12 57 08 PM" src="https://github.com/user-attachments/assets/84c09ea0-ce5b-4f8b-b6d1-8a084d23b1ff" />

