### PR TITLE
Set milestone on PRs after cherry-picking to release branch

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -397,6 +397,20 @@ function GHcommentAndRemoveLabel( pr ) {
 			] );
 		}
 
+		if ( LABEL === 'Backport to Gutenberg RC' ) {
+			const milestone = getMilestoneFromBranch();
+			if ( milestone ) {
+				cli( 'gh', [
+					'pr',
+					'edit',
+					number,
+					...repo,
+					'--milestone',
+					milestone,
+				] );
+			}
+		}
+
 		console.log( `✅ ${ number }: ${ comment }` );
 	} catch ( e ) {
 		console.log( `❌ ${ number }. ${ comment } ` );
@@ -459,6 +473,18 @@ function prUrl( number ) {
  */
 function prComment( cherryPickHash ) {
 	return `I just cherry-picked this PR to the ${ BRANCH } branch to get it included in the next release: ${ cherryPickHash }`;
+}
+
+/**
+ * Derives the Gutenberg milestone name from the current release branch.
+ *
+ * For example, "release/22.7" becomes "Gutenberg 22.7".
+ *
+ * @return {string|null} Milestone name, or null if the branch doesn't match.
+ */
+function getMilestoneFromBranch() {
+	const match = BRANCH.match( /release\/(\d+\.\d+)/ );
+	return match ? `Gutenberg ${ match[ 1 ] }` : null;
 }
 
 /**


### PR DESCRIPTION
## What?

Automatically sets the GitHub milestone on PRs after they are cherry-picked to a Gutenberg release branch.

## Why?

During the 22.8 release, several PRs that were backported to the previous release still appeared in the 22.8 changelog because their milestone wasn't updated. The changelog generation script uses milestones to determine which PRs belong to which release, so stale milestones cause PRs to appear in the wrong changelog.

## How?

Added a `getMilestoneFromBranch()` function that derives the milestone name from the current release branch (e.g. `release/22.7` → `Gutenberg 22.7`). After a successful cherry-pick, when the label is `Backport to Gutenberg RC`, the script updates the PR's milestone via `gh pr edit --milestone`. This does not run for WP Core backports (`Backport to WP Beta/RC`).

## Testing Instructions

Testing requires a fork since the script modifies PRs on GitHub.

### Setup

1. Fork `WordPress/gutenberg` to your account (e.g. `youruser/gutenberg`).
2. Add the fork as a remote and rename remotes so the fork is `origin`:
   ```
   git remote rename origin upstream
   git remote add origin https://github.com/youruser/gutenberg.git
   ```
3. Create a release branch from trunk and push it to the fork:
   ```
   git checkout trunk
   git checkout -b release/99.0
   git push origin release/99.0
   ```
4. Create a milestone on the fork: go to `https://github.com/youruser/gutenberg/milestones/new` and create `Gutenberg 99.0`.
5. Create the `Backport to Gutenberg RC` label on the fork if it doesn't exist.

### Apply and commit the changes on the release branch

6. Cherry-pick this PR's commit onto the release branch (or apply the diff manually).
7. Temporarily change `const REPO = 'WordPress/gutenberg'` to `const REPO = 'youruser/gutenberg'` in `bin/cherry-pick.mjs`.
8. Commit both changes on `release/99.0`.

### Create a test PR to cherry-pick

9. Switch to trunk and create a branch with a new file:
   ```
   git checkout trunk
   git checkout -b test/cherry-pick-milestone
   echo "test" > cherry-pick-test-file.txt
   git add cherry-pick-test-file.txt
   git commit -m "Test: cherry-pick milestone"
   git push origin test/cherry-pick-milestone
   ```
10. Create a PR on the fork targeting trunk, add the `Backport to Gutenberg RC` label, and squash-merge it.
11. Confirm the PR has no milestone set.

### Run the cherry-pick

12. Switch to the release branch and run the script:
    ```
    git checkout release/99.0
    npm run other:cherry-pick "Backport to Gutenberg RC"
    ```
13. Confirm the cherry-pick succeeds and the script pushes to the fork.
14. Verify the PR's milestone is now set to `Gutenberg 99.0`.

### Cleanup

15. Restore remotes: `git remote rename origin fork && git remote rename upstream origin`
16. Delete the fork if no longer needed.

## Use of AI Tools

Claude Code was used to assist with implementing the feature, setting up the fork-based test environment, and drafting this PR.