### PR TITLE
Add backport for WP_ALLOW_COLLABORATION

### DIFF
--- a/backport-changelog/7.0/11311.md
+++ b/backport-changelog/7.0/11311.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11311
+
+*

--- a/backport-changelog/7.0/11311.md
+++ b/backport-changelog/7.0/11311.md
@@ -1,3 +1,3 @@
 https://github.com/WordPress/wordpress-develop/pull/11311
 
-*
+* https://github.com/WordPress/gutenberg/pull/76716

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
@@ -101,7 +101,7 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 		 * Load the real-time collaboration setting and, when enabled, ensure that an
 		 * an autosave revision is always targeted.
 		 */
-		$is_collaboration_enabled = get_option( 'wp_collaboration_enabled' );
+		$is_collaboration_enabled = wp_is_collaboration_enabled();
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -125,14 +125,19 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 
 				if ( wp_is_collaboration_allowed() ) :
 					?>
-					<div class="notice notice-warning inline">
-						<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
-					</div>
-				<?php else : ?>
 					<label for="wp_collaboration_enabled">
 						<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
-						<?php _e( 'Enable real-time collaboration' ); ?>
+						<?php _e( "Enable early access to real-time collaboration. Real-time collaboration may affect your website's performance.", 'gutenberg' ); ?>
 					</label>
+				<?php else : ?>
+					<div class="notice notice-warning inline">
+						<?php printf(
+								/* translators: %s: Prefix "Note:". */
+								'<p>' . __( '%s Real-time collaboration has been disabled.', 'gutenberg' ) . '</p>',
+								'<strong>' . __( 'Note:', 'gutenberg' ) . '</strong>'
+							);
+						?>
+					</div>
 					<?php
 				endif;
 			},
@@ -170,7 +175,7 @@ if ( ! function_exists( 'wp_is_collaboration_allowed' ) ) {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return bool Whether real-time collaboration is enabled.
+	 * @return bool Whether real-time collaboration is allowed.
 	 */
 	function wp_is_collaboration_allowed() {
 		if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
@@ -245,7 +250,7 @@ add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_opt
 function gutenberg_post_list_collaboration_ui() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
+	if ( ! wp_is_collaboration_enabled() ) {
 		return;
 	}
 

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -124,7 +124,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 				$option_value = get_option( $option_name );
 
 				if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || false === WP_ALLOW_COLLABORATION ) :
-				?>
+					?>
 					<div class="notice notice-warning inline">
 						<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
 					</div>
@@ -133,7 +133,8 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 						<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
 						<?php _e( 'Enable real-time collaboration' ); ?>
 					</label>
-				<?php endif;
+					<?php
+				endif;
 			},
 			'writing'
 		);

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -123,12 +123,17 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 			function () use ( $option_name ) {
 				$option_value = get_option( $option_name );
 
+				if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || false === WP_ALLOW_COLLABORATION ) :
 				?>
-				<label for="wp_collaboration_enabled">
-					<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
-					<?php _e( 'Enable real-time collaboration', 'gutenberg' ); ?>
-				</label>
-				<?php
+					<div class="notice notice-warning inline">
+						<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
+					</div>
+				<?php else : ?>
+					<label for="wp_collaboration_enabled">
+						<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', $option_value ); ?>/>
+						<?php _e( 'Enable real-time collaboration' ); ?>
+					</label>
+				<?php endif;
 			},
 			'writing'
 		);
@@ -184,7 +189,7 @@ function gutenberg_inject_real_time_collaboration_setting() {
 
 	wp_add_inline_script(
 		'wp-core-data',
-		'window._wpCollaborationEnabled = ' . ( $enabled ? 'true' : 'false' ) . ';',
+		'window._wpCollaborationEnabled = ' . wp_json_encode( $enabled ) . ';',
 		'after'
 	);
 }

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -136,13 +136,34 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 	add_action( 'admin_init', 'gutenberg_register_real_time_collaboration_setting' );
 }
 
+if ( ! function_exists( 'wp_is_collaboration_enabled' ) ) {
+	/**
+	 * Determines whether real-time collaboration is enabled.
+	 *
+	 * If the WP_ALLOW_COLLABORATION constant is false,
+	 * collaboration is always disabled regardless of the database option.
+	 * Otherwise, falls back to the 'wp_collaboration_enabled' option.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return bool Whether real-time collaboration is enabled.
+	 */
+	function wp_is_collaboration_enabled() {
+		if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || ! WP_ALLOW_COLLABORATION ) {
+			return false;
+		}
+
+		return (bool) get_option( 'wp_collaboration_enabled' );
+	}
+}
+
 /**
  * Injects the real-time collaboration setting into a global variable.
  */
 function gutenberg_inject_real_time_collaboration_setting() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_collaboration_enabled' ) ) {
