### PR TITLE
Site Editor v2: Add Customize section to sidebar

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -25,6 +25,11 @@ add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
  */
 function gutenberg_site_editor_register_default_menu_items() {
 	gutenberg_register_site_editor_v2_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
+	gutenberg_register_site_editor_v2_menu_item( 'customize', __( 'Customize', 'gutenberg' ), '', '' );
+	gutenberg_register_site_editor_v2_menu_item( 'customize-identity', __( 'Logo & Icon', 'gutenberg' ), '/identity', 'customize' );
+	gutenberg_register_site_editor_v2_menu_item( 'customize-colors', __( 'Colors', 'gutenberg' ), '/styles', 'customize' );
+	gutenberg_register_site_editor_v2_menu_item( 'customize-typography', __( 'Typography', 'gutenberg' ), '/styles', 'customize' );
+	gutenberg_register_site_editor_v2_menu_item( 'customize-navigation', __( 'Navigation', 'gutenberg' ), '/navigation', 'customize' );
 	gutenberg_register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -9,6 +9,10 @@ import {
 	symbol,
 	symbolFilled,
 	layout,
+	cog,
+	siteLogo,
+	color,
+	typography,
 } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
 import { store as bootStore } from '@wordpress/boot';
@@ -21,6 +25,11 @@ export async function init() {
 	// Define icons for menu items
 	const menuIcons: Record< string, { icon: React.ReactElement } > = {
 		home: { icon: home },
+		customize: { icon: cog },
+		'customize-identity': { icon: siteLogo },
+		'customize-colors': { icon: color },
+		'customize-typography': { icon: typography },
+		'customize-navigation': { icon: navigation },
 		styles: { icon: styles },
 		navigation: { icon: navigation },
 		pages: { icon: page },
@@ -32,5 +41,10 @@ export async function init() {
 	// Update each menu item with its icon
 	Object.entries( menuIcons ).forEach( ( [ id, { icon } ] ) => {
 		dispatch( bootStore ).updateMenuItem( id, { icon } );
+	} );
+
+	// Mark the Customize item as a drilldown so clicking it reveals sub-items.
+	dispatch( bootStore ).updateMenuItem( 'customize', {
+		parent_type: 'drilldown',
 	} );
 }


### PR DESCRIPTION
## What?

Adds a **Customize** drilldown section to the v2 site editor sidebar (`admin.php?page=site-editor-v2`), grouping the most commonly needed site customization settings in one place.

## Why?

Classic themes offered the Customizer as a single, unified panel for quickly changing site identity, colors, typography, navigation, and more. The block-based Site Editor scatters these settings across different sections, making simple tasks harder to find for users coming from classic themes.

This adds a "Customize" entry to the v2 sidebar that drills into a focused sub-screen with quick links to the key settings:

- **Logo & Icon** → `/identity`
- **Colors** → `/styles`
- **Typography** → `/styles`
- **Navigation** → `/navigation`

This is the v2 equivalent of #76637, which adds the same feature to the v1 site editor.

## How?

- `lib/experimental/pages/site-editor.php`: Registers the `customize` parent menu item and four child items (with `parent: 'customize'`) via the existing `site-editor-v2_init` hook.
- `packages/edit-site-init/src/index.ts`: Sets icons for the new items and marks `customize` as `parent_type: 'drilldown'` so the `@wordpress/boot` Navigation component renders it as a drilldown (sliding sub-screen with a back button).

## Testing Instructions

1. Enable the **Extensible Site Editor** experiment under Gutenberg → Experiments.
2. Navigate to `wp-admin/admin.php?page=site-editor-v2`.
3. Verify a **Customize** item (cog icon) appears in the sidebar.
4. Click it — the sidebar should slide forward to a sub-screen showing Logo & Icon, Colors, Typography, and Navigation.
5. Clicking each sub-item should navigate to the correct section.
6. The back button should return to the main sidebar.

### Testing Instructions for Keyboard

- Tab to the **Customize** item and press Enter — sidebar should animate to the sub-screen.
- Tab through the child items and press Enter to navigate.
- Tab to the back button and press Enter to return.

## Screenshots or screencast

| Before | After |
|-|-|
| Standard sidebar with no Customize section | Sidebar with Customize entry (cog icon) that drills into Logo & Icon, Colors, Typography, Navigation |

## Use of AI Tools

This PR was developed with Claude Code (Sonnet 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)