### PR TITLE
Gate client-side media processing as plugin-only

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -448,7 +448,9 @@ function gutenberg_enqueue_latex_to_mathml_loader() {
  *
  * @see packages/vips/src/loader.ts
  */
-add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_vips_loader' );
+if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+	add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_vips_loader' );
+}
 function gutenberg_enqueue_vips_loader() {
 	wp_enqueue_script_module( '@wordpress/vips/loader' );
 }

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -5,6 +5,11 @@
  * @package gutenberg
  */
 
+// Client-side media processing is currently plugin-only while the feature matures.
+if ( ! defined( 'IS_GUTENBERG_PLUGIN' ) || ! IS_GUTENBERG_PLUGIN ) {
+	return;
+}
+
 if ( ! gutenberg_is_client_side_media_processing_enabled() ) {
 	return;
 }


### PR DESCRIPTION
## Summary

- Gates the client-side media processing (wasm-vips) feature behind `IS_GUTENBERG_PLUGIN` so it only loads when running as the Gutenberg plugin
- The vips WASM worker adds ~16MB to the build output, which is too much overhead for WordPress core at this stage
- The feature continues to work fully in the Gutenberg plugin but will be excluded when syncing to core
- Companion core PR: https://github.com/WordPress/wordpress-develop/pull/11309

### Changes

- `lib/media/load.php`: Early return when `IS_GUTENBERG_PLUGIN` is not defined, preventing all client-side media processing infrastructure (cross-origin isolation, JS flags, REST API modifications) from loading outside the plugin
- `lib/client-assets.php`: Gate the `gutenberg_enqueue_vips_loader` action hook behind `IS_GUTENBERG_PLUGIN`, preventing the vips script module from being enqueued outside the plugin

## Test plan

- [ ] Activate Gutenberg plugin on a local site with HTTPS, upload an image in the block editor — client-side media processing should still work
- [ ] Deactivate Gutenberg plugin, upload an image — standard server-side processing works normally
- [ ] Verify `gutenberg_is_client_side_media_processing_enabled()` still returns true in plugin context on secure origins
