### PR TITLE
Fix IS_GUTENBERG_PLUGIN env var override in build config 

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -118,22 +118,27 @@ const PAGES = WP_PLUGIN_CONFIG.pages || [];
  * are considered true while all other values are false.
  *
  * @param {string|undefined} value The configuration value to interpret.
- * @return {boolean} Boolean interpretation of the given configuration value.
+ * @return {boolean|undefined} Boolean interpretation of the given configuration value, or undefined if not set.
  */
 const boolConfigVal = ( value ) => {
-	return (
-		value !== undefined && [ 'true', '1' ].includes( value.toLowerCase() )
-	);
+	if ( value === undefined ) {
+		return undefined;
+	}
+	return [ 'true', '1' ].includes( value.toLowerCase() );
 };
 
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
-		boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
-			boolConfigVal( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
+		( boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
+			boolConfigVal(
+				process.env.npm_package_config_IS_GUTENBERG_PLUGIN
+			) ) ?? false
 	),
 	'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
-		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-			boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE )
+		( boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+			boolConfigVal(
+				process.env.npm_package_config_IS_WORDPRESS_CORE
+			) ) ?? false
 	),
 };
 const getDefine = ( scriptDebug ) => ( {
@@ -1807,7 +1812,7 @@ async function buildAll( baseUrlExpression ) {
 
 	// When building for WordPress Core, exclude experimental pages.
 	const isCoreBuild =
-		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ||
+		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
 		boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE );
 	const activePages = isCoreBuild
 		? normalizedPages.filter( ( page ) => ! page.experimental )

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -129,16 +129,16 @@ const boolConfigVal = ( value ) => {
 
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
-		( boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
+		boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
 			boolConfigVal(
 				process.env.npm_package_config_IS_GUTENBERG_PLUGIN
-			) ) ?? false
+			) ??
+			false
 	),
 	'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
-		( boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-			boolConfigVal(
-				process.env.npm_package_config_IS_WORDPRESS_CORE
-			) ) ?? false
+		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+			boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE ) ??
+			false
 	),
 };
 const getDefine = ( scriptDebug ) => ( {
@@ -2136,10 +2136,10 @@ async function main() {
 			'base-url': {
 				type: 'string',
 				default:
-					( boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
-						boolConfigVal(
-							process.env.npm_package_config_IS_WORDPRESS_CORE
-						) )
+					boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+					boolConfigVal(
+						process.env.npm_package_config_IS_WORDPRESS_CORE
+					)
 						? "includes_url( 'build/' )"
 						: 'plugin_dir_url( __FILE__ )',
 			},

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -346,7 +346,10 @@ function transformPhpContent( content, transforms ) {
 	 * class prefixes, etc.). When building for WordPress Core, it's not
 	 * necessary to perform these steps.
 	 */
-	if ( boolConfigVal( process.env.IS_WORDPRESS_CORE ) ) {
+	if (
+		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+		boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE )
+	) {
 		return content;
 	}
 
@@ -2132,9 +2135,13 @@ async function main() {
 			},
 			'base-url': {
 				type: 'string',
-				default: boolConfigVal( process.env.IS_WORDPRESS_CORE )
-					? "includes_url( 'build/' )"
-					: 'plugin_dir_url( __FILE__ )',
+				default:
+					( boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+						boolConfigVal(
+							process.env.npm_package_config_IS_WORDPRESS_CORE
+						) )
+						? "includes_url( 'build/' )"
+						: 'plugin_dir_url( __FILE__ )',
 			},
 		},
 		strict: false,

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -132,7 +132,7 @@ const baseDefine = {
 			boolConfigVal( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
 	),
 	'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
-		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ||
+		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
 			boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE )
 	),
 };

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -128,7 +128,7 @@ const boolConfigVal = ( value ) => {
 
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
-		boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ||
+		boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
 			boolConfigVal( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
 	),
 	'globalThis.IS_WORDPRESS_CORE': JSON.stringify(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

- Changes `||` to `??` for `IS_GUTENBERG_PLUGIN` and `IS_WORDPRESS_CORE` config value resolution in packages/wp-build/lib/build.mjs.
- Updates `boolConfigVal` to return `undefined` (instead of `false`) when the input value is not set, so that `?? `correctly falls through to the `npm_package_config_*` fallback.
- Applies the same `||` → `??` fix to the isCoreBuild check for consistency.

## Why?

When building for WordPress Core, it appears that the CI workflow sets `IS_GUTENBERG_PLUGIN=false`, but the `||` operator causes the fallback `npm_package_config_IS_GUTENBERG_PLUGIN` (always `true` from [package.json](https://github.com/WordPress/gutenberg/blob/trunk/package.json#L40)) to take precedence:

~~~
// Current: boolConfigVal("false") || boolConfigVal("true") → false || true → true
boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ||
    boolConfigVal( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
~~~

`??` only falls through on null/undefined, so an explicit `false` from the env var is respected:

~~~
// Fixed: boolConfigVal("false") ?? boolConfigVal("true") → false ?? true → false
boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??
    boolConfigVal( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
~~~

For this fix to work, `boolConfigVal` must return `undefined` (not `false`) when the env var is unset — otherwise the fallback would not fall through to the package.json config default.

The same change is applied to `IS_WORDPRESS_CORE` for consistency. It does not appear to be affected currently since `IS_WORDPRESS_CORE` is not in the `package.json` config, but this prevents the same issue if it is added in the future.

## Impact

`globalThis.IS_GUTENBERG_PLUGIN` is compiled to true in WordPress Core builds. This affects code paths guarded by this constant, including `useShouldIframe()` in `edit-post`, which forces the iframe editor on regardless of block API versions — preventing the block API version check introduced in #75187 from taking effect in the current WordPress 7.0 beta.

This was introduced in #75844 (commit 1bbed3c2f0), where a coding standards cleanup changed `??` to `||`.

## Testing Instructions

Build Gutenberg with the `IS_GUTENBERG_PLUGIN` env var set to both `true` and `false`. Without this fix, the compiled JS will always evaluate to `true`. With the fix, the value of the env var is correctly used.

```
# Before fix (outputs true):
IS_GUTENBERG_PLUGIN=false npm run build
grep "isGutenbergPlugin" build/scripts/edit-post/index.js

# After fix (outputs false):
IS_GUTENBERG_PLUGIN=false npm run build
grep "isGutenbergPlugin" build/scripts/edit-post/index.js

# After fix without env var (outputs true)
npm run build
grep "isGutenbergPlugin" build/scripts/edit-post/index.js
```

## Use of AI Tools

Cladue Code was used to troubleshoot and suggest code for this issue while looking into the related issue of the iframe being used in the post editor containing v2 blocks in WordPress 7.0-beta5.