### PR TITLE
Site Editor > Patterns: move config to the server

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11272
 
 * https://github.com/WordPress/gutenberg/pull/76573
+* https://github.com/WordPress/gutenberg/pull/76734

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -231,6 +231,54 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					),
 				),
 			);
+		} else if ( 'postType' === $kind && 'wp_block' === $name ) {
+			$default_layouts = array(
+				'table' => array(
+					'layout' => array(
+						'styles' => array(
+							'author' => array(
+								'width' => '1%',
+							),
+						),
+					),
+				),
+				'grid' => array(
+					'layout' => array(
+						'badgeFields' => array( 'sync-status' ),
+					),
+				),
+			);
+			$default_view = array(
+				'type'       => 'grid',
+				'perPage'    => 20,
+				'titleField' => 'title',
+				'mediaField' => 'preview',
+				'fields'  => array( 'sync-status' ),
+				'filters' => array(),
+				'layout'  => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
+			);
+		} else if ( 'postType' === $kind && 'wp_template_part' === $name ) {
+			$default_layouts = array(
+				'table' => array(
+					'layout' => array(
+						'styles' => array(
+							'author' => array(
+								'width' => '1%',
+							),
+						),
+					),
+				),
+				'grid' => array(),
+			);
+			$default_view = array(
+				'type'       => 'grid',
+				'perPage'    => 20,
+				'titleField' => 'title',
+				'mediaField' => 'preview',
+				'fields'  => array( 'author' ),
+				'filters' => array(),
+				'layout'  => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
+			);
 		}
 
 		$response = array(

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -113,172 +113,15 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			),
 		);
 		if ( 'postType' === $kind && 'page' === $name ) {
-			$default_view    = array(
-				'type'       => 'list',
-				'filters'    => array(),
-				'perPage'    => 20,
-				'sort'       => array(
-					'field'     => 'title',
-					'direction' => 'asc',
-				),
-				'showLevels' => true,
-				'titleField' => 'title',
-				'mediaField' => 'featured_media',
-				'fields'     => array( 'author', 'status' ),
-			);
-			$default_layouts = array(
-				'table' => array(
-					'layout' => array(
-						'styles' => array(
-							'author' => array(
-								'align' => 'start',
-							),
-						),
-					),
-				),
-				'grid'  => array(),
-				'list'  => array(),
-			);
-			$view_list       = array(
-				array(
-					'title' => $all_items_title,
-					'slug'  => 'all',
-				),
-				array(
-					'title' => __( 'Published', 'gutenberg' ),
-					'slug'  => 'published',
-					'view'  => array(
-						'filters' => array(
-							array(
-								'field'    => 'status',
-								'operator' => 'isAny',
-								'value'    => 'publish',
-								'isLocked' => true,
-							),
-						),
-					),
-				),
-				array(
-					'title' => __( 'Scheduled', 'gutenberg' ),
-					'slug'  => 'future',
-					'view'  => array(
-						'filters' => array(
-							array(
-								'field'    => 'status',
-								'operator' => 'isAny',
-								'value'    => 'future',
-								'isLocked' => true,
-							),
-						),
-					),
-				),
-				array(
-					'title' => __( 'Drafts', 'gutenberg' ),
-					'slug'  => 'drafts',
-					'view'  => array(
-						'filters' => array(
-							array(
-								'field'    => 'status',
-								'operator' => 'isAny',
-								'value'    => 'draft',
-								'isLocked' => true,
-							),
-						),
-					),
-				),
-				array(
-					'title' => __( 'Pending', 'gutenberg' ),
-					'slug'  => 'pending',
-					'view'  => array(
-						'filters' => array(
-							array(
-								'field'    => 'status',
-								'operator' => 'isAny',
-								'value'    => 'pending',
-								'isLocked' => true,
-							),
-						),
-					),
-				),
-				array(
-					'title' => __( 'Private', 'gutenberg' ),
-					'slug'  => 'private',
-					'view'  => array(
-						'filters' => array(
-							array(
-								'field'    => 'status',
-								'operator' => 'isAny',
-								'value'    => 'private',
-								'isLocked' => true,
-							),
-						),
-					),
-				),
-				array(
-					'title' => __( 'Trash', 'gutenberg' ),
-					'slug'  => 'trash',
-					'view'  => array(
-						'type'    => 'table',
-						'layout'  => isset( $default_layouts['table']['layout'] ) ? $default_layouts['table']['layout'] : array(),
-						'filters' => array(
-							array(
-								'field'    => 'status',
-								'operator' => 'isAny',
-								'value'    => 'trash',
-								'isLocked' => true,
-							),
-						),
-					),
-				),
-			);
+			$default_layouts = $this->get_default_layouts_for_page();
+			$default_view    = $this->get_default_view_for_page();
+			$view_list       = $this->get_view_list_for_page( $all_items_title, $default_layouts );
 		} elseif ( 'postType' === $kind && 'wp_block' === $name ) {
-			$default_layouts = array(
-				'table' => array(
-					'layout' => array(
-						'styles' => array(
-							'author' => array(
-								'width' => '1%',
-							),
-						),
-					),
-				),
-				'grid'  => array(
-					'layout' => array(
-						'badgeFields' => array( 'sync-status' ),
-					),
-				),
-			);
-			$default_view = array(
-				'type'       => 'grid',
-				'perPage'    => 20,
-				'titleField' => 'title',
-				'mediaField' => 'preview',
-				'fields'     => array( 'sync-status' ),
-				'filters'    => array(),
-				'layout'     => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
-			);
+			$default_layouts = $this->get_default_layouts_for_wp_block();
+			$default_view    = $this->get_default_view_for_wp_block( $default_layouts );
 		} elseif ( 'postType' === $kind && 'wp_template_part' === $name ) {
-			$default_layouts = array(
-				'table' => array(
-					'layout' => array(
-						'styles' => array(
-							'author' => array(
-								'width' => '1%',
-							),
-						),
-					),
-				),
-				'grid'  => array(),
-			);
-			$default_view = array(
-				'type'       => 'grid',
-				'perPage'    => 20,
-				'titleField' => 'title',
-				'mediaField' => 'preview',
-				'fields'     => array( 'author' ),
-				'filters'    => array(),
-				'layout'     => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
-			);
+			$default_layouts = $this->get_default_layouts_for_wp_template_part();
+			$default_view    = $this->get_default_view_for_wp_template_part( $default_layouts );
 		}
 
 		$response = array(
@@ -645,6 +488,191 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					'enum' => array( 'compact', 'balanced', 'comfortable' ),
 				),
 			),
