### PR TITLE
Connectors: Support non-AI provider types and add JS extensibility e2e test

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 * @since 7.0.0
 		 *
 		 * @param string $id   The unique connector identifier. Must contain only lowercase
-		 *                     alphanumeric characters and underscores.
+		 *                     alphanumeric characters, hyphens, and underscores.
 		 * @param array  $args {
 		 *     An associative array of arguments for the connector.
 		 *
@@ -82,11 +82,11 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 * @phpstan-return Connector|null
 		 */
 		public function register( string $id, array $args ): ?array {
-			if ( ! preg_match( '/^[a-z0-9_]+$/', $id ) ) {
+			if ( ! preg_match( '/^[a-z0-9_-]+$/', $id ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					__(
-						'Connector ID must contain only lowercase alphanumeric characters and underscores.'
+						'Connector ID must contain only lowercase alphanumeric characters, hyphens, and underscores.'
 					),
 					'7.0.0'
 				);
@@ -161,7 +161,8 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 					$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 				}
-				$connector['authentication']['setting_name'] = "connectors_ai_{$id}_api_key";
+				$sanitized_id                                = str_replace( '-', '_', $id );
+				$connector['authentication']['setting_name'] = "connectors_ai_{$sanitized_id}_api_key";
 			}
 
 			if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -15,7 +15,7 @@
  * @package gutenberg-test-connectors-js-extensibility
  */
 
-// Register a non Ai provider connector which does not have UI component wired.
+// Register two custom-type connectors for E2E testing.
 add_action(
 	'wp_connectors_init',
 	static function ( WP_Connector_Registry $registry ) {

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -4,9 +4,13 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Author: Gutenberg Team
  *
- * Registers a custom-type connector on the server and enqueues a script module
- * that registers it client-side using the merging strategy (two registerConnector
- * calls with the same slug: one providing the render function, the other metadata).
+ * Registers two custom-type connectors on the server:
+ *
+ * 1. test_custom_service — also registered client-side via a script module using
+ *    the merging strategy (two registerConnector calls with the same slug: one
+ *    providing the render function, the other metadata).
+ * 2. test_server_only_service — server-only, with no client-side render function,
+ *    so it should not display a card in the UI.
  *
  * @package gutenberg-test-connectors-js-extensibility
  */

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -26,6 +26,18 @@ add_action(
 				),
 			)
 		);
+
+		$registry->register(
+			'test_server_only_service',
+			array(
+				'name'           => 'Test Server Only Service',
+				'description'    => 'A server-only service with no JS render.',
+				'type'           => 'custom_service',
+				'authentication' => array(
+					'method' => 'none',
+				),
+			)
+		);
 	}
 );
 

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Connectors JS Extensibility
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * Registers a custom-type connector on the server and enqueues a script module
+ * that registers it client-side using the merging strategy (two registerConnector
+ * calls with the same slug: one providing the render function, the other metadata).
+ *
+ * @package gutenberg-test-connectors-js-extensibility
+ */
+
+// Register a non Ai provider connector which does not have UI component wired.
+add_action(
+	'wp_connectors_init',
+	static function ( WP_Connector_Registry $registry ) {
+		$registry->register(
+			'test_custom_service',
+			array(
+				'name'           => 'Test Custom Service',
+				'description'    => 'A custom service for E2E testing.',
+				'type'           => 'custom_service',
+				'authentication' => array(
+					'method' => 'none',
+				),
+			)
+		);
+	}
+);
+
+// Enqueue the script module on the connectors page.
+add_action(
+	'admin_enqueue_scripts',
+	static function () {
+		if ( ! isset( $_GET['page'] ) || 'options-connectors-wp-admin' !== $_GET['page'] ) {
+			return;
+		}
+
+		wp_register_script_module(
+			'gutenberg-test-connectors-js-extensibility',
+			plugins_url( 'connectors-js-extensibility/index.mjs', __FILE__ ),
+			array(
+				array(
+					'id'     => '@wordpress/connectors',
+					'import' => 'static',
+				),
+			)
+		);
+		wp_enqueue_script_module( 'gutenberg-test-connectors-js-extensibility' );
+	}
+);

