### PR TITLE
RTC: Update post lock backport PR

### DIFF
--- a/backport-changelog/7.0/11234.md
+++ b/backport-changelog/7.0/11234.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11234
+
+* https://github.com/WordPress/gutenberg/pull/76322

--- a/backport-changelog/7.0/11276.md
+++ b/backport-changelog/7.0/11276.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/11276
-
-* https://github.com/WordPress/gutenberg/pull/76322


### PR DESCRIPTION
## What?

Switching back to the approach in WordPress/wordpress-develop#11234 for the post lock back port.

## Why?

We had competing backport PRs but want to go with the approach that integrates more into core directly.