### PR TITLE
UI: Add Drawer primitive

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Dialog`, `AlertDialog`, `Popover`, `Tooltip`, `Select`: **`Popup` portal API** ([#77452](https://github.com/WordPress/gutenberg/pull/77452)). Add `Portal` subcomponents and an optional `portal` prop on `Popup` (when omitted, the default `Portal` is used). Remove `container` from every `Popup` and `portalClassName` from `Dialog.Popup` / `AlertDialog.Popup`; pass `portal={ <Matching.Portal … /> }` for `container`, `className`, `style`, and other portal options.
 
+### New Features
+
+-   Add `Drawer` primitive ([#76690](https://github.com/WordPress/gutenberg/pull/76690)).
+
 ### Documentation
 
 -   Restructure setup docs into "Within standard WordPress editor screens" and "Elsewhere" for clarity ([#77338](https://github.com/WordPress/gutenberg/pull/77338)).
@@ -45,7 +49,6 @@
 ### New Features
 
 -   Add `Popover` primitive ([#76438](https://github.com/WordPress/gutenberg/pull/76438)).
--   Add `Drawer` primitive ([#76690](https://github.com/WordPress/gutenberg/pull/76690)).
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### New Features
 
 -   Add `Popover` primitive ([#76438](https://github.com/WordPress/gutenberg/pull/76438)).
+-   Add `Drawer` primitive ([#76690](https://github.com/WordPress/gutenberg/pull/76690)).
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Enhancements
 
 -   `Dialog`: Add `Dialog.Description` sub-component, expose `onOpenChangeComplete`, skip the backdrop when `modal` is not `true`, use `100dvh` for viewport-based heights so the popup fits the dynamic viewport on mobile, and forward `className` on `Dialog.Title` ([#77194](https://github.com/WordPress/gutenberg/pull/77194)).
+-   `Dialog`: `Dialog.Header` and `Dialog.Footer` now default to `<header>` and `<footer>` elements for richer landmark semantics. Their `ref` type widens from `HTMLDivElement` to `HTMLElement`; pass `render` to opt out of the default tag ([#76690](https://github.com/WordPress/gutenberg/pull/76690)).
 -   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### New Features
 
 -   Add `Popover` primitive ([#76438](https://github.com/WordPress/gutenberg/pull/76438)).
+-   Add `Drawer` primitive ([#76690](https://github.com/WordPress/gutenberg/pull/76690)).
 
 ### Bug Fixes
 

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -111,6 +111,44 @@ export const WithCustomContent: Story = {
 	},
 };
 
+/**
+ * Popovers in Gutenberg are managed with explicit z-index values, which can
+ * create situations where an alert dialog renders below another popover when
+ * you want it above.
+ *
+ * `AlertDialog` reuses `Dialog`'s styles, so the same
+ * `--wp-ui-dialog-z-index` CSS variable controls the z-index of both the
+ * backdrop and the popup. Override it either:
+ *
+ * - **Globally**, by setting the variable on `:root` or `body` (raises every
+ *   dialog and alert dialog in the page), or
+ * - **Per instance**, by passing an `AlertDialog.Portal` with a `style` (or
+ *   `className`) to `AlertDialog.Popup`'s `portal` prop. The variable
+ *   cascades from the portal wrapper to the backdrop and the popup, which
+ *   are both rendered inside it.
+ *
+ * This story demonstrates the per-instance approach.
+ */
+export const WithCustomZIndex: Story = {
+	name: 'With Custom z-index',
+	args: {
+		children: (
+			<>
+				<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
+				<AlertDialog.Popup
+					title="Move to trash?"
+					description="This post will be moved to trash. You can restore it later."
+					portal={
+						<AlertDialog.Portal
+							style={ { '--wp-ui-dialog-z-index': '9999' } }
+						/>
+					}
+				/>
+			</>
+		),
+	},
+};
+
 const menuPopupStyles: React.CSSProperties = {
 	background: 'var(--wpds-color-bg-surface-neutral-strong)',
 	border: '1px solid var(--wpds-color-stroke-surface-neutral)',

--- a/packages/ui/src/dialog/context.tsx
+++ b/packages/ui/src/dialog/context.tsx
@@ -1,152 +1,29 @@
 import type { Dialog as _Dialog } from '@base-ui/react/dialog';
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
-import { useScheduleValidation } from '../utils/use-schedule-validation';
+import { createOverlayModalContext } from '../utils/create-overlay-modal-context';
+import { createOverlayTitleValidation } from '../utils/create-overlay-title-validation';
 
 // -- Modal context ----------------------------------------------------------
 
-const DialogModalContext =
-	createContext< _Dialog.Root.Props[ 'modal' ] >( true );
+const dialogModal =
+	createOverlayModalContext< _Dialog.Root.Props[ 'modal' ] >( true );
 
-export function DialogModalProvider( {
-	modal,
-	children,
-}: {
-	modal: _Dialog.Root.Props[ 'modal' ];
-	children: React.ReactNode;
-} ) {
-	return (
-		<DialogModalContext.Provider value={ modal }>
-			{ children }
-		</DialogModalContext.Provider>
-	);
-}
-
-export function useDialogModal() {
-	return useContext( DialogModalContext );
-}
+export const DialogModalProvider = dialogModal.Provider;
+export const useDialogModal = dialogModal.useModal;
 
 // -- Validation context (dev-only) ------------------------------------------
 
-/**
- * Whether validation is enabled. This is a build-time constant that allows
- * bundlers to tree-shake all validation code in production builds.
- */
-const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
-
-type DialogValidationContextType = {
-	registerTitle: ( element: HTMLElement | null ) => () => void;
-};
-
-// Context is only created in development mode.
-const DialogValidationContext = VALIDATION_ENABLED
-	? createContext< DialogValidationContextType | null >( null )
-	: ( null as unknown as React.Context< DialogValidationContextType | null > );
-
-/**
- * Development-only hook to access the dialog validation context.
- */
-function useDialogValidationContextDev() {
-	return useContext( DialogValidationContext );
-}
-
-/**
- * Production no-op hook.
- */
-function useDialogValidationContextProd() {
-	return null;
-}
+const dialogTitleValidation = createOverlayTitleValidation( 'Dialog' );
 
 /**
  * Hook to access the dialog validation context.
  * Returns null in production or if not within a Dialog.Popup.
  */
-export const useDialogValidationContext = VALIDATION_ENABLED
-	? useDialogValidationContextDev
-	: useDialogValidationContextProd;
-
-/**
- * Development-only provider that tracks whether Dialog.Title is rendered.
- */
-function DialogValidationProviderDev( {
-	children,
-}: {
-	children: React.ReactNode;
-} ) {
-	const titleElementRef = useRef< HTMLElement | null >( null );
-
-	const scheduleValidation = useScheduleValidation( () => {
-		const titleElement = titleElementRef.current;
-
-		if ( ! titleElement ) {
-			throw new Error(
-				'Dialog: Missing <Dialog.Title>. ' +
-					'For accessibility, every dialog requires a title. ' +
-					'If needed, the title can be visually hidden but must not be omitted.'
-			);
-		}
-
-		const textContent = titleElement.textContent?.trim();
-		if ( ! textContent ) {
-			throw new Error(
-				'Dialog: <Dialog.Title> cannot be empty. ' +
-					'Provide meaningful text content for the dialog title.'
-			);
-		}
-	} );
-
-	const registerTitle = useCallback(
-		( element: HTMLElement | null ) => {
-			titleElementRef.current = element;
-			scheduleValidation();
-
-			return () => {
-				titleElementRef.current = null;
-				scheduleValidation();
-			};
-		},
-		[ scheduleValidation ]
-	);
-
-	const contextValue = useMemo(
-		() => ( { registerTitle } ),
-		[ registerTitle ]
-	);
-
-	// Schedule an initial validation on mount to catch missing titles
-	// (when no Title component is rendered, registerTitle is never called).
-	useEffect( () => {
-		scheduleValidation();
-	}, [ scheduleValidation ] );
-
-	return (
-		<DialogValidationContext.Provider value={ contextValue }>
-			{ children }
-		</DialogValidationContext.Provider>
-	);
-}
-
-/**
- * Production no-op provider that just renders children.
- */
-function DialogValidationProviderProd( {
-	children,
-}: {
-	children: React.ReactNode;
-} ) {
-	return <>{ children }</>;
-}
+export const useDialogValidationContext =
+	dialogTitleValidation.useValidationContext;
 
 /**
  * Provider component that validates Dialog.Title presence in development mode.
  * In production, this component is a no-op and just renders children.
  */
-export const DialogValidationProvider = VALIDATION_ENABLED
-	? DialogValidationProviderDev
-	: DialogValidationProviderProd;
+export const DialogValidationProvider =
+	dialogTitleValidation.ValidationProvider;

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -1,5 +1,4 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
-import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
 import styles from './style.module.css';
@@ -11,13 +10,13 @@ import type { DescriptionProps } from './types';
  * The rendered element is linked to the popup via `aria-describedby`.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
-	function DialogDescription( { className, children, ...props }, ref ) {
+	function DialogDescription( { children, ...props }, ref ) {
 		return (
 			<Text
 				ref={ ref }
 				variant="body-md"
 				render={ <_Dialog.Description { ...props } /> }
-				className={ clsx( styles.description, className ) }
+				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/dialog/footer.tsx
+++ b/packages/ui/src/dialog/footer.tsx
@@ -8,9 +8,9 @@ import type { FooterProps } from './types';
  * Renders the footer section of the dialog, typically containing
  * action buttons.
  *
- * Defaults to a native `<footer>` element so the dialog exposes a landmark
- * that assistive technology can navigate to directly. Pass `render` to opt
- * out of the default tag.
+ * Defaults to a native `<footer>` element for richer semantics (contentinfo
+ * landmark navigation where screen readers expose landmarks nested in
+ * dialogs). Pass `render` to opt out of the default tag.
  */
 const Footer = forwardRef< HTMLElement, FooterProps >( function DialogFooter(
 	{ className, render, ...props },

--- a/packages/ui/src/dialog/footer.tsx
+++ b/packages/ui/src/dialog/footer.tsx
@@ -7,15 +7,20 @@ import type { FooterProps } from './types';
 /**
  * Renders the footer section of the dialog, typically containing
  * action buttons.
+ *
+ * Defaults to a native `<footer>` element so the dialog exposes a landmark
+ * that assistive technology can navigate to directly. Pass `render` to opt
+ * out of the default tag.
  */
-const Footer = forwardRef< HTMLDivElement, FooterProps >( function DialogFooter(
+const Footer = forwardRef< HTMLElement, FooterProps >( function DialogFooter(
 	{ className, render, ...props },
 	ref
 ) {
 	const element = useRender( {
+		defaultTagName: 'footer',
 		render,
 		ref,
-		props: mergeProps< 'div' >( props, {
+		props: mergeProps< 'footer' >( props, {
 			className: clsx( styles.footer, className ),
 		} ),
 	} );

--- a/packages/ui/src/dialog/header.tsx
+++ b/packages/ui/src/dialog/header.tsx
@@ -7,15 +7,20 @@ import type { HeaderProps } from './types';
 /**
  * Renders the header section of the dialog, typically containing
  * the heading and close button.
+ *
+ * Defaults to a native `<header>` element so the dialog exposes a landmark
+ * that assistive technology can navigate to directly. Pass `render` to opt
+ * out of the default tag.
  */
-const Header = forwardRef< HTMLDivElement, HeaderProps >( function DialogHeader(
+const Header = forwardRef< HTMLElement, HeaderProps >( function DialogHeader(
 	{ className, render, ...props },
 	ref
 ) {
 	const element = useRender( {
+		defaultTagName: 'header',
 		render,
 		ref,
-		props: mergeProps< 'div' >( props, {
+		props: mergeProps< 'header' >( props, {
 			className: clsx( styles.header, className ),
 		} ),
 	} );

--- a/packages/ui/src/dialog/header.tsx
+++ b/packages/ui/src/dialog/header.tsx
@@ -8,9 +8,9 @@ import type { HeaderProps } from './types';
  * Renders the header section of the dialog, typically containing
  * the heading and close button.
  *
- * Defaults to a native `<header>` element so the dialog exposes a landmark
- * that assistive technology can navigate to directly. Pass `render` to opt
- * out of the default tag.
+ * Defaults to a native `<header>` element for richer semantics (heading-level
+ * scanning, and banner landmark navigation where screen readers expose
+ * landmarks nested in dialogs). Pass `render` to opt out of the default tag.
  */
 const Header = forwardRef< HTMLElement, HeaderProps >( function DialogHeader(
 	{ className, render, ...props },

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -55,7 +55,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 			{ modal === true && (
 				<_Dialog.Backdrop
 					className={ styles.backdrop }
-					data-wp-ui-dialog-backdrop=""
+					data-testid="dialog-backdrop"
 				/>
 			) }
 			<ThemeProvider>

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -132,17 +132,51 @@ export const AllSizes: Story = {
 };
 
 /**
- * Popovers in Gutenberg are managed with explicit z-index values, which can create
- * situations where a dialog renders below another popover, when you want it to be rendered above.
+ * Popovers in Gutenberg are managed with explicit z-index values, which can
+ * create situations where a dialog renders below another popover when you
+ * want it above.
  *
  * The `--wp-ui-dialog-z-index` CSS variable controls the z-index of both the
- * backdrop and the popup. It can be overridden globally by setting the variable
- * on `:root` or `body`. (This story doesn't actually demonstrate the feature
- * because it requires a global CSS rule.)
+ * backdrop and the popup. Override it either:
+ *
+ * - **Globally**, by setting the variable on `:root` or `body` (raises every
+ *   dialog in the page), or
+ * - **Per instance**, by passing a `Dialog.Portal` with a `style` (or
+ *   `className`) to `Dialog.Popup`'s `portal` prop. The variable cascades
+ *   from the portal wrapper to the backdrop and the popup, which are both
+ *   rendered inside it.
+ *
+ * This story demonstrates the per-instance approach.
  */
 export const WithCustomZIndex: Story = {
-	..._Default,
 	name: 'With Custom z-index',
+	args: {
+		children: (
+			<>
+				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+				<Dialog.Popup
+					portal={
+						<Dialog.Portal
+							style={ { '--wp-ui-dialog-z-index': '9999' } }
+						/>
+					}
+				>
+					<Dialog.Header>
+						<Dialog.Title>Custom z-index</Dialog.Title>
+						<Dialog.CloseIcon />
+					</Dialog.Header>
+					<Dialog.Description>
+						The backdrop and popup render at `z-index: 9999` via
+						the `--wp-ui-dialog-z-index` CSS custom property, set
+						on `Dialog.Portal` through the `portal` prop.
+					</Dialog.Description>
+					<Dialog.Footer>
+						<Dialog.Action>Got it</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</>
+		),
+	},
 };
 
 /**

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -166,9 +166,9 @@ export const WithCustomZIndex: Story = {
 						<Dialog.CloseIcon />
 					</Dialog.Header>
 					<Dialog.Description>
-						The backdrop and popup render at `z-index: 9999` via
-						the `--wp-ui-dialog-z-index` CSS custom property, set
-						on `Dialog.Portal` through the `portal` prop.
+						The backdrop and popup render at `z-index: 9999` via the
+						`--wp-ui-dialog-z-index` CSS custom property, set on
+						`Dialog.Portal` through the `portal` prop.
 					</Dialog.Description>
 					<Dialog.Footer>
 						<Dialog.Action>Got it</Dialog.Action>

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -22,7 +22,7 @@
 	}
 
 	.popup {
-		--_viewport-inset: var(--wpds-dimension-padding-2xl);
+		--viewport-inset: var(--wpds-dimension-padding-2xl);
 
 		position: fixed;
 		top: 50%;
@@ -32,8 +32,8 @@
 		transform: translate(-50%, -50%);
 		box-sizing: border-box;
 		min-width: var(--wpds-dimension-surface-width-sm);
-		width: calc(100vw - 2 * var(--_viewport-inset));
-		max-height: calc(100dvh - 2 * var(--_viewport-inset));
+		width: calc(100vw - 2 * var(--viewport-inset));
+		max-height: calc(100dvh - 2 * var(--viewport-inset));
 		padding: var(--wpds-dimension-padding-2xl);
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-lg);

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
 import * as Dialog from '../index';
@@ -376,7 +376,9 @@ describe( 'Dialog', () => {
 			} );
 
 			// Allow deferred validation to settle.
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			cleanup();
@@ -482,7 +484,9 @@ describe( 'Dialog', () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
 
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			cleanup();
@@ -518,7 +522,9 @@ describe( 'Dialog', () => {
 			} );
 
 			// Let initial validation settle — no errors expected.
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			// Remove the title.
@@ -583,7 +589,9 @@ describe( 'Dialog', () => {
 			);
 
 			// Wait for deferred validation to settle.
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 
 			// No new errors should have been thrown.
 			expect( errors ).toHaveLength( errorCountAfterInitial );

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -22,11 +22,11 @@ describe( 'Dialog', () => {
 		const triggerRef = createRef< HTMLButtonElement >();
 		const popupRef = createRef< HTMLDivElement >();
 		const actionRef = createRef< HTMLButtonElement >();
-		const headerRef = createRef< HTMLDivElement >();
+		const headerRef = createRef< HTMLElement >();
 		const titleRef = createRef< HTMLHeadingElement >();
 		const descriptionRef = createRef< HTMLParagraphElement >();
 		const closeIconRef = createRef< HTMLButtonElement >();
-		const footerRef = createRef< HTMLDivElement >();
+		const footerRef = createRef< HTMLElement >();
 
 		render(
 			<Dialog.Root>
@@ -60,12 +60,14 @@ describe( 'Dialog', () => {
 		} );
 
 		// Now that the dialog is open, verify all inner refs
-		expect( headerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( headerRef.current ).toBeInstanceOf( HTMLElement );
+		expect( headerRef.current?.tagName ).toBe( 'HEADER' );
 		expect( titleRef.current ).toBeInstanceOf( HTMLHeadingElement );
 		expect( descriptionRef.current ).toBeInstanceOf( HTMLParagraphElement );
 		expect( closeIconRef.current ).toBeInstanceOf( HTMLButtonElement );
 		expect( actionRef.current ).toBeInstanceOf( HTMLButtonElement );
-		expect( footerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( footerRef.current ).toBeInstanceOf( HTMLElement );
+		expect( footerRef.current?.tagName ).toBe( 'FOOTER' );
 	} );
 
 	it( 'associates Dialog.Description with the popup via aria-describedby', async () => {

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -88,8 +88,11 @@ describe( 'Dialog', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
 
 		const heading = await screen.findByRole( 'heading', { name: 'Title' } );
+		// The regression this guards against: `useRender` must still forward
+		// the user-supplied className to the underlying DOM node. CSS module
+		// classes are stubbed in the Jest environment, so we can only assert
+		// the user class end-to-end.
 		expect( heading ).toHaveClass( 'custom-title' );
-		expect( heading.className ).toMatch( /title/ );
 	} );
 
 	it( 'associates Dialog.Description with the popup via aria-describedby', async () => {

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -70,6 +70,28 @@ describe( 'Dialog', () => {
 		expect( footerRef.current?.tagName ).toBe( 'FOOTER' );
 	} );
 
+	it( 'merges user `className` on Dialog.Title with the internal one', async () => {
+		// Regression test for the shared `useRender` class-name merge
+		// that also covers Popover.Title, Dialog.Description and
+		// Popover.Description.
+		const user = userEvent.setup();
+
+		render(
+			<Dialog.Root>
+				<Dialog.Trigger>Open</Dialog.Trigger>
+				<Dialog.Popup>
+					<Dialog.Title className="custom-title">Title</Dialog.Title>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+		const heading = await screen.findByRole( 'heading', { name: 'Title' } );
+		expect( heading ).toHaveClass( 'custom-title' );
+		expect( heading.className ).toMatch( /title/ );
+	} );
+
 	it( 'associates Dialog.Description with the popup via aria-describedby', async () => {
 		const user = userEvent.setup();
 		const popupRef = createRef< HTMLDivElement >();

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -124,9 +124,7 @@ describe( 'Dialog', () => {
 	} );
 
 	it( 'renders backdrop only when modal is true', async () => {
-		const getBackdrops = () =>
-			// eslint-disable-next-line testing-library/no-node-access -- The backdrop has no semantic role; querying by the stable `data-wp-ui-dialog-backdrop` attribute (mirroring the Dialog close-icon pattern) is more robust than the Base UI role/state it inherits.
-			document.querySelectorAll( '[data-wp-ui-dialog-backdrop]' );
+		const getBackdrops = () => screen.queryAllByTestId( 'dialog-backdrop' );
 
 		const view = render(
 			<Dialog.Root open modal>

--- a/packages/ui/src/dialog/title.tsx
+++ b/packages/ui/src/dialog/title.tsx
@@ -1,5 +1,4 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
-import clsx from 'clsx';
 import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
@@ -26,7 +25,7 @@ import type { TitleProps } from './types';
  * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function DialogTitle( { children, className, ...props }, forwardedRef ) {
+	function DialogTitle( { children, ...props }, forwardedRef ) {
 		const validationContext = useDialogValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -43,7 +42,7 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 				ref={ mergedRef }
 				variant="heading-xl"
 				render={ <_Dialog.Title { ...props } /> }
-				className={ clsx( styles.title, className ) }
+				className={ styles.title }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -76,14 +76,14 @@ export interface ActionProps extends ComponentProps< typeof Button > {
 	children?: ReactNode;
 }
 
-export interface FooterProps extends ComponentProps< 'div' > {
+export interface FooterProps extends ComponentProps< 'footer' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */
 	children?: ReactNode;
 }
 
-export interface HeaderProps extends ComponentProps< 'div' > {
+export interface HeaderProps extends ComponentProps< 'header' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/drawer/action.tsx
+++ b/packages/ui/src/drawer/action.tsx
@@ -1,0 +1,28 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import { forwardRef } from '@wordpress/element';
+import { Button } from '../button';
+import type { ActionProps } from './types';
+
+/**
+ * Renders a button that closes the drawer when clicked.
+ * Accepts all Button component props for styling.
+ */
+const Action = forwardRef< HTMLButtonElement, ActionProps >(
+	function DrawerAction( { render, disabled, loading, ...props }, ref ) {
+		// Resolve `disabled` the same way Button does so that
+		// _Drawer.Close's internal useButton (which controls
+		// aria-disabled) stays in sync with the rendered Button.
+		const resolvedDisabled = disabled ?? loading;
+
+		return (
+			<_Drawer.Close
+				ref={ ref }
+				render={ <Button render={ render } loading={ loading } /> }
+				disabled={ resolvedDisabled }
+				{ ...props }
+			/>
+		);
+	}
+);
+
+export { Action };

--- a/packages/ui/src/drawer/close-icon.tsx
+++ b/packages/ui/src/drawer/close-icon.tsx
@@ -1,0 +1,33 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import { forwardRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import { IconButton } from '../icon-button';
+import type { CloseIconProps } from './types';
+
+/**
+ * Renders an icon button that closes the drawer when clicked.
+ * Provides a default close icon and accessible label.
+ */
+const CloseIcon = forwardRef< HTMLButtonElement, CloseIconProps >(
+	function DrawerCloseIcon( { icon, label, ...props }, ref ) {
+		return (
+			<_Drawer.Close
+				ref={ ref }
+				render={
+					<IconButton
+						variant="minimal"
+						size="compact"
+						tone="neutral"
+						{ ...props }
+						icon={ icon ?? close }
+						label={ label ?? __( 'Close' ) }
+						data-wp-ui-drawer-close-icon=""
+					/>
+				}
+			/>
+		);
+	}
+);
+
+export { CloseIcon };

--- a/packages/ui/src/drawer/context.tsx
+++ b/packages/ui/src/drawer/context.tsx
@@ -1,152 +1,29 @@
 import type { Drawer as _Drawer } from '@base-ui/react/drawer';
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
-import { useScheduleValidation } from '../utils/use-schedule-validation';
+import { createOverlayModalContext } from '../utils/create-overlay-modal-context';
+import { createOverlayTitleValidation } from '../utils/create-overlay-title-validation';
 
 // -- Modal context ----------------------------------------------------------
 
-const DrawerModalContext =
-	createContext< _Drawer.Root.Props[ 'modal' ] >( true );
+const drawerModal =
+	createOverlayModalContext< _Drawer.Root.Props[ 'modal' ] >( true );
 
-export function DrawerModalProvider( {
-	modal,
-	children,
-}: {
-	modal: _Drawer.Root.Props[ 'modal' ];
-	children: React.ReactNode;
-} ) {
-	return (
-		<DrawerModalContext.Provider value={ modal }>
-			{ children }
-		</DrawerModalContext.Provider>
-	);
-}
-
-export function useDrawerModal() {
-	return useContext( DrawerModalContext );
-}
+export const DrawerModalProvider = drawerModal.Provider;
+export const useDrawerModal = drawerModal.useModal;
 
 // -- Validation context (dev-only) ------------------------------------------
 
-/**
- * Whether validation is enabled. This is a build-time constant that allows
- * bundlers to tree-shake all validation code in production builds.
- */
-const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
-
-type DrawerValidationContextType = {
-	registerTitle: ( element: HTMLElement | null ) => () => void;
-};
-
-// Context is only created in development mode.
-const DrawerValidationContext = VALIDATION_ENABLED
-	? createContext< DrawerValidationContextType | null >( null )
-	: ( null as unknown as React.Context< DrawerValidationContextType | null > );
-
-/**
- * Development-only hook to access the drawer validation context.
- */
-function useDrawerValidationContextDev() {
-	return useContext( DrawerValidationContext );
-}
-
-/**
- * Production no-op hook.
- */
-function useDrawerValidationContextProd() {
-	return null;
-}
+const drawerTitleValidation = createOverlayTitleValidation( 'Drawer' );
 
 /**
  * Hook to access the drawer validation context.
  * Returns null in production or if not within a Drawer.Popup.
  */
-export const useDrawerValidationContext = VALIDATION_ENABLED
-	? useDrawerValidationContextDev
-	: useDrawerValidationContextProd;
-
-/**
- * Development-only provider that tracks whether Drawer.Title is rendered.
- */
-function DrawerValidationProviderDev( {
-	children,
-}: {
-	children: React.ReactNode;
-} ) {
-	const titleElementRef = useRef< HTMLElement | null >( null );
-
-	const scheduleValidation = useScheduleValidation( () => {
-		const titleElement = titleElementRef.current;
-
-		if ( ! titleElement ) {
-			throw new Error(
-				'Drawer: Missing <Drawer.Title>. ' +
-					'For accessibility, every drawer requires a title. ' +
-					'If needed, the title can be visually hidden but must not be omitted.'
-			);
-		}
-
-		const textContent = titleElement.textContent?.trim();
-		if ( ! textContent ) {
-			throw new Error(
-				'Drawer: <Drawer.Title> cannot be empty. ' +
-					'Provide meaningful text content for the drawer title.'
-			);
-		}
-	} );
-
-	const registerTitle = useCallback(
-		( element: HTMLElement | null ) => {
-			titleElementRef.current = element;
-			scheduleValidation();
-
-			return () => {
-				titleElementRef.current = null;
-				scheduleValidation();
-			};
-		},
-		[ scheduleValidation ]
-	);
-
-	const contextValue = useMemo(
-		() => ( { registerTitle } ),
-		[ registerTitle ]
-	);
-
-	// Schedule an initial validation on mount to catch missing titles
-	// (when no Title component is rendered, registerTitle is never called).
-	useEffect( () => {
-		scheduleValidation();
-	}, [ scheduleValidation ] );
-
-	return (
-		<DrawerValidationContext.Provider value={ contextValue }>
-			{ children }
-		</DrawerValidationContext.Provider>
-	);
-}
-
-/**
- * Production no-op provider that just renders children.
- */
-function DrawerValidationProviderProd( {
-	children,
-}: {
-	children: React.ReactNode;
-} ) {
-	return <>{ children }</>;
-}
+export const useDrawerValidationContext =
+	drawerTitleValidation.useValidationContext;
 
 /**
  * Provider component that validates Drawer.Title presence in development mode.
  * In production, this component is a no-op and just renders children.
  */
-export const DrawerValidationProvider = VALIDATION_ENABLED
-	? DrawerValidationProviderDev
-	: DrawerValidationProviderProd;
+export const DrawerValidationProvider =
+	drawerTitleValidation.ValidationProvider;

--- a/packages/ui/src/drawer/context.tsx
+++ b/packages/ui/src/drawer/context.tsx
@@ -1,0 +1,138 @@
+import type { Drawer as _Drawer } from '@base-ui/react/drawer';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
+import { useScheduleValidation } from '../utils/use-schedule-validation';
+
+// -- Modal context ----------------------------------------------------------
+
+const DrawerModalContext =
+	createContext< _Drawer.Root.Props[ 'modal' ] >( true );
+
+export function DrawerModalProvider( {
+	modal = true,
+	children,
+}: {
+	modal?: _Drawer.Root.Props[ 'modal' ];
+	children: React.ReactNode;
+} ) {
+	return (
+		<DrawerModalContext.Provider value={ modal }>
+			{ children }
+		</DrawerModalContext.Provider>
+	);
+}
+
+export function useDrawerModal() {
+	return useContext( DrawerModalContext );
+}
+
+// -- Validation context (dev-only) ------------------------------------------
+
+/**
+ * Whether validation is enabled. This is a build-time constant that allows
+ * bundlers to tree-shake all validation code in production builds.
+ */
+const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
+
+type DrawerValidationContextType = {
+	registerTitle: ( element: HTMLElement | null ) => () => void;
+};
+
+const DrawerValidationContext = VALIDATION_ENABLED
+	? createContext< DrawerValidationContextType | null >( null )
+	: ( null as unknown as React.Context< DrawerValidationContextType | null > );
+
+function useDrawerValidationContextDev() {
+	return useContext( DrawerValidationContext );
+}
+
+function useDrawerValidationContextProd() {
+	return null;
+}
+
+/**
+ * Hook to access the drawer validation context.
+ * Returns null in production or if not within a Drawer.Popup.
+ */
+export const useDrawerValidationContext = VALIDATION_ENABLED
+	? useDrawerValidationContextDev
+	: useDrawerValidationContextProd;
+
+function DrawerValidationProviderDev( {
+	children,
+}: {
+	children: React.ReactNode;
+} ) {
+	const titleElementRef = useRef< HTMLElement | null >( null );
+	const scheduleValidation = useScheduleValidation( () => {
+		const titleElement = titleElementRef.current;
+
+		if ( ! titleElement ) {
+			throw new Error(
+				'Drawer: Missing <Drawer.Title>. ' +
+					'For accessibility, every drawer requires a title. ' +
+					'If needed, the title can be visually hidden but must not be omitted.'
+			);
+		}
+
+		const textContent = titleElement.textContent?.trim();
+		if ( ! textContent ) {
+			throw new Error(
+				'Drawer: <Drawer.Title> cannot be empty. ' +
+					'Provide meaningful text content for the drawer title.'
+			);
+		}
+	} );
+
+	const registerTitle = useCallback(
+		( element: HTMLElement | null ) => {
+			titleElementRef.current = element;
+			scheduleValidation();
+
+			return () => {
+				titleElementRef.current = null;
+				scheduleValidation();
+			};
+		},
+		[ scheduleValidation ]
+	);
+
+	const contextValue = useMemo(
+		() => ( { registerTitle } ),
+		[ registerTitle ]
+	);
+
+	// Schedule an initial validation on mount to catch missing titles
+	// (when no Title component is rendered, registerTitle is never called).
+	useEffect( () => {
+		scheduleValidation();
+	}, [ scheduleValidation ] );
+
+	return (
+		<DrawerValidationContext.Provider value={ contextValue }>
+			{ children }
+		</DrawerValidationContext.Provider>
+	);
+}
+
+function DrawerValidationProviderProd( {
+	children,
+}: {
+	children: React.ReactNode;
+} ) {
+	return <>{ children }</>;
+}
+
+/**
+ * Provider component that validates Drawer.Title presence in development mode.
+ * In production, this component is a no-op and just renders children.
+ */
+export const DrawerValidationProvider = VALIDATION_ENABLED
+	? DrawerValidationProviderDev
+	: DrawerValidationProviderProd;

--- a/packages/ui/src/drawer/context.tsx
+++ b/packages/ui/src/drawer/context.tsx
@@ -15,10 +15,10 @@ const DrawerModalContext =
 	createContext< _Drawer.Root.Props[ 'modal' ] >( true );
 
 export function DrawerModalProvider( {
-	modal = true,
+	modal,
 	children,
 }: {
-	modal?: _Drawer.Root.Props[ 'modal' ];
+	modal: _Drawer.Root.Props[ 'modal' ];
 	children: React.ReactNode;
 } ) {
 	return (
@@ -44,14 +44,21 @@ type DrawerValidationContextType = {
 	registerTitle: ( element: HTMLElement | null ) => () => void;
 };
 
+// Context is only created in development mode.
 const DrawerValidationContext = VALIDATION_ENABLED
 	? createContext< DrawerValidationContextType | null >( null )
 	: ( null as unknown as React.Context< DrawerValidationContextType | null > );
 
+/**
+ * Development-only hook to access the drawer validation context.
+ */
 function useDrawerValidationContextDev() {
 	return useContext( DrawerValidationContext );
 }
 
+/**
+ * Production no-op hook.
+ */
 function useDrawerValidationContextProd() {
 	return null;
 }
@@ -64,12 +71,16 @@ export const useDrawerValidationContext = VALIDATION_ENABLED
 	? useDrawerValidationContextDev
 	: useDrawerValidationContextProd;
 
+/**
+ * Development-only provider that tracks whether Drawer.Title is rendered.
+ */
 function DrawerValidationProviderDev( {
 	children,
 }: {
 	children: React.ReactNode;
 } ) {
 	const titleElementRef = useRef< HTMLElement | null >( null );
+
 	const scheduleValidation = useScheduleValidation( () => {
 		const titleElement = titleElementRef.current;
 
@@ -121,6 +132,9 @@ function DrawerValidationProviderDev( {
 	);
 }
 
+/**
+ * Production no-op provider that just renders children.
+ */
 function DrawerValidationProviderProd( {
 	children,
 }: {

--- a/packages/ui/src/drawer/description.tsx
+++ b/packages/ui/src/drawer/description.tsx
@@ -1,0 +1,24 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { Text } from '../text';
+import styles from './style.module.css';
+import type { DescriptionProps } from './types';
+
+/**
+ * Renders a paragraph with additional information about the drawer.
+ */
+const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
+	function DrawerDescription( { className, render, ...props }, ref ) {
+		return (
+			<_Drawer.Description
+				ref={ ref }
+				render={ <Text variant="body-md" render={ render ?? <p /> } /> }
+				className={ clsx( styles.description, className ) }
+				{ ...props }
+			/>
+		);
+	}
+);
+
+export { Description };

--- a/packages/ui/src/drawer/description.tsx
+++ b/packages/ui/src/drawer/description.tsx
@@ -6,17 +6,21 @@ import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
- * Renders a paragraph with additional information about the drawer.
+ * Renders an optional paragraph that describes the drawer content.
+ *
+ * The rendered element is linked to the popup via `aria-describedby`.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
-	function DrawerDescription( { className, render, ...props }, ref ) {
+	function DrawerDescription( { className, children, ...props }, ref ) {
 		return (
-			<_Drawer.Description
+			<Text
 				ref={ ref }
-				render={ <Text variant="body-md" render={ render ?? <p /> } /> }
+				variant="body-md"
+				render={ <_Drawer.Description { ...props } /> }
 				className={ clsx( styles.description, className ) }
-				{ ...props }
-			/>
+			>
+				{ children }
+			</Text>
 		);
 	}
 );

--- a/packages/ui/src/drawer/description.tsx
+++ b/packages/ui/src/drawer/description.tsx
@@ -1,5 +1,4 @@
 import { Drawer as _Drawer } from '@base-ui/react/drawer';
-import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
 import styles from './style.module.css';
@@ -11,13 +10,13 @@ import type { DescriptionProps } from './types';
  * The rendered element is linked to the popup via `aria-describedby`.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
-	function DrawerDescription( { className, children, ...props }, ref ) {
+	function DrawerDescription( { children, ...props }, ref ) {
 		return (
 			<Text
 				ref={ ref }
 				variant="body-md"
 				render={ <_Drawer.Description { ...props } /> }
-				className={ clsx( styles.description, className ) }
+				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/drawer/footer.tsx
+++ b/packages/ui/src/drawer/footer.tsx
@@ -1,0 +1,26 @@
+import { mergeProps, useRender } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import styles from './style.module.css';
+import type { FooterProps } from './types';
+
+/**
+ * Renders the footer section of the drawer, typically containing
+ * action buttons.
+ */
+const Footer = forwardRef< HTMLDivElement, FooterProps >( function DrawerFooter(
+	{ className, render, ...props },
+	ref
+) {
+	const element = useRender( {
+		render,
+		ref,
+		props: mergeProps< 'div' >( props, {
+			className: clsx( styles.footer, className ),
+		} ),
+	} );
+
+	return element;
+} );
+
+export { Footer };

--- a/packages/ui/src/drawer/footer.tsx
+++ b/packages/ui/src/drawer/footer.tsx
@@ -7,15 +7,20 @@ import type { FooterProps } from './types';
 /**
  * Renders the footer section of the drawer, typically containing
  * action buttons.
+ *
+ * Defaults to a native `<footer>` element so the drawer exposes a landmark
+ * that assistive technology can navigate to directly. Pass `render` to opt
+ * out of the default tag.
  */
-const Footer = forwardRef< HTMLDivElement, FooterProps >( function DrawerFooter(
+const Footer = forwardRef< HTMLElement, FooterProps >( function DrawerFooter(
 	{ className, render, ...props },
 	ref
 ) {
 	const element = useRender( {
+		defaultTagName: 'footer',
 		render,
 		ref,
-		props: mergeProps< 'div' >( props, {
+		props: mergeProps< 'footer' >( props, {
 			className: clsx( styles.footer, className ),
 		} ),
 	} );

--- a/packages/ui/src/drawer/footer.tsx
+++ b/packages/ui/src/drawer/footer.tsx
@@ -8,9 +8,9 @@ import type { FooterProps } from './types';
  * Renders the footer section of the drawer, typically containing
  * action buttons.
  *
- * Defaults to a native `<footer>` element so the drawer exposes a landmark
- * that assistive technology can navigate to directly. Pass `render` to opt
- * out of the default tag.
+ * Defaults to a native `<footer>` element for richer semantics (contentinfo
+ * landmark navigation where screen readers expose landmarks nested in
+ * dialogs). Pass `render` to opt out of the default tag.
  */
 const Footer = forwardRef< HTMLElement, FooterProps >( function DrawerFooter(
 	{ className, render, ...props },

--- a/packages/ui/src/drawer/header.tsx
+++ b/packages/ui/src/drawer/header.tsx
@@ -8,10 +8,9 @@ import type { HeaderProps } from './types';
  * Renders the header section of the drawer, typically containing
  * the heading and close button.
  *
- * Defaults to a native `<header>` element so the drawer exposes a landmark
- * that assistive technology can navigate to directly, useful for drawers
- * that contain many interactive elements before the action buttons in the
- * footer. Pass `render` to opt out of the default tag.
+ * Defaults to a native `<header>` element for richer semantics (heading-level
+ * scanning, and banner landmark navigation where screen readers expose
+ * landmarks nested in dialogs). Pass `render` to opt out of the default tag.
  */
 const Header = forwardRef< HTMLElement, HeaderProps >( function DrawerHeader(
 	{ className, render, ...props },

--- a/packages/ui/src/drawer/header.tsx
+++ b/packages/ui/src/drawer/header.tsx
@@ -1,0 +1,26 @@
+import { mergeProps, useRender } from '@base-ui/react';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import styles from './style.module.css';
+import type { HeaderProps } from './types';
+
+/**
+ * Renders the header section of the drawer, typically containing
+ * the heading and close button.
+ */
+const Header = forwardRef< HTMLDivElement, HeaderProps >( function DrawerHeader(
+	{ className, render, ...props },
+	ref
+) {
+	const element = useRender( {
+		render,
+		ref,
+		props: mergeProps< 'div' >( props, {
+			className: clsx( styles.header, className ),
+		} ),
+	} );
+
+	return element;
+} );
+
+export { Header };

--- a/packages/ui/src/drawer/header.tsx
+++ b/packages/ui/src/drawer/header.tsx
@@ -7,15 +7,21 @@ import type { HeaderProps } from './types';
 /**
  * Renders the header section of the drawer, typically containing
  * the heading and close button.
+ *
+ * Defaults to a native `<header>` element so the drawer exposes a landmark
+ * that assistive technology can navigate to directly, useful for drawers
+ * that contain many interactive elements before the action buttons in the
+ * footer. Pass `render` to opt out of the default tag.
  */
-const Header = forwardRef< HTMLDivElement, HeaderProps >( function DrawerHeader(
+const Header = forwardRef< HTMLElement, HeaderProps >( function DrawerHeader(
 	{ className, render, ...props },
 	ref
 ) {
 	const element = useRender( {
+		defaultTagName: 'header',
 		render,
 		ref,
-		props: mergeProps< 'div' >( props, {
+		props: mergeProps< 'header' >( props, {
 			className: clsx( styles.header, className ),
 		} ),
 	} );

--- a/packages/ui/src/drawer/index.ts
+++ b/packages/ui/src/drawer/index.ts
@@ -1,0 +1,21 @@
+import { Action } from './action';
+import { CloseIcon } from './close-icon';
+import { Description } from './description';
+import { Footer } from './footer';
+import { Header } from './header';
+import { Popup } from './popup';
+import { Root } from './root';
+import { Title } from './title';
+import { Trigger } from './trigger';
+
+export {
+	Action,
+	CloseIcon,
+	Description,
+	Footer,
+	Header,
+	Popup,
+	Root,
+	Title,
+	Trigger,
+};

--- a/packages/ui/src/drawer/index.ts
+++ b/packages/ui/src/drawer/index.ts
@@ -4,6 +4,7 @@ import { Description } from './description';
 import { Footer } from './footer';
 import { Header } from './header';
 import { Popup } from './popup';
+import { Portal } from './portal';
 import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
@@ -15,6 +16,7 @@ export {
 	Footer,
 	Header,
 	Popup,
+	Portal,
 	Root,
 	Title,
 	Trigger,

--- a/packages/ui/src/drawer/popup.tsx
+++ b/packages/ui/src/drawer/popup.tsx
@@ -47,7 +47,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DrawerPopup(
 			{ modal === true && (
 				<_Drawer.Backdrop
 					className={ styles.backdrop }
-					data-wp-ui-drawer-backdrop=""
+					data-testid="drawer-backdrop"
 				/>
 			) }
 			<_Drawer.Viewport className={ styles.viewport }>

--- a/packages/ui/src/drawer/popup.tsx
+++ b/packages/ui/src/drawer/popup.tsx
@@ -1,0 +1,91 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../lock-unlock';
+import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
+import { DrawerValidationProvider, useDrawerModal } from './context';
+import styles from './style.module.css';
+import type { PopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
+
+const CLOSE_ICON_ATTR = 'data-wp-ui-drawer-close-icon';
+
+/**
+ * Renders the drawer popup element that contains the drawer content.
+ * Uses a portal to render outside the DOM hierarchy.
+ */
+const Popup = forwardRef< HTMLDivElement, PopupProps >( function DrawerPopup(
+	{
+		className,
+		children,
+		container,
+		size,
+		initialFocus,
+		finalFocus,
+		...props
+	},
+	ref
+) {
+	const { resolvedInitialFocus, popupRef } = useDeprioritizedInitialFocus( {
+		initialFocus,
+		deprioritizedAttribute: CLOSE_ICON_ATTR,
+	} );
+	const mergedRef = useMergeRefs( [ ref, popupRef ] );
+	const modal = useDrawerModal();
+
+	return (
+		<_Drawer.Portal container={ container }>
+			{ /*
+			 * Only render a backdrop for fully modal drawers. Non-modal drawers
+			 * should not dim the page, and `trap-focus` keeps outside pointer
+			 * interactions enabled, so a backdrop would misrepresent that mode.
+			 */ }
+			{ modal === true && (
+				<_Drawer.Backdrop className={ styles.backdrop } />
+			) }
+			<_Drawer.Viewport className={ styles.viewport }>
+				{ /*
+				 * ThemeProvider wraps _Drawer.Popup directly (matching Dialog
+				 * and Popover) so the `display: contents` focus-trap workaround
+				 * selector in the CSS module actually targets this subtree.
+				 */ }
+				<ThemeProvider>
+					<_Drawer.Popup
+						ref={ mergedRef }
+						className={ ( state ) => {
+							const isVertical =
+								state.swipeDirection === 'up' ||
+								state.swipeDirection === 'down';
+							const resolvedSize =
+								size ?? ( isVertical ? 'auto' : 'medium' );
+
+							return clsx(
+								styles.popup,
+								styles[ `is-${ resolvedSize }` ],
+								className
+							);
+						} }
+						initialFocus={ resolvedInitialFocus }
+						finalFocus={ finalFocus }
+						{ ...props }
+					>
+						<_Drawer.Content className={ styles.content }>
+							<DrawerValidationProvider>
+								{ children }
+							</DrawerValidationProvider>
+						</_Drawer.Content>
+					</_Drawer.Popup>
+				</ThemeProvider>
+			</_Drawer.Viewport>
+		</_Drawer.Portal>
+	);
+} );
+
+export { Popup };

--- a/packages/ui/src/drawer/popup.tsx
+++ b/packages/ui/src/drawer/popup.tsx
@@ -8,7 +8,9 @@ import {
 } from '@wordpress/theme';
 import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
+import { renderPortalWithChildren } from '../utils/render-portal-with-children';
 import { DrawerValidationProvider, useDrawerModal } from './context';
+import { Portal } from './portal';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
 
@@ -20,17 +22,12 @@ const CLOSE_ICON_ATTR = 'data-wp-ui-drawer-close-icon';
 /**
  * Renders the drawer popup element that contains the drawer content.
  * Uses a portal to render outside the DOM hierarchy.
+ *
+ * When `portal` is omitted, defaults to `Drawer.Portal`. Portal merging is
+ * handled by `renderPortalWithChildren` (shared with other overlay `Popup`s).
  */
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function DrawerPopup(
-	{
-		className,
-		children,
-		container,
-		size,
-		initialFocus,
-		finalFocus,
-		...props
-	},
+	{ className, portal, children, size, initialFocus, finalFocus, ...props },
 	ref
 ) {
 	const { resolvedInitialFocus, popupRef } = useDeprioritizedInitialFocus( {
@@ -40,15 +37,18 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DrawerPopup(
 	const mergedRef = useMergeRefs( [ ref, popupRef ] );
 	const modal = useDrawerModal();
 
-	return (
-		<_Drawer.Portal container={ container }>
+	const portalChildren = (
+		<>
 			{ /*
 			 * Only render a backdrop for fully modal drawers. Non-modal drawers
 			 * should not dim the page, and `trap-focus` keeps outside pointer
 			 * interactions enabled, so a backdrop would misrepresent that mode.
 			 */ }
 			{ modal === true && (
-				<_Drawer.Backdrop className={ styles.backdrop } />
+				<_Drawer.Backdrop
+					className={ styles.backdrop }
+					data-wp-ui-drawer-backdrop=""
+				/>
 			) }
 			<_Drawer.Viewport className={ styles.viewport }>
 				{ /*
@@ -84,8 +84,10 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DrawerPopup(
 					</_Drawer.Popup>
 				</ThemeProvider>
 			</_Drawer.Viewport>
-		</_Drawer.Portal>
+		</>
 	);
+
+	return renderPortalWithChildren( portal, <Portal />, portalChildren );
 } );
 
 export { Popup };

--- a/packages/ui/src/drawer/popup.tsx
+++ b/packages/ui/src/drawer/popup.tsx
@@ -68,8 +68,8 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DrawerPopup(
 
 							return clsx(
 								styles.popup,
-								styles[ `is-${ resolvedSize }` ],
-								className
+								className,
+								styles[ `is-${ resolvedSize }` ]
 							);
 						} }
 						initialFocus={ resolvedInitialFocus }

--- a/packages/ui/src/drawer/portal.tsx
+++ b/packages/ui/src/drawer/portal.tsx
@@ -1,0 +1,18 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import { forwardRef } from '@wordpress/element';
+import type { PortalProps } from './types';
+
+/**
+ * Root element that portals `Drawer` overlay content (`Backdrop`, `Viewport`
+ * with the inner `Popup`, etc.) outside the DOM hierarchy. Pass to
+ * `Drawer.Popup`'s `portal` prop to customize `container`, `className`,
+ * `style`, and other Base UI portal options. When `portal` is omitted,
+ * `Drawer.Popup` uses this component with default props.
+ */
+const Portal = forwardRef< HTMLDivElement, PortalProps >(
+	function DrawerPortal( props, ref ) {
+		return <_Drawer.Portal ref={ ref } { ...props } />;
+	}
+);
+
+export { Portal };

--- a/packages/ui/src/drawer/root.tsx
+++ b/packages/ui/src/drawer/root.tsx
@@ -1,0 +1,22 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import { DrawerModalProvider } from './context';
+import type { RootProps } from './types';
+
+/**
+ * Groups the drawer trigger and popup.
+ *
+ * `Drawer` is a collection of React components that combine to render
+ * an ARIA-compliant drawer pattern with slide-in behavior and
+ * swipe-to-dismiss gestures.
+ */
+function Root( { modal, children, ...props }: RootProps ) {
+	return (
+		<_Drawer.Root modal={ modal } { ...props }>
+			<DrawerModalProvider modal={ modal }>
+				{ children }
+			</DrawerModalProvider>
+		</_Drawer.Root>
+	);
+}
+
+export { Root };

--- a/packages/ui/src/drawer/root.tsx
+++ b/packages/ui/src/drawer/root.tsx
@@ -19,9 +19,18 @@ import type { RootProps } from './types';
  * destructive actions), omit the close icon and rely on footer action buttons
  * like "Cancel" and "Confirm" instead.
  */
-function Root( { modal = true, children, ...props }: RootProps ) {
+function Root( {
+	modal = true,
+	swipeDirection = 'left',
+	children,
+	...props
+}: RootProps ) {
 	return (
-		<_Drawer.Root modal={ modal } { ...props }>
+		<_Drawer.Root
+			modal={ modal }
+			swipeDirection={ swipeDirection }
+			{ ...props }
+		>
 			<DrawerModalProvider modal={ modal }>
 				{ children }
 			</DrawerModalProvider>

--- a/packages/ui/src/drawer/root.tsx
+++ b/packages/ui/src/drawer/root.tsx
@@ -3,13 +3,23 @@ import { DrawerModalProvider } from './context';
 import type { RootProps } from './types';
 
 /**
- * Groups the drawer trigger and popup.
- *
- * `Drawer` is a collection of React components that combine to render
- * an ARIA-compliant drawer pattern with slide-in behavior and
+ * An ARIA-compliant drawer that slides in from a viewport edge, with
  * swipe-to-dismiss gestures.
+ *
+ * Every drawer must include a `Drawer.Title` component for accessibility — it
+ * serves as both the visible heading and the accessible label for the drawer.
+ *
+ * Always include a visible close affordance, either `Drawer.CloseIcon` or a
+ * clear dismissing action button. If your drawer has a "Cancel" button in the
+ * footer, the close icon may be redundant and create confusion about what
+ * clicking "X" means.
+ *
+ * Use `Drawer.CloseIcon` for informational drawers where dismissing is safe
+ * and expected. For drawers requiring explicit user choice (especially
+ * destructive actions), omit the close icon and rely on footer action buttons
+ * like "Cancel" and "Confirm" instead.
  */
-function Root( { modal, children, ...props }: RootProps ) {
+function Root( { modal = true, children, ...props }: RootProps ) {
 	return (
 		<_Drawer.Root modal={ modal } { ...props }>
 			<DrawerModalProvider modal={ modal }>

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -9,6 +9,7 @@ const meta: Meta< typeof Drawer.Root > = {
 	component: Drawer.Root,
 	subcomponents: {
 		'Drawer.Trigger': Drawer.Trigger,
+		'Drawer.Portal': Drawer.Portal,
 		'Drawer.Popup': Drawer.Popup,
 		'Drawer.Header': Drawer.Header,
 		'Drawer.Title': Drawer.Title,

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -35,7 +35,6 @@ type Story = StoryObj< typeof Drawer.Root >;
  */
 export const _Default: Story = {
 	args: {
-		swipeDirection: 'left',
 		children: (
 			<>
 				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
@@ -68,52 +67,62 @@ const directions = [
  * drawer from the corresponding edge.
  */
 export const AllSides: Story = {
-	render: () => (
-		<div
-			style={ {
-				display: 'grid',
-				gridTemplateColumns: '1fr 1fr',
-				gap: '8px',
-				maxWidth: '300px',
-			} }
-		>
-			{ directions.map( ( { swipeDirection, label, title } ) => (
-				<Drawer.Root
-					key={ swipeDirection }
-					swipeDirection={ swipeDirection }
-				>
-					<Drawer.Trigger>{ label }</Drawer.Trigger>
-					<Drawer.Popup>
-						<Drawer.Header>
-							<Drawer.Title>{ title }</Drawer.Title>
-							<Drawer.CloseIcon />
-						</Drawer.Header>
-						<Drawer.Description>
-							Slides in from the { label.toLowerCase() } edge.
-							Swipe to dismiss.
-						</Drawer.Description>
-						<Drawer.Footer>
-							<Drawer.Action>Close</Drawer.Action>
-						</Drawer.Footer>
-					</Drawer.Popup>
-				</Drawer.Root>
-			) ) }
-		</div>
-	),
+	render: function AllSidesRender( args ) {
+		return (
+			<div
+				style={ {
+					display: 'grid',
+					gridTemplateColumns: '1fr 1fr',
+					gap: '8px',
+					maxWidth: '300px',
+				} }
+			>
+				{ directions.map( ( { swipeDirection, label, title } ) => (
+					<Drawer.Root
+						key={ swipeDirection }
+						{ ...args }
+						swipeDirection={ swipeDirection }
+					>
+						<Drawer.Trigger>{ label }</Drawer.Trigger>
+						<Drawer.Popup>
+							<Drawer.Header>
+								<Drawer.Title>{ title }</Drawer.Title>
+								<Drawer.CloseIcon />
+							</Drawer.Header>
+							<Drawer.Description>
+								Slides in from the { label.toLowerCase() } edge.
+								Swipe to dismiss.
+							</Drawer.Description>
+							<Drawer.Footer>
+								<Drawer.Action>Close</Drawer.Action>
+							</Drawer.Footer>
+						</Drawer.Popup>
+					</Drawer.Root>
+				) ) }
+			</div>
+		);
+	},
+	argTypes: {
+		children: { control: false },
+		swipeDirection: { control: false },
+	},
 };
 
 /**
  * A controlled drawer where the open state is managed externally.
  */
 export const Controlled: Story = {
-	render: function ControlledRender() {
+	render: function ControlledRender( args ) {
 		const [ open, setOpen ] = useState( false );
 		return (
-			<Drawer.Root
-				open={ open }
-				onOpenChange={ setOpen }
-				swipeDirection="left"
-			>
+			<Drawer.Root { ...args } open={ open } onOpenChange={ setOpen }>
+				{ args.children }
+			</Drawer.Root>
+		);
+	},
+	args: {
+		children: (
+			<>
 				<Drawer.Trigger>Open Controlled Drawer</Drawer.Trigger>
 				<Drawer.Popup>
 					<Drawer.Header>
@@ -128,8 +137,14 @@ export const Controlled: Story = {
 						<Drawer.Action>Close</Drawer.Action>
 					</Drawer.Footer>
 				</Drawer.Popup>
-			</Drawer.Root>
-		);
+			</>
+		),
+	},
+	argTypes: {
+		open: { control: false },
+		defaultOpen: { control: false },
+		onOpenChange: { control: false },
+		onOpenChangeComplete: { control: false },
 	},
 };
 
@@ -159,6 +174,9 @@ export const NonModal: Story = {
 				</Drawer.Popup>
 			</>
 		),
+	},
+	render: function NonModalRender( args ) {
+		return <Drawer.Root { ...args }>{ args.children }</Drawer.Root>;
 	},
 };
 
@@ -238,15 +256,14 @@ function DirectionSelector( {
  * directions. Size controls the width (left/right) or height (up/down).
  */
 export const SizePlayground: Story = {
-	render: function SizePlaygroundRender() {
+	render: function SizePlaygroundRender( args ) {
 		const [ size, setSize ] =
 			useState< ComponentProps< typeof Drawer.Popup >[ 'size' ] >();
-		const [ direction, setDirection ] =
-			useState<
-				ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ]
-			>( 'left' );
+		const [ direction, setDirection ] = useState<
+			ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ]
+		>( args.swipeDirection ?? 'left' );
 		return (
-			<Drawer.Root swipeDirection={ direction }>
+			<Drawer.Root { ...args } swipeDirection={ direction }>
 				<div
 					style={ {
 						display: 'flex',
@@ -291,5 +308,8 @@ export const SizePlayground: Story = {
 				</Drawer.Popup>
 			</Drawer.Root>
 		);
+	},
+	argTypes: {
+		swipeDirection: { control: false },
 	},
 };

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -252,6 +252,55 @@ function DirectionSelector( {
 }
 
 /**
+ * Popovers in Gutenberg are managed with explicit z-index values, which can
+ * create situations where a drawer renders below another popover when you
+ * want it above.
+ *
+ * The `--wp-ui-drawer-z-index` CSS variable controls the z-index of the
+ * drawer's backdrop, viewport, and popup. Override it either:
+ *
+ * - **Globally**, by setting the variable on `:root` or `body` (raises every
+ *   drawer in the page), or
+ * - **Per instance**, by passing a `Drawer.Portal` with a `style` (or
+ *   `className`) to `Drawer.Popup`'s `portal` prop. The variable cascades
+ *   from the portal wrapper to everything rendered inside it (backdrop,
+ *   viewport, and popup).
+ *
+ * This story demonstrates the per-instance approach.
+ */
+export const WithCustomZIndex: Story = {
+	name: 'With Custom z-index',
+	args: {
+		children: (
+			<>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup
+					portal={
+						<Drawer.Portal
+							style={ { '--wp-ui-drawer-z-index': '9999' } }
+						/>
+					}
+				>
+					<Drawer.Header>
+						<Drawer.Title>Custom z-index</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<Drawer.Description>
+						The backdrop, viewport, and popup render at `z-index:
+						9999` via the `--wp-ui-drawer-z-index` CSS custom
+						property, set on `Drawer.Portal` through the `portal`
+						prop.
+					</Drawer.Description>
+					<Drawer.Footer>
+						<Drawer.Action>Got it</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</>
+		),
+	},
+};
+
+/**
  * Interactive playground to test the `size` prop across all swipe
  * directions. Size controls the width (left/right) or height (up/down).
  */

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -1,0 +1,444 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useId, useState } from '@wordpress/element';
+import type { ComponentProps } from 'react';
+import { Stack } from '../../stack';
+import * as Drawer from '../index';
+
+const meta: Meta< typeof Drawer.Root > = {
+	title: 'Design System/Components/Drawer',
+	component: Drawer.Root,
+	subcomponents: {
+		'Drawer.Trigger': Drawer.Trigger,
+		'Drawer.Popup': Drawer.Popup,
+		'Drawer.Header': Drawer.Header,
+		'Drawer.Title': Drawer.Title,
+		'Drawer.Description': Drawer.Description,
+		'Drawer.CloseIcon': Drawer.CloseIcon,
+		'Drawer.Action': Drawer.Action,
+		'Drawer.Footer': Drawer.Footer,
+	},
+	argTypes: {
+		modal: {
+			control: 'inline-radio',
+			options: [ true, false, 'trap-focus' ],
+		},
+	},
+};
+export default meta;
+
+type Story = StoryObj< typeof Drawer.Root >;
+
+/**
+ * A basic drawer sliding in from the left edge. Use the controls to
+ * experiment with `swipeDirection` and `modal`.
+ */
+export const _Default: Story = {
+	args: {
+		swipeDirection: 'left',
+		children: (
+			<>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Header>
+						<Drawer.Title>Navigation</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<Drawer.Description>
+						Browse through the available sections below.
+					</Drawer.Description>
+					<Drawer.Footer>
+						<Drawer.Action>Done</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</>
+		),
+	},
+};
+
+const directions = [
+	{ swipeDirection: 'left', label: 'Left', title: 'Left Drawer' },
+	{ swipeDirection: 'right', label: 'Right', title: 'Right Drawer' },
+	{ swipeDirection: 'down', label: 'Bottom', title: 'Bottom Sheet' },
+	{ swipeDirection: 'up', label: 'Top', title: 'Top Drawer' },
+] as const;
+
+function AllSidesContent() {
+	return (
+		<div
+			style={ {
+				display: 'grid',
+				gridTemplateColumns: '1fr 1fr',
+				gap: '8px',
+				maxWidth: '300px',
+			} }
+		>
+			{ directions.map( ( { swipeDirection, label, title } ) => (
+				<Drawer.Root
+					key={ swipeDirection }
+					swipeDirection={ swipeDirection }
+				>
+					<Drawer.Trigger>{ label }</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							<Drawer.Title>{ title }</Drawer.Title>
+							<Drawer.CloseIcon />
+						</Drawer.Header>
+						<Drawer.Description>
+							Slides in from the { label.toLowerCase() } edge.
+							Swipe to dismiss.
+						</Drawer.Description>
+						<Drawer.Footer>
+							<Drawer.Action>Close</Drawer.Action>
+						</Drawer.Footer>
+					</Drawer.Popup>
+				</Drawer.Root>
+			) ) }
+		</div>
+	);
+}
+
+/**
+ * Four drawers, one for each swipe direction. Each trigger opens a
+ * drawer from the corresponding edge.
+ */
+export const AllSides: Story = {
+	render: () => <AllSidesContent />,
+};
+
+function ControlledContent() {
+	const [ open, setOpen ] = useState( false );
+
+	return (
+		<Drawer.Root
+			open={ open }
+			onOpenChange={ setOpen }
+			swipeDirection="left"
+		>
+			<Drawer.Trigger>Open Controlled Drawer</Drawer.Trigger>
+			<Drawer.Popup>
+				<Drawer.Header>
+					<Drawer.Title>Controlled Drawer</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Description>
+					The open state is managed externally via <code>open</code>{ ' ' }
+					and <code>onOpenChange</code>.
+				</Drawer.Description>
+				<Drawer.Footer>
+					<Drawer.Action>Close</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	);
+}
+
+/**
+ * A controlled drawer where the open state is managed externally.
+ */
+export const Controlled: Story = {
+	render: () => <ControlledContent />,
+};
+
+function NonModalContent() {
+	return (
+		<Drawer.Root swipeDirection="right" modal={ false }>
+			<Drawer.Trigger>Open Non-Modal Drawer</Drawer.Trigger>
+			<Drawer.Popup>
+				<Drawer.Header>
+					<Drawer.Title>Non-Modal</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Description>
+					This drawer does not trap focus and allows interaction with
+					the rest of the page while open.
+				</Drawer.Description>
+				<Drawer.Footer>
+					<Drawer.Action>Close</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	);
+}
+
+/**
+ * A non-modal drawer that does not trap focus or lock page scroll.
+ * Users can interact with content behind the drawer while it is open.
+ */
+export const NonModal: Story = {
+	render: () => <NonModalContent />,
+};
+
+const navItems = [
+	'Overview',
+	'Components',
+	'Utilities',
+	'Patterns',
+	'Releases',
+	'Contributing',
+];
+
+const navItemStyle: React.CSSProperties = {
+	display: 'block',
+	width: '100%',
+	padding: '12px 16px',
+	borderRadius: '8px',
+	backgroundColor: 'var(--wpds-color-bg-surface-neutral)',
+	color: 'var(--wpds-color-fg-content-neutral)',
+	textDecoration: 'none',
+	boxSizing: 'border-box',
+};
+
+function MobileNavigationContent() {
+	return (
+		<Drawer.Root>
+			<Drawer.Trigger>Open Menu</Drawer.Trigger>
+			<Drawer.Popup>
+				<Drawer.Header>
+					<Drawer.Title>Menu</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Stack direction="column" gap="lg">
+					<Drawer.Description>
+						Swipe down to dismiss.
+					</Drawer.Description>
+					<nav>
+						<ul
+							style={ {
+								listStyle: 'none',
+								padding: 0,
+								margin: 0,
+								display: 'grid',
+								gap: '4px',
+							} }
+						>
+							{ navItems.map( ( item ) => (
+								<li key={ item }>
+									<button
+										type="button"
+										style={ navItemStyle }
+									>
+										{ item }
+									</button>
+								</li>
+							) ) }
+						</ul>
+					</nav>
+				</Stack>
+				<Drawer.Footer>
+					<Drawer.Action>Close</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	);
+}
+
+/**
+ * A bottom sheet used as a mobile navigation menu. The default
+ * `swipeDirection` (`"down"`) makes it dismissible by swiping down.
+ */
+export const MobileNavigation: Story = {
+	render: () => <MobileNavigationContent />,
+};
+
+const ALL_SIZES = [ 'small', 'medium', 'large', 'stretch', 'auto' ] as const;
+
+function SizeSelector( {
+	value,
+	onChange,
+}: {
+	value: ComponentProps< typeof Drawer.Popup >[ 'size' ];
+	onChange: ( size: ComponentProps< typeof Drawer.Popup >[ 'size' ] ) => void;
+} ) {
+	const selectId = useId();
+	return (
+		<div style={ { display: 'flex', gap: 8, alignItems: 'center' } }>
+			<label htmlFor={ selectId }>Size</label>
+			<select
+				id={ selectId }
+				value={ value ?? '' }
+				onChange={ ( e ) =>
+					onChange(
+						( e.target.value || undefined ) as ComponentProps<
+							typeof Drawer.Popup
+						>[ 'size' ]
+					)
+				}
+			>
+				<option value="">default</option>
+				{ ALL_SIZES.map( ( s ) => (
+					<option key={ s } value={ s }>
+						{ s }
+					</option>
+				) ) }
+			</select>
+		</div>
+	);
+}
+
+function DirectionSelector( {
+	value,
+	onChange,
+}: {
+	value: ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ];
+	onChange: (
+		dir: ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ]
+	) => void;
+} ) {
+	const selectId = useId();
+	return (
+		<div style={ { display: 'flex', gap: 8, alignItems: 'center' } }>
+			<label htmlFor={ selectId }>Direction</label>
+			<select
+				id={ selectId }
+				value={ value }
+				onChange={ ( e ) =>
+					onChange(
+						e.target.value as ComponentProps<
+							typeof Drawer.Root
+						>[ 'swipeDirection' ]
+					)
+				}
+			>
+				{ ( [ 'left', 'right', 'down', 'up' ] as const ).map( ( d ) => (
+					<option key={ d } value={ d }>
+						{ d }
+					</option>
+				) ) }
+			</select>
+		</div>
+	);
+}
+
+function SizePlaygroundContent() {
+	const [ size, setSize ] =
+		useState< ComponentProps< typeof Drawer.Popup >[ 'size' ] >();
+	const [ direction, setDirection ] =
+		useState< ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ] >(
+			'left'
+		);
+
+	return (
+		<Drawer.Root swipeDirection={ direction }>
+			<div
+				style={ {
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 16,
+					alignItems: 'start',
+				} }
+			>
+				<DirectionSelector
+					value={ direction }
+					onChange={ setDirection }
+				/>
+				<SizeSelector value={ size } onChange={ setSize } />
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+			</div>
+			<Drawer.Popup size={ size }>
+				<Drawer.Header>
+					<Drawer.Title>Size Playground</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Stack direction="column" gap="lg">
+					<div
+						style={ {
+							display: 'grid',
+							gap: 8,
+						} }
+					>
+						<SizeSelector value={ size } onChange={ setSize } />
+						<DirectionSelector
+							value={ direction }
+							onChange={ setDirection }
+						/>
+					</div>
+					<Drawer.Description>
+						Use the dropdowns to change the size and direction. Both
+						inside and outside controls stay in sync.
+					</Drawer.Description>
+				</Stack>
+				<Drawer.Footer>
+					<Drawer.Action>Got it</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	);
+}
+
+/**
+ * Interactive playground to test the `size` prop across all swipe
+ * directions. Size controls the width (left/right) or height (up/down).
+ */
+export const SizePlayground: Story = {
+	render: () => <SizePlaygroundContent />,
+};
+
+const actionItemStyle: React.CSSProperties = {
+	display: 'block',
+	width: '100%',
+	padding: '14px 16px',
+	border: 'none',
+	borderBottom: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
+	backgroundColor: 'transparent',
+	color: 'var(--wpds-color-fg-content-neutral)',
+	fontFamily: 'var(--wpds-typography-font-family-body)',
+	fontSize: 'var(--wpds-typography-font-size-md)',
+	textAlign: 'start' as const,
+	cursor: 'pointer',
+	boxSizing: 'border-box',
+};
+
+function ActionSheetContent() {
+	return (
+		<Drawer.Root>
+			<Drawer.Trigger>Open Action Sheet</Drawer.Trigger>
+			<Drawer.Popup>
+				<Drawer.Header>
+					<Drawer.Title>Photo Options</Drawer.Title>
+				</Drawer.Header>
+
+				<div
+					style={ {
+						borderRadius: '8px',
+						border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
+						overflow: 'hidden',
+					} }
+				>
+					<button style={ actionItemStyle }>Take Photo</button>
+					<button style={ actionItemStyle }>
+						Choose from Library
+					</button>
+					<button
+						style={ {
+							...actionItemStyle,
+							borderBottom: 'none',
+						} }
+					>
+						Browse Files
+					</button>
+				</div>
+
+				<Drawer.Footer>
+					<Drawer.Action
+						variant="outline"
+						style={ {
+							width: '100%',
+							color: 'var(--wpds-color-fg-content-error)',
+						} }
+					>
+						Delete Photo
+					</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	);
+}
+
+/**
+ * An action sheet presented as a bottom drawer with a grouped list of
+ * actions and a separate destructive action. This pattern is common on
+ * mobile for contextual menus.
+ */
+export const ActionSheet: Story = {
+	render: () => <ActionSheetContent />,
+};

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -63,8 +63,12 @@ const directions = [
 	{ swipeDirection: 'up', label: 'Top', title: 'Top Drawer' },
 ] as const;
 
-function AllSidesContent() {
-	return (
+/**
+ * Four drawers, one for each swipe direction. Each trigger opens a
+ * drawer from the corresponding edge.
+ */
+export const AllSides: Story = {
+	render: () => (
 		<div
 			style={ {
 				display: 'grid',
@@ -95,153 +99,72 @@ function AllSidesContent() {
 				</Drawer.Root>
 			) ) }
 		</div>
-	);
-}
-
-/**
- * Four drawers, one for each swipe direction. Each trigger opens a
- * drawer from the corresponding edge.
- */
-export const AllSides: Story = {
-	render: () => <AllSidesContent />,
+	),
 };
-
-function ControlledContent() {
-	const [ open, setOpen ] = useState( false );
-
-	return (
-		<Drawer.Root
-			open={ open }
-			onOpenChange={ setOpen }
-			swipeDirection="left"
-		>
-			<Drawer.Trigger>Open Controlled Drawer</Drawer.Trigger>
-			<Drawer.Popup>
-				<Drawer.Header>
-					<Drawer.Title>Controlled Drawer</Drawer.Title>
-					<Drawer.CloseIcon />
-				</Drawer.Header>
-				<Drawer.Description>
-					The open state is managed externally via <code>open</code>{ ' ' }
-					and <code>onOpenChange</code>.
-				</Drawer.Description>
-				<Drawer.Footer>
-					<Drawer.Action>Close</Drawer.Action>
-				</Drawer.Footer>
-			</Drawer.Popup>
-		</Drawer.Root>
-	);
-}
 
 /**
  * A controlled drawer where the open state is managed externally.
  */
 export const Controlled: Story = {
-	render: () => <ControlledContent />,
+	render: function ControlledRender() {
+		const [ open, setOpen ] = useState( false );
+		return (
+			<Drawer.Root
+				open={ open }
+				onOpenChange={ setOpen }
+				swipeDirection="left"
+			>
+				<Drawer.Trigger>Open Controlled Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Header>
+						<Drawer.Title>Controlled Drawer</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<Drawer.Description>
+						The open state is managed externally via{ ' ' }
+						<code>open</code> and <code>onOpenChange</code>.
+					</Drawer.Description>
+					<Drawer.Footer>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+	},
 };
-
-function NonModalContent() {
-	return (
-		<Drawer.Root swipeDirection="right" modal={ false }>
-			<Drawer.Trigger>Open Non-Modal Drawer</Drawer.Trigger>
-			<Drawer.Popup>
-				<Drawer.Header>
-					<Drawer.Title>Non-Modal</Drawer.Title>
-					<Drawer.CloseIcon />
-				</Drawer.Header>
-				<Drawer.Description>
-					This drawer does not trap focus and allows interaction with
-					the rest of the page while open.
-				</Drawer.Description>
-				<Drawer.Footer>
-					<Drawer.Action>Close</Drawer.Action>
-				</Drawer.Footer>
-			</Drawer.Popup>
-		</Drawer.Root>
-	);
-}
 
 /**
  * A non-modal drawer that does not trap focus or lock page scroll.
  * Users can interact with content behind the drawer while it is open.
  */
 export const NonModal: Story = {
-	render: () => <NonModalContent />,
-};
-
-const navItems = [
-	'Overview',
-	'Components',
-	'Utilities',
-	'Patterns',
-	'Releases',
-	'Contributing',
-];
-
-const navItemStyle: React.CSSProperties = {
-	display: 'block',
-	width: '100%',
-	padding: '12px 16px',
-	borderRadius: '8px',
-	backgroundColor: 'var(--wpds-color-bg-surface-neutral)',
-	color: 'var(--wpds-color-fg-content-neutral)',
-	textDecoration: 'none',
-	boxSizing: 'border-box',
-};
-
-function MobileNavigationContent() {
-	return (
-		<Drawer.Root>
-			<Drawer.Trigger>Open Menu</Drawer.Trigger>
-			<Drawer.Popup>
-				<Drawer.Header>
-					<Drawer.Title>Menu</Drawer.Title>
-					<Drawer.CloseIcon />
-				</Drawer.Header>
-				<Stack direction="column" gap="lg">
+	args: {
+		swipeDirection: 'right',
+		modal: false,
+		children: (
+			<>
+				<Drawer.Trigger>Open Non-Modal Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Header>
+						<Drawer.Title>Non-Modal</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
 					<Drawer.Description>
-						Swipe down to dismiss.
+						This drawer does not trap focus and allows interaction
+						with the rest of the page while open.
 					</Drawer.Description>
-					<nav>
-						<ul
-							style={ {
-								listStyle: 'none',
-								padding: 0,
-								margin: 0,
-								display: 'grid',
-								gap: '4px',
-							} }
-						>
-							{ navItems.map( ( item ) => (
-								<li key={ item }>
-									<button
-										type="button"
-										style={ navItemStyle }
-									>
-										{ item }
-									</button>
-								</li>
-							) ) }
-						</ul>
-					</nav>
-				</Stack>
-				<Drawer.Footer>
-					<Drawer.Action>Close</Drawer.Action>
-				</Drawer.Footer>
-			</Drawer.Popup>
-		</Drawer.Root>
-	);
-}
-
-/**
- * A bottom sheet used as a mobile navigation menu. The default
- * `swipeDirection` (`"down"`) makes it dismissible by swiping down.
- */
-export const MobileNavigation: Story = {
-	render: () => <MobileNavigationContent />,
+					<Drawer.Footer>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</>
+		),
+	},
 };
 
-const ALL_SIZES = [ 'small', 'medium', 'large', 'stretch', 'auto' ] as const;
+const ALL_SIZES: NonNullable<
+	ComponentProps< typeof Drawer.Popup >[ 'size' ]
+>[] = [ 'small', 'medium', 'large', 'stretch', 'auto' ];
 
 function SizeSelector( {
 	value,
@@ -310,136 +233,63 @@ function DirectionSelector( {
 	);
 }
 
-function SizePlaygroundContent() {
-	const [ size, setSize ] =
-		useState< ComponentProps< typeof Drawer.Popup >[ 'size' ] >();
-	const [ direction, setDirection ] =
-		useState< ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ] >(
-			'left'
-		);
-
-	return (
-		<Drawer.Root swipeDirection={ direction }>
-			<div
-				style={ {
-					display: 'flex',
-					flexDirection: 'column',
-					gap: 16,
-					alignItems: 'start',
-				} }
-			>
-				<DirectionSelector
-					value={ direction }
-					onChange={ setDirection }
-				/>
-				<SizeSelector value={ size } onChange={ setSize } />
-				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
-			</div>
-			<Drawer.Popup size={ size }>
-				<Drawer.Header>
-					<Drawer.Title>Size Playground</Drawer.Title>
-					<Drawer.CloseIcon />
-				</Drawer.Header>
-				<Stack direction="column" gap="lg">
-					<div
-						style={ {
-							display: 'grid',
-							gap: 8,
-						} }
-					>
-						<SizeSelector value={ size } onChange={ setSize } />
-						<DirectionSelector
-							value={ direction }
-							onChange={ setDirection }
-						/>
-					</div>
-					<Drawer.Description>
-						Use the dropdowns to change the size and direction. Both
-						inside and outside controls stay in sync.
-					</Drawer.Description>
-				</Stack>
-				<Drawer.Footer>
-					<Drawer.Action>Got it</Drawer.Action>
-				</Drawer.Footer>
-			</Drawer.Popup>
-		</Drawer.Root>
-	);
-}
-
 /**
  * Interactive playground to test the `size` prop across all swipe
  * directions. Size controls the width (left/right) or height (up/down).
  */
 export const SizePlayground: Story = {
-	render: () => <SizePlaygroundContent />,
-};
-
-const actionItemStyle: React.CSSProperties = {
-	display: 'block',
-	width: '100%',
-	padding: '14px 16px',
-	border: 'none',
-	borderBottom: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
-	backgroundColor: 'transparent',
-	color: 'var(--wpds-color-fg-content-neutral)',
-	fontFamily: 'var(--wpds-typography-font-family-body)',
-	fontSize: 'var(--wpds-typography-font-size-md)',
-	textAlign: 'start' as const,
-	cursor: 'pointer',
-	boxSizing: 'border-box',
-};
-
-function ActionSheetContent() {
-	return (
-		<Drawer.Root>
-			<Drawer.Trigger>Open Action Sheet</Drawer.Trigger>
-			<Drawer.Popup>
-				<Drawer.Header>
-					<Drawer.Title>Photo Options</Drawer.Title>
-				</Drawer.Header>
-
+	render: function SizePlaygroundRender() {
+		const [ size, setSize ] =
+			useState< ComponentProps< typeof Drawer.Popup >[ 'size' ] >();
+		const [ direction, setDirection ] =
+			useState<
+				ComponentProps< typeof Drawer.Root >[ 'swipeDirection' ]
+			>( 'left' );
+		return (
+			<Drawer.Root swipeDirection={ direction }>
 				<div
 					style={ {
-						borderRadius: '8px',
-						border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
-						overflow: 'hidden',
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 16,
+						alignItems: 'start',
 					} }
 				>
-					<button style={ actionItemStyle }>Take Photo</button>
-					<button style={ actionItemStyle }>
-						Choose from Library
-					</button>
-					<button
-						style={ {
-							...actionItemStyle,
-							borderBottom: 'none',
-						} }
-					>
-						Browse Files
-					</button>
+					<DirectionSelector
+						value={ direction }
+						onChange={ setDirection }
+					/>
+					<SizeSelector value={ size } onChange={ setSize } />
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
 				</div>
-
-				<Drawer.Footer>
-					<Drawer.Action
-						variant="outline"
-						style={ {
-							width: '100%',
-							color: 'var(--wpds-color-fg-content-error)',
-						} }
-					>
-						Delete Photo
-					</Drawer.Action>
-				</Drawer.Footer>
-			</Drawer.Popup>
-		</Drawer.Root>
-	);
-}
-
-/**
- * An action sheet presented as a bottom drawer with a grouped list of
- * actions and a separate destructive action. This pattern is common on
- * mobile for contextual menus.
- */
-export const ActionSheet: Story = {
-	render: () => <ActionSheetContent />,
+				<Drawer.Popup size={ size }>
+					<Drawer.Header>
+						<Drawer.Title>Size Playground</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<Stack direction="column" gap="lg">
+						<div
+							style={ {
+								display: 'grid',
+								gap: 8,
+							} }
+						>
+							<SizeSelector value={ size } onChange={ setSize } />
+							<DirectionSelector
+								value={ direction }
+								onChange={ setDirection }
+							/>
+						</div>
+						<Drawer.Description>
+							Use the dropdowns to change the size and direction.
+							Both inside and outside controls stay in sync.
+						</Drawer.Description>
+					</Stack>
+					<Drawer.Footer>
+						<Drawer.Action>Got it</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+	},
 };

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -57,7 +57,7 @@
 	}
 
 	.popup {
-		--_viewport-inset: var(--wpds-dimension-padding-2xl);
+		--viewport-inset: var(--wpds-dimension-padding-2xl);
 
 		position: fixed;
 		z-index: var(--wp-ui-drawer-z-index, initial);
@@ -127,14 +127,14 @@
 
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 		&[data-swipe-direction="left"] {
-			--stretch-size: calc(100vw - var(--_viewport-inset));
+			--stretch-size: calc(100vw - var(--viewport-inset));
 
 			top: 0;
 			bottom: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			left: 0;
 			width: var(--popup-size);
-			max-width: calc(100vw - var(--_viewport-inset));
+			max-width: calc(100vw - var(--viewport-inset));
 			border-start-end-radius: var(--wpds-border-radius-lg);
 			border-end-end-radius: var(--wpds-border-radius-lg);
 			transform: translateX(var(--drawer-swipe-movement-x));
@@ -147,14 +147,14 @@
 
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 		&[data-swipe-direction="right"] {
-			--stretch-size: calc(100vw - var(--_viewport-inset));
+			--stretch-size: calc(100vw - var(--viewport-inset));
 
 			top: 0;
 			bottom: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			right: 0;
 			width: var(--popup-size);
-			max-width: calc(100vw - var(--_viewport-inset));
+			max-width: calc(100vw - var(--viewport-inset));
 			border-start-start-radius: var(--wpds-border-radius-lg);
 			border-end-start-radius: var(--wpds-border-radius-lg);
 			transform: translateX(var(--drawer-swipe-movement-x));
@@ -166,7 +166,7 @@
 		}
 
 		&[data-swipe-direction="down"] {
-			--stretch-size: calc(100dvh - var(--_viewport-inset));
+			--stretch-size: calc(100dvh - var(--viewport-inset));
 
 			bottom: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
@@ -174,7 +174,7 @@
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			right: 0;
 			height: var(--popup-size);
-			max-height: calc(100dvh - var(--_viewport-inset));
+			max-height: calc(100dvh - var(--viewport-inset));
 			border-start-start-radius: var(--wpds-border-radius-lg);
 			border-start-end-radius: var(--wpds-border-radius-lg);
 			transform: translateY(var(--drawer-swipe-movement-y));
@@ -186,7 +186,7 @@
 		}
 
 		&[data-swipe-direction="up"] {
-			--stretch-size: calc(100dvh - var(--_viewport-inset));
+			--stretch-size: calc(100dvh - var(--viewport-inset));
 
 			top: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
@@ -194,7 +194,7 @@
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			right: 0;
 			height: var(--popup-size);
-			max-height: calc(100dvh - var(--_viewport-inset));
+			max-height: calc(100dvh - var(--viewport-inset));
 			border-end-start-radius: var(--wpds-border-radius-lg);
 			border-end-end-radius: var(--wpds-border-radius-lg);
 			transform: translateY(var(--drawer-swipe-movement-y));

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -57,7 +57,7 @@
 	}
 
 	.popup {
-		--viewport-inset: var(--wpds-dimension-padding-2xl);
+		--_viewport-inset: var(--wpds-dimension-padding-2xl);
 
 		position: fixed;
 		z-index: var(--wp-ui-drawer-z-index, initial);
@@ -123,14 +123,14 @@
 
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 		&[data-swipe-direction="left"] {
-			--stretch-size: calc(100vw - var(--viewport-inset));
+			--stretch-size: calc(100vw - var(--_viewport-inset));
 
 			top: 0;
 			bottom: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			left: 0;
 			width: var(--popup-size);
-			max-width: calc(100vw - var(--viewport-inset));
+			max-width: calc(100vw - var(--_viewport-inset));
 			border-start-end-radius: var(--wpds-border-radius-lg);
 			border-end-end-radius: var(--wpds-border-radius-lg);
 			transform: translateX(var(--drawer-swipe-movement-x));
@@ -143,14 +143,14 @@
 
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 		&[data-swipe-direction="right"] {
-			--stretch-size: calc(100vw - var(--viewport-inset));
+			--stretch-size: calc(100vw - var(--_viewport-inset));
 
 			top: 0;
 			bottom: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			right: 0;
 			width: var(--popup-size);
-			max-width: calc(100vw - var(--viewport-inset));
+			max-width: calc(100vw - var(--_viewport-inset));
 			border-start-start-radius: var(--wpds-border-radius-lg);
 			border-end-start-radius: var(--wpds-border-radius-lg);
 			transform: translateX(var(--drawer-swipe-movement-x));
@@ -162,7 +162,7 @@
 		}
 
 		&[data-swipe-direction="down"] {
-			--stretch-size: calc(100dvh - var(--viewport-inset));
+			--stretch-size: calc(100dvh - var(--_viewport-inset));
 
 			bottom: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
@@ -170,7 +170,7 @@
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			right: 0;
 			height: var(--popup-size);
-			max-height: calc(100dvh - var(--viewport-inset));
+			max-height: calc(100dvh - var(--_viewport-inset));
 			border-start-start-radius: var(--wpds-border-radius-lg);
 			border-start-end-radius: var(--wpds-border-radius-lg);
 			transform: translateY(var(--drawer-swipe-movement-y));
@@ -182,7 +182,7 @@
 		}
 
 		&[data-swipe-direction="up"] {
-			--stretch-size: calc(100dvh - var(--viewport-inset));
+			--stretch-size: calc(100dvh - var(--_viewport-inset));
 
 			top: 0;
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
@@ -190,7 +190,7 @@
 			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
 			right: 0;
 			height: var(--popup-size);
-			max-height: calc(100dvh - var(--viewport-inset));
+			max-height: calc(100dvh - var(--_viewport-inset));
 			border-end-start-radius: var(--wpds-border-radius-lg);
 			border-end-end-radius: var(--wpds-border-radius-lg);
 			transform: translateY(var(--drawer-swipe-movement-y));
@@ -245,5 +245,4 @@
 		margin-top: var(--wpds-dimension-gap-lg);
 		padding-top: var(--wpds-dimension-padding-lg);
 	}
-
 }

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -210,19 +210,19 @@
 		padding: var(--wpds-dimension-padding-2xl);
 	}
 
-	.popup[data-swipe-direction="left"] > .content {
+	.popup[data-swipe-direction="left"] .content {
 		padding-inline-start: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-left));
 	}
 
-	.popup[data-swipe-direction="right"] > .content {
+	.popup[data-swipe-direction="right"] .content {
 		padding-inline-end: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-right));
 	}
 
-	.popup[data-swipe-direction="down"] > .content {
+	.popup[data-swipe-direction="down"] .content {
 		padding-bottom: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-bottom));
 	}
 
-	.popup[data-swipe-direction="up"] > .content {
+	.popup[data-swipe-direction="up"] .content {
 		padding-top: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-top));
 	}
 

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -79,7 +79,23 @@
 		overflow-block: auto;
 		overscroll-behavior: contain;
 		touch-action: auto;
-		will-change: transform;
+
+		&[data-open],
+		&[data-swiping] {
+			will-change: transform;
+
+			@media not (prefers-reduced-motion) {
+				transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+
+				&[data-ending-style] {
+					transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
+				}
+
+				&[data-swiping] {
+					transition-duration: 0ms;
+				}
+			}
+		}
 
 		/*
 		 * TODO: should top/bottom sides use different tokens for the height
@@ -107,18 +123,6 @@
 
 		&[data-swiping] {
 			user-select: none;
-		}
-
-		@media not (prefers-reduced-motion) {
-			transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
-
-			&[data-ending-style] {
-				transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
-			}
-
-			&[data-swiping] {
-				transition-duration: 0ms;
-			}
 		}
 
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
@@ -204,6 +208,14 @@
 
 	.content {
 		padding: var(--wpds-dimension-padding-2xl);
+	}
+
+	.popup[data-swipe-direction="left"] > .content {
+		padding-inline-start: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-left));
+	}
+
+	.popup[data-swipe-direction="right"] > .content {
+		padding-inline-end: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-right));
 	}
 
 	.popup[data-swipe-direction="down"] > .content {

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -1,0 +1,249 @@
+@layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
+
+/*
+ * Temporary workaround for a Base UI tabbability regression with
+ * checkVisibility() and display: contents.
+ * See: https://github.com/mui/base-ui/issues/4622
+ *
+ * This must stay outside the CSS layers to override ThemeProvider's
+ * unlayered display: contents.
+ */
+[data-wpds-theme-provider-id]:has(> .popup) {
+	display: block;
+}
+
+@layer wp-ui-components {
+	.backdrop {
+		--backdrop-opacity: 0.35;
+		position: fixed;
+		inset: 0;
+		z-index: var(--wp-ui-drawer-z-index, initial);
+		min-height: 100dvh;
+		background-color: rgb(0, 0, 0);
+		opacity: calc(var(--backdrop-opacity) * (1 - var(--drawer-swipe-progress)));
+
+		/*
+		 * WebKit/iOS Safari workaround: use absolute positioning so the
+		 * backdrop tracks the visible viewport instead of the layout one.
+		 */
+		@supports (-webkit-touch-callout: none) {
+			position: absolute;
+		}
+
+		&[data-starting-style],
+		&[data-ending-style] {
+			opacity: 0;
+		}
+
+		@media not (prefers-reduced-motion) {
+			transition: opacity 450ms cubic-bezier(0.32, 0.72, 0, 1);
+
+			&[data-ending-style] {
+				pointer-events: none;
+				transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
+			}
+
+			&[data-swiping] {
+				transition-duration: 0ms;
+			}
+		}
+	}
+
+	.viewport {
+		position: fixed;
+		inset: 0;
+		z-index: var(--wp-ui-drawer-z-index, initial);
+		pointer-events: none;
+	}
+
+	.popup {
+		--viewport-inset: var(--wpds-dimension-padding-2xl);
+
+		position: fixed;
+		z-index: var(--wp-ui-drawer-z-index, initial);
+		box-sizing: border-box;
+		display: block;
+		outline: 0;
+		pointer-events: auto;
+		background-color: var(--wpds-color-bg-surface-neutral-strong);
+		box-shadow: var(--wpds-elevation-lg);
+		font-family: var(--wpds-typography-font-family-body);
+		font-size: var(--wpds-typography-font-size-md);
+		line-height: var(--wpds-typography-line-height-md);
+		color: var(--wpds-color-fg-content-neutral);
+		/*
+		 * Scroll on the block axis. For left/right drawers, swipe is on the
+		 * inline axis (no conflict). For up/down drawers, swipe dismissal only
+		 * engages once scroll reaches an edge.
+		 */
+		overflow-block: auto;
+		overscroll-behavior: contain;
+		touch-action: auto;
+		will-change: transform;
+
+		/*
+		 * TODO: should top/bottom sides use different tokens for the height
+		 * of the popup, compared to the width?
+		 */
+		&.is-small {
+			--popup-size: var(--wpds-dimension-surface-width-sm);
+		}
+
+		&.is-medium {
+			--popup-size: var(--wpds-dimension-surface-width-md);
+		}
+
+		&.is-large {
+			--popup-size: var(--wpds-dimension-surface-width-lg);
+		}
+
+		&.is-stretch {
+			--popup-size: var(--stretch-size);
+		}
+
+		&.is-auto {
+			--popup-size: auto;
+		}
+
+		&[data-swiping] {
+			user-select: none;
+		}
+
+		@media not (prefers-reduced-motion) {
+			transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+
+			&[data-ending-style] {
+				transition-duration: calc(var(--drawer-swipe-strength) * 400ms);
+			}
+
+			&[data-swiping] {
+				transition-duration: 0ms;
+			}
+		}
+
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+		&[data-swipe-direction="left"] {
+			--stretch-size: calc(100vw - var(--viewport-inset));
+
+			top: 0;
+			bottom: 0;
+			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+			left: 0;
+			width: var(--popup-size);
+			max-width: calc(100vw - var(--viewport-inset));
+			border-start-end-radius: var(--wpds-border-radius-lg);
+			border-end-end-radius: var(--wpds-border-radius-lg);
+			transform: translateX(var(--drawer-swipe-movement-x));
+
+			&[data-starting-style],
+			&[data-ending-style] {
+				transform: translateX(-100%);
+			}
+		}
+
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+		&[data-swipe-direction="right"] {
+			--stretch-size: calc(100vw - var(--viewport-inset));
+
+			top: 0;
+			bottom: 0;
+			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+			right: 0;
+			width: var(--popup-size);
+			max-width: calc(100vw - var(--viewport-inset));
+			border-start-start-radius: var(--wpds-border-radius-lg);
+			border-end-start-radius: var(--wpds-border-radius-lg);
+			transform: translateX(var(--drawer-swipe-movement-x));
+
+			&[data-starting-style],
+			&[data-ending-style] {
+				transform: translateX(100%);
+			}
+		}
+
+		&[data-swipe-direction="down"] {
+			--stretch-size: calc(100dvh - var(--viewport-inset));
+
+			bottom: 0;
+			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+			left: 0;
+			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+			right: 0;
+			height: var(--popup-size);
+			max-height: calc(100dvh - var(--viewport-inset));
+			border-start-start-radius: var(--wpds-border-radius-lg);
+			border-start-end-radius: var(--wpds-border-radius-lg);
+			transform: translateY(var(--drawer-swipe-movement-y));
+
+			&[data-starting-style],
+			&[data-ending-style] {
+				transform: translateY(100%);
+			}
+		}
+
+		&[data-swipe-direction="up"] {
+			--stretch-size: calc(100dvh - var(--viewport-inset));
+
+			top: 0;
+			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+			left: 0;
+			/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical positioning needed for slide-in animation direction */
+			right: 0;
+			height: var(--popup-size);
+			max-height: calc(100dvh - var(--viewport-inset));
+			border-end-start-radius: var(--wpds-border-radius-lg);
+			border-end-end-radius: var(--wpds-border-radius-lg);
+			transform: translateY(var(--drawer-swipe-movement-y));
+
+			&[data-starting-style],
+			&[data-ending-style] {
+				transform: translateY(-100%);
+			}
+		}
+	}
+
+	.content {
+		padding: var(--wpds-dimension-padding-2xl);
+	}
+
+	.popup[data-swipe-direction="down"] > .content {
+		padding-bottom: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-bottom));
+	}
+
+	.popup[data-swipe-direction="up"] > .content {
+		padding-top: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-top));
+	}
+
+	.header {
+		display: flex;
+		align-items: center;
+		gap: var(--wpds-dimension-gap-sm);
+		margin-bottom: var(--wpds-dimension-gap-lg);
+	}
+
+	.title {
+		margin-inline-end: auto;
+
+		/* Workaround: the GCD shorthand `margin` overrides the longhand above.
+		 * Keep both so the layout survives GCD removal. */
+		--_gcd-heading-margin: 0 auto 0 0;
+
+		&:dir(rtl) {
+			--_gcd-heading-margin: 0 0 0 auto;
+		}
+	}
+
+	.description {
+		color: var(--wpds-color-fg-content-neutral-weak);
+	}
+
+	.footer {
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		gap: var(--wpds-dimension-gap-sm);
+		margin-top: var(--wpds-dimension-gap-lg);
+		padding-top: var(--wpds-dimension-padding-lg);
+	}
+
+}

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -36,6 +36,13 @@
 		}
 
 		@media not (prefers-reduced-motion) {
+			/*
+			 * The duration and easing are intentionally different from
+			 * Dialog's backdrop: they match the popup's slide-in/out so the
+			 * two surfaces transition together. The ending-style duration is
+			 * further scaled by `--drawer-swipe-strength` so the backdrop
+			 * fades in lockstep with a swipe-dismissed popup.
+			 */
 			transition: opacity 450ms cubic-bezier(0.32, 0.72, 0, 1);
 
 			&[data-ending-style] {

--- a/packages/ui/src/drawer/style.module.css
+++ b/packages/ui/src/drawer/style.module.css
@@ -217,12 +217,20 @@
 		padding: var(--wpds-dimension-padding-2xl);
 	}
 
+	/*
+	 * The popup is anchored to a physical edge regardless of writing direction
+	 * (see `left: 0` / `right: 0` above), so the safe-area padding uses the
+	 * matching physical side. `env(safe-area-inset-*)` is already physical,
+	 * so pairing it with logical `padding-inline-*` would be wrong in RTL.
+	 */
 	.popup[data-swipe-direction="left"] .content {
-		padding-inline-start: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-left));
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- physical to match the physical popup anchoring */
+		padding-left: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-left));
 	}
 
 	.popup[data-swipe-direction="right"] .content {
-		padding-inline-end: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-right));
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- physical to match the physical popup anchoring */
+		padding-right: max(var(--wpds-dimension-padding-2xl), env(safe-area-inset-right));
 	}
 
 	.popup[data-swipe-direction="down"] .content {

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
 import * as Drawer from '../index';
@@ -568,7 +568,9 @@ describe( 'Drawer', () => {
 			await waitFor( () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			cleanup();
@@ -636,7 +638,9 @@ describe( 'Drawer', () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
 
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			await user.click(
@@ -697,7 +701,9 @@ describe( 'Drawer', () => {
 				screen.getByRole( 'button', { name: 'Toggle Title' } )
 			);
 
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 
 			expect( errors ).toHaveLength( errorCountAfterInitial );
 
@@ -764,7 +770,9 @@ describe( 'Drawer', () => {
 			await waitFor( () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			cleanup();

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -66,6 +66,32 @@ describe( 'Drawer', () => {
 		expect( actionRef.current ).toBeInstanceOf( HTMLButtonElement );
 	} );
 
+	it( 'renders Drawer.Header and supports render/className props', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Header
+						render={ <section data-testid="drawer-header" /> }
+						className="custom-header"
+					>
+						<Drawer.Title>Test Drawer</Drawer.Title>
+					</Drawer.Header>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Drawer' } )
+		);
+
+		const header = await screen.findByTestId( 'drawer-header' );
+		expect( header.tagName ).toBe( 'SECTION' );
+		expect( header ).toHaveClass( 'custom-header' );
+	} );
+
 	it( 'renders Drawer.Footer and supports render/className props', async () => {
 		const user = userEvent.setup();
 
@@ -232,6 +258,94 @@ describe( 'Drawer', () => {
 		expect( closeButton ).toHaveAttribute( 'data-wp-ui-drawer-close-icon' );
 	} );
 
+	it( 'does not move focus when initialFocus is false', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup initialFocus={ false }>
+					<Drawer.Header>
+						<Drawer.Title>Focus test</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<button>Content Button</button>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Drawer' } )
+		);
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Content Button' } )
+		).not.toHaveFocus();
+		expect(
+			screen.getByRole( 'button', { name: 'Close' } )
+		).not.toHaveFocus();
+	} );
+
+	it( 'uses a custom initialFocus callback as-is', async () => {
+		const user = userEvent.setup();
+		const customFocus = jest.fn( () => false as const );
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup initialFocus={ customFocus }>
+					<Drawer.Header>
+						<Drawer.Title>Focus test</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<button>Content Button</button>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Drawer' } )
+		);
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
+
+		expect( customFocus ).toHaveBeenCalled();
+	} );
+
+	it( 'closes on Escape and restores focus to the trigger', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Title>Escape test</Drawer.Title>
+					Drawer content
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		const trigger = screen.getByRole( 'button', { name: 'Open Drawer' } );
+
+		await user.click( trigger );
+		expect( await screen.findByText( 'Drawer content' ) ).toBeVisible();
+
+		await user.keyboard( '{Escape}' );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByText( 'Drawer content' )
+			).not.toBeInTheDocument();
+		} );
+		expect( trigger ).toHaveFocus();
+	} );
+
 	it( 'supports default and explicit size values across swipe directions', async () => {
 		const view = render(
 			<Drawer.Root open swipeDirection="left">
@@ -241,7 +355,10 @@ describe( 'Drawer', () => {
 			</Drawer.Root>
 		);
 
-		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( await screen.findByRole( 'dialog' ) ).toHaveAttribute(
+			'data-swipe-direction',
+			'left'
+		);
 
 		view.rerender(
 			<Drawer.Root open swipeDirection="up">
@@ -250,7 +367,10 @@ describe( 'Drawer', () => {
 				</Drawer.Popup>
 			</Drawer.Root>
 		);
-		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( await screen.findByRole( 'dialog' ) ).toHaveAttribute(
+			'data-swipe-direction',
+			'up'
+		);
 
 		view.rerender(
 			<Drawer.Root open swipeDirection="right">
@@ -259,16 +379,22 @@ describe( 'Drawer', () => {
 				</Drawer.Popup>
 			</Drawer.Root>
 		);
-		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( await screen.findByRole( 'dialog' ) ).toHaveAttribute(
+			'data-swipe-direction',
+			'right'
+		);
 
 		view.rerender(
-			<Drawer.Root open swipeDirection="up">
+			<Drawer.Root open swipeDirection="down">
 				<Drawer.Popup size="large">
-					<Drawer.Title>Large drawer</Drawer.Title>
+					<Drawer.Title>Down drawer</Drawer.Title>
 				</Drawer.Popup>
 			</Drawer.Root>
 		);
-		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( await screen.findByRole( 'dialog' ) ).toHaveAttribute(
+			'data-swipe-direction',
+			'down'
+		);
 	} );
 
 	it( 'marks Drawer.Action as disabled when loading is true', async () => {

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -1,0 +1,544 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef, useState } from '@wordpress/element';
+import * as Drawer from '../index';
+
+function collectUncaughtErrors() {
+	const errors: Error[] = [];
+	const handler = ( event: ErrorEvent ) => {
+		event.preventDefault();
+		errors.push( event.error );
+	};
+	window.addEventListener( 'error', handler );
+	return {
+		errors,
+		cleanup: () => window.removeEventListener( 'error', handler ),
+	};
+}
+
+describe( 'Drawer', () => {
+	it( 'forwards ref', async () => {
+		const user = userEvent.setup();
+		const triggerRef = createRef< HTMLButtonElement >();
+		const popupRef = createRef< HTMLDivElement >();
+		const actionRef = createRef< HTMLButtonElement >();
+		const footerRef = createRef< HTMLDivElement >();
+		const headerRef = createRef< HTMLDivElement >();
+		const titleRef = createRef< HTMLHeadingElement >();
+		const descriptionRef = createRef< HTMLParagraphElement >();
+		const closeIconRef = createRef< HTMLButtonElement >();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger ref={ triggerRef }>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup ref={ popupRef }>
+					<Drawer.Header ref={ headerRef }>
+						<Drawer.Title ref={ titleRef }>
+							Test Drawer
+						</Drawer.Title>
+						<Drawer.CloseIcon ref={ closeIconRef } />
+					</Drawer.Header>
+					<Drawer.Description ref={ descriptionRef }>
+						A test description
+					</Drawer.Description>
+					<Drawer.Footer ref={ footerRef }>
+						<Drawer.Action ref={ actionRef }>Close</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		expect( triggerRef.current ).toBeInstanceOf( HTMLButtonElement );
+
+		await user.click( triggerRef.current! );
+
+		await waitFor( () => {
+			expect( popupRef.current ).toBeInstanceOf( HTMLDivElement );
+		} );
+
+		expect( headerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( titleRef.current ).toBeInstanceOf( HTMLHeadingElement );
+		expect( descriptionRef.current ).toBeInstanceOf( HTMLParagraphElement );
+		expect( closeIconRef.current ).toBeInstanceOf( HTMLButtonElement );
+		expect( footerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( actionRef.current ).toBeInstanceOf( HTMLButtonElement );
+	} );
+
+	it( 'renders Drawer.Footer and supports render/className props', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Title>Test Drawer</Drawer.Title>
+					<Drawer.Footer
+						render={ <section data-testid="drawer-footer" /> }
+						className="custom-footer"
+					>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Drawer' } )
+		);
+
+		const footer = await screen.findByTestId( 'drawer-footer' );
+		expect( footer.tagName ).toBe( 'SECTION' );
+		expect( footer ).toHaveClass( 'custom-footer' );
+		expect(
+			screen.getByRole( 'button', { name: 'Close' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'uses provided portal container', async () => {
+		const user = userEvent.setup();
+		const container = document.createElement( 'div' );
+		container.setAttribute( 'data-testid', 'portal-container' );
+		document.body.appendChild( container );
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup container={ container }>
+					<Drawer.Title>In custom container</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Drawer' } )
+		);
+
+		const dialog = await screen.findByRole( 'dialog' );
+		expect( container ).toContainElement( dialog );
+
+		container.remove();
+	} );
+
+	it( 'renders backdrop only when modal is true', async () => {
+		const view = render(
+			<Drawer.Root open modal>
+				<Drawer.Popup>
+					<Drawer.Title>Modal drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect(
+			screen
+				.getAllByRole( 'presentation', { hidden: true } )
+				.filter( ( element ) => element.hasAttribute( 'data-open' ) )
+		).toHaveLength( 2 );
+
+		view.rerender(
+			<Drawer.Root open modal={ false }>
+				<Drawer.Popup>
+					<Drawer.Title>Non modal drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect(
+			screen
+				.getAllByRole( 'presentation', { hidden: true } )
+				.filter( ( element ) => element.hasAttribute( 'data-open' ) )
+		).toHaveLength( 1 );
+
+		view.rerender(
+			<Drawer.Root open modal="trap-focus">
+				<Drawer.Popup>
+					<Drawer.Title>Trap focus drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect(
+			screen
+				.getAllByRole( 'presentation', { hidden: true } )
+				.filter( ( element ) => element.hasAttribute( 'data-open' ) )
+		).toHaveLength( 1 );
+	} );
+
+	it( 'deprioritizes close icon for initial focus', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Header>
+						<Drawer.Title>Focus test</Drawer.Title>
+						<Drawer.CloseIcon />
+					</Drawer.Header>
+					<Drawer.Footer>
+						<Drawer.Action>Confirm</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Drawer' } )
+		);
+
+		const closeButton = screen.getByRole( 'button', { name: 'Close' } );
+		const actionButton = screen.getByRole( 'button', { name: 'Confirm' } );
+
+		await waitFor( () => {
+			expect( actionButton ).toHaveFocus();
+		} );
+		expect( closeButton ).toHaveAttribute( 'data-wp-ui-drawer-close-icon' );
+	} );
+
+	it( 'supports default and explicit size values across swipe directions', async () => {
+		const view = render(
+			<Drawer.Root open swipeDirection="left">
+				<Drawer.Popup>
+					<Drawer.Title>Left drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+
+		view.rerender(
+			<Drawer.Root open swipeDirection="up">
+				<Drawer.Popup>
+					<Drawer.Title>Up drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+
+		view.rerender(
+			<Drawer.Root open swipeDirection="right">
+				<Drawer.Popup size="auto">
+					<Drawer.Title>Auto drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+
+		view.rerender(
+			<Drawer.Root open swipeDirection="up">
+				<Drawer.Popup size="large">
+					<Drawer.Title>Large drawer</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+	} );
+
+	it( 'marks Drawer.Action as disabled when loading is true', async () => {
+		render(
+			<Drawer.Root open>
+				<Drawer.Popup>
+					<Drawer.Title>Action states</Drawer.Title>
+					<Drawer.Footer>
+						<Drawer.Action loading>Loading action</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		const action = await screen.findByRole( 'button', {
+			name: 'Loading action',
+		} );
+		expect( action ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'marks Drawer.Action as disabled when disabled is true', async () => {
+		render(
+			<Drawer.Root open>
+				<Drawer.Popup>
+					<Drawer.Title>Action states</Drawer.Title>
+					<Drawer.Footer>
+						<Drawer.Action disabled>Disabled action</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		const action = await screen.findByRole( 'button', {
+			name: 'Disabled action',
+		} );
+		expect( action ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'lets explicit disabled={ false } override loading on Drawer.Action', async () => {
+		// Mirrors Dialog.Action precedence: `disabled ?? loading`, so an
+		// explicit `disabled={ false }` wins over an active loading state.
+		render(
+			<Drawer.Root open>
+				<Drawer.Popup>
+					<Drawer.Title>Action states</Drawer.Title>
+					<Drawer.Footer>
+						<Drawer.Action disabled={ false } loading>
+							Explicit not-disabled
+						</Drawer.Action>
+					</Drawer.Footer>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		const action = await screen.findByRole( 'button', {
+			name: 'Explicit not-disabled',
+		} );
+		expect( action ).toHaveAttribute( 'aria-disabled', 'false' );
+	} );
+
+	describe( 'Development mode validation', () => {
+		let originalConsoleError: typeof console.error;
+
+		beforeEach( () => {
+			// eslint-disable-next-line no-console
+			originalConsoleError = console.error;
+			// eslint-disable-next-line no-console
+			console.error = jest.fn();
+		} );
+
+		afterEach( () => {
+			// eslint-disable-next-line no-console
+			console.error = originalConsoleError;
+		} );
+
+		it( 'should throw when Drawer.Title is missing', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			render(
+				<Drawer.Root>
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							{ /* Missing Drawer.Title */ }
+						</Drawer.Header>
+						<p>Content without a title</p>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Popup>
+				</Drawer.Root>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open Drawer' } )
+			);
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			expect( errors[ 0 ].message ).toBe(
+				'Drawer: Missing <Drawer.Title>. ' +
+					'For accessibility, every drawer requires a title. ' +
+					'If needed, the title can be visually hidden but must not be omitted.'
+			);
+
+			cleanup();
+		} );
+
+		it( 'should not throw before opening the drawer', async () => {
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			render(
+				<Drawer.Root>
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							<Drawer.Title>My Title</Drawer.Title>
+						</Drawer.Header>
+						<p>Content with a title</p>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Popup>
+				</Drawer.Root>
+			);
+
+			await expect( screen.findByRole( 'dialog' ) ).rejects.toThrow();
+
+			expect( errors ).toHaveLength( 0 );
+
+			cleanup();
+		} );
+
+		it( 'should not throw when Drawer.Title is present', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			render(
+				<Drawer.Root>
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							<Drawer.Title>My Title</Drawer.Title>
+						</Drawer.Header>
+						<p>Content with a title</p>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Popup>
+				</Drawer.Root>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open Drawer' } )
+			);
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			cleanup();
+		} );
+
+		it( 'should throw when Drawer.Title is empty', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			render(
+				<Drawer.Root>
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							<Drawer.Title>{ /* Empty title */ }</Drawer.Title>
+						</Drawer.Header>
+						<p>Content with empty title</p>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Popup>
+				</Drawer.Root>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open Drawer' } )
+			);
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			expect( errors[ 0 ].message ).toBe(
+				'Drawer: <Drawer.Title> cannot be empty. ' +
+					'Provide meaningful text content for the drawer title.'
+			);
+
+			cleanup();
+		} );
+
+		it( 'should throw when title is removed after mount', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			function Test() {
+				const [ showTitle, setShowTitle ] = useState( true );
+				return (
+					<Drawer.Root>
+						<Drawer.Trigger>Open</Drawer.Trigger>
+						<Drawer.Popup>
+							{ showTitle && (
+								<Drawer.Title>My Title</Drawer.Title>
+							) }
+							<button onClick={ () => setShowTitle( false ) }>
+								Remove Title
+							</button>
+						</Drawer.Popup>
+					</Drawer.Root>
+				);
+			}
+
+			render( <Test /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+
+			expect( errors ).toHaveLength( 0 );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Remove Title' } )
+			);
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			expect( errors[ 0 ].message ).toBe(
+				'Drawer: Missing <Drawer.Title>. ' +
+					'For accessibility, every drawer requires a title. ' +
+					'If needed, the title can be visually hidden but must not be omitted.'
+			);
+
+			cleanup();
+		} );
+
+		it( 'should throw when Drawer.Title contains only whitespace', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			render(
+				<Drawer.Root>
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							<Drawer.Title> </Drawer.Title>
+						</Drawer.Header>
+						<p>Content with whitespace-only title</p>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Popup>
+				</Drawer.Root>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open Drawer' } )
+			);
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			expect( errors[ 0 ].message ).toBe(
+				'Drawer: <Drawer.Title> cannot be empty. ' +
+					'Provide meaningful text content for the drawer title.'
+			);
+
+			cleanup();
+		} );
+
+		it( 'should not throw when Drawer.Title contains mixed content with text', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			render(
+				<Drawer.Root>
+					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+					<Drawer.Popup>
+						<Drawer.Header>
+							<Drawer.Title>
+								<span aria-hidden="true">☰</span>
+								Navigation
+							</Drawer.Title>
+						</Drawer.Header>
+						<p>Content with icon and text title</p>
+						<Drawer.Action>Close</Drawer.Action>
+					</Drawer.Popup>
+				</Drawer.Root>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open Drawer' } )
+			);
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			cleanup();
+		} );
+	} );
+} );

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -121,6 +121,26 @@ describe( 'Drawer', () => {
 		container.remove();
 	} );
 
+	it( 'merges user `className` on Drawer.Title with the internal one', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open</Drawer.Trigger>
+				<Drawer.Popup>
+					<Drawer.Title className="custom-title">Title</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+		const heading = await screen.findByRole( 'heading', { name: 'Title' } );
+		expect( heading ).toHaveClass( 'custom-title' );
+		// The internal module-scoped class name starts with a hashed prefix; assert both classes coexist.
+		expect( heading.className ).toMatch( /title/ );
+	} );
+
 	it( 'associates Drawer.Description with the popup via aria-describedby', async () => {
 		const user = userEvent.setup();
 		const popupRef = createRef< HTMLDivElement >();

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -103,7 +103,9 @@ describe( 'Drawer', () => {
 		render(
 			<Drawer.Root>
 				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
-				<Drawer.Popup container={ container }>
+				<Drawer.Popup
+					portal={ <Drawer.Portal container={ container } /> }
+				>
 					<Drawer.Title>In custom container</Drawer.Title>
 				</Drawer.Popup>
 			</Drawer.Root>
@@ -119,7 +121,34 @@ describe( 'Drawer', () => {
 		container.remove();
 	} );
 
+	it( 'associates Drawer.Description with the popup via aria-describedby', async () => {
+		const user = userEvent.setup();
+		const popupRef = createRef< HTMLDivElement >();
+
+		render(
+			<Drawer.Root>
+				<Drawer.Trigger>Open</Drawer.Trigger>
+				<Drawer.Popup ref={ popupRef }>
+					<Drawer.Title>Title</Drawer.Title>
+					<Drawer.Description>My description</Drawer.Description>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+		await waitFor( () => {
+			expect( popupRef.current ).toHaveAccessibleDescription(
+				'My description'
+			);
+		} );
+	} );
+
 	it( 'renders backdrop only when modal is true', async () => {
+		const getBackdrops = () =>
+			// eslint-disable-next-line testing-library/no-node-access -- The backdrop has no semantic role; querying by the stable `data-wp-ui-drawer-backdrop` attribute (mirroring the Drawer close-icon pattern) is more robust than the Base UI role/state it inherits.
+			document.querySelectorAll( '[data-wp-ui-drawer-backdrop]' );
+
 		const view = render(
 			<Drawer.Root open modal>
 				<Drawer.Popup>
@@ -129,11 +158,7 @@ describe( 'Drawer', () => {
 		);
 
 		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
-		expect(
-			screen
-				.getAllByRole( 'presentation', { hidden: true } )
-				.filter( ( element ) => element.hasAttribute( 'data-open' ) )
-		).toHaveLength( 2 );
+		expect( getBackdrops() ).toHaveLength( 1 );
 
 		view.rerender(
 			<Drawer.Root open modal={ false }>
@@ -143,11 +168,7 @@ describe( 'Drawer', () => {
 			</Drawer.Root>
 		);
 		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
-		expect(
-			screen
-				.getAllByRole( 'presentation', { hidden: true } )
-				.filter( ( element ) => element.hasAttribute( 'data-open' ) )
-		).toHaveLength( 1 );
+		expect( getBackdrops() ).toHaveLength( 0 );
 
 		view.rerender(
 			<Drawer.Root open modal="trap-focus">
@@ -157,11 +178,7 @@ describe( 'Drawer', () => {
 			</Drawer.Root>
 		);
 		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
-		expect(
-			screen
-				.getAllByRole( 'presentation', { hidden: true } )
-				.filter( ( element ) => element.hasAttribute( 'data-open' ) )
-		).toHaveLength( 1 );
+		expect( getBackdrops() ).toHaveLength( 0 );
 	} );
 
 	it( 'deprioritizes close icon for initial focus', async () => {

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -164,9 +164,11 @@ describe( 'Drawer', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
 
 		const heading = await screen.findByRole( 'heading', { name: 'Title' } );
+		// The regression this guards against: `useRender` must still forward
+		// the user-supplied className to the underlying DOM node. CSS module
+		// classes are stubbed in the Jest environment, so we can only assert
+		// the user class end-to-end.
 		expect( heading ).toHaveClass( 'custom-title' );
-		// The internal module-scoped class name starts with a hashed prefix; assert both classes coexist.
-		expect( heading.className ).toMatch( /title/ );
 	} );
 
 	it( 'associates Drawer.Description with the popup via aria-describedby', async () => {

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -22,8 +22,8 @@ describe( 'Drawer', () => {
 		const triggerRef = createRef< HTMLButtonElement >();
 		const popupRef = createRef< HTMLDivElement >();
 		const actionRef = createRef< HTMLButtonElement >();
-		const footerRef = createRef< HTMLDivElement >();
-		const headerRef = createRef< HTMLDivElement >();
+		const footerRef = createRef< HTMLElement >();
+		const headerRef = createRef< HTMLElement >();
 		const titleRef = createRef< HTMLHeadingElement >();
 		const descriptionRef = createRef< HTMLParagraphElement >();
 		const closeIconRef = createRef< HTMLButtonElement >();
@@ -56,11 +56,13 @@ describe( 'Drawer', () => {
 			expect( popupRef.current ).toBeInstanceOf( HTMLDivElement );
 		} );
 
-		expect( headerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( headerRef.current ).toBeInstanceOf( HTMLElement );
+		expect( headerRef.current?.tagName ).toBe( 'HEADER' );
 		expect( titleRef.current ).toBeInstanceOf( HTMLHeadingElement );
 		expect( descriptionRef.current ).toBeInstanceOf( HTMLParagraphElement );
 		expect( closeIconRef.current ).toBeInstanceOf( HTMLButtonElement );
-		expect( footerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( footerRef.current ).toBeInstanceOf( HTMLElement );
+		expect( footerRef.current?.tagName ).toBe( 'FOOTER' );
 		expect( actionRef.current ).toBeInstanceOf( HTMLButtonElement );
 	} );
 

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -167,9 +167,7 @@ describe( 'Drawer', () => {
 	} );
 
 	it( 'renders backdrop only when modal is true', async () => {
-		const getBackdrops = () =>
-			// eslint-disable-next-line testing-library/no-node-access -- The backdrop has no semantic role; querying by the stable `data-wp-ui-drawer-backdrop` attribute (mirroring the Drawer close-icon pattern) is more robust than the Base UI role/state it inherits.
-			document.querySelectorAll( '[data-wp-ui-drawer-backdrop]' );
+		const getBackdrops = () => screen.queryAllByTestId( 'drawer-backdrop' );
 
 		const view = render(
 			<Drawer.Root open modal>

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -634,6 +634,7 @@ describe( 'Drawer', () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
 
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
 			expect( errors ).toHaveLength( 0 );
 
 			await user.click(
@@ -649,6 +650,54 @@ describe( 'Drawer', () => {
 					'For accessibility, every drawer requires a title. ' +
 					'If needed, the title can be visually hidden but must not be omitted.'
 			);
+
+			cleanup();
+		} );
+
+		it( 'should recover when title is added back', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			function Test() {
+				const [ showTitle, setShowTitle ] = useState( false );
+				return (
+					<Drawer.Root>
+						<Drawer.Trigger>Open</Drawer.Trigger>
+						<Drawer.Popup>
+							{ showTitle && (
+								<Drawer.Title>My Title</Drawer.Title>
+							) }
+							<button
+								onClick={ () => setShowTitle( ( s ) => ! s ) }
+							>
+								Toggle Title
+							</button>
+						</Drawer.Popup>
+					</Drawer.Root>
+				);
+			}
+
+			render( <Test /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			const errorCountAfterInitial = errors.length;
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle Title' } )
+			);
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+
+			expect( errors ).toHaveLength( errorCountAfterInitial );
 
 			cleanup();
 		} );

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -346,6 +346,21 @@ describe( 'Drawer', () => {
 		expect( trigger ).toHaveFocus();
 	} );
 
+	it( 'defaults swipeDirection to "left"', async () => {
+		render(
+			<Drawer.Root open>
+				<Drawer.Popup>
+					<Drawer.Title>Default direction</Drawer.Title>
+				</Drawer.Popup>
+			</Drawer.Root>
+		);
+
+		expect( await screen.findByRole( 'dialog' ) ).toHaveAttribute(
+			'data-swipe-direction',
+			'left'
+		);
+	} );
+
 	it( 'supports default and explicit size values across swipe directions', async () => {
 		const view = render(
 			<Drawer.Root open swipeDirection="left">

--- a/packages/ui/src/drawer/title.tsx
+++ b/packages/ui/src/drawer/title.tsx
@@ -1,0 +1,53 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import { useMergeRefs } from '@wordpress/compose';
+import { forwardRef, useEffect, useRef } from '@wordpress/element';
+import { Text } from '../text';
+import { useDrawerValidationContext } from './context';
+import styles from './style.module.css';
+import type { TitleProps } from './types';
+
+/**
+ * Renders the drawer title. This component is required for accessibility
+ * and serves as both the visible heading and the accessible label for
+ * the drawer.
+ *
+ * **Required** — every drawer must include a `Drawer.Title`, even if
+ * visually hidden. The rendered element is linked to the popup via
+ * `aria-labelledby`. Renders an `<h2>` by default.
+ *
+ * To visually hide the title while keeping it accessible, wrap it with
+ * `VisuallyHidden` using the `render` prop:
+ *
+ * ```jsx
+ * <VisuallyHidden render={ <Drawer.Title /> }>
+ *   Accessible title text
+ * </VisuallyHidden>
+ * ```
+ */
+const Title = forwardRef< HTMLHeadingElement, TitleProps >(
+	function DrawerTitle( { children, ...props }, forwardedRef ) {
+		const validationContext = useDrawerValidationContext();
+		const internalRef = useRef< HTMLHeadingElement >( null );
+		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
+
+		useEffect( () => {
+			if ( validationContext ) {
+				return validationContext.registerTitle( internalRef.current );
+			}
+			return undefined;
+		}, [ validationContext ] );
+
+		return (
+			<Text
+				ref={ mergedRef }
+				variant="heading-xl"
+				render={ <_Drawer.Title { ...props } /> }
+				className={ styles.title }
+			>
+				{ children }
+			</Text>
+		);
+	}
+);
+
+export { Title };

--- a/packages/ui/src/drawer/title.tsx
+++ b/packages/ui/src/drawer/title.tsx
@@ -1,5 +1,4 @@
 import { Drawer as _Drawer } from '@base-ui/react/drawer';
-import clsx from 'clsx';
 import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
@@ -26,7 +25,7 @@ import type { TitleProps } from './types';
  * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function DrawerTitle( { children, className, ...props }, forwardedRef ) {
+	function DrawerTitle( { children, ...props }, forwardedRef ) {
 		const validationContext = useDrawerValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -43,7 +42,7 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 				ref={ mergedRef }
 				variant="heading-xl"
 				render={ <_Drawer.Title { ...props } /> }
-				className={ clsx( styles.title, className ) }
+				className={ styles.title }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/drawer/title.tsx
+++ b/packages/ui/src/drawer/title.tsx
@@ -1,4 +1,5 @@
 import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import clsx from 'clsx';
 import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
@@ -25,7 +26,7 @@ import type { TitleProps } from './types';
  * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function DrawerTitle( { children, ...props }, forwardedRef ) {
+	function DrawerTitle( { children, className, ...props }, forwardedRef ) {
 		const validationContext = useDrawerValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -42,7 +43,7 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 				ref={ mergedRef }
 				variant="heading-xl"
 				render={ <_Drawer.Title { ...props } /> }
-				className={ styles.title }
+				className={ clsx( styles.title, className ) }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/drawer/trigger.tsx
+++ b/packages/ui/src/drawer/trigger.tsx
@@ -1,0 +1,14 @@
+import { Drawer as _Drawer } from '@base-ui/react/drawer';
+import { forwardRef } from '@wordpress/element';
+import type { TriggerProps } from './types';
+
+/**
+ * Renders a button that opens the drawer popup when clicked.
+ */
+const Trigger = forwardRef< HTMLButtonElement, TriggerProps >(
+	function DrawerTrigger( props, ref ) {
+		return <_Drawer.Trigger ref={ ref } { ...props } />;
+	}
+);
+
+export { Trigger };

--- a/packages/ui/src/drawer/types.ts
+++ b/packages/ui/src/drawer/types.ts
@@ -1,8 +1,10 @@
 import type { Drawer as _Drawer } from '@base-ui/react/drawer';
-import type { ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react';
 import type { Button } from '../button';
 import type { IconButton } from '../icon-button';
 import type { ComponentProps } from '../utils/types';
+
+export type PortalProps = ComponentPropsWithoutRef< typeof _Drawer.Portal >;
 
 export interface RootProps
 	extends Pick<
@@ -37,12 +39,15 @@ export interface PopupProps
 	children?: ReactNode;
 
 	/**
-	 * A parent element to render the portal into.
+	 * Optional portal element, typically `<Drawer.Portal />` with custom
+	 * `container`, `className`, or `style`. The backdrop and inner viewport
+	 * are rendered as this portal's children (do not pass `children` on the
+	 * portal element; they would be ignored).
 	 *
-	 * Useful for cross-document rendering, such as rendering a drawer
-	 * in a parent document when the trigger is inside an iframe.
+	 * When omitted, `Drawer.Popup` uses `Drawer.Portal` with default props,
+	 * rendering the portal in the current document's `<body>`.
 	 */
-	container?: _Drawer.Portal.Props[ 'container' ];
+	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 
 	/**
 	 * Controls the size of the drawer along its relevant axis (width for

--- a/packages/ui/src/drawer/types.ts
+++ b/packages/ui/src/drawer/types.ts
@@ -1,0 +1,122 @@
+import type { Drawer as _Drawer } from '@base-ui/react/drawer';
+import type { ReactNode } from 'react';
+import type { Button } from '../button';
+import type { IconButton } from '../icon-button';
+import type { ComponentProps } from '../utils/types';
+
+export interface RootProps
+	extends Pick<
+		_Drawer.Root.Props,
+		| 'open'
+		| 'onOpenChange'
+		| 'onOpenChangeComplete'
+		| 'defaultOpen'
+		| 'modal'
+		| 'swipeDirection'
+		| 'disablePointerDismissal'
+	> {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface TriggerProps extends ComponentProps< 'button' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface PopupProps
+	extends ComponentProps< 'div' >,
+		Pick< _Drawer.Popup.Props, 'initialFocus' | 'finalFocus' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+
+	/**
+	 * A parent element to render the portal into.
+	 *
+	 * Useful for cross-document rendering, such as rendering a drawer
+	 * in a parent document when the trigger is inside an iframe.
+	 */
+	container?: _Drawer.Portal.Props[ 'container' ];
+
+	/**
+	 * Controls the size of the drawer along its relevant axis (width for
+	 * left/right drawers, height for up/down drawers).
+	 *
+	 * When not specified, left/right drawers use a default medium width
+	 * and up/down drawers fit their content.
+	 *
+	 * - `'small'` — narrow/short.
+	 * - `'medium'` — moderate.
+	 * - `'large'` — wide/tall.
+	 * - `'stretch'` — fills available space, respecting the viewport inset.
+	 * - `'auto'` — fit content along the relevant axis.
+	 *
+	 * @default 'medium' for left/right drawers, 'auto' for up/down drawers
+	 */
+	size?: 'small' | 'medium' | 'large' | 'stretch' | 'auto';
+}
+
+export interface ActionProps extends ComponentProps< typeof Button > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface FooterProps extends ComponentProps< 'div' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface HeaderProps extends ComponentProps< 'div' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface TitleProps extends ComponentProps< 'h2' > {
+	/**
+	 * The title content to be rendered. This serves as both the visible
+	 * heading and the accessible label for the drawer.
+	 *
+	 * When `Drawer.Title` is passed as a render element (e.g. to
+	 * `VisuallyHidden`), children can be provided by the wrapper instead.
+	 */
+	children?: ReactNode;
+}
+
+export interface DescriptionProps extends ComponentProps< 'p' > {
+	/**
+	 * The description content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface CloseIconProps
+	extends Omit<
+		ComponentProps< typeof IconButton >,
+		'label' | 'icon' | 'loading' | 'loadingAnnouncement'
+	> {
+	/**
+	 * A label describing the button's action, shown as a tooltip and to
+	 * assistive technology.
+	 *
+	 * @default __( 'Close' )
+	 */
+	label?: ComponentProps< typeof IconButton >[ 'label' ];
+	/**
+	 * The icon to display in the button.
+	 *
+	 * @default the `close` icon from `@wordpress/icons`
+	 */
+	icon?: ComponentProps< typeof IconButton >[ 'icon' ];
+}

--- a/packages/ui/src/drawer/types.ts
+++ b/packages/ui/src/drawer/types.ts
@@ -85,14 +85,14 @@ export interface ActionProps extends ComponentProps< typeof Button > {
 	children?: ReactNode;
 }
 
-export interface FooterProps extends ComponentProps< 'div' > {
+export interface FooterProps extends ComponentProps< 'footer' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */
 	children?: ReactNode;
 }
 
-export interface HeaderProps extends ComponentProps< 'div' > {
+export interface HeaderProps extends ComponentProps< 'header' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/drawer/types.ts
+++ b/packages/ui/src/drawer/types.ts
@@ -14,9 +14,20 @@ export interface RootProps
 		| 'onOpenChangeComplete'
 		| 'defaultOpen'
 		| 'modal'
-		| 'swipeDirection'
 		| 'disablePointerDismissal'
 	> {
+	/**
+	 * The edge the drawer slides in from, and the direction used to dismiss it
+	 * via swipe gesture.
+	 *
+	 * - `'left'` / `'right'`: side drawers; swipe horizontally to dismiss.
+	 * - `'down'`: bottom sheet; swipe down to dismiss.
+	 * - `'up'`: top drawer; swipe up to dismiss.
+	 *
+	 * @default 'left'
+	 */
+	swipeDirection?: _Drawer.Root.Props[ 'swipeDirection' ];
+
 	/**
 	 * The content to be rendered inside the component.
 	 */

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -251,12 +251,21 @@ export const WithCustomTriggerAndItem: Story = {
 };
 
 /**
- * Popovers in Gutenberg are managed with explicit z-index values, which can create
- * situations where a popover renders below another popover, when you want it to be rendered above.
+ * Popovers in Gutenberg are managed with explicit z-index values, which can
+ * create situations where a popover renders below another popover, when you
+ * want it to be rendered above.
  *
- * The `--wp-ui-select-z-index` CSS variable, available on the `Select.Popup` component,
- * is an escape hatch that can be used to override the z-index of a given `Select` popover
- * on a case-by-case basis.
+ * The `--wp-ui-select-z-index` CSS variable is an escape hatch for that
+ * case. Override it either:
+ *
+ * - **Globally**, by setting the variable on `:root` or `body` (raises every
+ *   `Select` popover in the page),
+ * - **Per instance on the popup**, by setting the variable via `style` on
+ *   `Select.Popup` (as this story does), or
+ * - **Per instance on the portal**, by passing a `Select.Portal` with a
+ *   `style` (or `className`) to `Select.Popup`'s `portal` prop. The
+ *   variable then cascades from the portal wrapper to everything rendered
+ *   inside it.
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export * as Collapsible from './collapsible';
 export * as CollapsibleCard from './collapsible-card';
 export * as AlertDialog from './alert-dialog';
 export * as Dialog from './dialog';
+export * as Drawer from './drawer';
 export * as EmptyState from './empty-state';
 export * from './form';
 export * from './icon';

--- a/packages/ui/src/popover/context.tsx
+++ b/packages/ui/src/popover/context.tsx
@@ -1,116 +1,17 @@
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
-import { useScheduleValidation } from '../utils/use-schedule-validation';
+import { createOverlayTitleValidation } from '../utils/create-overlay-title-validation';
 
-/**
- * Whether validation is enabled. This is a build-time constant that allows
- * bundlers to tree-shake all validation code in production builds.
- */
-const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
-
-type PopoverValidationContextType = {
-	registerTitle: ( element: HTMLElement | null ) => () => void;
-};
-
-const PopoverValidationContext = VALIDATION_ENABLED
-	? createContext< PopoverValidationContextType | null >( null )
-	: ( null as unknown as React.Context< PopoverValidationContextType | null > );
-
-function usePopoverValidationContextDev() {
-	return useContext( PopoverValidationContext );
-}
-
-function usePopoverValidationContextProd() {
-	return null;
-}
+const popoverTitleValidation = createOverlayTitleValidation( 'Popover' );
 
 /**
  * Hook to access the popover validation context.
  * Returns null in production or if not within a Popover.Popup.
  */
-export const usePopoverValidationContext = VALIDATION_ENABLED
-	? usePopoverValidationContextDev
-	: usePopoverValidationContextProd;
-
-/**
- * Development-only provider that tracks whether Popover.Title is rendered.
- */
-function PopoverValidationProviderDev( {
-	children,
-}: {
-	children: React.ReactNode;
-} ) {
-	const titleElementRef = useRef< HTMLElement | null >( null );
-
-	const scheduleValidation = useScheduleValidation( () => {
-		const titleElement = titleElementRef.current;
-
-		if ( ! titleElement ) {
-			throw new Error(
-				'Popover: Missing <Popover.Title>. ' +
-					'For accessibility, every popover requires a title. ' +
-					'If needed, the title can be visually hidden but must not be omitted.'
-			);
-		}
-
-		const textContent = titleElement.textContent?.trim();
-		if ( ! textContent ) {
-			throw new Error(
-				'Popover: <Popover.Title> cannot be empty. ' +
-					'Provide meaningful text content for the popover title.'
-			);
-		}
-	} );
-
-	const registerTitle = useCallback(
-		( element: HTMLElement | null ) => {
-			titleElementRef.current = element;
-			scheduleValidation();
-
-			return () => {
-				titleElementRef.current = null;
-				scheduleValidation();
-			};
-		},
-		[ scheduleValidation ]
-	);
-
-	// Schedule an initial validation on mount to catch missing titles
-	// (when no Title component is rendered, registerTitle is never called).
-	useEffect( () => {
-		scheduleValidation();
-	}, [ scheduleValidation ] );
-
-	const contextValue = useMemo(
-		() => ( { registerTitle } ),
-		[ registerTitle ]
-	);
-
-	return (
-		<PopoverValidationContext.Provider value={ contextValue }>
-			{ children }
-		</PopoverValidationContext.Provider>
-	);
-}
-
-function PopoverValidationProviderProd( {
-	children,
-}: {
-	children: React.ReactNode;
-} ) {
-	return <>{ children }</>;
-}
+export const usePopoverValidationContext =
+	popoverTitleValidation.useValidationContext;
 
 /**
  * Provider component that validates Popover.Title presence in development mode.
  * In production, this component is a no-op and just renders children.
  */
-export const PopoverValidationProvider = VALIDATION_ENABLED
-	? PopoverValidationProviderDev
-	: PopoverValidationProviderProd;
+export const PopoverValidationProvider =
+	popoverTitleValidation.ValidationProvider;

--- a/packages/ui/src/popover/description.tsx
+++ b/packages/ui/src/popover/description.tsx
@@ -1,5 +1,4 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
-import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
 import styles from './style.module.css';
@@ -11,13 +10,13 @@ import type { DescriptionProps } from './types';
  * The rendered element is linked to the popup via `aria-describedby`.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
-	function PopoverDescription( { className, children, ...props }, ref ) {
+	function PopoverDescription( { children, ...props }, ref ) {
 		return (
 			<Text
 				ref={ ref }
 				variant="body-md"
 				render={ <_Popover.Description { ...props } /> }
-				className={ clsx( styles.description, className ) }
+				className={ styles.description }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -765,9 +765,17 @@ export const CrossIframeWithSlotFill: Story = {
  * create situations where a popover renders below another popover, when you
  * want it to be rendered above.
  *
- * The `--wp-ui-popover-z-index` CSS variable, available on the
- * `Popover.Popup` component, is an escape hatch that can be used to override
- * the z-index of a given popover on a case-by-case basis.
+ * The `--wp-ui-popover-z-index` CSS variable is an escape hatch for that
+ * case. Override it either:
+ *
+ * - **Globally**, by setting the variable on `:root` or `body` (raises every
+ *   popover in the page),
+ * - **Per instance on the popup**, by setting the variable via `style` on
+ *   `Popover.Popup` (as this story does), or
+ * - **Per instance on the portal**, by passing a `Popover.Portal` with a
+ *   `style` (or `className`) to `Popover.Popup`'s `portal` prop. The
+ *   variable then cascades from the portal wrapper to everything rendered
+ *   inside it.
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
 import * as Popover from '../index';
@@ -748,7 +748,9 @@ describe( 'Popover', () => {
 				expect( screen.getByText( 'Valid Title' ) ).toBeVisible();
 			} );
 
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			cleanup();
@@ -775,7 +777,9 @@ describe( 'Popover', () => {
 			} );
 
 			// Let initial validation settle — no errors expected.
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 			expect( errors ).toHaveLength( 0 );
 
 			// Remove the title via rerender.
@@ -825,7 +829,9 @@ describe( 'Popover', () => {
 			rerender( ui( true ) );
 
 			// Wait for deferred validation to settle.
-			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			await act(
+				() => new Promise( ( resolve ) => setTimeout( resolve, 50 ) )
+			);
 
 			// No new errors should have been thrown.
 			expect( errors ).toHaveLength( errorCountAfterInitial );

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -389,6 +389,32 @@ describe( 'Popover', () => {
 				);
 			} );
 		} );
+
+		it( 'merges user `className` on Popover.Title with the internal one', async () => {
+			// Regression test for the shared `useRender` class-name merge
+			// that also covers Popover.Description and its Dialog/Drawer
+			// counterparts.
+			const user = userEvent.setup();
+
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Title className="custom-title">
+							Title
+						</Popover.Title>
+					</Popover.Popup>
+				</Popover.Root>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			const heading = await screen.findByRole( 'heading', {
+				name: 'Title',
+			} );
+			expect( heading ).toHaveClass( 'custom-title' );
+			expect( heading.className ).toMatch( /title/ );
+		} );
 	} );
 
 	describe( 'variant', () => {

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -412,8 +412,11 @@ describe( 'Popover', () => {
 			const heading = await screen.findByRole( 'heading', {
 				name: 'Title',
 			} );
+			// The regression this guards against: `useRender` must still
+			// forward the user-supplied className to the underlying DOM node.
+			// CSS module classes are stubbed in the Jest environment, so we
+			// can only assert the user class end-to-end.
 			expect( heading ).toHaveClass( 'custom-title' );
-			expect( heading.className ).toMatch( /title/ );
 		} );
 	} );
 

--- a/packages/ui/src/popover/title.tsx
+++ b/packages/ui/src/popover/title.tsx
@@ -22,7 +22,7 @@ import type { TitleProps } from './types';
  * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function PopoverTitle( { className, children, ...props }, forwardedRef ) {
+	function PopoverTitle( { children, ...props }, forwardedRef ) {
 		const validationContext = usePopoverValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -39,7 +39,6 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 				ref={ mergedRef }
 				variant="heading-xl"
 				render={ <_Popover.Title { ...props } /> }
-				className={ className }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -10,6 +10,7 @@ const meta: Meta< typeof Tooltip.Root > = {
 		Provider: Tooltip.Provider,
 		Trigger: Tooltip.Trigger,
 		Popup: Tooltip.Popup,
+		Portal: Tooltip.Portal,
 	},
 };
 export default meta;
@@ -73,6 +74,42 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
 			</Tooltip.Root>
 		</div>
 	),
+};
+
+/**
+ * Popovers in Gutenberg are managed with explicit z-index values, which can
+ * create situations where a tooltip renders below another popover when you
+ * want it above.
+ *
+ * The `--wp-ui-tooltip-z-index` CSS variable is an escape hatch for that
+ * case. Override it either:
+ *
+ * - **Globally**, by setting the variable on `:root` or `body` (raises every
+ *   tooltip in the page), or
+ * - **Per instance**, by passing a `Tooltip.Portal` with a `style` (or
+ *   `className`) to `Tooltip.Popup`'s `portal` prop. The variable cascades
+ *   from the portal wrapper to the popup rendered inside it.
+ *
+ * This story demonstrates the per-instance approach.
+ */
+export const WithCustomZIndex: StoryObj< typeof Tooltip.Root > = {
+	name: 'With Custom z-index',
+	args: {
+		children: (
+			<>
+				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+				<Tooltip.Popup
+					portal={
+						<Tooltip.Portal
+							style={ { '--wp-ui-tooltip-z-index': '9999' } }
+						/>
+					}
+				>
+					Save
+				</Tooltip.Popup>
+			</>
+		),
+	},
 };
 
 /**

--- a/packages/ui/src/utils/create-overlay-modal-context.tsx
+++ b/packages/ui/src/utils/create-overlay-modal-context.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from '@wordpress/element';
+
+type OverlayModalProviderProps< Modal > = {
+	modal: Modal;
+	children: React.ReactNode;
+};
+
+/**
+ * Creates a modal context pair (`Provider` + `useModal`) for overlay
+ * primitives like Dialog and Drawer.
+ */
+export function createOverlayModalContext< Modal >( initialValue: Modal ) {
+	const OverlayModalContext = createContext< Modal >( initialValue );
+
+	function OverlayModalProvider( {
+		modal,
+		children,
+	}: OverlayModalProviderProps< Modal > ) {
+		return (
+			<OverlayModalContext.Provider value={ modal }>
+				{ children }
+			</OverlayModalContext.Provider>
+		);
+	}
+
+	function useOverlayModal() {
+		return useContext( OverlayModalContext );
+	}
+
+	return {
+		Provider: OverlayModalProvider,
+		useModal: useOverlayModal,
+	};
+}

--- a/packages/ui/src/utils/create-overlay-title-validation.tsx
+++ b/packages/ui/src/utils/create-overlay-title-validation.tsx
@@ -1,0 +1,116 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
+import { useScheduleValidation } from './use-schedule-validation';
+
+/**
+ * Whether validation is enabled. This is a build-time constant that allows
+ * bundlers to tree-shake all validation code in production builds.
+ */
+const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
+
+type OverlayValidationContextType = {
+	registerTitle: ( element: HTMLElement | null ) => () => void;
+};
+
+type OverlayValidationProviderProps = {
+	children: React.ReactNode;
+};
+
+/**
+ * Creates development-only title validation helpers for overlay primitives.
+ */
+export function createOverlayTitleValidation( componentName: string ) {
+	const componentNameLowerCase = componentName.toLowerCase();
+	const OverlayValidationContext = VALIDATION_ENABLED
+		? createContext< OverlayValidationContextType | null >( null )
+		: ( null as unknown as React.Context< OverlayValidationContextType | null > );
+
+	function useValidationContextDev() {
+		return useContext( OverlayValidationContext );
+	}
+
+	function useValidationContextProd() {
+		return null;
+	}
+
+	const useValidationContext = VALIDATION_ENABLED
+		? useValidationContextDev
+		: useValidationContextProd;
+
+	function ValidationProviderDev( {
+		children,
+	}: OverlayValidationProviderProps ) {
+		const titleElementRef = useRef< HTMLElement | null >( null );
+
+		const scheduleValidation = useScheduleValidation( () => {
+			const titleElement = titleElementRef.current;
+
+			if ( ! titleElement ) {
+				throw new Error(
+					`${ componentName }: Missing <${ componentName }.Title>. ` +
+						`For accessibility, every ${ componentNameLowerCase } requires a title. ` +
+						'If needed, the title can be visually hidden but must not be omitted.'
+				);
+			}
+
+			const textContent = titleElement.textContent?.trim();
+			if ( ! textContent ) {
+				throw new Error(
+					`${ componentName }: <${ componentName }.Title> cannot be empty. ` +
+						`Provide meaningful text content for the ${ componentNameLowerCase } title.`
+				);
+			}
+		} );
+
+		const registerTitle = useCallback(
+			( element: HTMLElement | null ) => {
+				titleElementRef.current = element;
+				scheduleValidation();
+
+				return () => {
+					titleElementRef.current = null;
+					scheduleValidation();
+				};
+			},
+			[ scheduleValidation ]
+		);
+
+		const contextValue = useMemo(
+			() => ( { registerTitle } ),
+			[ registerTitle ]
+		);
+
+		// Schedule an initial validation on mount to catch missing titles
+		// (when no Title component is rendered, registerTitle is never called).
+		useEffect( () => {
+			scheduleValidation();
+		}, [ scheduleValidation ] );
+
+		return (
+			<OverlayValidationContext.Provider value={ contextValue }>
+				{ children }
+			</OverlayValidationContext.Provider>
+		);
+	}
+
+	function ValidationProviderProd( {
+		children,
+	}: OverlayValidationProviderProps ) {
+		return <>{ children }</>;
+	}
+
+	const ValidationProvider = VALIDATION_ENABLED
+		? ValidationProviderDev
+		: ValidationProviderProd;
+
+	return {
+		ValidationProvider,
+		useValidationContext,
+	};
+}


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/75291

## What?

Adds a `Drawer` primitive to `@wordpress/ui`: a WPDS-styled compound component wrapping Base UI's Drawer, for side panels and bottom sheets with consistent a11y, motion, and focus behavior.

Compound API: `Root`, `Trigger`, `Popup`, `Portal`, `Header`, `Title`, `Description`, `CloseIcon`, `Action`, `Footer`.

## Why?

Gutenberg needs a shared drawer primitive to avoid custom per-feature implementations, and to keep accessibility, motion, and interaction patterns aligned with `Dialog` and `Popover`.

## Testing

1. `npm run storybook:dev` → **Design System / Components / Drawer**.
2. Open each story; verify slide direction, focus behavior, and close behavior.
3. Run:
   - `npm run test:unit -- packages/ui/src/drawer/test/index.test.tsx`
   - `npm run test:unit -- packages/ui/src/dialog/test/index.test.tsx`
   - `npm run test:unit -- packages/ui/src/popover/test/index.test.tsx`

<details>
<summary>Keyboard checks</summary>

- Enter/Space on the trigger opens the drawer.
- Tab order stays within the drawer when modal; close icon is not incorrectly prioritized when other tabbables exist.
- Escape closes the drawer and restores focus to the trigger.

</details>

<details>
<summary>Supported props</summary>

- `swipeDirection`: `left | right | up | down`
  - Default: `left`.
- `size` on `Drawer.Popup`: `small | medium | large | stretch | auto`
  - Default: `medium` for `left`/`right`, `auto` for `up`/`down`.
- `portal`, `initialFocus`, `finalFocus` on `Drawer.Popup`
  - `portal` accepts a `Drawer.Portal` element for custom `container`/portal options.
- `Drawer.Action` mirrors `Dialog.Action` (`disabled ?? loading` precedence).

</details>

<details>
<summary>Implementation notes</summary>

- `Drawer` now follows the same portal composition pattern as `Dialog`/`Popover` (`Popup` + `Portal` + `renderPortalWithChildren`).
- `Drawer.Title` / `Drawer.Description` forward props to Base UI render elements and rely on Base UI merging for `className`, consistent with `Dialog`/`Popover`.
- Dev-only title validation is shared across `Drawer`/`Dialog`/`Popover` via extracted overlay utilities (same runtime behavior and error messages).
- Modal context plumbing is shared between `Drawer` and `Dialog` via a common overlay modal context utility.
- `Drawer.Header` / `Drawer.Footer` (and their `Dialog` counterparts) default to native `<header>` / `<footer>` landmarks so assistive technology can jump to them directly; consumers can still opt out via `render`.
- `ThemeProvider` wraps `_Drawer.Popup` directly (inside `_Drawer.Viewport`) so the `display: contents` workaround selector applies, matching sibling overlays.
- Motion layer and transition rules are scoped to active states (`[data-open]` / `[data-swiping]`) to avoid keeping layers around while idle.
- Safe-area insets are handled on all relevant edges (top/bottom and left/right content padding rules). The left/right overrides use physical `padding-left` / `padding-right` to match the popup's physical anchoring (`left: 0` / `right: 0`), so the inset stays on the correct side in RTL.
- The drawer backdrop transition intentionally diverges from `Dialog`'s — its duration and easing match the popup's slide-in/out (and scale with `--drawer-swipe-strength`) so both surfaces move together; documented inline.
- Backdrops use `data-testid="{drawer,dialog}-backdrop"` for test targeting (no ad-hoc `data-wp-ui-*-backdrop` attributes).
- Storybook: each overlay (`Dialog`, `AlertDialog`, `Drawer`, `Popover`, `Select`, `Tooltip`) now has a "With Custom z-index" story that documents both the global (`:root` / `body`) and per-instance (`portal` prop + `Portal` with `style` / `className`) ways to override `--wp-ui-*-z-index`; the `Dialog`, `AlertDialog`, `Drawer`, and `Tooltip` stories live-demo the per-instance approach.

</details>

<details>
<summary>Test coverage</summary>

Unit tests cover: ref forwarding (including `<header>`/`<footer>` landmark defaults), `Drawer.Header` and `Drawer.Footer` (`children`/`className`/`render`), custom portal rendering, modal/backdrop behavior (queried via `data-testid`), `aria-describedby` wiring for `Drawer.Description`, `Drawer.Title` className merging, deprioritized close-icon focus, `initialFocus={ false }` and custom-callback focus handling, Escape-to-close with focus restoration to the trigger, `data-swipe-direction` wiring across swipe directions, size resolution, `Drawer.Action` loading/disabled precedence, and dev-mode title validation.

A className-merge regression test is also added to `Dialog` and `Popover` to cover the shared `useRender` behavior.

</details>

<details>
<summary>Not in scope for v1</summary>

- `Drawer.Provider`, `Drawer.IndentBackground`, `Drawer.Indent`
- `Drawer.SwipeArea`
- Snap points (`snapPoints`, `snapPoint`, `defaultSnapPoint`, `onSnapPointChange`, `snapToSequentialPoints`)
- Nested drawer stacking (`--nested-drawers`)
- Detached trigger APIs (`handle`, `triggerId`, `defaultTriggerId`, `actionsRef`, `Drawer.createHandle`)
- `Drawer.Content` as a dedicated public scroll-container abstraction
- A built-in drag-handle slot

</details>

## Screen recording

https://github.com/user-attachments/assets/57df9626-0d91-427b-b4cc-d7e2665d50c5

## Use of AI Tools

This PR was authored with assistance from an AI coding agent in Cursor. All changes were reviewed by the author.



