### PR TITLE
Site Editor v2: Add Site Identity section

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -26,6 +26,7 @@ add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
 function gutenberg_site_editor_register_default_menu_items() {
 	gutenberg_register_site_editor_v2_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
+	gutenberg_register_site_editor_v2_menu_item( 'siteIdentity', __( 'Site Identity', 'gutenberg' ), '/site-identity', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'templates', __( 'Templates', 'gutenberg' ), '/templates', '' );

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -9,6 +9,7 @@ import {
 	symbol,
 	symbolFilled,
 	layout,
+	siteLogo,
 } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
 import { store as bootStore } from '@wordpress/boot';
@@ -27,6 +28,7 @@ export async function init() {
 		templateParts: { icon: symbolFilled },
 		patterns: { icon: symbol },
 		templates: { icon: layout },
+		siteIdentity: { icon: siteLogo },
 	};
 
 	// Update each menu item with its icon

--- a/routes/site-identity/canvas.tsx
+++ b/routes/site-identity/canvas.tsx
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { useEditorSettings } from '@wordpress/lazy-editor';
+
+const noop = () => {};
+
+function Canvas() {
+	const globalStylesId = useSelect(
+		( select ) =>
+			(
+				select( coreStore ) as any
+			).__experimentalGetCurrentGlobalStylesId(),
+		[]
+	);
+	const { editorSettings } = useEditorSettings( {
+		stylesId: globalStylesId,
+	} );
+
+	const blocks = useMemo(
+		() => [
+			createBlock( 'core/site-logo' ),
+			createBlock( 'core/site-title' ),
+			createBlock( 'core/site-tagline' ),
+		],
+		[]
+	);
+
+	return (
+		<BlockEditorProvider
+			settings={ editorSettings }
+			value={ blocks }
+			onChange={ noop }
+			onInput={ noop }
+		>
+			<BlockList />
+		</BlockEditorProvider>
+	);
+}
+
+export const canvas = Canvas;

--- a/routes/site-identity/package.json
+++ b/routes/site-identity/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@wordpress/site-identity-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/site-identity",
+		"page": "site-editor-v2"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/block-editor": "file:../../packages/block-editor",
+		"@wordpress/blocks": "file:../../packages/blocks",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor"
+	}
+}

--- a/routes/site-identity/package.json
+++ b/routes/site-identity/package.json
@@ -12,7 +12,9 @@
 		"@wordpress/blocks": "file:../../packages/blocks",
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/fields": "file:../../packages/fields",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor"
 	}

--- a/routes/site-identity/route.ts
+++ b/routes/site-identity/route.ts
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const route = {
+	title: () => __( 'Site Identity' ),
+};

--- a/routes/site-identity/route.ts
+++ b/routes/site-identity/route.ts
@@ -5,4 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 export const route = {
 	title: () => __( 'Site Identity' ),
+	async canvas() {
+		return null;
+	},
 };

--- a/routes/site-identity/stage.tsx
+++ b/routes/site-identity/stage.tsx
@@ -3,46 +3,68 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
-import { useEditorSettings } from '@wordpress/lazy-editor';
+import { DataForm } from '@wordpress/dataviews';
+import { MediaEdit } from '@wordpress/fields';
 
