### PR TITLE
Fix navigation block unit test and e2e test

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,9 +197,8 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    # TODO: Revert this change before merging.
-                    # - event: 'pull_request'
-                    #   wordpress: 'previous major version'
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,8 +197,9 @@ jobs:
                       php: '8.2'
                     - event: 'pull_request'
                       multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
+                    # TODO: Revert this change before merging.
+                    # - event: 'pull_request'
+                    #   wordpress: 'previous major version'
                     # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '8.0'
                       wordpress: 'previous major version'

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -31,8 +31,14 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $navigation_link_block );
 
-		$expected = '<li class="wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content"  href="/hello-world"><span class="wp-block-navigation-item__label">Sample Page</span></a></li>';
-		$this->assertEquals( $expected, $result );
+		if ( is_wp_version_compatible( '7.0' ) ) {
+			$expected = '<li class="wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content"  href="/hello-world"><span class="wp-block-navigation-item__label">Sample Page</span></a></li>';
+		} else {
+			// Block markup for WP 6.9 (space before wp-block-navigation-item class)
+			// TODO: Remove the second expected markup after WP 6.9 support is dropped and the old markup is no longer generated.
+			$expected = '<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content"  href="/hello-world"><span class="wp-block-navigation-item__label">Sample Page</span></a></li>';
+			$this->assertEquals( $expected, $result );
+		}
 	}
 
 	/**

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -122,15 +122,29 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 
 		$navigation_submenu_block = new WP_Block( $block, $context );
 
-		$this->assertStringContainsString(
-			'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . '" class="wp-block-navigation__submenu-container has-text-color has-background">',
-			gutenberg_render_block_core_navigation_submenu(
-				$navigation_submenu_block->attributes,
-				array(),
-				$navigation_submenu_block
-			),
-			'Submenu block colors inherited from context not applied correctly'
-		);
+		if ( is_wp_version_compatible( '7.0' ) ) {
+			$this->assertStringContainsString(
+				'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . '" class="wp-block-navigation__submenu-container has-text-color has-background">',
+				gutenberg_render_block_core_navigation_submenu(
+					$navigation_submenu_block->attributes,
+					array(),
+					$navigation_submenu_block
+				),
+				'Submenu block colors inherited from context not applied correctly'
+			);
+		} else {
+			// Block markup for WP 6.9 (semicolon in style attribute)
+			// TODO: Remove the second expected markup after WP 6.9 support is dropped and the old markup is no longer generated.
+			$this->assertStringContainsString(
+				'<ul style="color:' . $context['customOverlayTextColor'] . ';background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-background">',
+				gutenberg_render_block_core_navigation_submenu(
+					$navigation_submenu_block->attributes,
+					array(),
+					$navigation_submenu_block
+				),
+				'Submenu block colors inherited from context not applied correctly'
+			);
+		}
 	}
 
 	/**
@@ -158,15 +172,29 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 
 		$navigation_submenu_block = new WP_Block( $block, $context );
 
-		$this->assertStringContainsString(
-			'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . '" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
-			gutenberg_render_block_core_navigation_submenu(
-				$navigation_submenu_block->attributes,
-				array(),
-				$navigation_submenu_block
-			),
-			'Submenu block colors inherited from context not applied correctly'
-		);
+		if ( is_wp_version_compatible( '7.0' ) ) {
+			$this->assertStringContainsString(
+				'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . '" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
+				gutenberg_render_block_core_navigation_submenu(
+					$navigation_submenu_block->attributes,
+					array(),
+					$navigation_submenu_block
+				),
+				'Submenu block colors inherited from context not applied correctly'
+			);
+		} else {
+			// Block markup for WP 6.9 (semicolon in style attribute)
+			// TODO: Remove the second expected markup after WP 6.9 support is dropped and the old markup is no longer generated.
+			$this->assertStringContainsString(
+				'<ul style="background-color:' . $context['customOverlayBackgroundColor'] . ';" class="wp-block-navigation__submenu-container has-text-color has-' . $context['overlayTextColor'] . '-color has-background">',
+				gutenberg_render_block_core_navigation_submenu(
+					$navigation_submenu_block->attributes,
+					array(),
+					$navigation_submenu_block
+				),
+				'Submenu block colors inherited from context not applied correctly'
+			);
+		}
 	}
 
 	/**

--- a/test/e2e/specs/editor/plugins/block-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/block-hooks.spec.js
@@ -346,7 +346,7 @@ test.describe( 'Block Hooks API', () => {
 				page.locator( '.wp-block-navigation__container > *' )
 			).toHaveClass( [
 				'wp-block-navigation-item wp-block-home-link',
-				' wp-block-navigation-item wp-block-navigation-link',
+				'wp-block-navigation-item wp-block-navigation-link',
 				'wp-block-page-list',
 			] );
 		} );
@@ -424,7 +424,7 @@ test.describe( 'Block Hooks API', () => {
 			await expect(
 				page.locator( '.wp-block-navigation__container > *' )
 			).toHaveClass( [
-				' wp-block-navigation-item wp-block-navigation-link',
+				'wp-block-navigation-item wp-block-navigation-link',
 				'wp-block-navigation-item wp-block-home-link',
 				'wp-block-page-list',
 			] );


### PR DESCRIPTION
Follow-up on #76685

## What?

[Changeset 62068](https://core.trac.wordpress.org/changeset/62068) improved the behavior of `get_block_wrapper_attributes()` by trimming unnecessary whitespace and semicolon.   Following this new behavior, we corrected the unit test expected value in #76685.

However, this causes the tests to fail because the trunk branch runs unit tests on the older WP version as well as the latest WP version. Therefore, this PR adds `is_wp_version_compatible('7.0')` check to refer to the previous expectations for WP 6.9 and earlier.

## Testing Instructions

All CI checks should be green.

## Use of AI Tools

None