### PR TITLE
Upload Media: Loosen client-side media processing requirements

### DIFF
--- a/packages/upload-media/src/feature-detection.ts
+++ b/packages/upload-media/src/feature-detection.ts
@@ -35,8 +35,8 @@ let cachedResult: FeatureDetectionResult | null = null;
  * 2. SharedArrayBuffer support (required for WASM threading)
  * 3. CSP compatibility for blob URL workers (required for inline worker creation)
  * 4. Device memory (disables on devices with ≤2 GB RAM)
- * 5. Hardware concurrency (disables on devices with fewer than 4 CPU cores)
- * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 3g/2g/slow-2g)
+ * 5. Hardware concurrency (disables on devices with fewer than 2 CPU cores)
+ * 6. Network conditions (disables when data saver / reduced data mode is on or connection is 2g/slow-2g)
  * 7. Web Worker support (baseline requirement)
  *
  * Results are cached after the first call. Use `clearFeatureDetectionCache()` to reset.
@@ -93,7 +93,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 	if (
 		typeof navigator !== 'undefined' &&
 		'hardwareConcurrency' in navigator &&
-		navigator.hardwareConcurrency < 4
+		navigator.hardwareConcurrency < 2
 	) {
 		cachedResult = {
 			supported: false,
@@ -115,8 +115,7 @@ export function detectClientSideMediaSupport(): FeatureDetectionResult {
 			}
 			if (
 				connection.effectiveType === 'slow-2g' ||
-				connection.effectiveType === '2g' ||
-				connection.effectiveType === '3g'
+				connection.effectiveType === '2g'
 			) {
 				cachedResult = {
 					supported: false,

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -171,9 +171,9 @@ describe( 'feature-detection', () => {
 			expect( result.supported ).toBe( true );
 		} );
 
-		it( 'returns not supported when hardware concurrency is less than 4', () => {
+		it( 'returns not supported when hardware concurrency is less than 2', () => {
 			Object.defineProperty( navigator, 'hardwareConcurrency', {
-				value: 2,
+				value: 1,
 				configurable: true,
 			} );
 
@@ -183,9 +183,9 @@ describe( 'feature-detection', () => {
 			expect( result.reason ).toContain( 'insufficient CPU cores' );
 		} );
 
-		it( 'returns supported when hardware concurrency is 4 or more', () => {
+		it( 'returns supported when hardware concurrency is 2 or more', () => {
 			Object.defineProperty( navigator, 'hardwareConcurrency', {
-				value: 4,
+				value: 2,
 				configurable: true,
 			} );
 
@@ -218,7 +218,7 @@ describe( 'feature-detection', () => {
 			expect( result.reason ).toContain( 'too slow' );
 		} );
 
-		it( 'returns not supported when connection is 3g', () => {
+		it( 'returns supported when connection is 3g', () => {
 			Object.defineProperty( navigator, 'connection', {
 				value: { saveData: false, effectiveType: '3g' },
 				configurable: true,
@@ -226,8 +226,7 @@ describe( 'feature-detection', () => {
 
 			const result = detectClientSideMediaSupport();
 
-			expect( result.supported ).toBe( false );
-			expect( result.reason ).toContain( 'too slow' );
+			expect( result.supported ).toBe( true );
 		} );
 
 		it( 'returns not supported when connection is slow-2g', () => {


### PR DESCRIPTION
## Summary

Addresses feedback from #74333 (comment) to widen availability of client-side media processing to more devices:

- **CPU cores**: Lowered minimum from 4 cores to 2 cores. Most desktop machines have at least 2 cores, and the previous threshold was unnecessarily restrictive.
- **Network**: Now allows 3g connections (previously blocked). Only slow-2g and 2g are blocked. The 3MB WASM payload is manageable on 3g, and sub-size uploads will still work — they may just be slower.
- **Memory**: Kept at ≤2 GB threshold (unchanged).

These changes significantly increase the percentage of eligible devices, particularly addressing the ~41% availability concern raised in the issue.

## Test plan

- [ ] Verify unit tests pass: `npm run test:unit -- --testPathPattern="upload-media/src/test/feature-detection"`
- [ ] Test on a device with 2-3 CPU cores — feature should now be available
- [ ] Test on a 3g connection — feature should now be available
- [ ] Test on slow-2g/2g — feature should still be disabled
- [ ] Test with data saver enabled — feature should still be disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)