### PR TITLE
RTC: Fix RichTextData deserialization

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -123,6 +123,36 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
 	} );
 }
 
+const RICH_TEXT_CACHE_MAX_SIZE = 500;
+const richTextCache = new Map< string, RichTextData >();
+
+/**
+ * Returns a RichTextData instance for the given HTML string, using a cache to
+ * avoid re-parsing identical strings. Repeated calls with the same string
+ * (e.g. unchanged blocks on each remote CRDT update) return the cached instance
+ * without re-running the HTML parser and DOM traversal.
+ *
+ * @param value The HTML string to parse.
+ * @return The RichTextData instance.
+ */
+function cachedFromHTMLString( value: string ): RichTextData {
+	const cached = richTextCache.get( value );
+
+	if ( cached ) {
+		return cached;
+	}
+
+	const result = RichTextData.fromHTMLString( value );
+
+	if ( richTextCache.size >= RICH_TEXT_CACHE_MAX_SIZE ) {
+		// Evict the oldest entry (Map preserves insertion order).
+		richTextCache.delete( richTextCache.keys().next().value! );
+	}
+
+	richTextCache.set( value, result );
+	return result;
+}
+
 /**
  * Recursively walk an attribute value and convert any strings that correspond
  * to rich-text schema nodes into RichTextData instances. This is the inverse
@@ -137,7 +167,7 @@ function deserializeAttributeValue(
 	value: unknown
 ): unknown {
 	if ( schema?.type === 'rich-text' && typeof value === 'string' ) {
-		return RichTextData.fromHTMLString( value );
+		return cachedFromHTMLString( value );
 	}
 
 	// e.g. core/table `body`: [ { cells: [ { content: RichTextData } ] } ]
@@ -167,39 +197,11 @@ function deserializeAttributeValue(
 }
 
 /**
- * Convert rich-text string attributes in a block back to RichTextData
- * instances. This is the inverse of makeBlockAttributesSerializable and is
- * needed when blocks are extracted from the CRDT document, where rich-text
- * values are stored as Y.Text (which serializes to plain strings via
- * toJSON()). Without this conversion, block edit components that rely on
- * RichTextData methods (e.g. `.text`) will receive a raw string and
- * malfunction.
- *
- * @param blockName  The block type name, e.g. 'core/code'.
- * @param attributes The plain-object attributes from CRDT (toJSON).
- * @return Attributes with rich-text strings replaced by RichTextData.
- */
-function deserializeBlockAttributeValues(
-	blockName: string,
-	attributes: BlockAttributes
-): BlockAttributes {
-	const newAttributes = { ...attributes };
-
-	for ( const [ key, value ] of Object.entries( attributes ) ) {
-		const schema = getBlockAttributeType( blockName, key );
-
-		if ( schema ) {
-			newAttributes[ key ] = deserializeAttributeValue( schema, value );
-		}
-	}
-
-	return newAttributes;
-}
-
-/**
  * Convert blocks from their CRDT-serialized form back to the runtime form
- * expected by the block editor. This ensures that rich-text attributes are
- * RichTextData instances rather than raw strings.
+ * expected by the block editor. Rich-text attributes are stored as Y.Text in
+ * the CRDT document, which serializes to plain strings via toJSON(). This
+ * function restores them to RichTextData instances so that block edit
+ * components that rely on RichTextData methods (e.g. `.text`) work correctly.
  *
  * @param blocks Blocks as extracted from the CRDT document via toJSON().
  * @return Blocks with rich-text attributes restored to RichTextData.
@@ -207,10 +209,24 @@ function deserializeBlockAttributeValues(
 export function deserializeBlockAttributes( blocks: Block[] ): Block[] {
 	return blocks.map( ( block: Block ) => {
 		const { name, innerBlocks, attributes, ...rest } = block;
+
+		const newAttributes = { ...attributes };
+
+		for ( const [ key, value ] of Object.entries( attributes ) ) {
+			const schema = getBlockAttributeType( name, key );
+
+			if ( schema ) {
+				newAttributes[ key ] = deserializeAttributeValue(
+					schema,
+					value
+				);
+			}
+		}
+
 		return {
 			...rest,
 			name,
-			attributes: deserializeBlockAttributeValues( name, attributes ),
+			attributes: newAttributes,
 			innerBlocks: deserializeBlockAttributes( innerBlocks ?? [] ),
 		};
 	} );

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -16,6 +16,7 @@ import { Y } from '@wordpress/sync';
  * Internal dependencies
  */
 import { createYMap, type YMapRecord, type YMapWrap } from './crdt-utils';
