### PR TITLE
Site Editor > Templates: move config to the server

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 
 * https://github.com/WordPress/gutenberg/pull/76573
 * https://github.com/WordPress/gutenberg/pull/76734
+* https://github.com/WordPress/gutenberg/pull/76622

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -122,6 +122,83 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		} elseif ( 'postType' === $kind && 'wp_template_part' === $name ) {
 			$default_layouts = $this->get_default_layouts_for_wp_template_part();
 			$default_view    = $this->get_default_view_for_wp_template_part( $default_layouts );
+		} elseif ( 'postType' === $kind && 'wp_template' === $name ) {
+			$default_view    = array(
+				'type'             => 'grid',
+				'perPage'          => 20,
+				'sort'             => array(
+					'field'     => 'title',
+					'direction' => 'asc',
+				),
+				'titleField'       => 'title',
+				'descriptionField' => 'description',
+				'mediaField'       => 'preview',
+				'fields'           => array( 'author', 'active', 'slug', 'theme' ),
+				'filters'          => array(),
+				'showMedia'        => true,
+			);
+			$default_layouts = array(
+				'table' => array( 'showMedia' => false ),
+				'grid'  => array( 'showMedia' => true ),
+				'list'  => array( 'showMedia' => false ),
+			);
+			$view_list       = array(
+				array(
+					'title' => __( 'All templates', 'gutenberg' ),
+					'slug'  => 'all',
+				),
+			);
+
+			// Add unique author-based items from registered templates.
+			$registered_templates = gutenberg_get_registered_block_templates( array() );
+			$seen_authors         = array();
+			foreach ( $registered_templates as $template ) {
+				$original_source = self::get_template_original_source( $template );
+				$author_text     = self::get_template_author_text( $template, $original_source );
+				if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
+					$seen_authors[ $author_text ] = true;
+					$view_list[]                  = array(
+						'title' => $author_text,
+						'slug'  => $author_text,
+						'icon'  => $original_source,
+						'view'  => array(
+							'filters' => array(
+								array(
+									'field'    => 'author',
+									'operator' => 'is',
+									'value'    => $author_text,
+									'isLocked' => true,
+								),
+							),
+						),
+					);
+				}
+			}
+
+			// User-created DB templates.
+			$db_templates = get_block_templates( array(), 'wp_template' );
+			foreach ( $db_templates as $template ) {
+				$original_source = self::get_template_original_source( $template );
+				$author_text     = self::get_template_author_text( $template, $original_source );
+				if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
+					$seen_authors[ $author_text ] = true;
+					$view_list[]                  = array(
+						'title' => $author_text,
+						'slug'  => $author_text,
+						'icon'  => $original_source,
+						'view'  => array(
+							'filters' => array(
+								array(
+									'field'    => 'author',
+									'operator' => 'is',
+									'value'    => $author_text,
+									'isLocked' => true,
+								),
+							),
+						),
+					);
+				}
+			}
 		}
 
 		$response = array(
@@ -247,6 +324,9 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 								'type' => 'string',
 							),
 							'slug'  => array(
+								'type' => 'string',
+							),
+							'icon'  => array(
 								'type' => 'string',
 							),
 							'view'  => array(
@@ -674,5 +754,94 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'filters'    => array(),
 			'layout'     => $default_layouts['grid']['layout'],
 		);
