### PR TITLE
Fix: Create custom template modal content width

### DIFF
--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -118,10 +118,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			size="small"
 			overlayClassName="editor-post-template__create-template-modal"
 		>
-			<form
-				className="editor-post-template__create-form"
-				onSubmit={ submit }
-			>
+			<form onSubmit={ submit }>
 				<VStack spacing="3">
 					<TextControl
 						__next40pxDefaultSize

--- a/packages/editor/src/components/post-template/style.scss
+++ b/packages/editor/src/components/post-template/style.scss
@@ -52,12 +52,6 @@
 	}
 }
 
-.editor-post-template__create-form {
-	@include break-medium() {
-		width: $grid-unit * 40;
-	}
-}
-
 .editor-post-template__classic-theme-dropdown {
 	padding: $grid-unit-10;
 }


### PR DESCRIPTION
Notice this while reviewing #76539

## What?

| Before | After |
|--------|--------|
| <img width="443" height="293" alt="image" src="https://github.com/user-attachments/assets/86bc33a1-f5d3-4ead-a6ac-07edaf7f319d" /> | <img width="408" height="300" alt="image" src="https://github.com/user-attachments/assets/26709a47-3450-42bc-a924-9360d3ba4253" />| 

## Why?

- The custom form content width was added in https://github.com/WordPress/gutenberg/pull/56817/changes#diff-8c85545b9a3ff81ef5c0dbe9ab7e10cd1ec63b2415ea5eaebb26d978791bc877R44-R48
- Subsequently, a `size` prop was added to the modal component in https://github.com/WordPress/gutenberg/pull/62788/changes#diff-bce0b38089034e01f39d11f3619f4153e31d1c5934d21ab328763b2ae265412fR113, causing a discrepancy.
- Since it has a `size` prop, an explicit modal content width is no longer necessary.

## Testing Instructions

- Open the  post sidebar
- Click the Template row
- Click the Create custom template button

## Use of AI Tools

None