### PR TITLE
Storybook: Fix 'Open source file' links for storybook-local stories

### DIFF
--- a/storybook/addons/source-link/manager.ts
+++ b/storybook/addons/source-link/manager.ts
@@ -17,12 +17,19 @@ const SourceLinkTool = () => {
 	if ( storyData?.parameters?.sourceLink ) {
 		sourcePath = storyData.parameters.sourceLink;
 	} else if ( storyData?.importPath ) {
-		// importPath is like "../packages/components/src/button/stories/index.story.tsx"
-		// Convert to component directory path: "packages/components/src/button"
-		sourcePath = storyData.importPath
-			.replace( /^\.\.\//, '' ) // Remove leading "../"
-			.replace( /^\.\//, '' ) // Remove leading "./" (for stories in storybook folder)
-			.replace( /\/stories\/.*$/, '' ); // Remove "/stories/..." suffix
+		if ( storyData.importPath.startsWith( './' ) ) {
+			// Stories defined in storybook/ directory.
+			// importPath is like "./stories/introduction.mdx"
+			// Prepend "storybook/" to get the repo-root-relative path.
+			sourcePath = 'storybook/' + storyData.importPath.slice( 2 );
+		} else {
+			// Stories defined in the component package.
+			// importPath is like "../packages/components/src/button/stories/index.story.tsx"
+			// Convert to component directory path: "packages/components/src/button"
+			sourcePath = storyData.importPath
+				.replace( /^\.\.\//, '' ) // Remove leading "../"
+				.replace( /\/stories\/.*$/, '' ); // Remove "/stories/..." suffix
+		}
 	}
 
 	if ( ! sourcePath ) {


### PR DESCRIPTION
## What?

Fixes broken \"Open source file\" links in Storybook for stories defined inside the `storybook/` directory (e.g. `storybook/stories/introduction.mdx`).


https://github.com/user-attachments/assets/145ec283-8e5b-4d8a-a659-d3791b0dc00a



## Why?

I noticed that the "Open spurce file" links are a 404 in the stories within the `storybook/` directory.

The `source-link` addon generates GitHub source URLs from `importPath`. For storybook-local stories, `importPath` starts with `./` which is relative to the `storybook/` directory. The previous code simply stripped the `./` prefix, producing paths like `stories/introduction.mdx` instead of the correct `storybook/stories/introduction.mdx`, resulting in 404 errors.

## How?

Split the path transformation logic into two cases:

- **`./` prefix** (storybook-local stories): prepend `storybook/` to get the repo-root-relative file path.
- **`../` prefix** (package stories): strip `../` and remove the `/stories/...` suffix to link to the component source directory.

## Testing Instructions

1. Open the Storybook site.
2. Navigate to any of the following pages and click the \"Open source file\" icon in the toolbar:
   - http://localhost:50240/?path=/docs/introduction--page
   - http://localhost:50240/?path=/docs/playground-block-editor--docs
   - http://localhost:50240/?path=/docs/components-introduction--docs
   - http://localhost:50240/?path=/docs/design-system-theme-theme-provider-example-application--docs
3. Confirm the link opens the correct GitHub file (no 404).
4. Also verify that package component stories (e.g. any story under `packages/components`) still link correctly to their source directory.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (claude-sonnet-4-6).