### PR TITLE
Gallery: allow Image block drag-and-drop into empty Gallery

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -139,6 +139,7 @@ export function MediaPlaceholder( {
 	onDoubleClick,
 	onFilesPreUpload = noop,
 	onHTMLDrop: deprecatedOnHTMLDrop,
+	onBlocksDrop,
 	children,
 	mediaLibraryButton,
 	placeholder,
@@ -151,14 +152,18 @@ export function MediaPlaceholder( {
 		} );
 	}
 
-	const { mediaUpload, allowedMimeTypes } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return {
-			mediaUpload: settings.mediaUpload,
-			allowedMimeTypes: settings.allowedMimeTypes,
-		};
-	}, [] );
+	const { mediaUpload, allowedMimeTypes, getBlock } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const settings = getSettings();
+			return {
+				mediaUpload: settings.mediaUpload,
+				allowedMimeTypes: settings.allowedMimeTypes,
+				getBlock: select( blockEditorStore ).getBlock,
+			};
+		},
+		[]
+	);
 	const [ src, setSrc ] = useState( '' );
 
 	useEffect( () => {
@@ -247,14 +252,32 @@ export function MediaPlaceholder( {
 	};
 
 	async function handleBlocksDrop( event ) {
-		const { blocks } = parseDropEvent( event );
+		const { blocks, srcClientIds } = parseDropEvent( event );
+		let droppedBlocks = blocks;
 
-		if ( ! blocks?.length ) {
+		if ( ! droppedBlocks?.length && srcClientIds?.length ) {
+			droppedBlocks = srcClientIds
+				.map( ( clientId ) => getBlock( clientId ) )
+				.filter( Boolean );
+		}
+
+		if ( ! droppedBlocks?.length ) {
+			return;
+		}
+
+		if ( onBlocksDrop ) {
+			const { srcRootClientId, type } = parseDropEvent( event );
+			onBlocksDrop( {
+				blocks: droppedBlocks,
+				srcClientIds,
+				srcRootClientId,
+				type,
+			} );
 			return;
 		}
 
 		const uploadedMediaList = await Promise.all(
-			blocks.map( ( block ) => {
+			droppedBlocks.map( ( block ) => {
 				const blockType = block.name.split( '/' )[ 1 ];
 				if ( block.attributes.id ) {
 					block.attributes.type = blockType;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -165,6 +165,7 @@ export default function GalleryEdit( props ) {
 		replaceInnerBlocks,
 		updateBlockAttributes,
 		selectBlock,
+		moveBlocksToPosition,
 	} = useDispatch( blockEditorStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -438,6 +439,36 @@ export default function GalleryEdit( props ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
+	function onBlocksDrop( dropData ) {
+		const { blocks, srcClientIds, srcRootClientId } = dropData;
+		const imageBlocks = blocks.filter(
+			( block ) => block.name === 'core/image'
+		);
+		if ( ! imageBlocks.length ) {
+			return;
+		}
+
+		// If blocks are from the editor canvas (srcClientIds), move them instead of copying
+		if ( srcClientIds?.length && srcRootClientId !== clientId ) {
+			const galleryInnerBlockCount = innerBlockImages?.length ?? 0;
+			moveBlocksToPosition(
+				srcClientIds,
+				srcRootClientId,
+				clientId,
+				galleryInnerBlockCount
+			);
+			return;
+		}
+
+		// Otherwise, create new blocks from attributes (e.g., from media library)
+		updateImages(
+			imageBlocks.map( ( block ) => ( {
+				...block.attributes,
+				type: block.attributes.type || 'image',
+			} ) )
+		);
+	}
+
 	function setLinkTo( value ) {
 		setAttributes( { linkTo: value } );
 		const changedAttributes = {};
@@ -628,6 +659,7 @@ export default function GalleryEdit( props ) {
 			onSelect={ updateImages }
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			multiple
+			onBlocksDrop={ onBlocksDrop }
 			onError={ onUploadError }
 			{ ...mediaPlaceholderProps }
 		/>


### PR DESCRIPTION
## What?
Closes #72882

Allow dropping Image blocks into an empty Gallery placeholder, and preserve expected drag/drop behavior for both file uploads and in-editor block drags.

## Why?
The issue reports that once a Gallery becomes empty, users can upload/select images but cannot drag an existing Image block into it.  
This creates an inconsistent experience because non-empty Gallery accepts dropped Image blocks, but empty Gallery does not.

## How?
1. MediaPlaceholder drop handling now supports block-drop data from canvas drags, including cases where block data is represented by source client IDs.
2. MediaPlaceholder forwards structured block-drop context to Gallery through onBlocksDrop.
3. Gallery handles onBlocksDrop and:
    - accepts only core/image drops
    - moves dragged blocks from source canvas location into Gallery when source block IDs are present
    - appends at the end of Gallery inner blocks
    - falls back to attribute-based add path for non-canvas data scenarios
4. Existing file drag/drop upload behavior remains intact.

## Testing Instructions
1. Open a post/page in the editor.
2. Insert a Gallery block and add 2+ images.
3. Drag all images out of Gallery so Gallery becomes empty.
4. Drag an existing Image block from the canvas into the empty Gallery placeholder.
5. Confirm the drop is accepted and image appears inside Gallery.
6. Confirm the dragged Image block is removed from original canvas location (move behavior).
7. Drag another Image block into non-empty Gallery.
8. Confirm append behavior works.
9. Drag an image file from desktop/folder onto empty Gallery.
10. Confirm upload drop overlay and upload behavior still work.

### Testing Instructions for Keyboard
1. Tab to the Gallery block and ensure focus behavior is unchanged.
2. Trigger media upload/select controls via keyboard only.
3. Confirm no regression in keyboard access to placeholder controls and Gallery toolbar options.

## Screenshots or screencast

Before:

https://github.com/user-attachments/assets/77744ab9-c194-4617-b062-679715026f0e


After:

https://github.com/user-attachments/assets/789cf4d0-59ad-4b2e-8508-7cc55f0e2e00



## Use of AI Tools
Used AI assistance for code navigation, patch drafting, and PR text drafting.  
All generated changes were reviewed, adjusted, and validated manually.

