### PR TITLE
RTC: Fix CRDT serialization of nested RichText attributes

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -62,6 +62,37 @@ export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
+/**
+ * Recursively walk an attribute value and convert any RichTextData instances
+ * to their string (HTML) representation. This is necessary for array-type and
+ * object-type attributes, which can contain nested RichTextData.
+ *
+ * @param value The attribute value to serialize.
+ * @return The value with all RichTextData instances replaced by strings.
+ */
+function serializeAttributeValue( value: unknown ): unknown {
+	if ( value instanceof RichTextData ) {
+		return value.valueOf();
+	}
+
+	// e.g. core/table `body`: [ { cells: [ { content: RichTextData } ] } ]
+	if ( Array.isArray( value ) ) {
+		return value.map( serializeAttributeValue );
+	}
+
+	// e.g. a single row inside core/table `body`: { cells: [ ... ] }
+	if ( value && typeof value === 'object' ) {
+		const result: Record< string, unknown > = {};
+
+		for ( const [ k, v ] of Object.entries( value ) ) {
+			result[ k ] = serializeAttributeValue( v );
+		}
+		return result;
+	}
+
+	return value;
+}
+
 function makeBlockAttributesSerializable(
 	blockName: string,
 	attributes: BlockAttributes
@@ -73,9 +104,7 @@ function makeBlockAttributesSerializable(
 			continue;
 		}
 
-		if ( value instanceof RichTextData ) {
-			newAttributes[ key ] = value.valueOf();
-		}
+		newAttributes[ key ] = serializeAttributeValue( value );
 	}
 	return newAttributes;
 }

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -38,8 +38,23 @@ jest.mock( '@wordpress/blocks', () => ( {
 				url: { type: 'string' },
 			},
 		},
+		{
+			name: 'core/table',
+			attributes: {
+				hasFixedLayout: { type: 'boolean' },
+				caption: { type: 'rich-text' },
+				head: { type: 'array' },
+				body: { type: 'array' },
+				foot: { type: 'array' },
+			},
+		},
 	],
 } ) );
