### PR TITLE
Login/out block: Add button block class names to the submit button

### DIFF
--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -38,6 +38,26 @@ function render_block_core_loginout( $attributes ) {
 
 		// Get the form.
 		$contents = wp_login_form( array( 'echo' => false ) );
+
+		if ( wp_is_block_theme() ) {
+			$processor = new WP_HTML_Tag_Processor( $contents );
+
+			if (
+				$processor->next_tag( array( 'class_name' => 'login-submit' ) ) &&
+				$processor->next_tag( 'input' )
+			) {
+				do {
+					if ( 'submit' !== strtolower( (string) $processor->get_attribute( 'type' ) ) ) {
+						continue;
+					}
+
+					$processor->add_class( 'wp-block-button__link' );
+					$processor->add_class( wp_theme_get_element_class_name( 'button' ) );
+					$contents = $processor->get_updated_html();
+					break;
+				} while ( $processor->next_tag( 'input' ) );
+			}
+		}
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -42,20 +42,13 @@ function render_block_core_loginout( $attributes ) {
 		if ( wp_is_block_theme() ) {
 			$processor = new WP_HTML_Tag_Processor( $contents );
 
-			if (
-				$processor->next_tag( array( 'class_name' => 'login-submit' ) ) &&
-				$processor->next_tag( 'input' )
-			) {
-				do {
-					if ( 'submit' !== strtolower( (string) $processor->get_attribute( 'type' ) ) ) {
-						continue;
-					}
-
+			while ( $processor->next_tag( 'input' ) ) {
+				if ( 'submit' === $processor->get_attribute( 'type' ) && 'wp-submit' === $processor->get_attribute( 'name' ) ) {
 					$processor->add_class( 'wp-block-button__link' );
 					$processor->add_class( wp_theme_get_element_class_name( 'button' ) );
 					$contents = $processor->get_updated_html();
 					break;
-				} while ( $processor->next_tag( 'input' ) );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  https://github.com/WordPress/gutenberg/issues/50466

When the login form option is selected, and a block theme is active, add these CSS classes to the submit button, so that it can be styled with theme.json:

wp-block-button__link
wp-element-button

Props @justintadlock

## Testing Instructions

1. Activate a block theme that styles buttons
2. Insert a login/out block
3. In the block settings sidebar, enable the option "Display login as form"
4. Save and view the front while logged out (or in an incognito tab :) )
5. Confirm that the submit button is no longer unstyled, and matches the button block / button element

## Screenshots
Before:
<img width="565" height="235" alt="The login form with a submit button that uses the browser default styles" src="https://github.com/user-attachments/assets/06e31122-fd16-45f3-9468-06908dfdeb5d" />

After:
<img width="501" height="247" alt="The login form with a styled submit button with a black background and border radius" src="https://github.com/user-attachments/assets/36cdb23d-5ea1-46d1-98c9-6d13de08d88d" />
