### PR TITLE
CI: Don't build release notes during plugin build workflow for WP Cor…

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -234,7 +234,7 @@ jobs:
                   path: ./gutenberg.zip
 
             - name: Build release notes draft
-              if: ${{ needs.bump-version.outputs.new_version }}
+              if: ${{ matrix.IS_GUTENBERG_PLUGIN && needs.bump-version.outputs.new_version }}
               env:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               run: |
@@ -250,8 +250,8 @@ jobs:
                   fi
 
             - name: Upload release notes artifact
-              if: ${{ needs.bump-version.outputs.new_version }}
-              uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+              if: ${{ matrix.IS_GUTENBERG_PLUGIN && needs.bump-version.outputs.new_version }}
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
                   name: release-notes
                   path: ./release-notes.txt


### PR DESCRIPTION
## What?
This performs a `git cherry-pick` on d738de8b5ccd5cfc0dceee7e7c232738ebade15c from `trunk`/#76398, which is failing to be done by the workflow.

## Use of AI Tools
No AI was used.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
