### PR TITLE
Template field: match exactly the behavior of post template panel

### DIFF
--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -25,18 +25,20 @@ import ResetDefaultTemplate from './reset-default-template';
 import { unlock } from '../../lock-unlock';
 import CreateNewTemplate from './create-new-template';
 
-export default function BlockThemeControl( { id } ) {
+export default function BlockThemeControl() {
 	const {
 		isTemplateHidden,
 		onNavigateToEntityRecord,
 		getEditorSettings,
 		hasGoBack,
 		hasSpecificTemplate,
+		id,
 	} = useSelect( ( select ) => {
 		const {
 			getRenderingMode,
 			getEditorSettings: _getEditorSettings,
 			getCurrentPost,
+			getCurrentTemplateId,
 		} = unlock( select( editorStore ) );
 		const editorSettings = _getEditorSettings();
 		const currentPost = getCurrentPost();
@@ -48,6 +50,7 @@ export default function BlockThemeControl( { id } ) {
 				'onNavigateToPreviousEntityRecord'
 			),
 			hasSpecificTemplate: !! currentPost.template,
+			id: getCurrentTemplateId(),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -81,6 +81,48 @@ export function useAvailableTemplates( postType ) {
 	);
 }
 
+export function usePostTemplatePanelMode() {
+	return useSelect( ( select ) => {
+		const { getEditorSettings, getCurrentTemplateId, getCurrentPostType } =
+			select( editorStore );
+		const { getPostType, canUser } = select( coreStore );
+		const postTypeSlug = getCurrentPostType();
+		const postType = getPostType( postTypeSlug );
+		const settings = getEditorSettings();
+		const isBlockTheme = settings.__unstableIsBlockBasedTheme;
+		const hasTemplates =
+			!! settings.availableTemplates &&
+			Object.keys( settings.availableTemplates ).length > 0;
+		let isVisible;
+		if ( ! postType?.viewable ) {
+			isVisible = false;
+		} else if ( hasTemplates ) {
+			isVisible = true;
+		} else if ( ! settings.supportsTemplateMode ) {
+			isVisible = false;
+		} else {
+			isVisible =
+				canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} ) ?? false;
+		}
+		const canViewTemplates = isVisible
+			? !! canUser( 'read', {
+					kind: 'postType',
+					name: 'wp_template',
+			  } )
+			: false;
+		if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
+			return 'classic';
+		}
+		if ( isBlockTheme && !! getCurrentTemplateId() ) {
+			return 'block-theme';
+		}
+		return null;
+	}, [] );
+}
+
 export function useCurrentTemplateSlug() {
 	const { postType, postId } = useEditedPostContext();
 	const templates = useTemplates( postType );

--- a/packages/editor/src/components/post-template/panel.js
+++ b/packages/editor/src/components/post-template/panel.js
@@ -1,13 +1,7 @@
 /**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-
-/**
  * Internal dependencies
  */
-import { store as editorStore } from '../../store';
+import { usePostTemplatePanelMode } from './hooks';
 import ClassicThemeControl from './classic-theme';
 import BlockThemeControl from './block-theme';
 
@@ -17,60 +11,12 @@ import BlockThemeControl from './block-theme';
  * @return {React.ReactNode} The rendered PostTemplatePanel component.
  */
 export default function PostTemplatePanel() {
-	const { templateId, isBlockTheme } = useSelect( ( select ) => {
-		const { getCurrentTemplateId, getEditorSettings } =
-			select( editorStore );
-		return {
-			templateId: getCurrentTemplateId(),
-			isBlockTheme: getEditorSettings().__unstableIsBlockBasedTheme,
-		};
-	}, [] );
-
-	const isVisible = useSelect( ( select ) => {
-		const postTypeSlug = select( editorStore ).getCurrentPostType();
-		const postType = select( coreStore ).getPostType( postTypeSlug );
-		if ( ! postType?.viewable ) {
-			return false;
-		}
-
-		const settings = select( editorStore ).getEditorSettings();
-		const hasTemplates =
-			!! settings.availableTemplates &&
-			Object.keys( settings.availableTemplates ).length > 0;
-		if ( hasTemplates ) {
-			return true;
-		}
-
-		if ( ! settings.supportsTemplateMode ) {
-			return false;
-		}
-
-		const canCreateTemplates =
-			select( coreStore ).canUser( 'create', {
-				kind: 'postType',
-				name: 'wp_template',
-			} ) ?? false;
-		return canCreateTemplates;
-	}, [] );
-
-	const canViewTemplates = useSelect(
-		( select ) => {
-			return isVisible
-				? select( coreStore ).canUser( 'read', {
-						kind: 'postType',
-						name: 'wp_template',
-				  } )
-				: false;
-		},
-		[ isVisible ]
-	);
-
-	if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
+	const mode = usePostTemplatePanelMode();
+	if ( mode === 'classic' ) {
 		return <ClassicThemeControl />;
 	}
-
-	if ( isBlockTheme && !! templateId ) {
-		return <BlockThemeControl id={ templateId } />;
+	if ( mode === 'block-theme' ) {
+		return <BlockThemeControl />;
 	}
 	return null;
 }

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -17,6 +17,7 @@ import { store as editorStore } from '../../store';
 import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
 import { unlock } from '../../lock-unlock';
+import { usePostTemplatePanelMode } from '../post-template/hooks';
 
 const form = {
 	layout: {
@@ -93,7 +94,8 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 		[ postType, postId ]
 	);
 
-	// Fetch classic theme templates from editor settings.
+	const templatePanelMode = usePostTemplatePanelMode();
+
 	const availableTemplates = useSelect( ( select ) => {
 		if ( select( coreDataStore ).getCurrentTheme()?.is_block_theme ) {
 			return null;
@@ -119,18 +121,40 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 	const _fields = usePostFields( { postType } );
 	const fields = useMemo(
 		() =>
-			_fields?.map( ( field ) => {
-				if ( field.id === 'status' ) {
-					return {
-						...field,
-						elements: field.elements.filter(
-							( element ) => element.value !== 'trash'
-						),
-					};
-				}
-				return field;
-			} ),
-		[ _fields ]
+			_fields
+				?.map( ( field ) => {
+					if ( field.id === 'status' ) {
+						return {
+							...field,
+							elements: field.elements.filter(
+								( element ) => element.value !== 'trash'
+							),
+						};
+					}
+					if ( field.id === 'template' ) {
+						// `usePostTemplatePanelMode` is reused in the Post Template panel to match
+						// the existing behavior. If the panel rendered nothing we should exclude the
+						// template field from the form.
+						if ( ! templatePanelMode ) {
+							return null;
+						}
+						// In classic themes without available templates we need to make the field read-only.
+						if (
+							templatePanelMode === 'classic' &&
+							Object.keys( availableTemplates ?? {} ).length === 0
+						) {
+							return {
+								...field,
+								readOnly: true,
+								render: () => __( 'Default template' ),
+							};
+						}
+						return field;
+					}
+					return field;
+				} )
+				.filter( Boolean ),
+		[ _fields, templatePanelMode, availableTemplates ]
 	);
 
 	const onChange = ( edits ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/76441

`PostTemplatePanel` has complex logic that has been iterated over the years to handle differently different combinations of block, classic and hybrid themes that have custom templates or not, permissions etc..

In the linked PR I update the `template` field to match the template panel controls but there are a few more nuances.

I observed two cases that didn't match, that needed to be handled in `DataFormPostSummary` component.
1. A classic theme with no templates (2015) in the post summary doesn't render the panel at all. This PR excludes the field from the form in that case
2. A classic theme with no templates (2015) but with added template support through code, in the post summary renders a `default template`. With the experiment this translates to making the field `readonly`.


### Snippet to add template support
```
add_action( 'after_setup_theme', 'mytheme_setup' );
function mytheme_setup() {
    add_theme_support( 'block-templates' );
    add_theme_support( 'block-template-parts' );
}

```

## Testing Instructions
1. What I did was testing various type of themes, with and without template support, with and without existing templates (in case of classic themes). I'm sharing a lot of screenshots below that are examples of the different scenarios.
2. The above also need to happen by enabling/disabling the `Editor Inspector: Use DataForm` experiment for each case to validate matching behaviors.
3. The results should match.
4. Ensure that without the experiment there is no regression by extracting the logic in the reusable hook.

### Notes
While testing I observed a bug in the existing code for classic themes that had previously template support and created templates. The control shows the created templates, but this doesn't work if the template support is not enabled and errors. I have screenshot below.






#### Block theme 2025
It's expected that the template panel has actions and not the DataForm field. Actions are moved [here](https://github.com/WordPress/gutenberg/pull/76539).

|Experiment disabled |Enabled|
|-|-|
|<img width="571" height="644" alt="Screenshot 2026-03-17 at 6 51 21 PM" src="https://github.com/user-attachments/assets/01237c3f-fb43-4a4a-9223-638f393d89b9" />|<img width="571" height="644" alt="2025-block-exp" src="https://github.com/user-attachments/assets/9af796b8-5eaa-476e-8689-49acac9f7df4" />|


#### 2015 classic theme - It has no available templates

The `template` panel or field are not rendered


|Experiment disabled |Enabled|
|-|-|
|<img width="606" height="644" alt="2015-classic-no-templates" src="https://github.com/user-attachments/assets/59499798-2f81-4e0a-9b13-97069130a367" />|<img width="606" height="644" alt="2015-classic-no-templates-exp" src="https://github.com/user-attachments/assets/c1a09d0a-67ca-4e8c-a17c-f780a72e1374" />|

#### 2015 classic theme - It has no available templates - but with added template support

|Experiment disabled |Enabled|
|-|-|
|<img width="606" height="644" alt="2015-no-templates-with-added-support" src="https://github.com/user-attachments/assets/ffbf36c1-4391-4b6a-8506-796584bfb8c4" />|<img width="606" height="644" alt="2015-no-templates-with-added-support-exp" src="https://github.com/user-attachments/assets/ef621cd7-b200-41bd-88af-2269dc252f7f" />|












#### 2014 classic theme - **It has** available templates

In the `disabled` screenshot you can see the bug I mention above with previously created templates even if now it didn't have template support.

|Experiment disabled |Enabled|
|-|-|
|<img width="894" height="644" alt="2014-with-tpls-no-support-bug-with-existing-tpls" src="https://github.com/user-attachments/assets/c10fe3cf-caaa-46b8-add3-058c40144280" />|<img width="606" height="644" alt="2014-with-tpls-no-support-exp" src="https://github.com/user-attachments/assets/e68b127f-bc94-4512-a220-c25748b1cc14" />|



#### 2014 classic theme - **It has** available templates - but with added template support

|Experiment disabled |Enabled|
|-|-|
|<img width="571" height="644" alt="2014-with-tpls-and-support" src="https://github.com/user-attachments/assets/25e7363c-fee9-4792-b5d9-133d1ef07f65" />|<img width="571" height="644" alt="2014-with-tpls-and-support-exp" src="https://github.com/user-attachments/assets/4d3cffbc-22fa-45e7-ac96-56d8b67966c0" />|




