### PR TITLE
MediaUpload: Fix console error when reopening Gallery media library

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -294,9 +294,10 @@ class MediaUpload extends Component {
 			value = DEFAULT_EMPTY_GALLERY,
 		} = this.props;
 
-		// If the value did not change there is no need to rebuild the frame,
+		const isFrameAttached = !! this.frame?.el?.isConnected;
+		// If the value did not change and the existing frame is still attached,
 		// we can continue to use the existing one.
-		if ( value === this.lastGalleryValue ) {
+		if ( value === this.lastGalleryValue && isFrameAttached ) {
 			return;
 		}
 


### PR DESCRIPTION

## **What?**  
Fix a console error when reopening the Gallery block Media Library after closing it without making a selection.
Closes #71579 

## **Why?**  
The Gallery flow can reuse a previously-created media frame, but closing the modal removes uploader markup (ref #62168). Reusing the old frame on the next open can leave it referencing missing DOM, causing a `TypeError` in core media views.

## **How?**  
Only reuse the existing gallery frame if it’s still attached to the DOM; otherwise rebuild it.

## **Testing Instructions**
1. Add a Gallery block.
2. Click “Media Library”.
3. Close the modal without selecting.
4. Click “Media Library” again.
5. Confirm: no console error; modal opens normally.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/e5805488-2290-4d68-8ab6-85a2e2718e56



After:

https://github.com/user-attachments/assets/6992843d-193c-4668-9def-7ff8f233d5c2

