### PR TITLE
List View: Place caret at end of block when selecting

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -415,7 +415,7 @@ function ListViewBlock( {
 
 	const selectEditorBlock = useCallback(
 		( event ) => {
-			selectBlock( event, clientId );
+			selectBlock( event, clientId, -1 );
 			event.preventDefault();
 		},
 		[ clientId, selectBlock ]

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -1395,6 +1395,48 @@ test.describe( 'List View', () => {
 			'The dropdown menu should also be visible'
 		).toBeVisible();
 	} );
+
+	test( 'should place the caret at the end of the block when selecting from List View', async ( {
+		editor,
+		page,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert a paragraph with some text.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First paragraph' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second paragraph' },
+		} );
+
+		// Open List View.
+		const listView = await listViewUtils.openListView();
+
+		// Click the first paragraph in List View.
+		await listView
+			.getByRole( 'gridcell', { name: 'Paragraph' } )
+			.first()
+			.click();
+
+		// Press Enter to split the block at the caret position.
+		// If the caret is at the end, this creates a new block after the first paragraph.
+		// If the caret is at the start, this creates a new block before the first paragraph.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first()
+			.press( 'Enter' );
+
+		// Verify the block order: if the caret was at the end, the new empty
+		// block should be after the first paragraph, not before it.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'First paragraph' } },
+			{ name: 'core/paragraph', attributes: { content: '' } },
+			{ name: 'core/paragraph', attributes: { content: 'Second paragraph' } },
+		] );
+	} );
 } );
 
 /** @typedef {import('@playwright/test').Locator} Locator */


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/76774

Places the caret at the end of a block (instead of the start) when selecting a block from the List View panel.

## Why?
When selecting a block via List View, the caret was placed at the start of the block. This meant pressing Enter would create a new block _before_ the selected block, which is unexpected. Users expect a new block to be created _after_ the selected block.

## How?
Passes `-1` as the `focusPosition` parameter when selecting a block from the List View (`block.js`). The value `-1` tells `useFocusFirstElement` to place the caret at the end of the last text input in the block, rather than the start of the first.

## Testing Instructions
1. Open a post or page.
2. Insert two Paragraph blocks with some text content.
3. Open the List View panel (Alt+Shift+O / Ctrl+Shift+O).
4. Click the first Paragraph in List View to select it.
5. Observe the caret is at the **end** of the block text in the canvas.
6. Press Enter.
7. Verify a new empty block is created **after** the first paragraph (not before it).

### Testing Instructions for Keyboard
1. Open a post or page and insert two Paragraph blocks with text.
2. Open the List View panel using Alt+Shift+O (Windows) or Ctrl+Shift+O (Mac).
3. Use arrow keys to navigate to the first Paragraph block in the List View.
4. Press Enter or Space to select the block.
5. The canvas should now be focused with the caret at the end of the block text.
6. Press Enter to create a new block.
7. Verify the new block appears after the selected block.

## Use of AI Tools
This PR was authored with the assistance of Claude Code (Claude Opus 4.6).