### PR TITLE
RTC: Fix stuck "Join" link in post list when lock expires

### DIFF
--- a/backport-changelog/7.0/11346.md
+++ b/backport-changelog/7.0/11346.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11346
+
+* https://github.com/WordPress/gutenberg/pull/76795

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -266,16 +266,17 @@ function gutenberg_post_list_collaboration_styles() {
 		}
 		/*
 		 * Toggle "Edit" / "Join" action link text based on lock state.
-		 * The heartbeat adds/removes .wp-collaborative-editing on the row,
-		 * so CSS handles the swap without needing JS to rewrite link text.
+		 * The heartbeat adds/removes .wp-locked on locked rows. This
+		 * CSS only runs when RTC is enabled, so .wp-locked here always
+		 * means collaborative editing, not exclusive locking.
 		 */
 		.join-action-text {
 			display: none;
 		}
-		.wp-collaborative-editing .edit-action-text {
+		.wp-locked .edit-action-text {
 			display: none;
 		}
-		.wp-collaborative-editing .join-action-text {
+		.wp-locked .join-action-text {
 			display: inline;
 		}
 	</style>

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -233,7 +233,8 @@ function gutenberg_filter_locked_posts_heartbeat_for_rtc( $response ) {
  *
  * Also re-enables checkboxes and row actions that WordPress core hides for
  * locked posts, since collaborative editing means the post is not exclusively
- * locked.
+ * locked. Toggles "Edit" / "Join" action link text via the
+ * `.wp-collaborative-editing` class that the heartbeat already manages.
  */
 function gutenberg_post_list_collaboration_styles() {
 	?>
@@ -260,6 +261,20 @@ function gutenberg_post_list_collaboration_styles() {
 		}
 		.wp-locked .row-actions .inline {
 			display: revert;
+		}
+		/*
+		 * Toggle "Edit" / "Join" action link text based on lock state.
+		 * The heartbeat adds/removes .wp-collaborative-editing on the row,
+		 * so CSS handles the swap without needing JS to rewrite link text.
+		 */
+		.join-action-text {
+			display: none;
+		}
+		.wp-collaborative-editing .edit-action-text {
+			display: none;
+		}
+		.wp-collaborative-editing .join-action-text {
+			display: inline;
 		}
 	</style>
 	<?php
@@ -288,30 +303,42 @@ function gutenberg_filter_locked_post_text_for_rtc( $translation, $text, $domain
 }
 
 /**
- * Filters post row actions to change "Edit" to "Join" for locked posts
+ * Filters post row actions to render both "Edit" and "Join" link text
  * when real-time collaboration is enabled.
+ *
+ * Both labels are always present in the markup; CSS toggles visibility
+ * based on the `.wp-collaborative-editing` class the heartbeat manages.
+ * This ensures the link text updates when the lock state changes without
+ * requiring a page reload.
  *
  * @param string[] $actions An array of row action links.
  * @param WP_Post  $post    The post object.
  * @return string[] Modified row action links.
  */
 function gutenberg_post_list_collaboration_row_actions( $actions, $post ) {
-	if ( ! function_exists( 'wp_check_post_lock' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/post.php';
-	}
-
-	$lock_holder = wp_check_post_lock( $post->ID );
-	if ( ! $lock_holder ) {
+	if ( ! isset( $actions['edit'] ) ) {
 		return $actions;
 	}
 
-	if ( isset( $actions['edit'] ) ) {
-		$actions['edit'] = preg_replace(
-			'/>Edit</',
-			'>' . esc_html__( 'Join', 'gutenberg' ) . '<',
-			$actions['edit']
-		);
-	}
+	$title = _draft_or_post_title( $post->ID );
+
+	$link_text  = '<span class="edit-action-text">';
+	$link_text .= '<span aria-hidden="true">' . __( 'Edit' ) . '</span>';
+	/* translators: %s: Post title. */
+	$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) . '</span>';
+	$link_text .= '</span>';
+	$link_text .= '<span class="join-action-text">';
+	/* translators: Action link text for a singular post in the post list. Can be any type of post. */
+	$link_text .= '<span aria-hidden="true">' . _x( 'Join', 'post list', 'gutenberg' ) . '</span>';
+	/* translators: %s: Post title. */
+	$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Join editing &#8220;%s&#8221;', 'gutenberg' ), $title ) . '</span>';
+	$link_text .= '</span>';
+
+	$actions['edit'] = sprintf(
+		'<a href="%s">%s</a>',
+		get_edit_post_link( $post->ID ),
+		$link_text
+	);
 
 	return $actions;
 }

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -324,22 +324,31 @@ function gutenberg_post_list_collaboration_row_actions( $actions, $post ) {
 
 	$title = _draft_or_post_title( $post->ID );
 
-	$link_text  = '<span class="edit-action-text">';
-	$link_text .= '<span aria-hidden="true">' . __( 'Edit' ) . '</span>';
-	/* translators: %s: Post title. */
-	$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) . '</span>';
-	$link_text .= '</span>';
-	$link_text .= '<span class="join-action-text">';
-	/* translators: Action link text for a singular post in the post list. Can be any type of post. */
-	$link_text .= '<span aria-hidden="true">' . _x( 'Join', 'post list', 'gutenberg' ) . '</span>';
-	/* translators: %s: Post title. */
-	$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Join editing &#8220;%s&#8221;', 'gutenberg' ), $title ) . '</span>';
-	$link_text .= '</span>';
-
+	/*
+	 * Both "Edit" and "Join" labels are rendered. The visible label is
+	 * toggled by CSS based on the row's `wp-collaborative-editing` class,
+	 * which is added or removed by inline-edit-post.js in response to
+	 * heartbeat ticks.
+	 */
 	$actions['edit'] = sprintf(
-		'<a href="%s">%s</a>',
+		'<a href="%1$s">'
+		. '<span class="edit-action-text">'
+		. '<span aria-hidden="true">%2$s</span>'
+		. '<span class="screen-reader-text">%3$s</span>'
+		. '</span>'
+		. '<span class="join-action-text">'
+		. '<span aria-hidden="true">%4$s</span>'
+		. '<span class="screen-reader-text">%5$s</span>'
+		. '</span>'
+		. '</a>',
 		get_edit_post_link( $post->ID ),
-		$link_text
+		__( 'Edit' ),
+		/* translators: %s: Post title. */
+		sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ),
+		/* translators: Action link text for a singular post in the post list. Can be any type of post. */
+		_x( 'Join', 'post list', 'gutenberg' ),
+		/* translators: %s: Post title. */
+		sprintf( __( 'Join editing &#8220;%s&#8221;', 'gutenberg' ), $title )
 	);
 
 	return $actions;

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -254,12 +254,14 @@ function gutenberg_post_list_collaboration_styles() {
 		/*
 		 * Re-enable controls that core hides for locked posts,
 		 * since RTC allows collaborative editing.
+		 * Must use `tr.wp-locked` to match core's specificity in
+		 * list-tables.css and actually override its `display: none`.
 		 */
-		.wp-locked .check-column label,
-		.wp-locked .check-column input[type="checkbox"] {
+		tr.wp-locked .check-column label,
+		tr.wp-locked .check-column input[type="checkbox"] {
 			display: revert;
 		}
-		.wp-locked .row-actions .inline {
+		tr.wp-locked .row-actions .inline {
 			display: revert;
 		}
 		/*


### PR DESCRIPTION
## What?

Fixes two post list issues when RTC is enabled:
1. The "Join" action link gets stuck after the post lock expires
2. Checkboxes are hidden on locked post rows

## Why?

PR #76322 conditionally rendered "Edit" or "Join" based on `wp_check_post_lock()` at page load. The heartbeat correctly clears the lock status text when the lock expires, but never updates the action link text back to "Edit".

Additionally, on WordPress < 7.0 (where the Gutenberg compat layer handles RTC), the CSS selectors that re-enable checkboxes on locked rows used `.wp-locked`, but core's `list-tables.css` uses `tr.wp-locked` which has higher specificity — so the override never took effect. This doesn't affect WordPress 7.0+ where the styles live directly in core's stylesheet with correct specificity.

## How?

- Always render both "Edit" and "Join" as separate `<span>` elements in the row action link
- Toggle visibility via CSS using the `.wp-locked` class the heartbeat already manages
- Replace `aria-label` with `screen-reader-text` spans so the accessible name stays in sync with the visible text across lock state changes
- Fix CSS specificity for checkbox and inline edit overrides by adding the `tr` element selector to match core's `tr.wp-locked`

Same approach as the corresponding WordPress core fix: WordPress/wordpress-develop#11346

## Testing Instructions

1. Enable RTC (Settings → Writing → Collaboration)
2. Log in as **User A** in one browser, open a post
3. Log in as **User B** in another browser, join the same post, then navigate to the Posts list
4. Verify the locked post shows "Join" link and "Currently being edited" text
5. Verify the checkbox is visible on the locked post row
6. Have **User A** leave the post
7. Wait for the lock to clear (~150s) on User B's post list
8. Verify "Currently being edited" text disappears and "Join" reverts to "Edit"
