### PR TITLE
Site Title Block: Fix preview display

### DIFF
--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -20,7 +20,11 @@ export const settings = {
 	example: {
 		viewportWidth: 350,
 		attributes: {
-			textAlign: 'center',
+			style: {
+				typography: {
+					textAlign: 'center',
+				},
+			},
 		},
 	},
 	edit,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow Up #75551
<!-- In a few words, what is the PR actually doing? -->

The textAlign attribute of the Site Title  example has been moved to typography. 

The preview display had changed from before, so this fixes it.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="294" height="332" alt="before" src="https://github.com/user-attachments/assets/a2fa1bbc-0dc3-4645-80fd-f3666a610c20" /> | <img width="291" height="337" alt="after" src="https://github.com/user-attachments/assets/0f8b42e0-b544-473d-a3c5-f44d4f32d4fe" /> |


