### PR TITLE
Workflows: Improve manual cherry-pick instructions on conflict

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -145,41 +145,43 @@ jobs:
                   script: |
                       const prNumber = process.env.pr_number;
                       const commitSha = process.env.commit_sha;
+                      const shortSha = commitSha.substring(0, 7);
                       const targetBranch = `wp/${process.env.version}`;
+                      const branchName = `cherry-pick/${prNumber}-to-${targetBranch.replace('/', '-')}`;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`targetBranch: ${targetBranch}`);
                       await github.rest.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        body: `There was a conflict while trying to cherry-pick the commit to the ${targetBranch} branch. Please resolve the conflict manually and create a PR to the ${targetBranch} branch.
+                        body: `There was a conflict while trying to cherry-pick the commit to the \`${targetBranch}\` branch. Please resolve the conflict manually and create a PR to the \`${targetBranch}\` branch.
 
-                        PRs to ${targetBranch} are similar to PRs to trunk, but you should base your PR on the ${targetBranch} branch instead of trunk.
+PRs to \`${targetBranch}\` are similar to PRs to trunk, but you should base your PR on the \`${targetBranch}\` branch instead of trunk. This can be done from the main repository or from your fork.
 
-                        \`\`\`
-                        # Checkout the ${targetBranch} branch instead of trunk.
-                        git checkout ${targetBranch}
+\`\`\`bash
+# Checkout the ${targetBranch} branch instead of trunk.
+git checkout ${targetBranch}
 
-                        # Create a new branch for your PR.
-                        git checkout -b my-branch
+# Create a new branch for your cherry-pick PR.
+git checkout -b ${branchName}
 
-                        # Cherry-pick the commit.
-                        git cherry-pick ${commitSha}
+# Cherry-pick the commit.
+git cherry-pick ${commitSha}
 
-                        # Check which files have conflicts.
-                        git status
+# If there are conflicts, resolve them, then continue:
+# git status
+# git add .
+# git cherry-pick --continue
 
-                        # Resolve the conflict...
-                        # Add the resolved files to the staging area.
-                        git status
-                        git add .
-                        git cherry-pick --continue
+# Push the branch to the repository (or your fork).
+git push origin ${branchName}
+\`\`\`
 
-                        # Push the branch to the repository
-                        git push origin my-branch
+Then create a PR with the base set to \`${targetBranch}\`. You can use [GitHub CLI](https://cli.github.com/manual/gh_pr_create) to do this:
 
-                        # Create a PR and set the base to the ${targetBranch} branch.
-                        # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request.
-                        \`\`\`
-                        `
+\`\`\`bash
+gh pr create --base ${targetBranch} --title "Cherry-pick \\\`${shortSha}\\\` to \\\`${targetBranch}\\\`" --web
+\`\`\`
+
+Or manually set the base branch: [Changing the base branch of a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request).`
                       });

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -150,38 +150,43 @@ jobs:
                       const branchName = `cherry-pick/${prNumber}-to-${targetBranch.replace('/', '-')}`;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`targetBranch: ${targetBranch}`);
+
+                      const body = [
+                        `There was a conflict while trying to cherry-pick the commit to the \`${targetBranch}\` branch. Please resolve the conflict manually and create a PR to the \`${targetBranch}\` branch.`,
+                        '',
+                        `PRs to \`${targetBranch}\` are similar to PRs to trunk, but you should base your PR on the \`${targetBranch}\` branch instead of trunk. This can be done from the main repository or from your fork.`,
+                        '',
+                        '```bash',
+                        `# Checkout the ${targetBranch} branch instead of trunk.`,
+                        `git checkout ${targetBranch}`,
+                        '',
+                        '# Create a new branch for your cherry-pick PR.',
+                        `git checkout -b ${branchName}`,
+                        '',
+                        '# Cherry-pick the commit.',
+                        `git cherry-pick ${commitSha}`,
+                        '',
+                        '# If there are conflicts, resolve them, then continue:',
+                        '# git status',
+                        '# git add .',
+                        '# git cherry-pick --continue',
+                        '',
+                        '# Push the branch to the repository (or your fork).',
+                        `git push origin ${branchName}`,
+                        '```',
+                        '',
+                        `Then create a PR with the base set to \`${targetBranch}\`. You can use [GitHub CLI](https://cli.github.com/manual/gh_pr_create) to do this:`,
+                        '',
+                        '```bash',
+                        `gh pr create --base ${targetBranch} --title "Cherry-pick \`${shortSha}\` to \`${targetBranch}\`" --web`,
+                        '```',
+                        '',
+                        `Or manually set the base branch: [Changing the base branch of a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request).`,
+                      ].join('\n');
+
                       await github.rest.issues.createComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        body: `There was a conflict while trying to cherry-pick the commit to the \`${targetBranch}\` branch. Please resolve the conflict manually and create a PR to the \`${targetBranch}\` branch.
-
-PRs to \`${targetBranch}\` are similar to PRs to trunk, but you should base your PR on the \`${targetBranch}\` branch instead of trunk. This can be done from the main repository or from your fork.
-
-\`\`\`bash
-# Checkout the ${targetBranch} branch instead of trunk.
-git checkout ${targetBranch}
-
-# Create a new branch for your cherry-pick PR.
-git checkout -b ${branchName}
-
-# Cherry-pick the commit.
-git cherry-pick ${commitSha}
-
-# If there are conflicts, resolve them, then continue:
-# git status
-# git add .
-# git cherry-pick --continue
-
-# Push the branch to the repository (or your fork).
-git push origin ${branchName}
-\`\`\`
-
-Then create a PR with the base set to \`${targetBranch}\`. You can use [GitHub CLI](https://cli.github.com/manual/gh_pr_create) to do this:
-
-\`\`\`bash
-gh pr create --base ${targetBranch} --title "Cherry-pick \\\`${shortSha}\\\` to \\\`${targetBranch}\\\`" --web
-\`\`\`
-
-Or manually set the base branch: [Changing the base branch of a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request).`
+                        body,
                       });


### PR DESCRIPTION
## What?
Closes #76576

Improves the manual cherry-pick instructions left as a comment when the automatic cherry-pick workflow fails.

## Why?
The current instructions have several usability issues: a generic branch name, unclear whether conflict resolution is needed, no mention of fork support, a non-clickable documentation link, and no GitHub CLI alternative for creating the PR.

## How?
Updated the conflict comment template in `cherry-pick-wp-release.yml` with 5 improvements:

1. **Contextual branch name**: Uses `cherry-pick/{pr_number}-to-wp-{version}` instead of `my-branch`
2. **Optional conflict resolution**: Conflict resolution steps are commented out and noted as conditional
3. **Fork clarification**: Added note that the cherry-pick can be done from a fork
4. **Clickable link**: Moved the documentation link outside the code block so it renders as a clickable Markdown link
5. **GitHub CLI command**: Added `gh pr create --base wp/X.Y --web` as an alternative to manually setting the base branch

## Testing Instructions
1. This change only affects the GitHub Actions workflow file.
2. To test, a cherry-pick conflict would need to occur on a PR with a `Backport to WP X.Y Beta/RC` label.
3. Verify the resulting comment includes all 5 improvements listed above.

## Use of AI Tools
This PR was authored with the assistance of Claude Code (AI coding assistant). The change was reviewed and validated by the contributor.