### PR TITLE
Connectors: Align client registration API with server

### DIFF
--- a/packages/connectors/src/api.ts
+++ b/packages/connectors/src/api.ts
@@ -25,13 +25,13 @@ import type { ConnectorConfig } from './types';
  * import { __experimentalRegisterConnector as registerConnector, __experimentalConnectorItem as ConnectorItem } from '@wordpress/connectors';
  *
  * registerConnector( 'my-plugin/openai', {
- *     label: 'OpenAI',
+ *     name: 'OpenAI',
  *     description: 'Text, image, and code generation with GPT.',
- *     icon: <MyOpenAIIcon />,
- *     render: ( { slug, label, description, icon } ) => (
+ *     logo: <MyOpenAIIcon />,
+ *     render: ( { slug, name, description, logo } ) => (
  *         <ConnectorItem
- *             icon={ icon }
- *             name={ label }
+ *             logo={ logo }
+ *             name={ name }
  *             description={ description }
  *         >
  *             <MyCustomSettings />

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -18,10 +18,11 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ReactNode } from 'react';
+import type { ApiKeySource } from './types';
 
 export interface ConnectorItemProps {
 	className?: string;
-	icon?: ReactNode;
+	logo?: ReactNode;
 	name: string;
 	description: string;
 	actionArea?: ReactNode;
@@ -30,7 +31,7 @@ export interface ConnectorItemProps {
 
 export function ConnectorItem( {
 	className,
-	icon,
+	logo,
 	name,
 	description,
 	actionArea,
@@ -41,7 +42,7 @@ export function ConnectorItem( {
 		<Item className={ className }>
 			<VStack spacing={ 4 } role="group" aria-labelledby={ headingId }>
 				<HStack alignment="center" spacing={ 4 } wrap>
-					{ icon }
+					{ logo }
 					<FlexBlock>
 						<VStack spacing={ 0 }>
 							<Text
@@ -65,7 +66,7 @@ export function ConnectorItem( {
 	);
 }
 
-export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
+export type { ApiKeySource } from './types';
 
 export interface DefaultConnectorSettingsProps {
 	onSave?: ( apiKey: string ) => void | Promise< void >;

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -6,6 +6,6 @@ export {
 	ConnectorItem as __experimentalConnectorItem,
 	DefaultConnectorSettings as __experimentalDefaultConnectorSettings,
 } from './connector-item';
-export type { ApiKeySource as __experimentalApiKeySource } from './connector-item';
+export type { ApiKeySource as __experimentalApiKeySource } from './types';
 export type { ConnectorConfig, ConnectorRenderProps } from './types';
 export { privateApis } from './private-apis';

--- a/packages/connectors/src/test/store.ts
+++ b/packages/connectors/src/test/store.ts
@@ -37,7 +37,7 @@ describe( 'connectors store', () => {
 			const before = getConnectors();
 
 			registerConnector( 'test', {
-				label: 'Test',
+				name: 'Test',
 				description: 'A test connector',
 			} );
 
@@ -47,7 +47,7 @@ describe( 'connectors store', () => {
 			expect( after ).toHaveLength( 1 );
 			expect( after[ 0 ] ).toMatchObject( {
 				slug: 'test',
-				label: 'Test',
+				name: 'Test',
 			} );
 		} );
 	} );
@@ -61,23 +61,23 @@ describe( 'connectors store', () => {
 			);
 
 			registerConnector( 'test', {
-				label: 'Original',
+				name: 'Original',
 				description: 'Original description',
 			} );
 
 			registerConnector( 'test', {
-				label: 'Updated',
+				name: 'Updated',
 			} );
 
 			const connector = getConnector( 'test' );
 			expect( connector ).toMatchObject( {
 				slug: 'test',
-				label: 'Updated',
+				name: 'Updated',
 				description: 'Original description',
 			} );
 		} );
 
-		it( 'should allow updating render and icon independently', () => {
+		it( 'should allow updating render and logo independently', () => {
 			const registry = createRegistryWithStore();
 			const { getConnector } = unlock( registry.select( STORE_NAME ) );
 			const { registerConnector } = unlock(
@@ -86,7 +86,7 @@ describe( 'connectors store', () => {
 
 			const originalRender = () => null;
 			registerConnector( 'test', {
-				label: 'Test',
+				name: 'Test',
 				description: 'A test connector',
 				render: originalRender,
 			} );
@@ -98,7 +98,7 @@ describe( 'connectors store', () => {
 
 			const connector = getConnector( 'test' );
 			expect( connector?.render ).toBe( newRender );
-			expect( connector?.label ).toBe( 'Test' );
+			expect( connector?.name ).toBe( 'Test' );
 			expect( connector?.description ).toBe( 'A test connector' );
 		} );
 	} );
@@ -114,7 +114,7 @@ describe( 'connectors store', () => {
 			);
 
 			registerConnector( 'test', {
-				label: 'Test',
+				name: 'Test',
 				description: 'A test connector',
 			} );
 
@@ -134,7 +134,7 @@ describe( 'connectors store', () => {
 			);
 
 			registerConnector( 'test', {
-				label: 'Test',
+				name: 'Test',
 				description: 'A test connector',
 			} );
 

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -3,18 +3,40 @@
  */
 import type { ReactNode } from 'react';
 
+export type ApiKeySource = 'env' | 'constant' | 'database' | 'none';
+
+export type ConnectorAuthentication =
+	| {
+			method: 'api_key';
+			settingName: string;
+			credentialsUrl: string | null;
+			keySource?: ApiKeySource;
+			isConnected?: boolean;
+	  }
+	| { method: 'none' };
+
+export interface ConnectorPlugin {
+	slug: string;
+	isInstalled: boolean;
+	isActivated: boolean;
+}
+
 export interface ConnectorRenderProps {
 	slug: string;
-	label: string;
+	name: string;
 	description: string;
-	icon?: ReactNode;
+	logo?: ReactNode;
+	authentication?: ConnectorAuthentication;
+	plugin?: ConnectorPlugin;
 }
 
 export interface ConnectorConfig {
 	slug: string;
-	label: string;
+	name: string;
 	description: string;
-	icon?: ReactNode;
+	logo?: ReactNode;
+	authentication?: ConnectorAuthentication;
+	plugin?: ConnectorPlugin;
 	render?: ( props: ConnectorRenderProps ) => ReactNode;
 }
 

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
 	__experimentalDefaultConnectorSettings as DefaultConnectorSettings,
-	type __experimentalApiKeySource as ApiKeySource,
+	type ConnectorConfig,
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
 import { __ } from '@wordpress/i18n';
@@ -24,16 +24,6 @@ import {
 	DefaultConnectorLogo,
 } from './logos';
 
-type ConnectorAuthentication =
-	| {
-			method: 'api_key';
-			settingName: string;
-			credentialsUrl: string | null;
-			keySource?: ApiKeySource;
-			isConnected?: boolean;
-	  }
-	| { method: 'none' };
-
 interface ConnectorData {
 	name: string;
 	description: string;
@@ -44,7 +34,7 @@ interface ConnectorData {
 		isInstalled: boolean;
 		isActivated: boolean;
 	};
-	authentication: ConnectorAuthentication;
+	authentication: NonNullable< ConnectorConfig[ 'authentication' ] >;
 }
 
 /**
@@ -101,28 +91,19 @@ const ConnectedBadge = () => (
 
 const UnavailableActionBadge = () => <Badge>{ __( 'Not available' ) }</Badge>;
 
-interface ApiKeyConnectorConfig {
-	pluginSlug?: string;
-	settingName: string;
-	helpUrl?: string;
-	isInstalled?: boolean;
-	isActivated?: boolean;
-	keySource?: ApiKeySource;
-	initialIsConnected?: boolean;
-}
-
 function ApiKeyConnector( {
-	label,
+	name,
 	description,
-	pluginSlug,
-	settingName,
-	helpUrl,
-	icon,
-	isInstalled,
-	isActivated,
-	keySource: initialKeySource,
-	initialIsConnected,
-}: ConnectorRenderProps & ApiKeyConnectorConfig ) {
+	logo,
+	authentication,
+	plugin,
+}: ConnectorRenderProps ) {
+	const auth =
+		authentication?.method === 'api_key' ? authentication : undefined;
+	const settingName = auth?.settingName ?? '';
+	const helpUrl = auth?.credentialsUrl ?? undefined;
+	const pluginSlug = plugin?.slug;
+
 	let helpLabel: string | undefined;
 	try {
 		if ( helpUrl ) {
@@ -149,11 +130,11 @@ function ApiKeyConnector( {
 	} = useConnectorPlugin( {
 		pluginSlug,
 		settingName,
-		connectorName: label,
-		isInstalled,
-		isActivated,
-		keySource: initialKeySource,
-		initialIsConnected,
+		connectorName: name,
+		isInstalled: plugin?.isInstalled,
+		isActivated: plugin?.isActivated,
+		keySource: auth?.keySource,
+		initialIsConnected: auth?.isConnected,
 	} );
 	const isExternallyConfigured =
 		keySource === 'env' || keySource === 'constant';
@@ -185,8 +166,8 @@ function ApiKeyConnector( {
 			className={
 				pluginSlug ? `connector-item--${ pluginSlug }` : undefined
 			}
-			icon={ icon }
-			name={ label }
+			logo={ logo }
+			name={ name }
 			description={ description }
 			actionArea={
 				<HStack spacing={ 3 } expanded={ false }>
@@ -266,21 +247,12 @@ export function registerDefaultConnectors() {
 			connectorId
 		) }`;
 		registerConnector( connectorName, {
-			label: data.name,
+			name: data.name,
 			description: data.description,
-			icon: getConnectorLogo( connectorId, data.logoUrl ),
-			render: ( props ) => (
-				<ApiKeyConnector
-					{ ...props }
-					pluginSlug={ data.plugin?.slug }
-					settingName={ authentication.settingName }
-					helpUrl={ authentication.credentialsUrl ?? undefined }
-					isInstalled={ data.plugin?.isInstalled }
-					isActivated={ data.plugin?.isActivated }
-					keySource={ authentication.keySource }
-					initialIsConnected={ authentication.isConnected }
-				/>
-			),
+			logo: getConnectorLogo( connectorId, data.logoUrl ),
+			authentication,
+			plugin: data.plugin,
+			render: ApiKeyConnector,
 		} );
 	}
 }

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -86,9 +86,13 @@ function ConnectorsPage() {
 									<connector.render
 										key={ connector.slug }
 										slug={ connector.slug }
-										label={ connector.label }
+										name={ connector.name }
 										description={ connector.description }
-										icon={ connector.icon }
+										logo={ connector.logo }
+										authentication={
+											connector.authentication
+										}
+										plugin={ connector.plugin }
 									/>
 								);
 							}


### PR DESCRIPTION
## Summary

- Rename `label` → `name` and `icon` → `logo` in `ConnectorConfig` / `ConnectorRenderProps` to match the server-side PHP connector registry
- Promote `authentication` and `plugin` to first-class properties on connectors.
- Simplify `ApiKeyConnector` to accept `ConnectorRenderProps` directly instead of a flat mix of custom props

## Test plan

- [x] `npm run test:unit packages/connectors` — all 7 tests pass
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint clean (no new errors)
- [ ] Manual: verify the Connectors settings page renders identically