### PR TITLE
Allow post template responsive grid styles to be unset in the UI

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -754,6 +754,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Category:** theme
 -	**Ancestor:** core/query
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** hasOptionalResponsiveGrid
 
 ## Post Terms
 

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -16,6 +16,11 @@
 		"enhancedPagination",
 		"postType"
 	],
+	"attributes": {
+		"hasOptionalResponsiveGrid": {
+			"type": "boolean"
+		}
+	},
 	"supports": {
 		"anchor": true,
 		"reusable": false,

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies
@@ -296,9 +297,10 @@ export default function PostTemplateEdit( {
 			return;
 		}
 
-		const hasLayoutChanged =
-			JSON.stringify( previousLayoutRef.current ) !==
-			JSON.stringify( layout );
+		const hasLayoutChanged = ! fastDeepEqual(
+			previousLayoutRef.current,
+			layout
+		);
 
 		if (
 			hasLayoutChanged &&

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -315,6 +315,7 @@ export default function PostTemplateEdit( {
 				setDisplayLayout( {
 					type: 'grid',
 					columnCount,
+					minimumColumnWidth: '12rem',
 				} ),
 			isActive: layoutType === 'grid',
 		},

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { memo, useMemo, useState } from '@wordpress/element';
+import { memo, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import {
@@ -113,10 +113,12 @@ export default function PostTemplateEdit( {
 		templateSlug,
 		previewPostType,
 	},
-	attributes: { layout },
+	attributes: { layout, hasOptionalResponsiveGrid },
 	__unstableLayoutClassNames,
 } ) {
 	const { type: layoutType, columnCount = 3 } = layout || {};
+	const previousLayoutRef = useRef( layout );
+	const isFirstRenderRef = useRef( true );
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
 	const { posts, blocks } = useSelect(
 		( select ) => {
@@ -281,8 +283,40 @@ export default function PostTemplateEdit( {
 		className: clsx( __unstableLayoutClassNames, {
 			[ `columns-${ columnCount }` ]:
 				layoutType === 'grid' && columnCount, // Ensure column count is flagged via classname for backwards compatibility.
+			'has-optional-responsive-grid':
+				layoutType === 'grid' && hasOptionalResponsiveGrid,
 		} ),
 	} );
+
+	useEffect( () => {
+		if ( isFirstRenderRef.current ) {
+			isFirstRenderRef.current = false;
+			previousLayoutRef.current = layout;
+
+			return;
+		}
+
+		const hasLayoutChanged =
+			JSON.stringify( previousLayoutRef.current ) !==
+			JSON.stringify( layout );
+
+		if (
+			hasLayoutChanged &&
+			layoutType === 'grid' &&
+			layout?.columnCount &&
+			! hasOptionalResponsiveGrid
+		) {
+			setAttributes( { hasOptionalResponsiveGrid: true } );
+		} else if (
+			hasLayoutChanged &&
+			( layoutType !== 'grid' || ! layout?.columnCount ) &&
+			hasOptionalResponsiveGrid
+		) {
+			setAttributes( { hasOptionalResponsiveGrid: undefined } );
+		}
+
+		previousLayoutRef.current = layout;
+	}, [ hasOptionalResponsiveGrid, layout, layoutType, setAttributes ] );
 
 	if ( ! posts ) {
 		return (

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -93,6 +93,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	// Ensure backwards compatibility by flagging the number of columns via classname when using grid layout.
 	if ( isset( $attributes['layout']['type'] ) && 'grid' === $attributes['layout']['type'] && ! empty( $attributes['layout']['columnCount'] ) ) {
 		$classnames .= ' ' . sanitize_title( 'columns-' . $attributes['layout']['columnCount'] );
+
+		if ( ! empty( $attributes['hasOptionalResponsiveGrid'] ) ) {
+			$classnames .= ' has-optional-responsive-grid';
+		}
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classnames ) ) );

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -32,13 +32,6 @@
 	}
 }
 
-@media ( max-width: $break-small ) {
-	// Temporary specificity bump until "wp-container" layout specificity is revisited.
-	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid {
-		grid-template-columns: 1fr;
-	}
-}
-
 .wp-block-post-template-is-layout-constrained > li > .alignright,
 .wp-block-post-template-is-layout-flow > li > .alignright {
 	float: right;

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -32,6 +32,13 @@
 	}
 }
 
+// Legacy fallback for older grid layouts before responsive behaviour was implemented.
+@media (max-width: $break-small) {
+	.wp-block-post-template-is-layout-grid[class*="columns-"]:not(.has-optional-responsive-grid) {
+		grid-template-columns: 1fr;
+	}
+}
+
 .wp-block-post-template-is-layout-constrained > li > .alignright,
 .wp-block-post-template-is-layout-flow > li > .alignright {
 	float: right;
@@ -51,3 +58,4 @@
 	margin-inline-start: auto;
 	margin-inline-end: auto;
 }
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

In order to solve #34145 we should be able to use the existing grid controls to enabled or disable responsive behaviour. The problem is that, at the time Post Template was switched to using grid layout, grid wasn't responsive by default, so a CSS fallback was added to preserve the previous behaviour (which was based on a custom flex implementation).

Ideally, we'd remove that CSS fallback and just use grid controls going forward.

However, this raises back compat issues, namely for websites using a Post template with a specific `columnCount` and relying on those fallback styles for their responsive behaviour, given that grids defined with `columnCount` weren't previously responsive by default.

In this PR I'm addressing that problem by way of a new attribute that flags a newly-added Post template block with grid layout or a block where the grid layout has been adjusted _and_ contains a `columnCount`.

If that attribute doesn't exist and the layout contains a `columnCount`, the fallback styles will be applied. This way nothing should change for existing websites, while newly-added blocks, or editing the layout of existing blocks will unlock the new responsive possibilities.

This will solve #34145 by ensuring newly-added or edited blocks with `columnCount` don't have the fallback styles, so they aren't forced to be responsive.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On trunk, add a Query block and set its Post template to a grid layout. Ensure only the `columnCount` is defined.
2. Check out this branch and inspect that Query on the front end. The fallback styles should be there.
3. Go into the editor and edit the layout of the Post template, e.g. by setting `minimumColumnWidth` to 0px while maintaining the `columnCount` defined.
4. Check that the `has-optional-responsive-grid` is now added to the Post template.

While I don't love adding a new attribute and classname just to ensure that layout works sensibly in this block, I can't think of a better way of ensuring the fallback styles are present for back compat while not being there for new or edited blocks 🤷 