-const noop = () => {};
+const fields = [
+	{
+		id: 'site_logo',
+		type: 'media',
+		label: __( 'Site Logo' ),
+		description: __(
+			"Displays in your site's layout via the Site Logo block."
+		),
+		placeholder: __( 'Choose logo' ),
+		Edit: MediaEdit,
+		setValue: ( { value }: { value: number | null } ) => ( {
+			site_logo: value ?? 0,
+		} ),
+	},
+	{
+		id: 'title',
+		type: 'text',
+		label: __( 'Site Title' ),
+	},
+	{
+		id: 'description',
+		type: 'text',
+		label: __( 'Tagline' ),
+	},
+];
+
+const form = {
+	layout: {
+		type: 'regular' as const,
+		labelPosition: 'top' as const,
+	},
+	fields: [ 'site_logo', 'title', 'description' ],
+};
 
 function Stage() {
-	const globalStylesId = useSelect(
+	const data = useSelect(
 		( select ) =>
-			(
-				select( coreStore ) as any
-			).__experimentalGetCurrentGlobalStylesId(),
+			( select( coreStore ) as any ).getEditedEntityRecord(
+				'root',
+				'site'
+			),
 		[]
 	);
-	const { editorSettings } = useEditorSettings( {
-		stylesId: globalStylesId,
-	} );
+	const { editEntityRecord } = useDispatch( coreStore );
 
-	const blocks = useMemo(
-		() => [
-			createBlock( 'core/site-logo' ),
-			createBlock( 'core/site-title' ),
-			createBlock( 'core/site-tagline' ),
-		],
-		[]
-	);
+	const onChange = ( edits: Record< string, any > ) => {
+		editEntityRecord( 'root', 'site', undefined, edits );
+	};
 
 	return (
-		<Page title={ __( 'Site Identity' ) }>
-			<BlockEditorProvider
-				settings={ editorSettings }
-				value={ blocks }
-				onChange={ noop }
-				onInput={ noop }
-			>
-				<BlockList />
-			</BlockEditorProvider>
+		<Page title={ __( 'Site Identity' ) } hasPadding>
+			<DataForm
+				data={ data }
+				fields={ fields }
+				form={ form }
+				onChange={ onChange }
+			/>
 		</Page>
 	);
 }

--- a/routes/site-identity/stage.tsx
+++ b/routes/site-identity/stage.tsx
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { useEditorSettings } from '@wordpress/lazy-editor';
+
+const noop = () => {};
+
+function Stage() {
+	const globalStylesId = useSelect(
+		( select ) =>
+			(
+				select( coreStore ) as any
+			).__experimentalGetCurrentGlobalStylesId(),
+		[]
+	);
+	const { editorSettings } = useEditorSettings( {
+		stylesId: globalStylesId,
+	} );
+
+	const blocks = useMemo(
+		() => [
+			createBlock( 'core/site-logo' ),
+			createBlock( 'core/site-title' ),
+			createBlock( 'core/site-tagline' ),
+		],
+		[]
+	);
+
+	return (
+		<Page title={ __( 'Site Identity' ) }>
+			<BlockEditorProvider
+				settings={ editorSettings }
+				value={ blocks }
+				onChange={ noop }
+				onInput={ noop }
+			>
+				<BlockList />
+			</BlockEditorProvider>
+		</Page>
+	);
+}
+
+export const stage = Stage;


### PR DESCRIPTION
## What?

Adds a new "Site Identity" section to the Site Editor v2, allowing users to edit their site logo, site title, and site tagline using editable blocks.

## Why?

The Site Editor v2 currently has no dedicated place for managing core site identity settings. This provides a focused panel for the most fundamental site branding options.

## How?

- Creates a new `routes/site-identity/` route package with a `stage.tsx` that renders `core/site-logo`, `core/site-title`, and `core/site-tagline` blocks via `BlockEditorProvider` + `BlockList`.
- Registers the `siteIdentity` menu item in PHP (`lib/experimental/pages/site-editor.php`) at the `/site-identity` path.
- Adds the `siteLogo` icon for the menu item in `packages/edit-site-init/src/index.ts`.

## Testing Instructions

1. Enable the experimental extensible site editor.
2. Navigate to `/wp-admin/admin.php?page=site-editor-v2`.
3. Click "Site Identity" in the sidebar navigation.
4. Verify the content panel shows editable Site Logo, Site Title, and Site Tagline blocks.
5. Edit each block and confirm changes persist.

### Testing Instructions for Keyboard

1. Use Tab to navigate to the "Site Identity" menu item and press Enter.
2. Tab into the content panel and use the block editor keyboard controls to edit each block.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (claude-opus-4-6).