### PR TITLE
Card: Add overflow: clip to root container

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `Card`: Add `overflow: clip` to `Card.Root` to prevent child content from overflowing rounded corners ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `Card`: Add `overflow: clip` to `Card.Root` to prevent child content from overflowing rounded corners ([#76678](https://github.com/WordPress/gutenberg/pull/76678)).
 
 ### Internal
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Card`: Add `overflow: clip` to `Card.Root` to prevent child content from overflowing rounded corners ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+
 ### Internal
 
 -   `Tabs`: Add development-mode validation for Tab/Panel count matching ([#75170](https://github.com/WordPress/gutenberg/pull/75170)).

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -10,6 +10,7 @@
 		flex-direction: column;
 		border: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 		border-radius: var(--wpds-border-radius-lg);
+		overflow: clip;
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 	}
 


### PR DESCRIPTION
## What?

Extracted from https://github.com/WordPress/gutenberg/pull/76282#discussion_r2959390878

Add `overflow: clip` to `Card.Root` in `@wordpress/ui` so that child content with opaque backgrounds doesn't visually overflow the card's rounded corners.

## Why?

`Card.Root` has a `border-radius` but no overflow clipping. When full-bleed content (via `Card.FullBleed`) or any child with an opaque background extends to the card's edges, the rectangular background can "poke out" past the rounded corners, making them appear square.

This is a common pattern in design system Card components — pairing `border-radius` with overflow clipping to ensure visual consistency.

## How?

Added `overflow: clip` to `.root` in the Card's CSS module.

`overflow: clip` is preferred over `overflow: hidden` because:
- It clips content visually at the border-radius boundary (same as `hidden`)
- It does **not** create a new scroll container / block formatting context
- It preserves `position: sticky` behavior inside the card (important for consumers like DataViews with sticky table headers)

## Testing Instructions

1. Open Storybook and navigate to **Card** stories — verify cards render normally with rounded corners
2. Navigate to **DataViews / DataViews / WithCard** — verify the DataViews table inside the card doesn't overflow the rounded corners
3. If testing with full-bleed content that reaches the card's bottom edge, verify corners remain rounded

## Screenshots

_Note: for the sake of taking these screenshots, I applied `style={ { padding: 0, background: 'red' } }` to `Card.Content`_


| Before | After |
|---|---|
| ![Screenshot 2026-03-19 at 13 16 10](https://github.com/user-attachments/assets/95e4ce7f-71aa-4bba-b27d-1c54d3dc89f6) | ![Screenshot 2026-03-19 at 13 16 03](https://github.com/user-attachments/assets/b85fed4d-bf0a-4b4b-a196-0587d7d45a5b) |

Not the bottom left and bottom right corners of the card, and how the outer card radius is only respected after applying changes from this PR

## AI tools

Cursor + Claude Opus 4.6