### PR TITLE
WIP: Attempt to remove the need for PHP asset files.

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -457,9 +457,16 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 				'after'  => array(),
 			);
 
-			// Get boot module asset file for dependencies.
-			$boot_asset_file   = include __DIR__ . '/../../build/modules/boot/index.min.asset.php';
-			$boot_dependencies = $boot_asset_file['dependencies'] ?? array();
+			// Get boot module dependencies from the modules registry.
+			$modules_registry = require __DIR__ . '/../../build/modules/registry.php';
+			$boot_entry        = array();
+			foreach ( $modules_registry as $module ) {
+				if ( '@wordpress/boot' === $module['id'] ) {
+					$boot_entry = $module;
+					break;
+				}
+			}
+			$boot_dependencies = $boot_entry['dependencies'] ?? array();
 
 			// Get all dependencies that should be excluded (boot dependencies + their deep dependencies).
 			$excluded_scripts = $this->get_all_dependencies( $boot_dependencies, $wp_scripts );

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -940,7 +940,7 @@ async function generateModuleRegistrationPhp( modules, replacements ) {
 				`\t\t'path' => '${ module.path }',\n` +
 				`\t\t'dependencies' => array(${ depsPhp }),\n` +
 				`\t\t'module_dependencies' => array(${ moduleDepsPhp }),\n` +
-				`\t\t'version' => '${ module.version }',\n`;
+				`\t\t'version' => '${ module.version ?? '' }',\n`;
 			if ( module.min_only ) {
 				entry += `\t\t'min_only' => true,\n`;
 			}
@@ -993,7 +993,7 @@ async function generateScriptRegistrationPhp( scripts, replacements ) {
 			if ( moduleDepsPhp ) {
 				entry += `\t\t'module_dependencies' => array(${ moduleDepsPhp }),\n`;
 			}
-			entry += `\t\t'version' => '${ script.version }',\n` + `\t),`;
+			entry += `\t\t'version' => '${ script.version ?? '' }',\n` + `\t),`;
 			return entry;
 		} )
 		.join( '\n' );