+	}
+
+	/**
+	 * Returns the original source of a template.
+	 *
+	 * @param WP_Block_Template $template_object Template instance.
+	 * @return string The original source ('theme', 'plugin', 'site', or 'user').
+	 */
+	private static function get_template_original_source( $template_object ) {
+		if ( 'wp_template' === $template_object->type || 'wp_template_part' === $template_object->type ) {
+			if ( $template_object->has_theme_file &&
+				( 'theme' === $template_object->origin || (
+					empty( $template_object->origin ) && in_array(
+						$template_object->source,
+						array(
+							'theme',
+							'custom',
+						),
+						true
+					) )
+				)
+			) {
+				return 'theme';
+			}
+
+			if ( 'plugin' === $template_object->origin ) {
+				return 'plugin';
+			}
+
+			if ( empty( $template_object->has_theme_file ) && 'custom' === $template_object->source && empty( $template_object->author ) ) {
+				return 'site';
+			}
+		}
+
+		return 'user';
+	}
+
+	/**
+	 * Returns a human readable text for the author of a template.
+	 *
+	 * @param WP_Block_Template $template_object Template instance.
+	 * @param string            $original_source The original source of the template.
+	 * @return string Human readable text for the author.
+	 */
+	private static function get_template_author_text( $template_object, $original_source ) {
+		switch ( $original_source ) {
+			case 'theme':
+				$theme_name = wp_get_theme( $template_object->theme )->get( 'Name' );
+				return empty( $theme_name ) ? $template_object->theme : $theme_name;
+			case 'plugin':
+				if ( ! function_exists( 'get_plugins' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
+				}
+				if ( isset( $template_object->plugin ) ) {
+					$plugins = wp_get_active_and_valid_plugins();
+
+					foreach ( $plugins as $plugin_file ) {
+						$plugin_basename      = plugin_basename( $plugin_file );
+						list( $plugin_slug, ) = explode( '/', $plugin_basename );
+
+						if ( $plugin_slug === $template_object->plugin ) {
+							$plugin_data = get_plugin_data( $plugin_file );
+
+							if ( ! empty( $plugin_data['Name'] ) ) {
+								return $plugin_data['Name'];
+							}
+
+							break;
+						}
+					}
+				}
+
+				$plugins         = get_plugins();
+				$plugin_basename = plugin_basename( sanitize_text_field( $template_object->theme . '.php' ) );
+				if ( isset( $plugins[ $plugin_basename ] ) && isset( $plugins[ $plugin_basename ]['Name'] ) ) {
+					return $plugins[ $plugin_basename ]['Name'];
+				}
+				return $template_object->plugin ?? $template_object->theme;
+			case 'site':
+				return get_bloginfo( 'name' );
+			case 'user':
+				$author = get_user_by( 'id', $template_object->author );
+				if ( ! $author ) {
+					return __( 'Unknown author', 'gutenberg' );
+				}
+				return $author->get( 'display_name' );
+		}
+
+		return '';
 	}
 }

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -123,80 +123,9 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			$default_layouts = $this->get_default_layouts_for_wp_template_part();
 			$default_view    = $this->get_default_view_for_wp_template_part( $default_layouts );
 		} elseif ( 'postType' === $kind && 'wp_template' === $name ) {
-			$default_view    = array(
-				'type'             => 'grid',
-				'perPage'          => 20,
-				'sort'             => array(
-					'field'     => 'title',
-					'direction' => 'asc',
-				),
-				'titleField'       => 'title',
-				'descriptionField' => 'description',
-				'mediaField'       => 'preview',
-				'fields'           => array( 'author', 'active', 'slug', 'theme' ),
-				'filters'          => array(),
-				'showMedia'        => true,
-			);
-			$default_layouts = array(
-				'table' => array( 'showMedia' => false ),
-				'grid'  => array( 'showMedia' => true ),
-				'list'  => array( 'showMedia' => false ),
-			);
-			$view_list       = array(
-				array(
-					'title' => __( 'All templates', 'gutenberg' ),
-					'slug'  => 'all',
-				),
-			);
-
-			// Add unique author-based items from registered templates.
-			$registered_templates = gutenberg_get_registered_block_templates( array() );
-			$seen_authors         = array();
-			foreach ( $registered_templates as $template ) {
-				$original_source = self::get_template_original_source( $template );
-				$author_text     = self::get_template_author_text( $template, $original_source );
-				if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
-					$seen_authors[ $author_text ] = true;
-					$view_list[]                  = array(
-						'title' => $author_text,
-						'slug'  => $author_text,
-						'view'  => array(
-							'filters' => array(
-								array(
-									'field'    => 'author',
-									'operator' => 'is',
-									'value'    => $author_text,
-									'isLocked' => true,
-								),
-							),
-						),
-					);
-				}
-			}
-
-			// User-created DB templates.
-			$db_templates = get_block_templates( array(), 'wp_template' );
-			foreach ( $db_templates as $template ) {
-				$original_source = self::get_template_original_source( $template );
-				$author_text     = self::get_template_author_text( $template, $original_source );
-				if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
-					$seen_authors[ $author_text ] = true;
-					$view_list[]                  = array(
-						'title' => $author_text,
-						'slug'  => $author_text,
-						'view'  => array(
-							'filters' => array(
-								array(
-									'field'    => 'author',
-									'operator' => 'is',
-									'value'    => $author_text,
-									'isLocked' => true,
-								),
-							),
-						),
-					);
-				}
-			}
+			$default_view    = $this->get_default_view_for_wp_template();
+			$default_layouts = $this->get_default_layouts_for_wp_template();
+			$view_list       = $this->get_view_list_for_wp_template();
 		}
 
 		$response = array(
@@ -838,5 +767,90 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		}
 
 		return '';
