### PR TITLE
`ControlWithError`: Connect validation messages to controls via `aria-describedby`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `RadioControl`: Add `role="radiogroup"` to the wrapping `fieldset` element ([#76745](https://github.com/WordPress/gutenberg/pull/76745)).
+-   `ControlWithError`: Connect validation error messages to controls via `aria-describedby` ([#76742](https://github.com/WordPress/gutenberg/pull/76742)).
 -   `CustomGradientPicker`: Add state persistence when switching between Linear and Radial Gradient ([#76595](https://github.com/WordPress/gutenberg/pull/76595)).
 -   `Button`: fix focus styles in High Contrast (forced colors) mode ([#76719](https://github.com/WordPress/gutenberg/pull/76719)).
 

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -274,8 +274,8 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 			return;
 		}
 
-		function setDescribedBy( shouldAdd: boolean ) {
-			const ids = ( target.getAttribute( 'aria-describedby' ) ?? '' )
+		function setDescribedBy( el: Element, shouldAdd: boolean ) {
+			const ids = ( el.getAttribute( 'aria-describedby' ) ?? '' )
 				.split( ' ' )
 				.filter( ( id ) => id && id !== messageId );
 
@@ -284,15 +284,15 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 			}
 
 			if ( ids.length ) {
-				target.setAttribute( 'aria-describedby', ids.join( ' ' ) );
+				el.setAttribute( 'aria-describedby', ids.join( ' ' ) );
 			} else {
-				target.removeAttribute( 'aria-describedby' );
+				el.removeAttribute( 'aria-describedby' );
 			}
 		}
 
-		setDescribedBy( !! visibleMessage );
+		setDescribedBy( target, !! visibleMessage );
 
-		return () => setDescribedBy( false );
+		return () => setDescribedBy( target, false );
 	}, [ visibleMessage, messageId, getValidityTarget ] );
 
 	return (

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -265,15 +265,39 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 
 	const visibleMessage = showMessage ? message : null;
 
-	const describedBy =
-		[ children.props[ 'aria-describedby' ], visibleMessage && messageId ]
-			.filter( Boolean )
-			.join( ' ' ) || undefined;
+	// Imperatively manage `aria-describedby` on the validity target so we
+	// merge with any value the child control sets internally (e.g. from a
+	// `help` prop), rather than competing with it at the props level.
+	useEffect( () => {
+		const target = getValidityTarget();
+		if ( ! target ) {
+			return;
+		}
+
+		function setDescribedBy( shouldAdd: boolean ) {
+			const ids = ( target.getAttribute( 'aria-describedby' ) ?? '' )
+				.split( ' ' )
+				.filter( ( id ) => id && id !== messageId );
+
+			if ( shouldAdd ) {
+				ids.push( messageId );
+			}
+
+			if ( ids.length ) {
+				target.setAttribute( 'aria-describedby', ids.join( ' ' ) );
+			} else {
+				target.removeAttribute( 'aria-describedby' );
+			}
+		}
+
+		setDescribedBy( !! visibleMessage );
+
+		return () => setDescribedBy( false );
+	}, [ visibleMessage, messageId, getValidityTarget ] );
 
 	return (
 		<div className={ className } ref={ forwardedRef } onBlur={ onBlur }>
 			{ cloneElement( children, {
-				'aria-describedby': describedBy,
 				label: appendRequiredIndicator(
 					children.props.label,
 					required,

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -6,6 +6,7 @@ import {
 	cloneElement,
 	forwardRef,
 	useEffect,
+	useId,
 	useState,
 } from '@wordpress/element';
 
@@ -238,26 +239,41 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		}
 	};
 
-	const message = () => {
+	const messageId = useId();
+
+	const message = ( () => {
 		if ( errorMessage ) {
 			return (
-				<ValidityIndicator type="invalid" message={ errorMessage } />
+				<ValidityIndicator
+					id={ messageId }
+					type="invalid"
+					message={ errorMessage }
+				/>
 			);
 		}
 		if ( statusMessage?.type ) {
 			return (
 				<ValidityIndicator
+					id={ messageId }
 					type={ statusMessage.type }
 					message={ statusMessage.message }
 				/>
 			);
 		}
 		return null;
-	};
+	} )();
+
+	const visibleMessage = showMessage ? message : null;
+
+	const describedBy =
+		[ children.props[ 'aria-describedby' ], visibleMessage && messageId ]
+			.filter( Boolean )
+			.join( ' ' ) || undefined;
 
 	return (
 		<div className={ className } ref={ forwardedRef } onBlur={ onBlur }>
 			{ cloneElement( children, {
+				'aria-describedby': describedBy,
 				label: appendRequiredIndicator(
 					children.props.label,
 					required,
@@ -265,7 +281,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 				),
 				required,
 			} ) }
-			<div aria-live="polite">{ showMessage && message() }</div>
+			<div aria-live="polite">{ visibleMessage }</div>
 		</div>
 	);
 }

--- a/packages/components/src/validated-form-controls/test/checkbox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/checkbox-control.tsx
@@ -8,6 +8,7 @@ describe( 'ValidatedCheckboxControl', () => {
 			<ValidatedCheckboxControl
 				label="Agree"
 				help="You must agree to continue"
+				onChange={ () => {} }
 			/>
 		);
 
@@ -23,6 +24,7 @@ describe( 'ValidatedCheckboxControl', () => {
 				<ValidatedCheckboxControl
 					label="Agree"
 					help="You must agree to continue"
+					onChange={ () => {} }
 					required
 				/>
 				<button type="submit">Submit</button>

--- a/packages/components/src/validated-form-controls/test/checkbox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/checkbox-control.tsx
@@ -7,14 +7,14 @@ describe( 'ValidatedCheckboxControl', () => {
 		render(
 			<ValidatedCheckboxControl
 				label="Agree"
-				help="You must agree to continue"
+				help="You must agree to continue."
 				onChange={ () => {} }
 			/>
 		);
 
 		expect(
 			screen.getByRole( 'checkbox', { name: 'Agree' } )
-		).toHaveAccessibleDescription( 'You must agree to continue' );
+		).toHaveAccessibleDescription( 'You must agree to continue.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -23,7 +23,7 @@ describe( 'ValidatedCheckboxControl', () => {
 			<form>
 				<ValidatedCheckboxControl
 					label="Agree"
-					help="You must agree to continue"
+					help="You must agree to continue."
 					onChange={ () => {} }
 					required
 				/>
@@ -43,7 +43,7 @@ describe( 'ValidatedCheckboxControl', () => {
 			);
 		} );
 		expect( checkbox ).toHaveAccessibleDescription(
-			expect.stringContaining( 'You must agree to continue' )
+			expect.stringContaining( 'You must agree to continue.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/checkbox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/checkbox-control.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedCheckboxControl } from '../components';
+
+describe( 'ValidatedCheckboxControl', () => {
+	it( 'should preserve the help description', () => {
+		render(
+			<ValidatedCheckboxControl
+				label="Agree"
+				help="You must agree to continue"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Agree' } )
+		).toHaveAccessibleDescription( 'You must agree to continue' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedCheckboxControl
+					label="Agree"
+					help="You must agree to continue"
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /^Agree/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( checkbox ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( checkbox ).toHaveAccessibleDescription(
+			expect.stringContaining( 'You must agree to continue' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/combobox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/combobox-control.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedComboboxControl } from '../components';
+
+// The `help` prop is rendered visually by BaseControl but is not
+// programmatically associated with the combobox input via aria-describedby.
+// This is a pre-existing bug in ComboboxControl, not caused by ControlWithError.
+describe( 'ValidatedComboboxControl', () => {
+	const options = [
+		{ label: 'Apple', value: 'apple' },
+		{ label: 'Banana', value: 'banana' },
+	];
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'should preserve the help description', () => {
+		render(
+			<ValidatedComboboxControl
+				label="Fruit"
+				help="Pick a fruit"
+				options={ options }
+				onChange={ () => {} }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'combobox', { name: 'Fruit' } )
+		).toHaveAccessibleDescription( 'Pick a fruit' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedComboboxControl
+					label="Fruit"
+					help="Pick a fruit"
+					options={ options }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const combobox = screen.getByRole( 'combobox', {
+			name: /^Fruit/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( combobox ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( combobox ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Pick a fruit' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/combobox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/combobox-control.tsx
@@ -16,7 +16,7 @@ describe( 'ValidatedComboboxControl', () => {
 		render(
 			<ValidatedComboboxControl
 				label="Fruit"
-				help="Pick a fruit"
+				help="Pick a fruit."
 				options={ options }
 				onChange={ () => {} }
 			/>
@@ -24,7 +24,7 @@ describe( 'ValidatedComboboxControl', () => {
 
 		expect(
 			screen.getByRole( 'combobox', { name: 'Fruit' } )
-		).toHaveAccessibleDescription( 'Pick a fruit' );
+		).toHaveAccessibleDescription( 'Pick a fruit.' );
 	} );
 
 	// eslint-disable-next-line jest/no-disabled-tests
@@ -34,7 +34,7 @@ describe( 'ValidatedComboboxControl', () => {
 			<form>
 				<ValidatedComboboxControl
 					label="Fruit"
-					help="Pick a fruit"
+					help="Pick a fruit."
 					options={ options }
 					onChange={ () => {} }
 					required
@@ -55,7 +55,7 @@ describe( 'ValidatedComboboxControl', () => {
 			);
 		} );
 		expect( combobox ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Pick a fruit' )
+			expect.stringContaining( 'Pick a fruit.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/test/control-with-error.tsx
@@ -320,7 +320,7 @@ describe( 'ControlWithError', () => {
 							required
 							aria-describedby={ hintId }
 						/>
-						<p id={ hintId }>Enter a full URL</p>
+						<p id={ hintId }>Enter a full URL.</p>
 						<button type="submit">Submit</button>
 					</form>
 				);
@@ -330,7 +330,7 @@ describe( 'ControlWithError', () => {
 
 			const input = screen.getByRole( 'textbox', { name: /^URL/ } );
 
-			expect( input ).toHaveAccessibleDescription( 'Enter a full URL' );
+			expect( input ).toHaveAccessibleDescription( 'Enter a full URL.' );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Submit' } )
@@ -342,7 +342,7 @@ describe( 'ControlWithError', () => {
 				);
 			} );
 			expect( input ).toHaveAccessibleDescription(
-				expect.stringContaining( 'Enter a full URL' )
+				expect.stringContaining( 'Enter a full URL.' )
 			);
 		} );
 

--- a/packages/components/src/validated-form-controls/test/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/test/control-with-error.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useRef } from '@wordpress/element';
+import { useState, useCallback, useId, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -280,6 +280,187 @@ describe( 'ControlWithError', () => {
 
 			// Form is not submitted
 			expect( onSubmit ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'aria-describedby', () => {
+		it( 'should connect the error message to the input via aria-describedby', async () => {
+			const user = userEvent.setup();
+			render(
+				<form>
+					<ValidatedInputControl label="URL" required />
+					<button type="submit">Submit</button>
+				</form>
+			);
+
+			const input = screen.getByRole( 'textbox', { name: /^URL/ } );
+
+			expect( input ).not.toHaveAttribute( 'aria-describedby' );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit' } )
+			);
+
+			await waitFor( () => {
+				expect( input ).toHaveAccessibleDescription(
+					expect.stringContaining( 'Constraints not satisfied' )
+				);
+			} );
+		} );
+
+		it( 'should preserve existing aria-describedby values', async () => {
+			const user = userEvent.setup();
+
+			function TestComponent() {
+				const hintId = useId();
+				return (
+					<form>
+						<ValidatedInputControl
+							label="URL"
+							required
+							aria-describedby={ hintId }
+						/>
+						<p id={ hintId }>Enter a full URL</p>
+						<button type="submit">Submit</button>
+					</form>
+				);
+			}
+
+			render( <TestComponent /> );
+
+			const input = screen.getByRole( 'textbox', { name: /^URL/ } );
+
+			expect( input ).toHaveAccessibleDescription( 'Enter a full URL' );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit' } )
+			);
+
+			await waitFor( () => {
+				expect( input ).toHaveAccessibleDescription(
+					expect.stringContaining( 'Constraints not satisfied' )
+				);
+			} );
+			expect( input ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Enter a full URL' )
+			);
+		} );
+
+		it( 'should connect a custom validity error to the input via aria-describedby', async () => {
+			const user = userEvent.setup();
+
+			function TestComponent() {
+				const [ customValidity, setCustomValidity ] =
+					useState<
+						React.ComponentProps<
+							typeof ValidatedInputControl
+						>[ 'customValidity' ]
+					>( undefined );
+				const inputRef = useRef< HTMLInputElement >( null );
+
+				return (
+					<>
+						<ValidatedInputControl
+							ref={ inputRef }
+							label="URL"
+							customValidity={ customValidity }
+						/>
+						<button
+							type="button"
+							onClick={ () => {
+								setCustomValidity( {
+									type: 'invalid',
+									message: 'Please enter a valid URL.',
+								} );
+								requestAnimationFrame(
+									() => inputRef.current?.reportValidity()
+								);
+							} }
+						>
+							Validate
+						</button>
+					</>
+				);
+			}
+
+			render( <TestComponent /> );
+
+			const input = screen.getByRole( 'textbox', { name: 'URL' } );
+			expect( input ).not.toHaveAttribute( 'aria-describedby' );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Validate' } )
+			);
+
+			await waitFor( () => {
+				expect( input ).toHaveAccessibleDescription(
+					expect.stringContaining( 'Please enter a valid URL.' )
+				);
+			} );
+		} );
+
+		it( 'should remove aria-describedby when the error is resolved', async () => {
+			const user = userEvent.setup();
+
+			function TestComponent() {
+				const [ customValidity, setCustomValidity ] =
+					useState<
+						React.ComponentProps<
+							typeof ValidatedInputControl
+						>[ 'customValidity' ]
+					>( undefined );
+				const inputRef = useRef< HTMLInputElement >( null );
+
+				return (
+					<>
+						<ValidatedInputControl
+							ref={ inputRef }
+							label="URL"
+							customValidity={ customValidity }
+						/>
+						<button
+							type="button"
+							onClick={ () => {
+								setCustomValidity( {
+									type: 'invalid',
+									message: 'Please enter a valid URL.',
+								} );
+								requestAnimationFrame(
+									() => inputRef.current?.reportValidity()
+								);
+							} }
+						>
+							Validate
+						</button>
+						<button
+							type="button"
+							onClick={ () => setCustomValidity( undefined ) }
+						>
+							Clear
+						</button>
+					</>
+				);
+			}
+
+			render( <TestComponent /> );
+
+			const input = screen.getByRole( 'textbox', { name: 'URL' } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Validate' } )
+			);
+
+			await waitFor( () => {
+				expect( input ).toHaveAccessibleDescription(
+					expect.stringContaining( 'Please enter a valid URL.' )
+				);
+			} );
+
+			await user.click( screen.getByRole( 'button', { name: 'Clear' } ) );
+
+			await waitFor( () => {
+				expect( input ).not.toHaveAttribute( 'aria-describedby' );
+			} );
 		} );
 	} );
 

--- a/packages/components/src/validated-form-controls/test/custom-select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/custom-select-control.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedCustomSelectControl } from '../components';
+
+describe( 'ValidatedCustomSelectControl', () => {
+	const options = [
+		{ key: 'small', name: 'Small' },
+		{ key: 'large', name: 'Large' },
+	];
+
+	it( 'should preserve the built-in "Currently selected" description', async () => {
+		render(
+			<ValidatedCustomSelectControl
+				label="Font Size"
+				options={ options }
+				value={ options[ 0 ] }
+				onChange={ () => {} }
+			/>
+		);
+
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'combobox', { name: 'Font Size' } )
+			).toHaveAccessibleDescription( 'Currently selected: Small' );
+		} );
+	} );
+
+	it( 'should preserve the built-in description when validation is active', async () => {
+		const user = userEvent.setup();
+		render(
+			<form onSubmit={ ( e ) => e.preventDefault() }>
+				<ValidatedCustomSelectControl
+					label="Font Size"
+					options={ options }
+					value={ options[ 0 ] }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const combobox = await waitFor( () => {
+			return screen.getByRole( 'combobox', {
+				name: /^Font Size/,
+			} );
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		// The validation error targets the hidden delegate <select>, not
+		// the interactive combobox. The combobox's built-in description
+		// should be unaffected.
+		await waitFor( () => {
+			expect( combobox ).toHaveAccessibleDescription(
+				'Currently selected: Small'
+			);
+		} );
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/test/form-token-field.tsx
@@ -15,7 +15,7 @@ describe( 'ValidatedFormTokenField', () => {
 		expect(
 			screen.getByRole( 'combobox', { name: 'Tags' } )
 		).toHaveAccessibleDescription(
-			expect.stringContaining( 'Separate with commas' )
+			expect.stringContaining( 'Separate with commas or the Enter key.' )
 		);
 	} );
 
@@ -46,7 +46,7 @@ describe( 'ValidatedFormTokenField', () => {
 			).toBeVisible();
 		} );
 		expect( input ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Separate with commas' )
+			expect.stringContaining( 'Separate with commas or the Enter key.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/test/form-token-field.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedFormTokenField } from '../components';
+
+describe( 'ValidatedFormTokenField', () => {
+	it( 'should preserve the built-in howto description', () => {
+		render(
+			<ValidatedFormTokenField
+				label="Tags"
+				value={ [] }
+				onChange={ () => {} }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'combobox', { name: 'Tags' } )
+		).toHaveAccessibleDescription(
+			expect.stringContaining( 'Separate with commas' )
+		);
+	} );
+
+	it( 'should preserve the built-in howto description when validation is active', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedFormTokenField
+					label="Tags"
+					value={ [] }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const input = screen.getByRole( 'combobox', { name: /^Tags/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		// The validation error targets the hidden delegate input, not the
+		// interactive combobox. The combobox's built-in description should
+		// be unaffected.
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Constraints not satisfied' )
+			).toBeVisible();
+		} );
+		expect( input ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Separate with commas' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/input-control.tsx
+++ b/packages/components/src/validated-form-controls/test/input-control.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedInputControl } from '../components';
+
+describe( 'ValidatedInputControl', () => {
+	it( 'should preserve the help description', () => {
+		render( <ValidatedInputControl label="URL" help="Enter a full URL" /> );
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'URL' } )
+		).toHaveAccessibleDescription( 'Enter a full URL' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedInputControl
+					label="URL"
+					help="Enter a full URL"
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const input = screen.getByRole( 'textbox', { name: /^URL/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( input ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( input ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Enter a full URL' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/input-control.tsx
+++ b/packages/components/src/validated-form-controls/test/input-control.tsx
@@ -4,11 +4,13 @@ import { ValidatedInputControl } from '../components';
 
 describe( 'ValidatedInputControl', () => {
 	it( 'should preserve the help description', () => {
-		render( <ValidatedInputControl label="URL" help="Enter a full URL" /> );
+		render(
+			<ValidatedInputControl label="URL" help="Enter a full URL." />
+		);
 
 		expect(
 			screen.getByRole( 'textbox', { name: 'URL' } )
-		).toHaveAccessibleDescription( 'Enter a full URL' );
+		).toHaveAccessibleDescription( 'Enter a full URL.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -17,7 +19,7 @@ describe( 'ValidatedInputControl', () => {
 			<form>
 				<ValidatedInputControl
 					label="URL"
-					help="Enter a full URL"
+					help="Enter a full URL."
 					required
 				/>
 				<button type="submit">Submit</button>
@@ -34,7 +36,7 @@ describe( 'ValidatedInputControl', () => {
 			);
 		} );
 		expect( input ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Enter a full URL' )
+			expect.stringContaining( 'Enter a full URL.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/number-control.tsx
+++ b/packages/components/src/validated-form-controls/test/number-control.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedNumberControl } from '../components';
+
+describe( 'ValidatedNumberControl', () => {
+	it( 'should preserve the help description', () => {
+		render(
+			<ValidatedNumberControl label="Quantity" help="Enter a quantity" />
+		);
+
+		expect(
+			screen.getByRole( 'spinbutton', { name: 'Quantity' } )
+		).toHaveAccessibleDescription( 'Enter a quantity' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedNumberControl
+					label="Quantity"
+					help="Enter a quantity"
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const input = screen.getByRole( 'spinbutton', {
+			name: /^Quantity/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( input ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( input ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Enter a quantity' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/number-control.tsx
+++ b/packages/components/src/validated-form-controls/test/number-control.tsx
@@ -5,12 +5,12 @@ import { ValidatedNumberControl } from '../components';
 describe( 'ValidatedNumberControl', () => {
 	it( 'should preserve the help description', () => {
 		render(
-			<ValidatedNumberControl label="Quantity" help="Enter a quantity" />
+			<ValidatedNumberControl label="Quantity" help="Enter a quantity." />
 		);
 
 		expect(
 			screen.getByRole( 'spinbutton', { name: 'Quantity' } )
-		).toHaveAccessibleDescription( 'Enter a quantity' );
+		).toHaveAccessibleDescription( 'Enter a quantity.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -19,7 +19,7 @@ describe( 'ValidatedNumberControl', () => {
 			<form>
 				<ValidatedNumberControl
 					label="Quantity"
-					help="Enter a quantity"
+					help="Enter a quantity."
 					required
 				/>
 				<button type="submit">Submit</button>
@@ -38,7 +38,7 @@ describe( 'ValidatedNumberControl', () => {
 			);
 		} );
 		expect( input ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Enter a quantity' )
+			expect.stringContaining( 'Enter a quantity.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/radio-control.tsx
+++ b/packages/components/src/validated-form-controls/test/radio-control.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedRadioControl } from '../components';
+
+describe( 'ValidatedRadioControl', () => {
+	const options = [
+		{ label: 'Small', value: 'small' },
+		{ label: 'Medium', value: 'medium' },
+		{ label: 'Large', value: 'large' },
+	];
+
+	it( 'should preserve the help description on the radio group', () => {
+		render(
+			<ValidatedRadioControl
+				label="Size"
+				help="Choose a size"
+				options={ options }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'group', { name: 'Size' } )
+		).toHaveAccessibleDescription( 'Choose a size' );
+	} );
+
+	it( 'should append the validation error to the first radio input', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedRadioControl
+					label="Size"
+					help="Choose a size"
+					options={ options }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		// The validation error targets the first radio input (the validity
+		// target), while the help description stays on the radiogroup.
+		const firstRadio = screen.getByRole( 'radio', {
+			name: 'Small',
+		} );
+		await waitFor( () => {
+			expect( firstRadio ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+
+		expect(
+			screen.getByRole( 'group', { name: /^Size/ } )
+		).toHaveAccessibleDescription(
+			expect.stringContaining( 'Choose a size' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/radio-control.tsx
+++ b/packages/components/src/validated-form-controls/test/radio-control.tsx
@@ -15,6 +15,7 @@ describe( 'ValidatedRadioControl', () => {
 				label="Size"
 				help="Choose a size"
 				options={ options }
+				onChange={ () => {} }
 			/>
 		);
 
@@ -31,6 +32,7 @@ describe( 'ValidatedRadioControl', () => {
 					label="Size"
 					help="Choose a size"
 					options={ options }
+					onChange={ () => {} }
 					required
 				/>
 				<button type="submit">Submit</button>

--- a/packages/components/src/validated-form-controls/test/radio-control.tsx
+++ b/packages/components/src/validated-form-controls/test/radio-control.tsx
@@ -20,7 +20,7 @@ describe( 'ValidatedRadioControl', () => {
 		);
 
 		expect(
-			screen.getByRole( 'group', { name: 'Size' } )
+			screen.getByRole( 'radiogroup', { name: 'Size' } )
 		).toHaveAccessibleDescription( 'Choose a size.' );
 	} );
 
@@ -53,7 +53,7 @@ describe( 'ValidatedRadioControl', () => {
 		} );
 
 		expect(
-			screen.getByRole( 'group', { name: /^Size/ } )
+			screen.getByRole( 'radiogroup', { name: /^Size/ } )
 		).toHaveAccessibleDescription(
 			expect.stringContaining( 'Choose a size.' )
 		);

--- a/packages/components/src/validated-form-controls/test/radio-control.tsx
+++ b/packages/components/src/validated-form-controls/test/radio-control.tsx
@@ -13,7 +13,7 @@ describe( 'ValidatedRadioControl', () => {
 		render(
 			<ValidatedRadioControl
 				label="Size"
-				help="Choose a size"
+				help="Choose a size."
 				options={ options }
 				onChange={ () => {} }
 			/>
@@ -21,7 +21,7 @@ describe( 'ValidatedRadioControl', () => {
 
 		expect(
 			screen.getByRole( 'group', { name: 'Size' } )
-		).toHaveAccessibleDescription( 'Choose a size' );
+		).toHaveAccessibleDescription( 'Choose a size.' );
 	} );
 
 	it( 'should append the validation error to the first radio input', async () => {
@@ -30,7 +30,7 @@ describe( 'ValidatedRadioControl', () => {
 			<form>
 				<ValidatedRadioControl
 					label="Size"
-					help="Choose a size"
+					help="Choose a size."
 					options={ options }
 					onChange={ () => {} }
 					required
@@ -55,7 +55,7 @@ describe( 'ValidatedRadioControl', () => {
 		expect(
 			screen.getByRole( 'group', { name: /^Size/ } )
 		).toHaveAccessibleDescription(
-			expect.stringContaining( 'Choose a size' )
+			expect.stringContaining( 'Choose a size.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/range-control.tsx
+++ b/packages/components/src/validated-form-controls/test/range-control.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState, useRef } from '@wordpress/element';
+import { ValidatedRangeControl } from '../components';
+
+describe( 'ValidatedRangeControl', () => {
+	it( 'should preserve the help description', () => {
+		render(
+			<ValidatedRangeControl label="Opacity" help="Set the opacity" />
+		);
+
+		expect(
+			screen.getByRole( 'slider', { name: 'Opacity' } )
+		).toHaveAccessibleDescription( 'Set the opacity' );
+	} );
+
+	// Range inputs always have a value, so `required` never fails constraint
+	// validation. Use `customValidity` to trigger the validation error.
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+
+		function TestComponent() {
+			const [ customValidity, setCustomValidity ] =
+				useState<
+					React.ComponentProps<
+						typeof ValidatedRangeControl
+					>[ 'customValidity' ]
+				>( undefined );
+			const ref = useRef< HTMLInputElement >( null );
+
+			return (
+				<>
+					<ValidatedRangeControl
+						ref={ ref }
+						label="Opacity"
+						help="Set the opacity"
+						customValidity={ customValidity }
+					/>
+					<button
+						type="button"
+						onClick={ () => {
+							setCustomValidity( {
+								type: 'invalid',
+								message: 'Value out of range.',
+							} );
+							requestAnimationFrame(
+								() => ref.current?.reportValidity()
+							);
+						} }
+					>
+						Validate
+					</button>
+				</>
+			);
+		}
+
+		render( <TestComponent /> );
+
+		const slider = screen.getByRole( 'slider', { name: 'Opacity' } );
+		expect( slider ).toHaveAccessibleDescription( 'Set the opacity' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Validate' } ) );
+
+		await waitFor( () => {
+			expect( slider ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Value out of range.' )
+			);
+		} );
+		expect( slider ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Set the opacity' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/range-control.tsx
+++ b/packages/components/src/validated-form-controls/test/range-control.tsx
@@ -6,12 +6,12 @@ import { ValidatedRangeControl } from '../components';
 describe( 'ValidatedRangeControl', () => {
 	it( 'should preserve the help description', () => {
 		render(
-			<ValidatedRangeControl label="Opacity" help="Set the opacity" />
+			<ValidatedRangeControl label="Opacity" help="Set the opacity." />
 		);
 
 		expect(
 			screen.getByRole( 'slider', { name: 'Opacity' } )
-		).toHaveAccessibleDescription( 'Set the opacity' );
+		).toHaveAccessibleDescription( 'Set the opacity.' );
 	} );
 
 	// Range inputs always have a value, so `required` never fails constraint
@@ -33,7 +33,7 @@ describe( 'ValidatedRangeControl', () => {
 					<ValidatedRangeControl
 						ref={ ref }
 						label="Opacity"
-						help="Set the opacity"
+						help="Set the opacity."
 						customValidity={ customValidity }
 					/>
 					<button
@@ -57,7 +57,7 @@ describe( 'ValidatedRangeControl', () => {
 		render( <TestComponent /> );
 
 		const slider = screen.getByRole( 'slider', { name: 'Opacity' } );
-		expect( slider ).toHaveAccessibleDescription( 'Set the opacity' );
+		expect( slider ).toHaveAccessibleDescription( 'Set the opacity.' );
 
 		await user.click( screen.getByRole( 'button', { name: 'Validate' } ) );
 
@@ -67,7 +67,7 @@ describe( 'ValidatedRangeControl', () => {
 			);
 		} );
 		expect( slider ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Set the opacity' )
+			expect.stringContaining( 'Set the opacity.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/select-control.tsx
@@ -13,7 +13,7 @@ describe( 'ValidatedSelectControl', () => {
 		render(
 			<ValidatedSelectControl
 				label="Color"
-				help="Pick a color"
+				help="Pick a color."
 				options={ options }
 				onChange={ () => {} }
 			/>
@@ -21,7 +21,7 @@ describe( 'ValidatedSelectControl', () => {
 
 		expect(
 			screen.getByRole( 'combobox', { name: 'Color' } )
-		).toHaveAccessibleDescription( 'Pick a color' );
+		).toHaveAccessibleDescription( 'Pick a color.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -30,7 +30,7 @@ describe( 'ValidatedSelectControl', () => {
 			<form>
 				<ValidatedSelectControl
 					label="Color"
-					help="Pick a color"
+					help="Pick a color."
 					options={ options }
 					onChange={ () => {} }
 					required
@@ -51,7 +51,7 @@ describe( 'ValidatedSelectControl', () => {
 			);
 		} );
 		expect( select ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Pick a color' )
+			expect.stringContaining( 'Pick a color.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/select-control.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedSelectControl } from '../components';
+
+describe( 'ValidatedSelectControl', () => {
+	const options = [
+		{ label: 'Select a color...', value: '' },
+		{ label: 'Red', value: 'red' },
+		{ label: 'Blue', value: 'blue' },
+	];
+
+	it( 'should preserve the help description', () => {
+		render(
+			<ValidatedSelectControl
+				label="Color"
+				help="Pick a color"
+				options={ options }
+				onChange={ () => {} }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'combobox', { name: 'Color' } )
+		).toHaveAccessibleDescription( 'Pick a color' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedSelectControl
+					label="Color"
+					help="Pick a color"
+					options={ options }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const select = screen.getByRole( 'combobox', {
+			name: /^Color/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( select ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( select ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Pick a color' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/text-control.tsx
+++ b/packages/components/src/validated-form-controls/test/text-control.tsx
@@ -5,7 +5,12 @@ import { ValidatedTextControl } from '../components';
 describe( 'ValidatedTextControl', () => {
 	it( 'should preserve the help description', () => {
 		render(
-			<ValidatedTextControl label="Name" help="Enter your full name" />
+			<ValidatedTextControl
+				label="Name"
+				help="Enter your full name"
+				onChange={ () => {} }
+				value=""
+			/>
 		);
 
 		expect(
@@ -20,6 +25,8 @@ describe( 'ValidatedTextControl', () => {
 				<ValidatedTextControl
 					label="Name"
 					help="Enter your full name"
+					onChange={ () => {} }
+					value=""
 					required
 				/>
 				<button type="submit">Submit</button>

--- a/packages/components/src/validated-form-controls/test/text-control.tsx
+++ b/packages/components/src/validated-form-controls/test/text-control.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedTextControl } from '../components';
+
+describe( 'ValidatedTextControl', () => {
+	it( 'should preserve the help description', () => {
+		render(
+			<ValidatedTextControl label="Name" help="Enter your full name" />
+		);
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Name' } )
+		).toHaveAccessibleDescription( 'Enter your full name' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedTextControl
+					label="Name"
+					help="Enter your full name"
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const input = screen.getByRole( 'textbox', { name: /^Name/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( input ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( input ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Enter your full name' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/text-control.tsx
+++ b/packages/components/src/validated-form-controls/test/text-control.tsx
@@ -7,7 +7,7 @@ describe( 'ValidatedTextControl', () => {
 		render(
 			<ValidatedTextControl
 				label="Name"
-				help="Enter your full name"
+				help="Enter your full name."
 				onChange={ () => {} }
 				value=""
 			/>
@@ -15,7 +15,7 @@ describe( 'ValidatedTextControl', () => {
 
 		expect(
 			screen.getByRole( 'textbox', { name: 'Name' } )
-		).toHaveAccessibleDescription( 'Enter your full name' );
+		).toHaveAccessibleDescription( 'Enter your full name.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -24,7 +24,7 @@ describe( 'ValidatedTextControl', () => {
 			<form>
 				<ValidatedTextControl
 					label="Name"
-					help="Enter your full name"
+					help="Enter your full name."
 					onChange={ () => {} }
 					value=""
 					required
@@ -43,7 +43,7 @@ describe( 'ValidatedTextControl', () => {
 			);
 		} );
 		expect( input ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Enter your full name' )
+			expect.stringContaining( 'Enter your full name.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/textarea-control.tsx
+++ b/packages/components/src/validated-form-controls/test/textarea-control.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedTextareaControl } from '../components';
+
+describe( 'ValidatedTextareaControl', () => {
+	it( 'should preserve the help description', () => {
+		render( <ValidatedTextareaControl label="Bio" help="A short bio" /> );
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Bio' } )
+		).toHaveAccessibleDescription( 'A short bio' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedTextareaControl
+					label="Bio"
+					help="A short bio"
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const textarea = screen.getByRole( 'textbox', {
+			name: /^Bio/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( textarea ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( textarea ).toHaveAccessibleDescription(
+			expect.stringContaining( 'A short bio' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/textarea-control.tsx
+++ b/packages/components/src/validated-form-controls/test/textarea-control.tsx
@@ -4,7 +4,14 @@ import { ValidatedTextareaControl } from '../components';
 
 describe( 'ValidatedTextareaControl', () => {
 	it( 'should preserve the help description', () => {
-		render( <ValidatedTextareaControl label="Bio" help="A short bio" /> );
+		render(
+			<ValidatedTextareaControl
+				label="Bio"
+				help="A short bio"
+				onChange={ () => {} }
+				value=""
+			/>
+		);
 
 		expect(
 			screen.getByRole( 'textbox', { name: 'Bio' } )
@@ -18,6 +25,8 @@ describe( 'ValidatedTextareaControl', () => {
 				<ValidatedTextareaControl
 					label="Bio"
 					help="A short bio"
+					onChange={ () => {} }
+					value=""
 					required
 				/>
 				<button type="submit">Submit</button>

--- a/packages/components/src/validated-form-controls/test/textarea-control.tsx
+++ b/packages/components/src/validated-form-controls/test/textarea-control.tsx
@@ -7,7 +7,7 @@ describe( 'ValidatedTextareaControl', () => {
 		render(
 			<ValidatedTextareaControl
 				label="Bio"
-				help="A short bio"
+				help="A short bio."
 				onChange={ () => {} }
 				value=""
 			/>
@@ -15,7 +15,7 @@ describe( 'ValidatedTextareaControl', () => {
 
 		expect(
 			screen.getByRole( 'textbox', { name: 'Bio' } )
-		).toHaveAccessibleDescription( 'A short bio' );
+		).toHaveAccessibleDescription( 'A short bio.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -24,7 +24,7 @@ describe( 'ValidatedTextareaControl', () => {
 			<form>
 				<ValidatedTextareaControl
 					label="Bio"
-					help="A short bio"
+					help="A short bio."
 					onChange={ () => {} }
 					value=""
 					required
@@ -45,7 +45,7 @@ describe( 'ValidatedTextareaControl', () => {
 			);
 		} );
 		expect( textarea ).toHaveAccessibleDescription(
-			expect.stringContaining( 'A short bio' )
+			expect.stringContaining( 'A short bio.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-control.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ValidatedToggleControl } from '../components';
+
+describe( 'ValidatedToggleControl', () => {
+	it( 'should preserve the help description', () => {
+		render(
+			<ValidatedToggleControl
+				label="Dark mode"
+				help="Enable dark mode"
+				onChange={ () => {} }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Dark mode' } )
+		).toHaveAccessibleDescription( 'Enable dark mode' );
+	} );
+
+	it( 'should append the validation error alongside the help description', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedToggleControl
+					label="Dark mode"
+					help="Enable dark mode"
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const toggle = screen.getByRole( 'checkbox', {
+			name: /^Dark mode/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( toggle ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+		expect( toggle ).toHaveAccessibleDescription(
+			expect.stringContaining( 'Enable dark mode' )
+		);
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-control.tsx
@@ -7,14 +7,14 @@ describe( 'ValidatedToggleControl', () => {
 		render(
 			<ValidatedToggleControl
 				label="Dark mode"
-				help="Enable dark mode"
+				help="Enable dark mode."
 				onChange={ () => {} }
 			/>
 		);
 
 		expect(
 			screen.getByRole( 'checkbox', { name: 'Dark mode' } )
-		).toHaveAccessibleDescription( 'Enable dark mode' );
+		).toHaveAccessibleDescription( 'Enable dark mode.' );
 	} );
 
 	it( 'should append the validation error alongside the help description', async () => {
@@ -23,7 +23,7 @@ describe( 'ValidatedToggleControl', () => {
 			<form>
 				<ValidatedToggleControl
 					label="Dark mode"
-					help="Enable dark mode"
+					help="Enable dark mode."
 					onChange={ () => {} }
 					required
 				/>
@@ -43,7 +43,7 @@ describe( 'ValidatedToggleControl', () => {
 			);
 		} );
 		expect( toggle ).toHaveAccessibleDescription(
-			expect.stringContaining( 'Enable dark mode' )
+			expect.stringContaining( 'Enable dark mode.' )
 		);
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { ValidatedToggleGroupControl } from '../components';
+import { ToggleGroupControlOption } from '../../toggle-group-control';
+
+// The `help` prop is rendered visually by BaseControl but is not
+// programmatically associated with the toggle group via aria-describedby.
+// Additionally, the validity target is a hidden delegate radio input, not the
+// toggle group itself. These are pre-existing bugs, not caused by ControlWithError.
+describe( 'ValidatedToggleGroupControl', () => {
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'should preserve the help description', () => {
+		render(
+			<ValidatedToggleGroupControl
+				label="Alignment"
+				help="Choose text alignment"
+				value="left"
+				onChange={ () => {} }
+			>
+				<ToggleGroupControlOption label="Left" value="left" />
+				<ToggleGroupControlOption label="Center" value="center" />
+			</ValidatedToggleGroupControl>
+		);
+
+		expect(
+			screen.getByRole( 'radiogroup', { name: 'Alignment' } )
+		).toHaveAccessibleDescription( 'Choose text alignment' );
+	} );
+} );

--- a/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
@@ -12,7 +12,7 @@ describe( 'ValidatedToggleGroupControl', () => {
 		render(
 			<ValidatedToggleGroupControl
 				label="Alignment"
-				help="Choose text alignment"
+				help="Choose text alignment."
 				value="left"
 				onChange={ () => {} }
 			>
@@ -23,6 +23,6 @@ describe( 'ValidatedToggleGroupControl', () => {
 
 		expect(
 			screen.getByRole( 'radiogroup', { name: 'Alignment' } )
-		).toHaveAccessibleDescription( 'Choose text alignment' );
+		).toHaveAccessibleDescription( 'Choose text alignment.' );
 	} );
 } );

--- a/packages/components/src/validated-form-controls/validity-indicator.tsx
+++ b/packages/components/src/validated-form-controls/validity-indicator.tsx
@@ -15,9 +15,11 @@ import Icon from '../icon';
 import Spinner from '../spinner';
 
 export function ValidityIndicator( {
+	id,
 	type,
 	message,
 }: {
+	id?: string;
 	type: 'validating' | 'valid' | 'invalid';
 	message?: string;
 } ) {
@@ -27,6 +29,7 @@ export function ValidityIndicator( {
 	};
 	return (
 		<p
+			id={ id }
 			className={ clsx(
 				'components-validated-control__indicator',
 				`is-${ type }`


### PR DESCRIPTION
## What?

Closes #76694

Explicitly connect validation error messages to their respective form controls using `aria-describedby`, so that screen reader users can access error messages when navigating back to a field.

## Why?

Validation errors were displayed visually and announced via `aria-live`, but not programmatically associated with the input via `aria-describedby`. The errors are tied to the element through the Constraint Validation API, but if a user missed the live announcement (e.g. due to distraction or another announcement overriding it), there was no way to discover the error by returning to the field.

## How?

- Give `ValidityIndicator` an `id` prop and apply it to its root `<p>` element.
- In `ControlWithError`, generate a stable `messageId` via `useId()` and pass it to `ValidityIndicator`.
- Imperatively manage `aria-describedby` on the validity target element via a `useEffect`, merging the `messageId` alongside any existing `aria-describedby` values (e.g. from a `help` prop). In other words, we can't merge the attribute through `cloneElement` because we can't know the internals of the cloned element and whether a `help` prop or something maps to `aria-describedby` internally.

### Known limitation

For controls that use a hidden element as a validation delegate (`ValidatedCustomSelectControl`, `ValidatedFormTokenField`, `ValidatedToggleGroupControl`), the `aria-describedby` is attached to the hidden delegate rather than the interactive control, making this fix rather useless. Tracked separately in #76741, and bumped from this PR because it doesn't affect shipping features in WP 7.0.

## Testing Instructions

### Automated

New test coverage across 13 dedicated test files, one per validated control:

- Controls with a `help` prop (`CheckboxControl`, `TextControl`, `TextareaControl`, `InputControl`, `NumberControl`, `SelectControl`, `RadioControl`, `RangeControl`, `ToggleControl`): tests that the help description is preserved and that the validation error is appended alongside it.
- Controls with pre-existing `help` wiring bugs (`ComboboxControl`, `ToggleGroupControl`): tests asserting correct behavior, skipped with comments explaining the pre-existing issue.
- Delegate-based controls (`FormTokenField`, `CustomSelectControl`): tests that the interactive control's built-in description is not broken by validation.

The `control-with-error.tsx` test file retains tests for core `aria-describedby` mechanism behavior: basic connection, raw `aria-describedby` prop preservation, `customValidity` path, and cleanup on error resolution.

### Manual

1. Run `npm run storybook:dev` and navigate to the `ValidatedTextControl` story.
2. Leave the input empty (or set it to `required` via the controls panel).
3. Click the Submit button.
4. Using a screen reader, navigate away from the input and back to it.
5. Confirm the validation error message is announced as part of the field's description.

## Use of AI Tools

Authored with Cursor (Claude).