### PR TITLE
Stop keeping stale controlled blocks after reset

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -607,19 +607,22 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 		 * flags are cleaned up naturally by unsetControlledBlocks()
 		 * when useBlockSync unmounts.
 		 */
-		const preservedControlledInnerBlocks =
-			state?.controlledInnerBlocks ?? {};
 
 		const newState = {
-			...state,
 			byClientId: new Map(
 				getFlattenedBlocksWithoutAttributes( action.blocks )
 			),
 			attributes: new Map( getFlattenedBlockAttributes( action.blocks ) ),
 			order: mapBlockOrder( action.blocks ),
 			parents: new Map( mapBlockParents( action.blocks ) ),
-			controlledInnerBlocks: preservedControlledInnerBlocks,
+			controlledInnerBlocks: {},
+			tree: new Map(),
 		};
+
+		updateBlockTreeForBlocks( newState, action.blocks );
+
+		const preservedControlledInnerBlocks =
+			state?.controlledInnerBlocks ?? {};
 
 		// Preserve controlled inner blocks data from the old state.
 		// The maps above are rebuilt solely from action.blocks, but
@@ -637,23 +640,24 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 				if ( ! newState.byClientId.has( clientId ) ) {
 					continue;
 				}
+				newState.controlledInnerBlocks[ clientId ] = true;
 				const oldOrder = state.order.get( clientId );
 				if ( ! oldOrder?.length ) {
 					continue;
 				}
 				newState.order.set( clientId, oldOrder );
 				const preserveBlock = ( blockId, parentId ) => {
-					const blockData = state.byClientId?.get( blockId );
+					const blockData = state.byClientId.get( blockId );
 					if ( ! blockData ) {
 						return;
 					}
 					newState.byClientId.set( blockId, blockData );
 					newState.attributes.set(
 						blockId,
-						state.attributes?.get( blockId )
+						state.attributes.get( blockId )
 					);
 					newState.parents.set( blockId, parentId );
-					const childOrder = state.order?.get( blockId ) || [];
+					const childOrder = state.order.get( blockId ) || [];
 					newState.order.set( blockId, childOrder );
 					childOrder.forEach( ( childId ) =>
 						preserveBlock( childId, blockId )
@@ -663,18 +667,15 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			}
 		}
 
