### PR TITLE
Guidelines: Update actions-section and import/export workflow

### DIFF
--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -167,7 +167,7 @@ export async function importContentGuidelines( file: File ): Promise< void > {
 
 	const response = await saveGuidelinesBypassingStore(
 		guidelinesStore.getId(),
-		'draft',
+		guidelinesStore.getStatus() || 'draft',
 		newGuidelines
 	);
 

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -116,7 +116,6 @@ async function saveGuidelinesBypassingStore(
  * @param file Content Guidelines JSON file
  */
 export async function importContentGuidelines( file: File ): Promise< void > {
-	// @ts-ignore
 	const { setFromResponse } = dispatch( coreContentGuidelinesStore );
 	const guidelinesStore = select( coreContentGuidelinesStore );
 	const { createSuccessNotice } = dispatch( noticesStore );

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -209,7 +209,12 @@ export function exportContentGuidelines(): void {
 		},
 	};
 
-	const exportDate = new Date().toISOString().slice( 0, 10 );
+	const now = new Date();
+	const exportDate = [
+		now.getFullYear(),
+		String( now.getMonth() + 1 ).padStart( 2, '0' ),
+		String( now.getDate() ).padStart( 2, '0' ),
+	].join( '-' );
 	downloadBlob(
 		`guidelines-${ exportDate }.json`,
 		JSON.stringify( data, null, 2 ),

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -196,7 +196,7 @@ export function exportContentGuidelines(): void {
 	};
 
 	downloadBlob(
-		'guidelines.json',
+		`guidelines-${ exportDate }.json`,
 		JSON.stringify( data, null, 2 ),
 		'application/json'
 	);

--- a/routes/content-guidelines/api.ts
+++ b/routes/content-guidelines/api.ts
@@ -15,6 +15,7 @@ import type {
 	RestGuidelinesResponse,
 	GuidelinesImportData,
 	ContentGuidelinesRevision,
+	Categories,
 } from './types';
 
 const FLAT_CATEGORIES = [ 'site', 'copy', 'images', 'additional' ] as const;
@@ -52,8 +53,23 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 	const id = guidelinesStore.getId();
 	const status = guidelinesStore.getStatus() || 'draft';
 	const categories = guidelinesStore.getAllGuidelines();
-	const blockGuidelines = guidelinesStore.getBlockGuidelines();
 
+	const response = await saveGuidelinesBypassingStore(
+		id,
+		status,
+		categories
+	);
+
+	setFromResponse( response );
+
+	return response;
+}
+
+async function saveGuidelinesBypassingStore(
+	id: number | null,
+	status: string,
+	categories: Categories
+): Promise< RestGuidelinesResponse > {
 	const data = {
 		id,
 		status,
@@ -71,7 +87,7 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 				guidelines: categories.additional,
 			},
 			blocks: Object.fromEntries(
-				Object.entries( blockGuidelines ).map(
+				Object.entries( categories.blocks ).map(
 					( [ blockName, guidelines ] ) => [
 						blockName,
 						{ guidelines },
@@ -92,8 +108,6 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
 		data,
 	} ) ) as RestGuidelinesResponse;
 
-	setFromResponse( response );
-
 	return response;
 }
 
@@ -102,9 +116,9 @@ export async function saveContentGuidelines(): Promise< RestGuidelinesResponse >
  * @param file Content Guidelines JSON file
  */
 export async function importContentGuidelines( file: File ): Promise< void > {
-	const { setGuideline, setBlockGuideline } = dispatch(
-		coreContentGuidelinesStore
-	);
+	// @ts-ignore
+	const { setFromResponse } = dispatch( coreContentGuidelinesStore );
+	const guidelinesStore = select( coreContentGuidelinesStore );
 	const { createSuccessNotice } = dispatch( noticesStore );
 
 	const parsed: unknown = JSON.parse( await file.text() );
@@ -117,49 +131,50 @@ export async function importContentGuidelines( file: File ): Promise< void > {
 		);
 	}
 
-	const guidelinesStore = select( coreContentGuidelinesStore );
-	const previousCategories = guidelinesStore.getAllGuidelines();
-	const previousBlocks = { ...guidelinesStore.getBlockGuidelines() };
+	const existingGuidelines = guidelinesStore.getAllGuidelines();
 
-	const { guideline_categories: contentGuidelinesCategories } = parsed;
+	const newGuidelines = {
+		/**
+		 * Set empty string to all the simple guidelines so that if the category is not present
+		 * in the parsed data, the category gets removed.
+		 */
+		...Object.fromEntries(
+			FLAT_CATEGORIES.map( ( category ) => [ category, '' ] )
+		),
+		/**
+		 * Set empty string to all the existing block guidelines so that if the block is not present
+		 * in the parsed data, the block gets removed.
+		 */
+		blocks: Object.fromEntries(
+			Object.keys( existingGuidelines.blocks ).map( ( block ) => [
+				block,
+				'',
+			] )
+		),
+	} as Categories;
 
-	FLAT_CATEGORIES.forEach( ( guidelineCategory ) => {
-		const guidelines =
-			contentGuidelinesCategories[ guidelineCategory ]?.guidelines;
-		if ( typeof guidelines === 'string' ) {
-			setGuideline( guidelineCategory, guidelines );
-		}
+	// Now let's populate the simple guidelines with the parsed data.
+	for ( const cat of FLAT_CATEGORIES ) {
+		const guidelines = parsed.guideline_categories[ cat ]?.guidelines || '';
+		newGuidelines[ cat ] = guidelines;
+	}
+
+	// Now let's populate the block guidelines with the parsed data.
+	const parsedBlocks = parsed.guideline_categories?.blocks ?? {};
+	for ( const [ key, value ] of Object.entries( parsedBlocks ) ) {
+		newGuidelines.blocks[ key ] = value?.guidelines || '';
+	}
+
+	const response = await saveGuidelinesBypassingStore(
+		guidelinesStore.getId(),
+		'draft',
+		newGuidelines
+	);
+
+	setFromResponse( response );
+	createSuccessNotice( __( 'Guidelines imported.' ), {
+		type: 'snackbar',
 	} );
-
-	const blocksData = contentGuidelinesCategories.blocks;
-	if ( blocksData && typeof blocksData === 'object' ) {
-		Object.entries( blocksData ).forEach( ( [ blockName, blockData ] ) => {
-			if ( blockData && typeof blockData.guidelines === 'string' ) {
-				setBlockGuideline( blockName, blockData.guidelines );
-			}
-		} );
-	}
-
-	try {
-		await saveContentGuidelines();
-		createSuccessNotice( __( 'Guidelines imported.' ), {
-			type: 'snackbar',
-		} );
-	} catch ( error ) {
-		FLAT_CATEGORIES.forEach( ( cat ) => {
-			setGuideline( cat, previousCategories[ cat ] ?? '' );
-		} );
-
-		const currentBlocks = guidelinesStore.getBlockGuidelines();
-		Object.keys( currentBlocks ).forEach( ( blockName ) =>
-			setBlockGuideline( blockName, '' )
-		);
-		Object.entries( previousBlocks ).forEach( ( [ blockName, value ] ) =>
-			setBlockGuideline( blockName, value )
-		);
-
-		throw error;
-	}
 }
 
 /**
@@ -195,6 +210,7 @@ export function exportContentGuidelines(): void {
 		},
 	};
 
+	const exportDate = new Date().toISOString().slice( 0, 10 );
 	downloadBlob(
 		`guidelines-${ exportDate }.json`,
 		JSON.stringify( data, null, 2 ),

--- a/routes/content-guidelines/components/action-item.tsx
+++ b/routes/content-guidelines/components/action-item.tsx
@@ -1,3 +1,5 @@
+/* @jsxRuntime automatic */
+
 /**
  * WordPress dependencies
  */
@@ -32,43 +34,41 @@ export default function ActionItem( {
 	const descriptionId = `content-guidelines-action-${ slug }-description`;
 
 	return (
-		<li className="content-guidelines__action-list-item">
-			<HStack
-				justify="space-between"
-				className="content-guidelines__action-row"
-			>
-				<VStack spacing={ 1 }>
-					<Heading
-						level={ 3 }
-						size={ 13 }
-						weight={ 400 }
-						className="content-guidelines__action-title"
-					>
-						{ title }
-					</Heading>
-					<Text
-						id={ descriptionId }
-						size={ 13 }
-						weight={ 400 }
-						variant="muted"
-						className="content-guidelines__action-description"
-					>
-						{ description }
-					</Text>
-				</VStack>
-				<Button
-					size="compact"
-					variant="secondary"
-					className="content-guidelines__action-button"
-					aria-label={ ariaLabel }
-					aria-describedby={ descriptionId }
-					onClick={ onClick }
-					isBusy={ isBusy }
-					disabled={ disabled }
+		<HStack
+			justify="space-between"
+			className="content-guidelines__action-row"
+		>
+			<VStack spacing={ 1 }>
+				<Heading
+					level={ 3 }
+					size={ 13 }
+					weight={ 400 }
+					className="content-guidelines__action-title"
 				>
-					{ buttonLabel }
-				</Button>
-			</HStack>
-		</li>
+					{ title }
+				</Heading>
+				<Text
+					id={ descriptionId }
+					size={ 13 }
+					weight={ 400 }
+					variant="muted"
+					className="content-guidelines__action-description"
+				>
+					{ description }
+				</Text>
+			</VStack>
+			<Button
+				size="compact"
+				variant="secondary"
+				className="content-guidelines__action-button"
+				aria-label={ ariaLabel }
+				aria-describedby={ descriptionId }
+				onClick={ onClick }
+				isBusy={ isBusy }
+				disabled={ disabled }
+			>
+				{ buttonLabel }
+			</Button>
+		</HStack>
 	);
 }

--- a/routes/content-guidelines/components/action-item.tsx
+++ b/routes/content-guidelines/components/action-item.tsx
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 
 interface ActionProps {
-	slug: string;
+	slug: 'import' | 'export' | 'revert';
 	title: string;
 	description: string;
 	buttonLabel: string;
@@ -21,6 +21,7 @@ interface ActionProps {
 	disabled?: boolean;
 	isBusy?: boolean;
 }
+
 export default function ActionItem( {
 	slug,
 	title,

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -154,7 +154,6 @@ export default function GuidelineAccordionForm( {
 					<Button
 						variant="primary"
 						type="submit"
-						className="save-button"
 						disabled={ loading || ! draft }
 						accessibleWhenDisabled
 						isBusy={ loading }

--- a/routes/content-guidelines/components/guideline-actions-section.scss
+++ b/routes/content-guidelines/components/guideline-actions-section.scss
@@ -1,0 +1,56 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.content-guidelines__actions {
+	width: min(680px, 100%);
+	margin: $grid-unit-20 auto 0;
+}
+
+.content-guidelines__actions-card {
+	padding: 0;
+	overflow: hidden;
+}
+
+.content-guidelines__actions-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.content-guidelines__action-list-item {
+	margin-bottom: 0;
+	position: relative;
+
+	&:not(:first-child)::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: $grid-unit-30;
+		right: $grid-unit-30;
+		height: 1px;
+		background-color: $gray-100;
+	}
+}
+
+.content-guidelines__action-row {
+	padding: $grid-unit-20 $grid-unit-30;
+	align-items: center;
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.content-guidelines__actions-card .content-guidelines__action-button {
+	min-width: 100px;
+	justify-content: center;
+	font-size: 13px;
+	font-weight: 400;
+}
+
+.content-guidelines__action-title {
+	color: $gray-900;
+}
+
+.content-guidelines__action-description {
+	color: $gray-700;
+}
+

--- a/routes/content-guidelines/components/guideline-actions-section.tsx
+++ b/routes/content-guidelines/components/guideline-actions-section.tsx
@@ -21,6 +21,10 @@ import './guideline-actions-section.scss';
 import { importContentGuidelines, exportContentGuidelines } from '../api';
 import ActionItem from './action-item';
 
+function getErrorMessage( err: any ) {
+	return err instanceof Error ? err.message : __( 'Unknown error' );
+}
+
 export default function GuidelineActionsSection() {
 	const { goTo } = useNavigator();
 
@@ -57,7 +61,7 @@ export default function GuidelineActionsSection() {
 				sprintf(
 					/* translators: %s: Error message. */
 					__( 'We ran into a problem importing your guidelines: %s' ),
-					( err as Error ).message
+					getErrorMessage( err )
 				)
 			);
 		} finally {
@@ -74,7 +78,7 @@ export default function GuidelineActionsSection() {
 				sprintf(
 					/* translators: %s: Error message. */
 					__( 'We ran into a problem exporting your guidelines: %s' ),
-					( err as Error ).message
+					getErrorMessage( err )
 				)
 			);
 		}

--- a/routes/content-guidelines/components/guideline-actions-section.tsx
+++ b/routes/content-guidelines/components/guideline-actions-section.tsx
@@ -4,15 +4,12 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	Card,
-	Modal,
+	__experimentalConfirmDialog as ConfirmDialog,
 	Notice,
 	useNavigator,
-	__experimentalText as Text,
-	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
@@ -20,19 +17,9 @@ import { useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import './guideline-actions-section.scss';
 import { importContentGuidelines, exportContentGuidelines } from '../api';
 import ActionItem from './action-item';
-
-function getErrorMessage( error: unknown ): string {
-	if ( error instanceof Error ) {
-		return error.message;
-	}
-
-	if ( typeof error === 'object' && error !== null && 'message' in error ) {
-		return String( ( error as { message: unknown } ).message );
-	}
-	return __( 'Unknown error.' );
-}
 
 export default function ActionsSection() {
 	const { goTo } = useNavigator();
@@ -65,12 +52,12 @@ export default function ActionsSection() {
 		try {
 			await importContentGuidelines( file );
 			setError( null );
-		} catch ( importError ) {
+		} catch ( err ) {
 			setError(
 				sprintf(
 					/* translators: %s: Error message. */
-					__( 'We ran into a problem importing your guidelines. %s' ),
-					getErrorMessage( importError )
+					__( 'We ran into a problem importing your guidelines: %s' ),
+					err.message
 				)
 			);
 		} finally {
@@ -82,12 +69,12 @@ export default function ActionsSection() {
 		try {
 			exportContentGuidelines();
 			setError( null );
-		} catch ( exportError ) {
+		} catch ( err ) {
 			setError(
 				sprintf(
 					/* translators: %s: Error message. */
 					__( 'We ran into a problem exporting your guidelines: %s' ),
-					getErrorMessage( exportError )
+					err.message
 				)
 			);
 		}
@@ -151,49 +138,30 @@ export default function ActionsSection() {
 				/* eslint-disable jsx-a11y/no-redundant-roles */ }
 				<ul role="list" className="content-guidelines__actions-list">
 					{ ACTIONS.map( ( action ) => (
-						<ActionItem key={ action.slug } { ...action } />
+						<li
+							key={ action.slug }
+							className="content-guidelines__action-list-item"
+						>
+							<ActionItem { ...action } />
+						</li>
 					) ) }
 				</ul>
 				{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
 			</Card>
-			{ pendingImport && (
-				<Modal
-					title={ __( 'Import guidelines' ) }
-					onRequestClose={ () => setPendingImport( null ) }
-					size="medium"
-				>
-					<VStack spacing={ 4 }>
-						<Text size={ 13 } weight={ 400 }>
-							{ __(
-								'Importing new guidelines will replace your current guidelines.'
-							) }
-						</Text>
-						<Text size={ 13 } weight={ 400 }>
-							{ __(
-								'This can be undone from revision history.'
-							) }
-						</Text>
-					</VStack>
-					<HStack
-						justify="flex-end"
-						className="content-guidelines__import-modal-actions"
-					>
-						<Button
-							variant="tertiary"
-							onClick={ () => setPendingImport( null ) }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							variant="primary"
-							onClick={ handleModalContinue }
-							__next40pxDefaultSize
-						>
-							{ __( 'Continue' ) }
-						</Button>
-					</HStack>
-				</Modal>
-			) }
+
+			<ConfirmDialog
+				isOpen={ !! pendingImport }
+				__experimentalHideHeader={ false }
+				title={ __( 'Import guidelines' ) }
+				confirmButtonText={ __( 'Continue' ) }
+				onConfirm={ handleModalContinue }
+				onCancel={ () => setPendingImport( null ) }
+				size="small"
+			>
+				{ __(
+					'Importing new guidelines will replace your current guidelines. This can be undone from revision history.'
+				) }
+			</ConfirmDialog>
 		</VStack>
 	);
 }

--- a/routes/content-guidelines/components/guideline-actions-section.tsx
+++ b/routes/content-guidelines/components/guideline-actions-section.tsx
@@ -57,7 +57,7 @@ export default function ActionsSection() {
 				sprintf(
 					/* translators: %s: Error message. */
 					__( 'We ran into a problem importing your guidelines: %s' ),
-					err.message
+					( err as Error ).message
 				)
 			);
 		} finally {
@@ -74,7 +74,7 @@ export default function ActionsSection() {
 				sprintf(
 					/* translators: %s: Error message. */
 					__( 'We ran into a problem exporting your guidelines: %s' ),
-					err.message
+					( err as Error ).message
 				)
 			);
 		}

--- a/routes/content-guidelines/components/guideline-actions-section.tsx
+++ b/routes/content-guidelines/components/guideline-actions-section.tsx
@@ -21,7 +21,7 @@ import './guideline-actions-section.scss';
 import { importContentGuidelines, exportContentGuidelines } from '../api';
 import ActionItem from './action-item';
 
-export default function ActionsSection() {
+export default function GuidelineActionsSection() {
 	const { goTo } = useNavigator();
 
 	const fileInputRef = useRef< HTMLInputElement >( null );

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -21,7 +21,7 @@ import GuidelineAccordion from './components/guideline-accordion';
 import GuidelineAccordionForm from './components/guideline-accordion-form';
 import { fetchContentGuidelines } from './api';
 import BlockGuidelines from './components/block-guidelines';
-import ActionsSection from './components/actions-section';
+import GuidelineActionsSection from './components/guideline-actions-section';
 import RevisionHistory from './components/revision-history';
 
 const GUIDELINE_ITEMS = [
@@ -167,7 +167,7 @@ function ContentGuidelinesPage() {
 									} ) }
 								</ul>
 								{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
-								<ActionsSection />
+								<GuidelineActionsSection />
 							</VStack>
 						</Navigator.Screen>
 						<Navigator.Screen path="/revision-history">

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -79,10 +79,3 @@
 	margin-top: $grid-unit-30;
 }
 
-.content-guidelines__import-description {
-	margin: 0;
-
-	&:not(:last-child) {
-		margin-bottom: $grid-unit-10;
-	}
-}

--- a/routes/content-guidelines/style.scss
+++ b/routes/content-guidelines/style.scss
@@ -29,59 +29,6 @@
 	margin-top: $grid-unit-20;
 }
 
-.content-guidelines__actions {
-	width: min(680px, 100%);
-	margin: $grid-unit-20 auto 0;
-}
-
-.content-guidelines__actions-card {
-	padding: 0;
-	overflow: hidden;
-}
-
-.content-guidelines__actions-list {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-}
-
-.content-guidelines__action-list-item {
-	margin-bottom: 0;
-	position: relative;
-
-	&:not(:first-child)::before {
-		content: "";
-		position: absolute;
-		top: 0;
-		left: $grid-unit-30;
-		right: $grid-unit-30;
-		height: 1px;
-		background-color: $gray-100;
-	}
-}
-
-.content-guidelines__action-row {
-	padding: $grid-unit-20 $grid-unit-30;
-	align-items: center;
-	width: 100%;
-	box-sizing: border-box;
-}
-
-.content-guidelines__actions-card .content-guidelines__action-button {
-	min-width: 100px;
-	justify-content: center;
-	font-size: 13px;
-	font-weight: 400;
-}
-
-.content-guidelines__action-title {
-	color: $gray-900;
-}
-
-.content-guidelines__action-description {
-	color: $gray-700;
-}
-
 .content-guidelines__revision-history {
 	padding: $grid-unit-30;
 	display: flex;
@@ -128,7 +75,14 @@
 	padding-left: $grid-unit-10;
 }
 
-.content-guidelines__restore-modal-actions,
-.content-guidelines__import-modal-actions {
+.content-guidelines__restore-modal-actions {
 	margin-top: $grid-unit-30;
+}
+
+.content-guidelines__import-description {
+	margin: 0;
+
+	&:not(:last-child) {
+		margin-bottom: $grid-unit-10;
+	}
 }


### PR DESCRIPTION
## What?

Related issue: https://github.com/WordPress/gutenberg/issues/76384

Refactors the **Content Guidelines** “Actions” section (import/export/revert) and improves the guidelines import/export flows.

## Why?
- Improve maintainability by extracting a dedicated action row component and consolidating rendering/styling.
- Use `ConfirmDialog` component instead of using a custom modal to seek confirmation for import.
- Make exports easier to track by including the export date in the downloaded filename.

## How?
- Render actions from a single `ACTIONS` definition and use a new `GuidelineAction` component for each row.
- On import, clear categories/blocks not present in the JSON (so omissions remove existing guidelines instead of leaving stale values).
- Export downloads as `guidelines-YYYY-MM-DD.json`.

## Testing Instructions
1. Open the **Content Guidelines** page/route.
2. Scroll to **Actions**.
3. Click **Download** and confirm the filename is `guidelines-YYYY-MM-DD.json`.
4. Click **Upload**, select a valid guidelines JSON file, and confirm a dialog appears warning that current guidelines will be replaced.
5. Click **Continue** and verify:
   - A success snackbar appears.
   - Guidelines update to match the imported content.
   - Categories/blocks omitted from the imported file are removed/cleared.
6. Try importing an invalid JSON (or wrong schema) and verify an error `Notice` appears and is dismissible.
7. Click **View history** and verify it navigates to revision history.
