### PR TITLE
Button: restore specificity of high-contrast mode focus ring

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `CustomGradientPicker`: Add state persistence when switching between Linear and Radial Gradient ([#76595](https://github.com/WordPress/gutenberg/pull/76595)).
+-   `Button`: fix focus styles in High Contrast (forced colors) mode ([#76719](https://github.com/WordPress/gutenberg/pull/76719)).
 
 ## 32.4.0 (2026-03-18)
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -48,11 +48,6 @@
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 	}
 
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	&:focus {
-		outline: 3px solid transparent;
-	}
-
 	/**
 	 * Primary button style.
 	 */
@@ -239,6 +234,14 @@
 				background: rgba($alert-red, 0.08);
 			}
 		}
+	}
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	// This rule is placed after variant outline declarations (e.g. is-primary,
+	// is-secondary, is-tertiary) to ensure it wins by source order at the same
+	// specificity, while not using `:not(:active)` to avoid outline flicker.
+	&:focus {
+		outline: 3px solid transparent;
 	}
 
 	/**

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -236,14 +236,6 @@
 		}
 	}
 
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	// This rule is placed after variant outline declarations (e.g. is-primary,
-	// is-secondary, is-tertiary) to ensure it wins by source order at the same
-	// specificity, while not using `:not(:active)` to avoid outline flicker.
-	&:focus {
-		outline: 3px solid transparent;
-	}
-
 	/**
 	 * Link buttons.
 	 */
@@ -277,6 +269,14 @@
 		&[aria-disabled="true"] {
 			color: $gray-600;
 		}
+	}
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	// This rule is placed after variant outline declarations (e.g. is-primary,
+	// is-secondary, is-tertiary) to ensure it wins by source order at the same
+	// specificity, while not using `:not(:active)` to avoid outline flicker.
+	&:focus {
+		outline: 3px solid transparent;
 	}
 
 	&:not(:disabled, [aria-disabled="true"]):active {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76711

<!-- In a few words, what is the PR actually doing? -->

Restore the thicker focus ring for all variants of the `Button` component from `@wordpress/components` when seen in High Contrast (ie. forced colors) mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixing a regression (see #76711)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Moving styles around to let the declaration order win for rules with same CSS specificity

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load the Button examples on Storybook
- Check the "Primary" button examlpe
- Enable high contrast (forced colors) mode
- Focus the button, make sure you can see the thicker outline indicating the focused state
- Make sure that the fix introduced in https://github.com/WordPress/gutenberg/pull/75346 is still working 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![Screenshot 2026-03-20 at 09 49 44](https://github.com/user-attachments/assets/e1bbd5f4-4bc2-470d-a96d-820d1ca62145) | ![Screenshot 2026-03-20 at 09 49 57](https://github.com/user-attachments/assets/7813176e-651c-4d26-bf77-697572ebe5b3) |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Cursor + Claude Opus 4.6