+	if ( ! wp_is_collaboration_enabled() ) {
 		return;
 	}
 

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -112,7 +112,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 				'type'              => 'boolean',
 				'description'       => __( 'Enable Real-Time Collaboration', 'gutenberg' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
-				'default'           => false,
+				'default'           => true,
 				'show_in_rest'      => true,
 			)
 		);

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -131,11 +131,12 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 					</label>
 				<?php else : ?>
 					<div class="notice notice-warning inline">
-						<?php printf(
+						<?php
+						printf(
 								/* translators: %s: Prefix "Note:". */
-								'<p>' . __( '%s Real-time collaboration has been disabled.', 'gutenberg' ) . '</p>',
-								'<strong>' . __( 'Note:', 'gutenberg' ) . '</strong>'
-							);
+							'<p>' . __( '%s Real-time collaboration has been disabled.', 'gutenberg' ) . '</p>',
+							'<strong>' . __( 'Note:', 'gutenberg' ) . '</strong>'
+						);
 						?>
 					</div>
 					<?php

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -123,7 +123,7 @@ if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {
 			function () use ( $option_name ) {
 				$option_value = get_option( $option_name );
 
-				if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || false === WP_ALLOW_COLLABORATION ) :
+				if ( wp_is_collaboration_allowed() ) :
 					?>
 					<div class="notice notice-warning inline">
 						<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
@@ -155,11 +155,40 @@ if ( ! function_exists( 'wp_is_collaboration_enabled' ) ) {
 	 * @return bool Whether real-time collaboration is enabled.
 	 */
 	function wp_is_collaboration_enabled() {
-		if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || ! WP_ALLOW_COLLABORATION ) {
-			return false;
+		return ( wp_is_collaboration_allowed() && (bool) get_option( 'wp_collaboration_enabled' ) );
+	}
+}
+
+if ( ! function_exists( 'wp_is_collaboration_allowed' ) ) {
+	/**
+	 * Determines whether real-time collaboration is allowed.
+	 *
+	 * If the WP_ALLOW_COLLABORATION constant is false,
+	 * collaboration is not allowed and cannot be enabled.
+	 * The constant defaults to true, unless the WP_ALLOW_COLLABORATION
+	 * environment variable is set to string "false".
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return bool Whether real-time collaboration is enabled.
+	 */
+	function wp_is_collaboration_allowed() {
+		if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
+			$env_value = getenv( 'WP_ALLOW_COLLABORATION' );
+			if ( false === $env_value ) {
+				// Environment variable is not defined, default to allowing collaboration.
+				define( 'WP_ALLOW_COLLABORATION', true );
+			} else {
+				/*
+				* Environment variable is defined, let's confirm it is actually set to
+				* "true" as it may still have a string value "false" – the preceeding
+				* `if` branch only tests for the boolean `false`.
+				*/
+				define( 'WP_ALLOW_COLLABORATION', 'true' === $env_value );
+			}
 		}
 
-		return (bool) get_option( 'wp_collaboration_enabled' );
+		return WP_ALLOW_COLLABORATION;
 	}
 }
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -9,6 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+// Gutenberg should have RTC enabled by default, unlike in core.
+if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
+	define( 'WP_ALLOW_COLLABORATION', true );
+}
+
 define( 'IS_GUTENBERG_PLUGIN', true );
 
 require_once __DIR__ . '/init.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -9,11 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-// Gutenberg should have RTC enabled by default, unlike in core.
-if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
-	define( 'WP_ALLOW_COLLABORATION', true );
-}
-
 define( 'IS_GUTENBERG_PLUGIN', true );
 
 require_once __DIR__ . '/init.php';


### PR DESCRIPTION
## What?

Backport WP_ALLOW_COLLABORATION constant from https://github.com/WordPress/wordpress-develop/pull/11311

## Why?

This will allow collaboration to be disallowed at an environment level, or individually using a constant.

Backport PR for https://github.com/WordPress/wordpress-develop/pull/11311