### PR TITLE
RTC: Implement front-end peer limits

### DIFF
--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_MAX_CLIENTS_PER_USER = 2;
+export const DEFAULT_MAX_PEERS_PER_ROOM = 2;
 export const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 export const POLLING_INTERVAL_IN_MS = 1000; // 1 second or 1000 milliseconds

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -1,5 +1,4 @@
-export const DEFAULT_MAX_CLIENTS_PER_USER = 2;
-export const DEFAULT_MAX_PEERS_PER_ROOM = 2;
+export const DEFAULT_CLIENT_LIMIT_PER_ROOM = 3;
 export const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 export const POLLING_INTERVAL_IN_MS = 1000; // 1 second or 1000 milliseconds

--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -18,8 +18,6 @@ import { pollingManager } from './polling-manager';
 export interface ProviderOptions {
 	awareness?: Awareness;
 	debug?: boolean;
-	maxClientsPerUser?: number;
-	maxPeersPerRoom?: number;
 	room: string;
 	ydoc: Y.Doc;
 }
@@ -149,7 +147,6 @@ export function createHttpPollingProvider(): ProviderCreator {
 	} ): Promise< ProviderCreatorResult > => {
 		// Generate room name from objectType and objectId
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
-
 		const provider = new HttpPollingProvider( {
 			awareness,
 			// debug: true,

--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -149,7 +149,6 @@ export function createHttpPollingProvider(): ProviderCreator {
 	} ): Promise< ProviderCreatorResult > => {
 		// Generate room name from objectType and objectId
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
-		console.log( { room, ydoc, awareness } );
 
 		const provider = new HttpPollingProvider( {
 			awareness,

--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -6,11 +6,6 @@ import { ObservableV2 } from 'lib0/observable';
 import { Awareness } from 'y-protocols/awareness';
 
 /**
- * WordPress dependencies
- */
-import { applyFilters } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import type {
@@ -18,10 +13,6 @@ import type {
 	ProviderCreator,
 	ProviderCreatorResult,
 } from '../../types';
-import {
-	DEFAULT_MAX_CLIENTS_PER_USER,
-	DEFAULT_MAX_PEERS_PER_ROOM,
-} from './config';
 import { pollingManager } from './polling-manager';
 
 export interface ProviderOptions {
@@ -69,8 +60,6 @@ class HttpPollingProvider extends ObservableV2< HttpPollingEvents > {
 			doc: this.options.ydoc,
 			awareness: this.awareness,
 			log: this.log,
-			maxClientsPerUser: this.options.maxClientsPerUser,
-			maxPeersPerRoom: this.options.maxPeersPerRoom,
 			onStatusChange: this.emitStatus,
 			onSync: this.onSync,
 		} );
@@ -160,22 +149,11 @@ export function createHttpPollingProvider(): ProviderCreator {
 	} ): Promise< ProviderCreatorResult > => {
 		// Generate room name from objectType and objectId
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
-
-		const maxPeersPerRoom = applyFilters(
-			'sync.maxPeersPerRoom',
-			DEFAULT_MAX_PEERS_PER_ROOM
-		) as number;
-
-		const maxClientsPerUser = applyFilters(
-			'sync.maxClientsPerUser',
-			DEFAULT_MAX_CLIENTS_PER_USER
-		) as number;
+		console.log( { room, ydoc, awareness } );
 
 		const provider = new HttpPollingProvider( {
 			awareness,
 			// debug: true,
-			maxClientsPerUser,
-			maxPeersPerRoom,
 			room,
 			ydoc,
 		} );

--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -6,6 +6,11 @@ import { ObservableV2 } from 'lib0/observable';
 import { Awareness } from 'y-protocols/awareness';
 
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import type {
@@ -13,11 +18,17 @@ import type {
 	ProviderCreator,
 	ProviderCreatorResult,
 } from '../../types';
+import {
+	DEFAULT_MAX_CLIENTS_PER_USER,
+	DEFAULT_MAX_PEERS_PER_ROOM,
+} from './config';
 import { pollingManager } from './polling-manager';
 
 export interface ProviderOptions {
 	awareness?: Awareness;
 	debug?: boolean;
+	maxClientsPerUser?: number;
+	maxPeersPerRoom?: number;
 	room: string;
 	ydoc: Y.Doc;
 }
@@ -58,6 +69,8 @@ class HttpPollingProvider extends ObservableV2< HttpPollingEvents > {
 			doc: this.options.ydoc,
 			awareness: this.awareness,
 			log: this.log,
+			maxClientsPerUser: this.options.maxClientsPerUser,
+			maxPeersPerRoom: this.options.maxPeersPerRoom,
 			onStatusChange: this.emitStatus,
 			onSync: this.onSync,
 		} );
@@ -147,9 +160,22 @@ export function createHttpPollingProvider(): ProviderCreator {
 	} ): Promise< ProviderCreatorResult > => {
 		// Generate room name from objectType and objectId
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
+
+		const maxPeersPerRoom = applyFilters(
+			'sync.maxPeersPerRoom',
+			DEFAULT_MAX_PEERS_PER_ROOM
+		) as number;
+
+		const maxClientsPerUser = applyFilters(
+			'sync.maxClientsPerUser',
+			DEFAULT_MAX_CLIENTS_PER_USER
+		) as number;
+
 		const provider = new HttpPollingProvider( {
 			awareness,
 			// debug: true,
+			maxClientsPerUser,
+			maxPeersPerRoom,
 			room,
 			ydoc,
 		} );

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -275,7 +275,7 @@ function checkConnectionLimit(
 	roomState.enforceConnectionLimit = false;
 
 	const maxClientsPerRoom = applyFilters(
-		'collaboration.sync.maxClientsPerRoom',
+		'sync.pollingProvider.maxClientsPerRoom',
 		DEFAULT_CLIENT_LIMIT_PER_ROOM,
 		roomState.room
 	);
@@ -286,7 +286,17 @@ function checkConnectionLimit(
 		DEFAULT_CLIENT_LIMIT_PER_ROOM
 	);
 
-	return clientCount > validatedLimit;
+	if ( clientCount > validatedLimit ) {
+		roomState.log( 'Connection limit exceeded', {
+			clientCount,
+			maxClientsPerRoom: validatedLimit,
+			room: roomState.room,
+		} );
+
+		return true;
+	}
+
+	return false;
 }
 
 let areListenersRegistered = false;
@@ -418,7 +428,6 @@ function poll(): void {
 
 				// If a limit is exceeded, disconnect immediately without processing updates.
 				if ( checkConnectionLimit( room.awareness, roomState ) ) {
-					roomState.log( 'Peer limit exceeded, disconnecting' );
 					roomState.onStatusChange( {
 						status: 'disconnected',
 						error: new ConnectionError(

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -51,6 +51,8 @@ interface RegisterRoomOptions {
 	doc: Y.Doc;
 	awareness: Awareness;
 	log: LogFunction;
+	maxClientsPerUser?: number;
+	maxPeersPerRoom?: number;
 	onStatusChange: ( status: ConnectionStatus ) => void;
 	onSync: () => void;
 }
@@ -59,8 +61,11 @@ interface RoomState {
 	clientId: number;
 	createCompactionUpdate: () => SyncUpdate;
 	endCursor: number;
+	hasCompletedInitialSync: boolean;
 	localAwarenessState: LocalAwarenessState;
 	log: LogFunction;
+	maxClientsPerUser: number;
+	maxPeersPerRoom: number;
 	onStatusChange: ( status: ConnectionStatus ) => void;
 	processAwarenessUpdate: ( state: AwarenessState ) => void;
 	processDocUpdate: ( update: SyncUpdate ) => SyncUpdate | void;
@@ -247,6 +252,60 @@ function processDocUpdate(
 	}
 }
 
+/**
+ * Check whether the awareness state exceeds the configured peer limits.
+ *
+ * Extracts WordPress user IDs from awareness entries to count unique users
+ * and per-user clients. A limit of 0 disables the corresponding check.
+ *
+ * @param awareness The awareness state from the server response.
+ * @param roomState The room state containing limits and local awareness.
+ * @return True if a peer limit has been exceeded.
+ */
+function checkPeerLimits(
+	awareness: AwarenessState,
+	roomState: RoomState
+): boolean {
+	const userClientCounts = new Map< number, number >();
+
+	for ( const state of Object.values( awareness ) ) {
+		const userId = (
+			state as { collaboratorInfo?: { id?: number } } | null
+		 )?.collaboratorInfo?.id;
+		if ( 'number' !== typeof userId ) {
+			continue;
+		}
+		userClientCounts.set(
+			userId,
+			( userClientCounts.get( userId ) ?? 0 ) + 1
+		);
+	}
+
+	if (
+		roomState.maxPeersPerRoom > 0 &&
+		userClientCounts.size > roomState.maxPeersPerRoom
+	) {
+		return true;
+	}
+
+	const currentUserId = (
+		roomState.localAwarenessState as {
+			collaboratorInfo?: { id?: number };
+		} | null
+	 )?.collaboratorInfo?.id;
+	if (
+		roomState.maxClientsPerUser > 0 &&
+		'number' === typeof currentUserId
+	) {
+		const clientCount = userClientCounts.get( currentUserId ) ?? 0;
+		if ( clientCount > roomState.maxClientsPerUser ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 let areListenersRegistered = false;
 let hasCollaborators = false;
 let isActiveBrowser = 'visible' === document.visibilityState;
@@ -377,6 +436,26 @@ function poll(): void {
 				// Process awareness update.
 				roomState.processAwarenessUpdate( room.awareness );
 
+				// Check peer limits on initial sync only. If the room is
+				// already at capacity when this client first connects, it
+				// is the excess peer and should disconnect.
+				if ( ! roomState.hasCompletedInitialSync ) {
+					roomState.hasCompletedInitialSync = true;
+
+					if ( checkPeerLimits( room.awareness, roomState ) ) {
+						roomState.log( 'Peer limit exceeded, disconnecting' );
+						roomState.onStatusChange( {
+							status: 'disconnected',
+							error: new ConnectionError(
+								ConnectionErrorCode.CONNECTION_LIMIT_EXCEEDED,
+								'Connection limit exceeded'
+							),
+						} );
+						unregisterRoom( room.room );
+						return;
+					}
+				}
+
 				// If there is another collaborator, resume the queue for the next poll
 				// and increase polling frequency.
 				if ( Object.keys( room.awareness ).length > 1 ) {
@@ -469,6 +548,8 @@ function registerRoom( {
 	doc,
 	awareness,
 	log,
+	maxClientsPerUser,
+	maxPeersPerRoom,
 	onSync,
 	onStatusChange,
 }: RegisterRoomOptions ): void {
@@ -529,8 +610,11 @@ function registerRoom( {
 				SyncUpdateType.COMPACTION
 			),
 		endCursor: 0,
+		hasCompletedInitialSync: false,
 		localAwarenessState: awareness.getLocalState() ?? {},
 		log,
+		maxClientsPerUser: maxClientsPerUser ?? 0,
+		maxPeersPerRoom: maxPeersPerRoom ?? 0,
 		onStatusChange,
 		processAwarenessUpdate: ( state: AwarenessState ) =>
 			processAwarenessUpdate( state, awareness ),

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * External dependencies
  */
 import * as Y from 'yjs';
@@ -12,6 +17,7 @@ import * as syncProtocol from 'y-protocols/sync';
  * Internal dependencies
  */
 import {
+	DEFAULT_CLIENT_LIMIT_PER_ROOM,
 	MAX_ERROR_BACKOFF_IN_MS,
 	MAX_UPDATE_SIZE_IN_BYTES,
 	POLLING_INTERVAL_IN_MS,
@@ -32,6 +38,7 @@ import {
 	base64ToUint8Array,
 	createSyncUpdate,
 	createUpdateQueue,
+	intValueOrDefault,
 	postSyncUpdate,
 	postSyncUpdateNonBlocking,
 } from './utils';
@@ -51,8 +58,6 @@ interface RegisterRoomOptions {
 	doc: Y.Doc;
 	awareness: Awareness;
 	log: LogFunction;
-	maxClientsPerUser?: number;
-	maxPeersPerRoom?: number;
 	onStatusChange: ( status: ConnectionStatus ) => void;
 	onSync: () => void;
 }
@@ -61,14 +66,13 @@ interface RoomState {
 	clientId: number;
 	createCompactionUpdate: () => SyncUpdate;
 	endCursor: number;
-	hasCompletedInitialSync: boolean;
+	enforceConnectionLimit: boolean;
 	localAwarenessState: LocalAwarenessState;
 	log: LogFunction;
-	maxClientsPerUser: number;
-	maxPeersPerRoom: number;
 	onStatusChange: ( status: ConnectionStatus ) => void;
 	processAwarenessUpdate: ( state: AwarenessState ) => void;
 	processDocUpdate: ( update: SyncUpdate ) => SyncUpdate | void;
+	room: string;
 	unregister: () => void;
 	updateQueue: UpdateQueue;
 }
@@ -253,57 +257,36 @@ function processDocUpdate(
 }
 
 /**
- * Check whether the awareness state exceeds the configured peer limits.
- *
- * Extracts WordPress user IDs from awareness entries to count unique users
- * and per-user clients. A limit of 0 disables the corresponding check.
+ * Check whether the awareness state exceeds the configured connection limit.
  *
  * @param awareness The awareness state from the server response.
- * @param roomState The room state containing limits and local awareness.
+ * @param roomState The room state corresponding to the awareness state
  * @return True if a peer limit has been exceeded.
  */
-function checkPeerLimits(
+function checkConnectionLimit(
 	awareness: AwarenessState,
 	roomState: RoomState
 ): boolean {
-	const userClientCounts = new Map< number, number >();
-
-	for ( const state of Object.values( awareness ) ) {
-		const userId = (
-			state as { collaboratorInfo?: { id?: number } } | null
-		 )?.collaboratorInfo?.id;
-		if ( 'number' !== typeof userId ) {
-			continue;
-		}
-		userClientCounts.set(
-			userId,
-			( userClientCounts.get( userId ) ?? 0 ) + 1
-		);
+	if ( ! roomState.enforceConnectionLimit ) {
+		return false;
 	}
 
-	if (
-		roomState.maxPeersPerRoom > 0 &&
-		userClientCounts.size > roomState.maxPeersPerRoom
-	) {
-		return true;
-	}
+	// Limits are only enforced on the initial connection.
+	roomState.enforceConnectionLimit = false;
 
-	const currentUserId = (
-		roomState.localAwarenessState as {
-			collaboratorInfo?: { id?: number };
-		} | null
-	 )?.collaboratorInfo?.id;
-	if (
-		roomState.maxClientsPerUser > 0 &&
-		'number' === typeof currentUserId
-	) {
-		const clientCount = userClientCounts.get( currentUserId ) ?? 0;
-		if ( clientCount > roomState.maxClientsPerUser ) {
-			return true;
-		}
-	}
+	const maxClientsPerRoom = applyFilters(
+		'collaboration.sync.maxClientsPerRoom',
+		DEFAULT_CLIENT_LIMIT_PER_ROOM,
+		roomState.room
+	);
 
-	return false;
+	const clientCount = Object.keys( awareness ).length;
+	const validatedLimit = intValueOrDefault(
+		maxClientsPerRoom,
+		DEFAULT_CLIENT_LIMIT_PER_ROOM
+	);
+
+	return clientCount > validatedLimit;
 }
 
 let areListenersRegistered = false;
@@ -433,28 +416,22 @@ function poll(): void {
 				const roomState = roomStates.get( room.room )!;
 				roomState.endCursor = room.end_cursor;
 
+				// If a limit is exceeded, disconnect immediately without processing updates.
+				if ( checkConnectionLimit( room.awareness, roomState ) ) {
+					roomState.log( 'Peer limit exceeded, disconnecting' );
+					roomState.onStatusChange( {
+						status: 'disconnected',
+						error: new ConnectionError(
+							ConnectionErrorCode.CONNECTION_LIMIT_EXCEEDED,
+							'Connection limit exceeded'
+						),
+					} );
+					unregisterRoom( room.room );
+					return;
+				}
+
 				// Process awareness update.
 				roomState.processAwarenessUpdate( room.awareness );
-
-				// Check peer limits on initial sync only. If the room is
-				// already at capacity when this client first connects, it
-				// is the excess peer and should disconnect.
-				if ( ! roomState.hasCompletedInitialSync ) {
-					roomState.hasCompletedInitialSync = true;
-
-					if ( checkPeerLimits( room.awareness, roomState ) ) {
-						roomState.log( 'Peer limit exceeded, disconnecting' );
-						roomState.onStatusChange( {
-							status: 'disconnected',
-							error: new ConnectionError(
-								ConnectionErrorCode.CONNECTION_LIMIT_EXCEEDED,
-								'Connection limit exceeded'
-							),
-						} );
-						unregisterRoom( room.room );
-						return;
-					}
-				}
 
 				// If there is another collaborator, resume the queue for the next poll
 				// and increase polling frequency.
@@ -548,8 +525,6 @@ function registerRoom( {
 	doc,
 	awareness,
 	log,
-	maxClientsPerUser,
-	maxPeersPerRoom,
 	onSync,
 	onStatusChange,
 }: RegisterRoomOptions ): void {
@@ -559,6 +534,39 @@ function registerRoom( {
 
 	// Note: Queue is initially paused. Call .resume() to unpause.
 	const updateQueue = createUpdateQueue( [ createSyncStep1Update( doc ) ] );
+
+	/**
+	 * Connection limits are enforced on the first entity to be loaded for sync.
+	 * This is an inelegant solution to a hard problem: This sync provider and the
+	 * sync package in general intentionally have no knowledge of the individual
+	 * entities being synced.
+	 *
+	 * Let's say a user opens a document (Entity A) for editing. If you asked the
+	 * user what they are doing, they would reply "I'm editing Entity A." You might
+	 * say that Entity A is "primary."
+	 *
+	 * However, the action of editing Entity A also triggers the loading of a
+	 * collection of document categories (Entity B) and another document (Entity C)
+	 * that is embedded in Entity A. You might therefore say that Entity B and
+	 * Entity C are "secondary" in this session.
+	 *
+	 * Meanwhile, a different user opens Entity C for editing, which also triggers
+	 * the loading of Entity B. In this session, Entity C is "primary" and Entity B
+	 * is "secondary."
+	 *
+	 * How do we enforce limits? The intuitive answer is that we only want to count
+	 * connections when the entity is "primary." However, we have no ability to
+	 * detect this. A document might be loaded as a primary entity in one session
+	 * and a secondary entity in another.
+	 *
+	 * In practice, we can consider the first-loaded entity as "primary" and use it
+	 * to enforce our connection limit. This is an imperfect assumption of consumer
+	 * behavior.
+	 *
+	 * How might this approach be improved? We could develop some way to annotate
+	 * entity loading so that the consumer can indicate which entity is primary.
+	 */
+	const enforceConnectionLimit = 0 === roomStates.size;
 
 	function onAwarenessUpdate(): void {
 		roomState.localAwarenessState = awareness.getLocalState() ?? {};
@@ -610,16 +618,15 @@ function registerRoom( {
 				SyncUpdateType.COMPACTION
 			),
 		endCursor: 0,
-		hasCompletedInitialSync: false,
+		enforceConnectionLimit,
 		localAwarenessState: awareness.getLocalState() ?? {},
 		log,
-		maxClientsPerUser: maxClientsPerUser ?? 0,
-		maxPeersPerRoom: maxPeersPerRoom ?? 0,
 		onStatusChange,
 		processAwarenessUpdate: ( state: AwarenessState ) =>
 			processAwarenessUpdate( state, awareness ),
 		processDocUpdate: ( update: SyncUpdate ) =>
 			processDocUpdate( update, doc, onSync ),
+		room,
 		unregister,
 		updateQueue,
 	};

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -499,7 +499,7 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 
 			expect( mockApplyFilters ).toHaveBeenCalledWith(
-				'collaboration.sync.maxClientsPerRoom',
+				'sync.pollingProvider.maxClientsPerRoom',
 				3,
 				'my-custom-room'
 			);

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -67,6 +67,8 @@ interface PollingManager {
 		doc: unknown;
 		awareness: unknown;
 		log: () => void;
+		maxClientsPerUser?: number;
+		maxPeersPerRoom?: number;
 		onStatusChange: () => void;
 		onSync: () => void;
 	} ) => void;
@@ -249,6 +251,311 @@ describe( 'polling-manager', () => {
 					status: 'disconnected',
 					error: expect.objectContaining( {
 						code: 'document-size-limit-exceeded',
+					} ),
+				} )
+			);
+		} );
+	} );
+
+	describe( 'peer limits', () => {
+		function makeAwareness(
+			entries: Array< { clientId: number; userId: number } >
+		) {
+			const awareness: Record<
+				string,
+				{ collaboratorInfo: { id: number } }
+			> = {};
+			for ( const { clientId, userId } of entries ) {
+				awareness[ clientId ] = {
+					collaboratorInfo: { id: userId },
+				};
+			}
+			return awareness;
+		}
+
+		it( 'disconnects when unique users exceed maxPeersPerRoom on first poll', async () => {
+			const awareness3Users = makeAwareness( [
+				{ clientId: 1, userId: 100 },
+				{ clientId: 2, userId: 200 },
+				{ clientId: 3, userId: 300 },
+			] );
+
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awareness3Users,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
+			const mockAwareness = createMockAwareness();
+			mockAwareness.getLocalState.mockReturnValue( {
+				collaboratorInfo: { id: 300 },
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 3 ),
+				awareness: mockAwareness,
+				log: jest.fn(),
+				maxPeersPerRoom: 2,
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( {
+				status: 'disconnected',
+				error: expect.objectContaining( {
+					code: 'connection-limit-exceeded',
+				} ),
+			} );
+		} );
+
+		it( 'allows connection when under the peer limit', async () => {
+			const awareness2Users = makeAwareness( [
+				{ clientId: 1, userId: 100 },
+				{ clientId: 2, userId: 200 },
+			] );
+
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awareness2Users,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
+			const mockAwareness = createMockAwareness();
+			mockAwareness.getLocalState.mockReturnValue( {
+				collaboratorInfo: { id: 200 },
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 2 ),
+				awareness: mockAwareness,
+				log: jest.fn(),
+				maxPeersPerRoom: 2,
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( onStatusChange ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.objectContaining( {
+						code: 'connection-limit-exceeded',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'disconnects when same-user tabs exceed maxClientsPerUser', async () => {
+			const awareness3Tabs = makeAwareness( [
+				{ clientId: 1, userId: 100 },
+				{ clientId: 2, userId: 100 },
+				{ clientId: 3, userId: 100 },
+			] );
+
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awareness3Tabs,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
+			const mockAwareness = createMockAwareness();
+			mockAwareness.getLocalState.mockReturnValue( {
+				collaboratorInfo: { id: 100 },
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 3 ),
+				awareness: mockAwareness,
+				log: jest.fn(),
+				maxClientsPerUser: 2,
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( {
+				status: 'disconnected',
+				error: expect.objectContaining( {
+					code: 'connection-limit-exceeded',
+				} ),
+			} );
+		} );
+
+		it( 'does not re-check limits after initial sync', async () => {
+			// First poll: 2 users (at limit, passes).
+			const awareness2Users = makeAwareness( [
+				{ clientId: 1, userId: 100 },
+				{ clientId: 2, userId: 200 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awareness2Users,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
+			const mockAwareness = createMockAwareness();
+			mockAwareness.getLocalState.mockReturnValue( {
+				collaboratorInfo: { id: 200 },
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 2 ),
+				awareness: mockAwareness,
+				log: jest.fn(),
+				maxPeersPerRoom: 2,
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			// First poll passes.
+			await jest.advanceTimersByTimeAsync( 0 );
+			onStatusChange.mockClear();
+
+			// Second poll: 3 users (over limit).
+			const awareness3Users = makeAwareness( [
+				{ clientId: 1, userId: 100 },
+				{ clientId: 2, userId: 200 },
+				{ clientId: 3, userId: 300 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 2,
+						awareness: awareness3Users,
+						updates: [],
+					},
+				],
+			} );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			// Should NOT disconnect — limit check only runs on initial sync.
+			expect( onStatusChange ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.objectContaining( {
+						code: 'connection-limit-exceeded',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'skips awareness entries with null or missing collaboratorInfo', async () => {
+			const awarenessWithNulls: Record< string, object | null > = {
+				1: { collaboratorInfo: { id: 100 } },
+				2: null,
+				3: {},
+				4: { collaboratorInfo: { id: 200 } },
+			};
+
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awarenessWithNulls,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
+			const mockAwareness = createMockAwareness();
+			mockAwareness.getLocalState.mockReturnValue( {
+				collaboratorInfo: { id: 200 },
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 4 ),
+				awareness: mockAwareness,
+				log: jest.fn(),
+				maxPeersPerRoom: 2,
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			// Only 2 valid users (100, 200) — should not disconnect.
+			expect( onStatusChange ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.objectContaining( {
+						code: 'connection-limit-exceeded',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'does not enforce limits when set to 0', async () => {
+			const awareness5Users = makeAwareness( [
+				{ clientId: 1, userId: 100 },
+				{ clientId: 2, userId: 200 },
+				{ clientId: 3, userId: 300 },
+				{ clientId: 4, userId: 400 },
+				{ clientId: 5, userId: 500 },
+			] );
+
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awareness5Users,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 5 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				maxPeersPerRoom: 0,
+				maxClientsPerUser: 0,
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( onStatusChange ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.objectContaining( {
+						code: 'connection-limit-exceeded',
 					} ),
 				} )
 			);

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -36,27 +36,19 @@ jest.mock( 'y-protocols/awareness', () => ( {
 	removeAwarenessStates: jest.fn(),
 } ) );
 
+jest.mock( '@wordpress/hooks', () => ( {
+	applyFilters: jest.fn(
+		( _hook: string, defaultValue: unknown ) => defaultValue
+	),
+} ) );
+
 jest.mock( '../config', () => ( {
 	...( jest.requireActual( '../config' ) as object ),
 	MAX_UPDATE_SIZE_IN_BYTES: 10,
 } ) );
 
 jest.mock( '../utils', () => ( {
-	base64ToUint8Array: jest.fn( () => new Uint8Array() ),
-	createSyncUpdate: jest.fn( ( _data: unknown, type: string ) => ( {
-		data: '',
-		type,
-	} ) ),
-	createUpdateQueue: jest.fn( () => ( {
-		add: jest.fn(),
-		addBulk: jest.fn(),
-		clear: jest.fn(),
-		get: jest.fn( () => [] ),
-		pause: jest.fn(),
-		restore: jest.fn(),
-		resume: jest.fn(),
-		size: jest.fn( () => 0 ),
-	} ) ),
+	...( jest.requireActual( '../utils' ) as object ),
 	postSyncUpdate: jest.fn(),
 	postSyncUpdateNonBlocking: jest.fn(),
 } ) );
@@ -67,8 +59,6 @@ interface PollingManager {
 		doc: unknown;
 		awareness: unknown;
 		log: () => void;
-		maxClientsPerUser?: number;
-		maxPeersPerRoom?: number;
 		onStatusChange: () => void;
 		onSync: () => void;
 	} ) => void;
@@ -125,6 +115,7 @@ describe( 'polling-manager', () => {
 	let mockPostSyncUpdateNonBlocking: jest.Mock<
 		typeof import('../utils').postSyncUpdateNonBlocking
 	>;
+	let mockApplyFilters: jest.Mock;
 
 	beforeEach( () => {
 		jest.useFakeTimers();
@@ -136,6 +127,7 @@ describe( 'polling-manager', () => {
 			mockPostSyncUpdate = require( '../utils' ).postSyncUpdate;
 			mockPostSyncUpdateNonBlocking =
 				require( '../utils' ).postSyncUpdateNonBlocking;
+			mockApplyFilters = require( '@wordpress/hooks' ).applyFilters;
 		} );
 	} );
 
@@ -257,52 +249,34 @@ describe( 'polling-manager', () => {
 		} );
 	} );
 
-	describe( 'peer limits', () => {
-		function makeAwareness(
-			entries: Array< { clientId: number; userId: number } >
-		) {
-			const awareness: Record<
-				string,
-				{ collaboratorInfo: { id: number } }
-			> = {};
-			for ( const { clientId, userId } of entries ) {
-				awareness[ clientId ] = {
-					collaboratorInfo: { id: userId },
-				};
-			}
-			return awareness;
-		}
-
-		it( 'disconnects when unique users exceed maxPeersPerRoom on first poll', async () => {
-			const awareness3Users = makeAwareness( [
-				{ clientId: 1, userId: 100 },
-				{ clientId: 2, userId: 200 },
-				{ clientId: 3, userId: 300 },
-			] );
+	describe( 'connection limits', () => {
+		it( 'disconnects when clients exceed limit on first poll of first room', async () => {
+			// DEFAULT_CLIENT_LIMIT_PER_ROOM is 3. 4 clients should exceed it.
+			const awareness = {
+				1: { collaboratorInfo: { id: 100 } },
+				2: { collaboratorInfo: { id: 200 } },
+				3: { collaboratorInfo: { id: 300 } },
+				4: { collaboratorInfo: { id: 400 } },
+			};
 
 			mockPostSyncUpdate.mockResolvedValue( {
 				rooms: [
 					{
 						room: 'test-room',
 						end_cursor: 1,
-						awareness: awareness3Users,
+						awareness,
 						updates: [],
 					},
 				],
 			} );
 
 			const onStatusChange = jest.fn();
-			const mockAwareness = createMockAwareness();
-			mockAwareness.getLocalState.mockReturnValue( {
-				collaboratorInfo: { id: 300 },
-			} );
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
-				doc: createMockDoc( 3 ),
-				awareness: mockAwareness,
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
 				log: jest.fn(),
-				maxPeersPerRoom: 2,
 				onStatusChange,
 				onSync: jest.fn(),
 			} );
@@ -317,35 +291,32 @@ describe( 'polling-manager', () => {
 			} );
 		} );
 
-		it( 'allows connection when under the peer limit', async () => {
-			const awareness2Users = makeAwareness( [
-				{ clientId: 1, userId: 100 },
-				{ clientId: 2, userId: 200 },
-			] );
+		it( 'allows connection when clients are at or under the limit', async () => {
+			// DEFAULT_CLIENT_LIMIT_PER_ROOM is 3. 3 clients should be fine.
+			const awareness = {
+				1: { collaboratorInfo: { id: 100 } },
+				2: { collaboratorInfo: { id: 200 } },
+				3: { collaboratorInfo: { id: 300 } },
+			};
 
 			mockPostSyncUpdate.mockResolvedValue( {
 				rooms: [
 					{
 						room: 'test-room',
 						end_cursor: 1,
-						awareness: awareness2Users,
+						awareness,
 						updates: [],
 					},
 				],
 			} );
 
 			const onStatusChange = jest.fn();
-			const mockAwareness = createMockAwareness();
-			mockAwareness.getLocalState.mockReturnValue( {
-				collaboratorInfo: { id: 200 },
-			} );
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
-				doc: createMockDoc( 2 ),
-				awareness: mockAwareness,
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
 				log: jest.fn(),
-				maxPeersPerRoom: 2,
 				onStatusChange,
 				onSync: jest.fn(),
 			} );
@@ -361,79 +332,103 @@ describe( 'polling-manager', () => {
 			);
 		} );
 
-		it( 'disconnects when same-user tabs exceed maxClientsPerUser', async () => {
-			const awareness3Tabs = makeAwareness( [
-				{ clientId: 1, userId: 100 },
-				{ clientId: 2, userId: 100 },
-				{ clientId: 3, userId: 100 },
-			] );
-
+		it( 'does not enforce limits on the second registered room', async () => {
+			// Register a first room (which consumes the enforceConnectionLimit flag).
 			mockPostSyncUpdate.mockResolvedValue( {
 				rooms: [
 					{
-						room: 'test-room',
+						room: 'first-room',
 						end_cursor: 1,
-						awareness: awareness3Tabs,
+						awareness: { 1: {} },
 						updates: [],
 					},
 				],
 			} );
 
-			const onStatusChange = jest.fn();
-			const mockAwareness = createMockAwareness();
-			mockAwareness.getLocalState.mockReturnValue( {
-				collaboratorInfo: { id: 100 },
-			} );
-
 			pollingManager.registerRoom( {
-				room: 'test-room',
-				doc: createMockDoc( 3 ),
-				awareness: mockAwareness,
+				room: 'first-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
 				log: jest.fn(),
-				maxClientsPerUser: 2,
-				onStatusChange,
+				onStatusChange: jest.fn(),
 				onSync: jest.fn(),
 			} );
 
 			await jest.advanceTimersByTimeAsync( 0 );
 
-			expect( onStatusChange ).toHaveBeenCalledWith( {
-				status: 'disconnected',
-				error: expect.objectContaining( {
-					code: 'connection-limit-exceeded',
-				} ),
-			} );
-		} );
+			// Now register a second room with many clients — should not disconnect.
+			const awarenessMany = {
+				1: {},
+				2: {},
+				3: {},
+				4: {},
+				5: {},
+			};
 
-		it( 'does not re-check limits after initial sync', async () => {
-			// First poll: 2 users (at limit, passes).
-			const awareness2Users = makeAwareness( [
-				{ clientId: 1, userId: 100 },
-				{ clientId: 2, userId: 200 },
-			] );
 			mockPostSyncUpdate.mockResolvedValue( {
 				rooms: [
 					{
-						room: 'test-room',
+						room: 'first-room',
+						end_cursor: 2,
+						awareness: { 1: {} },
+						updates: [],
+					},
+					{
+						room: 'second-room',
 						end_cursor: 1,
-						awareness: awareness2Users,
+						awareness: awarenessMany,
 						updates: [],
 					},
 				],
 			} );
 
 			const onStatusChange = jest.fn();
-			const mockAwareness = createMockAwareness();
-			mockAwareness.getLocalState.mockReturnValue( {
-				collaboratorInfo: { id: 200 },
+
+			pollingManager.registerRoom( {
+				room: 'second-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange,
+				onSync: jest.fn(),
 			} );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			expect( onStatusChange ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.objectContaining( {
+						code: 'connection-limit-exceeded',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'does not re-check limits after initial sync', async () => {
+			// First poll: 3 clients (at limit, passes).
+			const awareness3 = {
+				1: {},
+				2: {},
+				3: {},
+			};
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: awareness3,
+						updates: [],
+					},
+				],
+			} );
+
+			const onStatusChange = jest.fn();
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
-				doc: createMockDoc( 2 ),
-				awareness: mockAwareness,
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
 				log: jest.fn(),
-				maxPeersPerRoom: 2,
 				onStatusChange,
 				onSync: jest.fn(),
 			} );
@@ -442,18 +437,20 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 			onStatusChange.mockClear();
 
-			// Second poll: 3 users (over limit).
-			const awareness3Users = makeAwareness( [
-				{ clientId: 1, userId: 100 },
-				{ clientId: 2, userId: 200 },
-				{ clientId: 3, userId: 300 },
-			] );
+			// Second poll: 5 clients (over limit).
+			const awareness5 = {
+				1: {},
+				2: {},
+				3: {},
+				4: {},
+				5: {},
+			};
 			mockPostSyncUpdate.mockResolvedValue( {
 				rooms: [
 					{
 						room: 'test-room',
 						end_cursor: 2,
-						awareness: awareness3Users,
+						awareness: awareness5,
 						updates: [],
 					},
 				],
@@ -471,12 +468,53 @@ describe( 'polling-manager', () => {
 			);
 		} );
 
-		it( 'skips awareness entries with null or missing collaboratorInfo', async () => {
-			const awarenessWithNulls: Record< string, object | null > = {
-				1: { collaboratorInfo: { id: 100 } },
-				2: null,
+		it( 'passes room name to applyFilters for per-room customization', async () => {
+			const awareness = {
+				1: {},
+				2: {},
 				3: {},
-				4: { collaboratorInfo: { id: 200 } },
+				4: {},
+			};
+
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'my-custom-room',
+						end_cursor: 1,
+						awareness,
+						updates: [],
+					},
+				],
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'my-custom-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( mockApplyFilters ).toHaveBeenCalledWith(
+				'collaboration.sync.maxClientsPerRoom',
+				3,
+				'my-custom-room'
+			);
+		} );
+
+		it( 'respects a custom limit from applyFilters', async () => {
+			// Override the filter to allow up to 10 clients.
+			mockApplyFilters.mockReturnValue( 10 );
+
+			const awareness = {
+				1: {},
+				2: {},
+				3: {},
+				4: {},
+				5: {},
 			};
 
 			mockPostSyncUpdate.mockResolvedValue( {
@@ -484,74 +522,26 @@ describe( 'polling-manager', () => {
 					{
 						room: 'test-room',
 						end_cursor: 1,
-						awareness: awarenessWithNulls,
+						awareness,
 						updates: [],
 					},
 				],
 			} );
 
 			const onStatusChange = jest.fn();
-			const mockAwareness = createMockAwareness();
-			mockAwareness.getLocalState.mockReturnValue( {
-				collaboratorInfo: { id: 200 },
-			} );
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
-				doc: createMockDoc( 4 ),
-				awareness: mockAwareness,
-				log: jest.fn(),
-				maxPeersPerRoom: 2,
-				onStatusChange,
-				onSync: jest.fn(),
-			} );
-
-			await jest.advanceTimersByTimeAsync( 0 );
-
-			// Only 2 valid users (100, 200) — should not disconnect.
-			expect( onStatusChange ).not.toHaveBeenCalledWith(
-				expect.objectContaining( {
-					error: expect.objectContaining( {
-						code: 'connection-limit-exceeded',
-					} ),
-				} )
-			);
-		} );
-
-		it( 'does not enforce limits when set to 0', async () => {
-			const awareness5Users = makeAwareness( [
-				{ clientId: 1, userId: 100 },
-				{ clientId: 2, userId: 200 },
-				{ clientId: 3, userId: 300 },
-				{ clientId: 4, userId: 400 },
-				{ clientId: 5, userId: 500 },
-			] );
-
-			mockPostSyncUpdate.mockResolvedValue( {
-				rooms: [
-					{
-						room: 'test-room',
-						end_cursor: 1,
-						awareness: awareness5Users,
-						updates: [],
-					},
-				],
-			} );
-
-			const onStatusChange = jest.fn();
-			pollingManager.registerRoom( {
-				room: 'test-room',
-				doc: createMockDoc( 5 ),
+				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
 				log: jest.fn(),
-				maxPeersPerRoom: 0,
-				maxClientsPerUser: 0,
 				onStatusChange,
 				onSync: jest.fn(),
 			} );
 
 			await jest.advanceTimersByTimeAsync( 0 );
 
+			// 5 clients under a limit of 10 — should not disconnect.
 			expect( onStatusChange ).not.toHaveBeenCalledWith(
 				expect.objectContaining( {
 					error: expect.objectContaining( {

--- a/packages/sync/src/providers/http-polling/test/utils.test.ts
+++ b/packages/sync/src/providers/http-polling/test/utils.test.ts
@@ -22,6 +22,7 @@ import {
 	base64ToUint8Array,
 	createSyncUpdate,
 	createUpdateQueue,
+	intValueOrDefault,
 	postSyncUpdate,
 	uint8ArrayToBase64,
 } from '../utils';
@@ -629,6 +630,34 @@ describe( 'http-polling utils', () => {
 			await expect( postSyncUpdate( { rooms: [] } ) ).rejects.toThrow(
 				'Network error'
 			);
+		} );
+	} );
+
+	describe( 'intValueOrDefault', () => {
+		it( 'returns the integer value when parsing succeeds', () => {
+			expect( intValueOrDefault( '42', 0 ) ).toBe( 42 );
+			expect( intValueOrDefault( '-10', 0 ) ).toBe( -10 );
+			expect( intValueOrDefault( '0', 1 ) ).toBe( 0 );
+		} );
+
+		it( 'returns the default value when parsing fails', () => {
+			expect( intValueOrDefault( 'abc', 100 ) ).toBe( 100 );
+			expect( intValueOrDefault( '', 50 ) ).toBe( 50 );
+			expect( intValueOrDefault( {}, 10 ) ).toBe( 10 );
+			expect( intValueOrDefault( [], 20 ) ).toBe( 20 );
+			expect( intValueOrDefault( null, 25 ) ).toBe( 25 );
+			expect( intValueOrDefault( undefined, 75 ) ).toBe( 75 );
+		} );
+
+		it( 'handles non-string inputs gracefully', () => {
+			expect( intValueOrDefault( 123, 0 ) ).toBe( 123 );
+			expect( intValueOrDefault( 45.67, 0 ) ).toBe( 45 ); // parseInt truncates
+			expect( intValueOrDefault( 0x10, 0 ) ).toBe( 16 ); // hex
+		} );
+
+		it( 'handles edge cases', () => {
+			expect( intValueOrDefault( '   15   ', 0 ) ).toBe( 15 ); // whitespace
+			expect( intValueOrDefault( '08', 0 ) ).toBe( 8 ); // leading zero
 		} );
 	} );
 } );

--- a/packages/sync/src/providers/http-polling/utils.ts
+++ b/packages/sync/src/providers/http-polling/utils.ts
@@ -133,3 +133,19 @@ export function postSyncUpdateNonBlocking( payload: SyncPayload ): void {
 		keepalive: true,
 	} ).catch( () => {} );
 }
+
+/**
+ * Parse an integer from an unknown value, returning a default if parsing fails.
+ *
+ * @param value        The value to parse as an integer.
+ * @param defaultValue The default value to return if parsing fails.
+ * @return The parsed integer or the default value.
+ */
+export function intValueOrDefault(
+	value: unknown,
+	defaultValue: number
+): number {
+	const intValue = parseInt( String( value ), 10 );
+
+	return isNaN( intValue ) ? defaultValue : intValue;
+}


### PR DESCRIPTION
## What?

Adds client-side peer limit enforcement for real-time collaboration (RTC) sync without any PHP changes, recreating PR #75381 as a purely front-end feature.

## Why?

PR #75381 limited concurrent RTC peers but required PHP backports. This implementation enforces the same limits purely on the client side by inspecting awareness data returned from the server. Avoids backport complexity while still protecting against server resource exhaustion.

## How?


~After each poll, count unique WordPress user IDs from awareness state.~

Consider the first loaded entity "primary" and enforce the connection limit on it. If over the limit, emit `connection-limit-exceeded` error and disconnect. Defaults: 3 clients per room. Configurable via `wp.hooks.applyFilters('sync.pollingProvider.maxPeersPerRoom', ...)`.

## Testing Instructions

1. Enable RTC: WP Admin > Settings > Writing > Enable real-time collaboration
2. Open a post in two browser tabs (3 editors)
3. Open the same post in a fourth tab — modal should appear: "Too many editors connected"
4. Click "Retry" or close and try again — will succeed after closing one of the first two tabs

### Testing Instructions for Keyboard

After step 3, press Tab to focus "Retry" button, then press Enter to retry the connection.