### PR TITLE
Card: Use Text component for Title typography

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `Dialog`: Use `--wpds-dimension-surface-width-*` design tokens for width constraints ([#76494](https://github.com/WordPress/gutenberg/pull/76494)).
 -   `Notice`: Improve narrow layout by letting description and actions span the icon column when a title is present ([#76202](https://github.com/WordPress/gutenberg/pull/76202)).
 -   `Notice`: Use `Text` component for `Title` and `Description` typography ([#75870](https://github.com/WordPress/gutenberg/pull/75870)).
+-   `Card`: Use `Text` component for `Title` typography ([#76642](https://github.com/WordPress/gutenberg/pull/76642)).
 -   `Card`, `CollapsibleCard`: update padding to match legacy `Card` component ([#76368](https://github.com/WordPress/gutenberg/pull/76368)).
 -   `CollapsibleCard`: move trigger to the header ([#76265](https://github.com/WordPress/gutenberg/pull/76265)).
 -   `CollapsibleCard`: add animations ([#76378](https://github.com/WordPress/gutenberg/pull/76378)).

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -39,10 +39,6 @@
 
 	.title {
 		margin: 0;
-		font-family: var(--wpds-font-family-heading);
-		font-size: var(--wpds-font-size-lg);
-		font-weight: var(--wpds-font-weight-medium);
-		line-height: var(--wpds-font-line-height-sm);
 		color: var(--wpds-color-fg-content-neutral);
 	}
 }

--- a/packages/ui/src/card/title.tsx
+++ b/packages/ui/src/card/title.tsx
@@ -1,5 +1,6 @@
-import { mergeProps, useRender } from '@base-ui/react';
 import { forwardRef } from '@wordpress/element';
+import clsx from 'clsx';
+import { Text } from '../text';
 import styles from './style.module.css';
 import type { TitleProps } from './types';
 
@@ -8,15 +9,15 @@ import type { TitleProps } from './types';
  * prop to swap in a semantic heading element when appropriate.
  */
 export const Title = forwardRef< HTMLDivElement, TitleProps >(
-	function CardTitle( { render, ...props }, ref ) {
-		const element = useRender( {
-			defaultTagName: 'div',
-			render,
-			ref,
-			// TODO: use `Text` component instead, when ready
-			props: mergeProps< 'div' >( { className: styles.title }, props ),
-		} );
-
-		return element;
+	function CardTitle( { className, render, children, ...props }, ref ) {
+		return (
+			<Text
+				variant="heading-lg"
+				render={ render ?? <div ref={ ref } { ...props } /> }
+				className={ clsx( styles.title, className ) }
+			>
+				{ children }
+			</Text>
+		);
 	}
 );


### PR DESCRIPTION
## What

Refactors `Card.Title` to use the `Text` component for its typography instead of declaring font properties directly in CSS.

## Why

The `Text` component (#75870) provides a shared set of typographic variants built on design tokens. `Card.Title`'s typography already matched the `heading-lg` variant exactly, and there was an existing TODO comment (`// TODO: use Text component instead, when ready`) flagging this as intended follow-up work. Using `Text` internally removes duplicated font declarations and ensures Card titles stay in sync with the type scale.

## How

- `card/title.tsx`: Replaced `useRender`/`mergeProps` with a `<Text variant="heading-lg">` wrapper. The default `<div>` element is preserved via `render={<div />}`, and the consumer's `render` prop takes precedence when provided (e.g., `render={<h2 />}` for semantic headings).
- `card/style.module.css`: Removed the 4 font declarations (`font-family`, `font-size`, `font-weight`, `line-height`) from `.title`. Kept `margin: 0` and `color`.

No changes to `CollapsibleCard` — it composes `Card.Title` directly and picks up the refactor automatically.

## Testing instructions

1. Open Storybook and navigate to **Design System / Components / Card**
2. Verify all Card stories render with the same typography as before (15px heading font, medium weight, 20px line-height)
3. Check the **"With semantic heading"** story — confirm `Card.Title render={<h2 />}` still renders an `<h2>` element
4. Navigate to **Design System / Components / CollapsibleCard** and verify titles render correctly in both expanded and collapsed states
5. Run `npm run test:unit packages/ui/src/card` — all existing tests should pass