### PR TITLE
Refactor: Use null coalescing operator for improved readability

### DIFF
--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
@@ -241,7 +241,7 @@ class Gutenberg_Content_Guidelines_Post_Type {
 		foreach ( $all_meta as $meta_key => $meta_values ) {
 			if ( self::is_block_meta_key( $meta_key ) ) {
 				$block_name = self::meta_key_to_block_name( $meta_key );
-				$value      = isset( $meta_values[0] ) ? $meta_values[0] : '';
+				$value      = $meta_values[0] ?? '';
 
 				if ( ! empty( $value ) ) {
 					$blocks[ $block_name ] = array(

--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-rest-controller.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-rest-controller.php
@@ -391,9 +391,7 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Posts_Control
 		foreach ( Gutenberg_Content_Guidelines_Post_Type::CATEGORY_META_KEYS as $category ) {
 			if ( isset( $categories[ $category ] ) ) {
 				$meta_key = '_content_guideline_' . $category;
-				$value    = isset( $categories[ $category ]['guidelines'] )
-					? $categories[ $category ]['guidelines']
-					: '';
+				$value    = $categories[ $category ]['guidelines'] ?? '';
 				update_post_meta( $post_id, $meta_key, $value );
 			}
 		}
@@ -402,7 +400,7 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Posts_Control
 		if ( isset( $categories['blocks'] ) && is_array( $categories['blocks'] ) ) {
 			foreach ( $categories['blocks'] as $block_name => $block_data ) {
 				$meta_key = Gutenberg_Content_Guidelines_Post_Type::block_name_to_meta_key( $block_name );
-				$value    = isset( $block_data['guidelines'] ) ? $block_data['guidelines'] : '';
+				$value    = $block_data['guidelines'] ?? '';
 
 				if ( ! empty( $value ) ) {
 					update_post_meta( $post_id, $meta_key, $value );


### PR DESCRIPTION
## What?
This pull request makes minor improvements to how values are retrieved from arrays in the content guidelines code. The main change is the use of the null coalescing operator (`??`) instead of the `isset(...)?...:...` ternary pattern, which simplifies and modernizes the code.