### PR TITLE
Storybook: disable autodocs for Icon library

### DIFF
--- a/storybook/stories/icons/library.story.tsx
+++ b/storybook/stories/icons/library.story.tsx
@@ -72,6 +72,7 @@ function nameToSlug( name: string ): string {
 const meta: Meta = {
 	component: Icon,
 	title: 'Icons/Icon',
+	tags: [ '!autodocs' ],
 	parameters: {
 		controls: { hideNoControlsWarning: true },
 	},


### PR DESCRIPTION
## What?

See https://github.com/WordPress/gutenberg/pull/76034#issuecomment-4075726446

The Icon Library page is a bit unique compared to other stories. It allows us to filter icons, and this filtering is synchronized with the URL. This filter doesn't seem to work in Docs. Disabling `autodocs` is probably the easiest solution.

## Testing Instructions

- Launch Storybook: `npm run storybook:dev`
- Access http://localhost:50240/?path=/docs/icons-icon--docs: Confirm that the only default story (Icons) is displayed.
- Access http://localhost:50240/?path=/story/icons-icon--library: Change the filter settings. The story state is stored in the URL as before.

## Screenshots or screencast

<img width="1388" height="720" alt="image" src="https://github.com/user-attachments/assets/211f0d48-c8fa-4445-b5df-245d8edaf719" />