### PR TITLE
Backport: invalidates_query_cache meta parameter

### DIFF
--- a/backport-changelog/7.0/11290.md
+++ b/backport-changelog/7.0/11290.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11290
+
+* https://github.com/WordPress/gutenberg/pull/76687

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -98,6 +98,22 @@ if ( ! function_exists( 'wp_collaboration_register_meta' ) ) {
 	add_action( 'init', 'gutenberg_rest_api_crdt_post_meta' );
 }
 
+if ( ! function_exists( 'wp_collaboration_register_non_cacheable_meta' ) ) {
+	/**
+	 * Registers RTC meta keys as non-cache-invalidating.
+	 *
+	 * These keys are written at high frequency during collaborative editing
+	 * and should not bump the `last_changed` timestamp in the posts cache group.
+	 *
+	 * @since 20.3.0
+	 */
+	function gutenberg_collaboration_register_non_cacheable_meta() {
+		gutenberg_register_non_cacheable_post_meta( 'wp_sync_awareness' );
+		gutenberg_register_non_cacheable_post_meta( 'wp_sync_update' );
+	}
+	add_action( 'init', 'gutenberg_collaboration_register_non_cacheable_meta' );
+}
+
 if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 	/**
 	 * Registers the real-time collaboration setting.

--- a/lib/compat/wordpress-7.0/post-meta-cache.php
+++ b/lib/compat/wordpress-7.0/post-meta-cache.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Post meta cache invalidation control.
+ *
+ * Backports the `invalidates_query_cache` parameter from WordPress Core.
+ * Allows specific post meta keys to be marked as non-cache-invalidating,
+ * preventing unnecessary `last_changed` bumps in the posts cache group.
+ *
+ * @package gutenberg
+ * @since 20.3.0
+ *
+ * @see https://core.trac.wordpress.org/ticket/64696
+ * @see https://github.com/WordPress/wordpress-develop/pull/11290
+ */
+
+if ( ! function_exists( 'wp_post_meta_invalidates_query_cache' ) ) {
+
+	/**
+	 * Manages the registry of non-cache-invalidating post meta keys.
+	 *
+	 * When called with a meta key, registers it as non-cacheable.
+	 * Always returns the full list of registered keys.
+	 *
+	 * @since 20.3.0
+	 * @access private
+	 *
+	 * @param string|null $meta_key Optional. Meta key to register. Default null.
+	 * @return string[] Array of non-cacheable meta keys.
+	 */
+	function gutenberg_non_cacheable_post_meta_keys( $meta_key = null ) {
+		static $keys = array();
+
+		if ( null !== $meta_key && ! in_array( $meta_key, $keys, true ) ) {
+			$keys[] = $meta_key;
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * Registers a post meta key as non-cache-invalidating.
+	 *
+	 * Meta keys registered this way will not bump the `last_changed`
+	 * timestamp in the `posts` cache group when added, updated, or deleted.
+	 *
+	 * @since 20.3.0
+	 *
+	 * @param string $meta_key Meta key to register as non-cacheable.
+	 */
+	function gutenberg_register_non_cacheable_post_meta( $meta_key ) {
+		gutenberg_non_cacheable_post_meta_keys( $meta_key );
+	}
+
+	/**
+	 * Checks whether a post meta key invalidates query caches when updated.
+	 *
+	 * Unregistered meta keys are assumed to invalidate query caches.
+	 *
+	 * @since 20.3.0
+	 *
+	 * @param string $meta_key  Metadata key.
+	 * @param string $post_type Post type to check. Not used in the backport
+	 *                          but included for API compatibility with Core.
+	 * @return bool True if the meta key invalidates query caches, false otherwise.
+	 */
+	function wp_post_meta_invalidates_query_cache( $meta_key, $post_type = '' ) {
+		$non_cacheable = gutenberg_non_cacheable_post_meta_keys();
+		return ! in_array( $meta_key, $non_cacheable, true );
+	}
+
+	/**
+	 * Conditionally sets the last changed time for the 'posts' cache group.
+	 *
+	 * Skips cache invalidation for meta keys registered as non-cacheable
+	 * via `gutenberg_register_non_cacheable_post_meta()`.
+	 *
+	 * @since 20.3.0
+	 *
+	 * @param int    $meta_id   Meta ID.
+	 * @param int    $object_id Object ID.
+	 * @param string $meta_key  Meta key.
+	 */
+	function gutenberg_cache_set_posts_last_changed( $meta_id, $object_id, $meta_key ) {
+		if ( $meta_key && ! wp_post_meta_invalidates_query_cache( $meta_key ) ) {
+			return;
+		}
+
+		wp_cache_set_posts_last_changed();
+	}
+
+	// Replace Core's unconditional cache invalidation hooks with the
+	// conditional version that checks the meta key registry.
+	remove_action( 'added_post_meta', 'wp_cache_set_posts_last_changed' );
+	remove_action( 'updated_post_meta', 'wp_cache_set_posts_last_changed' );
+	remove_action( 'deleted_post_meta', 'wp_cache_set_posts_last_changed' );
+
+	add_action( 'added_post_meta', 'gutenberg_cache_set_posts_last_changed', 10, 3 );
+	add_action( 'updated_post_meta', 'gutenberg_cache_set_posts_last_changed', 10, 3 );
+	add_action( 'deleted_post_meta', 'gutenberg_cache_set_posts_last_changed', 10, 3 );
+}

--- a/lib/compat/wordpress-7.0/post-meta-cache.php
+++ b/lib/compat/wordpress-7.0/post-meta-cache.php
@@ -63,7 +63,7 @@ if ( ! function_exists( 'wp_post_meta_invalidates_query_cache' ) ) {
 	 *                          but included for API compatibility with Core.
 	 * @return bool True if the meta key invalidates query caches, false otherwise.
 	 */
-	function wp_post_meta_invalidates_query_cache( $meta_key, $post_type = '' ) {
+	function wp_post_meta_invalidates_query_cache( $meta_key, $post_type = '' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- $post_type kept for API compatibility with Core.
 		$non_cacheable = gutenberg_non_cacheable_post_meta_keys();
 		return ! in_array( $meta_key, $non_cacheable, true );
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -72,6 +72,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.0/class-gutenberg-rest-static-templates-controller.php';
 	require __DIR__ . '/compat/wordpress-7.0/class-wp-icons-registry.php';
 	require __DIR__ . '/compat/wordpress-7.0/class-wp-rest-icons-controller.php';
+	require __DIR__ . '/compat/wordpress-7.0/post-meta-cache.php';
 	require __DIR__ . '/compat/wordpress-7.0/collaboration.php';
 	require __DIR__ . '/compat/wordpress-7.0/template-activate.php';
 	require __DIR__ . '/compat/wordpress-7.0/rest-api.php';


### PR DESCRIPTION
## What?

Backports WordPress Core PR #11290: Allow registering post meta keys that skip query cache invalidation.

## Why?

RTC (real-time collaboration) meta keys (`wp_sync_awareness`, `wp_sync_update`) are written at high frequency during collaborative editing. Each write was invalidating the posts cache group's `last_changed` timestamp site-wide, causing all post queries to miss their caches. This backport prevents non-cacheable meta keys from triggering cache invalidation.

## How?

Uses hook-based interception since Core's `register_meta()` cannot be modified:
- New file: `lib/compat/wordpress-7.0/post-meta-cache.php` with standalone registry
- Replaces Core's `added/updated/deleted_post_meta` hooks with conditional version
- Registers RTC meta keys as non-cacheable in collaboration.php
- Automatically disabled when WordPress 7.0+ ships with native support

## Testing

- Verifies that non-cacheable meta writes do not bump `wp_cache_get_last_changed( 'posts' )`
- Existing tests should pass unchanged
- Function is guarded by `! function_exists( 'wp_post_meta_invalidates_query_cache' )`