### PR TITLE
Editor: Fix autosaves for draft and auto-draft posts

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -189,10 +189,7 @@ export const savePost =
 		}
 
 		const content = select.getEditedPostContent();
-
-		if ( ! options.isAutosave ) {
-			dispatch.editPost( { content }, { undoIgnore: true } );
-		}
+		dispatch.editPost( { content }, { undoIgnore: true } );
 
 		const previousRecord = select.getCurrentPost();
 		let edits = {

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -501,6 +501,40 @@ test.describe( 'Change detection', () => {
 				.getByRole( 'button', { name: 'Save draft' } )
 		).toBeEnabled();
 	} );
+
+	// See: https://github.com/WordPress/gutenberg/issues/76143.
+	test( 'should not be dirty after autosaving content changes for draft post', async ( {
+		page,
+		editor,
+		changeDetectionUtils,
+	} ) => {
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Hello World' );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'Paragraph' );
+
+		// Force autosave to occur immediately.
+		await Promise.all( [
+			page.evaluate( () =>
+				window.wp.data.dispatch( 'core/editor' ).autosave()
+			),
+			expect(
+				page
+					.getByRole( 'region', { name: 'Editor top bar' } )
+					.getByRole( 'button', { name: 'saved' } )
+			).toBeDisabled(),
+		] );
+
+		// With RTC enabled, all autosaves target an autosave revision. Vary our
+		// expectation accordingly.
+		const isRTCEnabled = Boolean(
+			await page.evaluate( () => window._wpCollaborationEnabled )
+		);
+		expect( await changeDetectionUtils.getIsDirty() ).toBe( isRTCEnabled );
+	} );
 } );
 
 class ChangeDetectionUtils {


### PR DESCRIPTION
## What?
Closes #76143.

PR fixes a bug when post content remained "dirty" (`content: fn()`) after autosaving a draft or auto-draft post, which is usually processed as a normal save.

## Why?
During autosave, `content` was replaced with the evaluated value, which later prevented cleanup in `RECEIVE_ITEMS` because `fastDeepEqual(fn, string)` was always false.

## How?
Remove `! options.isAutosave` guard, which was introduced in #17420, but was no longer needed after #17452.

Ideally, we could remove content evaluation from `savePost` and let [the `saveEntityRecord` handle it](https://github.com/WordPress/gutenberg/blob/cd4bc05b9ee385408d7610ebb2dcc890be79b88c/packages/core-data/src/actions.js#L630-L636), but this would be a breaking change since filters expect `edits.content` to be a string.

## Testing Instructions
1. Create a post or page.
2. Add title and content.
3. Trigger an autosave - `window.wp.data.dispatch( 'core/editor' ).autosave()`.
4. Confirm that the "Save Draft" button remains disabled.

I've added an e2e test that fails on trunk when RTC is disabled.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Used Cluade to run simulations for a couple of fix options I had in mind.
