### PR TITLE
Core Data: Optimize getRawEntityRecord selector

### DIFF
--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -523,25 +523,26 @@ export const getRawEntityRecord = createSelector(
 			name,
 			key
 		);
-		return (
-			record &&
-			Object.keys( record ).reduce( ( accumulator, _key ) => {
-				if (
-					isRawAttribute( getEntityConfig( state, kind, name ), _key )
-				) {
-					// Because edits are the "raw" attribute values,
-					// we return those from record selectors to make rendering,
-					// comparisons, and joins with edits easier.
-					accumulator[ _key ] =
-						record[ _key ]?.raw !== undefined
-							? record[ _key ]?.raw
-							: record[ _key ];
-				} else {
-					accumulator[ _key ] = record[ _key ];
+		const config = getEntityConfig( state, kind, name );
+		if ( ! record || ! config?.rawAttributes?.length ) {
+			return record;
+		}
+
+		// Because edits are the "raw" attribute values,
+		// we return those from record selectors to make rendering,
+		// comparisons, and joins with edits easier.
+		return Object.fromEntries(
+			Object.keys( record ).map( ( _key ) => {
+				if ( isRawAttribute( config, _key ) ) {
+					const rawValue = record[ _key ]?.raw;
+					return [
+						_key,
+						rawValue !== undefined ? rawValue : record[ _key ],
+					];
 				}
-				return accumulator;
-			}, {} as any )
-		);
+				return [ _key, record[ _key ] ];
+			} )
+		) as EntityRecord;
 	},
 	(
 		state: State,


### PR DESCRIPTION
## What?
A minor optimization for `getRawEntityRecord` selector:

* Move `getEntityConfig` outside the reducer loop to avoid lookups per key.
* Return early and avoid iterations when possible, for example entity has no `rawAttributes`.
* Replace `reduce` with `Object.fromEntries` for readability. Seems to work better with types, too.

P.S. I know `reduce` vs `Object.fromEntries` readability is debatable 😄 

## Testing Instructions
Unit and e2e tests are passing.

### Testing Instructions for Keyboard
Same.