### PR TITLE
RTC: Scroll to collaborator on click

### DIFF
--- a/packages/editor/src/components/collaborators-overlay/cursor-registry.ts
+++ b/packages/editor/src/components/collaborators-overlay/cursor-registry.ts
@@ -1,0 +1,97 @@
+interface ScrollToCursorOptions {
+	behavior?: ScrollBehavior;
+	block?: ScrollLogicalPosition;
+	inline?: ScrollLogicalPosition;
+	highlightDuration?: number;
+}
+
+/**
+ * Cursor Registry
+ * ===
+ * This registry stores references to cursor elements so that we can access them
+ * in different parts of the component tree. This would more ideally be solved
+ * with React context or state in the awareness store, but:
+ *
+ * 1. EditorPresence and BlockCanvasCover slot/fill break context propagation. We
+ *    don't currently have a way to provide context to both the slot and fill.
+ * 2. Storing pointers to the cursor elements in the awareness store might be a
+ *    better solution, but would require broader refactoring.
+ *
+ * For now, we create a single instance of this registry and pass it down to the
+ * components that need it. It's important that we create a single instance and
+ * not a new instance per component or render; use useState with a lazy
+ * initializer to accomplish this.
+ */
+
+function highlightCursor( element: HTMLElement, duration: number ): void {
+	element.classList.add( 'collaborators-overlay-cursor-highlighted' );
+
+	setTimeout( () => {
+		element.classList.remove( 'collaborators-overlay-cursor-highlighted' );
+	}, duration );
+}
+
+export function createCursorRegistry() {
+	const cursorMap = new Map< number, HTMLElement >();
+
+	return {
+		/**
+		 * Register a cursor element when it's created.
+		 *
+		 * @param clientId - The clientId of the cursor to register.
+		 * @param element  - The cursor element to register.
+		 */
+		registerCursor( clientId: number, element: HTMLElement ): void {
+			cursorMap.set( clientId, element );
+		},
+
+		/**
+		 * Unregister a cursor element when it's removed.
+		 *
+		 * @param clientId - The clientId of the cursor to unregister.
+		 */
+		unregisterCursor( clientId: number ): void {
+			cursorMap.delete( clientId );
+		},
+
+		/**
+		 * Scroll to a cursor by clientId.
+		 *
+		 * @param clientId - The clientId of the cursor to scroll to.
+		 * @param options  - The options for the scroll.
+		 * @return true if cursor was found and scrolled to, false otherwise.
+		 */
+		scrollToCursor(
+			clientId: number,
+			options?: ScrollToCursorOptions
+		): boolean {
+			const cursorElement = cursorMap.get( clientId );
+
+			if ( ! cursorElement ) {
+				return false;
+			}
+
+			cursorElement.scrollIntoView( {
+				behavior: options?.behavior ?? 'smooth',
+				block: options?.block ?? 'center',
+				inline: options?.inline ?? 'nearest',
+			} );
+
+			if ( options?.highlightDuration ) {
+				highlightCursor( cursorElement, options.highlightDuration );
+			}
+
+			return true;
+		},
+
+		/**
+		 * Remove all cursor elements from DOM and clear the registry.
+		 */
+		removeAll(): void {
+			cursorMap.forEach( ( element ) => element.remove() );
+			cursorMap.clear();
+		},
+	};
+}
+
+export type CursorRegistry = ReturnType< typeof createCursorRegistry >;

--- a/packages/editor/src/components/collaborators-overlay/cursor-registry.ts
+++ b/packages/editor/src/components/collaborators-overlay/cursor-registry.ts
@@ -85,10 +85,9 @@ export function createCursorRegistry() {
 		},
 
 		/**
-		 * Remove all cursor elements from DOM and clear the registry.
+		 * Clear the registry.
 		 */
 		removeAll(): void {
-			cursorMap.forEach( ( element ) => element.remove() );
 			cursorMap.clear();
 		},
 	};

