### PR TITLE
Workflows: Remove cherry-pick label and add failure label on conflict

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -138,6 +138,30 @@ jobs:
                         body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}`
                       });
 
+            - name: Remove cherry-pick label and add failure label
+              if: env.cherry_pick == 'true' && env.conflict == 'true'
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: |
+                      const prNumber = process.env.pr_number;
+                      const version = process.env.version;
+                      console.log(`prNumber: ${prNumber}`);
+                      console.log(`version: ${version}`);
+                      const oldLabel = `Backport to WP ${version} Beta/RC`;
+                      const failureLabel = `Backport Failed`;
+                      await github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        name: oldLabel
+                      });
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        labels: [failureLabel]
+                      });
+
             - name: Comment on the PR about conflict
               if: env.cherry_pick == 'true' && env.conflict == 'true'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
## What?
Closes #76157

When the automatic cherry-pick workflow fails due to a conflict, remove the `Backport to WP X.Y Beta/RC` label and add a `Backport Failed` label.

## Why?
Currently, when a cherry-pick fails, no modifications are made to the labels. This makes it hard to notice failures and difficult to retry (re-adding the label triggers a new attempt).

## How?
Added a new step in the `cherry-pick-wp-release.yml` workflow that runs when `conflict == 'true'`. It mirrors the existing success-path label handling:
- Removes the `Backport to WP X.Y Beta/RC` label
- Adds the `Backport Failed` label

This step runs before the conflict comment step, so the label state is updated before the user is notified.

## Testing Instructions
1. This change only affects the GitHub Actions workflow file.
2. To test, a cherry-pick conflict would need to occur on a PR with a `Backport to WP X.Y Beta/RC` label.
3. Verify that after the conflict, the original label is removed and `Backport Failed` is added.

## Use of AI Tools
This PR was authored with the assistance of Claude Code (AI coding assistant). The change was reviewed and validated by the contributor.