+import { getCachedRichTextData } from './crdt-text';
 import { Delta } from '../sync';
 
 interface BlockAttributes {
@@ -123,36 +124,6 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
 	} );
 }
 
-const RICH_TEXT_CACHE_MAX_SIZE = 500;
-const richTextCache = new Map< string, RichTextData >();
-
-/**
- * Returns a RichTextData instance for the given HTML string, using a cache to
- * avoid re-parsing identical strings. Repeated calls with the same string
- * (e.g. unchanged blocks on each remote CRDT update) return the cached instance
- * without re-running the HTML parser and DOM traversal.
- *
- * @param value The HTML string to parse.
- * @return The RichTextData instance.
- */
-function cachedFromHTMLString( value: string ): RichTextData {
-	const cached = richTextCache.get( value );
-
-	if ( cached ) {
-		return cached;
-	}
-
-	const result = RichTextData.fromHTMLString( value );
-
-	if ( richTextCache.size >= RICH_TEXT_CACHE_MAX_SIZE ) {
-		// Evict the oldest entry (Map preserves insertion order).
-		richTextCache.delete( richTextCache.keys().next().value! );
-	}
-
-	richTextCache.set( value, result );
-	return result;
-}
-
 /**
  * Recursively walk an attribute value and convert any strings that correspond
  * to rich-text schema nodes into RichTextData instances. This is the inverse
@@ -167,7 +138,7 @@ function deserializeAttributeValue(
 	value: unknown
 ): unknown {
 	if ( schema?.type === 'rich-text' && typeof value === 'string' ) {
-		return cachedFromHTMLString( value );
+		return getCachedRichTextData( value );
 	}
 
 	// e.g. core/table `body`: [ { cells: [ { content: RichTextData } ] } ]

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -25,6 +25,7 @@ interface BlockAttributes {
 interface BlockAttributeType {
 	role?: string;
 	type?: string;
+	query?: Record< string, BlockAttributeType >;
 }
 
 interface BlockType {
@@ -123,6 +124,49 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
 }
 
 /**
+ * Recursively walk an attribute value and convert any strings that correspond
+ * to rich-text schema nodes into RichTextData instances. This is the inverse
+ * of serializeAttributeValue and handles nested structures like table cells.
+ *
+ * @param schema The attribute type definition for this value.
+ * @param value  The attribute value from CRDT (toJSON).
+ * @return The value with rich-text strings replaced by RichTextData.
+ */
+function deserializeAttributeValue(
+	schema: BlockAttributeType | undefined,
+	value: unknown
+): unknown {
+	if ( schema?.type === 'rich-text' && typeof value === 'string' ) {
+		return RichTextData.fromHTMLString( value );
+	}
+
+	// e.g. core/table `body`: [ { cells: [ { content: RichTextData } ] } ]
+	if ( Array.isArray( value ) ) {
+		return value.map( ( item ) =>
+			deserializeAttributeValue( schema, item )
+		);
+	}
+
+	// e.g. a single row inside core/table `body`: { cells: [ ... ] }
+	if ( value && typeof value === 'object' ) {
+		const result: Record< string, unknown > = {};
+
+		for ( const [ key, innerValue ] of Object.entries(
+			value as Record< string, unknown >
+		) ) {
+			result[ key ] = deserializeAttributeValue(
+				schema?.query?.[ key ],
+				innerValue
+			);
+		}
+
+		return result;
+	}
+
+	return value;
+}
+
+/**
  * Convert rich-text string attributes in a block back to RichTextData
  * instances. This is the inverse of makeBlockAttributesSerializable and is
  * needed when blocks are extracted from the CRDT document, where rich-text
@@ -142,11 +186,10 @@ function deserializeBlockAttributeValues(
 	const newAttributes = { ...attributes };
 
 	for ( const [ key, value ] of Object.entries( attributes ) ) {
-		if (
-			isRichTextAttribute( blockName, key ) &&
-			typeof value === 'string'
-		) {
-			newAttributes[ key ] = RichTextData.fromHTMLString( value );
+		const schema = getBlockAttributeType( blockName, key );
+
+		if ( schema ) {
+			newAttributes[ key ] = deserializeAttributeValue( schema, value );
 		}
 	}
 
@@ -532,8 +575,8 @@ function getBlockAttributeType(
 				new Map< string, BlockAttributeType >(
 					Object.entries( blockType.attributes ?? {} ).map(
 						( [ name, definition ] ) => {
-							const { role, type } = definition;
-							return [ name, { role, type } ];
+							const { role, type, query } = definition;
+							return [ name, { role, type, query } ];
 						}
 					)
 				)

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -123,6 +123,57 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
 }
 
 /**
+ * Convert rich-text string attributes in a block back to RichTextData
+ * instances. This is the inverse of makeBlockAttributesSerializable and is
+ * needed when blocks are extracted from the CRDT document, where rich-text
+ * values are stored as Y.Text (which serializes to plain strings via
+ * toJSON()). Without this conversion, block edit components that rely on
+ * RichTextData methods (e.g. `.text`) will receive a raw string and
+ * malfunction.
+ *
+ * @param blockName  The block type name, e.g. 'core/code'.
+ * @param attributes The plain-object attributes from CRDT (toJSON).
+ * @return Attributes with rich-text strings replaced by RichTextData.
+ */
+function deserializeBlockAttributeValues(
+	blockName: string,
+	attributes: BlockAttributes
+): BlockAttributes {
+	const newAttributes = { ...attributes };
+
+	for ( const [ key, value ] of Object.entries( attributes ) ) {
+		if (
+			isRichTextAttribute( blockName, key ) &&
+			typeof value === 'string'
+		) {
+			newAttributes[ key ] = RichTextData.fromHTMLString( value );
+		}
+	}
+
+	return newAttributes;
+}
+
+/**
+ * Convert blocks from their CRDT-serialized form back to the runtime form
+ * expected by the block editor. This ensures that rich-text attributes are
+ * RichTextData instances rather than raw strings.
+ *
+ * @param blocks Blocks as extracted from the CRDT document via toJSON().
+ * @return Blocks with rich-text attributes restored to RichTextData.
+ */
+export function deserializeBlockAttributes( blocks: Block[] ): Block[] {
+	return blocks.map( ( block: Block ) => {
+		const { name, innerBlocks, attributes, ...rest } = block;
+		return {
+			...rest,
+			name,
+			attributes: deserializeBlockAttributeValues( name, attributes ),
+			innerBlocks: deserializeBlockAttributes( innerBlocks ?? [] ),
+		};
+	} );
+}
+
+/**
  * @param {any}   gblock
  * @param {Y.Map} yblock
  */

