### PR TITLE
Media: Add HEIC upload support via canonical plugin installer

### DIFF
--- a/packages/block-editor/src/components/provider/use-media-upload-settings.js
+++ b/packages/block-editor/src/components/provider/use-media-upload-settings.js
@@ -20,6 +20,7 @@ function useMediaUploadSettings( settings = {} ) {
 			allowedMimeTypes: settings.allowedMimeTypes,
 			allImageSizes: settings.allImageSizes,
 			bigImageSizeThreshold: settings.bigImageSizeThreshold,
+			onHeicPluginRequired: settings.onHeicPluginRequired,
 		} ),
 		[ settings ]
 	);

--- a/packages/editor/src/components/heic-upload-prompt/index.js
+++ b/packages/editor/src/components/heic-upload-prompt/index.js
@@ -49,8 +49,7 @@ export default function HeicUploadPrompt( { files, onRetry, onDismiss } ) {
 	}, [] );
 
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const { createInfoNotice, createErrorNotice } =
-		useDispatch( noticesStore );
+	const { createInfoNotice } = useDispatch( noticesStore );
 
 	// If the user has previously dismissed the prompt, silently dismiss.
 	if ( isDismissed ) {
@@ -97,14 +96,11 @@ export default function HeicUploadPrompt( { files, onRetry, onDismiss } ) {
 						data: { status: 'active' },
 					} );
 
-					createInfoNotice(
-						__( 'HEIC support plugin activated.' ),
-						{
-							type: 'snackbar',
-							speak: true,
-							isDismissible: true,
-						}
-					);
+					createInfoNotice( __( 'HEIC support plugin activated.' ), {
+						type: 'snackbar',
+						speak: true,
+						isDismissible: true,
+					} );
 
 					onRetry();
 					return;
@@ -176,6 +172,8 @@ export default function HeicUploadPrompt( { files, onRetry, onDismiss } ) {
 					} }
 				>
 					<Button
+						__next40pxDefaultSize
+						accessibleWhenDisabled
 						variant="tertiary"
 						onClick={ handleDismiss }
 						disabled={ isInstalling }
