### PR TITLE
Workflows: Include workflow run URL in cherry-pick PR comments

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -123,11 +123,14 @@ jobs:
             - name: Comment on the PR
               if: env.cherry_pick == 'true' && env.conflict == 'false'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               with:
                   script: |
                       const prNumber = process.env.pr_number;
                       const cherryPickSha = process.env.cherry_pick_sha;
                       const targetBranch = `wp/${process.env.version}`;
+                      const runUrl = process.env.run_url;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`cherryPickSha: ${cherryPickSha}`);
                       console.log(`targetBranch: ${targetBranch}`);
@@ -135,17 +138,20 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}`
+                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}\n\n[Workflow run](${runUrl})`
                       });
 
             - name: Comment on the PR about conflict
               if: env.cherry_pick == 'true' && env.conflict == 'true'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               with:
                   script: |
                       const prNumber = process.env.pr_number;
                       const commitSha = process.env.commit_sha;
                       const targetBranch = `wp/${process.env.version}`;
+                      const runUrl = process.env.run_url;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`targetBranch: ${targetBranch}`);
                       await github.rest.issues.createComment({
@@ -181,5 +187,6 @@ jobs:
                         # Create a PR and set the base to the ${targetBranch} branch.
                         # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request.
                         \`\`\`
-                        `
+
+                        [Workflow run](${runUrl})`
                       });

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -123,14 +123,12 @@ jobs:
             - name: Comment on the PR
               if: env.cherry_pick == 'true' && env.conflict == 'false'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-              env:
-                  run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               with:
                   script: |
                       const prNumber = process.env.pr_number;
                       const cherryPickSha = process.env.cherry_pick_sha;
                       const targetBranch = `wp/${process.env.version}`;
-                      const runUrl = process.env.run_url;
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`cherryPickSha: ${cherryPickSha}`);
                       console.log(`targetBranch: ${targetBranch}`);
@@ -138,20 +136,18 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: prNumber,
-                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}\n\n[Workflow run](${runUrl})`
+                        body: `I just cherry-picked this PR to the ${targetBranch} branch to get it included in the next release: ${cherryPickSha}\n\nSee the [workflow run](${runUrl}) for more details.`
                       });
 
             - name: Comment on the PR about conflict
               if: env.cherry_pick == 'true' && env.conflict == 'true'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-              env:
-                  run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               with:
                   script: |
                       const prNumber = process.env.pr_number;
                       const commitSha = process.env.commit_sha;
                       const targetBranch = `wp/${process.env.version}`;
-                      const runUrl = process.env.run_url;
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
                       console.log(`prNumber: ${prNumber}`);
                       console.log(`targetBranch: ${targetBranch}`);
                       await github.rest.issues.createComment({
@@ -188,5 +184,5 @@ jobs:
                         # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request.
                         \`\`\`
 
-                        [Workflow run](${runUrl})`
+                        See the [workflow run](${runUrl}) for more details.`
                       });


### PR DESCRIPTION
## What?

Add a link to the GitHub Actions workflow run in the comments posted by the `cherry-pick-wp-release` workflow.

## Why?

When the cherry-pick workflow comments on a PR (either for a successful cherry-pick or a conflict notification), there is no link back to the workflow run logs. This makes it harder for contributors to debug failures or verify the cherry-pick. See #76575.

## How?

For each `actions/github-script` step that posts a PR comment, this PR:

1. Adds a `run_url` environment variable using `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
2. Appends a `[Workflow run](${runUrl})` link to the comment body

This applies to both the success comment ("Comment on the PR") and the conflict comment ("Comment on the PR about conflict") steps.

## Testing Instructions

This change only affects workflow comment formatting. It can be verified by:
1. Triggering the cherry-pick workflow on a test PR with the appropriate label
2. Confirming the resulting comment includes a clickable link to the workflow run

Fixes #76575