-		newState.tree = new Map( state?.tree );
-		updateBlockTreeForBlocks( newState, action.blocks );
-
 		// Fix tree entries for controlled blocks. updateBlockTreeForBlocks
 		// built tree entries using action.blocks' inner block structure
 		// (entity-level IDs), but we need them to reference the preserved
 		// cloned inner blocks instead. Mutating the existing object
 		// preserves references held by ancestor tree entries.
 		for ( const clientId of Object.keys(
-			preservedControlledInnerBlocks
+			newState.controlledInnerBlocks
 		) ) {
-			if ( ! preservedControlledInnerBlocks[ clientId ] ) {
+			if ( ! newState.controlledInnerBlocks[ clientId ] ) {
 				continue;
 			}
 			if ( ! newState.byClientId.has( clientId ) ) {
@@ -685,13 +686,23 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 				continue;
 			}
 			const innerBlocks = controlledOrder.map( ( id ) =>
-				newState.tree.get( id )
+				state.tree.get( id )
 			);
 			const existingEntry = newState.tree.get( clientId );
 			if ( existingEntry ) {
 				existingEntry.innerBlocks = innerBlocks;
 			}
 			newState.tree.set( 'controlled||' + clientId, { innerBlocks } );
+			const preserveTreeEntry = ( blockId ) => {
+				const treeEntry = state.tree.get( blockId );
+				if ( ! treeEntry ) {
+					return;
+				}
+				newState.tree.set( blockId, treeEntry );
+				const childOrder = newState.order.get( blockId ) || [];
+				childOrder.forEach( preserveTreeEntry );
+			};
+			controlledOrder.forEach( preserveTreeEntry );
 		}
 
 		newState.tree.set( '', {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -601,25 +601,19 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 	if ( action.type === 'RESET_BLOCKS' ) {
 		/**
 		 * Preserve controlled inner block flags across RESET_BLOCKS.
-		 * Previously this was cleared to `{}`, which caused nested
-		 * controllers (e.g. post-content, patterns) to lose their
-		 * controlled status and unnecessarily re-clone blocks. Stale
-		 * flags are cleaned up naturally by unsetControlledBlocks()
-		 * when useBlockSync unmounts.
+		 * If there are old and new blocks that:
+		 * - have the same `clientId`
+		 * - have the `controlledInnerBlocks` flag
+		 * - don't have any own, uncontrolled children
+		 * then we preserve the `controlledInnerBlocks` flag and the controlled sub-trees.
+		 * Nested controllers (e.g., `post-content`, patterns) don't lose their
+		 * controlled status and don't unnecessarily re-clone blocks.
 		 */
-
-		const newState = {
-			byClientId: new Map(
-				getFlattenedBlocksWithoutAttributes( action.blocks )
-			),
-			attributes: new Map( getFlattenedBlockAttributes( action.blocks ) ),
-			order: mapBlockOrder( action.blocks ),
-			parents: new Map( mapBlockParents( action.blocks ) ),
-			controlledInnerBlocks: {},
-			tree: new Map(),
-		};
-
-		updateBlockTreeForBlocks( newState, action.blocks );
+		const newState = reducer( undefined, {
+			type: 'INSERT_BLOCKS',
+			rootClientId: '',
+			blocks: action.blocks,
+		} );
 
 		const preservedControlledInnerBlocks =
 			state?.controlledInnerBlocks ?? {};
@@ -675,12 +669,6 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 		for ( const clientId of Object.keys(
 			newState.controlledInnerBlocks
 		) ) {
-			if ( ! newState.controlledInnerBlocks[ clientId ] ) {
-				continue;
-			}
-			if ( ! newState.byClientId.has( clientId ) ) {
-				continue;
-			}
 			const controlledOrder = newState.order.get( clientId );
 			if ( ! controlledOrder?.length ) {
 				continue;
@@ -704,12 +692,6 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			};
 			controlledOrder.forEach( preserveTreeEntry );
 		}
-
-		newState.tree.set( '', {
-			innerBlocks: action.blocks.map( ( subBlock ) =>
-				newState.tree.get( subBlock.clientId )
-			),
-		} );
 
 		return newState;
 	}

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2478,6 +2478,129 @@ describe( 'state', () => {
 					expect( state.controlledInnerBlocks.chicken ).toBe( true );
 				} );
 
+				it( 'should preserve controlledInnerBlocks blocks across RESET_BLOCKS', () => {
+					const original = blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					} );
+					const withControlled = blocks( original, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'chicken',
+						hasControlledInnerBlocks: true,
+					} );
+
+					const withControlledContent = blocks( withControlled, {
+						type: 'REPLACE_INNER_BLOCKS',
+						rootClientId: 'chicken',
+						blocks: [
+							{
+								clientId: 'content',
+								innerBlocks: [
+									{
+										clientId: 'content-inner',
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					} );
+
+					expect(
+						getBlocks(
+							{ blocks: withControlledContent },
+							'chicken'
+						).map( ( b ) => b.clientId )
+					).toEqual( [ 'content' ] );
+					expect(
+						getBlocks(
+							{ blocks: withControlledContent },
+							'content'
+						).map( ( b ) => b.clientId )
+					).toEqual( [ 'content-inner' ] );
+
+					const state = blocks( withControlledContent, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					} );
+
+					expect( state.controlledInnerBlocks.chicken ).toBe( true );
+					expect(
+						getBlocks( { blocks: state }, 'chicken' ).map(
+							( b ) => b.clientId
+						)
+					).toEqual( [ 'content' ] );
+					expect(
+						getBlocks( { blocks: state }, 'content' ).map(
+							( b ) => b.clientId
+						)
+					).toEqual( [ 'content-inner' ] );
+				} );
+
+				it( 'should forget controlledInnerBlocks during full RESET_BLOCKS', () => {
+					const templateBlock = {
+						clientId: 'template',
+						name: 'core/post-content',
+						attributes: {},
+						innerBlocks: [],
+					};
+					const contentBlock = {
+						clientId: 'content',
+						name: 'core/paragraph',
+						attributes: {},
+						innerBlocks: [],
+					};
+
+					let state = blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ templateBlock ],
+					} );
+
+					state = blocks( state, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'template',
+						hasControlledInnerBlocks: true,
+					} );
+
+					state = blocks( state, {
+						type: 'REPLACE_INNER_BLOCKS',
+						rootClientId: 'template',
+						blocks: [ contentBlock ],
+					} );
+
+					// Reset blocks completely, we expect that the controlled blocks are forgotten.
+					state = blocks( state, {
+						type: 'RESET_BLOCKS',
+						blocks: [],
+					} );
+
+					// Reset back to the template.
+					state = blocks( state, {
+						type: 'RESET_BLOCKS',
+						blocks: [ templateBlock ],
+					} );
+
+					// Expect that the `template`/`content` blocks are reconstructed.
+					const fullState = { blocks: state };
+					expect( getBlocks( fullState, 'template' ) ).toEqual( [] );
+					expect( getBlockOrder( fullState, 'template' ) ).toEqual(
+						[]
+					);
+				} );
+
 				it( 'should not leave stale controlled tree entries after root replacement and reset', () => {
 					const templateBlock = {
 						clientId: 'template',

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2479,70 +2479,77 @@ describe( 'state', () => {
 				} );
 
 				it( 'should not leave stale controlled tree entries after root replacement and reset', () => {
-					const chickenBlock = {
-						clientId: 'chicken',
-						name: 'core/test-block',
+					const templateBlock = {
+						clientId: 'template',
+						name: 'core/post-content',
 						attributes: {},
 						innerBlocks: [],
 					};
-					const eggBlock = {
-						clientId: 'egg',
-						name: 'core/test-block',
+					const contentBlock = {
+						clientId: 'content',
+						name: 'core/paragraph',
 						attributes: {},
 						innerBlocks: [],
 					};
 
-					// Initialize content, simulates root useBlockSync initialization.
+					// Initialize template, simulates root `useBlockSync` initialization.
 					let state = blocks( undefined, {
 						type: 'RESET_BLOCKS',
-						blocks: [ chickenBlock ],
+						blocks: [ templateBlock ],
 					} );
 
-					// Give chicken a controlled child with two actions, simulates inner useBlockSync initialization.
+					// Add a controlled child to the template using two actions, simulates inner `useBlockSync` initialization.
 					state = blocks( state, {
 						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
-						clientId: 'chicken',
+						clientId: 'template',
 						hasControlledInnerBlocks: true,
 					} );
 
 					state = blocks( state, {
 						type: 'REPLACE_INNER_BLOCKS',
-						rootClientId: 'chicken',
-						blocks: [ eggBlock ],
+						rootClientId: 'template',
+						blocks: [ contentBlock ],
 					} );
 
-					// Reset blocks completely, simulates root useBlockSync cleanup.
+					// Reset blocks completely, simulates root `useBlockSync` cleanup.
 					state = blocks( state, {
 						type: 'RESET_BLOCKS',
 						blocks: [],
 					} );
 
-					// Unset controlled inner blocks, simulates inner useBlockSync cleanup.
+					// Unset controlled inner blocks, simulates inner `useBlockSync` cleanup.
 					state = blocks( state, {
 						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
-						clientId: 'chicken',
+						clientId: 'template',
 						hasControlledInnerBlocks: false,
 					} );
 
-					// Initialize content again, simulates useBlockSync after navigation.
+					// Initialize template again, simulates `useBlockSync` after navigation.
 					state = blocks( state, {
 						type: 'RESET_BLOCKS',
-						blocks: [ chickenBlock ],
+						blocks: [ templateBlock ],
 					} );
 
-					// Set controlled inner blocks again.
+					// Set controlled inner blocks again, this time to empty.
 					state = blocks( state, {
 						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
-						clientId: 'chicken',
+						clientId: 'template',
 						hasControlledInnerBlocks: true,
 					} );
 
-					// At this point useInnerBlockTemplateSync would check if `getBlocks` is empty before applying the template.
+					state = blocks( state, {
+						type: 'REPLACE_INNER_BLOCKS',
+						rootClientId: 'template',
+						blocks: [],
+					} );
+
+					// At this point the template has empty content, and `useInnerBlockTemplateSync` should apply
+					// its template content. It will check if `getBlocks` is empty before applying the template.
 					const fullState = { blocks: state };
-					expect( getBlockOrder( fullState, 'chicken' ) ).toEqual(
+					expect( getBlockOrder( fullState, 'template' ) ).toEqual(
 						[]
 					);
-					expect( getBlocks( fullState, 'chicken' ) ).toEqual( [] );
+					expect( getBlocks( fullState, 'template' ) ).toEqual( [] );
 				} );
 
 				it( 'should not create new state references when setting controlled inner blocks on a block with no inner blocks', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -44,7 +44,7 @@ import {
 	withDerivedBlockEditingModes,
 	viewportModalClientIds,
 } from '../reducer';
-
+import { getBlockOrder, getBlocks } from '../selectors';
 import { unlock } from '../../lock-unlock';
 import { sectionRootClientIdKey, isIsolatedEditorKey } from '.././private-keys';
 
@@ -2476,6 +2476,73 @@ describe( 'state', () => {
 					} );
 
 					expect( state.controlledInnerBlocks.chicken ).toBe( true );
+				} );
+
+				it( 'should not leave stale controlled tree entries after root replacement and reset', () => {
+					const chickenBlock = {
+						clientId: 'chicken',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					};
+					const eggBlock = {
+						clientId: 'egg',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					};
+
+					// Initialize content, simulates root useBlockSync initialization.
+					let state = blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ chickenBlock ],
+					} );
+
+					// Give chicken a controlled child with two actions, simulates inner useBlockSync initialization.
+					state = blocks( state, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'chicken',
+						hasControlledInnerBlocks: true,
+					} );
+
+					state = blocks( state, {
+						type: 'REPLACE_INNER_BLOCKS',
+						rootClientId: 'chicken',
+						blocks: [ eggBlock ],
+					} );
+
+					// Reset blocks completely, simulates root useBlockSync cleanup.
+					state = blocks( state, {
+						type: 'RESET_BLOCKS',
+						blocks: [],
+					} );
+
+					// Unset controlled inner blocks, simulates inner useBlockSync cleanup.
+					state = blocks( state, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'chicken',
+						hasControlledInnerBlocks: false,
+					} );
+
+					// Initialize content again, simulates useBlockSync after navigation.
+					state = blocks( state, {
+						type: 'RESET_BLOCKS',
+						blocks: [ chickenBlock ],
+					} );
+
+					// Set controlled inner blocks again.
+					state = blocks( state, {
+						type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+						clientId: 'chicken',
+						hasControlledInnerBlocks: true,
+					} );
+
+					// At this point useInnerBlockTemplateSync would check if `getBlocks` is empty before applying the template.
+					const fullState = { blocks: state };
+					expect( getBlockOrder( fullState, 'chicken' ) ).toEqual(
+						[]
+					);
+					expect( getBlocks( fullState, 'chicken' ) ).toEqual( [] );
 				} );
 
 				it( 'should not create new state references when setting controlled inner blocks on a block with no inner blocks', () => {


### PR DESCRIPTION
In this PR I managed to isolate a bug described in https://github.com/WordPress/gutenberg/issues/76310#issuecomment-4065620486 (the second one). Sometimes the `core/block-editor` state ends up with block tree where `order` and `parents` say that there are no child blocks, but `tree` contains child blocks.

At this moment the PR has only a failing unit test that isolates the bug.

The key events and problems are:
1. The `resetBlocks( [] )` action leaves stale `tree` records behind, although they are no longer relevant. Namely there is the `controlled||chicken` tree entry although the `chicken` block is completely gone from the tree.
2. When calling `setHasControlledInnerBlocks( 'chicken', false )` afterwards, the action fails (in `withResetControlledBlocks`) to reset the inner blocks to empty array. Because `innerBlockOrder` is undefined. Then the stale `controlled||chicken` record survives.

I'm not sure about the fix yet, but the most suspicious place is `withBlockReset` where it handles `RESET_BLOCKS` and copies the entire old `state.tree`. We shouldn't do that, we should cherry-pick only the records that are still relevant.

fyi @youknowriad @talldan 