### PR TITLE
Block Editor: Strip per-block custom CSS on save for users without edit_css

### DIFF
--- a/backport-changelog/7.0/11347.md
+++ b/backport-changelog/7.0/11347.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11347
+
+* https://github.com/WordPress/gutenberg/pull/76650

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -137,7 +137,7 @@ function gutenberg_register_custom_css_support( $block_type ) {
  * replace only the attribute JSON that changed — no parse_blocks() +
  * serialize_blocks() round-trip needed.
  *
- * @param string $content Post content to filter.
+ * @param string $content Post content to filter, expected to be escaped with slashes.
  * @return string Filtered post content with block custom CSS removed.
  */
 function gutenberg_strip_custom_css_from_blocks( $content ) {
@@ -145,15 +145,7 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 		return $content;
 	}
 
-	// The content may be slashed (e.g. via content_save_pre),
-	// which breaks JSON parsing. Unslash first,
-	// then re-slash the result before returning.
-	$unslashed = wp_unslash( $content );
-
-	// Fast check: if no "css" key anywhere, skip parsing entirely.
-	if ( ! str_contains( $unslashed, '"css"' ) ) {
-		return $content;
-	}
+	$unslashed = stripslashes( $content );
 
 	$parser           = new WP_Block_Parser();
 	$parser->document = $unslashed;
@@ -212,15 +204,15 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 
 	foreach ( $replacements as $replacement ) {
 		list( $offset, $length, $new_json ) = $replacement;
-		$result .= substr( $unslashed, $was_at, $offset - $was_at ) . $new_json;
-		$was_at  = $offset + $length;
+		$result                            .= substr( $unslashed, $was_at, $offset - $was_at ) . $new_json;
+		$was_at                             = $offset + $length;
 	}
 
 	if ( $was_at < $end ) {
 		$result .= substr( $unslashed, $was_at );
 	}
 
-	return wp_slash( $result );
+	return addslashes( $result );
 }
 
 /**

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -8,8 +8,6 @@
 /**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
- * @since 7.0.0
- *
  * @param array $parsed_block The parsed block.
  * @return array The same parsed block with custom CSS class name added if appropriate.
  */
