### PR TITLE
RTC: send `onSuccess` value to useCopyToClipboard for backwards compatibility in sync connection error modal

### DIFF
--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -73,10 +73,10 @@ function DefaultSyncConnectionErrorModal(
 			return serialize( blocks );
 		},
 		/*
-		 * This no-op isn't required after https://github.com/WordPress/gutenberg/pull/75723,
+		 * This "no callback" value isn't required after https://github.com/WordPress/gutenberg/pull/75723,
 		 * but is kept for backwards compatibility with WordPress 7.0 and earlier.
 		 */
-		() => {}
+		undefined
 	);
 
 	let retryCountdownText: string = '';

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -67,10 +67,17 @@ function DefaultSyncConnectionErrorModal(
 		secondsRemainingUntilAutoRetry,
 		title,
 	} = props;
-	const copyButtonRef = useCopyToClipboard( () => {
-		const blocks = select( blockEditorStore ).getBlocks();
-		return serialize( blocks );
-	} );
+	const copyButtonRef = useCopyToClipboard(
+		() => {
+			const blocks = select( blockEditorStore ).getBlocks();
+			return serialize( blocks );
+		},
+		/*
+		 * This no-op isn't required after https://github.com/WordPress/gutenberg/pull/75723,
+		 * but is kept for backwards compatibility with WordPress 7.0 and earlier.
+		 */
+		() => {}
+	);
 
 	let retryCountdownText: string = '';
 	let isRetrying = false;


### PR DESCRIPTION
## Description

I prepped this PR in case backporting https://github.com/WordPress/gutenberg/pull/76554 to `wp/7.0` isn't feasible. I guess if folks are using a mix of old packages it's safer to just add the noop value. I don't know 😄 

Follow up to:

- https://github.com/WordPress/gutenberg/pull/76554

Fixes a TypeScript error in `SyncConnectionErrorModal` when building on `wp/7.0` and earlier branches.

`useCopyToClipboard` from `@wordpress/compose` is called with only one argument (the text getter), but on `wp/7.0` the generated types require both `text` and `onSuccess`. 

On trunk, the hook was rewritten in TypeScript ([#75723](https://github.com/WordPress/gutenberg/pull/75723)) and `onSuccess` is optional, so the single-argument call is valid there.

## Changes

- Pass `undefined` as the second argument to `useCopyToClipboard` to satisfy the type checker on wp/7.0.
- Add a comment noting that this second argument is only needed for backwards compatibility with WordPress 7.0 and earlier.

## Testing

- [ ] `npm run build` passes on wp/7.0
- [ ] Copy Post Content button in the sync connection error modal still copies block content correctly