### PR TITLE
Allow Image resizing using resize handles when nested in Group block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -113,6 +113,7 @@ export function ImageEdit( {
 	} = attributes;
 
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
+	const [ isShrinkWrapped, setIsShrinkWrapped ] = useState( false );
 
 	const containerRef = useRef();
 	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
@@ -147,6 +148,28 @@ export function ImageEdit( {
 			} );
 		}
 	}, [ __unstableMarkNextChangeAsNotPersistent, align, setAttributes ] );
+
+	useEffect( () => {
+		if ( ! containerRef.current ) {
+			return;
+		}
+		const parent = containerRef?.current?.parentElement;
+		const grandParent = parent?.parentElement;
+
+		if ( ! parent || ! grandParent ) {
+			return;
+		}
+
+		const grandParentDisplay =
+			window.getComputedStyle( grandParent ).display;
+		const isFlexChild =
+			grandParentDisplay === 'flex' ||
+			grandParentDisplay === 'inline-flex';
+		const flexGrow = parseFloat(
+			window.getComputedStyle( parent ).flexGrow
+		);
+		setIsShrinkWrapped( isFlexChild && flexGrow === 0 );
+	}, [ containerRef ] );
 
 	const {
 		getSettings,
@@ -480,7 +503,7 @@ export function ImageEdit( {
 					clientId={ clientId }
 					blockEditingMode={ blockEditingMode }
 					parentLayoutType={ layoutType }
-					maxContentWidth={ maxContentWidth }
+					maxContentWidth={ isShrinkWrapped ? null : maxContentWidth }
 				/>
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }


### PR DESCRIPTION
## What?
Ref https://github.com/WordPress/gutenberg/issues/70484

## Why?
The Image Block Resize Handle do not work when group block is set to fit but the dimensions can be altered using the controls.

## How?
Add logic to determine if image is shrink wrapped and prevent applying max content width.

## Testing Instructions
1. Create a dummy post.
2. Add a Row block and inside it add a Group Block.
3. Add an image inside group block and resize it using resize handles.

## Working Demo
https://github.com/user-attachments/assets/86079e29-1a82-47b8-a782-6389662ba3f0
