### PR TITLE
Storybook: Add redirect for moved introduction page

### DIFF
--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -27,6 +27,10 @@
 		];
 		const REDIRECTS = [
 			{
+				from: /^\/docs\/docs-introduction--/,
+				to: '/docs/introduction--',
+			},
+			{
 				from: /\/components-deprecated-/,
 				to: '/components-',
 			},


### PR DESCRIPTION
Follow-up to #76671

## What?

Adds a URL redirect for the introduction docs page that was moved from `Docs/Introduction` to top-level `Introduction` in #76671.

## Why?

The move changed the Storybook URL path from `?path=/docs/docs-introduction--page` to `?path=/docs/introduction--page`, which would break any existing bookmarks or shared links to the old URL.

## How?

Added a redirect entry to the existing redirect script in `storybook/manager-head.html`. The pattern is anchored to the start of the path string to avoid false matches.

## Testing Instructions

1. `npm run storybook:dev`
2. Visit the old URL directly: `http://localhost:50241/?path=/docs/docs-introduction--page`
3. Verify it redirects to `http://localhost:50241/?path=/docs/introduction--page`

## Use of AI Tools

Cursor was used for initial drafting.