### PR TITLE
vips: ensure single instance

### DIFF
--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -28,7 +28,7 @@ interface EmscriptenModule {
 
 let cleanup: () => void;
 
-let vipsInstance: typeof Vips;
+let vipsPromise: Promise< typeof Vips > | undefined;
 
 /**
  * Instantiates and returns a new vips instance.
@@ -36,11 +36,11 @@ let vipsInstance: typeof Vips;
  * Reuses any existing instance.
  */
 async function getVips(): Promise< typeof Vips > {
-	if ( vipsInstance ) {
-		return vipsInstance;
+	if ( vipsPromise ) {
+		return await vipsPromise;
 	}
 
-	vipsInstance = await Vips( {
+	vipsPromise = Vips( {
 		// Load HEIF dynamic module for HEIF/HEIC and AVIF format support.
 		// JXL is omitted as WordPress Core does not currently support it.
 		// It can be re-added when Core adds JXL support.
@@ -65,7 +65,7 @@ async function getVips(): Promise< typeof Vips > {
 		},
 	} );
 
-	return vipsInstance;
+	return await vipsPromise;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR ensures that a single instance of `vips` gets created, by caching a promise instead of a fully initialised instance.

## Why?
The existing code has a race condition where successive calls to `getVips()` can end up creating multiple instances. Since `getVips` is async, if a new call is made before the instance initialisation is complete, it will create a new instance.

## How?
This PR changes the cache to a promise instead of an instance. This way, the promise is immediately set the first time `getVips()` is called, and subsequent calls will wait for the same promise, instead of creating their own.

## Testing Instructions
- Smoke-test client-side media uploads and ensure everything still works properly
- Verify `npm run test:unit -- packages/upload-media` passes
- Verify `npm run test:unit -- packages/vips` passes

## Use of AI Tools

No AI tools were used.
