### PR TITLE
Image/Site Logo: hide crop toolbar when editMediaEntity is unavailable

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -70,7 +70,9 @@ import {
 } from './constants';
 import { evalAspectRatio, mediaPosition } from './utils';
 
-const { DimensionsTool, ResolutionTool } = unlock( blockEditorPrivateApis );
+const { DimensionsTool, ResolutionTool, mediaEditKey } = unlock(
+	blockEditorPrivateApis
+);
 
 const scaleOptions = [
 	{
@@ -342,7 +344,13 @@ export default function Image( {
 		[ id, isSingleSelected ]
 	);
 
-	const { canInsertCover, imageEditing, imageSizes, maxWidth } = useSelect(
+	const {
+		canInsertCover,
+		imageEditing,
+		imageSizes,
+		maxWidth,
+		editMediaEntity,
+	} = useSelect(
 		( select ) => {
 			const { getBlockRootClientId, canInsertBlockType, getSettings } =
 				select( blockEditorStore );
@@ -354,6 +362,7 @@ export default function Image( {
 				imageEditing: settings.imageEditing,
 				imageSizes: settings.imageSizes,
 				maxWidth: settings.maxWidth,
+				editMediaEntity: settings?.[ mediaEditKey ],
 				canInsertCover: canInsertBlockType(
 					'core/cover',
 					rootClientId
@@ -550,7 +559,12 @@ export default function Image( {
 		}
 	}, [ isSingleSelected ] );
 
-	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;
+	const canEditImage =
+		id &&
+		naturalWidth &&
+		naturalHeight &&
+		imageEditing &&
+		!! editMediaEntity;
 	const allowCrop =
 		isSingleSelected &&
 		canEditImage &&

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -776,6 +776,7 @@ export default function Image( {
 		id &&
 		isSingleSelected &&
 		canUserEdit &&
+		!! editMediaEntity &&
 		! isExternalImage( id, url ) &&
 		! isEditingImage &&
 		onNavigateToEntityRecord && (

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -35,6 +35,7 @@ import {
 	store as blockEditorStore,
 	__experimentalImageEditor as ImageEditor,
 	useBlockEditingMode,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -46,9 +47,11 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { MIN_SIZE } from '../image/constants';
 import { MediaControl, MediaControlPreview } from '../utils/media-control';
+import { unlock } from '../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
+const { mediaEditKey } = unlock( blockEditorPrivateApis );
 
 const SiteLogo = ( {
 	alt,
@@ -75,18 +78,22 @@ const SiteLogo = ( {
 	const blockEditingMode = useBlockEditingMode();
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 
-	const { imageEditing, maxWidth, title } = useSelect( ( select ) => {
-		const settings = select( blockEditorStore ).getSettings();
-		const siteEntities = select( coreStore ).getEntityRecord(
-			'root',
-			'__unstableBase'
-		);
-		return {
-			title: siteEntities?.name,
-			imageEditing: settings.imageEditing,
-			maxWidth: settings.maxWidth,
-		};
-	}, [] );
+	const { imageEditing, maxWidth, title, editMediaEntity } = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+			const siteEntities = select( coreStore ).getEntityRecord(
+				'root',
+				'__unstableBase'
+			);
+			return {
+				title: siteEntities?.name,
+				imageEditing: settings.imageEditing,
+				maxWidth: settings.maxWidth,
+				editMediaEntity: settings?.[ mediaEditKey ],
+			};
+		},
+		[]
+	);
 
 	useEffect( () => {
 		// Turn the `Use as site icon` toggle off if it is on but the logo and icon have
@@ -200,7 +207,11 @@ const SiteLogo = ( {
 	/* eslint-enable no-lonely-if */
 
 	const canEditImage =
-		logoId && naturalWidth && naturalHeight && imageEditing;
+		logoId &&
+		naturalWidth &&
+		naturalHeight &&
+		imageEditing &&
+		!! editMediaEntity;
 
 	// Hide crop and dimensions editing in write mode
 	const shouldShowCropAndDimensions = ! isContentOnlyMode;


### PR DESCRIPTION

## What?

Follow up to: 

- https://github.com/WordPress/gutenberg/pull/70967

> [!NOTE]
> See also the alternative https://github.com/WordPress/gutenberg/pull/76628, which proposes to stabilize the `editMedia` settings property so that custom block implementations can provide their own cropping callback.

Currently, users without upload permissions can see and interact with the crop toolbar in the Image and Site Logo blocks. 

But attempting to apply a crop fails with the error message "Sorry, you are not allowed to edit images on this site."

<img width="828" height="300" alt="Screenshot 2026-03-18 at 10 01 50 pm" src="https://github.com/user-attachments/assets/8502bdb9-193e-4c7b-a3a8-3913dcb9026d" />


## Why?

[The attachments REST controller rejects any request to edit for users without upload permissions](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php#L682-L692).

For consistency, the crop UI should not be shown at all if the user cannot save the result.

## How?

Check for the existence of [editMediaEntity](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/image-editor/use-save-image.js#L46). Show the crop tools if it's available.

`editMediaEntity` is gated behind a `hasUploadPermissions` check.

## Testing Instructions


Add this to a must-use plugin or functions.php to strip upload permissions from the Author role.

```php
add_filter( 'user_has_cap', function( $caps, $required_caps, $args, $user ) {
	if ( in_array( 'author', $user->roles, true ) ) {
		$upload_caps = [ 'upload_files' ];
		foreach ( $upload_caps as $cap ) {
			$caps[ $cap ] = false;
		}
	}
	return $caps;
}, 10, 4 );
```

As an editor/admin, first add an image to the Site Logo block. While you're there, verify that you can still see the crop button and can crop images in both blocks without issue.

1. Log in as an Author with the hook above active.
2. Open a post and insert an Image block with an uploaded image. 
3. Insert a Site Logo block too.
4. Confirm the crop button is absent from the toolbar for both the Image and Site Logoblocks.
5. Remove the hook and repeat. Check that the crop button appears and works normally.


|Before|After|
|-|-|
|<img width="805" height="574" alt="Screenshot 2026-03-18 at 9 41 47 pm" src="https://github.com/user-attachments/assets/1b1d8087-81b4-403c-b2ff-cd0d394db5a6" />|<img width="787" height="540" alt="Screenshot 2026-03-18 at 9 48 48 pm" src="https://github.com/user-attachments/assets/ab0f7245-f8e1-415b-b257-eeacce941f3c" />|
|<img width="492" height="263" alt="Screenshot 2026-03-18 at 9 44 07 pm" src="https://github.com/user-attachments/assets/1855ef2a-abb4-4ea9-aff7-43084c6ad165" />|<img width="522" height="185" alt="Screenshot 2026-03-18 at 9 48 44 pm" src="https://github.com/user-attachments/assets/0eb69ee0-3b93-4aae-bbf7-f6450463f9f3" />|







