### PR TITLE
Fix navigation block rendering unit test

### DIFF
--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -31,7 +31,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $navigation_link_block );
 
-		$expected = '<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content"  href="/hello-world"><span class="wp-block-navigation-item__label">Sample Page</span></a></li>';
+		$expected = '<li class="wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content"  href="/hello-world"><span class="wp-block-navigation-item__label">Sample Page</span></a></li>';
 		$this->assertEquals( $expected, $result );
 	}
 

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -123,7 +123,7 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		$navigation_submenu_block = new WP_Block( $block, $context );
 
 		$this->assertStringContainsString(
-			'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-background">',
+			'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . '" class="wp-block-navigation__submenu-container has-text-color has-background">',
 			gutenberg_render_block_core_navigation_submenu(
 				$navigation_submenu_block->attributes,
 				array(),
@@ -159,7 +159,7 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 		$navigation_submenu_block = new WP_Block( $block, $context );
 
 		$this->assertStringContainsString(
-			'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
+			'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . '" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
 			gutenberg_render_block_core_navigation_submenu(
 				$navigation_submenu_block->attributes,
 				array(),


### PR DESCRIPTION
## What?

[Changeset 62068](https://core.trac.wordpress.org/changeset/62068) improved the behavior of `get_block_wrapper_attributes()` by trimming unnecessary whitespace and semicolon, which has caused some unit tests to start failing.

## How?

Simply remove the space and semicolon from the expected values.

## Testing Instructions

All CI checks should be green.

## Use of AI Tools

None