### PR TITLE
Base Styles: Remove $palette-max-height variable

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -107,7 +107,6 @@ $admin-sidebar-width-big: 190px;
 $admin-sidebar-width-collapsed: 36px;
 $spinner-size: 16px;
 $canvas-padding: $grid-unit-20;
-$palette-max-height: 368px;
 
 // Deprecated, please use --wpds-dimension-surface-width-* design tokens instead.
 $modal-min-width: 320px;

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -119,7 +119,7 @@
 	}
 
 	[cmdk-root] > [cmdk-list] {
-		max-height: $palette-max-height; // Specific to not have commands overflow oddly.
+		max-height: 368px; // Specific to not have commands overflow oddly.
 		overflow: auto;
 		scroll-padding-top: $grid-unit-10;
 		scroll-padding-bottom: $grid-unit-10;

--- a/packages/workflow/src/components/workflow-menu.scss
+++ b/packages/workflow/src/components/workflow-menu.scss
@@ -94,7 +94,7 @@
 	}
 
 	[cmdk-root] > [cmdk-list] {
-		max-height: $palette-max-height; // Specific to not have workflows overflow oddly.
+		max-height: 368px; // Specific to not have workflows overflow oddly.
 		overflow: auto;
 
 		// Ensures there is always padding bottom on the last group, when there are workflows.


### PR DESCRIPTION
## Summary

- Remove the `$palette-max-height` SCSS variable from `packages/base-styles/_variables.scss` as it was never intended to be part of the public API
- Inline the `368px` value at the two usage sites (commands and workflow palettes)
- The variable was introduced in #72703 and has not shipped in any official WordPress core release yet

## Context

`_variables.scss` is effectively a public API surface ([flagged in #75691](https://github.com/WordPress/gutenberg/pull/75691#discussion_r2823126178)). This variable should be removed before WordPress 7.0 ships to avoid it becoming a public commitment.

**Backport needed:** This should be backported to `wp/7.0` before the official release (April 9, 2026).

## Test plan

- [ ] Verify command palette renders with correct max-height
- [ ] Verify workflow palette renders with correct max-height
- [ ] Confirm no other usages of `$palette-max-height` exist