--- a/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
@@ -1,0 +1,34 @@
+/**
+ * Script module that demonstrates client-side connector registration
+ * using the merging (upsert) strategy.
+ *
+ * Two registerConnector() calls target the same slug. The store
+ * shallow-merges each call, so the final connector combines the
+ * render function from one call with label/description from the other.
+ */
+
+import {
+	__experimentalRegisterConnector as registerConnector,
+	__experimentalConnectorItem as ConnectorItem,
+} from '@wordpress/connectors';
+
+const h = window.React.createElement;
+
+// Register the render function for the connector.
+registerConnector( 'test_custom_service', {
+	render: ( props ) =>
+		h(
+			ConnectorItem,
+			{
+				className: 'connector-item--test_custom_service',
+				name: props.label,
+				description: props.description,
+				icon: props.icon,
+			},
+			h(
+				'p',
+				{ className: 'test-custom-service-content' },
+				'Custom rendered content for testing.'
+			)
+		),
+} );

--- a/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
@@ -7,6 +7,7 @@
  * combines the render function from JS with the metadata from PHP.
  */
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,

--- a/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
@@ -1,10 +1,10 @@
 /**
- * Script module that demonstrates client-side connector registration
- * using the merging (upsert) strategy.
+ * Script module that demonstrates client-side connector registration.
  *
- * Two registerConnector() calls target the same slug. The store
- * shallow-merges each call, so the final connector combines the
- * render function from one call with label/description from the other.
+ * The server registers test_custom_service with its name and description.
+ * This module calls registerConnector() with the same slug to add a render
+ * function. The store merges both registrations, so the final connector
+ * combines the render function from JS with the metadata from PHP.
  */
 
 import {

--- a/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
@@ -22,9 +22,9 @@ registerConnector( 'test_custom_service', {
 			ConnectorItem,
 			{
 				className: 'connector-item--test_custom_service',
-				name: props.label,
+				name: props.name,
 				description: props.description,
-				icon: props.icon,
+				logo: props.logo,
 			},
 			h(
 				'p',

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -28,7 +28,7 @@ interface ConnectorData {
 	name: string;
 	description: string;
 	logoUrl?: string;
-	type: 'ai_provider';
+	type: string;
 	plugin?: {
 		slug: string;
 		isInstalled: boolean;

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -231,28 +231,26 @@ function ApiKeyConnector( {
 export function registerDefaultConnectors() {
 	const connectors = getConnectorData();
 
-	const sanitize = ( s: string ) => s.replace( /[^a-z0-9-]/gi, '-' );
+	const sanitize = ( s: string ) => s.replace( /[^a-z0-9-_]/gi, '-' );
 
 	for ( const [ connectorId, data ] of Object.entries( connectors ) ) {
 		const { authentication } = data;
 
-		if (
-			data.type !== 'ai_provider' ||
-			authentication.method !== 'api_key'
-		) {
-			continue;
-		}
-
-		const connectorName = `${ sanitize( data.type ) }/${ sanitize(
-			connectorId
-		) }`;
-		registerConnector( connectorName, {
+		const connectorName = sanitize( connectorId );
+		const args: Partial< Omit< ConnectorConfig, 'slug' > > = {
 			name: data.name,
 			description: data.description,
 			logo: getConnectorLogo( connectorId, data.logoUrl ),
 			authentication,
 			plugin: data.plugin,
-			render: ApiKeyConnector,
-		} );
+		};
+		if (
+			data.type === 'ai_provider' &&
+			authentication.method === 'api_key'
+		) {
+			args.render = ApiKeyConnector;
+		}
+
+		registerConnector( connectorName, args );
 	}
 }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -42,7 +42,10 @@ function ConnectorsPage() {
 		[]
 	);
 
-	const isEmpty = connectors.length === 0;
+	const renderableConnectors = connectors.filter(
+		( connector: ConnectorConfig ) => connector.render
+	);
+	const isEmpty = renderableConnectors.length === 0;
 
 	return (
 		<Page

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -530,6 +530,26 @@ test.describe( 'Connectors', () => {
 			await requestUtils.deactivatePlugin( PLUGIN_SLUG );
 		} );
 
+		test( 'should not display a card for a server-only connector without a JS render function', async ( {
+			page,
+			admin,
+		} ) => {
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONNECTORS_PAGE_QUERY
+			);
+
+			// The server registers test_server_only_service but no JS
+			// registerConnector call provides a render function for it,
+			// so no card should appear in the UI.
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Test Server Only Service',
+					level: 2,
+				} )
+			).toBeHidden();
+		} );
+
 		test( 'should display a custom connector registered via JS with merging strategy', async ( {
 			page,
 			admin,

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -518,4 +518,46 @@ test.describe( 'Connectors', () => {
 			} );
 		} );
 	} );
+
+	test.describe( 'JS extensibility', () => {
+		const PLUGIN_SLUG = 'gutenberg-test-connectors-js-extensibility';
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin( PLUGIN_SLUG );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin( PLUGIN_SLUG );
+		} );
+
+		test( 'should display a custom connector registered via JS with merging strategy', async ( {
+			page,
+			admin,
+		} ) => {
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONNECTORS_PAGE_QUERY
+			);
+
+			const card = page.locator( '.connector-item--test_custom_service' );
+			await expect( card ).toBeVisible();
+
+			// Verify the custom content from the render function is visible.
+			await expect(
+				card.getByText( 'Custom rendered content for testing.' )
+			).toBeVisible();
+
+			// Verify label and description provided via a separate registerConnector
+			// call are merged into the same connector (upsert).
+			await expect(
+				card.getByRole( 'heading', {
+					name: 'Test Custom Service',
+					level: 2,
+				} )
+			).toBeVisible();
+			await expect(
+				card.getByText( 'A custom service for E2E testing.' )
+			).toBeVisible();
+		} );
+	} );
 } );

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -567,8 +567,8 @@ test.describe( 'Connectors', () => {
 				card.getByText( 'Custom rendered content for testing.' )
 			).toBeVisible();
 
-			// Verify label and description provided via a separate registerConnector
-			// call are merged into the same connector (upsert).
+			// Verify label and description from the server-side PHP registration
+			// are merged with the client-side JS render function.
 			await expect(
 				card.getByRole( 'heading', {
 					name: 'Test Custom Service',


### PR DESCRIPTION
## Summary
- Extends `registerDefaultConnectors` to handle connector types beyond `ai_provider` (previously non-AI connectors were skipped).
- The `sanitize` function in `default-connectors.tsx` needed updating to reflect [wordpress-develop@b8e0c3df](https://github.com/WordPress/wordpress-develop/commit/b8e0c3df769ce9ddbfb634bf25fdbb88111549bb), which now allows hyphens in connector IDs. The connector ID validation regex changed from `/^[a-z0-9_]+$/` to `/^[a-z0-9_-]+$/`, so the client-side sanitize should pass through valid IDs unchanged rather than replacing characters.
- Adds a test plugin (`connectors-js-extensibility`) that registers two custom-type connectors on the server:
  1. `test_custom_service` — also registered client-side via a script module. The store merges both registrations so the final connector combines the render function from JS with the metadata from PHP.
  2. `test_server_only_service` — server-only, with no client-side render function.
- Adds e2e tests verifying:
  - The custom connector with a JS render function displays correctly with merged metadata.
  - The server-only connector without a JS render function does **not** display a card in the UI.
- Moves the plugin's `.mjs` file into a subdirectory to follow existing e2e test plugin conventions.

## Test plan
- [x] All 17 connectors e2e tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)