### PR TITLE
Metabox: Fix checkbox style in sidebar

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -87,24 +87,6 @@
 	.is-hidden {
 		display: none;
 	}
-
-
-	// Until checkboxes WordPress-wide are updated to match the new style,
-	// checkboxes used in metaboxes have to be slightly unstyled here.
-	// @todo remove this entire rule once checkboxes are the same everywhere.
-	// See: https://github.com/WordPress/gutenberg/issues/18053
-	.metabox-location-side .postbox input[type="checkbox"] {
-		border: $border-width solid $gray-700;
-
-		&:checked {
-			background: $white;
-			border-color: $gray-700;
-		}
-
-		&::before {
-			margin: -3px -4px;
-		}
-	}
 }
 
 .edit-post-meta-boxes-area__clear {


### PR DESCRIPTION
Fixes #76717

## What?

Fixes a bug in the metabox sidebar where the checked status could not be visually confirmed.

## Why?

These styles were introduced in the following PRs to address specific issues, but they conflict with the core form styles that rely on CSS custom properties.

- https://github.com/WordPress/gutenberg/pull/18183/
- https://github.com/WordPress/gutenberg/pull/18108/

These styles were added several years ago and should no longer be necessary.

## Testing Instructions

Use the following code to inject metabox content:

```php
add_action( 'add_meta_boxes', function() {
	add_meta_box(
		'my_test_metabox',
		'Test checkbox and radio',
		function() {
			echo <<<HTML
			<p><label><input type="checkbox" name="test_check" value="1" checked>Checked</label></p>
			<p><label><input type="checkbox" name="test_check" value="1">Unchecked</label></p>
			<p><label><input type="radio" name="test_radio" value="option1" checked>Option 1 (Checked)</label>
			<label><input type="radio" name="test_radio" value="option2">Option 2</label>
			<label><input type="radio" name="test_radio" value="option3">Option 3</label></p>
			HTML;
		},
		'post',
		'side',
		'default'
	);
} );
```

Ensure that checkbox styles display correctly in **both WordPress 7.0 and WordPress 6.9**.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|  |WordPress 7.0 | Wordpress 6.9 |
|-|-|-|
| Modern theme | <img width="258" height="177" alt="image" src="https://github.com/user-attachments/assets/b0acd631-10d8-4966-95d1-34f28f085a6a" /> | <img width="262" height="180" alt="image" src="https://github.com/user-attachments/assets/db3c800a-9bda-4153-a26f-7890484e40e7" /> |
| Fresh theme | <img width="264" height="168" alt="image" src="https://github.com/user-attachments/assets/4bf74c1a-bed4-4353-9f37-ea9f75535403" /> | <img width="262" height="180" alt="image" src="https://github.com/user-attachments/assets/4e79fa23-32e9-4861-9e3c-5776f49c5794" /> |
| Sunrise theme | <img width="259" height="181" alt="image" src="https://github.com/user-attachments/assets/43d526ef-e75f-49ca-a942-7088e679bcf8" /> | <img width="256" height="174" alt="image" src="https://github.com/user-attachments/assets/49806492-f9c8-4c70-b491-c6a141a54710" /> |

## Use of AI Tools

None