### PR TITLE
Fix homepage badge incorrectly shown for draft pages

### DIFF
--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -211,6 +211,18 @@ describe( 'isHomepage', () => {
 	] )( 'should return false for non-homepage "%s"', ( url, homeUrlParam ) => {
 		expect( isHomepage( url, homeUrlParam ) ).toBe( false );
 	} );
+
+	test.each( [
+		[ `https://${ host }/?p=123`, homeUrl ],
+		[ `https://${ host }/?p=456`, homeUrl ],
+		[ `https://${ host }/?page_id=99`, homeUrl ],
+		[ '/?p=123', homeUrl ],
+	] )(
+		'should return false for URLs with query params "%s"',
+		( url, homeUrlParam ) => {
+			expect( isHomepage( url, homeUrlParam ) ).toBe( false );
+		}
+	);
 } );
 
 describe( 'computeBadges', () => {
@@ -321,6 +333,29 @@ describe( 'computeBadges', () => {
 
 			expect( badges ).toContainEqual( {
 				label: 'Page',
+				intent: 'default',
+			} );
+		} );
+
+		it( 'should show Page and Draft badges for draft page with ?p= URL, not Homepage', () => {
+			const badges = computeBadges( {
+				url: 'https://example.com/?p=123',
+				homeUrl: 'https://example.com',
+				type: 'page',
+				entityStatus: 'draft',
+				isExternal: false,
+			} );
+
+			expect( badges ).toContainEqual( {
+				label: 'Page',
+				intent: 'default',
+			} );
+			expect( badges ).toContainEqual( {
+				label: 'Draft',
+				intent: 'warning',
+			} );
+			expect( badges ).not.toContainEqual( {
+				label: 'Homepage',
 				intent: 'default',
 			} );
 		} );

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -55,7 +55,19 @@ export function isHomepage( url, homeUrl ) {
 		const urlPath = urlParsed.pathname.replace( /\/$/, '' );
 		const homePath = homeParsed.pathname.replace( /\/$/, '' );
 
-		return urlPath === homePath;
+		// Check paths match
+		if ( urlPath !== homePath ) {
+			return false;
+		}
+
+		// URLs with query params (e.g. ?p=123 for drafts, ?page_id=2 for pages)
+		// are not the homepage. We cannot distinguish homepage from other pages
+		// when pretty permalinks are off, so we exclude all to avoid false positives.
+		if ( urlParsed.search ) {
+			return false;
+		}
+
+		return true;
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
## What

Fixes the bug where draft pages added to navigation were incorrectly badged as "Homepage" in the link picker.

## Why

Draft URLs like `/?p=123` share the same pathname (`/`) as the homepage, so the previous logic treated them as homepage. We cannot reliably distinguish homepage from other pages when URLs have query params, so we exclude all to avoid false positives.

## How

`isHomepage()` now excludes URLs with query parameters. Draft pages show "Page" + "Draft" instead of "Homepage".

## Testing Instructions

1. Create a draft page
2. Add it to a Navigation block
3. Open the link picker for that item
4. **Expected:** Shows "Page" + "Draft" badges (NOT "Homepage")
