### PR TITLE
Site Editor > Templates: fix author filter

### DIFF
--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -150,9 +150,6 @@ export const authorField = {
 	label: __( 'Author' ),
 	id: 'author',
 	getValue: ( { item } ) => item.author_text ?? item.author,
-	filterBy: {
-		operators: [ 'isAny', 'isNone' ],
-	},
 	render: AuthorField,
 };
 

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -150,6 +150,9 @@ export const authorField = {
 	label: __( 'Author' ),
 	id: 'author',
 	getValue: ( { item } ) => item.author_text ?? item.author,
+	filterBy: {
+		operators: [ 'isAny', 'isNone' ],
+	},
 	render: AuthorField,
 };
 

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -43,6 +43,7 @@ export function getActiveViewOverridesForTab( activeView ) {
 				field: 'author',
 				operator: 'isAny',
 				value: [ activeView ],
+				isLocked: true,
 			},
 		],
 	};

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -41,8 +41,8 @@ export function getActiveViewOverridesForTab( activeView ) {
 		filters: [
 			{
 				field: 'author',
-				operator: 'isAny',
-				value: [ activeView ],
+				operator: 'is',
+				value: activeView,
 				isLocked: true,
 			},
 		],


### PR DESCRIPTION
## What?

Fix the author filter functionality in the Site Editor's Templates view.

Before:

https://github.com/user-attachments/assets/b6db8f2a-84a3-455c-8847-e9f29c239bc3


After:

https://github.com/user-attachments/assets/5c7608aa-bbd4-4693-aad8-b7e2329b8cab


## Why?

It's broken.

## How?                                                  

- Added `isLocked: true` to the filtered view, to prevent users from being able to remove it. This follows suit of what we do for the views in Site Editor > Pages.
- Set the proper filter operator and value (`is` instead of `isAny`).

## Testing Instructions

1. Open the Site Editor → Templates. Verify the author filter still works as expected.
2. On the sidebar, select the filtered view (depending on your setup you may have one by the theme, from some author, etc.). Verify the filter cannot be removed and it is set.