+	}
+
+	private function get_default_view_for_wp_template() {
+		return array(
+			'type'             => 'grid',
+			'perPage'          => 20,
+			'sort'             => array(
+				'field'     => 'title',
+				'direction' => 'asc',
+			),
+			'titleField'       => 'title',
+			'descriptionField' => 'description',
+			'mediaField'       => 'preview',
+			'fields'           => array( 'author', 'active', 'slug', 'theme' ),
+			'filters'          => array(),
+			'showMedia'        => true,
+		);
+	}
+
+	private function get_default_layouts_for_wp_template() {
+		return array(
+			'table' => array( 'showMedia' => false ),
+			'grid'  => array( 'showMedia' => true ),
+			'list'  => array( 'showMedia' => false ),
+		);
+	}
+
+	private function get_view_list_for_wp_template() {
+		$view_list = array(
+			array(
+				'title' => __( 'All templates', 'gutenberg' ),
+				'slug'  => 'all',
+			),
+		);
+
+		// Add unique author-based items from registered templates.
+		$registered_templates = gutenberg_get_registered_block_templates( array() );
+		$seen_authors         = array();
+		foreach ( $registered_templates as $template ) {
+			$original_source = self::get_template_original_source( $template );
+			$author_text     = self::get_template_author_text( $template, $original_source );
+			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
+				$seen_authors[ $author_text ] = true;
+				$view_list[]                  = array(
+					'title' => $author_text,
+					'slug'  => $author_text,
+					'view'  => array(
+						'filters' => array(
+							array(
+								'field'    => 'author',
+								'operator' => 'is',
+								'value'    => $author_text,
+								'isLocked' => true,
+							),
+						),
+					),
+				);
+			}
+		}
+
+		// User-created DB templates.
+		$db_templates = get_block_templates( array(), 'wp_template' );
+		foreach ( $db_templates as $template ) {
+			$original_source = self::get_template_original_source( $template );
+			$author_text     = self::get_template_author_text( $template, $original_source );
+			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
+				$seen_authors[ $author_text ] = true;
+				$view_list[]                  = array(
+					'title' => $author_text,
+					'slug'  => $author_text,
+					'view'  => array(
+						'filters' => array(
+							array(
+								'field'    => 'author',
+								'operator' => 'is',
+								'value'    => $author_text,
+								'isLocked' => true,
+							),
+						),
+					),
+				);
+			}
+		}
+
+		return $view_list;
 	}
 }

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -680,6 +680,115 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		);
 	}
 
