### PR TITLE
Core Data: Fix per_page query logic for when offset is present in the query

### DIFF
--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -15,6 +15,8 @@ import { withWeakMapCache, getNormalizedCommaSeparable } from '../utils';
  *
  * @property {number}      page      The query page (1-based index, default 1).
  * @property {number}      perPage   Items per page for query (default 10).
+ * @property {number}      offset    Absolute item offset (default undefined).
+ *                                   When present, also encoded into stableKey.
  * @property {string}      stableKey An encoded stable string of all non-
  *                                   pagination, non-fields query parameters.
  * @property {?(string[])} fields    Target subset of fields to derive from
@@ -41,6 +43,7 @@ export function getQueryParts( query ) {
 		stableKey: '',
 		page: 1,
 		perPage: 10,
+		offset: undefined,
 		fields: null,
 		include: null,
 		context: 'default',
@@ -67,6 +70,13 @@ export function getQueryParts( query ) {
 				break;
 
 			default:
+				// Extract offset for use in pagination calculations while
+				// still including it in the stableKey (different offsets
+				// produce different result sets).
+				if ( key === 'offset' ) {
+					parts.offset = Number( value );
+				}
+
 				// While in theory, we could exclude "_fields" from the stableKey
 				// because two request with different fields have the same results
 				// We're not able to ensure that because the server can decide to omit

--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -74,7 +74,10 @@ export function getQueryParts( query ) {
 				// still including it in the stableKey (different offsets
 				// produce different result sets).
 				if ( key === 'offset' ) {
-					parts.offset = Number( value );
+					const numericOffset = Number( value );
+					if ( Number.isFinite( numericOffset ) ) {
+						parts.offset = numericOffset;
+					}
 				}
 
 				// While in theory, we could exclude "_fields" from the stableKey

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -32,8 +32,15 @@ const queriedItemsCacheByState = new WeakMap();
  * @return {?Array} Query items.
  */
 function getQueriedItemsUncached( state, query ) {
-	const { stableKey, page, perPage, include, fields, context } =
-		getQueryParts( query );
+	const {
+		stableKey,
+		page,
+		perPage,
+		offset: queryOffset,
+		include,
+		fields,
+		context,
+	} = getQueryParts( query );
 
 	const itemIds = state.queries?.[ context ]?.[ stableKey ]?.itemIds;
 	if ( ! itemIds ) {
@@ -52,8 +59,18 @@ function getQueriedItemsUncached( state, query ) {
 	if ( perPage !== -1 && itemIds.length < startOffset + perPage ) {
 		const totalItems =
 			state.queries[ context ][ stableKey ].meta?.totalItems;
-		if ( Number.isFinite( totalItems ) && itemIds.length < totalItems ) {
-			return null;
+		if ( Number.isFinite( totalItems ) ) {
+			// For offset-based queries, totalItems (from X-WP-Total)
+			// reflects the global count of all matching items, not the
+			// count remaining after the offset. The number of items
+			// available for this query is (totalItems - offset), so a
+			// partial last page is expected and valid.
+			const effectiveTotal = Number.isFinite( queryOffset )
+				? totalItems - queryOffset
+				: totalItems;
+			if ( itemIds.length < effectiveTotal ) {
+				return null;
+			}
 		}
 	}
 

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -65,9 +65,10 @@ function getQueriedItemsUncached( state, query ) {
 			// count remaining after the offset. The number of items
 			// available for this query is (totalItems - offset), so a
 			// partial last page is expected and valid.
-			const effectiveTotal = Number.isFinite( queryOffset )
-				? totalItems - queryOffset
-				: totalItems;
+			const effectiveTotal =
+				queryOffset !== undefined
+					? totalItems - queryOffset
+					: totalItems;
 			if ( itemIds.length < effectiveTotal ) {
 				return null;
 			}

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -7,7 +7,6 @@ describe( 'getQueryParts', () => {
 	it( 'parses out pagination data', () => {
 		const parts = getQueryParts( { page: 2, per_page: 2 } );
 
-		// Use toEqual here to pin the complete return shape.
 		expect( parts ).toEqual( {
 			context: 'default',
 			page: 2,
@@ -26,10 +25,11 @@ describe( 'getQueryParts', () => {
 
 		expect( first ).toEqual( second );
 		expect( second ).toEqual( parts );
-		expect( parts ).toMatchObject( {
+		expect( parts ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
+			offset: undefined,
 			stableKey: 'include=1',
 			fields: null,
 			include: [ 1 ],
@@ -41,10 +41,11 @@ describe( 'getQueryParts', () => {
 		const second = getQueryParts( { b: 2, '?': '&' } );
 
 		expect( first ).toEqual( second );
-		expect( first ).toMatchObject( {
+		expect( first ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
+			offset: undefined,
 			stableKey: '%3F=%26&b=2',
 			fields: null,
 			include: null,
@@ -54,10 +55,11 @@ describe( 'getQueryParts', () => {
 	it( 'encodes deep values', () => {
 		const parts = getQueryParts( { a: [ 1, 2 ] } );
 
-		expect( parts ).toMatchObject( {
+		expect( parts ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
+			offset: undefined,
 			stableKey: 'a%5B0%5D=1&a%5B1%5D=2',
 			fields: null,
 			include: null,
@@ -69,10 +71,11 @@ describe( 'getQueryParts', () => {
 		const second = getQueryParts( { b: 2, page: '1', per_page: '10' } );
 
 		expect( first ).toEqual( second );
-		expect( first ).toMatchObject( {
+		expect( first ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
+			offset: undefined,
 			stableKey: 'b=2',
 			fields: null,
 			include: null,
@@ -82,10 +85,11 @@ describe( 'getQueryParts', () => {
 	it( 'returns -1 for unlimited queries', () => {
 		const parts = getQueryParts( { b: 2, page: 1, per_page: -1 } );
 
-		expect( parts ).toMatchObject( {
+		expect( parts ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: -1,
+			offset: undefined,
 			stableKey: 'b=2',
 			fields: null,
 			include: null,
@@ -95,10 +99,11 @@ describe( 'getQueryParts', () => {
 	it( 'encodes stable string key with fields parameters', () => {
 		const parts = getQueryParts( { _fields: [ 'id', 'title' ] } );
 
-		expect( parts ).toMatchObject( {
+		expect( parts ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
+			offset: undefined,
 			stableKey: '_fields=id%2Ctitle',
 			fields: [ 'id', 'title' ],
 			include: null,
@@ -108,9 +113,10 @@ describe( 'getQueryParts', () => {
 	it( 'returns the context as a dedicated query part', () => {
 		const parts = getQueryParts( { context: 'view' } );
 
-		expect( parts ).toMatchObject( {
+		expect( parts ).toEqual( {
 			page: 1,
 			perPage: 10,
+			offset: undefined,
 			stableKey: '',
 			include: null,
 			fields: null,
@@ -124,7 +130,7 @@ describe( 'getQueryParts', () => {
 			offset: 100,
 		} );
 
-		expect( parts ).toMatchObject( {
+		expect( parts ).toEqual( {
 			context: 'default',
 			page: 1,
 			perPage: 50,

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -140,4 +140,13 @@ describe( 'getQueryParts', () => {
 			include: null,
 		} );
 	} );
+
+	it( 'ignores non-numeric offset values', () => {
+		const parts = getQueryParts( {
+			per_page: 10,
+			offset: 'abc',
+		} );
+
+		expect( parts.offset ).toBeUndefined();
+	} );
 } );

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -7,10 +7,12 @@ describe( 'getQueryParts', () => {
 	it( 'parses out pagination data', () => {
 		const parts = getQueryParts( { page: 2, per_page: 2 } );
 
+		// Use toEqual here to pin the complete return shape.
 		expect( parts ).toEqual( {
 			context: 'default',
 			page: 2,
 			perPage: 2,
+			offset: undefined,
 			stableKey: '',
 			fields: null,
 			include: null,
@@ -24,7 +26,7 @@ describe( 'getQueryParts', () => {
 
 		expect( first ).toEqual( second );
 		expect( second ).toEqual( parts );
-		expect( parts ).toEqual( {
+		expect( parts ).toMatchObject( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
@@ -39,7 +41,7 @@ describe( 'getQueryParts', () => {
 		const second = getQueryParts( { b: 2, '?': '&' } );
 
 		expect( first ).toEqual( second );
-		expect( first ).toEqual( {
+		expect( first ).toMatchObject( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
@@ -52,7 +54,7 @@ describe( 'getQueryParts', () => {
 	it( 'encodes deep values', () => {
 		const parts = getQueryParts( { a: [ 1, 2 ] } );
 
-		expect( parts ).toEqual( {
+		expect( parts ).toMatchObject( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
@@ -67,7 +69,7 @@ describe( 'getQueryParts', () => {
 		const second = getQueryParts( { b: 2, page: '1', per_page: '10' } );
 
 		expect( first ).toEqual( second );
-		expect( first ).toEqual( {
+		expect( first ).toMatchObject( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
@@ -80,7 +82,7 @@ describe( 'getQueryParts', () => {
 	it( 'returns -1 for unlimited queries', () => {
 		const parts = getQueryParts( { b: 2, page: 1, per_page: -1 } );
 
-		expect( parts ).toEqual( {
+		expect( parts ).toMatchObject( {
 			context: 'default',
 			page: 1,
 			perPage: -1,
@@ -93,7 +95,7 @@ describe( 'getQueryParts', () => {
 	it( 'encodes stable string key with fields parameters', () => {
 		const parts = getQueryParts( { _fields: [ 'id', 'title' ] } );
 
-		expect( parts ).toEqual( {
+		expect( parts ).toMatchObject( {
 			context: 'default',
 			page: 1,
 			perPage: 10,
@@ -106,13 +108,30 @@ describe( 'getQueryParts', () => {
 	it( 'returns the context as a dedicated query part', () => {
 		const parts = getQueryParts( { context: 'view' } );
 
-		expect( parts ).toEqual( {
+		expect( parts ).toMatchObject( {
 			page: 1,
 			perPage: 10,
 			stableKey: '',
 			include: null,
 			fields: null,
 			context: 'view',
+		} );
+	} );
+
+	it( 'extracts offset and includes it in stableKey', () => {
+		const parts = getQueryParts( {
+			per_page: 50,
+			offset: 100,
+		} );
+
+		expect( parts ).toMatchObject( {
+			context: 'default',
+			page: 1,
+			perPage: 50,
+			offset: 100,
+			stableKey: 'offset=100',
+			fields: null,
+			include: null,
 		} );
 	} );
 } );

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -264,4 +264,134 @@ describe( 'getQueriedItems', () => {
 		const result = getQueriedItems( state, { per_page: 3 } );
 		expect( result ).toBe( null );
 	} );
+
+	it( 'should return items for offset-based query on the last partial page', () => {
+		// Infinite scroll scenario: 103 total items, perPage=50, and the
+		// last batch starts at offset=100. The API returns 3 items (items
+		// 101-103). X-WP-Total is 103 (the global count). The selector
+		// should recognise this as a complete response since
+		// 103 - 100 = 3 expected items.
+		const state = {
+			items: {
+				default: {
+					101: { id: 101 },
+					102: { id: 102 },
+					103: { id: 103 },
+				},
+			},
+			itemIsComplete: {
+				default: { 101: true, 102: true, 103: true },
+			},
+			queries: {
+				default: {
+					'offset=100': {
+						itemIds: [ 101, 102, 103 ],
+						meta: { totalItems: 103 },
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state, {
+			per_page: 50,
+			offset: 100,
+		} );
+		expect( result ).toEqual( [ { id: 101 }, { id: 102 }, { id: 103 } ] );
+	} );
+
+	it( 'should return null for offset-based query when items are still missing', () => {
+		// Offset=50, perPage=50, totalItems=200: the API should return
+		// 50 items for this batch but only 2 are stored so far.
+		const state = {
+			items: {
+				default: {
+					51: { id: 51 },
+					52: { id: 52 },
+				},
+			},
+			itemIsComplete: {
+				default: { 51: true, 52: true },
+			},
+			queries: {
+				default: {
+					'offset=50': {
+						itemIds: [ 51, 52 ],
+						meta: { totalItems: 200 },
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state, {
+			per_page: 50,
+			offset: 50,
+		} );
+		expect( result ).toBe( null );
+	} );
+
+	it( 'should return null for offset query when items are still missing', () => {
+		// Query Block scenario: offset=3 with per_page=10. The effective
+		// total is totalItems - offset = 47. Only 5 items are stored, so
+		// the data is still incomplete.
+		const state = {
+			items: {
+				default: {
+					4: { id: 4 },
+					5: { id: 5 },
+					6: { id: 6 },
+					7: { id: 7 },
+					8: { id: 8 },
+				},
+			},
+			itemIsComplete: {
+				default: { 4: true, 5: true, 6: true, 7: true, 8: true },
+			},
+			queries: {
+				default: {
+					'offset=3': {
+						itemIds: [ 4, 5, 6, 7, 8 ],
+						meta: { totalItems: 50 },
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state, {
+			per_page: 10,
+			offset: 3,
+		} );
+		expect( result ).toBe( null );
+	} );
+
+	it( 'should treat offset=0 the same as no offset', () => {
+		// The Query Block defaults to offset=0. Since
+		// effectiveTotal = totalItems - 0 = totalItems, this should
+		// behave identically to a query without offset.
+		const state = {
+			items: {
+				default: {
+					1: { id: 1 },
+					2: { id: 2 },
+				},
+			},
+			itemIsComplete: {
+				default: { 1: true, 2: true },
+			},
+			queries: {
+				default: {
+					'offset=0': {
+						itemIds: [ 1, 2 ],
+						meta: { totalItems: 5 },
+					},
+				},
+			},
+		};
+
+		// 2 items stored, but 5 total exist — should return null.
+		const result = getQueriedItems( state, {
+			per_page: 3,
+			offset: 0,
+		} );
+		expect( result ).toBe( null );
+	} );
 } );

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -394,4 +394,32 @@ describe( 'getQueriedItems', () => {
 		} );
 		expect( result ).toBe( null );
 	} );
+
+	it( 'should return empty array when offset equals totalItems', () => {
+		// Edge case: offset lands exactly at the end (e.g. 84 items,
+		// per_page=7, offset=84). The API returns 0 items and that is
+		// a complete response — effectiveTotal is 0.
+		const state = {
+			items: {
+				default: {},
+			},
+			itemIsComplete: {
+				default: {},
+			},
+			queries: {
+				default: {
+					'offset=84': {
+						itemIds: [],
+						meta: { totalItems: 84 },
+					},
+				},
+			},
+		};
+
+		const result = getQueriedItems( state, {
+			per_page: 7,
+			offset: 84,
+		} );
+		expect( result ).toEqual( [] );
+	} );
 } );


### PR DESCRIPTION
## What?

Follows:

* #76422

Update the calculation of total items in the `getQueriedItemsUncached` function to factor in `offset`.

## Why?

While working on infinite scroll @tellthemachines located a bug where the last page of results (retrieved via `offset`) would never appear. It turns out that in the logic we added in #76422 we didn't factor in an offset when looking at the number of items available and the total items — this would result in `offset` based queries returning `null` but never actually resolving because for the last page of results `itemIds.length` would always be less than `totalItems` as the offset means that the actual number of items will be that amount less than `totalItems`.

## How?

When calculating the total items, treat it as an _effective_ total items, substracting `offset` from the value (if present).

And in `getQueryParts` add `parts.offset` to the parts we're extracting. Offset is still part of the stableKey, but this allows us to access `offset` in `getQueriedItemsUncached` in the same way as we access the other parts of the query.

## Testing Instructions

I've added some tests to hopefully cover the desired behaviour. But you can manually test via the following in your browser console to test the last (effective) page of results when using an `offset`:

```js
  // Run in browser console in the block editor.
  // Tests that offset-based queries return data on the last partial page.
  ( async () => {
    // Use a small odd number to (try to) guarantee a partial last page.
    // If (as on my test site) your total attachments uploaded is divisible by 7, pick a different number.
    const PER_PAGE = 7;
    const query = { per_page: PER_PAGE, status: 'inherit' };

    // Fetch first page to get the total count
    await wp.data.resolveSelect( 'core' ).getEntityRecords( 'postType', 'attachment', query );
    const total = wp.data.select( 'core' ).getEntityRecordsTotalItems( 'postType', 'attachment', query );
    console.log( 'Total attachments:', total );

    // Pick an offset that leaves a partial page
    const offset = Math.floor( total / PER_PAGE ) * PER_PAGE;
    const expected = total - offset;
    console.log( 'Fetching offset=' + offset + ', expecting ' + expected + ' items' );

    // Fetch and read back
    const offsetQuery = { per_page: PER_PAGE, offset, status: 'inherit' };
    await wp.data.resolveSelect( 'core' ).getEntityRecords( 'postType', 'attachment', offsetQuery );
    const result = wp.data.select( 'core' ).getEntityRecords( 'postType', 'attachment', offsetQuery );

    console.log( result === null ? '❌ BUG: returned null' : '✅ OK: got ' + result.length + ' items' );
  } )();
```

To be thorough, double check that the steps in #76422 still work as expected.

## Use of AI Tools

I used Claude Code to generate tests, verify logic, add code comments, and to perform four separate rounds of reviews to try to catch any problems from the changes added here. I also used Claude to generate the above testing snippet. This PR description is otherwise written by me, and I tested and verified the code is working in my local env, but any further testing from reviewers is greatly appreciated! 😄