--- a/packages/editor/src/components/collaborators-overlay/index.tsx
+++ b/packages/editor/src/components/collaborators-overlay/index.tsx
@@ -9,22 +9,29 @@ import { privateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 import { Overlay } from './overlay';
+import { type CursorRegistry } from './cursor-registry';
 
 const { BlockCanvasCover } = unlock( privateApis );
 
 interface Props {
 	postId: number | null;
 	postType: string | null;
+	cursorRegistry?: CursorRegistry;
 }
 
 /**
  * Collaborators Overlay component
- * @param props          - The props for the CollaboratorsOverlay component
- * @param props.postId   - The ID of the post
- * @param props.postType - The type of the post
+ * @param props                - The props for the CollaboratorsOverlay component
+ * @param props.postId         - The ID of the post
+ * @param props.postType       - The type of the post
+ * @param props.cursorRegistry - The shared cursor registry
  * @return The CollaboratorsOverlay component
  */
-export function CollaboratorsOverlay( { postId, postType }: Props ) {
+export function CollaboratorsOverlay( {
+	postId,
+	postType,
+	cursorRegistry,
+}: Props ) {
 	return (
 		<BlockCanvasCover.Fill>
 			{ ( {
@@ -36,6 +43,7 @@ export function CollaboratorsOverlay( { postId, postType }: Props ) {
 					blockEditorDocument={ containerRef.current?.ownerDocument }
 					postId={ postId }
 					postType={ postType }
+					cursorRegistry={ cursorRegistry }
 				/>
 			) }
 		</BlockCanvasCover.Fill>

--- a/packages/editor/src/components/collaborators-overlay/overlay.tsx
+++ b/packages/editor/src/components/collaborators-overlay/overlay.tsx
@@ -102,11 +102,7 @@ export function Overlay( {
 			cursorRegistry.registerCursor( id, el );
 		}
 
-		return () => {
-			for ( const id of refs.keys() ) {
-				cursorRegistry.unregisterCursor( id );
-			}
-		};
+		return () => cursorRegistry.removeAll();
 	}, [ cursors, cursorRegistry ] );
 
 	// Callback ref factory to capture each cursor's DOM element.

--- a/packages/editor/src/components/collaborators-overlay/overlay.tsx
+++ b/packages/editor/src/components/collaborators-overlay/overlay.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import Avatar from '../collaborators-presence/avatar';
@@ -7,6 +7,7 @@ import { AVATAR_IFRAME_STYLES } from './avatar-iframe-styles';
 import { OVERLAY_IFRAME_STYLES } from './overlay-iframe-styles';
 import { useBlockHighlighting } from './use-block-highlighting';
 import { useRenderCursors } from './use-render-cursors';
+import { type CursorRegistry } from './cursor-registry';
 
 const RERENDER_DELAY_MS = 500;
 
@@ -14,6 +15,7 @@ interface OverlayProps {
 	blockEditorDocument?: Document;
 	postId: number | null;
 	postType: string | null;
+	cursorRegistry?: CursorRegistry;
 }
 
 /**
@@ -23,12 +25,14 @@ interface OverlayProps {
  * @param props.blockEditorDocument - The block editor document.
  * @param props.postId              - The ID of the post.
  * @param props.postType            - The type of the post.
+ * @param props.cursorRegistry      - The shared cursor registry.
  * @return The Overlay component.
  */
 export function Overlay( {
 	blockEditorDocument,
 	postId,
 	postType,
+	cursorRegistry,
 }: OverlayProps ) {
 	// Use state for the overlay element so that the hook re-runs once the ref is attached.
 	const [ overlayElement, setOverlayElement ] =
@@ -74,6 +78,49 @@ export function Overlay( {
 		resizeObserverRef,
 	] );
 
+	// Track cursor element refs for registry registration.
+	const cursorRefsMap = useRef< Map< number, HTMLElement > >( new Map() );
+
+	// Keep the registry in sync whenever the rendered cursors change.
+	useEffect( () => {
+		if ( ! cursorRegistry ) {
+			return;
+		}
+		const refs = cursorRefsMap.current;
+		const currentIds = new Set( cursors.map( ( c ) => c.clientId ) );
+
+		// Unregister cursors that are no longer rendered.
+		for ( const id of refs.keys() ) {
+			if ( ! currentIds.has( id ) ) {
+				cursorRegistry.unregisterCursor( id );
+				refs.delete( id );
+			}
+		}
+
+		// Register or update cursors that are currently rendered.
+		for ( const [ id, el ] of refs.entries() ) {
+			cursorRegistry.registerCursor( id, el );
+		}
+
+		return () => {
+			for ( const id of refs.keys() ) {
+				cursorRegistry.unregisterCursor( id );
+			}
+		};
+	}, [ cursors, cursorRegistry ] );
+
+	// Callback ref factory to capture each cursor's DOM element.
+	const setCursorRef = useCallback(
+		( clientId: number ) => ( el: HTMLDivElement | null ) => {
+			if ( el ) {
+				cursorRefsMap.current.set( clientId, el );
+			} else {
+				cursorRefsMap.current.delete( clientId );
+			}
+		},
+		[]
+	);
+
 	// This is a full overlay that covers the entire iframe document. Good for
 	// scrollable elements like cursor indicators.
 	return (
@@ -96,6 +143,7 @@ export function Overlay( {
 							/>
 						) ) }
 					<div
+						ref={ setCursorRef( cursor.clientId ) }
 						className="collaborators-overlay-user"
 						style={ {
 							left: `${ cursor.x }px`,

--- a/packages/editor/src/components/collaborators-presence/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/index.tsx
@@ -12,6 +12,7 @@ import { CollaboratorsList } from './list';
 import { unlock } from '../../lock-unlock';
 import { getAvatarUrl } from '../collaborators-overlay/get-avatar-url';
 import { getAvatarBorderColor } from '../collab-sidebar/utils';
+import { createCursorRegistry } from '../collaborators-overlay/cursor-registry';
 
 import './styles/collaborators-presence.scss';
 import { CollaboratorsOverlay } from '../collaborators-overlay';
@@ -56,6 +57,8 @@ export function CollaboratorsPresence( {
 			return 0;
 		} );
 	}, [ activeCollaborators ] );
+
+	const [ cursorRegistry ] = useState( createCursorRegistry );
 
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
@@ -123,10 +126,15 @@ export function CollaboratorsPresence( {
 						activeCollaborators={ collaboratorsForList }
 						popoverAnchor={ popoverAnchor }
 						setIsPopoverVisible={ setIsPopoverVisible }
+						cursorRegistry={ cursorRegistry }
 					/>
 				) }
 			</div>
-			<CollaboratorsOverlay postId={ postId } postType={ postType } />
+			<CollaboratorsOverlay
+				postId={ postId }
+				postType={ postType }
+				cursorRegistry={ cursorRegistry }
+			/>
 		</>
 	);
 }

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -2,10 +2,12 @@ import { __ } from '@wordpress/i18n';
 import { Popover, Button } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
 import { type PostEditorAwarenessState } from '@wordpress/core-data';
+import { speak } from '@wordpress/a11y';
 
 import Avatar from './avatar';
 import { getAvatarUrl } from '../collaborators-overlay/get-avatar-url';
 import { getAvatarBorderColor } from '../collab-sidebar/utils';
+import { type CursorRegistry } from '../collaborators-overlay/cursor-registry';
 
 import './styles/collaborators-list.scss';
 
@@ -13,6 +15,7 @@ interface CollaboratorsListProps {
 	activeCollaborators: PostEditorAwarenessState[];
 	popoverAnchor?: HTMLElement | null;
 	setIsPopoverVisible: ( isVisible: boolean ) => void;
+	cursorRegistry: CursorRegistry;
 }
 
 /**
@@ -23,12 +26,34 @@ interface CollaboratorsListProps {
  * @param props.activeCollaborators List of active collaborators
  * @param props.popoverAnchor       Anchor element for the popover
  * @param props.setIsPopoverVisible Callback to set the visibility of the popover
+ * @param props.cursorRegistry      Shared registry for scroll-to-cursor support
  */
 export function CollaboratorsList( {
 	activeCollaborators,
 	popoverAnchor,
 	setIsPopoverVisible,
+	cursorRegistry,
 }: CollaboratorsListProps ) {
+	const handleCollaboratorClick = ( clientId: number ) => {
+		const userName = activeCollaborators.find(
+			( collaborator ) => collaborator.clientId === clientId
+		)?.collaboratorInfo.name;
+
+		const success = cursorRegistry.scrollToCursor( clientId, {
+			behavior: 'smooth',
+			block: 'center',
+			highlightDuration: 2000,
+		} );
+
+		if ( success && userName ) {
+			speak( `Scrolled to ${ userName }'s cursor`, 'polite' );
+		}
+
+		if ( success ) {
+			setIsPopoverVisible( false );
+		}
+	};
+
 	return (
 		<Popover
 			anchor={ popoverAnchor }
@@ -60,7 +85,12 @@ export function CollaboratorsList( {
 							<button
 								key={ collaboratorState.clientId }
 								className="editor-collaborators-presence__list-item"
-								disabled
+								disabled={ isCurrentUser }
+								onClick={ () =>
+									handleCollaboratorClick(
+										collaboratorState.clientId
+									)
+								}
 							>
 								<Avatar
 									src={ getAvatarUrl(

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -35,18 +35,14 @@ export function CollaboratorsList( {
 	cursorRegistry,
 }: CollaboratorsListProps ) {
 	const handleCollaboratorClick = ( clientId: number ) => {
-		const userName = activeCollaborators.find(
-			( collaborator ) => collaborator.clientId === clientId
-		)?.collaboratorInfo.name;
-
 		const success = cursorRegistry.scrollToCursor( clientId, {
 			behavior: 'smooth',
 			block: 'center',
 			highlightDuration: 2000,
 		} );
 
-		if ( success && userName ) {
-			speak( `Scrolled to ${ userName }'s cursor`, 'polite' );
+		if ( success ) {
+			speak( __( 'Scrolled to cursor' ), 'polite' );
 		}
 
 		if ( success ) {

--- a/packages/editor/src/components/collaborators-presence/list.tsx
+++ b/packages/editor/src/components/collaborators-presence/list.tsx
@@ -43,9 +43,7 @@ export function CollaboratorsList( {
 
 		if ( success ) {
 			speak( __( 'Scrolled to cursor' ), 'polite' );
-		}
 
-		if ( success ) {
 			setIsPopoverVisible( false );
 		}
 	};


### PR DESCRIPTION
## What?

Closes #76562

When clicking on a collaborator in the dropdown, scroll their cursor into view.

## Why?

This makes it easier to find where content is being edited in larger posts.

## How?

Adds a cursor registry factory that is used to track the position of the DOM elements and scroll them into view.

## Testing Instructions
1. Enable RTC
2. Open two tabs with the same post
3. Put enough content to cause scrolling
4. In tab 1, scroll down and put the cursor at the bottom
5. in tab 2, open the collaborator list and click on the collaborator for tab 1
6. The content should scroll to reveal the collaborator

## Video

https://github.com/user-attachments/assets/66bed205-d1cb-428d-bcc1-b01bff68448f