+		);
+	}
+
+	private function get_default_view_for_page() {
+		return array(
+			'type'       => 'list',
+			'filters'    => array(),
+			'perPage'    => 20,
+			'sort'       => array(
+				'field'     => 'title',
+				'direction' => 'asc',
+			),
+			'showLevels' => true,
+			'titleField' => 'title',
+			'mediaField' => 'featured_media',
+			'fields'     => array( 'author', 'status' ),
+		);
+	}
+
+	private function get_default_layouts_for_page() {
+		return array(
+			'table' => array(
+				'layout' => array(
+					'styles' => array(
+						'author' => array(
+							'align' => 'start',
+						),
+					),
+				),
+			),
+			'grid'  => array(),
+			'list'  => array(),
+		);
+	}
+
+	private function get_view_list_for_page( $all_items_title, $default_layouts ) {
+		return array(
+			array(
+				'title' => $all_items_title,
+				'slug'  => 'all',
+			),
+			array(
+				'title' => __( 'Published', 'gutenberg' ),
+				'slug'  => 'published',
+				'view'  => array(
+					'filters' => array(
+						array(
+							'field'    => 'status',
+							'operator' => 'isAny',
+							'value'    => 'publish',
+							'isLocked' => true,
+						),
+					),
+				),
+			),
+			array(
+				'title' => __( 'Scheduled', 'gutenberg' ),
+				'slug'  => 'future',
+				'view'  => array(
+					'filters' => array(
+						array(
+							'field'    => 'status',
+							'operator' => 'isAny',
+							'value'    => 'future',
+							'isLocked' => true,
+						),
+					),
+				),
+			),
+			array(
+				'title' => __( 'Drafts', 'gutenberg' ),
+				'slug'  => 'drafts',
+				'view'  => array(
+					'filters' => array(
+						array(
+							'field'    => 'status',
+							'operator' => 'isAny',
+							'value'    => 'draft',
+							'isLocked' => true,
+						),
+					),
+				),
+			),
+			array(
+				'title' => __( 'Pending', 'gutenberg' ),
+				'slug'  => 'pending',
+				'view'  => array(
+					'filters' => array(
+						array(
+							'field'    => 'status',
+							'operator' => 'isAny',
+							'value'    => 'pending',
+							'isLocked' => true,
+						),
+					),
+				),
+			),
+			array(
+				'title' => __( 'Private', 'gutenberg' ),
+				'slug'  => 'private',
+				'view'  => array(
+					'filters' => array(
+						array(
+							'field'    => 'status',
+							'operator' => 'isAny',
+							'value'    => 'private',
+							'isLocked' => true,
+						),
+					),
+				),
+			),
+			array(
+				'title' => __( 'Trash', 'gutenberg' ),
+				'slug'  => 'trash',
+				'view'  => array(
+					'type'    => 'table',
+					'layout'  => $default_layouts['table']['layout'],
+					'filters' => array(
+						array(
+							'field'    => 'status',
+							'operator' => 'isAny',
+							'value'    => 'trash',
+							'isLocked' => true,
+						),
+					),
+				),
+			),
+		);
+	}
+
+	private function get_default_layouts_for_wp_block() {
+		return array(
+			'table' => array(
+				'layout' => array(
+					'styles' => array(
+						'author' => array(
+							'width' => '1%',
+						),
+					),
+				),
+			),
+			'grid'  => array(
+				'layout' => array(
+					'badgeFields' => array( 'sync-status' ),
+				),
+			),
+		);
+	}
+
+	private function get_default_view_for_wp_block( $default_layouts ) {
+		return array(
+			'type'       => 'grid',
+			'perPage'    => 20,
+			'titleField' => 'title',
+			'mediaField' => 'preview',
+			'fields'     => array( 'sync-status' ),
+			'filters'    => array(),
+			'layout'     => $default_layouts['grid']['layout'],
+		);
+	}
+
+	private function get_default_layouts_for_wp_template_part() {
+		return array(
+			'table' => array(
+				'layout' => array(
+					'styles' => array(
+						'author' => array(
+							'width' => '1%',
+						),
+					),
+				),
+			),
+			'grid'  => array(),
+		);
+	}
+
+	private function get_default_view_for_wp_template_part( $default_layouts ) {
+		return array(
+			'type'       => 'grid',
+			'perPage'    => 20,
+			'titleField' => 'title',
+			'mediaField' => 'preview',
+			'fields'     => array( 'author' ),
+			'filters'    => array(),
+			'layout'     => $default_layouts['grid']['layout'],
 		);
 	}
 }

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -231,7 +231,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					),
 				),
 			);
