### PR TITLE
Feature : Permalinks ordered by Date for Breadcrumbs

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail showing the path to the current page. ([Source](https
 -	**Name:** core/breadcrumbs
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
+-	**Attributes:** breadcrumbStyle, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -7,9 +7,10 @@
 	"description": "Display a breadcrumb trail showing the path to the current page.",
 	"textdomain": "default",
 	"attributes": {
-		"prefersTaxonomy": {
-			"type": "boolean",
-			"default": false
+		"breadcrumbStyle": {
+			"type": "string",
+			"default": "default",
+			"enum": [ "default", "date" ]
 		},
 		"separator": {
 			"type": "string",

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -6,7 +6,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	TextControl,
-	CheckboxControl,
+	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	Spinner,
@@ -25,6 +25,11 @@ import HtmlRenderer from '../utils/html-renderer';
 
 const separatorDefaultValue = '/';
 
+const BREADCRUMB_STYLE_OPTIONS = [
+	{ label: __( 'Default' ), value: 'default' },
+	{ label: __( 'Date' ), value: 'date' },
+];
+
 export default function BreadcrumbEdit( {
 	attributes,
 	setAttributes,
@@ -35,62 +40,62 @@ export default function BreadcrumbEdit( {
 		separator,
 		showHomeItem,
 		showCurrentItem,
-		prefersTaxonomy,
+		breadcrumbStyle,
 		showOnHomePage,
 	} = attributes;
-	const {
-		post,
-		isPostTypeHierarchical,
-		postTypeHasTaxonomies,
-		hasTermsAssigned,
-		isLoading,
-	} = useSelect(
-		( select ) => {
-			if ( ! postType ) {
-				return {};
-			}
-			const _post = select( coreStore ).getEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			const postTypeObject = select( coreStore ).getPostType( postType );
-			const _postTypeHasTaxonomies =
-				postTypeObject && postTypeObject.taxonomies.length;
-			let taxonomies;
-			if ( _postTypeHasTaxonomies ) {
-				taxonomies = select( coreStore ).getTaxonomies( {
-					type: postType,
-					per_page: -1,
-				} );
-			}
-			return {
-				post: _post,
-				isPostTypeHierarchical: postTypeObject?.hierarchical,
-				postTypeHasTaxonomies: _postTypeHasTaxonomies,
-				hasTermsAssigned:
-					_post &&
-					( taxonomies || [] )
-						.filter(
-							( { visibility } ) => visibility?.publicly_queryable
-						)
-						.some( ( taxonomy ) => {
-							return !! _post[ taxonomy.rest_base ]?.length;
-						} ),
-				isLoading:
-					( postId && ! _post ) ||
-					! postTypeObject ||
-					( _postTypeHasTaxonomies && ! taxonomies ),
-			};
-		},
-		[ postType, postId ]
-	);
+	// Handle backward compatibility for the old prefersTaxonomy attribute.
+	const effectiveBreadcrumbStyle =
+		breadcrumbStyle ||
+		( attributes.prefersTaxonomy ? 'default' : 'default' );
+	const { post, isPostTypeHierarchical, hasTermsAssigned, isLoading } =
+		useSelect(
+			( select ) => {
+				if ( ! postType ) {
+					return {};
+				}
+				const _post = select( coreStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				const postTypeObject =
+					select( coreStore ).getPostType( postType );
+				const _postTypeHasTaxonomies =
+					postTypeObject && postTypeObject.taxonomies.length;
+				let taxonomies;
+				if ( _postTypeHasTaxonomies ) {
+					taxonomies = select( coreStore ).getTaxonomies( {
+						type: postType,
+						per_page: -1,
+					} );
+				}
+				return {
+					post: _post,
+					isPostTypeHierarchical: postTypeObject?.hierarchical,
+					hasTermsAssigned:
+						_post &&
+						( taxonomies || [] )
+							.filter(
+								( { visibility } ) =>
+									visibility?.publicly_queryable
+							)
+							.some( ( taxonomy ) => {
+								return !! _post[ taxonomy.rest_base ]?.length;
+							} ),
+					isLoading:
+						( postId && ! _post ) ||
+						! postTypeObject ||
+						( _postTypeHasTaxonomies && ! taxonomies ),
+				};
+			},
+			[ postType, postId ]
+		);
 
 	/**
 	 * Counter used to cache-bust `useServerSideRender`.
 	 *
 	 * This is a catch-all signal to re-render the block when a post's title,
-	 * parent ID, or terms change.
+	 * parent ID, terms, or breadcrumb style change.
 	 *
 	 * This is fundamentally imperfect, because there are other entities which
 	 * could change in the meantime (the titles of ancestor posts, or the
@@ -100,7 +105,7 @@ export default function BreadcrumbEdit( {
 	const [ invalidationKey, setInvalidationKey ] = useState( 0 );
 	useEffect( () => {
 		setInvalidationKey( ( c ) => c + 1 );
-	}, [ post ] );
+	}, [ post, effectiveBreadcrumbStyle ] );
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { content, status, error } = useServerSideRender( {
@@ -110,11 +115,18 @@ export default function BreadcrumbEdit( {
 		urlQueryArgs: { post_id: postId, invalidationKey },
 	} );
 	const prevContentRef = useRef( '' );
+	const prevBreadcrumbStyleRef = useRef( effectiveBreadcrumbStyle );
 	useEffect( () => {
+		// Clear cached content when breadcrumb style changes to prevent
+		// showing stale content from a different style during the transition.
+		if ( prevBreadcrumbStyleRef.current !== effectiveBreadcrumbStyle ) {
+			prevBreadcrumbStyleRef.current = effectiveBreadcrumbStyle;
+			prevContentRef.current = '';
+		}
 		if ( status === 'success' ) {
 			prevContentRef.current = content;
 		}
-	}, [ content, status ] );
+	}, [ content, status, effectiveBreadcrumbStyle ] );
 	const [ showLoader, setShowLoader ] = useState( false );
 	useEffect( () => {
 		if ( status !== 'loading' ) {
@@ -140,18 +152,15 @@ export default function BreadcrumbEdit( {
 	}
 
 	// Try to determine breadcrumb type for more accurate previews.
-	let _showTerms;
+	let _breadcrumbStyle = effectiveBreadcrumbStyle;
 	// Some non-hierarchical post types (e.g., attachments) can have parents.
-	// Use hierarchical breadcrumbs if a parent exists, otherwise use taxonomy breadcrumbs.
-	if ( ! isPostTypeHierarchical && ! post?.parent ) {
-		_showTerms = true;
-	} else if ( ! postTypeHasTaxonomies ) {
-		// Hierarchical post type without taxonomies can only use ancestors.
-		_showTerms = false;
-	} else {
-		// For hierarchical post types with taxonomies, use the attribute.
-		_showTerms = prefersTaxonomy;
+	// For 'default' style, determine if we should show taxonomy or hierarchy.
+	if ( effectiveBreadcrumbStyle === 'default' ) {
+		if ( ! isPostTypeHierarchical && ! post?.parent ) {
+			_breadcrumbStyle = 'taxonomy';
+		}
 	}
+
 	let placeholder = null;
 	// This is fragile because this block is server side rendered and we'll have to
 	// update the placeholder html if the server side rendering output changes.
@@ -162,8 +171,11 @@ export default function BreadcrumbEdit( {
 		// This is needed because when we are showing the template in post editor we
 		// want to show the real breadcrumbs if we have the post type.
 		( templateSlug && ! postType ) ||
-		( ! _showTerms && ! isPostTypeHierarchical ) ||
-		( _showTerms && ! hasTermsAssigned );
+		( _breadcrumbStyle === 'default' &&
+			! isPostTypeHierarchical &&
+			! post?.parent &&
+			! hasTermsAssigned ) ||
+		( _breadcrumbStyle === 'taxonomy' && ! hasTermsAssigned );
 	if ( showPlaceholder ) {
 		const placeholderItems = [];
 		if ( showHomeItem ) {
@@ -171,7 +183,7 @@ export default function BreadcrumbEdit( {
 		}
 		if ( templateSlug && ! postId ) {
 			placeholderItems.push( __( 'Page' ) );
-		} else if ( _showTerms ) {
+		} else if ( _breadcrumbStyle === 'taxonomy' ) {
 			placeholderItems.push( __( 'Category' ) );
 		} else {
 			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
@@ -280,27 +292,40 @@ export default function BreadcrumbEdit( {
 							} }
 						/>
 					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Breadcrumb style' ) }
+						isShownByDefault
+						hasValue={ () =>
+							breadcrumbStyle && breadcrumbStyle !== 'default'
+						}
+						onDeselect={ () =>
+							setAttributes( { breadcrumbStyle: 'default' } )
+						}
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							label={ __( 'Breadcrumb style' ) }
+							options={ BREADCRUMB_STYLE_OPTIONS }
+							value={ effectiveBreadcrumbStyle }
+							onChange={ ( value ) =>
+								setAttributes( { breadcrumbStyle: value } )
+							}
+							help={ __(
+								'Choose how to display the breadcrumb trail for single posts. "Default" shows post hierarchy for hierarchical post types, taxonomy terms for non-hierarchical post types. "Date" shows the publish date path (Year > Month > Day).'
+							) }
+						/>
+					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			<InspectorControls group="advanced">
-				<CheckboxControl
+				<ToggleControl
 					label={ __( 'Show on homepage' ) }
 					checked={ showOnHomePage }
 					onChange={ ( value ) =>
 						setAttributes( { showOnHomePage: value } )
 					}
 					help={ __(
-						'If this breadcrumbs block appears in a template or template part that’s shown on the homepage, enable this option to display the breadcrumb trail. Otherwise, this setting has no effect.'
-					) }
-				/>
-				<CheckboxControl
-					label={ __( 'Prefer taxonomy terms' ) }
-					checked={ prefersTaxonomy }
-					onChange={ ( value ) =>
-						setAttributes( { prefersTaxonomy: value } )
-					}
-					help={ __(
-						'The exact type of breadcrumbs shown will vary automatically depending on the page in which this block is displayed. In the specific case of a hierarchical post type with taxonomies, the breadcrumbs can either reflect its post hierarchy (default) or the hierarchy of its assigned taxonomy terms.'
+						"If this breadcrumbs block appears in a template or template part that's shown on the homepage, enable this option to display the breadcrumb trail. Otherwise, this setting has no effect."
 					) }
 				/>
 			</InspectorControls>

--- a/packages/block-library/src/breadcrumbs/index.js
+++ b/packages/block-library/src/breadcrumbs/index.js
@@ -18,6 +18,87 @@ export const settings = {
 	icon: breadcrumbs,
 	example: {},
 	edit,
+	deprecated: [
+		{
+			attributes: {
+				prefersTaxonomy: {
+					type: 'boolean',
+					default: false,
+				},
+				separator: {
+					type: 'string',
+					default: '/',
+				},
+				showHomeItem: {
+					type: 'boolean',
+					default: true,
+				},
+				showCurrentItem: {
+					type: 'boolean',
+					default: true,
+				},
+				showOnHomePage: {
+					type: 'boolean',
+					default: false,
+				},
+			},
+			supports: metadata.supports,
+			save() {
+				return null;
+			},
+			migrate( attributes ) {
+				// prefersTaxonomy is no longer needed - 'default' style already
+				// uses taxonomy for non-hierarchical post types.
+				// Just remove the old attribute.
+				const { prefersTaxonomy, ...rest } = attributes;
+				return {
+					...rest,
+					breadcrumbStyle: 'default',
+				};
+			},
+		},
+		{
+			attributes: {
+				breadcrumbStyle: {
+					type: 'string',
+					default: 'default',
+					enum: [ 'default', 'taxonomy', 'date' ],
+				},
+				separator: {
+					type: 'string',
+					default: '/',
+				},
+				showHomeItem: {
+					type: 'boolean',
+					default: true,
+				},
+				showCurrentItem: {
+					type: 'boolean',
+					default: true,
+				},
+				showOnHomePage: {
+					type: 'boolean',
+					default: false,
+				},
+			},
+			supports: metadata.supports,
+			save() {
+				return null;
+			},
+			migrate( attributes ) {
+				// Migration from 'taxonomy' style to 'default'
+				// since 'default' now handles taxonomy automatically for non-hierarchical posts.
+				const { breadcrumbStyle, ...rest } = attributes;
+				return {
+					...rest,
+					breadcrumbStyle:
+						breadcrumbStyle === 'taxonomy'
+							? 'default'
+							: breadcrumbStyle,
+				};
+			},
+		},
+	],
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -103,36 +103,59 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			}
 		}
 
-		// Determine breadcrumb type.
+		// Determine breadcrumb style.
+		// Handle backward compatibility: prefersTaxonomy was a boolean, now breadcrumbStyle is an enum.
+		// The 'taxonomy' value is deprecated - 'default' now automatically uses taxonomy for non-hierarchical posts.
+		$breadcrumb_style = 'default';
+		if ( isset( $attributes['breadcrumbStyle'] ) && 'date' === $attributes['breadcrumbStyle'] ) {
+			$breadcrumb_style = 'date';
+		}
+		// Note: prefersTaxonomy is no longer needed - 'default' already uses taxonomy for non-hierarchical posts.
+
+		// Determine which breadcrumb type to show for 'default' style.
 		// Some non-hierarchical post types (e.g., attachments) can have parents.
-		// Use hierarchical breadcrumbs if a parent exists, otherwise use taxonomy breadcrumbs.
-		$show_terms = false;
-		if ( ! is_post_type_hierarchical( $post_type ) && ! $post_parent ) {
-			$show_terms = true;
-		} elseif ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
-			$show_terms = false;
+		$show_date        = false;
+		$show_terms       = false;
+		$show_hierarchy   = false;
+
+		if ( 'date' === $breadcrumb_style ) {
+			$show_date = true;
 		} else {
-			$show_terms = $attributes['prefersTaxonomy'];
+			// Default: Use hierarchical breadcrumbs if hierarchical post type and has parent,
+			// or use taxonomy breadcrumbs for non-hierarchical post types.
+			if ( ! is_post_type_hierarchical( $post_type ) && ! $post_parent ) {
+				$show_terms = true;
+			} elseif ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
+				$show_hierarchy = true;
+			} else {
+				$show_hierarchy = true;
+			}
 		}
 
 		// Add post type archive link if applicable.
-		$post_type_object = get_post_type_object( $post_type );
-		$archive_link     = get_post_type_archive_link( $post_type );
-		if ( $archive_link && untrailingslashit( home_url() ) !== untrailingslashit( $archive_link ) ) {
-			$label = $post_type_object->labels->archives;
-			if ( 'post' === $post_type && $page_for_posts ) {
-				$label = block_core_breadcrumbs_get_post_title( $page_for_posts );
+		// Skip archive link for date-based breadcrumbs (already have date structure).
+		if ( $show_hierarchy || $show_terms ) {
+			$post_type_object = get_post_type_object( $post_type );
+			$archive_link     = get_post_type_archive_link( $post_type );
+			if ( $archive_link && untrailingslashit( home_url() ) !== untrailingslashit( $archive_link ) ) {
+				$label = $post_type_object->labels->archives;
+				if ( 'post' === $post_type && $page_for_posts ) {
+					$label = block_core_breadcrumbs_get_post_title( $page_for_posts );
+				}
+				$breadcrumb_items[] = array(
+					'label' => $label,
+					'url'   => $archive_link,
+				);
 			}
-			$breadcrumb_items[] = array(
-				'label' => $label,
-				'url'   => $archive_link,
-			);
 		}
-		// Build breadcrumb trail based on hierarchical structure or taxonomy terms.
-		if ( ! $show_terms ) {
-			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
-		} else {
+
+		// Build breadcrumb trail based on selected style.
+		if ( $show_date ) {
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_date_breadcrumbs( $post_id ) );
+		} elseif ( $show_terms ) {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
+		} else {
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
 		}
 
 		// Add post title: linked when viewing a paginated page, plain text otherwise.
@@ -312,6 +335,54 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 			'allow_html' => true,
 		);
 	}
+	return $breadcrumb_items;
+}
+
+/**
+ * Generates breadcrumb items for date-based permalinks.
+ *
+ * Creates year/month/day breadcrumb trail based on the post's publish date.
+ *
+ * @since 7.0.0
+ *
+ * @param int $post_id The post ID.
+ *
+ * @return array Array of breadcrumb item data.
+ */
+function block_core_breadcrumbs_get_date_breadcrumbs( $post_id ) {
+	$post             = get_post( $post_id );
+	$breadcrumb_items = array();
+
+	if ( ! $post ) {
+		return $breadcrumb_items;
+	}
+
+	// Get the post's publish date components.
+	$year       = get_the_date( 'Y', $post );
+	$month      = get_the_date( 'm', $post );
+	$month_name = get_the_date( 'F', $post );
+	$day        = get_the_date( 'd', $post );
+	$monthnum   = (int) $month;
+	$daynum     = (int) $day;
+
+	// Add year archive link.
+	$breadcrumb_items[] = array(
+		'label' => $year,
+		'url'   => get_year_link( (int) $year ),
+	);
+
+	// Add month archive link with localized month name.
+	$breadcrumb_items[] = array(
+		'label' => $month_name,
+		'url'   => get_month_link( (int) $year, $monthnum ),
+	);
+
+	// Add day archive link.
+	$breadcrumb_items[] = array(
+		'label' => $day,
+		'url'   => get_day_link( (int) $year, $monthnum, $daynum ),
+	);
+
 	return $breadcrumb_items;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

-   Closes https://github.com/WordPress/gutenberg/issues/74966

Adds date-based permalinks support to the Breadcrumbs block. Now you can show breadcrumb trails like `Home > 2026 > March > 12 > My Post Title` to match date-based permalink structures.

## Why?

If you use date-based permalinks on your site (like `/2026/03/12/my-post/`), your breadcrumbs should reflect that structure. Before this PR, the Breadcrumbs block only gave you two options:

1.  **Hierarchy** - Home > Parent Page > Child Page (for pages)
2.  **Taxonomy** - Home > Blog > Category > Post (for posts)

But a lot of sites use date-based permalinks, and there was no way to show `Home > Year > Month > Day > Post Title` in the breadcrumb trail. This PR adds that option.

## How?

### What changed

**Block attribute**

Added a new `breadcrumbStyle` dropdown with two options:

-   **Default** - Uses the existing behavior (hierarchy for pages, taxonomy for posts)
-   **Date** - Shows Year > Month > Day before the post title

The old `prefersTaxonomy` checkbox has been replaced with this dropdown. Existing blocks get migrated automatically.

**PHP changes**

Added a new `block_core_breadcrumbs_get_date_breadcrumbs()` function that builds the date trail from the post's publish date:

-   Year links to the year archive
-   Month links to the month archive (with localized month name)
-   Day links to the day archive

**Editor changes**

Replaced the "Prefer taxonomy terms" checkbox with a cleaner "Breadcrumb style" dropdown. Also fixed a bug where switching styles would briefly show stale content.

## Testing Instructions

1. Start the dev environment: `npm run wp-env start`
2. Create a few posts with different publish dates
3. Add a Breadcrumbs block to a post template (like `single.html`)
4. In the sidebar, try the **Breadcrumb style** dropdown:
    - **Default** should show taxonomy or hierarchy depending on your post type
    - **Date** should show Year > Month > Day > Post Title
5. On the frontend, click each date link and verify it goes to the right archive page

## Preview
<img width="283" height="592" alt="Screenshot 2026-03-17 at 2 06 00 PM" src="https://github.com/user-attachments/assets/a51b2bc6-ce99-42ed-8464-7818f682160d" />
<img width="421" height="140" alt="Screenshot 2026-03-17 at 2 06 08 PM" src="https://github.com/user-attachments/assets/2ec442ed-7587-48a2-bb0f-dcbbd1876a38" />
