### PR TITLE
RTC: Keep sync engine running even when there are no providers

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -28,6 +28,7 @@ import {
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
+import { stripServerManagedMeta } from './utils/crdt';
 
 /**
  * Requests authors from the REST API.
@@ -247,13 +248,25 @@ export const getEntityRecord =
 										return;
 									}
 
+									// Shallow-clone the record and its meta so we
+									// don't mutate the cached selector result.
+									// Strip server-managed meta keys before saving —
+									// sending their (possibly stale) client values
+									// can overwrite what the server calculates
+									// during save (e.g. _wp_ignored_hooked_blocks).
+									const recordToSave = {
+										...editedRecord,
+										meta: { ...meta },
+									};
+									stripServerManagedMeta( recordToSave );
+
 									// Trigger a save to persist the CRDT document. The entity's
 									// pre-persist hooks will create the persisted CRDT document
 									// and apply it to the record's meta.
 									dispatch.saveEntityRecord(
 										kind,
 										name,
-										editedRecord
+										recordToSave
 									);
 								} );
 						},

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -76,10 +76,36 @@ export interface YPostRecord extends YMapRecord {
 
 export const POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE = '_crdt_document';
 
-// Post meta keys that should *not* be synced.
+// Post meta keys that should *not* be synced between peers via the CRDT doc.
 const disallowedPostMetaKeys = new Set< string >( [
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 ] );
+
+// Post meta keys that are server-managed and must not be sent by the client
+// during saves. Sending stale client values for these keys overwrites the
+// server's calculations (e.g. update_ignored_hooked_blocks_postmeta).
+const serverManagedPostMetaKeys = new Set< string >( [
+	'_wp_ignored_hooked_blocks',
+] );
+
+/**
+ * Remove server-managed meta keys from a record's meta object in place.
+ * These keys are calculated by the server during save and must not be
+ * overwritten by possibly stale client values.
+ *
+ * @param {Object} record An entity record with an optional `meta` property.
+ */
+export function stripServerManagedMeta(
+	record: Record< string, unknown >
+): void {
+	const meta = record.meta;
+	if ( ! meta || typeof meta !== 'object' ) {
+		return;
+	}
+	serverManagedPostMetaKeys.forEach( ( metaKey ) => {
+		delete ( meta as Record< string, unknown > )[ metaKey ];
+	} );
+}
 
 /**
  * Given a set of local changes to a generic entity record, apply those changes

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -59,6 +59,7 @@ import {
 	applyPostChangesToCRDTDoc,
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
+	stripServerManagedMeta,
 	type PostChanges,
 	type YPostRecord,
 } from '../crdt';
@@ -932,3 +933,34 @@ function addBlockToDoc(
 
 	return ytext;
 }
+
+describe( 'stripServerManagedMeta', () => {
+	it( 'should remove _wp_ignored_hooked_blocks from meta', () => {
+		const record = {
+			meta: {
+				_wp_ignored_hooked_blocks: '',
+				footnotes: '',
+			},
+		};
+		stripServerManagedMeta( record );
+		expect( record.meta ).toEqual( { footnotes: '' } );
+	} );
+
+	it( 'should be a no-op when the key is not present', () => {
+		const record = { meta: { footnotes: '' } };
+		stripServerManagedMeta( record );
+		expect( record.meta ).toEqual( { footnotes: '' } );
+	} );
+
+	it( 'should be a no-op when meta is null', () => {
+		const record = { meta: null };
+		stripServerManagedMeta( record );
+		expect( record.meta ).toBeNull();
+	} );
+
+	it( 'should be a no-op when meta is undefined', () => {
+		const record = {};
+		stripServerManagedMeta( record );
+		expect( record ).toEqual( {} );
+	} );
+} );

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -26,7 +26,6 @@ import type {
 	ObjectID,
 	ObjectData,
 	ObjectType,
-	ProviderCreator,
 	RecordHandlers,
 	SyncConfig,
 	SyncManager,
@@ -157,13 +156,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		record: ObjectData,
 		handlers: RecordHandlers
 	): Promise< void > {
-		const providerCreators = getProviderCreators();
 		const entityId = getEntityId( objectType, objectId );
-
-		if ( 0 === providerCreators.length ) {
-			log( 'loadEntity', 'no providers, skipping', entityId );
-			return; // No provider creators, so syncing is effectively disabled.
-		}
 
 		if ( entityStates.has( entityId ) ) {
 			log( 'loadEntity', 'already loaded', entityId );
@@ -263,10 +256,12 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		entityStates.set( entityId, entityState );
 
-		// Create providers for the given entity and its Yjs document.
+		// Create providers for the given entity and its Yjs document. When no
+		// providers are available (e.g. real-time collaboration is off), the
+		// transport layer is disabled but the sync engine remains active.
 		log( 'loadEntity', 'connecting', entityId );
 		const providerResults = await Promise.all(
-			providerCreators.map( async ( create ) => {
+			getProviderCreators().map( async ( create ) => {
 				const provider = await create( {
 					objectType,
 					objectId,
@@ -304,13 +299,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		objectType: ObjectType,
 		handlers: CollectionHandlers
 	): Promise< void > {
-		const providerCreators: ProviderCreator[] = getProviderCreators();
 		const entityId = getEntityId( objectType, null );
-
-		if ( 0 === providerCreators.length ) {
-			log( 'loadCollection', 'no providers, skipping', entityId );
-			return; // No provider creators, so syncing is effectively disabled.
-		}
 
 		if ( collectionStates.has( objectType ) ) {
 			log( 'loadCollection', 'already loaded', entityId );
@@ -368,10 +357,12 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		collectionStates.set( objectType, collectionState );
 
-		// Create providers for the given entity and its Yjs document.
+		// Create providers for the given entity and its Yjs document. When no
+		// providers are available, the transport layer is disabled but the
+		// sync engine remains active.
 		log( 'loadCollection', 'connecting', entityId );
 		const providerResults = await Promise.all(
-			providerCreators.map( async ( create ) => {
+			getProviderCreators().map( async ( create ) => {
 				const provider = await create( {
 					awareness,
 					objectType,

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -153,7 +153,7 @@ describe( 'SyncManager', () => {
 			} );
 		} );
 
-		it( 'does not load entity when no providers are available', async () => {
+		it( 'loads entity without transport when no providers are available', async () => {
 			mockGetProviderCreators.mockReturnValue( [] );
 
 			const manager = createSyncManager();
@@ -166,9 +166,13 @@ describe( 'SyncManager', () => {
 				mockHandlers
 			);
 
-			expect(
-				mockSyncConfig.applyChangesToCRDTDoc
-			).not.toHaveBeenCalled();
+			// The sync engine should still initialize the CRDT document.
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalledWith(
+				expect.any( Y.Doc ),
+				mockRecord
+			);
+
+			// No providers should be created (transport is disabled).
 			expect( mockProviderCreator ).not.toHaveBeenCalled();
 		} );
 

--- a/test/e2e/specs/editor/plugins/block-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/block-hooks.spec.js
@@ -3,13 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-/**
- * Internal dependencies
- */
-const {
-	setCollaboration,
-} = require( '../../editor/collaboration/fixtures/collaboration-utils' );
-
 const dummyBlocksContent = `<!-- wp:heading -->
 <h2 class="wp-block-heading">This is a dummy heading</h2>
 <!-- /wp:heading -->
@@ -72,12 +65,6 @@ test.describe( 'Block Hooks API', () => {
 				} else {
 					containerPost = postObject;
 				}
-
-				/**
-				 * Since the Block Hooks API relies on server-side rendering to insert
-				 * the hooked blocks, there is a fundamental incompatibility with RTC.
-				 */
-				await setCollaboration( requestUtils, false );
 			} );
 
 			test.afterAll( async ( { requestUtils } ) => {
@@ -87,7 +74,6 @@ test.describe( 'Block Hooks API', () => {
 
 				await requestUtils.deleteAllPosts();
 				await requestUtils.deleteAllBlocks();
-				await setCollaboration( requestUtils, true );
 			} );
 
 			test( `should insert hooked blocks into ${ name } on frontend`, async ( {
@@ -212,12 +198,6 @@ test.describe( 'Block Hooks API', () => {
 				} else {
 					containerPost = postObject;
 				}
-
-				/**
-				 * Since the Block Hooks API relies on server-side rendering to insert
-				 * the hooked blocks, there is a fundamental incompatibility with RTC.
-				 */
-				await setCollaboration( requestUtils, false );
 			} );
 
 			test.afterAll( async ( { requestUtils } ) => {
@@ -227,7 +207,6 @@ test.describe( 'Block Hooks API', () => {
 
 				await requestUtils.deleteAllPosts();
 				await requestUtils.deleteAllBlocks();
-				await setCollaboration( requestUtils, true );
 			} );
 
 			test( `should insert hooked blocks into ${ name } on frontend`, async ( {


### PR DESCRIPTION

## What?

Keep sync engine "running" even when there are no registered sync providers.

## Why?

When real-time collaboration is disabled, what we really mean is that we want to disable sharing updates with other collaborators and use the existing post locking functionality.

However, representing entities as Yjs documents and keeping them up-to-date still has value. We can continue to battle-test the performance and undo functionality. We can also add new bindings to the sync manager that power new features like suggested edits, regardless of whether RTC is enabled.

## How?

Remove early return when there are no registered sync providers.

