### PR TITLE
ui/CollapsibleCard: do not animate focus ring

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `Card`: Add `overflow: clip` to `Card.Root` to prevent child content from overflowing rounded corners ([#76678](https://github.com/WordPress/gutenberg/pull/76678)).
+-   `CollapsibleCard`: do not animate the focus ring when expanding/collapsing the card ([#76459](https://github.com/WordPress/gutenberg/pull/76459)).
 
 ### Internal
 

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -35,17 +35,23 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 				nativeButton={ false }
 			>
 				<div className={ styles[ 'header-content' ] }>{ children }</div>
-				<div className={ styles[ 'header-trigger-wrapper' ] }>
-					<Icon
-						icon={ chevronDown }
+				<div
+					className={ clsx( styles[ 'header-trigger-positioner' ] ) }
+				>
+					<div
 						className={ clsx(
-							styles[ 'header-trigger' ],
+							styles[ 'header-trigger-wrapper' ],
 							// While the interactive trigger element is the whole header,
 							// the focus ring will be displayed only on the icon to visually
 							// emulate it being the button.
 							focusStyles[ 'outset-ring--focus-parent-visible' ]
 						) }
-					/>
+					>
+						<Icon
+							icon={ chevronDown }
+							className={ styles[ 'header-trigger' ] }
+						/>
+					</div>
 				</div>
 			</Collapsible.Trigger>
 		);

--- a/packages/ui/src/collapsible-card/style.module.css
+++ b/packages/ui/src/collapsible-card/style.module.css
@@ -6,7 +6,7 @@
 		min-width: 0;
 	}
 
-	.header-trigger-wrapper {
+	.header-trigger-positioner {
 		flex-shrink: 0;
 		align-self: center;
 		/* Prevent the trigger from making the header taller than its content,
@@ -15,7 +15,9 @@
 		overflow: visible;
 	}
 
-	.header-trigger {
+	.header-trigger-wrapper {
+		display: flex;
+
 		/* Offset by half the button's own height so it visually centers
 		   at the wrapper's midpoint (which `align-self: center` places at
 		   the vertical center of the header). */
@@ -23,7 +25,9 @@
 
 		/* For an outline that looks like `IconButton`'s */
 		border-radius: var(--wpds-border-radius-sm);
+	}
 
+	.header-trigger {
 		@media not (prefers-reduced-motion) {
 			transition: rotate 0.15s ease-out;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Remove unwanted animation for the focus ring around the chevron in the `CollapsibleCard` component in the `@wordpress/ui` repo

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The chevron is supposed to animate; the focus ring should not

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add an additional intermediate wrapper to show the focus ring; keep the rotating animation on the SVG element itself

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

_Note: the focus ring is only visible when using the keyboard to focus and trigger the animation_

- Using the keyboard, move focus to the `CollapsibleCard.Header`
- The focus ring should show around the chevron arrow
- Press spacebar to expand/collapse the card
- Notice how the chevron rotates, but the focus ring stays still

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/be41136d-63f3-4323-8149-16608f72956b" /> | <video src="https://github.com/user-attachments/assets/6f243d69-98bd-4b6b-b6c1-aca4b9836952" /> |

## Use of AI Tools

Cursor + Claude Opus 4.6