### PR TITLE
Build: Fix vips worker 404 when SCRIPT_DEBUG is true

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -919,19 +919,13 @@ async function generateModuleRegistrationPhp( modules, replacements ) {
 	// Generate modules array for registry
 	const modulesArray = modules
 		.map(
-			( module ) => {
-				const minOnlyLine = module.min_only
-					? `\t\t'min_only' => true,\n`
-					: '';
-				return (
-					`\tarray(\n` +
-					`\t\t'id' => '${ module.id }',\n` +
-					`\t\t'path' => '${ module.path }',\n` +
-					`\t\t'asset' => '${ module.asset }',\n` +
-					minOnlyLine +
-					`\t),`
-				);
-			}
+			( module ) =>
+				`\tarray(\n` +
+				`\t\t'id' => '${ module.id }',\n` +
+				`\t\t'path' => '${ module.path }',\n` +
+				`\t\t'asset' => '${ module.asset }',\n` +
+				( module.min_only ? `\t\t'min_only' => true,\n` : '' ) +
+				`\t),`
 		)
 		.join( '\n' );
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -661,6 +661,7 @@ async function bundlePackage( packageName, options = {} ) {
 				id: scriptModuleId,
 				path: `${ packageName }/${ fileName }`,
 				asset: `${ packageName }/${ fileName }.min.asset.php`,
+				min_only: isWasmWorker,
 			} );
 		}
 	}
@@ -918,12 +919,19 @@ async function generateModuleRegistrationPhp( modules, replacements ) {
 	// Generate modules array for registry
 	const modulesArray = modules
 		.map(
-			( module ) =>
-				`\tarray(\n` +
-				`\t\t'id' => '${ module.id }',\n` +
-				`\t\t'path' => '${ module.path }',\n` +
-				`\t\t'asset' => '${ module.asset }',\n` +
-				`\t),`
+			( module ) => {
+				const minOnlyLine = module.min_only
+					? `\t\t'min_only' => true,\n`
+					: '';
+				return (
+					`\tarray(\n` +
+					`\t\t'id' => '${ module.id }',\n` +
+					`\t\t'path' => '${ module.path }',\n` +
+					`\t\t'asset' => '${ module.asset }',\n` +
+					minOnlyLine +
+					`\t),`
+				);
+			}
 		)
 		.join( '\n' );
 

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -31,9 +31,13 @@ function {{PREFIX}}_register_script_modules() {
 
 	$modules = require $modules_file;
 	$base_url = $build_constants['build_url'] . 'modules/';
-	$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 
 	foreach ( $modules as $module ) {
+		// WASM-only modules (e.g., vips worker) only have .min.js; use it even when SCRIPT_DEBUG.
+		$extension = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && empty( $module['min_only'] ) )
+			? '.js'
+			: '.min.js';
+
 		$asset_path = $modules_dir . '/' . $module['asset'];
 		$asset = file_exists( $asset_path ) ? require $asset_path : array();
 

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -33,7 +33,7 @@ function {{PREFIX}}_register_script_modules() {
 	$base_url = $build_constants['build_url'] . 'modules/';
 
 	foreach ( $modules as $module ) {
-		// WASM-only modules (e.g., vips worker) only have .min.js; use it even when SCRIPT_DEBUG.
+		// WASM-only modules (e.g., vips worker) only have .min.js; use it even when SCRIPT_DEBUG is `true`.
 		$extension = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && empty( $module['min_only'] ) )
 			? '.js'
 			: '.min.js';


### PR DESCRIPTION
> [!NOTE]
> It would be good to get verification on whether this bug is real and this fix works. Sometimes my env sends me into parallel universes.


Follow up to:

- https://github.com/WordPress/gutenberg/pull/76615

Fixes image upload failures in the block editor when `SCRIPT_DEBUG` is enabled. The vips worker module was requested as `worker.js` while only `worker.min.js` exists, causing a 404 and "Failed to fetch dynamically imported module".

### Why

- WASM workers (vips) only produce `.min.js` (~16MB, no separate debug build).
- Module registration used `.js` when `SCRIPT_DEBUG` was true.
- Result: 404 for `worker.js` and uploads failing with `UploadError: File could not be uploaded`.

### How

- Add `min_only` flag to script module registry for WASM workers.
- In module registration, use `.min.js` for `min_only` modules even when `SCRIPT_DEBUG` is true.


## Testing

I am testing in the default wp-env dev environment, which has `define( 'SCRIPT_DEBUG', true );` in `wp-config.php`

1. Open block editor (new post)
2. Add Image block and upload an image (try with gif, png, heic, avif, jpg, webp in all sizes)
3. Confirm upload completes without "File could not be uploaded" in the console

Check for regression:

With `SCRIPT_DEBUG` false, upload an image and confirm it still works
