### PR TITLE
Build: Skip non-minified build for WASM-inlined workers

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -583,6 +583,15 @@ async function bundlePackage( packageName, options = {} ) {
 			const entryPoint = path.join( packageDir, exportPath );
 			const baseFileName = path.basename( fileName );
 
+			// Skip non-minified build for WASM-inlined workers (e.g., vips).
+			// These are ~16MB of base64-encoded WASM with no debugging value
+			// over the minified version.
+			const isWasmWorker =
+				packageJson.wpWorkers &&
+				Object.keys( packageJson.wpWorkers ).some(
+					( key ) => key.replace( /^\.\//, '' ) === fileName
+				);
+
 			builds.push(
 				esbuild.build( {
 					entryPoints: [ entryPoint ],
@@ -605,30 +614,35 @@ async function bundlePackage( packageName, options = {} ) {
 							true // Generate asset file for minified build
 						),
 					],
-				} ),
-				esbuild.build( {
-					entryPoints: [ entryPoint ],
-					outfile: path.join(
-						rootBuildModuleDir,
-						`${ fileName }.js`
-					),
-					bundle: true,
-					sourcemap: true,
-					format: 'esm',
-					target,
-					platform: 'browser',
-					minify: false,
-					define: getDefine( true ),
-					plugins: [
-						wordpressExternalsPlugin(
-							`${ baseFileName }.min`,
-							'esm',
-							[],
-							false // Skip asset file for non-minified build
-						),
-					],
 				} )
 			);
+
+			if ( ! isWasmWorker ) {
+				builds.push(
+					esbuild.build( {
+						entryPoints: [ entryPoint ],
+						outfile: path.join(
+							rootBuildModuleDir,
+							`${ fileName }.js`
+						),
+						bundle: true,
+						sourcemap: true,
+						format: 'esm',
+						target,
+						platform: 'browser',
+						minify: false,
+						define: getDefine( true ),
+						plugins: [
+							wordpressExternalsPlugin(
+								`${ baseFileName }.min`,
+								'esm',
+								[],
+								false // Skip asset file for non-minified build
+							),
+						],
+					} )
+				);
+			}
 
 			const scriptModuleId =
 				exportName === '.'


### PR DESCRIPTION
## Summary

Skips generating the non-minified `.js` version for script module exports that correspond to `wpWorkers` entries (currently only `@wordpress/vips/worker`).

### Why

The vips worker bundles ~16 MB of base64-encoded WASM data. Minification has negligible effect on this content, so `worker.js` and `worker.min.js` are nearly identical in size. The non-minified version provides zero debugging value since the content is all inlined binary WASM data.

### Size impact

| | Before | After | Saved |
|--|--------|-------|-------|
| Build output (`build/modules/vips/`) | 64 MB (worker.js + worker.min.js + maps) | 32 MB (worker.min.js + map only) | **~32 MB (50%)** |
| `worker.min.js` (shipped file) | 16.1 MB | 16.1 MB (unchanged) | 0 |

This PR reduces the **build output** by eliminating redundant files. The shipped `worker.min.js` size is unchanged.

### Related PRs for further size reduction

- #76639 — Remove unused JXL WASM module (**saves 3.1 MB from worker.min.js**, 16.1 → 13.1 MB)
- https://github.com/WordPress/wordpress-develop/pull/11281 — Core Gruntfile exclusion (safety net)

## Test plan

- [ ] Run `npm run build` — verify `build/modules/vips/` contains only `worker.min.js`, `worker.min.js.map`, and `worker.min.asset.php` (no `worker.js` or `worker.js.map`)
- [ ] Verify `build/modules/vips/loader.js` (non-worker module) still gets both minified and non-minified versions
- [ ] Test image upload/processing in the editor to confirm vips still works correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)