### PR TITLE
Cross Origin Isolation: Remove `img` from the list of elements that get mutated

### DIFF
--- a/backport-changelog/7.0/11291.md
+++ b/backport-changelog/7.0/11291.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11291
+
+* https://github.com/WordPress/gutenberg/pull/76618

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -345,7 +345,6 @@ function gutenberg_add_crossorigin_attributes( string $html ): string {
 	// See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin.
 	$tags = array(
 		'AUDIO'  => 'src',
-		'IMG'    => 'src',
 		'LINK'   => 'href',
 		'SCRIPT' => 'src',
 		'VIDEO'  => 'src',

--- a/packages/block-editor/src/hooks/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/cross-origin-isolation.js
@@ -27,14 +27,14 @@ if ( window.crossOriginIsolated ) {
 						return;
 					}
 
-					el.querySelectorAll(
-						'img,source,script,video,link'
-					).forEach( ( v ) => {
-						addCrossOriginAttribute( v );
-					} );
+					el.querySelectorAll( 'source,script,video,link' ).forEach(
+						( v ) => {
+							addCrossOriginAttribute( v );
+						}
+					);
 
 					if (
-						[ 'IMG', 'SOURCE', 'SCRIPT', 'VIDEO', 'LINK' ].includes(
+						[ 'SOURCE', 'SCRIPT', 'VIDEO', 'LINK' ].includes(
 							el.nodeName
 						)
 					) {

--- a/packages/block-editor/src/hooks/test/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/test/cross-origin-isolation.js
@@ -152,7 +152,7 @@ describe( 'cross-origin-isolation', () => {
 		expect( observeSpy ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should add crossorigin="anonymous" to images', async () => {
+	it( 'should not add crossorigin="anonymous" to images', async () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: true,
 			writable: true,
@@ -172,8 +172,12 @@ describe( 'cross-origin-isolation', () => {
 		// Wait for MutationObserver callback to fire (async microtask).
 		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
-		// The image should get the crossorigin attribute
-		expect( img ).toHaveAttribute( 'crossorigin', 'anonymous' );
+		// Images should NOT get the crossorigin attribute.
+		// Under Document-Isolation-Policy: isolate-and-credentialless,
+		// the credentialless mode handles image loading without CORS headers.
+		// Adding crossorigin="anonymous" would override this and break
+		// external images that don't serve CORS headers.
+		expect( img ).not.toHaveAttribute( 'crossorigin' );
 
 		document.body.removeChild( img );
 	} );

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -163,8 +163,8 @@ class Media_Processing_Test extends WP_UnitTestCase {
 HTML;
 
 		$expected = <<<HTML
-<img crossorigin="anonymous" src="https://www.someothersite.com/test1.jpg" />
-<img crossorigin="anonymous" src="test2.jpg" />
+<img src="https://www.someothersite.com/test1.jpg" />
+<img src="test2.jpg" />
 <audio crossorigin="anonymous"><source src="https://www.someothersite.com/test1.mp3"></audio>
 <audio crossorigin="anonymous" src="https://www.someothersite.com/test1.mp3"></audio>
 <audio src="/test2.mp3"></audio>


### PR DESCRIPTION
## What?

Tries to fix #76476 

> [!NOTE]
> This is probably the wrong approach for the issue at hand, but I've opened this PR as a discussion point / in case it helps get to a proper fix — feel free to open an alternative if folks have other ideas for a fix

Remove `img` from the list of elements that get mutated for cross origin isolation.

## Why?

As raised in #76476, when image blocks are added that link to external images that don't have CORS headers, then `img` elements in the admin will break due to the inclusion of `crossorigin="anonymous"`.

To replicate, here is a test image that doesn't allow CORS (as referenced in the issue): `https://placehold.jp/1024x768.jpg`

In https://github.com/WordPress/gutenberg/pull/75991 the approach for client-side media processing was switched to depend on Document-Isolation-Policy instead of Cross-Origin-Embedder-Policy / Cross-Origin-Opener-Policy (COEP/COOP) headers — so, in theory, we can remove the `img` element mutation for now. However, it'll have the negative consequence that for plugins that attempt to use COEP/COOP headers again, there will likely be an issue.

I'm not 100% sure of the consequences either way, so just pinging @adamsilverstein for feedback on this one.

The goal for WP 7.0 should be: no broken img elements 🙂

## How?

* Remove `img` from the list of elements that get mutated, and update tests to match.

## Questions

* How else could we fix it?
* If we remove `img`, should we remove all the injection of `crossorigin` attributes across the board?

## Testing Instructions

* In Chrome:
* Add an image block and select to use an external image url, and give it: `https://placehold.jp/1024x768.jpg`
* With this PR applied, the preview image in the controls in the sidebar should render correctly
* With the Network tab open: Also, go to drag an image from your desktop onto the block editor canvas to upload it
* You should see `sideload` requests confirming that your uploaded image was processed by client-side media processing

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="2554" height="1810" alt="image" src="https://github.com/user-attachments/assets/9246f242-1e7f-4b97-a2f7-185ee705ffc2" />

### After

<img width="1163" height="638" alt="image" src="https://github.com/user-attachments/assets/c9714b9b-c710-4771-9f05-feecaad195b9" />

## Use of AI Tools

I used Claude Code to explore options and apply the changes for me locally, but I otherwise wrote the PR and description myself.