### PR TITLE
fix: Original PRs may not be tagged properly when a manual cherry-pick i

### DIFF
--- a/.github/workflows/label-manual-cherry-pick.yml
+++ b/.github/workflows/label-manual-cherry-pick.yml
@@ -1,16 +1,9 @@
 name: Label Manual Cherry-Picks
-
 on:
     pull_request_target:
         types: [closed]
-        branches:
-            - 'wp/**'
-            - 'release/**'
-
-# Disable permissions for all available scopes by default.
-# Any needed permissions should be configured at the job level.
+        branches: ['wp/**', 'release/**']
 permissions: {}
-
 jobs:
     label-original-pr:
         runs-on: 'ubuntu-24.04'
@@ -25,44 +18,27 @@ jobs:
               with:
                   script: |
                       const pr = context.payload.pull_request;
-                      const body = pr.body || '';
-                      const title = pr.title || '';
-                      const text = `${title}\n${body}`;
-
+                      const text = `${pr.title || ''}\n${pr.body || ''}`;
                       const prNumbers = new Set();
                       const regex = /cherry[- ]?pick(?:ed)?(?:\s+(?:of|from))?\s+#(\d+)/gi;
                       let match;
                       while ((match = regex.exec(text)) !== null) {
-                          if (match[1]) {
-                              prNumbers.add(parseInt(match[1], 10));
-                          }
+                          if (match[1]) prNumbers.add(parseInt(match[1], 10));
                       }
-
                       if (prNumbers.size === 0) {
-                          console.log('No original PR references found in the PR body or title.');
+                          console.log('No original PR references found.');
                           return;
                       }
-
                       const label = 'Backported to WP Core';
+                      const { owner, repo } = context.repo;
                       for (const prNumber of prNumbers) {
                           try {
-                              const { data: originalPr } = await github.rest.pulls.get({
-                                  owner: context.repo.owner,
-                                  repo: context.repo.repo,
-                                  pull_number: prNumber,
-                              });
-
+                              const { data: originalPr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
                               if (originalPr.base.ref !== 'trunk') {
                                   console.log(`PR #${prNumber} does not target trunk, skipping.`);
                                   continue;
                               }
-
-                              await github.rest.issues.addLabels({
-                                  owner: context.repo.owner,
-                                  repo: context.repo.repo,
-                                  issue_number: prNumber,
-                                  labels: [label],
-                              });
+                              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [label] });
                               console.log(`Added "${label}" label to PR #${prNumber}.`);
                           } catch (error) {
                               console.log(`Could not process PR #${prNumber}: ${error.message}`);

--- a/.github/workflows/label-manual-cherry-pick.yml
+++ b/.github/workflows/label-manual-cherry-pick.yml
@@ -1,0 +1,70 @@
+name: Label Manual Cherry-Picks
+
+on:
+    pull_request_target:
+        types: [closed]
+        branches:
+            - 'wp/**'
+            - 'release/**'
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    label-original-pr:
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            pull-requests: write
+        if: >
+            github.event.pull_request.merged == true &&
+            github.repository == 'WordPress/gutenberg'
+        steps:
+            - name: Label original PR
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: |
+                      const pr = context.payload.pull_request;
+                      const body = pr.body || '';
+                      const title = pr.title || '';
+                      const text = `${title}\n${body}`;
+
+                      const prNumbers = new Set();
+                      const regex = /cherry[- ]?pick(?:ed)?(?:\s+(?:of|from))?\s+#(\d+)/gi;
+                      let match;
+                      while ((match = regex.exec(text)) !== null) {
+                          if (match[1]) {
+                              prNumbers.add(parseInt(match[1], 10));
+                          }
+                      }
+
+                      if (prNumbers.size === 0) {
+                          console.log('No original PR references found in the PR body or title.');
+                          return;
+                      }
+
+                      const label = 'Backported to WP Core';
+                      for (const prNumber of prNumbers) {
+                          try {
+                              const { data: originalPr } = await github.rest.pulls.get({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  pull_number: prNumber,
+                              });
+
+                              if (originalPr.base.ref !== 'trunk') {
+                                  console.log(`PR #${prNumber} does not target trunk, skipping.`);
+                                  continue;
+                              }
+
+                              await github.rest.issues.addLabels({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  issue_number: prNumber,
+                                  labels: [label],
+                              });
+                              console.log(`Added "${label}" label to PR #${prNumber}.`);
+                          } catch (error) {
+                              console.log(`Could not process PR #${prNumber}: ${error.message}`);
+                          }
+                      }


### PR DESCRIPTION
Fixes #76579

When a manual cherry-pick is merged to a `wp/**` or `release/**` branch, the original trunk PR was never labeled, leaving it untracked. No automated workflow existed to detect cherry-picks and apply labels. Adds `.github/workflows/label-manual-cherry-pick.yml`, which triggers on `pull_request_target` closed events, parses the PR title and body for cherry-pick references via regex, verifies the referenced PR targets `trunk`, and applies the `Backported to WP Core` label.