### PR TITLE
Reduce the added halo for selected block.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -689,7 +689,7 @@
 	outline-style: solid;
 	outline-width: calc(#{$widthRatio} * (var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1)));
 	outline-offset: calc(#{$widthRatio} * ((-1 * var(--wp-admin-border-width-focus) ) / var(--wp-block-editor-iframe-zoom-out-scale, 1)));
-	box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus, #{variables.$border-width-focus-fallback}) + #{variables.$border-width}) colors.$white, 0 0 0 variables.$border-width colors.$white, variables.$elevation-x-small;
+	box-shadow: inset 0 0 0 calc((#{$widthRatio} * (var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1))) + 0.5px) rgba(colors.$white, 0.7);
 }
 
 @mixin selected-block-focus($widthRatio: 1) {

--- a/packages/editor/src/components/collaborators-overlay/overlay-iframe-styles.ts
+++ b/packages/editor/src/components/collaborators-overlay/overlay-iframe-styles.ts
@@ -119,7 +119,7 @@ export const OVERLAY_IFRAME_STYLES = `
 	outline-style: solid;
 	outline-width: calc(var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1));
 	outline-offset: calc(-1 * var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1));
-	box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus, ${ BORDER_WIDTH_FOCUS_FALLBACK }) + ${ BORDER_WIDTH }) ${ WHITE }, 0 0 0 ${ BORDER_WIDTH } ${ WHITE }, ${ ELEVATION_X_SMALL };
+	box-shadow: inset 0 0 0 calc((var(--wp-admin-border-width-focus) / var(--wp-block-editor-iframe-zoom-out-scale, 1)) + 0.5px) rgba(${ WHITE }, 0.7);
 	z-index: 1;
 }
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/76413#discussion_r2940573949.

An extra set of borders were added to the selected-block-outline in that PR. As I understand the motivation, this was to make the selected style clearer when **multiple users were editing at the same time, each user with their own color**. But these added outlines were quite heavy in dark contexts:

<img width="573" height="119" alt="image" src="https://github.com/user-attachments/assets/87183a51-515e-4ac3-a307-0b5e718b67e1" />

<img width="570" height="109" alt="image" src="https://github.com/user-attachments/assets/ff275cb5-a424-43f9-b3a4-f790122bc0f1" />

This PR reduces it to a single .5px semi-transparent inner halo:

<img width="563" height="106" alt="image" src="https://github.com/user-attachments/assets/e5ce3c8d-d548-458e-bf30-8445c6a7b989" />

<img width="554" height="94" alt="image" src="https://github.com/user-attachments/assets/9e11f009-ccf8-4269-b296-ec548793686a" />

## Why?

The existing style makes the selected outline substantially thicker, 3.5px instead of 1.5px, actively obscuring additional context and through its high contrast in dark themes making it harder to see the contents.

In fact the .5px inner halo this PR adds may still be slightly too much, but it's a compromise. 

It needs design feedback, but whatever we land on should be backported to 7.0. 

