### PR TITLE
Core Abilities: fix sideEffects flag

### DIFF
--- a/packages/core-abilities/package.json
+++ b/packages/core-abilities/package.json
@@ -44,9 +44,7 @@
 		".": "./build-module/index.mjs"
 	},
 	"types": "build-types",
-	"sideEffects": [
-		"{src,build,build-module}/index.js"
-	],
+	"sideEffects": true,
 	"dependencies": {
 		"@wordpress/abilities": "file:../abilities",
 		"@wordpress/api-fetch": "file:../api-fetch",


### PR DESCRIPTION
Fixing a little `package.json` error I noticed when reviewing #76609. The `core-abilities` `sideEffects` flag is wrong:
- esbuild doesn't support the `{src,build,build-module}` expansion lists in globs, the match result against a filename will be always `false`.
- The file suffixes in `build` and `build-module` are `.cjs` and `.mjs`, respectively, not `.js`.

Let's go with a simple `true` value. There is exactly one file in the package, and it calls `initialize()` at top-level, therefore it has side effects.