### PR TITLE
Updating versions in WordPress ahead of 7.0

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -8,7 +8,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Version | WordPress Version |
 |  ---------------- | ----------------- |
-| 22.6              | 6.9.X             |
+| 22.6              | 7.0.X             |
 | 21.9              | 6.9.X             |
 | 20.4              | 6.8.X             |
 | 19.3              | 6.7.X             |

--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -8,6 +8,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Version | WordPress Version |
 |  ---------------- | ----------------- |
+| 22.6              | 6.9.X             |
 | 21.9              | 6.9.X             |
 | 20.4              | 6.8.X             |
 | 19.3              | 6.7.X             |


### PR DESCRIPTION
This is just a quick update to keep the documentation up to date for WordPress 7.0. 