### PR TITLE
Connectors: fix button size

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -211,9 +211,15 @@ export function DefaultConnectorSettings( {
 			/>
 			{ readOnly ? (
 				onRemove && (
-					<Button variant="link" isDestructive onClick={ onRemove }>
-						{ __( 'Remove and replace' ) }
-					</Button>
+					<HStack justify="flex-start">
+						<Button
+							variant="link"
+							isDestructive
+							onClick={ onRemove }
+						>
+							{ __( 'Remove and replace' ) }
+						</Button>
+					</HStack>
 				)
 			) : (
 				<HStack justify="flex-start">

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -201,11 +201,7 @@ function ApiKeyConnector( {
 									? 'tertiary'
 									: 'secondary'
 							}
-							size={
-								isExpanded || isConnected
-									? undefined
-									: 'compact'
-							}
+							size="compact"
 							onClick={ handleActionClick }
 							disabled={ pluginStatus === 'checking' || isBusy }
 							isBusy={ isBusy }


### PR DESCRIPTION
## What?

This PR fixes the following two incorrect button sizes:

- The size of the cancel and edit buttons is 36px, which is not the recommended size
- The width of the Remove and Replace button is 100%

| Before | After |
|--------|--------|
| <img width="670" height="464" alt="image" src="https://github.com/user-attachments/assets/df61932a-9579-4f52-b622-4de0510d8c63" /> | <img width="662" height="469" alt="image" src="https://github.com/user-attachments/assets/513bbeca-6416-4872-91c6-e2cb5f574a6a" /> |

## Testing Instructions

Access http://localhost:8888/wp-admin/options-connectors.php