--- a/packages/core-data/src/utils/crdt-text.ts
+++ b/packages/core-data/src/utils/crdt-text.ts
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+
+const RICH_TEXT_CACHE_MAX_SIZE = 500;
+
+/**
+ * Returns a function that converts HTML strings to RichTextData instances,
+ * using a FIFO cache bounded by `maxSize` to avoid re-parsing identical
+ * strings. Repeated calls with the same string return the cached instance
+ * without re-running the HTML parser and DOM traversal.
+ *
+ * @param maxSize Maximum number of entries to hold in the cache.
+ * @return A cached version of RichTextData.fromHTMLString.
+ */
+export function createRichTextDataCache(
+	maxSize: number
+): ( value: string ) => RichTextData {
+	const cache = new Map< string, RichTextData >();
+
+	return function ( value: string ): RichTextData {
+		const cached = cache.get( value );
+
+		if ( cached ) {
+			return cached;
+		}
+
+		const result = RichTextData.fromHTMLString( value );
+
+		if ( cache.size >= maxSize ) {
+			// Evict the oldest entry (Map preserves insertion order).
+			cache.delete( cache.keys().next().value! );
+		}
+
+		cache.set( value, result );
+		return result;
+	};
+}
+
+export const getCachedRichTextData = createRichTextDataCache(
+	RICH_TEXT_CACHE_MAX_SIZE
+);

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -20,6 +20,7 @@ import {
  */
 import { BaseAwareness } from '../awareness/base-awareness';
 import {
+	deserializeBlockAttributes,
 	mergeCrdtBlocks,
 	mergeRichTextUpdate,
 	type Block,
@@ -381,6 +382,15 @@ export function getPostChangesFromCRDTDoc(
 			}
 		} )
 	);