+	/**
+	 * Returns the original source of a template.
+	 *
+	 * @param WP_Block_Template $template_object Template instance.
+	 * @return string The original source ('theme', 'plugin', 'site', or 'user').
+	 */
+	private static function get_wp_templates_original_source_field( $template_object ) {
+		if ( 'wp_template' === $template_object->type || 'wp_template_part' === $template_object->type ) {
+			/*
+			 * Added by theme.
+			 * Template originally provided by a theme, but customized by a user.
+			 * Templates originally didn't have the 'origin' field so identify
+			 * older customized templates by checking for no origin and a 'theme'
+			 * or 'custom' source.
+			 */
+			if ( $template_object->has_theme_file &&
+				( 'theme' === $template_object->origin || (
+					empty( $template_object->origin ) && in_array(
+						$template_object->source,
+						array(
+							'theme',
+							'custom',
+						),
+						true
+					) )
+				)
+			) {
+				return 'theme';
+			}
+
+			// Added by plugin.
+			if ( 'plugin' === $template_object->origin ) {
+				return 'plugin';
+			}
+
+			/*
+			 * Added by site.
+			 * Template was created from scratch, but has no author. Author support
+			 * was only added to templates in WordPress 5.9. Fallback to showing the
+			 * site logo and title.
+			 */
+			if ( empty( $template_object->has_theme_file ) && 'custom' === $template_object->source && empty( $template_object->author ) ) {
+				return 'site';
+			}
+		}
+
+		// Added by user.
+		return 'user';
+	}
+
+	/**
+	 * Returns a human readable text for the author of a template.
+	 *
+	 * @param WP_Block_Template $template_object Template instance.
+	 * @return string Human readable text for the author.
+	 */
+	private static function get_wp_templates_author_text_field( $template_object ) {
+		$original_source = self::get_wp_templates_original_source_field( $template_object );
+		switch ( $original_source ) {
+			case 'theme':
+				$theme_name = wp_get_theme( $template_object->theme )->get( 'Name' );
+				return empty( $theme_name ) ? $template_object->theme : $theme_name;
+			case 'plugin':
+				if ( ! function_exists( 'get_plugins' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/plugin.php';
+				}
+				if ( isset( $template_object->plugin ) ) {
+					$plugins = wp_get_active_and_valid_plugins();
+
+					foreach ( $plugins as $plugin_file ) {
+						$plugin_basename      = plugin_basename( $plugin_file );
+						list( $plugin_slug, ) = explode( '/', $plugin_basename );
+
+						if ( $plugin_slug === $template_object->plugin ) {
+							$plugin_data = get_plugin_data( $plugin_file );
+
+							if ( ! empty( $plugin_data['Name'] ) ) {
+								return $plugin_data['Name'];
+							}
+
+							break;
+						}
+					}
+				}
+
+				/*
+				 * Fall back to the theme name if the plugin is not defined. That's needed to keep backwards
+				 * compatibility with templates that were registered before the plugin attribute was added.
+				 */
+				$plugins         = get_plugins();
+				$plugin_basename = plugin_basename( sanitize_text_field( $template_object->theme . '.php' ) );
+				if ( isset( $plugins[ $plugin_basename ] ) && isset( $plugins[ $plugin_basename ]['Name'] ) ) {
+					return $plugins[ $plugin_basename ]['Name'];
+				}
+				return $template_object->plugin ?? $template_object->theme;
+			case 'site':
+				return get_bloginfo( 'name' );
+			case 'user':
+				$author = get_user_by( 'id', $template_object->author );
+				if ( ! $author ) {
+					return __( 'Unknown author', 'gutenberg' );
+				}
+				return $author->get( 'display_name' );
+		}
+
+		// Fail-safe to return a string should the original source ever fall through.
+		return '';
+	}
+
 	private function get_default_view_for_wp_template() {
 		return array(
 			'type'             => 'grid',
@@ -713,16 +822,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			),
 		);
 
-		// Fetch all templates via the REST API to get computed author_text values.
-		$request = new WP_REST_Request( 'GET', '/wp/v2/templates' );
-		$request->set_param( '_fields', 'author_text,original_source' );
-		$response = rest_do_request( $request );
-
-		if ( $response->is_error() ) {
-			return $view_list;
-		}
-
-		$templates = $response->get_data();
+		$templates = get_block_templates( array(), 'wp_template' );
 
 		// Collect unique authors, tracking whether they come from a registered
 		// source (theme, plugin, site) so we can sort those before user ones.
@@ -730,8 +830,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$registered_authors = array();
 		$user_authors       = array();
 		foreach ( $templates as $template ) {
-			$author_text     = $template['author_text'] ?? '';
-			$original_source = $template['original_source'] ?? 'user';
+			$original_source = self::get_wp_templates_original_source_field( $template );
+			$author_text     = self::get_wp_templates_author_text_field( $template );
 			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
 				$seen_authors[ $author_text ] = true;
 				$entry                        = array(
@@ -756,7 +856,6 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			}
 		}
 
-		// Registered sources (theme, plugin, site) first, then user-created.
 		$view_list = array_merge( $view_list, $registered_authors, $user_authors );
 
 		return $view_list;

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -680,95 +680,6 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		);
 	}
 
