### PR TITLE
Admin UI: Add CSS files to sideEffects array

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -43,7 +43,9 @@
 	},
 	"react-native": "src/index",
 	"types": "build-types",
-	"sideEffects": false,
+	"sideEffects": [
+		"*.css"
+	],
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -44,7 +44,8 @@
 	"react-native": "src/index",
 	"types": "build-types",
 	"sideEffects": [
-		"*.css"
+		"build-style/**",
+		"src/**/*.scss"
 	],
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76606

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To avoid CSS file imports from the admin-ui package being ignored.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding an array to the `sideEffects` value containing CSS files.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
This one is tricky to test. I'm using https://github.com/dhasilva/minimal-wp-build-test/tree/test/admin-ui-side-effects to test this.
* Clone the repo above and checkout the `test/admin-ui-side-effects` branch
* `pnpm install`
* `pnpm run build`, you should see the errors shown in #76606
* Manually edit the `package.json` files of the admin-ui package to be the same as this PR. In my environment, they are located in:
  1. node_modules/@wordpress/admin-ui/package.json
  2. routes/root/node_modules/@wordpress/admin-ui/package.json
  3. routes/root/node_modules/.pnpm/@wordpress+admin-ui@1.9.0_@emotion+is-prop-valid@1.4.0_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@wordpress/admin-ui/package.json
  4. node_modules/.pnpm/@wordpress+admin-ui@1.9.0_@emotion+is-prop-valid@1.4.0_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@wordpress/admin-ui/package.json
* Run `pnpm run build` again
* Check that the warning messages are gone

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
No AI tool used.