### PR TITLE
RTC: Increase polling intervals, increase polling on primary room only

### DIFF
--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -35,11 +35,11 @@ const { BlockCanvasCover } = unlock( privateApis );
 const { retrySyncConnection } = unlock( coreDataPrivateApis );
 
 // Debounce time for initial disconnected status to allow connection to establish.
-const INITIAL_DISCONNECTED_DEBOUNCE_MS = 5000;
+const INITIAL_DISCONNECTED_DEBOUNCE_MS = 20000;
 
 // Debounce time for showing the disconnect dialog after the intial connection,
 // allowing brief network interruptions to resolve.
-const DISCONNECTED_DEBOUNCE_MS = 2000;
+const DISCONNECTED_DEBOUNCE_MS = 8000;
 
 export interface SyncConnectionErrorModalProps {
 	description: string; // Modal description.

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -9,12 +9,12 @@ export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 
 export const POLLING_INTERVAL_IN_MS = applyFilters(
 	'sync.pollingManager.pollingInterval',
-	1000 // 1 second or 1000 milliseconds
+	4000 // 4 seconds
 ) as number;
 
 export const POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS = applyFilters(
 	'sync.pollingManager.pollingIntervalWithCollaborators',
-	250 // 250 milliseconds
+	1000 // 1 second
 ) as number;
 
 // Must be less than the server-side AWARENESS_TIMEOUT (30 s) to avoid

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -306,6 +306,7 @@ let isPolling = false;
 let isUnloadPending = false;
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
+let primaryRoom: string | null = null;
 
 /**
  * Mark that a page unload has been requested. This fires on
@@ -445,9 +446,14 @@ function poll(): void {
 				// Process awareness update.
 				roomState.processAwarenessUpdate( room.awareness );
 
-				// If there is another collaborator, resume the queue for the next poll
-				// and increase polling frequency.
-				if ( Object.keys( room.awareness ).length > 1 ) {
+				// If there is another collaborator on the primary entity,
+				// resume the queue for the next poll and increase polling
+				// frequency. We only check the primary room to avoid false
+				// positives from shared collection rooms (e.g. taxonomy/category).
+				if (
+					room.room === primaryRoom &&
+					Object.keys( room.awareness ).length > 1
+				) {
 					hasCollaborators = true;
 					roomState.updateQueue.resume();
 				}
@@ -581,6 +587,13 @@ function registerRoom( {
 	 */
 	const enforceConnectionLimit = 0 === roomStates.size;
 
+	// The first room registered is treated as the "primary" entity.
+	// Used to scope the collaborator check to only this room, avoiding
+	// awareness results from shared collection rooms (e.g. taxonomy/category).
+	if ( ! primaryRoom ) {
+		primaryRoom = room;
+	}
+
 	function onAwarenessUpdate(): void {
 		roomState.localAwarenessState = awareness.getLocalState() ?? {};
 	}
@@ -678,6 +691,10 @@ function unregisterRoom( room: string ): void {
 		postSyncUpdateNonBlocking( { rooms } );
 		state.unregister();
 		roomStates.delete( room );
+
+		if ( room === primaryRoom ) {
+			primaryRoom = null;
+		}
 	}
 
 	if ( 0 === roomStates.size && areListenersRegistered ) {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -66,7 +66,7 @@ interface RoomState {
 	clientId: number;
 	createCompactionUpdate: () => SyncUpdate;
 	endCursor: number;
-	enforceConnectionLimit: boolean;
+	isPrimaryRoom: boolean;
 	localAwarenessState: LocalAwarenessState;
 	log: LogFunction;
 	onStatusChange: ( status: ConnectionStatus ) => void;
@@ -267,12 +267,12 @@ function checkConnectionLimit(
 	awareness: AwarenessState,
 	roomState: RoomState
 ): boolean {
-	if ( ! roomState.enforceConnectionLimit ) {
+	if ( ! roomState.isPrimaryRoom || hasCheckedConnectionLimit ) {
 		return false;
 	}
 
 	// Limits are only enforced on the initial connection.
-	roomState.enforceConnectionLimit = false;
+	hasCheckedConnectionLimit = true;
 
 	const maxClientsPerRoom = applyFilters(
 		'sync.pollingProvider.maxClientsPerRoom',
@@ -300,13 +300,13 @@ function checkConnectionLimit(
 }
 
 let areListenersRegistered = false;
+let hasCheckedConnectionLimit = false;
 let hasCollaborators = false;
 let isActiveBrowser = 'visible' === document.visibilityState;
 let isPolling = false;
 let isUnloadPending = false;
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
-let primaryRoom: string | null = null;
 
 /**
  * Mark that a page unload has been requested. This fires on
@@ -451,7 +451,7 @@ function poll(): void {
 				// frequency. We only check the primary room to avoid false
 				// positives from shared collection rooms (e.g. taxonomy/category).
 				if (
-					room.room === primaryRoom &&
+					roomState.isPrimaryRoom &&
 					Object.keys( room.awareness ).length > 1
 				) {
 					hasCollaborators = true;
@@ -585,14 +585,7 @@ function registerRoom( {
 	 * How might this approach be improved? We could develop some way to annotate
 	 * entity loading so that the consumer can indicate which entity is primary.
 	 */
-	const enforceConnectionLimit = 0 === roomStates.size;
-
-	// The first room registered is treated as the "primary" entity.
-	// Used to scope the collaborator check to only this room, avoiding
-	// awareness results from shared collection rooms (e.g. taxonomy/category).
-	if ( ! primaryRoom ) {
-		primaryRoom = room;
-	}
+	const isPrimaryRoom = 0 === roomStates.size;
 
 	function onAwarenessUpdate(): void {
 		roomState.localAwarenessState = awareness.getLocalState() ?? {};
@@ -644,7 +637,7 @@ function registerRoom( {
 				SyncUpdateType.COMPACTION
 			),
 		endCursor: 0,
-		enforceConnectionLimit,
+		isPrimaryRoom,
 		localAwarenessState: awareness.getLocalState() ?? {},
 		log,
 		onStatusChange,
@@ -691,10 +684,6 @@ function unregisterRoom( room: string ): void {
 		postSyncUpdateNonBlocking( { rooms } );
 		state.unregister();
 		roomStates.delete( room );
-
-		if ( room === primaryRoom ) {
-			primaryRoom = null;
-		}
 	}
 
 	if ( 0 === roomStates.size && areListenersRegistered ) {
@@ -705,6 +694,7 @@ function unregisterRoom( room: string ): void {
 			handleVisibilityChange
 		);
 		areListenersRegistered = false;
+		hasCheckedConnectionLimit = false;
 	}
 }
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -418,6 +418,9 @@ function poll(): void {
 				state.onStatusChange( { status: 'connected' } );
 			} );
 
+			// Reset before checking each room
+			hasCollaborators = false;
+
 			rooms.forEach( ( room ) => {
 				if ( ! roomStates.has( room.room ) ) {
 					return;

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -7,7 +7,10 @@ export { expect } from '@wordpress/e2e-test-utils-playwright';
 /**
  * Internal dependencies
  */
-import CollaborationUtils, { SECOND_USER } from './collaboration-utils';
+import CollaborationUtils, {
+	SECOND_USER,
+	setCollaboration,
+} from './collaboration-utils';
 
 type Fixtures = {
 	collaborationUtils: CollaborationUtils;
@@ -27,7 +30,9 @@ export const test = base.extend< Fixtures >( {
 		// Clean up any leftover users from previous runs before creating.
 		await requestUtils.deleteAllUsers();
 		await requestUtils.createUser( SECOND_USER );
+		await setCollaboration( requestUtils, true );
 		await use( utils );
 		await utils.teardown();
+		await setCollaboration( requestUtils, false );
 	},
 } );


### PR DESCRIPTION
## What?

Increases RTC polling intervals by 4x to reduce server load during collaborative editing sessions.

## Why?

The current polling intervals (1s solo, 250ms with collaborators) are aggressive. Increasing these intervals reduces the number of HTTP requests in short-polling, which may be helpful to hosting environments worried about collaboration traffic.

## How?

The solo polling interval goes from 1s to 4s, and the collaborator interval from 250ms to 1s. The disconnect dialog debounce timers are also scaled by the same 4x factor (initial: 5s to 20s, reconnect: 2s to 8s) so that slower polling doesn't cause the disconnect modal to appear prematurely.

The background tab polling interval (25s), server-side awareness timeout (30s), and max error backoff (30s) are left unchanged since they're already decently long.

## Testing Instructions

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Open a post in one tab.
3. Open the network inspector and filter by requests to `wp-sync/v1/updates`. Verify these requests happen once every 4 seconds.
4. Open the post a second time in another browser tab.
5. Verify that the network inspector shows requests every 1 second.
6. Verify edits sync between tabs (expect slightly higher latency, around 1-4s).
7. Disconnect your network briefly (under 8s), then reconnect. Verify the disconnect dialog does not appear for transient interruptions.
8. Disconnect your network for longer than 8s. Verify the disconnect dialog appears.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Implementation