### PR TITLE
Build: Remove unused JXL WASM module from vips worker

### DIFF
--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -7,9 +7,6 @@ import Vips from 'wasm-vips';
 import VipsModule from 'wasm-vips/vips.wasm';
 
 // @ts-expect-error - WASM files are inlined as base64 data URLs at build time
-import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
-
-// @ts-expect-error - WASM files are inlined as base64 data URLs at build time
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
 
 /**
@@ -44,17 +41,16 @@ async function getVips(): Promise< typeof Vips > {
 	}
 
 	vipsInstance = await Vips( {
-		// Load JXL and HEIF dynamic modules for full format support.
-		// wasm-vips defaults to ["vips-jxl.wasm", "vips-heif.wasm"].
-		dynamicLibraries: [ 'vips-jxl.wasm', 'vips-heif.wasm' ],
+		// Load HEIF dynamic module for HEIF/HEIC and AVIF format support.
+		// JXL is omitted as WordPress Core does not currently support it.
+		// It can be re-added when Core adds JXL support.
+		dynamicLibraries: [ 'vips-heif.wasm' ],
 		locateFile: ( fileName: string ) => {
 			// WASM files are inlined as base64 data URLs at build time,
 			// eliminating the need for separate file downloads and avoiding
 			// issues with hosts not serving WASM files with correct MIME types.
 			if ( fileName.endsWith( 'vips.wasm' ) ) {
 				return VipsModule;
-			} else if ( fileName.endsWith( 'vips-jxl.wasm' ) ) {
-				return VipsJxlModule;
 			} else if ( fileName.endsWith( 'vips-heif.wasm' ) ) {
 				return VipsHeifModule;
 			}


### PR DESCRIPTION
## Summary

Removes the unused `vips-jxl.wasm` module from the vips worker bundle to reduce build size. WordPress Core does not currently support JXL images — it is not in `CLIENT_SIDE_SUPPORTED_MIME_TYPES` — so this WASM module is loaded but never used.

### Size impact

| | Before | After | Saved |
|--|--------|-------|-------|
| `worker.min.js` | 16.1 MB (16,859,314 bytes) | 13.1 MB (13,749,830 bytes) | **3.1 MB (18.4%)** |

### Changes
- Removed the `vips-jxl.wasm` import from `packages/vips/src/index.ts`
- Updated `dynamicLibraries` to only load `vips-heif.wasm` (still needed for HEIF/HEIC input and AVIF support)
- Removed the JXL branch from the `locateFile` callback

### Future size reduction opportunities

Beyond this PR, a custom `wasm-vips` build could yield further savings:

| Optimization | Estimated savings |
|--------------|-------------------|
| Enable LTO (`--enable-lto`) | ~1.6–3.2 MB |
| Remove unused libs from vips.wasm (TIFF, imagequant, expat) | ~0.5 MB |
| Web-only build (`-e web`) | minor |
| **Combined additional** | **~2–4 MB** |
| **Total potential (including this PR)** | **worker.min.js ~10 MB** |

See also:
- #76615 — Skip non-minified vips worker build (saves ~16 MB from build output)
- https://github.com/WordPress/wordpress-develop/pull/11281 — Core Gruntfile exclusion

### Re-adding JXL

If WordPress Core adds JXL support in the future, it can be trivially restored by:
1. Re-adding `import VipsJxlModule from 'wasm-vips/vips-jxl.wasm'`
2. Adding `'vips-jxl.wasm'` back to the `dynamicLibraries` array
3. Adding the JXL branch to `locateFile`

## Test plan

- [ ] Run `npm run build` and verify `build/modules/vips/worker.min.js` is ~13.1 MB (down from 16.1 MB)
- [ ] Test image upload/processing in the editor (JPEG, PNG, WebP, GIF, AVIF)
- [ ] Test HEIF/HEIC image upload (should still convert correctly via vips-heif.wasm)
- [ ] Verify no JXL-related errors in console


🤖 Generated with [Claude Code](https://claude.com/claude-code)