### PR TITLE
Storybook: Make "introduction" top level

### DIFF
--- a/storybook/stories/introduction.mdx
+++ b/storybook/stories/introduction.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { JumpToIcon } from '@storybook/icons';
-import { InlineIcon } from './inline-icon';
+import { InlineIcon } from './docs/inline-icon';
 
-<Meta title="Docs/Introduction" name="page" />
+<Meta title="Introduction" name="page" />
 
 # Introduction
 


### PR DESCRIPTION
## What?

Followup/related to #76361. 

Tiny PR to change the introduction.mdx file to not be inside a folder. Before:

<img width="536" height="363" alt="Skærmbillede 2026-03-19 kl  10 28 47" src="https://github.com/user-attachments/assets/b2e0cbc4-1665-47f1-bf22-9c9b17fec9dc" />

After:

<img width="701" height="434" alt="Skærmbillede 2026-03-19 kl  10 29 55" src="https://github.com/user-attachments/assets/f59b72a1-83f3-4651-8b8b-a80a6060363d" />

## Why?

"Docs" has only introduction.mdx. If that's the only folder, it's just an extra click, and takes up another item of vertical space. The only reason to keep it would be to have additional files inside the docs folder, but conceptually they belong in named categories, e.g. foundations, components, etc.

## Testing Instructions

npm run storybook:dev