-	/**
-	 * Returns the original source of a template.
-	 *
-	 * @param WP_Block_Template $template_object Template instance.
-	 * @return string The original source ('theme', 'plugin', 'site', or 'user').
-	 */
-	private static function get_wp_templates_original_source_field( $template_object ) {
-		if ( 'wp_template' === $template_object->type || 'wp_template_part' === $template_object->type ) {
-			if ( $template_object->has_theme_file &&
-				( 'theme' === $template_object->origin || (
-					empty( $template_object->origin ) && in_array(
-						$template_object->source,
-						array(
-							'theme',
-							'custom',
-						),
-						true
-					) )
-				)
-			) {
-				return 'theme';
-			}
-
-			if ( 'plugin' === $template_object->origin ) {
-				return 'plugin';
-			}
-
-			if ( empty( $template_object->has_theme_file ) && 'custom' === $template_object->source && empty( $template_object->author ) ) {
-				return 'site';
-			}
-		}
-
-		return 'user';
-	}
-
-	/**
-	 * Returns a human readable text for the author of a template.
-	 *
-	 * @param WP_Block_Template $template_object Template instance.
-	 * @param string            $original_source The original source of the template.
-	 * @return string Human readable text for the author.
-	 */
-	private static function get_wp_templates_author_text_field( $template_object, $original_source ) {
-		switch ( $original_source ) {
-			case 'theme':
-				$theme_name = wp_get_theme( $template_object->theme )->get( 'Name' );
-				return empty( $theme_name ) ? $template_object->theme : $theme_name;
-			case 'plugin':
-				if ( ! function_exists( 'get_plugins' ) ) {
-					require_once ABSPATH . 'wp-admin/includes/plugin.php';
-				}
-				if ( isset( $template_object->plugin ) ) {
-					$plugins = wp_get_active_and_valid_plugins();
-
-					foreach ( $plugins as $plugin_file ) {
-						$plugin_basename      = plugin_basename( $plugin_file );
-						list( $plugin_slug, ) = explode( '/', $plugin_basename );
-
-						if ( $plugin_slug === $template_object->plugin ) {
-							$plugin_data = get_plugin_data( $plugin_file );
-
-							if ( ! empty( $plugin_data['Name'] ) ) {
-								return $plugin_data['Name'];
-							}
-
-							break;
-						}
-					}
-				}
-
-				$plugins         = get_plugins();
-				$plugin_basename = plugin_basename( sanitize_text_field( $template_object->theme . '.php' ) );
-				if ( isset( $plugins[ $plugin_basename ] ) && isset( $plugins[ $plugin_basename ]['Name'] ) ) {
-					return $plugins[ $plugin_basename ]['Name'];
-				}
-				return $template_object->plugin ?? $template_object->theme;
-			case 'site':
-				return get_bloginfo( 'name' );
-			case 'user':
-				$author = get_user_by( 'id', $template_object->author );
-				if ( ! $author ) {
-					return __( 'Unknown author', 'gutenberg' );
-				}
-				return $author->get( 'display_name' );
-		}
-
-		return '';
-	}
-
 	private function get_default_view_for_wp_template() {
 		return array(
 			'type'             => 'grid',
@@ -802,36 +713,19 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			),
 		);
 
-		// Add unique author-based items from registered templates.
-		$registered_templates = gutenberg_get_registered_block_templates( array() );
-		$seen_authors         = array();
-		foreach ( $registered_templates as $template ) {
-			$original_source = self::get_wp_templates_original_source_field( $template );
-			$author_text     = self::get_wp_templates_author_text_field( $template, $original_source );
-			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
-				$seen_authors[ $author_text ] = true;
-				$view_list[]                  = array(
-					'title' => $author_text,
-					'slug'  => $author_text,
-					'view'  => array(
-						'filters' => array(
-							array(
-								'field'    => 'author',
-								'operator' => 'is',
-								'value'    => $author_text,
-								'isLocked' => true,
-							),
-						),
-					),
-				);
-			}
+		// Fetch all templates via the REST API to get computed author_text values.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/templates' );
+		$request->set_param( '_fields', 'author_text' );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			return $view_list;
 		}
 
