### PR TITLE
Fix: Fit text toggle disappears when turned off

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -243,7 +243,7 @@ function useFitText( { fitText, name, clientId } ) {
  */
 export function FitTextControl( {
 	clientId,
-	fitText = false,
+	fitText,
 	setAttributes,
 	name,
 	fontSize,
@@ -256,7 +256,7 @@ export function FitTextControl( {
 	return (
 		<InspectorControls group="typography">
 			<ToolsPanelItem
-				hasValue={ () => fitText }
+				hasValue={ () => fitText === true || fitText === false }
 				label={ __( 'Fit text' ) }
 				onDeselect={ () => setAttributes( { fitText: undefined } ) }
 				resetAllFilter={ () => ( { fitText: undefined } ) }
@@ -264,9 +264,9 @@ export function FitTextControl( {
 			>
 				<ToggleControl
 					label={ __( 'Fit text' ) }
-					checked={ fitText }
+					checked={ fitText === true }
 					onChange={ () => {
-						const newFitText = ! fitText || undefined;
+						const newFitText = fitText ? false : true;
 						const updates = { fitText: newFitText };
 
 						// When enabling fit text, clear font size if it has a value
@@ -288,7 +288,7 @@ export function FitTextControl( {
 						setAttributes( updates );
 					} }
 					help={
-						fitText
+						fitText === true
 							? __( 'Text will resize to fit its container.' )
 							: __(
 									'The text will resize to fit its container, resetting other font size settings.'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76691 

<!-- In a few words, what is the PR actually doing? -->

Fixes the fit text toggle disappearing when turned off in the typography panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The fit text toggle was disappearing from the typography panel when users toggled it off, making it difficult to re-enable the feature without navigating back through the 3-dots menu.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updated the component to properly distinguish between undefined and false states.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a paragraph or heading block to a post
2. Open the Typography settings panel
3. Click the 3-dots menu and enable "Fit text"
4. Toggle the fit text option ON
5. Toggle the fit text option OFF (it should stay visible in the panel)