-		} else if ( 'postType' === $kind && 'wp_block' === $name ) {
+		} elseif ( 'postType' === $kind && 'wp_block' === $name ) {
 			$default_layouts = array(
 				'table' => array(
 					'layout' => array(
@@ -242,7 +242,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						),
 					),
 				),
-				'grid' => array(
+				'grid'  => array(
 					'layout' => array(
 						'badgeFields' => array( 'sync-status' ),
 					),
@@ -253,11 +253,11 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 				'perPage'    => 20,
 				'titleField' => 'title',
 				'mediaField' => 'preview',
-				'fields'  => array( 'sync-status' ),
-				'filters' => array(),
-				'layout'  => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
+				'fields'     => array( 'sync-status' ),
+				'filters'    => array(),
+				'layout'     => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
 			);
-		} else if ( 'postType' === $kind && 'wp_template_part' === $name ) {
+		} elseif ( 'postType' === $kind && 'wp_template_part' === $name ) {
 			$default_layouts = array(
 				'table' => array(
 					'layout' => array(
@@ -268,16 +268,16 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						),
 					),
 				),
-				'grid' => array(),
+				'grid'  => array(),
 			);
 			$default_view = array(
 				'type'       => 'grid',
 				'perPage'    => 20,
 				'titleField' => 'title',
 				'mediaField' => 'preview',
-				'fields'  => array( 'author' ),
-				'filters' => array(),
-				'layout'  => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
+				'fields'     => array( 'author' ),
+				'filters'    => array(),
+				'layout'     => isset( $default_layouts['grid']['layout'] ) ? $default_layouts['grid']['layout'] : array(),
 			);
 		}
 

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -329,5 +329,11 @@ export function getViewConfig(
 	kind: string,
 	name: string
 ): Record< string, any > | undefined {
-	return state.viewConfigs?.[ `${ kind }/${ name }` ];
+	return (
+		state.viewConfigs?.[ `${ kind }/${ name }` ] ?? {
+			default_view: undefined,
+			default_layouts: undefined,
+			view_list: undefined,
+		}
+	);
 }

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -9,7 +9,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useView } from '@wordpress/views';
+import { useView, useViewConfig } from '@wordpress/views';
 import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -17,8 +17,6 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import {
-	LAYOUT_GRID,
-	LAYOUT_TABLE,
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_DEFAULT_CATEGORY,
@@ -40,31 +38,6 @@ const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
-const defaultLayouts = {
-	[ LAYOUT_TABLE ]: {
-		layout: {
-			styles: {
-				author: {
-					width: '1%',
-				},
-			},
-		},
-	},
-	[ LAYOUT_GRID ]: {
-		layout: {
-			badgeFields: [ 'sync-status' ],
-		},
-	},
-};
-const DEFAULT_VIEW = {
-	type: LAYOUT_GRID,
-	perPage: 20,
-	titleField: 'title',
-	mediaField: 'preview',
-	fields: [ 'sync-status' ],
-	filters: [],
-	...defaultLayouts[ LAYOUT_GRID ],
-};
 
 function usePagePatternsHeader( type, categoryId ) {
 	const { patternCategories } = usePatternCategories();
@@ -99,11 +72,17 @@ export default function DataviewsPatterns() {
 	const { postType = 'wp_block', categoryId: categoryIdFromURL } = query;
 	const history = useHistory();
 	const categoryId = categoryIdFromURL || PATTERN_DEFAULT_CATEGORY;
+	const { default_view: defaultView, default_layouts: defaultLayouts } =
+		useViewConfig( {
+			kind: 'postType',
+			name: postType,
+		} );
 	const { view, updateView, isModified, resetToDefault } = useView( {
 		kind: 'postType',
 		name: postType,
 		slug: 'default',
-		defaultView: DEFAULT_VIEW,
+		defaultView,
+		defaultLayouts,
 		queryParams: {
 			page: query.pageNumber,
 			search: query.search,
@@ -235,7 +214,7 @@ export default function DataviewsPatterns() {
 					} }
 					view={ view }
 					onChangeView={ updateView }
-					defaultLayouts={ defaultLayouts }
+					defaultLayouts={ defaultLayouts ?? {} }
 					onReset={ isModified ? resetToDefault : false }
 				/>
 			</Page>

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -32,7 +32,13 @@ export function useViewConfig( {
 } {
 	return useSelect(
 		( select ) => {
-			return unlock( select( coreStore ) ).getViewConfig( kind, name );
+			return (
+				unlock( select( coreStore ) ).getViewConfig( kind, name ) ?? {
+					default_view: undefined,
+					default_layouts: undefined,
+					view_list: undefined,
+				}
+			);
 		},
 		[ kind, name ]
 	);

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -32,13 +32,7 @@ export function useViewConfig( {
 } {
 	return useSelect(
 		( select ) => {
-			return (
-				unlock( select( coreStore ) ).getViewConfig( kind, name ) ?? {
-					default_view: undefined,
-					default_layouts: undefined,
-					view_list: undefined,
-				}
-			);
+			return unlock( select( coreStore ) ).getViewConfig( kind, name );
 		},
 		[ kind, name ]
 	);


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76544
Backported at https://github.com/WordPress/wordpress-develop/pull/11272

## What?     
                                                                                                                                                                                                                                                                                                                      
Moves the default view configuration for wp_block (patterns) and wp_template_part post types from client-side JavaScript to the server-side REST view config controller.

## Why?                                                                                                                                                                                                                                                                                                                

See https://github.com/WordPress/gutenberg/issues/76544

## How?                                                  

  - Update endpoint to return data for patterns and parts.
  - Removed data from the client and gather it via the `useViewConfig` hook.
                                                                                                                                                                                                                                                                                                                      
## Testing Instructions                                                                                                                                                                                                                                                                                                

  1. Open the Site Editor.                                                                                                                                                                                                                                                                                            
  2. Navigate to Patterns in the sidebar.
  3. Verify the patterns grid view loads correctly with the expected layout (grid, 20 per page, preview media field, sync-status badge).                                                                                                                                                                              
  4. Switch to table view and confirm the author column has a narrow width.                                                                                                                                                                                                                                           
  5. Navigate to Template Parts.                                                                                                                                                                                                                                                                                      
  6. Verify the grid view loads with the author field visible and preview as the media field.                                                                                                                                                                                                                         
  7. Switch between grid and table layouts and confirm they work as expected.                                                                                                                                                                                                                                         

## Use of AI Tools                                                                                                                                                                                                                                                                                                     

Claude Code (Claude Opus 4.6) was used to generate this PR description and parts of this code.