+
+	// Blocks extracted from the CRDT document have rich-text attributes as
+	// plain strings (from Y.Text.toJSON()). Convert them back to RichTextData
+	// so block edit components receive the same types as locally-created blocks.
+	if ( changes.blocks ) {
+		changes.blocks = deserializeBlockAttributes(
+			changes.blocks as Block[]
+		);
+	}
 
 	// Meta changes must be merged with the edited record since not all meta
 	// properties are synced.

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -67,6 +67,7 @@ import {
 	type YBlocks,
 	type YBlockAttributes,
 } from '../crdt-blocks';
+import { getCachedRichTextData, createRichTextDataCache } from '../crdt-text';
 
 describe( 'crdt-blocks', () => {
 	let doc: Y.Doc;
@@ -1579,5 +1580,57 @@ describe( 'crdt-blocks', () => {
 				expect( yText.toString() ).toBe( 'a𝄞xb' );
 			} );
 		} );
+	} );
+} );
+
+describe( 'getCachedRichTextData', () => {
+	let spy: ReturnType< typeof jest.spyOn >;
+
+	beforeEach( () => {
+		spy = jest.spyOn( RichTextData, 'fromHTMLString' );
+	} );
+
+	afterEach( () => {
+		spy.mockRestore();
+	} );
+
+	it( 'does not call fromHTMLString again for the same HTML string', () => {
+		getCachedRichTextData( '<strong>cached-hit</strong>' );
+		getCachedRichTextData( '<strong>cached-hit</strong>' );
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls fromHTMLString for each unique HTML string', () => {
+		getCachedRichTextData( '<strong>cached-miss-a</strong>' );
+		getCachedRichTextData( '<em>cached-miss-b</em>' );
+
+		expect( spy ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'calls fromHTMLString again for an evicted entry', () => {
+		const cacheSize = 10;
+		const getCachedValue = createRichTextDataCache( cacheSize );
+
+		const firstString = 'eviction-test-first';
+
+		getCachedValue( firstString );
+
+		for ( let i = 1; i < cacheSize; i++ ) {
+			getCachedValue( `eviction-test-${ i }` );
+		}
+
+		// This should push firstString out of the cache.
+		getCachedValue( 'eviction-test-overflow' );
+
+		spy.mockClear();
+
+		// firstString was evicted, so fromHTMLString should be called again.
+		getCachedValue( firstString );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+
+		// The overflow entry is still cached, so fromHTMLString should not be called.
+		getCachedValue( 'eviction-test-overflow' );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -23,6 +23,25 @@ jest.mock( '@wordpress/blocks', () => {
 				name: 'core/paragraph',
 				attributes: { content: { type: 'rich-text' } },
 			},
+			{
+				name: 'core/table',
+				attributes: {
+					hasFixedLayout: { type: 'boolean' },
+					caption: { type: 'rich-text' },
+					body: {
+						type: 'array',
+						query: {
+							cells: {
+								type: 'array',
+								query: {
+									content: { type: 'rich-text' },
+									tag: { type: 'string' },
+								},
+							},
+						},
+					},
+				},
+			},
 		],
 	};
 } );
@@ -556,6 +575,49 @@ describe( 'crdt', () => {
 			expect( block ).toBeDefined();
 			expect( block.attributes.content ).toBeInstanceOf( RichTextData );
 			expect( block.attributes.content.text ).toBe( 'Hello world' );
+		} );
+
+		it( 'returns nested rich-text in array attributes as RichTextData', () => {
+			// Add a table block to the CRDT doc with nested cell content
+			// stored as plain strings.
+			let blocks = map.get( 'blocks' );
+			if ( ! ( blocks instanceof Y.Array ) ) {
+				blocks = new Y.Array< YBlock >();
+				map.set( 'blocks', blocks );
+			}
+
+			const tableBlock = createYMap< YBlockRecord >();
+			tableBlock.set( 'name', 'core/table' );
+			tableBlock.set( 'clientId', 'table-1' );
+			const attrs = new Y.Map();
+			attrs.set( 'body', [
+				{
+					cells: [
+						{ content: '<strong>Cell</strong>', tag: 'td' },
+						{ content: 'Plain', tag: 'td' },
+					],
+				},
+			] );
+			tableBlock.set( 'attributes', attrs );
+			tableBlock.set( 'innerBlocks', new Y.Array() );
+			( blocks as YBlocks ).push( [ tableBlock ] );
+
+			const editedRecord = { blocks: [] } as unknown as Post;
+
+			const changes = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				defaultSyncedProperties
+			);
+
+			const block = ( changes.blocks as any[] )?.[ 0 ];
+			expect( block ).toBeDefined();
+
+			const cell = block.attributes.body[ 0 ].cells[ 0 ];
+			expect( cell.content ).toBeInstanceOf( RichTextData );
+			expect( ( cell.content as RichTextData ).toHTMLString() ).toBe(
+				'<strong>Cell</strong>'
+			);
 		} );
 
 		it( 'includes undefined blocks in changes', () => {

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -9,6 +9,30 @@ import { Y } from '@wordpress/sync';
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 /**
+ * Mock getBlockTypes so isRichTextAttribute can identify rich-text attrs.
+ */
+jest.mock( '@wordpress/blocks', () => {
+	const actual = jest.requireActual( '@wordpress/blocks' ) as Record<
+		string,
+		unknown
+	>;
+	return {
+		...actual,
+		getBlockTypes: () => [
+			{
+				name: 'core/paragraph',
+				attributes: { content: { type: 'rich-text' } },
+			},
+		],
+	};
+} );
+
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+
+/**
  * Internal dependencies
  */
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
@@ -515,6 +539,25 @@ describe( 'crdt', () => {
 			expect( changes ).toHaveProperty( 'blocks' );
 		} );
 
+		it( 'returns rich-text block attributes as RichTextData, not strings', () => {
+			// Simulate User A writing a paragraph block into the CRDT doc.
+			addBlockToDoc( map, 'block-1', 'Hello world' );
+
+			// Simulate User B reading the CRDT doc with no local blocks.
+			const editedRecord = { blocks: [] } as unknown as Post;
+
+			const changes = getPostChangesFromCRDTDoc(
+				doc,
+				editedRecord,
+				defaultSyncedProperties
+			);
+
+			const block = ( changes.blocks as any[] )?.[ 0 ];
+			expect( block ).toBeDefined();
+			expect( block.attributes.content ).toBeInstanceOf( RichTextData );
+			expect( block.attributes.content.text ).toBe( 'Hello world' );
+		} );
+
 		it( 'includes undefined blocks in changes', () => {
 			map.set( 'blocks', undefined );
 
@@ -801,11 +844,13 @@ describe( 'crdt', () => {
  * @param map
  * @param clientId Block client ID.
  * @param content  Initial text content.
+ * @param name     Block name (default: 'core/paragraph').
  */
 function addBlockToDoc(
 	map: YMapWrap< YPostRecord >,
 	clientId: string,
-	content: string
+	content: string,
+	name = 'core/paragraph'
 ): Y.Text {
 	let blocks = map.get( 'blocks' );
 	if ( ! ( blocks instanceof Y.Array ) ) {
@@ -814,6 +859,7 @@ function addBlockToDoc(
 	}
 
 	const block = createYMap< YBlockRecord >();
+	block.set( 'name', name );
 	block.set( 'clientId', clientId );
 	const attrs = new Y.Map();
 	const ytext = new Y.Text( content );


### PR DESCRIPTION
## What?

Fixes an issue we've observed with the `jetpack-mu-wpcom` [code block override](https://github.com/Automattic/jetpack/blob/427717163ca8d01135fceec2689887ee093ac4b7/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php#L240-L250) that causes code content to be cleared out when another user loads the editor:

https://github.com/user-attachments/assets/bf810aa7-b68a-4ebc-8378-fbe3c1c23183

This in particular resulted from the custom code block accessing a `RichText` attribute value [via `attributes.content?.text`](https://github.com/Automattic/jetpack/blob/427717163ca8d01135fceec2689887ee093ac4b7/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx#L343). In `trunk`, our CRDT code caused the `attributes.content` value to be a `string` instead of `RichTextData` so the `.text` property failed to exist.

## Why?

The Jetpack enhanced code block (and any block whose edit component accesses `content.text` and expects a rich text object) breaks when a second user joins a collaborative session. The CRDT serialization path correctly converts `RichTextData` to strings when writing to the Y.Doc (`serializeAttributeValue`), but the deserialization path has no corresponding conversion back.

This meant blocks received from CRDT had `content` as a raw string, so `content.text` (a `RichTextData` getter) was `undefined`. The edit component then initialized with empty content and wrote that back, wiping the block's content entirely.

## How?

Added `deserializeBlockAttributes`  as the inverse of the existing serialization path. When `getPostChangesFromCRDTDoc` extracts blocks from the CRDT document, it now converts any rich-text string attributes back to `RichTextData` via `RichTextData.fromHTMLString()`. This ensures block edit components receive the same attribute types regardless of whether blocks were created locally or arrived via CRDT sync.

## Testing Instructions

### Unit test

```bash
npm run test:unit -- --testPathPattern='core-data/src/utils/test/crdt' --testNamePattern='rich-text block attributes'
```

You can see the test failing before the fix here: https://github.com/WordPress/gutenberg/actions/runs/23220557291/job/67491959921?pr=76607.

### Manual testing

Manual testing with `jetpack-mu-wpcom`-specific blocks is difficult locally, so I've included test files that can be used locally to reproduce the same issue. Here's what the reproduction looks like using the "RTC Test Code Block":

---

https://github.com/user-attachments/assets/4747e085-08b1-40b8-b926-55e492c2cf47

*Test code block with fix disabled to show local reproduction*

---

Here's how to run this locally to reproduce the bug against `trunk`:

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.

2. Create a `rtc-test-code-block/` folder at the root of your `gutenberg` repository. Add these two files:

   <details>
   <summary><code>rtc-test-code-block.php</code></summary>

   ```php
   <?php
   /**
    * Plugin Name: RTC Test Code Block
    * Description: A minimal block that reproduces the Jetpack code block's RTC sync
    *              issue. The edit component accesses content.text (a RichTextData
    *              getter), which fails when CRDT delivers content as a plain string.
    */

   add_action( 'init', function () {
   	register_block_type(
   		'test/rtc-code-block',
   		array(
   			'api_version' => 3,
   			'title'       => 'RTC Test Code Block',
   			'category'    => 'text',
   			'attributes'  => array(
   				'content' => array(
   					'type'                          => 'rich-text',
   					'source'                        => 'rich-text',
   					'selector'                      => 'code',
   					'__unstablePreserveWhiteSpace'  => true,
   					'role'                          => 'content',
   				),
   			),
   		)
   	);
   } );

   add_action( 'enqueue_block_editor_assets', function () {
   	wp_enqueue_script(
   		'rtc-test-code-block',
   		plugins_url( 'rtc-test-code-block.js', __FILE__ ),
   		array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-rich-text' ),
   		'1.0',
   		true
   	);
   } );
   ```

   </details>

   <details>
   <summary><code>rtc-test-code-block.js</code></summary>

   ```js
   /**
    * Minimal block reproducing the Jetpack enhanced code block's RTC bug.
    *
    * The edit component reads `content.text` on mount (a RichTextData getter)
    * and writes derived state back. When CRDT delivers `content` as a plain
    * string, `.text` is undefined and the content is overwritten with "".
    */
   ( function () {
   	const { createElement: el, useEffect, useRef, useCallback } = wp.element;
   	const { registerBlockType } = wp.blocks;
   	const { useBlockProps } = wp.blockEditor;
   	const { RichTextData } = wp.richText;

   	registerBlockType( 'test/rtc-code-block', {
   		title: 'RTC Test Code Block',
   		category: 'text',
   		icon: 'editor-code',
   		attributes: {
   			content: {
   				type: 'rich-text',
   				source: 'rich-text',
   				selector: 'code',
   				role: 'content',
   			},
   		},

   		edit: function Edit( { attributes, setAttributes } ) {
   			const codeRef = useRef( null );
   			const didInit = useRef( false );

   			// On mount, read content.text and initialise internal state.
   			// Same pattern as Jetpack CodeMirror (block-edit-function.tsx:343):
   			//   doc: attributes.content?.text ?? ''
   			useEffect( () => {
   				if ( didInit.current ) {
   					return;
   				}
   				didInit.current = true;

   				const text = attributes.content?.text ?? '';

   				// Populate the editable element with the initial text.
   				if ( codeRef.current ) {
   					codeRef.current.textContent = text;
   				}

   				// Write it back as RichTextData, same as Jetpack's updateCode().
   				setAttributes( {
   					content: RichTextData.fromPlainText( text ),
   				} );
   			}, [] ); // eslint-disable-line react-hooks/exhaustive-deps

   			const onInput = useCallback( () => {
   				if ( codeRef.current ) {
   					const text = codeRef.current.textContent || '';
   					setAttributes( {
   						content: RichTextData.fromPlainText( text ),
   					} );
   				}
   			}, [ setAttributes ] );

   			return el(
   				'pre',
   				useBlockProps(),
   				el( 'code', {
   					ref: codeRef,
   					contentEditable: true,
   					suppressContentEditableWarning: true,
   					onInput,
   					style: {
   						outline: 'none',
   						whiteSpace: 'pre-wrap',
   						minHeight: '1em',
   						display: 'block',
   					},
   				} )
   			);
   		},

   		save( { attributes } ) {
   			return el(
   				'pre',
   				useBlockProps.save(),
   				el( 'code', null, attributes.content?.toHTMLString?.() ?? '' )
   			);
   		},
   	} );
   } )();
   ```

   </details>

    These implement a block that reads from content via `attributes.content?.text` and writes it back to the block attributes, replicating the same bug.

3. Add the "plugin" to your `.wp-env.json`:

    ```diff
    {
        "$schema": "./schemas/json/wp-env.json",
        "testsEnvironment": false,
        "core": "WordPress/WordPress",
    -   "plugins": [ "." ],
    +   "plugins": [ ".", "./rtc-test-code-block" ],
        /* ... */
    }
    ```

3. Activate the plugin and open a draft post. Insert a "RTC Test Code Block", a heading block, and another "RTC Test Code Block", each with content.

4. Open the same post in a second browser.
5. After the collaborator list appears, the second user should see the code block contents cleared out.

Try again on this branch (`fix/rich-text-deserialization`) and the content should stay.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Diagnosing the CRDT serialization problem and implementing the fix.