### PR TITLE
Experimental: Add `revisions` panel

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -9,7 +9,7 @@ import {
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { moreVertical, close } from '@wordpress/icons';
+import { close } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -52,7 +52,7 @@ export default function PostCardPanel( {
 		() => ( Array.isArray( postId ) ? postId : [ postId ] ),
 		[ postId ]
 	);
-	const { postTitle, icon, labels, isRevision } = useSelect(
+	const { postTitle, icon, labels } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, getCurrentTheme, getPostType } =
 				select( coreStore );
@@ -75,7 +75,6 @@ export default function PostCardPanel( {
 						area: _record?.area,
 					} ),
 					labels: getPostType( parentPostType )?.labels,
-					isRevision: true,
 				};
 			}
 
@@ -146,24 +145,11 @@ export default function PostCardPanel( {
 					) }
 				</Text>
 				{ ! hideActions && postIds.length === 1 && (
-					<>
-						{ isRevision ? (
-							<Button
-								size="small"
-								icon={ moreVertical }
-								label={ __( 'Actions' ) }
-								disabled
-								accessibleWhenDisabled
-								className="editor-all-actions-button"
-							/>
-						) : (
-							<PostActions
-								postType={ postType }
-								postId={ postIds[ 0 ] }
-								onActionPerformed={ onActionPerformed }
-							/>
-						) }
-					</>
+					<PostActions
+						postType={ postType }
+						postId={ postIds[ 0 ] }
+						onActionPerformed={ onActionPerformed }
+					/>
 				) }
 				{ onClose && (
 					<Button

--- a/packages/editor/src/components/post-content-information/index.js
+++ b/packages/editor/src/components/post-content-information/index.js
@@ -12,7 +12,6 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
 import {
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
@@ -23,19 +22,9 @@ const AVERAGE_READING_RATE = 189;
 
 // This component renders the wordcount and reading time for the post.
 export default function PostContentInformation() {
-	const { postContent } = useSelect( ( select ) => {
+	const postContent = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getCurrentPostType, getCurrentPostId } =
 			select( editorStore );
-		const { getCurrentRevision, isRevisionsMode } = unlock(
-			select( editorStore )
-		);
-
-		if ( isRevisionsMode() ) {
-			return {
-				postContent: getCurrentRevision()?.content?.raw,
-			};
-		}
-
 		const { canUser } = select( coreStore );
 		const { getEntityRecord } = select( coreStore );
 		const siteSettings = canUser( 'read', {
@@ -52,12 +41,12 @@ export default function PostContentInformation() {
 			! [ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
 				postType
 			);
-		return {
-			postContent:
-				showPostContentInfo && getEditedPostAttribute( 'content' ),
-		};
+		return showPostContentInfo && getEditedPostAttribute( 'content' );
 	}, [] );
+	return <PostContentInformationUI postContent={ postContent } />;
+}
 
+export function PostContentInformationUI( { postContent } ) {
 	/*
 	 * translators: If your word count is based on single characters (e.g. East Asian characters),
 	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.

--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -10,14 +10,10 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { DataViews } from '@wordpress/dataviews';
-import {
-	humanTimeDiff,
-	dateI18n,
-	getSettings as getDateSettings,
-} from '@wordpress/date';
+import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { authorField } from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -27,6 +23,8 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { Badge } = unlock( componentsPrivateApis );
+const DAY_IN_MILLISECONDS = 86400000;
+const EMPTY_ARRAY = [];
 
 const REVISIONS_QUERY = {
 	per_page: 3,
@@ -39,12 +37,7 @@ const defaultLayouts = { activity: {} };
 const view = {
 	type: 'activity',
 	titleField: 'date',
-	descriptionField: 'authorName',
-	groupBy: {
-		field: 'day',
-		direction: 'desc',
-		showLabel: false,
-	},
+	fields: [ 'author' ],
 	layout: {
 		density: 'compact',
 	},
@@ -53,98 +46,68 @@ const fields = [
 	{
 		id: 'date',
 		label: __( 'Date' ),
-		render: ( { item } ) => humanTimeDiff( item.date ),
+		render: ( { item } ) => {
+			const dateNowInMs = getDate( null ).getTime();
+			const date = getDate( item.date ?? null );
+			const displayDate =
+				dateNowInMs - date.getTime() > DAY_IN_MILLISECONDS
+					? dateI18n(
+							getSettings().formats.datetimeAbbreviated,
+							date
+					  )
+					: humanTimeDiff( date );
+			return (
+				<time
+					className="editor-post-revisions-panel__revision-date"
+					dateTime={ item.date }
+				>
+					{ displayDate }
+				</time>
+			);
+		},
 		enableSorting: false,
 		enableHiding: false,
 	},
-	{
-		id: 'authorName',
-		label: __( 'Author' ),
-		enableSorting: false,
-		enableHiding: false,
-	},
-	{
-		id: 'day',
-		label: __( 'Day' ),
-		getValue: ( { item } ) => dateI18n( 'Y-m-d', item.date ),
-		render: ( { item } ) =>
-			dateI18n( getDateSettings().formats.date, item.date ),
-		enableSorting: false,
-		enableHiding: false,
-	},
+	authorField,
 ];
 const noop = () => {};
 const paginationInfo = {};
 
 function PostRevisionsPanelContent() {
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
-	const { revisionsCount, revisions, isLoading, authors, lastRevisionId } =
-		useSelect( ( select ) => {
+	const { revisionsCount, revisions, isLoading, lastRevisionId } = useSelect(
+		( select ) => {
 			const { getCurrentPostId, getCurrentPostType } =
 				select( editorStore );
 			const {
 				getCurrentPostRevisionsCount,
 				getCurrentPostLastRevisionId,
 			} = select( editorStore );
-			const { getRevisions, isResolving, getUsers } = select( coreStore );
-			const _postId = getCurrentPostId();
-			const _postType = getCurrentPostType();
-			const _revisions =
-				_postId && _postType
-					? getRevisions(
-							'postType',
-							_postType,
-							_postId,
-							REVISIONS_QUERY
-					  )
-					: null;
-			// Collect unique author IDs from revisions.
-			const authorIds = _revisions
-				? [ ...new Set( _revisions.map( ( r ) => r.author ) ) ]
-				: [];
-			const _authors =
-				authorIds.length > 0
-					? getUsers( {
-							include: authorIds,
-							per_page: authorIds.length,
-							context: 'view',
-					  } )
-					: null;
+			const { getRevisions, isResolving } = select( coreStore );
+			const query = [
+				'postType',
+				getCurrentPostType(),
+				getCurrentPostId(),
+				REVISIONS_QUERY,
+			];
+			const _revisions = getRevisions( ...query );
 			return {
 				revisionsCount: getCurrentPostRevisionsCount(),
 				lastRevisionId: getCurrentPostLastRevisionId(),
 				revisions: _revisions,
-				isLoading: isResolving( 'getRevisions', [
-					'postType',
-					_postType,
-					_postId,
-					REVISIONS_QUERY,
-				] ),
-				authors: _authors,
+				isLoading: isResolving( 'getRevisions', query ),
 			};
-		}, [] );
-	const data = useMemo( () => {
-		if ( ! revisions ) {
-			return [];
-		}
-		const authorsMap = Object.fromEntries(
-			authors?.map( ( a ) => [ a.id, a ] ) ?? []
-		);
-		return revisions.map( ( revision ) => ( {
-			id: String( revision.id ),
-			revisionId: revision.id,
-			authorName: authorsMap[ revision.author ]?.name,
-			date: revision.date,
-			content: revision.content,
-			modified: revision.modified,
-		} ) );
-	}, [ revisions, authors ] );
+		},
+		[]
+	);
 	return (
 		<PanelBody
 			title={
 				<HStack justify="space-between" align="center" as="span">
 					<span>{ __( 'Revisions' ) }</span>
-					<Badge>{ revisionsCount }</Badge>
+					<Badge className="editor-post-revisions-panel__revisions-count">
+						{ revisionsCount }
+					</Badge>
 				</HStack>
 			}
 			initialOpen={ false }
@@ -154,14 +117,14 @@ function PostRevisionsPanelContent() {
 					view={ view }
 					onChangeView={ noop }
 					fields={ fields }
-					data={ data }
+					data={ revisions || EMPTY_ARRAY }
 					isLoading={ isLoading }
 					paginationInfo={ paginationInfo }
 					defaultLayouts={ defaultLayouts }
 					getItemId={ ( item ) => item.id }
 					isItemClickable={ () => true }
 					onClickItem={ ( item ) => {
-						setCurrentRevisionId( item.revisionId );
+						setCurrentRevisionId( item.id );
 					} }
 				>
 					<DataViews.Layout />

--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -1,0 +1,188 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	PanelBody,
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { DataViews } from '@wordpress/dataviews';
+import {
+	humanTimeDiff,
+	dateI18n,
+	getSettings as getDateSettings,
+} from '@wordpress/date';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import PostLastRevisionCheck from '../post-last-revision/check';
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
+
+const REVISIONS_QUERY = {
+	per_page: 3,
+	orderby: 'date',
+	order: 'desc',
+	context: 'embed',
+	_fields: 'id,date,author',
+};
+const defaultLayouts = { activity: {} };
+const view = {
+	type: 'activity',
+	titleField: 'date',
+	descriptionField: 'authorName',
+	groupBy: {
+		field: 'day',
+		direction: 'desc',
+		showLabel: false,
+	},
+	layout: {
+		density: 'compact',
+	},
+};
+const fields = [
+	{
+		id: 'date',
+		label: __( 'Date' ),
+		render: ( { item } ) => humanTimeDiff( item.date ),
+		enableSorting: false,
+		enableHiding: false,
+	},
+	{
+		id: 'authorName',
+		label: __( 'Author' ),
+		enableSorting: false,
+		enableHiding: false,
+	},
+	{
+		id: 'day',
+		label: __( 'Day' ),
+		getValue: ( { item } ) => dateI18n( 'Y-m-d', item.date ),
+		render: ( { item } ) =>
+			dateI18n( getDateSettings().formats.date, item.date ),
+		enableSorting: false,
+		enableHiding: false,
+	},
+];
+const noop = () => {};
+const paginationInfo = {};
+
+function PostRevisionsPanelContent() {
+	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
+	const { revisionsCount, revisions, isLoading, authors, lastRevisionId } =
+		useSelect( ( select ) => {
+			const { getCurrentPostId, getCurrentPostType } =
+				select( editorStore );
+			const {
+				getCurrentPostRevisionsCount,
+				getCurrentPostLastRevisionId,
+			} = select( editorStore );
+			const { getRevisions, isResolving, getUsers } = select( coreStore );
+			const _postId = getCurrentPostId();
+			const _postType = getCurrentPostType();
+			const _revisions =
+				_postId && _postType
+					? getRevisions(
+							'postType',
+							_postType,
+							_postId,
+							REVISIONS_QUERY
+					  )
+					: null;
+			// Collect unique author IDs from revisions.
+			const authorIds = _revisions
+				? [ ...new Set( _revisions.map( ( r ) => r.author ) ) ]
+				: [];
+			const _authors =
+				authorIds.length > 0
+					? getUsers( {
+							include: authorIds,
+							per_page: authorIds.length,
+							context: 'view',
+					  } )
+					: null;
+			return {
+				revisionsCount: getCurrentPostRevisionsCount(),
+				lastRevisionId: getCurrentPostLastRevisionId(),
+				revisions: _revisions,
+				isLoading: isResolving( 'getRevisions', [
+					'postType',
+					_postType,
+					_postId,
+					REVISIONS_QUERY,
+				] ),
+				authors: _authors,
+			};
+		}, [] );
+	const data = useMemo( () => {
+		if ( ! revisions ) {
+			return [];
+		}
+		const authorsMap = Object.fromEntries(
+			authors?.map( ( a ) => [ a.id, a ] ) ?? []
+		);
+		return revisions.map( ( revision ) => ( {
+			id: String( revision.id ),
+			revisionId: revision.id,
+			authorName: authorsMap[ revision.author ]?.name,
+			date: revision.date,
+			content: revision.content,
+			modified: revision.modified,
+		} ) );
+	}, [ revisions, authors ] );
+	return (
+		<PanelBody
+			title={
+				<HStack justify="space-between" align="center" as="span">
+					<span>{ __( 'Revisions' ) }</span>
+					<Badge>{ revisionsCount }</Badge>
+				</HStack>
+			}
+			initialOpen={ false }
+		>
+			<VStack className="editor-post-revisions-panel">
+				<DataViews
+					view={ view }
+					onChangeView={ noop }
+					fields={ fields }
+					data={ data }
+					isLoading={ isLoading }
+					paginationInfo={ paginationInfo }
+					defaultLayouts={ defaultLayouts }
+					getItemId={ ( item ) => item.id }
+					isItemClickable={ () => true }
+					onClickItem={ ( item ) => {
+						setCurrentRevisionId( item.revisionId );
+					} }
+				>
+					<DataViews.Layout />
+				</DataViews>
+				<Button
+					className="editor-post-revisions-panel__view-all"
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ () => setCurrentRevisionId( lastRevisionId ) }
+				>
+					{ __( 'View all revisions' ) }
+				</Button>
+			</VStack>
+		</PanelBody>
+	);
+}
+
+export default function PostRevisionsPanel() {
+	return (
+		<PostLastRevisionCheck>
+			<PostRevisionsPanelContent />
+		</PostLastRevisionCheck>
+	);
+}

--- a/packages/editor/src/components/post-revisions-panel/style.scss
+++ b/packages/editor/src/components/post-revisions-panel/style.scss
@@ -1,0 +1,12 @@
+.editor-post-revisions-panel {
+	.dataviews-layout__container {
+		overflow: visible;
+	}
+	.dataviews-view-activity {
+		padding: 0;
+	}
+}
+
+.editor-post-revisions-panel__view-all {
+	justify-content: center;
+}

--- a/packages/editor/src/components/post-revisions-panel/style.scss
+++ b/packages/editor/src/components/post-revisions-panel/style.scss
@@ -1,11 +1,4 @@
 .editor-post-revisions-panel {
-	.dataviews-layout__container {
-		overflow: visible;
-	}
-	.dataviews-view-activity {
-		padding: 0;
-	}
-
 	.editor-post-revisions-panel__view-all {
 		justify-content: center;
 	}

--- a/packages/editor/src/components/post-revisions-panel/style.scss
+++ b/packages/editor/src/components/post-revisions-panel/style.scss
@@ -5,8 +5,19 @@
 	.dataviews-view-activity {
 		padding: 0;
 	}
+
+	.editor-post-revisions-panel__view-all {
+		justify-content: center;
+	}
+
+	.editor-post-revisions-panel__revision-date {
+		text-transform: uppercase;
+		font-weight: 600;
+		font-size: 12px;
+	}
 }
 
-.editor-post-revisions-panel__view-all {
-	justify-content: center;
+.editor-post-revisions-panel__revisions-count {
+	margin-top: -4.5px;
+	margin-bottom: -4.5px;
 }

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -16,12 +16,7 @@ import PostPanelSection from '../post-panel-section';
 import { store as editorStore } from '../../store';
 import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
-import { unlock } from '../../lock-unlock';
 import { usePostTemplatePanelMode } from '../post-template/hooks';
-import RevisionAuthorPanel from '../revision-author-panel';
-import RevisionCreatedPanel from '../revision-created-panel';
-import PostContentInformation from '../post-content-information';
-import { OpenRevisionsClassicScreen } from './post-summary';
 
 const EMPTY_ARRAY = [];
 const form = {
@@ -76,25 +71,24 @@ const form = {
 };
 
 export default function DataFormPostSummary( { onActionPerformed } ) {
-	const { postType, postId, revisionId, isPostStatusPanelRemoved } =
-		useSelect( ( select ) => {
+	const { postType, postId, isPostStatusPanelRemoved } = useSelect(
+		( select ) => {
 			// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do
 			// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
 			const {
 				isEditorPanelRemoved,
 				getCurrentPostType,
 				getCurrentPostId,
-				getCurrentRevisionId,
-			} = unlock( select( editorStore ) );
+			} = select( editorStore );
 			return {
 				postType: getCurrentPostType(),
 				postId: getCurrentPostId(),
-				revisionId: getCurrentRevisionId(),
 				isPostStatusPanelRemoved: isEditorPanelRemoved( 'post-status' ),
 			};
-		}, [] );
-	const shouldShowPostStatusPanel =
-		! isPostStatusPanelRemoved && ! revisionId;
+		},
+		[]
+	);
+	const shouldShowPostStatusPanel = ! isPostStatusPanelRemoved;
 	const record = useSelect(
 		( select ) => {
 			if ( ! postType || ! postId ) {
@@ -210,16 +204,6 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 							onChange={ onChange }
 						/>
 						<PostTrash onActionPerformed={ onActionPerformed } />
-					</>
-				) }
-				{ !! revisionId && (
-					<>
-						<VStack spacing={ 1 }>
-							<PostContentInformation />
-							<RevisionCreatedPanel />
-						</VStack>
-						<OpenRevisionsClassicScreen revisionId={ revisionId } />
-						<RevisionAuthorPanel />
 					</>
 				) }
 			</VStack>

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -18,7 +18,12 @@ import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
 import { unlock } from '../../lock-unlock';
 import { usePostTemplatePanelMode } from '../post-template/hooks';
+import RevisionAuthorPanel from '../revision-author-panel';
+import RevisionCreatedPanel from '../revision-created-panel';
+import PostContentInformation from '../post-content-information';
+import { OpenRevisionsClassicScreen } from './post-summary';
 
+const EMPTY_ARRAY = [];
 const form = {
 	layout: {
 		type: 'panel',
@@ -71,16 +76,25 @@ const form = {
 };
 
 export default function DataFormPostSummary( { onActionPerformed } ) {
-	const { postType, postId } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = unlock(
-			select( editorStore )
-		);
-		return {
-			postType: getCurrentPostType(),
-			postId: getCurrentPostId(),
-		};
-	}, [] );
-
+	const { postType, postId, revisionId, isPostStatusPanelRemoved } =
+		useSelect( ( select ) => {
+			// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do
+			// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
+			const {
+				isEditorPanelRemoved,
+				getCurrentPostType,
+				getCurrentPostId,
+				getCurrentRevisionId,
+			} = unlock( select( editorStore ) );
+			return {
+				postType: getCurrentPostType(),
+				postId: getCurrentPostId(),
+				revisionId: getCurrentRevisionId(),
+				isPostStatusPanelRemoved: isEditorPanelRemoved( 'post-status' ),
+			};
+		}, [] );
+	const shouldShowPostStatusPanel =
+		! isPostStatusPanelRemoved && ! revisionId;
 	const record = useSelect(
 		( select ) => {
 			if ( ! postType || ! postId ) {
@@ -120,43 +134,49 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 	const { editEntityRecord } = useDispatch( coreDataStore );
 
 	const _fields = usePostFields( { postType } );
-	const fields = useMemo(
-		() =>
-			_fields
-				?.map( ( field ) => {
-					if ( field.id === 'status' ) {
+	const fields = useMemo( () => {
+		if ( ! shouldShowPostStatusPanel ) {
+			return EMPTY_ARRAY;
+		}
+		return _fields
+			?.map( ( field ) => {
+				if ( field.id === 'status' ) {
+					return {
+						...field,
+						elements: field.elements.filter(
+							( element ) => element.value !== 'trash'
+						),
+					};
+				}
+				if ( field.id === 'template' ) {
+					// `usePostTemplatePanelMode` is reused in the Post Template panel to match
+					// the existing behavior. If the panel rendered nothing we should exclude the
+					// template field from the form.
+					if ( ! templatePanelMode ) {
+						return null;
+					}
+					// In classic themes without available templates we need to make the field read-only.
+					if (
+						templatePanelMode === 'classic' &&
+						Object.keys( availableTemplates ?? {} ).length === 0
+					) {
 						return {
 							...field,
-							elements: field.elements.filter(
-								( element ) => element.value !== 'trash'
-							),
+							readOnly: true,
+							render: () => __( 'Default template' ),
 						};
 					}
-					if ( field.id === 'template' ) {
-						// `usePostTemplatePanelMode` is reused in the Post Template panel to match
-						// the existing behavior. If the panel rendered nothing we should exclude the
-						// template field from the form.
-						if ( ! templatePanelMode ) {
-							return null;
-						}
-						// In classic themes without available templates we need to make the field read-only.
-						if (
-							templatePanelMode === 'classic' &&
-							Object.keys( availableTemplates ?? {} ).length === 0
-						) {
-							return {
-								...field,
-								readOnly: true,
-								render: () => __( 'Default template' ),
-							};
-						}
-						return field;
-					}
 					return field;
-				} )
-				.filter( Boolean ),
-		[ _fields, templatePanelMode, availableTemplates ]
-	);
+				}
+				return field;
+			} )
+			.filter( Boolean );
+	}, [
+		_fields,
+		templatePanelMode,
+		availableTemplates,
+		shouldShowPostStatusPanel,
+	] );
 
 	const onChange = ( edits ) => {
 		if (
@@ -173,7 +193,6 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 
 		editEntityRecord( 'postType', postType, postId, edits );
 	};
-
 	return (
 		<PostPanelSection className="editor-post-summary">
 			<VStack spacing={ 4 }>
@@ -182,13 +201,27 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					postId={ postId }
 					onActionPerformed={ onActionPerformed }
 				/>
-				<DataForm
-					data={ augmentedRecord }
-					fields={ fields }
-					form={ form }
-					onChange={ onChange }
-				/>
-				<PostTrash onActionPerformed={ onActionPerformed } />
+				{ shouldShowPostStatusPanel && (
+					<>
+						<DataForm
+							data={ augmentedRecord }
+							fields={ fields }
+							form={ form }
+							onChange={ onChange }
+						/>
+						<PostTrash onActionPerformed={ onActionPerformed } />
+					</>
+				) }
+				{ !! revisionId && (
+					<>
+						<VStack spacing={ 1 }>
+							<PostContentInformation />
+							<RevisionCreatedPanel />
+						</VStack>
+						<OpenRevisionsClassicScreen revisionId={ revisionId } />
+						<RevisionAuthorPanel />
+					</>
+				) }
 			</VStack>
 		</PostPanelSection>
 	);

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -18,7 +18,6 @@ import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
 import { usePostTemplatePanelMode } from '../post-template/hooks';
 
-const EMPTY_ARRAY = [];
 const form = {
 	layout: {
 		type: 'panel',
@@ -71,24 +70,13 @@ const form = {
 };
 
 export default function DataFormPostSummary( { onActionPerformed } ) {
-	const { postType, postId, isPostStatusPanelRemoved } = useSelect(
-		( select ) => {
-			// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do
-			// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
-			const {
-				isEditorPanelRemoved,
-				getCurrentPostType,
-				getCurrentPostId,
-			} = select( editorStore );
-			return {
-				postType: getCurrentPostType(),
-				postId: getCurrentPostId(),
-				isPostStatusPanelRemoved: isEditorPanelRemoved( 'post-status' ),
-			};
-		},
-		[]
-	);
-	const shouldShowPostStatusPanel = ! isPostStatusPanelRemoved;
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		return {
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
+	}, [] );
 	const record = useSelect(
 		( select ) => {
 			if ( ! postType || ! postId ) {
@@ -128,49 +116,43 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 	const { editEntityRecord } = useDispatch( coreDataStore );
 
 	const _fields = usePostFields( { postType } );
-	const fields = useMemo( () => {
-		if ( ! shouldShowPostStatusPanel ) {
-			return EMPTY_ARRAY;
-		}
-		return _fields
-			?.map( ( field ) => {
-				if ( field.id === 'status' ) {
-					return {
-						...field,
-						elements: field.elements.filter(
-							( element ) => element.value !== 'trash'
-						),
-					};
-				}
-				if ( field.id === 'template' ) {
-					// `usePostTemplatePanelMode` is reused in the Post Template panel to match
-					// the existing behavior. If the panel rendered nothing we should exclude the
-					// template field from the form.
-					if ( ! templatePanelMode ) {
-						return null;
-					}
-					// In classic themes without available templates we need to make the field read-only.
-					if (
-						templatePanelMode === 'classic' &&
-						Object.keys( availableTemplates ?? {} ).length === 0
-					) {
+	const fields = useMemo(
+		() =>
+			_fields
+				?.map( ( field ) => {
+					if ( field.id === 'status' ) {
 						return {
 							...field,
-							readOnly: true,
-							render: () => __( 'Default template' ),
+							elements: field.elements.filter(
+								( element ) => element.value !== 'trash'
+							),
 						};
 					}
+					if ( field.id === 'template' ) {
+						// `usePostTemplatePanelMode` is reused in the Post Template panel to match
+						// the existing behavior. If the panel rendered nothing we should exclude the
+						// template field from the form.
+						if ( ! templatePanelMode ) {
+							return null;
+						}
+						// In classic themes without available templates we need to make the field read-only.
+						if (
+							templatePanelMode === 'classic' &&
+							Object.keys( availableTemplates ?? {} ).length === 0
+						) {
+							return {
+								...field,
+								readOnly: true,
+								render: () => __( 'Default template' ),
+							};
+						}
+						return field;
+					}
 					return field;
-				}
-				return field;
-			} )
-			.filter( Boolean );
-	}, [
-		_fields,
-		templatePanelMode,
-		availableTemplates,
-		shouldShowPostStatusPanel,
-	] );
+				} )
+				.filter( Boolean ),
+		[ _fields, templatePanelMode, availableTemplates ]
+	);
 
 	const onChange = ( edits ) => {
 		if (
@@ -195,17 +177,13 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					postId={ postId }
 					onActionPerformed={ onActionPerformed }
 				/>
-				{ shouldShowPostStatusPanel && (
-					<>
-						<DataForm
-							data={ augmentedRecord }
-							fields={ fields }
-							form={ form }
-							onChange={ onChange }
-						/>
-						<PostTrash onActionPerformed={ onActionPerformed } />
-					</>
-				) }
+				<DataForm
+					data={ augmentedRecord }
+					fields={ fields }
+					form={ form }
+					onChange={ onChange }
+				/>
+				<PostTrash onActionPerformed={ onActionPerformed } />
 			</VStack>
 		</PostPanelSection>
 	);

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -26,8 +26,8 @@ import PatternOverridesPanel from '../pattern-overrides-panel';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebar from '../plugin-sidebar';
 import PostSummary from './post-summary';
+import PostRevisionSummary from './post-revision-summary';
 import PostTaxonomiesPanel from '../post-taxonomies/panel';
-import RevisionFieldsDiffPanel from '../revision-fields-diff';
 import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
 import TemplateActionsPanel from '../template-actions-panel';
@@ -98,6 +98,35 @@ const SidebarContent = ( {
 		}
 	}, [ tabName ] );
 
+	let tabContent;
+	if ( isAttachment ) {
+		tabContent = (
+			<MediaMetadataPanel onActionPerformed={ onActionPerformed } />
+		);
+	} else if ( isRevisionsMode ) {
+		tabContent = <PostRevisionSummary />;
+	} else {
+		tabContent = (
+			<>
+				<PostSummary onActionPerformed={ onActionPerformed } />
+				<PluginDocumentSettingPanel.Slot />
+				<TemplateContentPanel />
+				{ window?.__experimentalDataFormInspector &&
+					[ 'post', 'page' ].includes( postType ) && (
+						<>
+							<TemplateActionsPanel />
+							<PostRevisionsPanel />
+						</>
+					) }
+				<TemplatePartContentPanel />
+				<PostTransformPanel />
+				<PostTaxonomiesPanel />
+				<PatternOverridesPanel />
+				{ extraPanels }
+			</>
+		);
+	}
+
 	return (
 		<PluginSidebar
 			identifier={ tabName }
@@ -122,36 +151,7 @@ const SidebarContent = ( {
 		>
 			<Tabs.Context.Provider value={ tabsContextValue }>
 				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					{ isAttachment ? (
-						<MediaMetadataPanel
-							onActionPerformed={ onActionPerformed }
-						/>
-					) : (
-						<>
-							<PostSummary
-								onActionPerformed={ onActionPerformed }
-							/>
-							{ isRevisionsMode && <RevisionFieldsDiffPanel /> }
-							{ ! isRevisionsMode && (
-								<>
-									<PluginDocumentSettingPanel.Slot />
-									<TemplateContentPanel />
-									{ window?.__experimentalDataFormInspector && (
-										<TemplateActionsPanel />
-									) }
-									{ window?.__experimentalDataFormInspector &&
-										[ 'post', 'page' ].includes(
-											postType
-										) && <PostRevisionsPanel /> }
-									<TemplatePartContentPanel />
-									<PostTransformPanel />
-									<PostTaxonomiesPanel />
-									<PatternOverridesPanel />
-									{ extraPanels }
-								</>
-							) }
-						</>
-					) }
+					{ tabContent }
 				</Tabs.TabPanel>
 				{ ! isAttachment && (
 					<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -134,15 +134,15 @@ const SidebarContent = ( {
 							{ isRevisionsMode && <RevisionFieldsDiffPanel /> }
 							{ ! isRevisionsMode && (
 								<>
-									{ window?.__experimentalDataFormInspector &&
-										[ 'post', 'page' ].includes(
-											postType
-										) && <PostRevisionsPanel /> }
 									<PluginDocumentSettingPanel.Slot />
 									<TemplateContentPanel />
 									{ window?.__experimentalDataFormInspector && (
 										<TemplateActionsPanel />
 									) }
+									{ window?.__experimentalDataFormInspector &&
+										[ 'post', 'page' ].includes(
+											postType
+										) && <PostRevisionsPanel /> }
 									<TemplatePartContentPanel />
 									<PostTransformPanel />
 									<PostTaxonomiesPanel />

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -34,6 +34,7 @@ import TemplateActionsPanel from '../template-actions-panel';
 import TemplateContentPanel from '../template-content-panel';
 import TemplatePartContentPanel from '../template-part-content-panel';
 import { MediaMetadataPanel } from '../media';
+import PostRevisionsPanel from '../post-revisions-panel';
 import RevisionBlockDiffPanel from '../revision-block-diff';
 import useAutoSwitchEditorSidebars from '../provider/use-auto-switch-editor-sidebars';
 import { sidebars } from './constants';
@@ -133,6 +134,10 @@ const SidebarContent = ( {
 							{ isRevisionsMode && <RevisionFieldsDiffPanel /> }
 							{ ! isRevisionsMode && (
 								<>
+									{ window?.__experimentalDataFormInspector &&
+										[ 'post', 'page' ].includes(
+											postType
+										) && <PostRevisionsPanel /> }
 									<PluginDocumentSettingPanel.Slot />
 									<TemplateContentPanel />
 									{ window?.__experimentalDataFormInspector && (

--- a/packages/editor/src/components/sidebar/post-revision-summary.js
+++ b/packages/editor/src/components/sidebar/post-revision-summary.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+import RevisionAuthorPanel from '../revision-author-panel';
+import RevisionCreatedPanel from '../revision-created-panel';
+import { PostContentInformationUI } from '../post-content-information';
+import RevisionFieldsDiffPanel from '../revision-fields-diff';
+import PostPanelSection from '../post-panel-section';
+import PostCardPanel from '../post-card-panel';
+import { OpenRevisionsClassicScreen } from './post-summary';
+
+export default function PostRevisionSummary() {
+	const { revisionId, postId, postContent } = useSelect( ( select ) => {
+		const { getCurrentRevisionId, getCurrentRevision, getCurrentPostId } =
+			unlock( select( editorStore ) );
+		const _revisionId = getCurrentRevisionId();
+		return {
+			revisionId: _revisionId,
+			postId: getCurrentPostId(),
+			postContent: _revisionId && getCurrentRevision()?.content?.raw,
+		};
+	}, [] );
+	if ( ! revisionId ) {
+		return null;
+	}
+	return (
+		<>
+			<PostPanelSection className="editor-post-summary">
+				<VStack spacing={ 4 }>
+					<PostCardPanel postId={ postId } hideActions />
+					<VStack spacing={ 1 }>
+						<PostContentInformationUI postContent={ postContent } />
+						<RevisionCreatedPanel />
+					</VStack>
+					<OpenRevisionsClassicScreen revisionId={ revisionId } />
+					<RevisionAuthorPanel />
+				</VStack>
+			</PostPanelSection>
+			<RevisionFieldsDiffPanel />
+		</>
+	);
+}

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -23,7 +23,6 @@ import { PrivatePostExcerptPanel as PostExcerptPanel } from '../post-excerpt/pan
 import PostFeaturedImagePanel from '../post-featured-image/panel';
 import PostFormatPanel from '../post-format/panel';
 import PostLastEditedPanel from '../post-last-edited-panel';
-import RevisionCreatedPanel from '../revision-created-panel';
 import PostPanelSection from '../post-panel-section';
 import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
@@ -36,8 +35,6 @@ import SiteDiscussion from '../site-discussion';
 import { store as editorStore } from '../../store';
 import { PrivatePostLastRevision } from '../post-last-revision';
 import PostTrash from '../post-trash';
-import RevisionAuthorPanel from '../revision-author-panel';
-import { unlock } from '../../lock-unlock';
 
 /**
  * Module Constants
@@ -71,28 +68,23 @@ export default function PostSummary( { onActionPerformed } ) {
 }
 
 function ClassicPostSummary( { onActionPerformed } ) {
-	const { isRemovedPostStatusPanel, postType, postId, revisionId } =
-		useSelect( ( select ) => {
+	const { isRemovedPostStatusPanel, postType, postId } = useSelect(
+		( select ) => {
 			// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do
 			// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
 			const {
 				isEditorPanelRemoved,
 				getCurrentPostType,
 				getCurrentPostId,
-				getCurrentRevisionId,
-			} = unlock( select( editorStore ) );
+			} = select( editorStore );
 			return {
 				isRemovedPostStatusPanel: isEditorPanelRemoved( PANEL_NAME ),
 				postType: getCurrentPostType(),
 				postId: getCurrentPostId(),
-				revisionId: getCurrentRevisionId(),
 			};
-		}, [] );
-
-	const isRevisionsMode = !! revisionId;
-	const shouldShowPostStatusPanel =
-		! isRemovedPostStatusPanel && ! isRevisionsMode;
-
+		},
+		[]
+	);
 	return (
 		<PostPanelSection className="editor-post-summary">
 			<PluginPostStatusInfo.Slot>
@@ -104,29 +96,13 @@ function ClassicPostSummary( { onActionPerformed } ) {
 								postId={ postId }
 								onActionPerformed={ onActionPerformed }
 							/>
-							{ ! isRevisionsMode && (
-								<PostFeaturedImagePanel
-									withPanelBody={ false }
-								/>
-							) }
-							{ ! isRevisionsMode && <PostExcerptPanel /> }
+							<PostFeaturedImagePanel withPanelBody={ false } />
+							<PostExcerptPanel />
 							<VStack spacing={ 1 }>
 								<PostContentInformation />
-								{ isRevisionsMode ? (
-									<RevisionCreatedPanel />
-								) : (
-									<PostLastEditedPanel />
-								) }
+								<PostLastEditedPanel />
 							</VStack>
-							{ isRevisionsMode && revisionId && (
-								<>
-									<OpenRevisionsClassicScreen
-										revisionId={ revisionId }
-									/>
-									<RevisionAuthorPanel />
-								</>
-							) }
-							{ shouldShowPostStatusPanel && (
+							{ ! isRemovedPostStatusPanel && (
 								<VStack spacing={ 4 }>
 									<VStack spacing={ 1 }>
 										<PostStatusPanel />

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -44,6 +44,18 @@ import { unlock } from '../../lock-unlock';
  */
 const PANEL_NAME = 'post-status';
 
+export function OpenRevisionsClassicScreen( { revisionId } ) {
+	return (
+		<ExternalLink
+			href={ addQueryArgs( 'revision.php', {
+				revision: revisionId,
+			} ) }
+		>
+			{ __( 'Open classic revisions screen' ) }
+		</ExternalLink>
+	);
+}
+
 export default function PostSummary( { onActionPerformed } ) {
 	const postType = useSelect(
 		( select ) => select( editorStore ).getCurrentPostType(),
@@ -108,15 +120,9 @@ function ClassicPostSummary( { onActionPerformed } ) {
 							</VStack>
 							{ isRevisionsMode && revisionId && (
 								<>
-									<ExternalLink
-										href={ addQueryArgs( 'revision.php', {
-											revision: revisionId,
-										} ) }
-									>
-										{ __(
-											'Open classic revisions screen'
-										) }
-									</ExternalLink>
+									<OpenRevisionsClassicScreen
+										revisionId={ revisionId }
+									/>
 									<RevisionAuthorPanel />
 								</>
 							) }

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -38,6 +38,7 @@
 @use "./components/post-panel-row/style.scss" as *;
 @use "./components/post-panel-section/style.scss" as *;
 @use "./components/post-publish-panel/style.scss" as *;
+@use "./components/post-revisions-panel/style.scss" as *;
 @use "./components/post-revisions-preview/style.scss" as *;
 @use "./components/revision-diff-panel/style.scss" as *;
 @use "./components/post-saved-state/style.scss" as *;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/76246
Which is part of the bigger: https://github.com/WordPress/gutenberg/issues/76076


This PR affects the `Editor Inspector: Use DataForm` experiment and adds a `revisions` panel based on the designs shared [here](https://github.com/WordPress/gutenberg/issues/76076#issuecomment-4040669296).

<img width="1200" height="1695" alt="Image" src="https://github.com/user-attachments/assets/d1e0ed03-1e37-439e-a27e-8a4ba74a4f7f" />


## Notes
1. The `Budge` for the revisions count seem to make the panel header a bit taller than the rest
2. We need to figure out what info we should show for each revision. I don't think we have a way for displaying info about specific block changes since revisions hold the content, and revisions' page does complex calculations do just add a state like `added/removed/modified` without providing more details. 

## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment
3. Go to a post or a page and view/try the `revisions` panel


## Screenshots



<img width="464" height="519" alt="Screenshot 2026-03-26 at 11 00 12 AM" src="https://github.com/user-attachments/assets/5f4158e9-e202-4cb2-b5e9-e7f7baedabc7" />
