### PR TITLE
Navigation overlay close button may be displayed twice

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -697,14 +697,10 @@ class WP_Navigation_Block_Renderer {
 		if ( ! empty( $attributes['overlay'] ) ) {
 			// Get blocks from the overlay template part.
 			$overlay_blocks = static::get_overlay_blocks_from_template_part( $attributes['overlay'], $attributes );
-			// Check if overlay contains a navigation-overlay-close block.
-			$has_custom_overlay_close_block = block_core_navigation_block_tree_has_block_type(
-				$overlay_blocks,
-				'core/navigation-overlay-close',
-				array( 'core/navigation' ) // Skip navigation blocks, as they cannot contain an overlay close block
-			);
 			// Render template part blocks directly without navigation container wrapper.
 			$overlay_blocks_html = static::get_template_part_blocks_html( $overlay_blocks );
+			// Check if overlay contains a navigation-overlay-close block (detect in rendered HTML so it works with patterns).
+			$has_custom_overlay_close_block = block_core_navigation_overlay_html_has_close_block( $overlay_blocks_html );
 			// Add Interactivity API directives to the overlay close block if present.
 			if ( $has_custom_overlay_close_block && $is_interactive ) {
 				$tags                = new WP_HTML_Tag_Processor( $overlay_blocks_html );
@@ -1092,6 +1088,28 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 		$parsed_blocks           = block_core_navigation_parse_blocks_from_menu_items( $menu_items_by_parent_id[0], $menu_items_by_parent_id );
 		return new WP_Block_List( $parsed_blocks, $attributes );
 	}
+}
+
+/**
+ * Checks if the overlay HTML contains a navigation-overlay-close block.
+ *
+ * Uses WP_HTML_Tag_Processor to detect the close button in rendered output,
+ * so it works when the overlay uses patterns (pattern content is rendered at
+ * output time, not in the block tree).
+ *
+ * @since 7.0.0
+ *
+ * @param string $html The rendered overlay HTML.
+ * @return bool True if a close button element is found.
+ */
+function block_core_navigation_overlay_html_has_close_block( $html ) {
+	$tags = new WP_HTML_Tag_Processor( $html );
+	return $tags->next_tag(
+		array(
+			'tag_name'   => 'BUTTON',
+			'class_name' => 'wp-block-navigation-overlay-close',
+		)
+	);
 }
 
 /**

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -261,7 +261,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
 	 */
 	public function test_block_core_navigation_overlay_html_has_close_block_returns_true_when_close_button_present() {
-		$html  = '<div class="wp-block-group"><button class="wp-block-navigation-overlay-close" type="button">Close</button></div>';
+		$html   = '<div class="wp-block-group"><button class="wp-block-navigation-overlay-close" type="button">Close</button></div>';
 		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
 		$this->assertTrue( $result );
 	}
@@ -327,7 +327,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
 		// Simulate overlay template part content: just a pattern block (unresolved in block tree).
 		$parsed_blocks = parse_blocks( '<!-- wp:pattern {"slug":"test/navigation-overlay-pattern"} /-->' );
-		$blocks       = new WP_Block_List( $parsed_blocks, array() );
+		$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
 		// Render blocks (pattern block's render_callback outputs pattern content).
 		$html = '';

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -260,7 +260,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
 	 */
-	public function test_block_core_navigation_overlay_html_has_close_block_returns_true_when_close_button_present() {
+	public function test_gutenberg_block_core_navigation_overlay_html_has_close_block_returns_true_when_close_button_present() {
 		$html   = '<div class="wp-block-group"><button class="wp-block-navigation-overlay-close" type="button">Close</button></div>';
 		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
 		$this->assertTrue( $result );
@@ -273,7 +273,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
 	 */
-	public function test_block_core_navigation_overlay_html_has_close_block_returns_false_when_absent() {
+	public function test_gutenberg_block_core_navigation_overlay_html_has_close_block_returns_false_when_absent() {
 		$html   = '<div class="wp-block-group"><p>No close button here</p></div>';
 		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
 		$this->assertFalse( $result );
@@ -286,7 +286,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
 	 */
-	public function test_block_core_navigation_overlay_html_has_close_block_returns_false_when_class_in_text_only() {
+	public function test_gutenberg_block_core_navigation_overlay_html_has_close_block_returns_false_when_class_in_text_only() {
 		$html   = '<p>Use the wp-block-navigation-overlay-close button to close</p>';
 		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
 		$this->assertFalse( $result );
@@ -325,22 +325,24 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 			)
 		);
 
-		// Simulate overlay template part content: just a pattern block (unresolved in block tree).
-		$parsed_blocks = parse_blocks( '<!-- wp:pattern {"slug":"test/navigation-overlay-pattern"} /-->' );
-		$blocks        = new WP_Block_List( $parsed_blocks, array() );
+		try {
+			// Simulate overlay template part content: just a pattern block (unresolved in block tree).
+			$parsed_blocks = parse_blocks( '<!-- wp:pattern {"slug":"test/navigation-overlay-pattern"} /-->' );
+			$blocks        = new WP_Block_List( $parsed_blocks, array() );
 
-		// Render blocks (pattern block's render_callback outputs pattern content).
-		$html = '';
-		foreach ( $blocks as $block ) {
-			$html .= $block->render();
+			// Render blocks (pattern block's render_callback outputs pattern content).
+			$html = '';
+			foreach ( $blocks as $block ) {
+				$html .= $block->render();
+			}
+
+			$this->assertTrue(
+				gutenberg_block_core_navigation_overlay_html_has_close_block( $html ),
+				'Close block should be detected in rendered pattern output (fixes #76567).'
+			);
+		} finally {
+			unregister_block_pattern( 'test/navigation-overlay-pattern' );
 		}
-
-		$this->assertTrue(
-			gutenberg_block_core_navigation_overlay_html_has_close_block( $html ),
-			'Close block should be detected in rendered pattern output (fixes #76567).'
-		);
-
-		unregister_block_pattern( 'test/navigation-overlay-pattern' );
 	}
 
 	/**

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -254,6 +254,96 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that gutenberg_block_core_navigation_overlay_html_has_close_block returns true when HTML contains the close button element.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
+	 */
+	public function test_block_core_navigation_overlay_html_has_close_block_returns_true_when_close_button_present() {
+		$html  = '<div class="wp-block-group"><button class="wp-block-navigation-overlay-close" type="button">Close</button></div>';
+		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that gutenberg_block_core_navigation_overlay_html_has_close_block returns false when HTML does not contain the close button.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
+	 */
+	public function test_block_core_navigation_overlay_html_has_close_block_returns_false_when_absent() {
+		$html   = '<div class="wp-block-group"><p>No close button here</p></div>';
+		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that gutenberg_block_core_navigation_overlay_html_has_close_block returns false when class string appears only in text content.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
+	 */
+	public function test_block_core_navigation_overlay_html_has_close_block_returns_false_when_class_in_text_only() {
+		$html   = '<p>Use the wp-block-navigation-overlay-close button to close</p>';
+		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that gutenberg_block_core_navigation_overlay_html_has_close_block finds nested close button.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
+	 */
+	public function test_block_core_navigation_overlay_html_has_close_block_finds_nested_close_button() {
+		$html   = '<div class="wp-block-group"><div class="wp-block-group"><button class="wp-block-navigation-overlay-close" type="button" aria-label="Close"><svg>...</svg></button></div></div>';
+		$result = gutenberg_block_core_navigation_overlay_html_has_close_block( $html );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that gutenberg_block_core_navigation_overlay_html_has_close_block detects close block when overlay content is a pattern.
+	 *
+	 * Simulates the bug scenario: template part contains wp:pattern, pattern renders its content including the close block.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers ::gutenberg_block_core_navigation_overlay_html_has_close_block
+	 */
+	public function test_block_core_navigation_overlay_html_has_close_block_detects_close_in_pattern_output() {
+		register_block_pattern(
+			'test/navigation-overlay-pattern',
+			array(
+				'title'       => 'Navigation Overlay Pattern',
+				'content'     => '<!-- wp:group --><div class="wp-block-group"><!-- wp:navigation-overlay-close /--></div><!-- /wp:group -->',
+				'description' => 'Pattern containing navigation-overlay-close (simulates overlay template part using pattern).',
+				'categories'  => array( 'navigation' ),
+			)
+		);
+
+		// Simulate overlay template part content: just a pattern block (unresolved in block tree).
+		$parsed_blocks = parse_blocks( '<!-- wp:pattern {"slug":"test/navigation-overlay-pattern"} /-->' );
+		$blocks       = new WP_Block_List( $parsed_blocks, array() );
+
+		// Render blocks (pattern block's render_callback outputs pattern content).
+		$html = '';
+		foreach ( $blocks as $block ) {
+			$html .= $block->render();
+		}
+
+		$this->assertTrue(
+			gutenberg_block_core_navigation_overlay_html_has_close_block( $html ),
+			'Close block should be detected in rendered pattern output (fixes #76567).'
+		);
+
+		unregister_block_pattern( 'test/navigation-overlay-pattern' );
+	}
+
+	/**
 	 * Test that gutenberg_block_core_navigation_block_tree_has_block_type skips searching inside specified block types.
 	 *
 	 * @group navigation-renderer


### PR DESCRIPTION



## What

When a navigation overlay template part uses a pattern (`<!-- wp:pattern {"slug":"..."} /-->`) that contained a close block, the close button was displayed twice - once for the close in the pattern and then a fallback. This PR fixes that.

Fixes #76567

## Why

The fallback close button must only be shown when the overlay does not already contain a close block. The issue was that if the close block was within a Pattern the fallback detection logic failed to detect it thus leading to the duplication.



## How

- Detect the close block in the rendered overlay HTML using `WP_HTML_Tag_Processor`
- Add `block_core_navigation_overlay_html_has_close_block()` helper
- Suppress the fallback close button when the overlay HTML contains the close button element

### Why not check the block tree?

Pattern blocks are self-closing in the tree (`<!-- wp:pattern {"slug":"..."} /-->`); their inner content is not expanded there. A check like `block_core_navigation_block_tree_has_block_type()` never sees the close block inside patterns, so it always reports "no close block" and the fallback is incorrectly added.

### Why check rendered HTML?

When the block renders, patterns are resolved and their content is output. The close button appears in the actual HTML. Detecting it there (e.g. via `WP_HTML_Tag_Processor`) correctly reflects what the user sees. It also accounts for edge cases such as hooks/filters adding close blocks...etc

## Testing Instructions

1. Create a block theme with a navigation overlay template part
2. **Inline close block:** Add `<!-- wp:navigation-overlay-close /-->` directly in the template part. Verify one close button appears.
3. **Pattern with close block:** Create a pattern containing the overlay content (including `<!-- wp:navigation-overlay-close /-->`). Use `<!-- wp:pattern {"slug":"theme/navigation-overlay"} /-->` in the template part. Verify one close button appears (not two).
4. **No close block:** Use an overlay without the close block. Verify the fallback close button appears.
