### PR TITLE
RTC: Use activation hook to enable RTC by default

### DIFF
--- a/backport-changelog/7.0/11289.md
+++ b/backport-changelog/7.0/11289.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11289
 
 * https://github.com/WordPress/gutenberg/pull/76643
+* https://github.com/WordPress/gutenberg/pull/76736

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -170,10 +170,13 @@ function gutenberg_inject_real_time_collaboration_setting() {
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 
 /**
- * Core filters the default value, so hook with a higher priority to ensure the
- * setting is enabled by default when the Gutenberg plugin is active.
+ * Core adds an option with the default value, so we need to set the option to
+ * our intended default when the Gutenberg plugin is activated.
  */
-add_filter( 'default_option_wp_collaboration_enabled', '__return_true', 500 );
+function gutenberg_set_collaboration_option_on_activation() {
+	update_option( 'wp_collaboration_enabled', '1' );
+}
+register_activation_hook( __FILE__, 'gutenberg_set_collaboration_option_on_activation' );
 
 /**
  * Modifies the post list UI and heartbeat responses for real-time collaboration.

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -176,7 +176,7 @@ add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 function gutenberg_set_collaboration_option_on_activation() {
 	update_option( 'wp_collaboration_enabled', '1' );
 }
-register_activation_hook( __FILE__, 'gutenberg_set_collaboration_option_on_activation' );
+register_activation_hook( dirname( __DIR__, 3 ) . '/gutenberg.php', 'gutenberg_set_collaboration_option_on_activation' );
 
 /**
  * Modifies the post list UI and heartbeat responses for real-time collaboration.

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -176,7 +176,7 @@ add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 function gutenberg_set_collaboration_option_on_activation() {
 	update_option( 'wp_collaboration_enabled', '1' );
 }
-register_activation_hook( dirname( __DIR__, 3 ) . '/gutenberg.php', 'gutenberg_set_collaboration_option_on_activation' );
+add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_option_on_activation' );
 
 /**
  * Modifies the post list UI and heartbeat responses for real-time collaboration.


### PR DESCRIPTION

## What?

Use activation hook to enable RTC by default.

## Why?

[As noted by @t-hamano](https://github.com/WordPress/gutenberg/pull/76643#discussion_r2963569341), since Core sets the `wp_collaboration_enabled` option to `0`, we can't override the value with the `default_option_` filter. We also can't use a `pre_option_` filter, as that would prevent the user from disabling it entirely.

## How?

A plugin activation hook allows us to set the option to our desired value.
