### PR TITLE
Revert: Simplify toolbar for hidden blocks

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -38,7 +38,6 @@ import ChangeDesign from './change-design';
 import SwitchSectionStyle from './switch-section-style';
 import EditSectionButton from './edit-section-button';
 import { unlock } from '../../lock-unlock';
-import { deviceTypeKey } from '../../store/private-keys';
 import BlockToolbarIcon from './block-toolbar-icon';
 
 /**
@@ -77,7 +76,6 @@ export function PrivateBlockToolbar( {
 		showLockButtons,
 		showBlockVisibilityButton,
 		showSwitchSectionStyleButton,
-		areSelectedBlocksHiddenOnViewport,
 		canEdit,
 	} = useSelect( ( select ) => {
 		const { canEditBlock } = select( blockEditorStore );
@@ -89,12 +87,10 @@ export function PrivateBlockToolbar( {
 			isBlockValid,
 			getBlockEditingMode,
 			getBlockAttributes,
-			getSettings,
 			getTemplateLock,
 			getParentSectionBlock,
 			isZoomOut,
 			isSectionBlock,
-			isBlockHiddenAtViewport,
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -128,14 +124,6 @@ export function PrivateBlockToolbar( {
 		const _showSwitchSectionStyleButton =
 			_canEditBlock && ( _isZoomOut || _isSectionBlock );
 
-		const _currentDeviceType =
-			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
-		const _areSelectedBlocksHiddenOnViewport =
-			selectedBlockClientIds.length > 0 &&
-			selectedBlockClientIds.every( ( id ) =>
-				isBlockHiddenAtViewport( id, _currentDeviceType )
-			);
-
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -163,8 +151,6 @@ export function PrivateBlockToolbar( {
 			showLockButtons: ! _isZoomOut,
 			showBlockVisibilityButton: ! _isZoomOut,
 			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
-			areSelectedBlocksHiddenOnViewport:
-				_areSelectedBlocksHiddenOnViewport,
 			canEdit: _canEditBlock,
 		};
 	}, [] );
@@ -245,49 +231,45 @@ export function PrivateBlockToolbar( {
 						</ToolbarGroup>
 					</div>
 				) }
-				{ ! areSelectedBlocksHiddenOnViewport &&
-					! hasContentOnlyLocking &&
+				{ ! hasContentOnlyLocking &&
 					shouldShowVisualToolbar &&
 					isMultiToolbar &&
 					showGroupButtons && <BlockGroupToolbar /> }
 				{ ! isMultiToolbar && canEdit && (
 					<EditSectionButton clientId={ blockClientIds[ 0 ] } />
 				) }
-				{ ! areSelectedBlocksHiddenOnViewport && showShuffleButton && (
+				{ showShuffleButton && (
 					<ChangeDesign clientId={ blockClientIds[ 0 ] } />
 				) }
-				{ ! areSelectedBlocksHiddenOnViewport &&
-					showSwitchSectionStyleButton && (
-						<SwitchSectionStyle clientId={ blockClientIds[ 0 ] } />
-					) }
-				{ ! areSelectedBlocksHiddenOnViewport &&
-					shouldShowVisualToolbar &&
-					showSlots && (
-						<>
-							{ ! isSectionContainer && (
-								<>
-									<BlockControls.Slot
-										group="parent"
-										className="block-editor-block-toolbar__slot"
-									/>
-									<BlockControls.Slot
-										group="block"
-										className="block-editor-block-toolbar__slot"
-									/>
-									<BlockControls.Slot className="block-editor-block-toolbar__slot" />
-									<BlockControls.Slot
-										group="inline"
-										className="block-editor-block-toolbar__slot"
-									/>
-								</>
-							) }
-							<BlockControls.Slot
-								group="other"
-								className="block-editor-block-toolbar__slot"
-							/>
-							<__unstableBlockToolbarLastItem.Slot />
-						</>
-					) }
+				{ showSwitchSectionStyleButton && (
+					<SwitchSectionStyle clientId={ blockClientIds[ 0 ] } />
+				) }
+				{ shouldShowVisualToolbar && showSlots && (
+					<>
+						{ ! isSectionContainer && (
+							<>
+								<BlockControls.Slot
+									group="parent"
+									className="block-editor-block-toolbar__slot"
+								/>
+								<BlockControls.Slot
+									group="block"
+									className="block-editor-block-toolbar__slot"
+								/>
+								<BlockControls.Slot className="block-editor-block-toolbar__slot" />
+								<BlockControls.Slot
+									group="inline"
+									className="block-editor-block-toolbar__slot"
+								/>
+							</>
+						) }
+						<BlockControls.Slot
+							group="other"
+							className="block-editor-block-toolbar__slot"
+						/>
+						<__unstableBlockToolbarLastItem.Slot />
+					</>
+				) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
 			</div>


### PR DESCRIPTION
Closes #76733

## What?

This PR reverts #75335

## Why?

- We simplified the block toolbar for hidden blocks in #75335. However, sometimes, the controls in the block toolbar are not related to the visual state of the block, and some should always be visible. Also, some users might want to pre-configure a layout even if they can't see the blocks yet.
- Some argue that hidden blocks should be visible in the editor. In this case, the block toolbar should not be simplified. See https://github.com/WordPress/gutenberg/issues/73838

Considering these two points, I think the best course of action for the 7.0 release is to revert #75335 and restore the previous behavior.

## Testing Instructions

- Create a new post
- Add a few blocks
- Select a block and open the block visibility modal
- Hide the block on the current viewport
- Click the hidden block
- The icons in the block toolbar will remain unchanged; only the hide icon should be added

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="938" height="275" alt="before" src="https://github.com/user-attachments/assets/c273219b-8c76-4051-b65c-c181f441a0ae" />

### After

<img width="938" height="275" alt="after" src="https://github.com/user-attachments/assets/232721c6-768e-4721-a59a-f9e0de29a194" />


## Use of AI Tools

None