@@ -58,8 +56,6 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 
 /**
  * Enqueues the block custom CSS styles.
- *
- * @since 7.0.0
  */
 function gutenberg_enqueue_block_custom_css() {
 	wp_enqueue_style( 'wp-block-custom-css' );
@@ -70,8 +66,6 @@ function gutenberg_enqueue_block_custom_css() {
  *
  * The class name is generated in `gutenberg_render_custom_css_support_styles`
  * and stored in block attributes. This filter adds it to the actual markup.
- *
- * @since 7.0.0
  *
  * @param string $block_content Rendered block content.
  * @param array  $block         Block object.
@@ -143,8 +137,6 @@ function gutenberg_register_custom_css_support( $block_type ) {
  * (including inner blocks), removes `attrs.style.css`, and
  * re-serializes the content.
  *
- * @since 21.2.0
- *
  * @param string $content Post content to filter.
  * @return string Filtered post content with block custom CSS removed.
  */
@@ -192,8 +184,6 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 
 /**
  * Adds the filters to strip custom CSS from block content on save.
- *
- * @since 21.2.0
  * @access private
  */
 function gutenberg_custom_css_kses_init_filters() {
@@ -203,8 +193,6 @@ function gutenberg_custom_css_kses_init_filters() {
 
 /**
  * Removes the filters that strip custom CSS from block content on save.
- *
- * @since 21.2.0
  * @access private
  */
 function gutenberg_custom_css_remove_filters() {
@@ -214,8 +202,6 @@ function gutenberg_custom_css_remove_filters() {
 
 /**
  * Registers the custom CSS content filters if the user does not have the edit_css capability.
- *
- * @since 21.2.0
  * @access private
  */
 function gutenberg_custom_css_kses_init() {
@@ -231,8 +217,6 @@ function gutenberg_custom_css_kses_init() {
  * This filter is the last being executed on force_filtered_html_on_import.
  * If the input of the filter is true it means we are in an import situation and should
  * enable the custom CSS filters, independently of the user capabilities.
- *
- * @since 21.2.0
  * @access private
  *
  * @param mixed $arg Input argument of the filter.

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -133,7 +133,7 @@ function gutenberg_register_custom_css_support( $block_type ) {
 /**
  * Strips `style.css` attributes from all blocks in post content.
  *
- * Parses the content into blocks, recursively walks all blocks
+ * Parses the content into blocks, iteratively walks all blocks
  * (including inner blocks), removes `attrs.style.css`, and
  * re-serializes the content.
  *
@@ -152,28 +152,30 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 	$blocks    = parse_blocks( $unslashed );
 	$changed   = false;
 
-	/**
-	 * Recursively strip style.css from blocks.
-	 *
-	 * @param array $blocks Blocks to process.
-	 */
-	$strip = static function ( &$blocks ) use ( &$strip, &$changed ) {
-		foreach ( $blocks as &$block ) {
-			if ( isset( $block['attrs']['style']['css'] ) ) {
-				unset( $block['attrs']['style']['css'] );
-				// Clean up empty style object.
-				if ( empty( $block['attrs']['style'] ) ) {
-					unset( $block['attrs']['style'] );
-				}
-				$changed = true;
-			}
-			if ( ! empty( $block['innerBlocks'] ) ) {
-				$strip( $block['innerBlocks'] );
-			}
-		}
-	};
+	// Stack-based traversal — avoids recursive function call overhead.
+	$stack = array();
+	foreach ( $blocks as &$block ) {
+		$stack[] = &$block;
+	}
+	unset( $block );
 
-	$strip( $blocks );
+	while ( ! empty( $stack ) ) {
+		$block = &$stack[ count( $stack ) - 1 ];
+		array_pop( $stack );
+
+		if ( isset( $block['attrs']['style']['css'] ) ) {
+			unset( $block['attrs']['style']['css'] );
+			if ( empty( $block['attrs']['style'] ) ) {
+				unset( $block['attrs']['style'] );
+			}
+			$changed = true;
+		}
+
+		foreach ( $block['innerBlocks'] as &$inner_block ) {
+			$stack[] = &$inner_block;
+		}
+		unset( $inner_block, $block );
+	}
 
 	if ( ! $changed ) {
 		return $content;

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -151,7 +151,7 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 	$unslashed = wp_unslash( $content );
 
 	// Fast check: if no "css" key anywhere, skip parsing entirely.
-	if ( false === strpos( $unslashed, '"css"' ) ) {
+	if ( ! str_contains( $unslashed, '"css"' ) ) {
 		return $content;
 	}
 
@@ -189,10 +189,6 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 		$token_string   = substr( $unslashed, $start_offset, $token_length );
 		$json_rel_start = strcspn( $token_string, '{' );
 		$json_rel_end   = strrpos( $token_string, '}' );
-
-		if ( false === $json_rel_end || $json_rel_start >= $json_rel_end ) {
-			continue;
-		}
 
 		$json_start  = $start_offset + $json_rel_start;
 		$json_length = $json_rel_end - $json_rel_start + 1;

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -153,14 +153,17 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 		return $content;
 	}
 
-	$blocks  = parse_blocks( $content );
-	$changed = false;
+	// The content may be slashed (e.g. via content_save_pre),
+	// which breaks parse_blocks JSON parsing. Unslash first,
+	// then re-slash the result before returning.
+	$unslashed = wp_unslash( $content );
+	$blocks    = parse_blocks( $unslashed );
+	$changed   = false;
 
 	/**
 	 * Recursively strip style.css from blocks.
 	 *
 	 * @param array $blocks Blocks to process.
-	 * @return array Processed blocks.
 	 */
 	$strip = static function ( &$blocks ) use ( &$strip, &$changed ) {
 		foreach ( $blocks as &$block ) {
@@ -184,7 +187,7 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 		return $content;
 	}
 
-	return serialize_blocks( $blocks );
+	return wp_slash( serialize_blocks( $blocks ) );
 }
 
 /**

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -155,7 +155,7 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 
 	while ( $parser->offset < $end ) {
 		$next_token = $parser->next_token();
-		list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
+		list( $token_type, , $attrs, $start_offset, $token_length ) = $next_token;
 
 		if ( 'no-more-tokens' === $token_type ) {
 			break;

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -133,9 +133,9 @@ function gutenberg_register_custom_css_support( $block_type ) {
 /**
  * Strips `style.css` attributes from all blocks in post content.
  *
- * Parses the content into blocks, iteratively walks all blocks
- * (including inner blocks), removes `attrs.style.css`, and
- * re-serializes the content.
+ * Uses WP_Block_Parser::next_token() to scan block tokens and surgically
+ * replace only the attribute JSON that changed — no parse_blocks() +
+ * serialize_blocks() round-trip needed.
  *
  * @param string $content Post content to filter.
  * @return string Filtered post content with block custom CSS removed.
@@ -146,42 +146,85 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 	}
 
 	// The content may be slashed (e.g. via content_save_pre),
-	// which breaks parse_blocks JSON parsing. Unslash first,
+	// which breaks JSON parsing. Unslash first,
 	// then re-slash the result before returning.
 	$unslashed = wp_unslash( $content );
-	$blocks    = parse_blocks( $unslashed );
-	$changed   = false;
 
-	// Stack-based traversal — avoids recursive function call overhead.
-	$stack = array();
-	foreach ( $blocks as &$block ) {
-		$stack[] = &$block;
-	}
-	unset( $block );
-
-	while ( ! empty( $stack ) ) {
-		$block = &$stack[ count( $stack ) - 1 ];
-		array_pop( $stack );
-
-		if ( isset( $block['attrs']['style']['css'] ) ) {
-			unset( $block['attrs']['style']['css'] );
-			if ( empty( $block['attrs']['style'] ) ) {
-				unset( $block['attrs']['style'] );
-			}
-			$changed = true;
-		}
-
-		foreach ( $block['innerBlocks'] as &$inner_block ) {
-			$stack[] = &$inner_block;
-		}
-		unset( $inner_block, $block );
-	}
-
-	if ( ! $changed ) {
+	// Fast check: if no "css" key anywhere, skip parsing entirely.
+	if ( false === strpos( $unslashed, '"css"' ) ) {
 		return $content;
 	}
 
-	return wp_slash( serialize_blocks( $blocks ) );
+	$parser           = new WP_Block_Parser();
+	$parser->document = $unslashed;
+	$parser->offset   = 0;
+	$end              = strlen( $unslashed );
+	$replacements     = array();
+
+	while ( $parser->offset < $end ) {
+		$next_token = $parser->next_token();
+		list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
+
+		if ( 'no-more-tokens' === $token_type ) {
+			break;
+		}
+
+		$parser->offset = $start_offset + $token_length;
+
+		if ( 'block-opener' !== $token_type && 'void-block' !== $token_type ) {
+			continue;
+		}
+
+		if ( ! isset( $attrs['style']['css'] ) ) {
+			continue;
+		}
+
+		// Remove css and clean up empty style.
+		unset( $attrs['style']['css'] );
+		if ( empty( $attrs['style'] ) ) {
+			unset( $attrs['style'] );
+		}
+
+		// Locate the JSON portion within the token.
+		$token_string   = substr( $unslashed, $start_offset, $token_length );
+		$json_rel_start = strcspn( $token_string, '{' );
+		$json_rel_end   = strrpos( $token_string, '}' );
+
+		if ( false === $json_rel_end || $json_rel_start >= $json_rel_end ) {
+			continue;
+		}
+
+		$json_start  = $start_offset + $json_rel_start;
+		$json_length = $json_rel_end - $json_rel_start + 1;
+
+		// Re-encode attributes. If attrs is now empty, remove JSON and trailing space.
+		if ( empty( $attrs ) ) {
+			// Remove the trailing space after JSON: `{"style":{"css":"x"}} ` → ``
+			$replacements[] = array( $json_start, $json_length + 1, '' );
+		} else {
+			$replacements[] = array( $json_start, $json_length, serialize_block_attributes( $attrs ) );
+		}
+	}
+
+	if ( empty( $replacements ) ) {
+		return $content;
+	}
+
+	// Build the result by splicing replacements into the original string.
+	$result = '';
+	$was_at = 0;
+
+	foreach ( $replacements as $replacement ) {
+		list( $offset, $length, $new_json ) = $replacement;
+		$result .= substr( $unslashed, $was_at, $offset - $was_at ) . $new_json;
+		$was_at  = $offset + $length;
+	}
+
+	if ( $was_at < $end ) {
+		$result .= substr( $unslashed, $was_at );
+	}
+
+	return wp_slash( $result );
 }
 
 /**

--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -136,6 +136,116 @@ function gutenberg_register_custom_css_support( $block_type ) {
 	}
 }
 
+/**
+ * Strips `style.css` attributes from all blocks in post content.
+ *
+ * Parses the content into blocks, recursively walks all blocks
+ * (including inner blocks), removes `attrs.style.css`, and
+ * re-serializes the content.
+ *
+ * @since 21.2.0
+ *
+ * @param string $content Post content to filter.
+ * @return string Filtered post content with block custom CSS removed.
+ */
+function gutenberg_strip_custom_css_from_blocks( $content ) {
+	if ( ! has_blocks( $content ) ) {
+		return $content;
+	}
+
+	$blocks  = parse_blocks( $content );
+	$changed = false;
+
+	/**
+	 * Recursively strip style.css from blocks.
+	 *
+	 * @param array $blocks Blocks to process.
+	 * @return array Processed blocks.
+	 */
+	$strip = static function ( &$blocks ) use ( &$strip, &$changed ) {
+		foreach ( $blocks as &$block ) {
+			if ( isset( $block['attrs']['style']['css'] ) ) {
+				unset( $block['attrs']['style']['css'] );
+				// Clean up empty style object.
+				if ( empty( $block['attrs']['style'] ) ) {
+					unset( $block['attrs']['style'] );
+				}
+				$changed = true;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$strip( $block['innerBlocks'] );
+			}
+		}
+	};
+
+	$strip( $blocks );
+
+	if ( ! $changed ) {
+		return $content;
+	}
+
+	return serialize_blocks( $blocks );
+}
+
+/**
+ * Adds the filters to strip custom CSS from block content on save.
+ *
+ * @since 21.2.0
+ * @access private
+ */
+function gutenberg_custom_css_kses_init_filters() {
+	add_filter( 'content_save_pre', 'gutenberg_strip_custom_css_from_blocks', 8 );
+	add_filter( 'content_filtered_save_pre', 'gutenberg_strip_custom_css_from_blocks', 8 );
+}
+
+/**
+ * Removes the filters that strip custom CSS from block content on save.
+ *
+ * @since 21.2.0
+ * @access private
+ */
+function gutenberg_custom_css_remove_filters() {
+	remove_filter( 'content_save_pre', 'gutenberg_strip_custom_css_from_blocks', 8 );
+	remove_filter( 'content_filtered_save_pre', 'gutenberg_strip_custom_css_from_blocks', 8 );
+}
+
+/**
+ * Registers the custom CSS content filters if the user does not have the edit_css capability.
+ *
+ * @since 21.2.0
+ * @access private
+ */
+function gutenberg_custom_css_kses_init() {
+	gutenberg_custom_css_remove_filters();
+	if ( ! current_user_can( 'edit_css' ) ) {
+		gutenberg_custom_css_kses_init_filters();
+	}
+}
+
+/**
+ * Initializes custom CSS content filters when imported data should be filtered.
+ *
+ * This filter is the last being executed on force_filtered_html_on_import.
+ * If the input of the filter is true it means we are in an import situation and should
+ * enable the custom CSS filters, independently of the user capabilities.
+ *
+ * @since 21.2.0
+ * @access private
+ *
+ * @param mixed $arg Input argument of the filter.
+ * @return mixed Input argument of the filter.
+ */
+function gutenberg_custom_css_force_filtered_html_on_import_filter( $arg ) {
+	if ( $arg ) {
+		gutenberg_custom_css_kses_init_filters();
+	}
+	return $arg;
+}
+
+add_action( 'init', 'gutenberg_custom_css_kses_init', 20 );
+add_action( 'set_current_user', 'gutenberg_custom_css_kses_init' );
+add_filter( 'force_filtered_html_on_import', 'gutenberg_custom_css_force_filtered_html_on_import_filter', 999 );
+
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'custom-css',

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -85,23 +85,6 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
 		[ clientId ]
 	);
 
-	const { createWarningNotice } = useDispatch( noticesStore );
-
-	const hasCustomCSS = !! style?.css;
-	useEffect( () => {
-		if ( ! canEditCSS && hasCustomCSS ) {
-			createWarningNotice(
-				__(
-					'This post contains blocks with custom CSS. You do not have permission to edit CSS, so any custom CSS will be removed if you save this post.'
-				),
-				{
-					id: CUSTOM_CSS_WARNING_NOTICE_ID,
-					isDismissible: true,
-				}
-			);
-		}
-	}, [ canEditCSS, hasCustomCSS, createWarningNotice ] );
-
 	// Don't render the panel if user lacks edit_css capability.
 	if ( ! canEditCSS ) {
 		return null;
@@ -132,6 +115,31 @@ function useBlockProps( { style } ) {
 		typeof customCSS === 'string' &&
 		customCSS.trim().length > 0 &&
 		validateCSS( customCSS );
+
+	const canEditCSS = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().canEditCSS,
+		[]
+	);
+
+	const { createWarningNotice } = useDispatch( noticesStore );
+
+	// Show a warning notice when the user lacks edit_css and a block has
+	// custom CSS. The fixed notice ID ensures only one notice is shown
+	// regardless of how many blocks have CSS.
+	const hasCustomCSS = !! customCSS;
+	useEffect( () => {
+		if ( ! canEditCSS && hasCustomCSS ) {
+			createWarningNotice(
+				__(
+					'This post contains blocks with custom CSS. You do not have permission to edit CSS, so any custom CSS will be removed if you save this post.'
+				),
+				{
+					id: CUSTOM_CSS_WARNING_NOTICE_ID,
+					isDismissible: true,
+				}
+			);
+		}
+	}, [ canEditCSS, hasCustomCSS, createWarningNotice ] );
 
 	const customCSSIdentifier = useInstanceId(
 		CUSTOM_CSS_INSTANCE_REFERENCE,

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -126,7 +126,7 @@ function useBlockProps( { style } ) {
 	// Show a warning notice when the user lacks edit_css and a block has
 	// custom CSS. The fixed notice ID ensures only one notice is shown
 	// regardless of how many blocks have CSS.
-	const hasCustomCSS = !! customCSS;
+	const hasCustomCSS = !! customCSS?.trim();
 	useEffect( () => {
 		if ( ! canEditCSS && hasCustomCSS ) {
 			createWarningNotice(

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -131,7 +131,7 @@ function useBlockProps( { style } ) {
 		if ( ! canEditCSS && hasCustomCSS ) {
 			createWarningNotice(
 				__(
-					'This post contains blocks with custom CSS. You do not have permission to edit CSS, so any custom CSS will be removed if you save this post.'
+					'This post contains blocks with custom CSS. You do not have permission to edit CSS. If you save this post, the custom CSS will be removed.'
 				),
 				{
 					id: CUSTOM_CSS_WARNING_NOTICE_ID,

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useEffect, useMemo } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import { processCSSNesting } from '@wordpress/global-styles-engine';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -69,6 +70,8 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	);
 }
 
+const CUSTOM_CSS_WARNING_NOTICE_ID = 'custom-css-edit-warning';
+
 function CustomCSSEdit( { clientId, name, setAttributes } ) {
 	const { style, canEditCSS } = useSelect(
 		( select ) => {
@@ -81,6 +84,23 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
 		},
 		[ clientId ]
 	);
+
+	const { createWarningNotice } = useDispatch( noticesStore );
+
+	const hasCustomCSS = !! style?.css;
+	useEffect( () => {
+		if ( ! canEditCSS && hasCustomCSS ) {
+			createWarningNotice(
+				__(
+					'This post contains blocks with custom CSS. You do not have permission to edit CSS, so any custom CSS will be removed if you save this post.'
+				),
+				{
+					id: CUSTOM_CSS_WARNING_NOTICE_ID,
+					isDismissible: true,
+				}
+			);
+		}
+	}, [ canEditCSS, hasCustomCSS, createWarningNotice ] );
 
 	// Don't render the panel if user lacks edit_css capability.
 	if ( ! canEditCSS ) {

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -447,7 +447,7 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	public function test_strip_custom_css_removes_css_from_block() {
 		$content = '<!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph -->';
 
-		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$result = wp_unslash( gutenberg_strip_custom_css_from_blocks( $content ) );
 		$blocks = parse_blocks( $result );
 
 		$this->assertArrayNotHasKey( 'css', $blocks[0]['attrs']['style'] ?? array(), 'style.css should be stripped from block attributes.' );
@@ -461,7 +461,7 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	public function test_strip_custom_css_removes_css_from_inner_blocks() {
 		$content = '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
 
-		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$result = wp_unslash( gutenberg_strip_custom_css_from_blocks( $content ) );
 		$blocks = parse_blocks( $result );
 
 		$inner_block = $blocks[0]['innerBlocks'][0];
@@ -502,7 +502,7 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	public function test_strip_custom_css_preserves_other_style_properties() {
 		$content = '<!-- wp:paragraph {"style":{"css":"color: red;","color":{"text":"#ff0000"}}} --><p>Hello</p><!-- /wp:paragraph -->';
 
-		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$result = wp_unslash( gutenberg_strip_custom_css_from_blocks( $content ) );
 		$blocks = parse_blocks( $result );
 
 		$this->assertArrayNotHasKey( 'css', $blocks[0]['attrs']['style'], 'style.css should be stripped.' );
@@ -517,9 +517,24 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	public function test_strip_custom_css_cleans_up_empty_style_object() {
 		$content = '<!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph -->';
 
-		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$result = wp_unslash( gutenberg_strip_custom_css_from_blocks( $content ) );
 		$blocks = parse_blocks( $result );
 
 		$this->assertArrayNotHasKey( 'style', $blocks[0]['attrs'], 'Empty style object should be cleaned up after stripping css.' );
+	}
+
+	/**
+	 * Tests that slashed content is handled correctly.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_handles_slashed_content() {
+		$content = '<!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph -->';
+		$slashed = wp_slash( $content );
+
+		$result = gutenberg_strip_custom_css_from_blocks( $slashed );
+		$blocks = parse_blocks( wp_unslash( $result ) );
+
+		$this->assertArrayNotHasKey( 'css', $blocks[0]['attrs']['style'] ?? array(), 'style.css should be stripped even from slashed content.' );
 	}
 }

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -438,4 +438,88 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added for valid CSS.' );
 	}
+
+	/**
+	 * Tests that style.css is stripped from a single block.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_removes_css_from_block() {
+		$content = '<!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph -->';
+
+		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$blocks = parse_blocks( $result );
+
+		$this->assertArrayNotHasKey( 'css', $blocks[0]['attrs']['style'] ?? array(), 'style.css should be stripped from block attributes.' );
+	}
+
+	/**
+	 * Tests that style.css is stripped from nested inner blocks.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_removes_css_from_inner_blocks() {
+		$content = '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+
+		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$blocks = parse_blocks( $result );
+
+		$inner_block = $blocks[0]['innerBlocks'][0];
+		$this->assertArrayNotHasKey( 'css', $inner_block['attrs']['style'] ?? array(), 'style.css should be stripped from inner block attributes.' );
+	}
+
+	/**
+	 * Tests that content without blocks is returned unchanged.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_returns_non_block_content_unchanged() {
+		$content = '<p>This is plain HTML content with no blocks.</p>';
+
+		$result = gutenberg_strip_custom_css_from_blocks( $content );
+
+		$this->assertSame( $content, $result, 'Non-block content should be returned unchanged.' );
+	}
+
+	/**
+	 * Tests that content without style.css attributes is returned unchanged.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_returns_unchanged_when_no_css_attributes() {
+		$content = '<!-- wp:paragraph {"style":{"color":{"text":"#ff0000"}}} --><p class="has-text-color" style="color:#ff0000">Hello</p><!-- /wp:paragraph -->';
+
+		$result = gutenberg_strip_custom_css_from_blocks( $content );
+
+		$this->assertSame( $content, $result, 'Content without style.css attributes should be returned unchanged.' );
+	}
+
+	/**
+	 * Tests that other style properties are preserved when css is stripped.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_preserves_other_style_properties() {
+		$content = '<!-- wp:paragraph {"style":{"css":"color: red;","color":{"text":"#ff0000"}}} --><p>Hello</p><!-- /wp:paragraph -->';
+
+		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$blocks = parse_blocks( $result );
+
+		$this->assertArrayNotHasKey( 'css', $blocks[0]['attrs']['style'], 'style.css should be stripped.' );
+		$this->assertSame( '#ff0000', $blocks[0]['attrs']['style']['color']['text'], 'Other style properties should be preserved.' );
+	}
+
+	/**
+	 * Tests that empty style object is cleaned up after stripping css.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_cleans_up_empty_style_object() {
+		$content = '<!-- wp:paragraph {"style":{"css":"color: red;"}} --><p>Hello</p><!-- /wp:paragraph -->';
+
+		$result = gutenberg_strip_custom_css_from_blocks( $content );
+		$blocks = parse_blocks( $result );
+
+		$this->assertArrayNotHasKey( 'style', $blocks[0]['attrs'], 'Empty style object should be cleaned up after stripping css.' );
+	}
 }


### PR DESCRIPTION
## What?

Adds server-side enforcement of the `edit_css` capability for per-block custom CSS (`style.css` block attribute). Also adds an editor warning notice for users who lack the capability when editing a post that contains blocks with custom CSS.

## Why?

PR #73959 added per-block custom CSS support, but the `edit_css` capability check is only performed client-side (hiding the CSS panel in the editor). Any user with `edit_posts` can bypass this by using Code Editor or the REST API to inject `style.css` into block attributes, which gets rendered as arbitrary inline CSS on the frontend. This enables UI redress attacks, phishing overlays, and content defacement.

Trac ticket for backport: https://core.trac.wordpress.org/ticket/64771
## How?

### PHP (`lib/block-supports/custom-css.php`)

Adds a `content_save_pre` filter following the established kses pattern used for footnotes in `lib/blocks.php`:

- `gutenberg_strip_custom_css_from_blocks()` — parses blocks, recursively walks all blocks (including `innerBlocks`), removes `attrs.style.css`, and re-serializes. Short-circuits if content has no blocks or nothing changed.
- `gutenberg_custom_css_kses_init()` — hooked on `init` (priority 20) and `set_current_user`. Only activates the filter when `! current_user_can( 'edit_css' )`.
- `gutenberg_custom_css_kses_init_filters()` / `gutenberg_custom_css_remove_filters()` — add/remove the `content_save_pre` and `content_filtered_save_pre` hooks at priority 8 (before kses at 9).
- `gutenberg_custom_css_force_filtered_html_on_import_filter()` — forces the filter on during imports (priority 999).

### JS (`packages/block-editor/src/hooks/custom-css.js`)

In the `CustomCSSEdit` component, when `canEditCSS` is false and the block has `style.css` set, dispatches a one-time warning notice (deduplicated via fixed notice ID) informing the user that custom CSS will be removed on save.

## Not covered 

Existing posts with the custom CSS already saved won't be cleaned up, and that saved custom CSS will still render on the frontend. As this feature has only been out for a short time and only in the experimental plugin, there is not enough risk from this to warrant trying to clean up any existing content that may have been added by users without edit-css permissions.

## Testing Instructions

### 1. Test as Author user (has `edit_posts`, no `edit_css`):
- Log in as an Author
- Open a post that contains blocks with custom CSS (added by an Admin)
- Verify the warning banner appears at the top of the editor
- Save the post
- Verify `style.css` is stripped from all blocks in the saved content
- Verify the CSS no longer renders on the frontend

### 2. Test as Admin user (has `edit_css`):
- Open the same post — no warning banner should appear
- Save — custom CSS should be preserved in block attributes
- Frontend should still render the CSS

### 3. Code Editor bypass test:
- As Author, switch to Code Editor
- Manually type `<!-- wp:paragraph {"style":{"css":"body{background:red}"}} -->`
- Save → verify the `style.css` attribute is stripped from saved content

### 4. REST API test:
- As Author, `PUT /wp-json/wp/v2/posts/<id>` with a content payload containing CSS in block attributes
- Verify CSS is stripped from the saved content

### 5. Existing tests:
- Existing PHP tests in `phpunit/block-supports/custom-css-test.php` should still pass (they test render behaviour, not save filtering)