### PR TITLE
RadioControl: Add `role="radiogroup"` to fieldset

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `RadioControl`: Add `role="radiogroup"` to the wrapping `fieldset` element ([#76745](https://github.com/WordPress/gutenberg/pull/76745)).
 -   `CustomGradientPicker`: Add state persistence when switching between Linear and Radial Gradient ([#76595](https://github.com/WordPress/gutenberg/pull/76595)).
 
 ## 32.4.0 (2026-03-18)

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -87,6 +87,7 @@ export function RadioControl(
 	return (
 		<fieldset
 			id={ id }
+			role="radiogroup"
 			className={ clsx( className, 'components-radio-control' ) }
 			aria-describedby={ !! help ? generateHelpId( id ) : undefined }
 		>

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -56,18 +56,18 @@ describe.each( [
 	const [ , Component ] = modeAndComponent;
 
 	describe( 'semantics and labelling', () => {
-		it( 'should group all radios under a fieldset with an accessible label (legend)', () => {
+		it( 'should render a radiogroup with an accessible label (legend)', () => {
 			const onChangeSpy = jest.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);
 
 			expect(
-				screen.getByRole( 'group', { name: defaultProps.label } )
+				screen.getByRole( 'radiogroup', { name: defaultProps.label } )
 			).toBeVisible();
 		} );
 
-		it( 'should group all radios under a fieldset with an accessible label even when the label is visually hidden', () => {
+		it( 'should render a radiogroup with an accessible label even when the label is visually hidden', () => {
 			const onChangeSpy = jest.fn();
 			render(
 				<Component
@@ -78,7 +78,7 @@ describe.each( [
 			);
 
 			expect(
-				screen.getByRole( 'group', { name: defaultProps.label } )
+				screen.getByRole( 'radiogroup', { name: defaultProps.label } )
 			).toBeVisible();
 		} );
 
@@ -93,7 +93,7 @@ describe.each( [
 			);
 
 			expect(
-				screen.getByRole( 'group', { name: defaultProps.label } )
+				screen.getByRole( 'radiogroup', { name: defaultProps.label } )
 			).toHaveAccessibleDescription( 'Test help text' );
 		} );
 


### PR DESCRIPTION
## What?

Add `role="radiogroup"` to the `RadioControl` fieldset element.

## Why?

`RadioControl` renders a `<fieldset>` that contains radio inputs, but the implicit role of `<fieldset>` is `group`. The [WAI-ARIA Radio Group Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) specifies that a container of radio inputs should use `role="radiogroup"`, which allows assistive technology to convey that the options are mutually exclusive.

## How?

Add `role="radiogroup"` to the `<fieldset>` in `packages/components/src/radio-control/index.tsx`. Update existing unit tests to query by the `radiogroup` role instead of `group`.

## Testing Instructions

Check the rendered HTML in Storybook.

## Use of AI Tools

Authored with Cursor (Claude).