### PR TITLE
Typography: Add column-width support to text columns block support

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -159,6 +159,10 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$typography_block_styles['textColumns'] = $block_attributes['style']['typography']['textColumns'] ?? null;
 	}
 
+	if ( $has_text_columns_support && ! $should_skip_text_columns && isset( $block_attributes['style']['typography']['textColumnMinWidth'] ) ) {
+		$typography_block_styles['textColumnMinWidth'] = $block_attributes['style']['typography']['textColumnMinWidth'] ?? null;
+	}
+
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
 		$typography_block_styles['textDecoration'] =
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['textDecoration'], 'text-decoration' );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -278,6 +278,7 @@ class WP_Theme_JSON_Gutenberg {
 		'color'                             => array( 'color', 'text' ),
 		'text-align'                        => array( 'typography', 'textAlign' ),
 		'column-count'                      => array( 'typography', 'textColumns' ),
+		'column-width'                      => array( 'typography', 'textColumnMinWidth' ),
 		'font-family'                       => array( 'typography', 'fontFamily' ),
 		'font-size'                         => array( 'typography', 'fontSize' ),
 		'font-style'                        => array( 'typography', 'fontStyle' ),

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -3,7 +3,6 @@
  */
 import {
 	FontSizePicker,
-	__experimentalNumberControl as NumberControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	Notice,
@@ -25,6 +24,7 @@ import TextTransformControl from '../text-transform-control';
 import TextDecorationControl from '../text-decoration-control';
 import TextIndentControl from '../text-indent-control';
 import WritingModeControl from '../writing-mode-control';
+import TextColumnsControl from '../text-columns-control';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import {
@@ -32,9 +32,6 @@ import {
 	findNearestStyleAndWeight,
 } from './typography-utils';
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
-
-const MIN_TEXT_COLUMNS = 1;
-const MAX_TEXT_COLUMNS = 6;
 
 export function useHasTypographyPanel( settings ) {
 	const hasFontFamily = useHasFontFamilyControl( settings );
@@ -413,17 +410,58 @@ export default function TypographyPanel( {
 	// Text Columns
 	const hasTextColumnsControl = useHasTextColumnsControl( settings );
 	const textColumns = decodeValue( inheritedValue?.typography?.textColumns );
-	const setTextColumns = ( newValue ) => {
+	const textColumnMinWidth = inheritedValue?.typography?.textColumnMinWidth;
+	const setTextColumnMinWidth = ( newValue ) => {
 		onChange(
 			setImmutably(
 				value,
-				[ 'typography', 'textColumns' ],
+				[ 'typography', 'textColumnMinWidth' ],
 				newValue || undefined
 			)
 		);
 	};
-	const hasTextColumns = () => !! value?.typography?.textColumns;
-	const resetTextColumns = () => setTextColumns( undefined );
+	const setTextColumns = ( newValue ) => {
+		let newStyle = setImmutably(
+			value,
+			[ 'typography', 'textColumns' ],
+			newValue || undefined
+		);
+		if (
+			newValue &&
+			newValue > 1 &&
+			! value?.typography?.textColumnMinWidth
+		) {
+			newStyle = setImmutably(
+				newStyle,
+				[ 'typography', 'textColumnMinWidth' ],
+				'16em'
+			);
+		}
+		if ( ! newValue || newValue <= 1 ) {
+			newStyle = setImmutably(
+				newStyle,
+				[ 'typography', 'textColumnMinWidth' ],
+				undefined
+			);
+		}
+		onChange( newStyle );
+	};
+	const hasTextColumns = () =>
+		!! value?.typography?.textColumns ||
+		!! value?.typography?.textColumnMinWidth;
+	const resetTextColumns = () => {
+		let newStyle = setImmutably(
+			value,
+			[ 'typography', 'textColumns' ],
+			undefined
+		);
+		newStyle = setImmutably(
+			newStyle,
+			[ 'typography', 'textColumnMinWidth' ],
+			undefined
+		);
+		onChange( newStyle );
+	};
 
 	// Text Transform
 	const hasTextTransformControl = useHasTextTransformControl( settings );
@@ -630,15 +668,11 @@ export default function TypographyPanel( {
 					isShownByDefault={ defaultControls.textColumns }
 					panelId={ panelId }
 				>
-					<NumberControl
-						label={ __( 'Columns' ) }
-						max={ MAX_TEXT_COLUMNS }
-						min={ MIN_TEXT_COLUMNS }
-						onChange={ setTextColumns }
-						size="__unstable-large"
-						spinControls="custom"
-						value={ textColumns }
-						initialPosition={ 1 }
+					<TextColumnsControl
+						textColumns={ textColumns }
+						setTextColumns={ setTextColumns }
+						textColumnMinWidth={ textColumnMinWidth }
+						setTextColumnMinWidth={ setTextColumnMinWidth }
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-editor/src/components/text-columns-control/index.js
+++ b/packages/block-editor/src/components/text-columns-control/index.js
@@ -1,0 +1,140 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { settings as settingsIcon } from '@wordpress/icons';
+import {
+	__experimentalNumberControl as NumberControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalUnitControl as UnitControl,
+	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	BaseControl,
+	Button,
+} from '@wordpress/components';
+
+const MIN_TEXT_COLUMNS = 1;
+const MAX_TEXT_COLUMNS = 6;
+
+const TEXT_COLUMN_MIN_WIDTH_OPTIONS = [
+	{ label: __( 'S' ), value: '10em' },
+	{ label: __( 'M' ), value: '16em' },
+	{ label: __( 'L' ), value: '24em' },
+];
+
+const COLUMN_MIN_WIDTH_UNITS = [
+	{ value: 'em', label: 'em', default: 24 },
+	{ value: 'rem', label: 'rem', default: 24 },
+	{ value: 'px', label: 'px', default: 300 },
+];
+
+/**
+ * Control for managing text column count and column minimum width.
+ *
+ * @param {Object}   props                       Component props.
+ * @param {number}   props.textColumns           Current column count value.
+ * @param {Function} props.setTextColumns        Callback to update column count.
+ * @param {string}   props.textColumnMinWidth    Current column min width value.
+ * @param {Function} props.setTextColumnMinWidth Callback to update column min width.
+ * @return {Element} Text columns control.
+ */
+export default function TextColumnsControl( {
+	textColumns,
+	setTextColumns,
+	textColumnMinWidth,
+	setTextColumnMinWidth,
+} ) {
+	const [ showCustomColumnMinWidth, setShowCustomColumnMinWidth ] =
+		useState( false );
+
+	const isCustomColumnMinWidth =
+		!! textColumnMinWidth &&
+		! TEXT_COLUMN_MIN_WIDTH_OPTIONS.some(
+			( opt ) => opt.value === textColumnMinWidth
+		);
+
+	return (
+		<>
+			<NumberControl
+				label={ __( 'Columns' ) }
+				max={ MAX_TEXT_COLUMNS }
+				min={ MIN_TEXT_COLUMNS }
+				onChange={ setTextColumns }
+				size="__unstable-large"
+				spinControls="custom"
+				value={ textColumns }
+				initialPosition={ 1 }
+			/>
+			{ textColumns && textColumns > 1 && (
+				<Spacer marginTop={ 4 }>
+					<fieldset className="block-editor-typography-panel__column-min-width">
+						<HStack className="block-editor-typography-panel__column-min-width-header">
+							<BaseControl.VisualLabel as="legend">
+								{ __( 'Min Width' ) }
+							</BaseControl.VisualLabel>
+							<Button
+								label={
+									showCustomColumnMinWidth ||
+									isCustomColumnMinWidth
+										? __( 'Use size preset' )
+										: __( 'Set custom size' )
+								}
+								icon={ settingsIcon }
+								onClick={ () => {
+									if (
+										showCustomColumnMinWidth ||
+										isCustomColumnMinWidth
+									) {
+										// Switching back to presets - snap to nearest preset.
+										if ( isCustomColumnMinWidth ) {
+											setTextColumnMinWidth( '16em' );
+										}
+										setShowCustomColumnMinWidth( false );
+									} else {
+										setShowCustomColumnMinWidth( true );
+									}
+								} }
+								isPressed={
+									showCustomColumnMinWidth ||
+									isCustomColumnMinWidth
+								}
+								size="small"
+							/>
+						</HStack>
+						{ showCustomColumnMinWidth || isCustomColumnMinWidth ? (
+							<UnitControl
+								value={ textColumnMinWidth ?? '' }
+								onChange={ setTextColumnMinWidth }
+								units={ COLUMN_MIN_WIDTH_UNITS }
+								size="__unstable-large"
+							/>
+						) : (
+							<ToggleGroupControl
+								__next40pxDefaultSize
+								label={ __( 'Min Width' ) }
+								hideLabelFromVision
+								value={ textColumnMinWidth ?? '' }
+								onChange={ setTextColumnMinWidth }
+								isDeselectable
+								isBlock
+							>
+								{ TEXT_COLUMN_MIN_WIDTH_OPTIONS.map(
+									( option ) => (
+										<ToggleGroupControlOption
+											key={ option.value }
+											value={ option.value }
+											label={ option.label }
+											aria-label={ option.label }
+										/>
+									)
+								) }
+							</ToggleGroupControl>
+						) }
+					</fieldset>
+				</Spacer>
+			) }
+		</>
+	);
+}

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 				),
 			),
 			'typography' => array(
-				'fontSize'       => array(
+				'fontSize'           => array(
 					'property_keys' => array(
 						'default' => 'font-size',
 					),
@@ -261,7 +261,7 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 						'has-$slug-font-size' => 'font-size',
 					),
 				),
-				'fontFamily'     => array(
+				'fontFamily'         => array(
 					'property_keys' => array(
 						'default' => 'font-family',
 					),
@@ -273,55 +273,61 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 						'has-$slug-font-family' => 'font-family',
 					),
 				),
-				'fontStyle'      => array(
+				'fontStyle'          => array(
 					'property_keys' => array(
 						'default' => 'font-style',
 					),
 					'path'          => array( 'typography', 'fontStyle' ),
 				),
-				'fontWeight'     => array(
+				'fontWeight'         => array(
 					'property_keys' => array(
 						'default' => 'font-weight',
 					),
 					'path'          => array( 'typography', 'fontWeight' ),
 				),
-				'lineHeight'     => array(
+				'lineHeight'         => array(
 					'property_keys' => array(
 						'default' => 'line-height',
 					),
 					'path'          => array( 'typography', 'lineHeight' ),
 				),
-				'textColumns'    => array(
+				'textColumns'        => array(
 					'property_keys' => array(
 						'default' => 'column-count',
 					),
 					'path'          => array( 'typography', 'textColumns' ),
 				),
-				'textDecoration' => array(
+				'textColumnMinWidth' => array(
+					'property_keys' => array(
+						'default' => 'column-width',
+					),
+					'path'          => array( 'typography', 'textColumnMinWidth' ),
+				),
+				'textDecoration'     => array(
 					'property_keys' => array(
 						'default' => 'text-decoration',
 					),
 					'path'          => array( 'typography', 'textDecoration' ),
 				),
-				'textIndent'     => array(
+				'textIndent'         => array(
 					'property_keys' => array(
 						'default' => 'text-indent',
 					),
 					'path'          => array( 'typography', 'textIndent' ),
 				),
-				'textTransform'  => array(
+				'textTransform'      => array(
 					'property_keys' => array(
 						'default' => 'text-transform',
 					),
 					'path'          => array( 'typography', 'textTransform' ),
 				),
-				'letterSpacing'  => array(
+				'letterSpacing'      => array(
 					'property_keys' => array(
 						'default' => 'letter-spacing',
 					),
 					'path'          => array( 'typography', 'letterSpacing' ),
 				),
-				'writingMode'    => array(
+				'writingMode'        => array(
 					'property_keys' => array(
 						'default' => 'writing-mode',
 					),

--- a/packages/style-engine/src/styles/typography/index.ts
+++ b/packages/style-engine/src/styles/typography/index.ts
@@ -88,6 +88,18 @@ const textColumns = {
 	},
 };
 
+const textColumnMinWidth = {
+	name: 'textColumnMinWidth',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'typography', 'textColumnMinWidth' ],
+			'columnWidth'
+		);
+	},
+};
+
 const textDecoration = {
 	name: 'textDecoration',
 	generate: ( style: Style, options: StyleOptions ) => {
@@ -144,6 +156,7 @@ export default [
 	letterSpacing,
 	lineHeight,
 	textColumns,
+	textColumnMinWidth,
 	textDecoration,
 	textIndent,
 	textTransform,

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -64,6 +64,7 @@ export interface Style {
 		letterSpacing?: CSSProperties[ 'letterSpacing' ];
 		lineHeight?: CSSProperties[ 'lineHeight' ];
 		textColumns?: CSSProperties[ 'columnCount' ];
+		textColumnMinWidth?: CSSProperties[ 'columnWidth' ];
 		textDecoration?: CSSProperties[ 'textDecoration' ];
 		textTransform?: CSSProperties[ 'textTransform' ];
 		writingMode?: CSSProperties[ 'writingMode' ];


### PR DESCRIPTION
## What?

Related: #27118
Follow up to: #74656, #33587

Adds CSS `column-width` support to the existing `textColumns` block support, enabling responsive multi-column text layouts.

## Why?

The existing `textColumns` support only outputs `column-count`, which forces a fixed number of columns at all viewport widths. On narrow screens, columns become unreadably narrow or cause overflow. The CSS `column-width` property works together with `column-count` as a responsive pair -- `column-count` sets the maximum number of columns, and `column-width` sets the minimum width before the browser drops a column. This is the behavior described in #27118.

## How?

- Adds a new `textColumnMinWidth` style property to the JS and PHP style engines, mapping to the CSS `column-width` property.
- Registers the property in the theme.json CSS property mapping (`lib/class-wp-theme-json-gutenberg.php`).
- Adds the property to the block supports typography pipeline (`lib/block-supports/typography.php`).
- Creates a new `TextColumnsControl` component (`packages/block-editor/src/components/text-columns-control/`) that bundles column count and minimum width into a single `ToolsPanelItem`.
- When the user sets columns > 1, a default minimum width of `16em` is automatically applied. The user can adjust via S/M/L presets or switch to a custom value input with unit selection (em, rem, px).
- Resetting the Columns control clears both `column-count` and `column-width`.

## Testing Instructions

1. Create or open a post.
2. Add a Paragraph block with a large amount of text (several sentences).
3. In the Typography panel, enable the **Columns** control via the panel options menu if not already visible.
4. Set columns to **3**.
5. Confirm that the **Min Width** sub-control appears below with **M** selected by default.
6. Try each preset (S, M, L) and confirm the column layout adjusts in the editor.
7. Click the custom input button (sliders) next to "Min Width" to switch to custom input. Enter a value like `12em` and confirm it applies.
8. Click the custom input button again to switch back to presets. Confirm it snaps to **M** and the toggle group displays correctly.
9. Save the post and view the frontend. Resize the browser window or use Responsive Design mode in your browser and confirm columns reduce responsively on narrow viewports.
10. Reset the Columns control (via the panel options menu) and confirm both `column-count` and `column-width` are removed from the block's inline styles.

### Testing Instructions for Keyboard

1. Tab to the Columns number input in the Typography panel and set a value > 1.
2. Tab to the Min Width toggle group. Use arrow keys to select between S, M, L.
3. Tab to the settings icon button and press Enter/Space to toggle custom input.
4. Tab to the UnitControl input, type a value, and Tab to the unit selector to change units.
5. Press Enter/Space on the custom input button again to return to presets.
6. Confirm all interactions are reachable and operable via keyboard alone.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1454" height="772" alt="image" src="https://github.com/user-attachments/assets/69278c1a-ae5a-4383-89e2-eb5ff89f5565" /> | <img width="1451" height="775" alt="image" src="https://github.com/user-attachments/assets/f09730ad-42f2-428b-b9ca-d0aa31093969" /> | 
|Columns forced at all widths, broken on mobile | Columns adapt responsively based on min width|

## Changelog

- Typography: Add column-width (textColumnMinWidth) support to text columns block support.

## Use of AI Tools

Claude was used as a coding assistant throughout this PR for guidance on Gutenberg architecture, component patterns, debugging, and drafting code. All code was reviewed, tested, and manually integrated.