@@ -1042,7 +1042,7 @@ async function generateStyleRegistrationPhp( styles, replacements ) {
 				`\tarray(\n` +
 				`\t\t'handle' => '${ style.handle }',\n` +
 				`\t\t'path' => '${ style.path }',\n` +
-				`\t\t'dependencies' => array(${ style.dependencies
+				`\t\t'dependencies' => array(${ ( style.dependencies || [] )
 					.map( ( dep ) => `'${ dep }'` )
 					.join( ', ' ) }),\n` +
 				`\t),`

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -488,6 +488,8 @@ async function bundlePackage( packageName, options = {} ) {
 	const builtModules = [];
 	const builtScripts = [];
 	const builtStyles = [];
+	const scriptAssetResult = {};
+	const moduleAssetResultEntries = [];
 	const packageDir = path.join( sourceDir, packageName );
 	const packageJson = getPackageInfoFromFile(
 		path.join( sourceDir, packageName, 'package.json' )
@@ -542,7 +544,8 @@ async function bundlePackage( packageName, options = {} ) {
 						'index.min',
 						'iife',
 						packageJson.wpScriptExtraDependencies || [],
-						true // Generate asset file for minified build
+						false, // Do not generate asset file; data goes into registry.php
+						scriptAssetResult
 					),
 				],
 			} ),
@@ -557,17 +560,12 @@ async function bundlePackage( packageName, options = {} ) {
 						'index.min',
 						'iife',
 						packageJson.wpScriptExtraDependencies || [],
-						false // Skip asset file for non-minified build
+						false
 					),
 				],
 			} )
 		);
-
-		builtScripts.push( {
-			handle: `${ handlePrefix }-${ packageName }`,
-			path: `${ packageName }/index`,
-			asset: `${ packageName }/index.min.asset.php`,
-		} );
+		// builtScripts is populated after Promise.all( builds ) below.
 	}
 
 	if ( packageJson.wpScriptModuleExports ) {
@@ -600,6 +598,8 @@ async function bundlePackage( packageName, options = {} ) {
 					( key ) => key.replace( /^\.\//, '' ) === fileName
 				);
 
+			const moduleAssetResult = {};
+
 			builds.push(
 				esbuild.build( {
 					entryPoints: [ entryPoint ],
@@ -619,7 +619,8 @@ async function bundlePackage( packageName, options = {} ) {
 							`${ baseFileName }.min`,
 							'esm',
 							[],
-							true // Generate asset file for minified build
+							false, // Do not generate asset file; data goes into registry.php
+							moduleAssetResult
 						),
 					],
 				} )
@@ -645,7 +646,7 @@ async function bundlePackage( packageName, options = {} ) {
 								`${ baseFileName }.min`,
 								'esm',
 								[],
-								false // Skip asset file for non-minified build
+								false
 							),
 						],
 					} )
@@ -657,12 +658,13 @@ async function bundlePackage( packageName, options = {} ) {
 					? `@${ packageNamespace }/${ packageName }`
 					: `@${ packageNamespace }/${ packageName }/${ fileName }`;
 
-			builtModules.push( {
+			moduleAssetResultEntries.push( {
 				id: scriptModuleId,
 				path: `${ packageName }/${ fileName }`,
-				asset: `${ packageName }/${ fileName }.min.asset.php`,
 				min_only: isWasmWorker,
+				result: moduleAssetResult,
 			} );
+			// builtModules is populated after Promise.all( builds ) below.
 		}
 	}
 
@@ -799,30 +801,34 @@ async function bundlePackage( packageName, options = {} ) {
 
 	await Promise.all( builds );
 
-	// Collect style metadata after builds complete (so asset files exist)
+	// Populate builtScripts from the result container captured during the build.
+	if ( packageJson.wpScript ) {
+		builtScripts.push( {
+			handle: `${ handlePrefix }-${ packageName }`,
+			path: `${ packageName }/index`,
+			dependencies: scriptAssetResult.dependencies ?? [],
+			module_dependencies: scriptAssetResult.module_dependencies ?? [],
+			version: scriptAssetResult.version,
+		} );
+	}
+
+	// Populate builtModules from the per-export result containers captured during the build.
+	for ( const entry of moduleAssetResultEntries ) {
+		builtModules.push( {
+			id: entry.id,
+			path: entry.path,
+			min_only: entry.min_only,
+			dependencies: entry.result.dependencies ?? [],
+			module_dependencies: entry.result.module_dependencies ?? [],
+			version: entry.result.version,
+		} );
+	}
+
+	// Collect style metadata after builds complete.
 	// Only register the main style.css file - complex cases handled manually in lib/client-assets.php
 	if ( hasMainStyle ) {
-		// Read script asset file to get dependencies
-		const scriptAssetPath = path.join(
-			BUILD_DIR,
-			'scripts',
-			packageName,
-			'index.min.asset.php'
-		);
-
-		const assetContent = await readFile( scriptAssetPath, 'utf8' );
-		const depsMatch = assetContent.match(
-			/'dependencies' => array\((.*?)\)/s
-		);
-
-		let scriptDependencies = [];
-		if ( depsMatch ) {
-			const depsString = depsMatch[ 1 ];
-			scriptDependencies =
-				depsString
-					.match( /'([^']+)'/g )
-					?.map( ( d ) => d.replace( /'/g, '' ) ) || [];
-		}
+		// Use in-memory script dependencies from the build result.
+		const scriptDependencies = scriptAssetResult.dependencies ?? [];
 
 		const styleDeps = await inferStyleDependencies(
 			scriptDependencies,
@@ -918,15 +924,29 @@ async function generateModuleRegistrationPhp( modules, replacements ) {
 
 	// Generate modules array for registry
 	const modulesArray = modules
-		.map(
-			( module ) =>
+		.map( ( module ) => {
+			const depsPhp = ( module.dependencies || [] )
+				.map( ( d ) => `'${ d }'` )
+				.join( ', ' );
+			const moduleDepsPhp = ( module.module_dependencies || [] )
+				.map(
+					( { id, import: importType } ) =>
+						`array('id' => '${ id }', 'import' => '${ importType }')`
+				)
+				.join( ', ' );
+			let entry =
 				`\tarray(\n` +
 				`\t\t'id' => '${ module.id }',\n` +
 				`\t\t'path' => '${ module.path }',\n` +
-				`\t\t'asset' => '${ module.asset }',\n` +
-				( module.min_only ? `\t\t'min_only' => true,\n` : '' ) +
-				`\t),`
-		)
+				`\t\t'dependencies' => array(${ depsPhp }),\n` +
+				`\t\t'module_dependencies' => array(${ moduleDepsPhp }),\n` +
+				`\t\t'version' => '${ module.version }',\n`;
+			if ( module.min_only ) {
+				entry += `\t\t'min_only' => true,\n`;
+			}
+			entry += `\t),`;
+			return entry;
+		} )
 		.join( '\n' );
 
 	await Promise.all( [
@@ -955,14 +975,27 @@ async function generateScriptRegistrationPhp( scripts, replacements ) {
 
 	// Generate scripts array for registry
 	const scriptsArray = scripts
-		.map(
-			( script ) =>
+		.map( ( script ) => {
+			const depsPhp = ( script.dependencies || [] )
+				.map( ( d ) => `'${ d }'` )
+				.join( ', ' );
+			const moduleDepsPhp = ( script.module_dependencies || [] )
+				.map(
+					( { id, import: importType } ) =>
+						`array('id' => '${ id }', 'import' => '${ importType }')`
+				)
+				.join( ', ' );
+			let entry =
 				`\tarray(\n` +
 				`\t\t'handle' => '${ script.handle }',\n` +
 				`\t\t'path' => '${ script.path }',\n` +
-				`\t\t'asset' => '${ script.asset }',\n` +
-				`\t),`
-		)
+				`\t\t'dependencies' => array(${ depsPhp }),\n`;
+			if ( moduleDepsPhp ) {
+				entry += `\t\t'module_dependencies' => array(${ moduleDepsPhp }),\n`;
+			}
+			entry += `\t\t'version' => '${ script.version }',\n` + `\t),`;
+			return entry;
+		} )
 		.join( '\n' );
 
 	await Promise.all( [

--- a/packages/wp-build/lib/wordpress-externals-plugin.mjs
+++ b/packages/wp-build/lib/wordpress-externals-plugin.mjs
@@ -65,13 +65,15 @@ export function createWordpressExternalsPlugin(
 	 * @param {string}        buildFormat       Build format: 'iife' for classic scripts, 'esm' for modules.
 	 * @param {Array<string>} extraDependencies Additional dependencies to include in the asset file.
 	 * @param {boolean}       generateAssetFile Whether to generate the .asset.php file. Default true.
+	 * @param {Object|null}   resultContainer   Optional object to populate with { dependencies, module_dependencies, version }.
 	 * @return {Object} esbuild plugin object.
 	 */
 	return function wordpressExternalsPlugin(
 		assetName = 'index.min',
 		buildFormat = 'iife',
 		extraDependencies = [],
-		generateAssetFile = true
+		generateAssetFile = true,
+		resultContainer = null
 	) {
 		return {
 			name: 'wordpress-externals',
@@ -317,36 +319,26 @@ export function createWordpressExternalsPlugin(
 							return;
 						}
 
-						// Format module dependencies as array of arrays with 'id' and 'import' keys
-						const moduleDependenciesArray = Array.from(
-							moduleDependencies.entries()
-						)
-							.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
-							.map(
-								( [ dep, kind ] ) =>
-									`array('id' => '${ dep }', 'import' => '${ kind }')`
-							);
-
-						const moduleDependenciesString =
-							moduleDependenciesArray.length > 0
-								? moduleDependenciesArray.join( ', ' )
-								: '';
-
-						// Only generate asset file if requested
-						if ( ! generateAssetFile ) {
+						// Skip if there's nothing to do.
+						if ( ! generateAssetFile && ! resultContainer ) {
 							return;
 						}
 
-						// Merge discovered dependencies with extra dependencies
+						// Merge discovered dependencies with extra dependencies.
 						const allDependencies = new Set( [
 							...dependencies,
 							...extraDependencies,
 						] );
 
-						const dependenciesString = Array.from( allDependencies )
-							.sort()
-							.map( ( dep ) => `'${ dep }'` )
-							.join( ', ' );
+						// Build sorted module dependencies as raw objects.
+						const moduleDependenciesObjects = Array.from(
+							moduleDependencies.entries()
+						)
+							.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+							.map( ( [ id, importType ] ) => ( {
+								id,
+								import: importType,
+							} ) );
 
 						// Determine output file path from build config
 						let outputFilePath;
@@ -370,6 +362,34 @@ export function createWordpressExternalsPlugin(
 						// Generate content-based version hash
 						const version =
 							await generateContentHash( filesToHash );
+
+						// Populate result container if provided.
+						if ( resultContainer ) {
+							resultContainer.dependencies = Array.from(
+								allDependencies
+							).sort();
+							resultContainer.module_dependencies =
+								moduleDependenciesObjects;
+							resultContainer.version = version;
+						}
+
+						// Only generate asset file if requested.
+						if ( ! generateAssetFile ) {
+							return;
+						}
+
+						const dependenciesString = Array.from( allDependencies )
+							.sort()
+							.map( ( dep ) => `'${ dep }'` )
+							.join( ', ' );
+
+						const moduleDependenciesString =
+							moduleDependenciesObjects
+								.map(
+									( { id, import: importType } ) =>
+										`array('id' => '${ id }', 'import' => '${ importType }')`
+								)
+								.join( ', ' );
 
 						const parts = [
 							`'dependencies' => array(${ dependenciesString })`,

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -22,8 +22,7 @@ function {{PREFIX}}_register_script_modules() {
 
 	// Load build constants
 	$build_constants = require __DIR__ . '/constants.php';
-	$modules_dir     = __DIR__ . '/modules';
-	$modules_file    = $modules_dir . '/registry.php';
+	$modules_file    = __DIR__ . '/modules/registry.php';
 
 	if ( ! file_exists( $modules_file ) ) {
 		return;
@@ -38,8 +37,7 @@ function {{PREFIX}}_register_script_modules() {
 			? '.js'
 			: '.min.js';
 
-		$asset_path = $modules_dir . '/' . $module['asset'];
-		$asset = file_exists( $asset_path ) ? require $asset_path : array();
+		$version = SCRIPT_DEBUG ? false : ( $module['version'] ?? false );
 
 		// Deregister first to override any previously registered version
 		// (e.g., Core's default modules when running as a plugin).
@@ -48,8 +46,8 @@ function {{PREFIX}}_register_script_modules() {
 		wp_register_script_module(
 			$module['id'],
 			$base_url . $module['path'] . $extension,
-			$asset['module_dependencies'] ?? array(),
-			$asset['version'] ?? false,
+			$module['module_dependencies'] ?? array(),
+			$version,
 			array(
 				'fetchpriority' => 'low',
 				'in_footer'     => true,

--- a/packages/wp-build/templates/script-registration.php.template
+++ b/packages/wp-build/templates/script-registration.php.template
@@ -55,21 +55,17 @@ function {{PREFIX}}_register_package_scripts( $scripts ) {
 	$default_version = ! SCRIPT_DEBUG ? $build_constants['version'] : time();
 	$extension       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 
-	$scripts_dir  = __DIR__ . '/scripts';
-	$scripts_file = $scripts_dir . '/registry.php';
+	$scripts_file = __DIR__ . '/scripts/registry.php';
 
 	if ( ! file_exists( $scripts_file ) ) {
 		return;
 	}
 
 	$scripts_data = require $scripts_file;
-	$plugin_dir   = dirname( __FILE__ );
 
 	foreach ( $scripts_data as $script_data ) {
-		$asset_file   = $scripts_dir . '/' . $script_data['asset'];
-		$asset        = file_exists( $asset_file ) ? require $asset_file : array();
-		$dependencies = $asset['dependencies'] ?? array();
-		$version      = $asset['version'] ?? $default_version;
+		$dependencies = $script_data['dependencies'] ?? array();
+		$version      = SCRIPT_DEBUG ? $default_version : ( $script_data['version'] ?? $default_version );
 
 		{{PREFIX}}_override_script(
 			$scripts,


### PR DESCRIPTION
DO NOT MERGE

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This aims to remove the need for any `.min.asset.php` files for script modules. The contents of these files are PHP arrays containing a list of dependencies at the `dependencies` key, and a version string keyed at `version`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
While this information is important, it would be nice to skip having to generate these files entirely by including this information in the `registry.php` file instead.

The `registry.php` related to styles is not bundled with a `version` key, but the `dependencies` are included in that file.

The `wordpress-develop` [build script has a function dedicated to parsing all of these](https://github.com/WordPress/wordpress-develop/blob/trunk/tools/gutenberg/copy.js#L241-L308) `.php` files in order to include the `dependencies` and `version` details in a built file. Including these details in one registry file by default eliminates the need for that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
