### PR TITLE
Fix: Fit Text sizing inside CSS Grid layouts in Firefox

### DIFF
--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -28,7 +28,12 @@ function findOptimalFontSize( textElement, applyFontSize ) {
 	if ( parentElement ) {
 		const parentElementComputedStyle =
 			window.getComputedStyle( parentElement );
-		if ( parentElementComputedStyle?.display === 'flex' ) {
+		const { display } = parentElementComputedStyle;
+		if (
+			display === 'flex' ||
+			display === 'grid' ||
+			display === 'inline-grid'
+		) {
 			referenceElement = parentElement;
 			paddingLeft +=
 				parseFloat( parentElementComputedStyle.paddingLeft ) || 0;

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -54,6 +54,9 @@
 	/*rtl:end:ignore*/
 	padding: 0 8% 0 8%;
 	word-break: break-word;
+	// Add min-width to prevent overflow issues in CSS Grid layouts in Firefox.
+	// See: https://github.com/WordPress/gutenberg/issues/76647
+	min-width: 0;
 }
 
 .wp-block-media-text.has-media-on-the-right > .wp-block-media-text__media {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
When "Fit text" (Typography > Fit text toggle) is enabled on a Paragraph or Heading block placed inside a Media & Text block, the text does not scale correctly in Firefox. It renders properly in Chrome, Edge, Brave, and Safari.

The text either overflows the content area or renders at an incorrect (too large) size on both the frontend and backend (editor).

Closes #76647
Related to PR #73652 (flex container fix that didn't cover grid layouts)
Related to issue #73549 (1fr width intrinsic sizing issue)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Media & Text block uses a CSS Grid layout with `grid-template-columns: 50% 1fr`, placing the content in the flexible `1fr` column (`.wp-block-media-text__content`).

The Fit Text algorithm uses a binary search to find the maximum font size that fits by comparing:
- `scrollWidth` / `scrollHeight` against `clientWidth` / `clientHeight`

**Firefox Bug:** Firefox reports different (often unstable) `scrollWidth` values for descendants inside `1fr` grid tracks compared to Chromium browsers. This causes the binary search to converge on an incorrect (too large) font size.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Implemented a two-layer fix that mirrors the successful approach:
1. **JavaScript Enhancement** (fit-text-utils.js): Extended `findOptimalFontSize()` to recognize CSS Grid containers (`display: grid` or `inline-grid`) in addition to flex containers. When detected, the parent container becomes the reference element for width/height calculations, providing stable sizing measurements.
2. **CSS Stabilization** (media-text/style.scss): Added `min-width: 0` to `.wp-block-media-text__content` to establish proper intrinsic sizing constraints in grid contexts, which stabilizes the measurement in Firefox.



## Testing Instructions
1. Create a new post/page
2. Add a Media & Text block
3. Add an image to the media side
4. Add a Heading or Paragraph to the content area
5. Enable "Fit text" under Typography settings
6. Test in Firefox : Text should scale to fit without overflowing
7. Test in Chrome/Edge/Safari: Verify no regressions



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/497e2646-60ec-489f-874d-994c2dbd10d2

After:

https://github.com/user-attachments/assets/b6d3c9c3-ba01-4d43-9bb6-f162c6287ef2


