### PR TITLE
E2E Tests: Enable client-side media processing for site editor image test

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -1089,12 +1089,6 @@ test.describe( 'Image - Site editor', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllMedia();
 		await requestUtils.activateTheme( 'emptytheme' );
-		// Client-side media processing is not yet fully supported in the
-		// site editor context (upload pipeline gets stuck). Disable it
-		// so the test can use the traditional server-side upload path.
-		await requestUtils.activatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 	} );
 
 	test.beforeEach( async ( { admin } ) => {
@@ -1110,9 +1104,6 @@ test.describe( 'Image - Site editor', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
@@ -1136,8 +1127,9 @@ test.describe( 'Image - Site editor', () => {
 		} );
 		await expect( image ).toBeVisible();
 
-		// Wait for upload to complete.
-		await expect( image ).toHaveAttribute( 'src', /\/[^\s]+\.\w+$/i, {
+		// Wait for upload to complete (includes client-side media processing time).
+		// With client-side processing, the filename may be changed by the server.
+		await expect( image ).toHaveAttribute( 'src', /^https?:\/\//, {
 			timeout: 30_000,
 		} );
 


### PR DESCRIPTION
## Summary

- Remove the `gutenberg-test-plugin-disable-client-side-media-processing` workaround from the "Image - Site editor" E2E test
- The upload pipeline issue that originally required this workaround (items getting stuck in the `core/upload-media` store queue) has been resolved by subsequent improvements to the upload pipeline
- The test now runs with client-side media processing enabled and passes reliably (verified with `--repeat-each=3`)

Contributes to #74367

## Test plan

- [ ] Run `npm run test:e2e -- test/e2e/specs/editor/blocks/image.spec.js --grep "Site editor"` — should pass
- [ ] Run `npm run test:e2e -- test/e2e/specs/editor/blocks/image.spec.js` — all 23 image block tests should pass
- [ ] Verify no flakiness by running with `--repeat-each=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)