### PR TITLE
Admin UI: Use hasPadding prop in Page stories

### DIFF
--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -35,9 +35,8 @@ export const Default: Story = {
 	args: {
 		title: 'Page title',
 		showSidebarToggle: false,
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
 	},
 };
 
@@ -46,9 +45,8 @@ export const WithSubtitle: Story = {
 		title: 'Page title',
 		subTitle: 'All of the subtitle text you need goes here.',
 		showSidebarToggle: false,
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
 	},
 };
 
@@ -63,9 +61,8 @@ export const WithBreadcrumbs: Story = {
 				] }
 			/>
 		),
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
 	},
 };
 
@@ -81,8 +78,7 @@ export const WithBreadcrumbsAndSubtitle: Story = {
 				] }
 			/>
 		),
-		children: (
-			<Text style={ { padding: '24px 24px' } }>Page content here</Text>
-		),
+		hasPadding: true,
+		children: <Text>Page content here</Text>,
 	},
 };


### PR DESCRIPTION
## What?

Updates Page Storybook stories to use the `hasPadding` prop instead of inline padding styles on children.

## Why?

As noted in https://github.com/WordPress/gutenberg/pull/76467#discussion_r2935553202, consumers of `Page` should not have to pass custom padding every time — the component provides `hasPadding` for this purpose.

## How?

Replace `<Text style={ { padding: '24px 24px' } }>` with `hasPadding: true` on all Page stories and simplify the children to `<Text>Page content here</Text>`.

## Testing Instructions

1. Run Storybook (`npm run storybook:dev`)
2. Navigate to Admin UI > Page stories
3. Verify all stories render with proper padding around the content area

### Keyboard Testing

No keyboard-specific changes.

---

Follow-up to #76467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)