+
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -1086,6 +1101,137 @@ describe( 'crdt-blocks', () => {
 			const attrs2 = block2.get( 'attributes' ) as YBlockAttributes;
 			expect( attrs2.has( 'content' ) ).toBe( true );
 			expect( attrs2.has( 'caption' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'table block', () => {
+		it( 'preserves table cell content through CRDT round-trip', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						hasFixedLayout: true,
+						body: [
+							{
+								cells: [
+									{
+										content:
+											RichTextData.fromPlainText( '1' ),
+										tag: 'td',
+									},
+									{
+										content:
+											RichTextData.fromPlainText( '2' ),
+										tag: 'td',
+									},
+								],
+							},
+							{
+								cells: [
+									{
+										content:
+											RichTextData.fromPlainText( '3' ),
+										tag: 'td',
+									},
+									{
+										content:
+											RichTextData.fromPlainText( '4' ),
+										tag: 'td',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			// Simulate a CRDT encode/decode cycle (persistence or sync).
+			const encoded = Y.encodeStateAsUpdate( doc );
+			const doc2 = new Y.Doc();
+			Y.applyUpdate( doc2, encoded );
+
+			const yblocks2 = doc2.getArray< YBlock >();
+			expect( yblocks2.length ).toBe( 1 );
+
+			const block = yblocks2.get( 0 );
+			const attrs = block.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as {
+				cells: { content: string; tag: string }[];
+			}[];
+
+			expect( body ).toHaveLength( 2 );
+			expect( body[ 0 ].cells[ 0 ].content ).toBe( '1' );
+			expect( body[ 0 ].cells[ 1 ].content ).toBe( '2' );
+			expect( body[ 1 ].cells[ 0 ].content ).toBe( '3' );
+			expect( body[ 1 ].cells[ 1 ].content ).toBe( '4' );
+
+			doc2.destroy();
+		} );
+
+		it( 'preserves table cell content with HTML formatting', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						hasFixedLayout: true,
+						head: [
+							{
+								cells: [
+									{
+										content: RichTextData.fromHTMLString(
+											'<strong>Header</strong>'
+										),
+										tag: 'th',
+									},
+								],
+							},
+						],
+						body: [
+							{
+								cells: [
+									{
+										content: RichTextData.fromHTMLString(
+											'<a href="https://example.com">Link</a>'
+										),
+										tag: 'td',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			// Round-trip through encode/decode.
+			const encoded = Y.encodeStateAsUpdate( doc );
+			const doc2 = new Y.Doc();
+			Y.applyUpdate( doc2, encoded );
+
+			const yblocks2 = doc2.getArray< YBlock >();
+			const block = yblocks2.get( 0 );
+			const attrs = block.get( 'attributes' ) as YBlockAttributes;
+
+			const head = attrs.get( 'head' ) as {
+				cells: { content: string }[];
+			}[];
+			expect( head[ 0 ].cells[ 0 ].content ).toBe(
+				'<strong>Header</strong>'
+			);
+
+			const body = attrs.get( 'body' ) as {
+				cells: { content: string }[];
+			}[];
+			expect( body[ 0 ].cells[ 0 ].content ).toBe(
+				'<a href="https://example.com">Link</a>'
+			);
+
+			doc2.destroy();
 		} );
 	} );
 


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/76555.

Fixes table block cell content syncing (and any other nested `array`-type attributes with nested rich text) in real-time collaboration.

## Why?

The corruption happens at Yjs encode time, when the CRDT doc is synced or persisted:

1. Page loads and blocks are parsed from post content. Table cell content becomes `RichTextData` class instances, but deeply nested (e.g. `body[].cells[].content`).
2. `makeBlocksSerializable` runs but only converts top-level `RichTextData` to strings. The nested instances of `RichTextData` inside the table's `body`/`head`/`foot` aren't properly mapped to strings with `.valueOf()` and instead stay as deeply-nested objects instead of being properly converted to serializable data.
3. When Yjs encodes the doc, it serializes these `RichTextData` instances the same way it would any plain object, using `Object.keys()`. Since `RichTextData` stores its data in a private field, there are no enumerable keys, so each cell's content is encoded as `{}`.
4. This is stored in post meta and sent to peers. On reload, the persisted doc is decoded and the cells are shown as empty.

## How?

Added a `serializeAttributeValue` helper that recursively walks  attribute values and converts any deeply-nested `RichTextData` instances to their HTML string representation via `.valueOf()`.

This approach handles the table block's deeply nested structure (`body[].cells[].content`) and will also cover any other blocks that store `RichTextData` inside array or object attributes.

## Testing Instructions

Here's the original reproduction from [this comment](https://github.com/WordPress/gutenberg/issues/76555#issuecomment-4076856477):

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Create a post with a table:

    ```bash
    npm run wp-env run cli -- wp post create --post_title='Table Test' --post_status='publish' --post_content='<!-- wp:table --><figure class="wp-block-table"><table class="has-fixed-layout"><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure><!-- /wp:table -->'
    ```

3. As user A, load the post in one tab with RTC enabled.
4. As user B, load the same post in a second tab with RTC enabled.
5. See user A's table get cleared out.

   https://github.com/user-attachments/assets/878765cb-e1a5-43dd-9d3d-554c6c96c5a9

On this branch (`fix/crdt-table-emptying`), you should no longer see the table cleared.

---

Also see the added unit tests:

```
npm run test:unit -- --testPathPattern='core-data/src/utils/test/crdt-blocks' --testNamePattern='table block'
```

[which failed](https://github.com/WordPress/gutenberg/actions/runs/23209734187/job/67454909831?pr=76597) before these changes.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Identifying the root cause and implementing the fix.