### PR TITLE
Add text align controls to breadcrumbs

### DIFF
--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -68,7 +68,8 @@
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
-			}
+			},
+			"textAlign": true
 		},
 		"interactivity": {
 			"clientNavigation": true

--- a/packages/block-library/src/breadcrumbs/style.scss
+++ b/packages/block-library/src/breadcrumbs/style.scss
@@ -9,6 +9,15 @@
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
+		justify-content: var(--breadcrumbs-justify-content, flex-start);
+	}
+
+	&.has-text-align-center ol {
+		--breadcrumbs-justify-content: center;
+	}
+
+	&.has-text-align-right ol {
+		--breadcrumbs-justify-content: flex-end;
 	}
 
 	li {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76739

This PR add text align controls breadcrumbs block.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Breadcrumbs benefit from text align support

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added `typography.textAlign` support block and wrote couple lines of CSS to create the support.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open page or post
2. Add "Breadcrumbs" block
3. See the text align control block toolbar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="560" height="402" alt="Screenshot 2026-03-21 at 19 16 56" src="https://github.com/user-attachments/assets/ec5b6948-acf8-4ec6-a83a-e11ba76f58ed" />

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
