### PR TITLE
Snackbar: Use surface-width design token for max-width

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 -   `DateCalendar`, `DateRangeCalendar`: Add `showOutsideDays` and `fixedWeeks` props and style outside-month days ([#76199](https://github.com/WordPress/gutenberg/pull/76199)).
 -   `Modal`: Use `--wpds-dimension-surface-width-*` design tokens for width constraints ([#76494](https://github.com/WordPress/gutenberg/pull/76494)).
+-   `Snackbar`: Use `--wpds-dimension-surface-width-lg` design token for max-width ([#76592](https://github.com/WordPress/gutenberg/pull/76592)).
 
 ### Internal
 

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -14,8 +14,7 @@
 	color: $white;
 	padding: $grid-unit-15 ($grid-unit-05 * 5);
 	width: 100%;
-	// TODO: Replace with a --wpds-dimension-surface-width-* token.
-	max-width: 600px;
+	max-width: var(--wpds-dimension-surface-width-lg);
 	box-sizing: border-box;
 	cursor: pointer;
 


### PR DESCRIPTION
## What

Follow-up to #76494. Use a `--wpds-dimension-surface-width-*` design token for [Snackbar](https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs) `max-width`.

## Why

As part of the ongoing adoption of surface-width design tokens from `@wordpress/theme`, the Snackbar's hardcoded `max-width: 600px` can be replaced with a token from the scale. This brings the Snackbar in line with other components (Dialog, Modal) that have already adopted these tokens.

## How

Replaced `max-width: 600px` with `var(--wpds-dimension-surface-width-lg)` (560px) in `packages/components/src/snackbar/style.scss`.

> [!NOTE]  
> The previous value of 600px sits between `lg` (560px) and `xl` (720px) on the token scale, so there isn't an exact match. This PR uses `lg` to keep the Snackbar compact, but I'm open to feedback if there's a feeling that`xl` (720px) would be more appropriate.