-		// User-created DB templates.
-		$db_templates = get_block_templates( array(), 'wp_template' );
-		foreach ( $db_templates as $template ) {
-			$original_source = self::get_wp_templates_original_source_field( $template );
-			$author_text     = self::get_wp_templates_author_text_field( $template, $original_source );
+		$templates    = $response->get_data();
+		$seen_authors = array();
+		foreach ( $templates as $template ) {
+			$author_text = $template['author_text'] ?? '';
 			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
 				$seen_authors[ $author_text ] = true;
 				$view_list[]                  = array(

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -160,7 +160,6 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					$view_list[]                  = array(
 						'title' => $author_text,
 						'slug'  => $author_text,
-						'icon'  => $original_source,
 						'view'  => array(
 							'filters' => array(
 								array(
@@ -185,7 +184,6 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					$view_list[]                  = array(
 						'title' => $author_text,
 						'slug'  => $author_text,
-						'icon'  => $original_source,
 						'view'  => array(
 							'filters' => array(
 								array(
@@ -324,9 +322,6 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 								'type' => 'string',
 							),
 							'slug'  => array(
-								'type' => 'string',
-							),
-							'icon'  => array(
 								'type' => 'string',
 							),
 							'view'  => array(

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -686,7 +686,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 * @param WP_Block_Template $template_object Template instance.
 	 * @return string The original source ('theme', 'plugin', 'site', or 'user').
 	 */
-	private static function get_template_original_source( $template_object ) {
+	private static function get_wp_templates_original_source_field( $template_object ) {
 		if ( 'wp_template' === $template_object->type || 'wp_template_part' === $template_object->type ) {
 			if ( $template_object->has_theme_file &&
 				( 'theme' === $template_object->origin || (
@@ -722,7 +722,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 * @param string            $original_source The original source of the template.
 	 * @return string Human readable text for the author.
 	 */
-	private static function get_template_author_text( $template_object, $original_source ) {
+	private static function get_wp_templates_author_text_field( $template_object, $original_source ) {
 		switch ( $original_source ) {
 			case 'theme':
 				$theme_name = wp_get_theme( $template_object->theme )->get( 'Name' );
@@ -806,8 +806,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$registered_templates = gutenberg_get_registered_block_templates( array() );
 		$seen_authors         = array();
 		foreach ( $registered_templates as $template ) {
-			$original_source = self::get_template_original_source( $template );
-			$author_text     = self::get_template_author_text( $template, $original_source );
+			$original_source = self::get_wp_templates_original_source_field( $template );
+			$author_text     = self::get_wp_templates_author_text_field( $template, $original_source );
 			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
 				$seen_authors[ $author_text ] = true;
 				$view_list[]                  = array(
@@ -830,8 +830,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		// User-created DB templates.
 		$db_templates = get_block_templates( array(), 'wp_template' );
 		foreach ( $db_templates as $template ) {
-			$original_source = self::get_template_original_source( $template );
-			$author_text     = self::get_template_author_text( $template, $original_source );
+			$original_source = self::get_wp_templates_original_source_field( $template );
+			$author_text     = self::get_wp_templates_author_text_field( $template, $original_source );
 			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
 				$seen_authors[ $author_text ] = true;
 				$view_list[]                  = array(

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -715,20 +715,26 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 
 		// Fetch all templates via the REST API to get computed author_text values.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/templates' );
-		$request->set_param( '_fields', 'author_text' );
+		$request->set_param( '_fields', 'author_text,original_source' );
 		$response = rest_do_request( $request );
 
 		if ( $response->is_error() ) {
 			return $view_list;
 		}
 
-		$templates    = $response->get_data();
-		$seen_authors = array();
+		$templates = $response->get_data();
+
+		// Collect unique authors, tracking whether they come from a registered
+		// source (theme, plugin, site) so we can sort those before user ones.
+		$seen_authors       = array();
+		$registered_authors = array();
+		$user_authors       = array();
 		foreach ( $templates as $template ) {
-			$author_text = $template['author_text'] ?? '';
+			$author_text     = $template['author_text'] ?? '';
+			$original_source = $template['original_source'] ?? 'user';
 			if ( ! empty( $author_text ) && ! isset( $seen_authors[ $author_text ] ) ) {
 				$seen_authors[ $author_text ] = true;
-				$view_list[]                  = array(
+				$entry                        = array(
 					'title' => $author_text,
 					'slug'  => $author_text,
 					'view'  => array(
@@ -742,8 +748,16 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						),
 					),
 				);
+				if ( 'user' === $original_source ) {
+					$user_authors[] = $entry;
+				} else {
+					$registered_authors[] = $entry;
+				}
 			}
 		}
+
+		// Registered sources (theme, plugin, site) first, then user-created.
+		$view_list = array_merge( $view_list, $registered_authors, $user_authors );
 
 		return $view_list;
 	}

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -10,7 +10,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { addQueryArgs } from '@wordpress/url';
 import { useEvent } from '@wordpress/compose';
-import { useView } from '@wordpress/views';
+import { useView, useViewConfig } from '@wordpress/views';
 
 /**
  * Internal dependencies
@@ -20,11 +20,6 @@ import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
 import { authorField, descriptionField, previewField } from './fields';
-import {
-	defaultLayouts,
-	DEFAULT_VIEW,
-	getActiveViewOverridesForTab,
-} from './view-utils';
 
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -32,13 +27,20 @@ const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 
 export default function PageTemplates() {
 	const { path, query } = useLocation();
-	const { activeView = 'active', postId } = query;
+	const { activeView = 'all', postId } = query;
 	const [ selection, setSelection ] = useState( [ postId ] );
 
-	const defaultView = DEFAULT_VIEW;
+	const {
+		default_view: defaultView,
+		default_layouts: defaultLayouts,
+		view_list: viewList,
+	} = useViewConfig( {
+		kind: 'postType',
+		name: TEMPLATE_POST_TYPE,
+	} );
 	const activeViewOverrides = useMemo(
-		() => getActiveViewOverridesForTab( activeView ),
-		[ activeView ]
+		() => viewList?.find( ( v ) => v.slug === activeView )?.view ?? {},
+		[ viewList, activeView ]
 	);
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
@@ -46,6 +48,7 @@ export default function PageTemplates() {
 		slug: 'default',
 		defaultView,
 		activeViewOverrides,
+		defaultLayouts,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,
@@ -150,7 +153,7 @@ export default function PageTemplates() {
 					history.navigate( `/wp_template/${ id }?canvas=edit` );
 				} }
 				selection={ selection }
-				defaultLayouts={ defaultLayouts }
+				defaultLayouts={ defaultLayouts ?? {} }
 				onReset={
 					isModified
 						? () => {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
@@ -1,79 +1,63 @@
 /**
  * WordPress dependencies
  */
-import { useEntityRecords } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs } from '@wordpress/url';
+import { useViewConfig } from '@wordpress/views';
+import {
+	commentAuthorAvatar,
+	layout,
+	plugins as pluginIcon,
+	globe,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
-import { useAddedBy } from '../page-templates/hooks';
-import { layout } from '@wordpress/icons';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-const EMPTY_ARRAY = [];
-
-function TemplateDataviewItem( { template, isActive } ) {
-	const { text, icon } = useAddedBy( template.type, template.id );
-
-	return (
-		<SidebarNavigationItem
-			to={ addQueryArgs( '/template', { activeView: text } ) }
-			icon={ icon }
-			aria-current={ isActive }
-		>
-			{ text }
-		</SidebarNavigationItem>
-	);
-}
+const SLUG_TO_ICON = {
+	all: layout,
+	user: commentAuthorAvatar,
+	theme: layout,
+	plugin: pluginIcon,
+	site: globe,
+};
 
 export default function DataviewsTemplatesSidebarContent() {
 	const {
 		query: { activeView = 'all' },
 	} = useLocation();
-	const { records } = useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
-		per_page: -1,
+	const { view_list: viewList } = useViewConfig( {
+		kind: 'postType',
+		name: TEMPLATE_POST_TYPE,
 	} );
-	const firstItemPerAuthorText = useMemo( () => {
-		const firstItemPerAuthor = records?.reduce( ( acc, template ) => {
-			const author = template.author_text;
-			if ( author && ! acc[ author ] ) {
-				acc[ author ] = template;
-			}
-			return acc;
-		}, {} );
-		return (
-			( firstItemPerAuthor && Object.values( firstItemPerAuthor ) ) ??
-			EMPTY_ARRAY
-		);
-	}, [ records ] );
 
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-templates-browse">
-			<SidebarNavigationItem
-				to="/template"
-				icon={ layout }
-				aria-current={ activeView === 'all' }
-			>
-				{ __( 'All templates' ) }
-			</SidebarNavigationItem>
-			{ firstItemPerAuthorText.map( ( template ) => {
-				return (
-					<TemplateDataviewItem
-						key={ template.author_text }
-						template={ template }
-						isActive={ activeView === template.author_text }
-					/>
-				);
-			} ) }
+			{ viewList?.map( ( item ) => (
+				<SidebarNavigationItem
+					key={ item.slug }
+					to={
+						item.slug === 'all'
+							? '/template'
+							: addQueryArgs( '/template', {
+									activeView: item.slug,
+							  } )
+					}
+					icon={
+						SLUG_TO_ICON[ item.icon ] || SLUG_TO_ICON[ item.slug ]
+					}
+					aria-current={ activeView === item.slug }
+				>
+					{ item.title }
+				</SidebarNavigationItem>
+			) ) }
 		</ItemGroup>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
@@ -24,7 +24,6 @@ import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
 
 const SOURCE_TO_ICON = {
-	all: layout,
 	user: commentAuthorAvatar,
 	theme: layout,
 	plugin: pluginIcon,
@@ -73,7 +72,9 @@ export default function DataviewsTemplatesSidebarContent() {
 									activeView: item.slug,
 							  } )
 					}
-					icon={ SOURCE_TO_ICON[ authorSourceMap[ item.slug ] ] }
+					icon={
+						SOURCE_TO_ICON[ authorSourceMap[ item.slug ] ] ?? layout
+					}
 					aria-current={ activeView === item.slug }
 				>
 					{ item.title }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content-legacy.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs } from '@wordpress/url';
 import { useViewConfig } from '@wordpress/views';
@@ -21,7 +23,7 @@ import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-const SLUG_TO_ICON = {
+const SOURCE_TO_ICON = {
 	all: layout,
 	user: commentAuthorAvatar,
 	theme: layout,
@@ -37,6 +39,27 @@ export default function DataviewsTemplatesSidebarContent() {
 		kind: 'postType',
 		name: TEMPLATE_POST_TYPE,
 	} );
+	const authorSourceMap = useSelect( ( select ) => {
+		const templates = select( coreStore ).getEntityRecords(
+			'postType',
+			TEMPLATE_POST_TYPE,
+			{ per_page: -1 }
+		);
+		if ( ! templates ) {
+			return {};
+		}
+		const map = {};
+		for ( const template of templates ) {
+			if (
+				template.author_text &&
+				template.original_source &&
+				! map[ template.author_text ]
+			) {
+				map[ template.author_text ] = template.original_source;
+			}
+		}
+		return map;
+	}, [] );
 
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-templates-browse">
@@ -50,9 +73,7 @@ export default function DataviewsTemplatesSidebarContent() {
 									activeView: item.slug,
 							  } )
 					}
-					icon={
-						SLUG_TO_ICON[ item.icon ] || SLUG_TO_ICON[ item.slug ]
-					}
+					icon={ SOURCE_TO_ICON[ authorSourceMap[ item.slug ] ] }
 					aria-current={ activeView === item.slug }
 				>
 					{ item.title }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { loadView } from '@wordpress/views';
 
 /**
@@ -11,19 +13,24 @@ import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import PageTemplates from '../page-templates';
 import PageTemplatesLegacy from '../page-templates/index-legacy';
-import {
-	DEFAULT_VIEW,
-	getActiveViewOverridesForTab,
-} from '../page-templates/view-utils';
+import { unlock } from '../../lock-unlock';
 
 async function isTemplateListView( query ) {
 	const { activeView = 'active' } = query;
+	const config = await unlock( resolveSelect( coreStore ) ).getViewConfig(
+		'postType',
+		'wp_template'
+	);
+	const defaultView = config?.default_view;
+	const viewEntry = config?.view_list?.find( ( v ) => v.slug === activeView );
+	// For author-based views, no overrides needed for type determination.
+	const activeViewOverrides = viewEntry?.view ?? {};
 	const view = await loadView( {
 		kind: 'postType',
 		name: 'wp_template',
 		slug: 'default',
-		defaultView: DEFAULT_VIEW,
-		activeViewOverrides: getActiveViewOverridesForTab( activeView ),
+		defaultView,
+		activeViewOverrides,
 	} );
 	return view.type === 'list';
 }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -22,9 +22,8 @@ async function isTemplateListView( query ) {
 		'wp_template'
 	);
 	const defaultView = config?.default_view;
-	const viewEntry = config?.view_list?.find( ( v ) => v.slug === activeView );
-	// For author-based views, no overrides needed for type determination.
-	const activeViewOverrides = viewEntry?.view ?? {};
+	const activeViewOverrides =
+		config?.view_list?.find( ( v ) => v.slug === activeView ).view ?? {};
 	const view = await loadView( {
 		kind: 'postType',
 		name: 'wp_template',

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -23,7 +23,7 @@ async function isTemplateListView( query ) {
 	);
 	const defaultView = config?.default_view;
 	const activeViewOverrides =
-		config?.view_list?.find( ( v ) => v.slug === activeView ).view ?? {};
+		config?.view_list?.find( ( v ) => v.slug === activeView )?.view ?? {};
 	const view = await loadView( {
 		kind: 'postType',
 		name: 'wp_template',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76544
Backported at https://github.com/WordPress/wordpress-develop/pull/11272

## What?

Moves the template view configuration (default view, layouts, and view list) from client-side JavaScript (page-templates/view-utils.js) to the server-side REST endpoint (/wp/v2/view-config), continuing the pattern established for pages in https://github.com/WordPress/gutenberg/pull/76573
                                                                                                                                                                                                                                                           
## Why?                                                      

See https://github.com/WordPress/gutenberg/issues/76544

This is part of an ongoing effort to centralize view configuration on the server so that it can be managed, extended, and overridden consistently across entity types.

## How?

- Endpoint: added the view config for templates.
- Sidebar: generated from the viewList.
- Stage: generated from the `useViewConfig` hook.

## Testing Instructions

Test the Site Editor > Templates screen.

## Use of AI Tools

This PR was authored with Claude Code (Claude Opus 4.6).
