### PR TITLE
UI Tooltip: Improve documentation to cover intended accessibility practices

### DIFF
--- a/packages/ui/src/tooltip/root.tsx
+++ b/packages/ui/src/tooltip/root.tsx
@@ -1,6 +1,18 @@
 import { Tooltip } from '@base-ui/react/tooltip';
 import type { RootProps } from './types';
 
+/**
+ * `Tooltip` is used to visually show the label of an icon button, or other such interactive controls
+ * that don't have a visual text label.
+ *
+ * Tooltips are not available on touch devices, and thus should not be used for infotips,
+ * descriptions, or dynamic status messages.
+ *
+ * The tooltip itself does not provide any accessible labeling, so when using the
+ * `Tooltip` primitive you must ensure that the trigger is accessibly labeled (e.g. with an `aria-label`).
+ *
+ * See also: [`IconButton`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs)
+ */
 function Root( props: RootProps ) {
 	return <Tooltip.Root { ...props } />;
 }

--- a/packages/ui/src/tooltip/root.tsx
+++ b/packages/ui/src/tooltip/root.tsx
@@ -11,7 +11,7 @@ import type { RootProps } from './types';
  * The tooltip itself does not provide any accessible labeling, so when using the
  * `Tooltip` primitive you must ensure that the trigger is accessibly labeled (e.g. with an `aria-label`).
  *
- * See also: [`IconButton`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs)
+ * See also: [IconButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs)
  */
 function Root( props: RootProps ) {
 	return <Tooltip.Root { ...props } />;

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Tooltip } from '../..';
+import { formatBold, formatItalic } from '@wordpress/icons';
+import { Icon, Tooltip } from '../..';
 
 const meta: Meta< typeof Tooltip.Root > = {
 	title: 'Design System/Components/Tooltip',
@@ -83,12 +84,16 @@ export const WithProvider: StoryObj< typeof Tooltip.Root > = {
 		<Tooltip.Provider delay={ 0 }>
 			<div style={ { display: 'flex', gap: '1rem' } }>
 				<Tooltip.Root>
-					<Tooltip.Trigger aria-label="Bold">𝐁</Tooltip.Trigger>
+					<Tooltip.Trigger aria-label="Bold">
+						<Icon icon={ formatBold } />
+					</Tooltip.Trigger>
 					<Tooltip.Popup>Bold</Tooltip.Popup>
 				</Tooltip.Root>
 
 				<Tooltip.Root>
-					<Tooltip.Trigger aria-label="Italic">𝐼</Tooltip.Trigger>
+					<Tooltip.Trigger aria-label="Italic">
+						<Icon icon={ formatItalic } />
+					</Tooltip.Trigger>
 					<Tooltip.Popup>Italic</Tooltip.Popup>
 				</Tooltip.Root>
 			</div>

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -16,8 +16,8 @@ export const Default: StoryObj< typeof Tooltip.Root > = {
 	args: {
 		children: (
 			<>
-				<Tooltip.Trigger>Hover me</Tooltip.Trigger>
-				<Tooltip.Popup>Tooltip text</Tooltip.Popup>
+				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+				<Tooltip.Popup>Save</Tooltip.Popup>
 			</>
 		),
 	},
@@ -51,23 +51,23 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
 			} }
 		>
 			<Tooltip.Root>
-				<Tooltip.Trigger>Top</Tooltip.Trigger>
-				<Tooltip.Popup side="top">Tooltip on top</Tooltip.Popup>
+				<Tooltip.Trigger aria-label="Up">⬆️</Tooltip.Trigger>
+				<Tooltip.Popup side="top">Up</Tooltip.Popup>
 			</Tooltip.Root>
 
 			<Tooltip.Root>
-				<Tooltip.Trigger>Right</Tooltip.Trigger>
-				<Tooltip.Popup side="right">Tooltip on right</Tooltip.Popup>
+				<Tooltip.Trigger aria-label="Forward">➡️</Tooltip.Trigger>
+				<Tooltip.Popup side="right">Forward</Tooltip.Popup>
 			</Tooltip.Root>
 
 			<Tooltip.Root>
-				<Tooltip.Trigger>Bottom</Tooltip.Trigger>
-				<Tooltip.Popup side="bottom">Tooltip on bottom</Tooltip.Popup>
+				<Tooltip.Trigger aria-label="Down">⬇️</Tooltip.Trigger>
+				<Tooltip.Popup side="bottom">Down</Tooltip.Popup>
 			</Tooltip.Root>
 
 			<Tooltip.Root>
-				<Tooltip.Trigger>Left</Tooltip.Trigger>
-				<Tooltip.Popup side="left">Tooltip on left</Tooltip.Popup>
+				<Tooltip.Trigger aria-label="Back">⬅️</Tooltip.Trigger>
+				<Tooltip.Popup side="left">Back</Tooltip.Popup>
 			</Tooltip.Root>
 		</div>
 	),
@@ -83,13 +83,13 @@ export const WithProvider: StoryObj< typeof Tooltip.Root > = {
 		<Tooltip.Provider delay={ 0 }>
 			<div style={ { display: 'flex', gap: '1rem' } }>
 				<Tooltip.Root>
-					<Tooltip.Trigger>First</Tooltip.Trigger>
-					<Tooltip.Popup>First tooltip</Tooltip.Popup>
+					<Tooltip.Trigger aria-label="Bold">𝐁</Tooltip.Trigger>
+					<Tooltip.Popup>Bold</Tooltip.Popup>
 				</Tooltip.Root>
 
 				<Tooltip.Root>
-					<Tooltip.Trigger>Second</Tooltip.Trigger>
-					<Tooltip.Popup>Second tooltip</Tooltip.Popup>
+					<Tooltip.Trigger aria-label="Italic">𝐼</Tooltip.Trigger>
+					<Tooltip.Popup>Italic</Tooltip.Popup>
 				</Tooltip.Root>
 			</div>
 		</Tooltip.Provider>


### PR DESCRIPTION
## What?

Add a JSDoc description to the `Tooltip` component and update the Storybook examples to follow accessibility best practices.

## Why?

The Tooltip stories previously used text-labeled buttons as triggers, which doesn't reflect the intended use case. Tooltips are meant for controls that lack a visible text label (like icon buttons), and the trigger must be accessibly labeled independently of the tooltip.

We continue to see misuse and misunderstanding of what the `Tooltip` components do, and I think the documentation should be blamed first.

## How?

- Added a JSDoc comment to `Tooltip.Root` documenting the component's purpose, touch device limitations, accessible labeling requirements, and a cross-reference to `IconButton`.
- Updated all story triggers to use icon-only content (emojis or `@wordpress/icons` via `Icon`) with explicit `aria-label` attributes, demonstrating the recommended accessible pattern.

## Testing Instructions

See `Tooltip` stories in Storybook (`@wordpress/ui`)

## AI tools

Actual accessibility guidance authored by me, examples improved on my guidance, executed by Opus 4.6