### PR TITLE
RTC: Change RTC option name

### DIFF
--- a/backport-changelog/7.0/11289.md
+++ b/backport-changelog/7.0/11289.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11289
+
+* https://github.com/WordPress/gutenberg/pull/76643

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
@@ -101,7 +101,7 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 		 * Load the real-time collaboration setting and, when enabled, ensure that an
 		 * an autosave revision is always targeted.
 		 */
-		$is_collaboration_enabled = get_option( 'wp_enable_real_time_collaboration' );
+		$is_collaboration_enabled = get_option( 'wp_collaboration_enabled' );
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 function gutenberg_inject_real_time_collaboration_setting() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
+	if ( ! get_option( 'wp_collaboration_enabled' ) || ! get_option( 'wp_enable_real_time_collaboration' ) ) {
 		return;
 	}
 

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -146,6 +146,12 @@ function gutenberg_inject_real_time_collaboration_setting() {
 		return;
 	}
 
+	// Temporary check to bridge the short time when this is change is merged in
+	// Gutenberg but not in core.
+	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
+		return;
+	}
+
 	// Disable real-time collaboration on the site editor.
 	$enabled = true;
 	if (

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 function gutenberg_inject_real_time_collaboration_setting() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_collaboration_enabled' ) || ! get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
 		return;
 	}
 

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -103,7 +103,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 	 * Registers the real-time collaboration setting.
 	 */
 	function gutenberg_register_real_time_collaboration_setting() {
-		$option_name = 'wp_enable_real_time_collaboration';
+		$option_name = 'wp_collaboration_enabled';
 
 		register_setting(
 			'writing',
@@ -124,8 +124,8 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 				$option_value = get_option( $option_name );
 
 				?>
-				<label for="wp_enable_real_time_collaboration">
-					<input name="wp_enable_real_time_collaboration" type="checkbox" id="wp_enable_real_time_collaboration" value="1" <?php checked( '1', $option_value ); ?>/>
+				<label for="wp_collaboration_enabled">
+					<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
 					<?php _e( 'Enable real-time collaboration', 'gutenberg' ); ?>
 				</label>
 				<?php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 function gutenberg_inject_real_time_collaboration_setting() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
 		return;
 	}
 
@@ -162,7 +162,12 @@ function gutenberg_inject_real_time_collaboration_setting() {
 	);
 }
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
-add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' );
+
+/**
+ * Core filters the default value, so hook with a higher priority to ensure the
+ * setting is enabled by default when the Gutenberg plugin is active.
+ */
+add_filter( 'default_option_wp_collaboration_enabled', '__return_true', 500 );
 
 /**
  * Modifies the post list UI and heartbeat responses for real-time collaboration.
@@ -175,7 +180,7 @@ add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' 
 function gutenberg_post_list_collaboration_ui() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
 		return;
 	}
 

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -25,7 +25,7 @@ function _gutenberg_migrate_database() {
 			_gutenberg_migrate_remove_fse_drafts();
 		}
 
-		if ( version_compare( $gutenberg_installed_version, '22.6.0', '<' ) ) {
+		if ( version_compare( $gutenberg_installed_version, '22.8.0', '<' ) ) {
 			_gutenberg_migrate_enable_real_time_collaboration();
 		}
 
@@ -62,3 +62,27 @@ function _gutenberg_migrate_remove_fse_drafts() {
 	delete_option( 'gutenberg_last_synchronize_theme_template_checks' );
 	delete_option( 'gutenberg_last_synchronize_theme_template-part_checks' );
 }
+
+/**
+ * Update RTC option name.
+ *
+ * @since 22.8.0
+ */
+function _gutenberg_migrate_enable_real_time_collaboration() {
+	$value1 = get_option( 'enable_real_time_collaboration', '1' );
+	$value2 = get_option( 'wp_enable_real_time_collaboration', '1' );
+
+	// RTC is enabled by default in the plugin, so only set the value if it was
+	// previously disabled. Otherwise rely on the default value.
+	if ( ! $value1 || ! $value2 ) {
+		update_option( 'wp_collaboration_enabled', '0' );
+	}
+
+	delete_option( 'enable_real_time_collaboration' );
+	delete_option( 'wp_enable_real_time_collaboration' );
+}
+
+// Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_fse_drafts) must happen
+// after its taxonomy (`wp_theme`) is registered. This happens in `gutenberg_register_wp_theme_taxonomy`,
+// which is hooked into `init` (default priority, i.e. 10).
+add_action( 'init', '_gutenberg_migrate_database', 20 );

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -7,7 +7,7 @@
 
 if ( ! defined( '_GUTENBERG_VERSION_MIGRATION' ) ) {
 	// It's necessary to update this version every time a new migration is needed.
-	define( '_GUTENBERG_VERSION_MIGRATION', '22.6.0' );
+	define( '_GUTENBERG_VERSION_MIGRATION', '22.8.0' );
 }
 
 /**

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -349,9 +349,6 @@ export async function setCollaboration(
 
 	formData[ optionName ] = optionValue;
 
-	// Also set it for the previous option name until it is merged into Core.
-	formData.wp_enable_real_time_collaboration = optionValue;
-
 	await requestUtils.request.post( '/wp-admin/options.php', {
 		form: formData,
 		failOnStatusCode: true,

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -349,6 +349,9 @@ export async function setCollaboration(
 
 	formData[ optionName ] = optionValue;
 
+	// Also set it for the previous option name until it is merged into Core.
+	formData.wp_enable_real_time_collaboration = optionValue;
+
 	await requestUtils.request.post( '/wp-admin/options.php', {
 		form: formData,
 		failOnStatusCode: true,

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -349,6 +349,10 @@ export async function setCollaboration(
 
 	formData[ optionName ] = optionValue;
 
+	// Temporary addition to bridge the short time when this is change is merged in
+	// Gutenberg but not in core.
+	formData.wp_enable_real_time_collaboration = optionValue;
+
 	await requestUtils.request.post( '/wp-admin/options.php', {
 		form: formData,
 		failOnStatusCode: true,

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -334,7 +334,7 @@ export async function setCollaboration(
 	const html = await response.text();
 	const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
 
-	const optionName = 'wp_enable_real_time_collaboration';
+	const optionName = 'wp_collaboration_enabled';
 	const optionValue = enabled ? 1 : 0;
 
 	const formData: Record< string, string | number > = {


### PR DESCRIPTION

## What?

Change RTC option name to `wp_collaboration_enabled`.

## Why?

Backport of https://github.com/WordPress/wordpress-develop/pull/11289.

