### PR TITLE
Admin UI: ensure consistent header spacing with and without actions

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Small spacing adjustments between title, subtitle and action elements in the header. [#76683](https://github.com/WordPress/gutenberg/pull/76683)
+
 ### Breaking Changes
 
 -   Change default `headingLevel` for the `Page` component's header from `2` to `1`, meaning from `h2` to `h1`. If you need to keep previous behaviour, use `<Page title="Example" headingLevel={ 2 }>` [#77617](https://github.com/WordPress/gutenberg/pull/77617)

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Small spacing adjustments between title, subtitle and action elements in the header. [#76683](https://github.com/WordPress/gutenberg/pull/76683)
+-   `Page`: Keep the header row at a consistent height regardless of whether actions are present, and stop rendering an empty actions container when no actions are provided [#76683](https://github.com/WordPress/gutenberg/pull/76683).
 
 ### Breaking Changes
 

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,16 +2,14 @@
 
 ## Unreleased
 
-<<<<<<< HEAD
+-   Small spacing adjustments between title, subtitle and action elements in the header. [#76683](https://github.com/WordPress/gutenberg/pull/76683)
+
 ## 1.11.0 (2026-04-01)
 
 ### Bug Fixes
 
 -   `Breadcrumbs`: throw a runtime error when non-last items are missing a `to` prop [#76493](https://github.com/WordPress/gutenberg/pull/76493/)
 -   Fix Page Header not rendering when only `actions` prop is provided. [#76695](https://github.com/WordPress/gutenberg/pull/76695)
-=======
-- Small spacing adjustments between title, subtitle and action elements in the header.
->>>>>>> 808a70d845d (Admin UI: don't output actions container when no actions)
 
 ## 1.10.0 (2026-03-18)
 

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 
+<<<<<<< HEAD
 ## 1.11.0 (2026-04-01)
 
 ### Bug Fixes
 
 -   `Breadcrumbs`: throw a runtime error when non-last items are missing a `to` prop [#76493](https://github.com/WordPress/gutenberg/pull/76493/)
 -   Fix Page Header not rendering when only `actions` prop is provided. [#76695](https://github.com/WordPress/gutenberg/pull/76695)
+=======
+- Small spacing adjustments between title, subtitle and action elements in the header.
+>>>>>>> 808a70d845d (Admin UI: don't output actions container when no actions)
 
 ## 1.10.0 (2026-03-18)
 

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -2,8 +2,6 @@
 	list-style: none;
 	padding: 0;
 	margin: 0;
-	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
-	min-height: calc(var(--wpds-dimension-base) * 8);
 }
 
 /*

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -35,12 +35,12 @@ export default function Header( {
 			className={ styles.header }
 			render={ <header /> }
 		>
-		<Stack
-			className={ styles[ 'header-content' ] }
-			direction="row"
-			gap="sm"
-			justify="space-between"
-		>
+			<Stack
+				className={ styles[ 'header-content' ] }
+				direction="row"
+				gap="sm"
+				justify="space-between"
+			>
 				<Stack direction="row" gap="sm" align="center" justify="start">
 					{ showSidebarToggle && (
 						<SidebarToggleSlot
@@ -72,7 +72,6 @@ export default function Header( {
 					<Stack
 						direction="row"
 						gap="sm"
-						style={ { width: 'auto', flexShrink: 0 } }
 						className={ styles[ 'header-actions' ] }
 						align="center"
 					>

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -63,15 +63,17 @@ export default function Header( {
 					{ breadcrumbs }
 					{ badges }
 				</Stack>
-				<Stack
-					direction="row"
-					gap="sm"
-					style={ { width: 'auto', flexShrink: 0 } }
-					className={ styles[ 'header-actions' ] }
-					align="center"
-				>
-					{ actions }
-				</Stack>
+				{ actions && (
+					<Stack
+						direction="row"
+						gap="sm"
+						style={ { width: 'auto', flexShrink: 0 } }
+						className={ styles[ 'header-actions' ] }
+						align="center"
+					>
+						{ actions }
+					</Stack>
+				) }
 			</Stack>
 			{ subTitle && (
 				<Text

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -70,10 +70,10 @@ export default function Header( {
 				</Stack>
 				{ actions && (
 					<Stack
+						align="center"
+						className={ styles[ 'header-actions' ] }
 						direction="row"
 						gap="sm"
-						className={ styles[ 'header-actions' ] }
-						align="center"
 					>
 						{ actions }
 					</Stack>

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -35,7 +35,12 @@ export default function Header( {
 			className={ styles.header }
 			render={ <header /> }
 		>
-			<Stack direction="row" justify="space-between" gap="sm">
+		<Stack
+			className={ styles[ 'header-content' ] }
+			direction="row"
+			gap="sm"
+			justify="space-between"
+		>
 				<Stack direction="row" gap="sm" align="center" justify="start">
 					{ showSidebarToggle && (
 						<SidebarToggleSlot

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -32,7 +32,12 @@ export default function Header( {
 			className="admin-ui-page__header"
 			render={ <header /> }
 		>
-			<Stack direction="row" justify="space-between" gap="sm">
+			<Stack
+				className="admin-ui-page__header-content"
+				direction="row"
+				gap="sm"
+				justify="space-between"
+			>
 				<Stack direction="row" gap="sm" align="center" justify="start">
 					{ showSidebarToggle && (
 						<SidebarToggleSlot

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -48,15 +48,17 @@ export default function Header( {
 					{ breadcrumbs }
 					{ badges }
 				</Stack>
-				<Stack
-					direction="row"
-					gap="sm"
-					style={ { width: 'auto', flexShrink: 0 } }
-					className="admin-ui-page__header-actions"
-					align="center"
-				>
-					{ actions }
-				</Stack>
+				{ actions && (
+					<Stack
+						direction="row"
+						gap="sm"
+						style={ { width: 'auto', flexShrink: 0 } }
+						className="admin-ui-page__header-actions"
+						align="center"
+					>
+						{ actions }
+					</Stack>
+				) }
 			</Stack>
 			{ subTitle && (
 				<p className="admin-ui-page__header-subtitle">{ subTitle }</p>

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -39,7 +39,7 @@
 	grid-template-columns: 1fr;
 	grid-template-rows: 1fr;
 	flex-shrink: 0;
-	/* @TODO: Replace with a `size` token once that category exists in the theme package. *
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
 	width: calc(var(--wpds-dimension-base) * 6);
 	height: calc(var(--wpds-dimension-base) * 6);
 

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -19,8 +19,8 @@
 }
 
 .header-content {
-	/* TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-md. See https://github.com/WordPress/gutenberg/pull/76545 */
-	min-height: 32px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	min-height: calc(var(--wpds-dimension-base) * 8);
 }
 
 .header-actions {

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -39,9 +39,9 @@
 	grid-template-columns: 1fr;
 	grid-template-rows: 1fr;
 	flex-shrink: 0;
-	/* TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-sm. See https://github.com/WordPress/gutenberg/pull/76545 */
-	width: 24px;
-	height: 24px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. *
+	width: calc(var(--wpds-dimension-base) * 6);
+	height: calc(var(--wpds-dimension-base) * 6);
 
 	> * {
 		grid-column: 1 / -1;

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -18,6 +18,15 @@
 	z-index: 1;
 }
 
+.header-content {
+	min-height: 32px;
+}
+
+.header-actions {
+	width: auto;
+	flex-shrink: 0;
+}
+
 /* @TODO: Remove truncation styles once `Text` supports truncation natively. See https://github.com/WordPress/gutenberg/issues/77391 */
 .header-title {
 	overflow: hidden;

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -19,6 +19,7 @@
 }
 
 .header-content {
+	/* TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-md. See https://github.com/WordPress/gutenberg/pull/76545 */
 	min-height: 32px;
 }
 
@@ -39,7 +40,7 @@
 	grid-template-columns: 1fr;
 	grid-template-rows: 1fr;
 	flex-shrink: 0;
-	/* TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-sm. */
+	/* TODO: replace fixed size values with design tokens when ready, likely --wpds-dimension-size-sm. See https://github.com/WordPress/gutenberg/pull/76545 */
 	width: 24px;
 	height: 24px;
 

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -24,7 +24,6 @@
 }
 
 .header-actions {
-	width: auto;
 	flex-shrink: 0;
 }
 

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -22,6 +22,10 @@
 	z-index: 1;
 }
 
+.admin-ui-page__header-content {
+	min-height: 40px;
+}
+
 .admin-ui-page__header-title {
 	// @TODO: use Text component from UI when available.
 	font-family: var(--wpds-font-family-heading);

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -23,7 +23,7 @@
 }
 
 .admin-ui-page__header-content {
-	min-height: 40px;
+	min-height: 32px;
 }
 
 .admin-ui-page__header-title {


### PR DESCRIPTION
See design convo https://github.com/WordPress/gutenberg/issues/76709


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Follow-up to findings in title/breadcrumb size adjustment PR:
- https://github.com/WordPress/gutenberg/pull/76452#issuecomment-4081636476

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of the changes suggested in:
- https://github.com/WordPress/gutenberg/issues/76448

Set consistent height for title + breadcrumbs + badge + actions row; previously, the row height would depend on whether there were actions or not, making the gap between title and subtitle inconsistent.

Also stops outputting the actions container if there are no actions.

### Set consistent height for title + breadcrumbs + badge + actions row

#### All patterns

Before
<img width="712" height="150" alt="Screenshot 2026-03-19 at 15 37 04" src="https://github.com/user-attachments/assets/d37fe6bb-b8ee-4011-a653-79d8542ce58d" />

After
<img width="695" height="154" alt="Screenshot 2026-03-19 at 15 36 56" src="https://github.com/user-attachments/assets/8ce22dc6-460a-4da8-ba72-cc0f6ee17e38" />

#### Connectors

Before
<img width="892" height="135" alt="Screenshot 2026-03-19 at 15 54 44" src="https://github.com/user-attachments/assets/756fcdd8-e35c-483e-879a-57fa5c96fa2a" />

After
<img width="903" height="159" alt="Screenshot 2026-03-19 at 15 54 33" src="https://github.com/user-attachments/assets/1ff428cf-9118-4ee9-b1ca-2bdfb31471eb" />


#### Fonts
Before
<img width="930" height="126" alt="Screenshot 2026-03-19 at 15 36 36" src="https://github.com/user-attachments/assets/7c5c8bf9-9680-4a37-900c-04a442ae4a09" />

After
<img width="929" height="160" alt="Screenshot 2026-03-19 at 15 36 06" src="https://github.com/user-attachments/assets/3cf0b72b-c803-4147-a390-3ce32a482421" />

Helps with the gap between the title row and the subtitle to always stay consistent regardless if there are actions or not.



### Don't output actions container if there are no actions

Before
<img width="1494" height="379" alt="Screenshot 2026-03-19 at 14 49 43" src="https://github.com/user-attachments/assets/92c28bcd-84fa-4e62-af12-cbda228ad080" />

After
<img width="1512" height="339" alt="Screenshot 2026-03-19 at 15 27 51" src="https://github.com/user-attachments/assets/3fc3dd77-d55c-4e4b-8af5-cc01cee036f1" />



<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. ->
See pages which ommit title, subtitle, or actions in different combinations, such as:
- Appearance → Fonts
- Appearance → Editor → Patterns
- Settings → Connectors

You can also test changes via storybook. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
