### PR TITLE
Tabs: Disable Duplicate button

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -60,6 +60,11 @@ export default function BlockActions( {
 					return (
 						!! block &&
 						hasBlockSupport( block.name, 'multiple', true ) &&
+						hasBlockSupport(
+							block.name,
+							'__experimentalDuplicate',
+							true
+						) &&
 						canInsertBlockType( block.name, rootClientId )
 					);
 				} ),

--- a/packages/block-library/src/tab-panel/block.json
+++ b/packages/block-library/src/tab-panel/block.json
@@ -16,6 +16,7 @@
 		"html": false,
 		"reusable": false,
 		"lock": false,
+		"__experimentalDuplicate": false,
 		"dimensions": {
 			"aspectRatio": false,
 			"height": false,

--- a/packages/block-library/src/tab/block.json
+++ b/packages/block-library/src/tab/block.json
@@ -23,6 +23,7 @@
 		"anchor": true,
 		"html": false,
 		"reusable": false,
+		"__experimentalDuplicate": false,
 		"color": {
 			"background": true,
 			"text": true,

--- a/packages/block-library/src/tabs-menu-item/block.json
+++ b/packages/block-library/src/tabs-menu-item/block.json
@@ -27,6 +27,7 @@
 		"html": false,
 		"reusable": false,
 		"lock": false,
+		"__experimentalDuplicate": false,
 		"color": {
 			"background": true,
 			"text": true,

--- a/packages/block-library/src/tabs-menu/block.json
+++ b/packages/block-library/src/tabs-menu/block.json
@@ -16,6 +16,7 @@
 		"html": false,
 		"reusable": false,
 		"lock": false,
+		"__experimentalDuplicate": false,
 		"dimensions": {
 			"aspectRatio": false,
 			"height": false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Alternative to https://github.com/WordPress/gutenberg/pull/76449
Follow-up to https://github.com/WordPress/gutenberg/pull/75954

<!-- In a few words, what is the PR actually doing? -->

Adds an `__experimentalDuplicate` block support flag and uses it to disable the "Duplicate" block action for Tabs-related blocks (`tab`, `tab-panel`, `tabs-menu`, `tabs-menu-item`).

I'm not sure if we need to include "experimental" in the name of this property, maybe just "duplicate" would be better. This would be similar to the "multiple" property (which controls whether more than one block instance can exist).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Duplicating individual Tabs inner blocks (tabs, tab panels, menu items) in isolation breaks the synchronised relationship between those components, i.e. a duplicated tab panel won't have a corresponding tab menu item, and vice versa. Disabling "Duplicate" for these blocks prevents an inconsistent state.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adds `__experimentalDuplicate` block support (defaults to true)
- Updates `BlockActions` to check this support flag before offering the duplicate action
- Sets `"__experimentalDuplicate": false` in block.json for `tab`, `tab-panel`, `tabs-menu`, and `tabs-menu-item`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Insert a Tabs block.
3. Select an individual Tab, Tab Panel, Tabs Menu, or Tabs Menu Item block.
4. Open the block toolbar or right-click context menu.
5. Verify the Duplicate option is not present for these blocks.
6. Select a different block (e.g., Paragraph or Heading).
7. Verify the Duplicate option is present for regular blocks.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

This PR was written with assistance from Claude Code. All code changes were reviewed by the author.
