### PR TITLE
wp-build: Hash transformed CSS for `data-wp-hash` dedupe key

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Salt `data-wp-hash` with a build-tool identifier to prevent CSS module class name mismatches when multiple build pipelines process the same source file ([#76743](https://github.com/WordPress/gutenberg/pull/76743)).
+-   Derive `data-wp-hash` from the transformed CSS instead of the raw source to prevent style mismatches when multiple build pipelines process the same source file ([#76743](https://github.com/WordPress/gutenberg/pull/76743)).
 
 ## 0.10.0 (2026-03-18)
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Salt `data-wp-hash` with a build-tool identifier to prevent CSS module class name mismatches when multiple build pipelines process the same source file ([#76743](https://github.com/WordPress/gutenberg/pull/76743)).
+
 ## 0.10.0 (2026-03-18)
 
 ### Breaking Changes

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -182,14 +182,6 @@ function getSassOptions( workingDir ) {
 
 function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 	return async function styleType( cssText, _dirname, filePath ) {
-		// Always hash the untransformed code. The salt ensures that different
-		// build pipelines (which may produce different CSS module class names
-		// from the same source) never collide on the same data-wp-hash value.
-		const hash = createHash( 'sha1' )
-			.update( '@wordpress/wp-build' + cssText )
-			.digest( 'hex' )
-			.slice( 0, 10 );
-
 		let moduleExports = null;
 
 		// Transform the code: token fallbacks, CSS modules and minification.
@@ -215,6 +207,13 @@ function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 			from: filePath,
 			map: false,
 		} );
+
+		// Hash the transformed CSS so that the dedup key reflects the actual
+		// injected content, including mangled CSS module class names.
+		const hash = createHash( 'sha1' )
+			.update( css )
+			.digest( 'hex' )
+			.slice( 0, 10 );
 
 		let cssModule = `if (typeof document !== 'undefined' && process.env.NODE_ENV !== 'test' && !document.head.querySelector("style[data-wp-hash='${ hash }']")) {
 	const style = document.createElement("style");

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -182,9 +182,11 @@ function getSassOptions( workingDir ) {
 
 function compileInlineStyle( { cssModules = false, minify = true } = {} ) {
 	return async function styleType( cssText, _dirname, filePath ) {
-		// Always hash the untransformed code.
+		// Always hash the untransformed code. The salt ensures that different
+		// build pipelines (which may produce different CSS module class names
+		// from the same source) never collide on the same data-wp-hash value.
 		const hash = createHash( 'sha1' )
-			.update( cssText )
+			.update( '@wordpress/wp-build' + cssText )
 			.digest( 'hex' )
 			.slice( 0, 10 );
 


### PR DESCRIPTION
## Description

Closes #76738

Derive the `data-wp-hash` dedupe key from the transformed CSS instead of the raw source.

## Why?

`@wordpress/wp-build` deduplicates injected `<style>` tags using a `data-wp-hash` attribute derived from `SHA1(rawCSS)`. Since the hash is computed from the raw (untransformed) CSS, two independent build pipelines processing the same `.module.css` source will produce the same hash but different CSS module class names. Whichever bundle loads first wins the dedup check, and the other bundle's class names silently have no matching styles.

This is uncommon today, but will become more likely as `@wordpress/ui` adoption grows and consumers build the same simple source files with different CSS module tools.

## How?

Hash the transformed CSS (after postcss-modules and cssnano) instead of the raw source. The dedupe key now reflects the actual injected content, including mangled class names, so two pipelines that produce different output naturally get different hashes.

## Testing Instructions

This is a build-time change with no runtime UI to test. To verify the hash output changed:

1. Pick any `.module.css` file in a package that uses `@wordpress/wp-build`
2. Build before and after this change
3. Confirm the `data-wp-hash` value in the generated JS module is different

## Use of AI Tools

Authored with Cursor (Claude).