@@ -187,6 +185,8 @@ export default function HeicUploadPrompt( { files, onRetry, onDismiss } ) {
 
 					{ canInstallPlugins !== false && (
 						<Button
+							__next40pxDefaultSize
+							accessibleWhenDisabled
 							variant="primary"
 							onClick={ handleInstall }
 							disabled={ isInstalling }

--- a/packages/editor/src/components/heic-upload-prompt/index.js
+++ b/packages/editor/src/components/heic-upload-prompt/index.js
@@ -1,0 +1,208 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	Modal,
+	Button,
+	CheckboxControl,
+	Spinner,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+const PLUGIN_SLUG = 'client-side-heic';
+const PREFERENCE_SCOPE = 'core/media';
+const PREFERENCE_KEY = 'dismissHeicPrompt';
+
+/**
+ * Modal component that prompts users to install the HEIC support plugin
+ * when they attempt to upload HEIC/HEIF files.
+ *
+ * @param {Object}   props           Component props.
+ * @param {File[]}   props.files     The HEIC files pending upload.
+ * @param {Function} props.onRetry   Callback to retry the upload after plugin install.
+ * @param {Function} props.onDismiss Callback when the prompt is dismissed.
+ */
+export default function HeicUploadPrompt( { files, onRetry, onDismiss } ) {
+	const [ isInstalling, setIsInstalling ] = useState( false );
+	const [ dontAskAgain, setDontAskAgain ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const { canInstallPlugins, isDismissed } = useSelect( ( select ) => {
+		return {
+			canInstallPlugins: select( coreStore ).canUser( 'create', {
+				kind: 'root',
+				name: 'plugin',
+			} ),
+			isDismissed: select( preferencesStore ).get(
+				PREFERENCE_SCOPE,
+				PREFERENCE_KEY
+			),
+		};
+	}, [] );
+
+	const { set: setPreference } = useDispatch( preferencesStore );
+	const { createInfoNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	// If the user has previously dismissed the prompt, silently dismiss.
+	if ( isDismissed ) {
+		return null;
+	}
+
+	const fileCount = files?.length || 0;
+	if ( fileCount === 0 ) {
+		return null;
+	}
+
+	const handleInstall = async () => {
+		setIsInstalling( true );
+		setError( null );
+
+		try {
+			await apiFetch( {
+				method: 'POST',
+				path: '/wp/v2/plugins',
+				data: { slug: PLUGIN_SLUG, status: 'active' },
+			} );
+
+			createInfoNotice(
+				__( 'HEIC support plugin installed and activated.' ),
+				{
+					type: 'snackbar',
+					speak: true,
+					isDismissible: true,
+				}
+			);
+
+			onRetry();
+		} catch ( installError ) {
+			const message =
+				installError?.message ||
+				__( 'Failed to install the HEIC support plugin.' );
+
+			// Handle the case where the plugin is already installed but inactive.
+			if ( installError?.code === 'folder_exists' ) {
+				try {
+					await apiFetch( {
+						method: 'PUT',
+						path: `/wp/v2/plugins/${ PLUGIN_SLUG }/${ PLUGIN_SLUG }`,
+						data: { status: 'active' },
+					} );
+
+					createInfoNotice(
+						__( 'HEIC support plugin activated.' ),
+						{
+							type: 'snackbar',
+							speak: true,
+							isDismissible: true,
+						}
+					);
+
+					onRetry();
+					return;
+				} catch ( activateError ) {
+					setError(
+						activateError?.message ||
+							__( 'Failed to activate the HEIC support plugin.' )
+					);
+					setIsInstalling( false );
+					return;
+				}
+			}
+
+			setError( message );
+			setIsInstalling( false );
+		}
+	};
+
+	const handleDismiss = () => {
+		if ( dontAskAgain ) {
+			setPreference( PREFERENCE_SCOPE, PREFERENCE_KEY, true );
+		}
+		onDismiss();
+	};
+
+	return (
+		<Modal
+			title={ __( 'HEIC Image Support' ) }
+			onRequestClose={ handleDismiss }
+			size="small"
+		>
+			<VStack spacing={ 4 }>
+				<Text>
+					{ fileCount === 1
+						? __(
+								'This image is in HEIC format, commonly used by iPhones. To upload HEIC images, a small plugin needs to be installed.'
+						  )
+						: __(
+								'These images are in HEIC format, commonly used by iPhones. To upload HEIC images, a small plugin needs to be installed.'
+						  ) }
+				</Text>
+
+				{ canInstallPlugins === false && (
+					<Text>
+						{ __(
+							'Please ask your site administrator to install the "Client-Side HEIC Support" plugin.'
+						) }
+					</Text>
+				) }
+
+				{ error && (
+					<Text style={ { color: '#cc1818' } }>{ error }</Text>
+				) }
+
+				{ canInstallPlugins !== false && (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ __( "Don't ask again" ) }
+						checked={ dontAskAgain }
+						onChange={ setDontAskAgain }
+					/>
+				) }
+
+				<div
+					style={ {
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '8px',
+					} }
+				>
+					<Button
+						variant="tertiary"
+						onClick={ handleDismiss }
+						disabled={ isInstalling }
+					>
+						{ canInstallPlugins === false
+							? __( 'OK' )
+							: __( 'No Thanks' ) }
+					</Button>
+
+					{ canInstallPlugins !== false && (
+						<Button
+							variant="primary"
+							onClick={ handleInstall }
+							disabled={ isInstalling }
+						>
+							{ isInstalling ? (
+								<>
+									<Spinner />
+									{ __( 'Installing…' ) }
+								</>
+							) : (
+								__( 'Install & Upload' )
+							) }
+						</Button>
+					) }
+				</div>
+			</VStack>
+		</Modal>
+	);
+}

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -45,6 +45,8 @@ import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
+import HeicUploadPrompt from '../heic-upload-prompt';
+import useHeicUploadPrompt from './use-heic-upload-prompt';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -289,11 +291,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			postTypeEntities,
 		] );
 		const { id, type } = rootLevelPost;
+		const { heicPromptState, onHeicPluginRequired, dismissHeicPrompt } =
+			useHeicUploadPrompt();
 		const blockEditorSettings = useBlockEditorSettings(
 			editorSettings,
 			type,
 			id,
-			mode
+			mode,
+			{ onHeicPluginRequired }
 		);
 		const [ blocks, onInput, onChange ] = useBlockEditorProps(
 			post,
@@ -465,6 +470,16 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 									<StartTemplateOptions />
 									<PatternRenameModal />
 									<PatternDuplicateModal />
+									{ heicPromptState && (
+										<HeicUploadPrompt
+											files={ heicPromptState.files }
+											onRetry={ () => {
+												heicPromptState.retry();
+												dismissHeicPrompt();
+											} }
+											onDismiss={ dismissHeicPrompt }
+										/>
+									) }
 								</>
 							) }
 						</BlockEditorProviderComponent>

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -119,7 +119,13 @@ const {
  *
  * @return {Object} Block Editor Settings.
  */
-function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
+function useBlockEditorSettings(
+	settings,
+	postType,
+	postId,
+	renderingMode,
+	{ onHeicPluginRequired } = {}
+) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const {
 		allImageSizes,
@@ -340,6 +346,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				? editMediaEntity
 				: undefined,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
+			onHeicPluginRequired: hasUploadPermissions
+				? onHeicPluginRequired
+				: undefined,
 			[ mediaUploadOnSuccessKey ]: hasUploadPermissions
 				? mediaUploadOnSuccess
 				: undefined,
@@ -440,6 +449,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		allImageSizes,
 		bigImageSizeThreshold,
 		isNavigationOverlayContext,
+		onHeicPluginRequired,
 	] );
 }
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -117,7 +117,7 @@ const {
  * @param {string}   postId                       Editor root level post ID.
  * @param {string}   renderingMode                Editor rendering mode.
  * @param {Object}   options                      Additional options.
- * @param {Function} options.onHeicPluginRequired  Callback when HEIC plugin installation is needed.
+ * @param {Function} options.onHeicPluginRequired Callback when HEIC plugin installation is needed.
  *
  * @return {Object} Block Editor Settings.
  */

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -112,10 +112,12 @@ const {
 /**
  * React hook used to compute the block editor settings to use for the post editor.
  *
- * @param {Object} settings      EditorProvider settings prop.
- * @param {string} postType      Editor root level post type.
- * @param {string} postId        Editor root level post ID.
- * @param {string} renderingMode Editor rendering mode.
+ * @param {Object}   settings                          EditorProvider settings prop.
+ * @param {string}   postType                          Editor root level post type.
+ * @param {string}   postId                            Editor root level post ID.
+ * @param {string}   renderingMode                     Editor rendering mode.
+ * @param {Object}   options                           Additional options.
+ * @param {Function} options.onHeicPluginRequired       Callback when HEIC plugin installation is needed.
  *
  * @return {Object} Block Editor Settings.
  */

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -112,12 +112,12 @@ const {
 /**
  * React hook used to compute the block editor settings to use for the post editor.
  *
- * @param {Object}   settings                          EditorProvider settings prop.
- * @param {string}   postType                          Editor root level post type.
- * @param {string}   postId                            Editor root level post ID.
- * @param {string}   renderingMode                     Editor rendering mode.
- * @param {Object}   options                           Additional options.
- * @param {Function} options.onHeicPluginRequired       Callback when HEIC plugin installation is needed.
+ * @param {Object}   settings                     EditorProvider settings prop.
+ * @param {string}   postType                     Editor root level post type.
+ * @param {string}   postId                       Editor root level post ID.
+ * @param {string}   renderingMode                Editor rendering mode.
+ * @param {Object}   options                      Additional options.
+ * @param {Function} options.onHeicPluginRequired  Callback when HEIC plugin installation is needed.
  *
  * @return {Object} Block Editor Settings.
  */

--- a/packages/editor/src/components/provider/use-heic-upload-prompt.js
+++ b/packages/editor/src/components/provider/use-heic-upload-prompt.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+
+/**
+ * Hook that manages the HEIC upload prompt state.
+ *
+ * Returns the prompt state (files and retry callback) and an
+ * `onHeicPluginRequired` callback to be passed into the upload-media store settings.
+ *
+ * @return {Object} The hook return value.
+ * @return {Object|null} return.heicPromptState  The current prompt state or null.
+ * @return {Function}    return.onHeicPluginRequired Callback for the upload-media store.
+ * @return {Function}    return.dismissHeicPrompt    Callback to dismiss the prompt.
+ */
+export default function useHeicUploadPrompt() {
+	const [ heicPromptState, setHeicPromptState ] = useState( null );
+
+	const onHeicPluginRequired = useCallback( ( files, retry ) => {
+		setHeicPromptState( { files, retry } );
+	}, [] );
+
+	const dismissHeicPrompt = useCallback( () => {
+		setHeicPromptState( null );
+	}, [] );
+
+	return {
+		heicPromptState,
+		onHeicPluginRequired,
+		dismissHeicPrompt,
+	};
+}

--- a/packages/editor/src/components/provider/use-heic-upload-prompt.js
+++ b/packages/editor/src/components/provider/use-heic-upload-prompt.js
@@ -9,10 +9,7 @@ import { useState, useCallback } from '@wordpress/element';
  * Returns the prompt state (files and retry callback) and an
  * `onHeicPluginRequired` callback to be passed into the upload-media store settings.
  *
- * @return {Object} The hook return value.
- * @return {Object|null} return.heicPromptState  The current prompt state or null.
- * @return {Function}    return.onHeicPluginRequired Callback for the upload-media store.
- * @return {Function}    return.dismissHeicPrompt    Callback to dismiss the prompt.
+ * @return {Object} Object with heicPromptState, onHeicPluginRequired, and dismissHeicPrompt.
  */
 export default function useHeicUploadPrompt() {
 	const [ heicPromptState, setHeicPromptState ] = useState( null );

--- a/packages/media-utils/README.md
+++ b/packages/media-utils/README.md
@@ -57,6 +57,7 @@ _Parameters_
 -   _$0.wpAllowedMimeTypes_ `UploadMediaArgs[ 'wpAllowedMimeTypes' ]`: List of allowed mime types and file extensions.
 -   _$0.signal_ `UploadMediaArgs[ 'signal' ]`: Abort signal.
 -   _$0.multiple_ `UploadMediaArgs[ 'multiple' ]`: Whether to allow multiple files to be uploaded.
+-   _$0.onHeicPluginRequired_ `UploadMediaArgs[ 'onHeicPluginRequired' ]`: Callback when HEIC plugin installation is needed.
 
 ### validateFileSize
 

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -25,6 +25,21 @@ declare global {
 	}
 }
 
+/**
+ * Checks whether a file is HEIC or HEIF format.
+ *
+ * @param file The file to check.
+ * @return True if the file is HEIC/HEIF.
+ */
+function isHeicFile( file: File ): boolean {
+	const heicTypes = [ 'image/heic', 'image/heif' ];
+	if ( heicTypes.includes( file.type ) ) {
+		return true;
+	}
+	const ext = file.name.split( '.' ).pop()?.toLowerCase();
+	return ext === 'heic' || ext === 'heif';
+}
+
 interface UploadMediaArgs {
 	// Additional data to include in the request.
 	additionalData?: AdditionalData;
@@ -44,6 +59,8 @@ interface UploadMediaArgs {
 	signal?: AbortSignal;
 	// Whether to allow multiple files to be uploaded.
 	multiple?: boolean;
+	// Callback invoked when HEIC files need a plugin to be uploaded.
+	onHeicPluginRequired?: ( files: File[], retry: () => void ) => void;
 }
 
 /**
@@ -71,6 +88,7 @@ export function uploadMedia( {
 	onFileChange,
 	signal,
 	multiple = true,
+	onHeicPluginRequired,
 }: UploadMediaArgs ) {
 	if ( ! multiple && filesList.length > 1 ) {
 		onError?.( new Error( __( 'Only one file can be used here.' ) ) );
@@ -93,12 +111,40 @@ export function uploadMedia( {
 		);
 	};
 
+	let heicPromptShown = false;
 	for ( const mediaFile of filesList ) {
 		// Verify if user is allowed to upload this mime type.
 		// Defer to the server when type not detected.
 		try {
 			validateMimeTypeForUser( mediaFile, wpAllowedMimeTypes );
 		} catch ( error: unknown ) {
+			// If a HEIC file fails MIME validation and a handler is registered,
+			// prompt for plugin installation instead of showing an error.
+			if (
+				! heicPromptShown &&
+				isHeicFile( mediaFile ) &&
+				onHeicPluginRequired
+			) {
+				heicPromptShown = true;
+				const heicFiles = Array.from( filesList ).filter( isHeicFile );
+				onHeicPluginRequired( heicFiles, () => {
+					uploadMedia( {
+						wpAllowedMimeTypes,
+						allowedTypes,
+						additionalData,
+						filesList: heicFiles,
+						maxUploadFileSize,
+						onError,
+						onFileChange,
+						signal,
+						multiple,
+					} );
+				} );
+				continue;
+			}
+			if ( heicPromptShown && isHeicFile( mediaFile ) ) {
+				continue;
+			}
 			onError?.( error as Error );
 			continue;
 		}

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -75,8 +75,9 @@ interface UploadMediaArgs {
  * @param $0.onError            Function called when an error happens.
  * @param $0.onFileChange       Function called each time a file or a temporary representation of the file is available.
  * @param $0.wpAllowedMimeTypes List of allowed mime types and file extensions.
- * @param $0.signal             Abort signal.
- * @param $0.multiple           Whether to allow multiple files to be uploaded.
+ * @param $0.signal                 Abort signal.
+ * @param $0.multiple               Whether to allow multiple files to be uploaded.
+ * @param $0.onHeicPluginRequired   Callback when HEIC plugin installation is needed.
  */
 export function uploadMedia( {
 	wpAllowedMimeTypes,

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -67,17 +67,17 @@ interface UploadMediaArgs {
  * Upload a media file when the file upload button is activated
  * or when adding a file to the editor via drag & drop.
  *
- * @param $0                       Parameters object passed to the function.
- * @param $0.allowedTypes          Array with the types of media that can be uploaded, if unset all types are allowed.
- * @param $0.additionalData        Additional data to include in the request.
- * @param $0.filesList             List of files.
- * @param $0.maxUploadFileSize     Maximum upload size in bytes allowed for the site.
- * @param $0.onError               Function called when an error happens.
- * @param $0.onFileChange          Function called each time a file or a temporary representation of the file is available.
- * @param $0.wpAllowedMimeTypes    List of allowed mime types and file extensions.
- * @param $0.signal                Abort signal.
- * @param $0.multiple              Whether to allow multiple files to be uploaded.
- * @param $0.onHeicPluginRequired  Callback when HEIC plugin installation is needed.
+ * @param $0                      Parameters object passed to the function.
+ * @param $0.allowedTypes         Array with the types of media that can be uploaded, if unset all types are allowed.
+ * @param $0.additionalData       Additional data to include in the request.
+ * @param $0.filesList            List of files.
+ * @param $0.maxUploadFileSize    Maximum upload size in bytes allowed for the site.
+ * @param $0.onError              Function called when an error happens.
+ * @param $0.onFileChange         Function called each time a file or a temporary representation of the file is available.
+ * @param $0.wpAllowedMimeTypes   List of allowed mime types and file extensions.
+ * @param $0.signal               Abort signal.
+ * @param $0.multiple             Whether to allow multiple files to be uploaded.
+ * @param $0.onHeicPluginRequired Callback when HEIC plugin installation is needed.
  */
 export function uploadMedia( {
 	wpAllowedMimeTypes,

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -67,17 +67,17 @@ interface UploadMediaArgs {
  * Upload a media file when the file upload button is activated
  * or when adding a file to the editor via drag & drop.
  *
- * @param $0                    Parameters object passed to the function.
- * @param $0.allowedTypes       Array with the types of media that can be uploaded, if unset all types are allowed.
- * @param $0.additionalData     Additional data to include in the request.
- * @param $0.filesList          List of files.
- * @param $0.maxUploadFileSize  Maximum upload size in bytes allowed for the site.
- * @param $0.onError            Function called when an error happens.
- * @param $0.onFileChange       Function called each time a file or a temporary representation of the file is available.
- * @param $0.wpAllowedMimeTypes List of allowed mime types and file extensions.
- * @param $0.signal                 Abort signal.
- * @param $0.multiple               Whether to allow multiple files to be uploaded.
- * @param $0.onHeicPluginRequired   Callback when HEIC plugin installation is needed.
+ * @param $0                       Parameters object passed to the function.
+ * @param $0.allowedTypes          Array with the types of media that can be uploaded, if unset all types are allowed.
+ * @param $0.additionalData        Additional data to include in the request.
+ * @param $0.filesList             List of files.
+ * @param $0.maxUploadFileSize     Maximum upload size in bytes allowed for the site.
+ * @param $0.onError               Function called when an error happens.
+ * @param $0.onFileChange          Function called each time a file or a temporary representation of the file is available.
+ * @param $0.wpAllowedMimeTypes    List of allowed mime types and file extensions.
+ * @param $0.signal                Abort signal.
+ * @param $0.multiple              Whether to allow multiple files to be uploaded.
+ * @param $0.onHeicPluginRequired  Callback when HEIC plugin installation is needed.
  */
 export function uploadMedia( {
 	wpAllowedMimeTypes,

--- a/packages/upload-media/src/is-heic-file.ts
+++ b/packages/upload-media/src/is-heic-file.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks whether a file is HEIC or HEIF format.
+ *
+ * @param file The file to check.
+ * @return True if the file is HEIC/HEIF.
+ */
+export function isHeicFile( file: File ): boolean {
+	const heicTypes = [ 'image/heic', 'image/heif' ];
+	if ( heicTypes.includes( file.type ) ) {
+		return true;
+	}
+	// Some browsers don't set the MIME type for HEIC files.
+	const ext = file.name.split( '.' ).pop()?.toLowerCase();
+	return ext === 'heic' || ext === 'heif';
+}

--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -35,6 +35,7 @@ import { vipsCancelOperations } from './utils';
 import { validateMimeType } from '../validate-mime-type';
 import { validateMimeTypeForUser } from '../validate-mime-type-for-user';
 import { validateFileSize } from '../validate-file-size';
+import { isHeicFile } from '../is-heic-file';
 
 type ActionCreators = {
 	addItem: typeof addItem;
@@ -95,6 +96,7 @@ export function addItems( {
 }: AddItemsArgs ) {
 	return async ( { select, dispatch }: ThunkArgs ) => {
 		const batchId = uuidv4();
+		let heicPromptShown = false;
 		for ( const file of files ) {
 			/*
 			 Check if the caller (e.g. a block) supports this mime type.
@@ -108,6 +110,33 @@ export function addItems( {
 					select.getSettings().allowedMimeTypes
 				);
 			} catch ( error: unknown ) {
+				// If a HEIC file fails MIME validation and a handler is registered,
+				// prompt for plugin installation instead of showing an error.
+				const settings = select.getSettings();
+				if (
+					! heicPromptShown &&
+					isHeicFile( file ) &&
+					settings.onHeicPluginRequired
+				) {
+					heicPromptShown = true;
+					const heicFiles = files.filter( isHeicFile );
+					settings.onHeicPluginRequired( heicFiles, () => {
+						dispatch.addItems( {
+							files: heicFiles,
+							onChange,
+							onSuccess,
+							onBatchSuccess,
+							onError,
+							additionalData,
+							allowedTypes,
+						} );
+					} );
+					continue;
+				}
+				if ( heicPromptShown && isHeicFile( file ) ) {
+					// Already prompted for this batch, skip remaining HEIC files.
+					continue;
+				}
 				onError?.( error as Error );
 				continue;
 			}

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -183,6 +183,12 @@ export interface Settings {
 	imageQuality?: number;
 	// Function for finalizing an upload after all client-side processing is complete.
 	mediaFinalize?: ( id: number ) => Promise< void >;
+	// Callback invoked when HEIC files need a plugin to be uploaded.
+	// Receives the pending files and a retry function to re-attempt the upload.
+	onHeicPluginRequired?: (
+		files: File[],
+		retry: () => void
+	) => void;
 }
 
 // Matches the Attachment type from the media-utils package.

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -185,10 +185,7 @@ export interface Settings {
 	mediaFinalize?: ( id: number ) => Promise< void >;
 	// Callback invoked when HEIC files need a plugin to be uploaded.
 	// Receives the pending files and a retry function to re-attempt the upload.
-	onHeicPluginRequired?: (
-		files: File[],
-		retry: () => void
-	) => void;
+	onHeicPluginRequired?: ( files: File[], retry: () => void ) => void;
 }
 
 // Matches the Attachment type from the media-utils package.


### PR DESCRIPTION
## Summary

When users attempt to upload HEIC/HEIF images (the default format from iPhones), WordPress rejects them because HEIC is not in the allowed MIME types. This PR adds an installer flow that prompts users to install the [client-side-heic](https://github.com/adamsilverstein/client-side-heic) plugin with a single click.

### How it works

1. User selects a `.heic` file for upload in the block editor
2. MIME validation fails (HEIC not in allowed types)
3. Instead of showing a generic error, a modal prompts the user to install the HEIC support plugin
4. On "Install & Upload": the plugin is installed/activated via `POST /wp/v2/plugins`, then the upload is retried
5. On "No Thanks": the modal closes without uploading
6. "Don't ask again" checkbox saves a preference so the user is not prompted again
7. Non-admin users see a message asking their administrator to install the plugin

### Changes

- **`packages/upload-media/src/is-heic-file.ts`** - New HEIC/HEIF detection utility
- **`packages/upload-media/src/store/types.ts`** - Added `onHeicPluginRequired` callback to `Settings` interface
- **`packages/upload-media/src/store/actions.ts`** - Intercepts HEIC MIME validation failures, invokes callback instead of `onError`
- **`packages/media-utils/src/utils/upload-media.ts`** - Same interception for the legacy upload path
- **`packages/editor/src/components/heic-upload-prompt/index.js`** - New modal component for the install prompt
- **`packages/editor/src/components/provider/use-heic-upload-prompt.js`** - Hook managing prompt state
- **`packages/editor/src/components/provider/use-block-editor-settings.js`** - Wires callback into block editor settings
- **`packages/editor/src/components/provider/index.js`** - Mounts the HeicUploadPrompt modal
- **`packages/block-editor/src/components/provider/use-media-upload-settings.js`** - Passes callback through to upload-media store

### Architecture

Follows existing package layering:
- **upload-media** (generic): HEIC detection + callback in Settings
- **editor** (WordPress-aware): Modal UI, REST API plugin install, preferences
- **block-editor**: Passes the callback through to the upload-media store (no WordPress-specific logic added)

Uses the same plugin install pattern as `packages/block-directory/src/store/actions.js`.

## Test plan

- [ ] Upload a HEIC file without the plugin installed — verify modal appears
- [ ] Click "Install & Upload" — verify plugin installs and file uploads
- [ ] Click "No Thanks" — verify modal closes, file is not uploaded
- [ ] Check "Don't ask again" + "No Thanks" — verify future HEIC uploads show error, no modal
- [ ] Upload HEIC as a non-admin user — verify "ask your administrator" message
- [ ] Upload HEIC with plugin already active — verify no modal, upload works directly
- [ ] Upload a mix of HEIC and JPEG files — verify JPEG files upload normally, HEIC triggers prompt