### PR TITLE
Image block media placeholder: remove duotone

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -52,6 +52,11 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
+// Disable any duotone filter applied in the selected state.
+.wp-block-image.is-selected .block-editor-media-placeholder {
+	filter: none !important;
+}
+
 .block-editor-block-list__block[data-type="core/image"] .block-editor-block-toolbar .block-editor-url-input__button-modal {
 	position: absolute;
 	left: 0;


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/76720

When a duotone is applied to an image block that has no image yet, the filter shows when the block is selected.
It is only intended to show on the placeholder illustration, when the block is not selected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It is not intended to affect the interface this way.
If the duotone has a low color contrast, it can be difficult to read the text and use the controls.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add CSS to the editor.scss file of the image block to disable the duotone when the image block is selected and the media placeholder shows.

## Testing Instructions
1. Activate a theme that has duotones. If you use Twenty Twenty-Five, first select the Midnight style variation, it is the only one that has a duotone.
2. Insert an image block.
3. If you are using TT5 with Midnight, the duotone is already applied, otherwise, apply one.
4. Confirm that the placeholder where you add the image do not have the duotone (The block is selected).
5. Confirm that the placeholder illustration has the duotone. though it may be faint (The block is not selected).

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|<img width="668" height="181" alt="Screenshot 2026-03-20 065206" src="https://github.com/user-attachments/assets/ff795e21-27ac-42b8-b5bc-6423b7b91fd4" />|<img width="671" height="175" alt="Screenshot 2026-03-20 112013" src="https://github.com/user-attachments/assets/4b99ae7c-dbc1-4a3a-8996-b448c97fe55b" />|

## Use of AI Tools
I used Codex to locate where the bug was, not to add the CSS.

