### PR TITLE
Boot: Fix black area below content when sidebar is taller than page content

### DIFF
--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -2,7 +2,7 @@
 @use "@wordpress/base-styles/mixins";
 
 .boot-layout {
-	height: 100%;
+	min-height: 100%;
 	width: 100%;
 	display: flex;
 	flex-direction: row;
@@ -112,6 +112,11 @@
 		height: auto;
 		border-radius: 8px;
 		margin: 0;
+
+		.boot-layout--single-page & {
+			top: auto;
+			height: auto;
+		}
 	}
 }
 
@@ -164,6 +169,11 @@
 		height: auto;
 		border-radius: 8px;
 		z-index: auto;
+
+		.boot-layout--single-page & {
+			top: auto;
+			height: auto;
+		}
 	}
 }
 

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -2,7 +2,7 @@
 @use "@wordpress/base-styles/mixins";
 
 .boot-layout {
-	min-height: 100%;
+	height: 100%;
 	width: 100%;
 	display: flex;
 	flex-direction: row;
@@ -219,6 +219,7 @@
 
 		@include mixins.break-medium {
 			top: variables.$admin-bar-height;
+
 		}
 	}
 }

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -51,6 +51,7 @@
 	.boot-layout--single-page & {
 		top: variables.$admin-bar-height-big;
 	}
+
 	z-index: 3;
 	background: var(--wpds-color-bg-surface-neutral);
 	padding: variables.$grid-unit-20;
@@ -114,7 +115,6 @@
 		margin: 0;
 
 		.boot-layout--single-page & {
-			top: auto;
 			height: auto;
 		}
 	}
@@ -171,7 +171,6 @@
 		z-index: auto;
 
 		.boot-layout--single-page & {
-			top: auto;
 			height: auto;
 		}
 	}


### PR DESCRIPTION
…ontent

The `.boot-layout--single-page` selector (specificity 0,2,0) was setting `height: calc(100vh - $admin-bar-height-big)` for all viewports, but the desktop `@include mixins.break-medium` reset (specificity 0,1,0) could not override it. This locked content height to the viewport on desktop in single-page mode, creating a black gap below when scrolling.

Fix:
- Add matching-specificity `.boot-layout--single-page &` overrides inside the `break-medium` blocks for stage/inspector and canvas to reset `top` and `height` to `auto` on desktop.
- Change `.boot-layout` from `height: 100%` to `min-height: 100%` so the layout container can grow when content exceeds the viewport.

Closes #76478

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
