### PR TITLE
Site Editor v2: Add missing menu items to navigation leaf more menu

### DIFF
--- a/routes/navigation-edit/editor/leaf-more-menu.tsx
+++ b/routes/navigation-edit/editor/leaf-more-menu.tsx
@@ -8,6 +8,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 // @ts-expect-error - No type declarations available for @wordpress/block-editor
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	hasBlockSupport,
+	store as blocksStore,
+	// @ts-expect-error - No type declarations available for @wordpress/blocks
+} from '@wordpress/blocks';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -18,11 +23,17 @@ export default function LeafMoreMenu( {
 	block,
 	...props
 }: {
-	block: { clientId: string };
+	block: { clientId: string; name: string };
 } ) {
 	const { clientId } = block;
-	const { moveBlocksDown, moveBlocksUp, removeBlocks } =
-		useDispatch( blockEditorStore );
+	const {
+		moveBlocksDown,
+		moveBlocksUp,
+		removeBlocks,
+		duplicateBlocks,
+		insertBeforeBlock,
+		insertAfterBlock,
+	} = useDispatch( blockEditorStore );
 
 	const removeLabel = sprintf(
 		/* translators: %s: block name */
@@ -30,14 +41,45 @@ export default function LeafMoreMenu( {
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 
-	const rootClientId = useSelect(
-		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
+	const { rootClientId, canDuplicate, canInsertBlock, isFirst, isLast } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockRootClientId,
+					canInsertBlockType,
+					getDirectInsertBlock,
+					getBlockIndex,
+					getBlockCount,
+				} = select( blockEditorStore );
+				const { getDefaultBlockName } = select( blocksStore );
 
-			return getBlockRootClientId( clientId );
-		},
-		[ clientId ]
-	);
+				const _rootClientId = getBlockRootClientId( clientId );
+				const canInsertDefaultBlock = canInsertBlockType(
+					getDefaultBlockName(),
+					_rootClientId
+				);
+				const directInsertBlock = _rootClientId
+					? getDirectInsertBlock( _rootClientId )
+					: null;
+
+				return {
+					rootClientId: _rootClientId,
+					canDuplicate:
+						!! block &&
+						hasBlockSupport( block.name, 'multiple', true ) &&
+						canInsertBlockType( block.name, _rootClientId ),
+					canInsertBlock:
+						( canInsertDefaultBlock || !! directInsertBlock ) &&
+						!! block &&
+						canInsertBlockType( block.name, _rootClientId ),
+					isFirst: getBlockIndex( clientId ) === 0,
+					isLast:
+						getBlockIndex( clientId ) ===
+						getBlockCount( _rootClientId ) - 1,
+				};
+			},
+			[ clientId, block ]
+		);
 
 	return (
 		<DropdownMenu
@@ -53,6 +95,8 @@ export default function LeafMoreMenu( {
 					<MenuGroup>
 						<MenuItem
 							icon={ chevronUp }
+							disabled={ isFirst }
+							accessibleWhenDisabled
 							onClick={ () => {
 								moveBlocksUp( [ clientId ], rootClientId );
 								onClose();
@@ -62,6 +106,8 @@ export default function LeafMoreMenu( {
 						</MenuItem>
 						<MenuItem
 							icon={ chevronDown }
+							disabled={ isLast }
+							accessibleWhenDisabled
 							onClick={ () => {
 								moveBlocksDown( [ clientId ], rootClientId );
 								onClose();
@@ -69,6 +115,36 @@ export default function LeafMoreMenu( {
 						>
 							{ __( 'Move down' ) }
 						</MenuItem>
+						{ canDuplicate && (
+							<MenuItem
+								onClick={ () => {
+									duplicateBlocks( [ clientId ] );
+									onClose();
+								} }
+							>
+								{ __( 'Duplicate' ) }
+							</MenuItem>
+						) }
+						{ canInsertBlock && (
+							<>
+								<MenuItem
+									onClick={ () => {
+										insertBeforeBlock( clientId );
+										onClose();
+									} }
+								>
+									{ __( 'Add before' ) }
+								</MenuItem>
+								<MenuItem
+									onClick={ () => {
+										insertAfterBlock( clientId );
+										onClose();
+									} }
+								>
+									{ __( 'Add after' ) }
+								</MenuItem>
+							</>
+						) }
 					</MenuGroup>
 					<MenuGroup>
 						<MenuItem


### PR DESCRIPTION
## What?

Follow up to #75979

Add missing menu items to the navigation edit LeafMoreMenu in the extensible site editor (site editor v2), matching the unification done in #75979 for the v1 site editor.

## Why?

PR #75979 unified the block settings dropdown menu items across list views in the current Site Editor, but the site editor v2 has its own `LeafMoreMenu` component (`routes/navigation-edit/editor/leaf-more-menu.tsx`) that was not updated. This leaves the v2 navigation editor with fewer menu options than the v1 editor.

## How?

Updated `routes/navigation-edit/editor/leaf-more-menu.tsx` to:
- Add **Duplicate** menu item (when the block supports duplication)
- Add **Add before** and **Add after** menu items (when block insertion is allowed)
- Add `disabled` + `accessibleWhenDisabled` props to **Move up** / **Move down** based on position (first/last item)
- Expand `useSelect` to compute `canDuplicate`, `canInsertBlock`, `isFirst`, `isLast`
- Add `duplicateBlocks`, `insertBeforeBlock`, `insertAfterBlock` dispatch actions

## Testing Instructions

1. Enable the **Extensible Site Editor** experiment in Gutenberg settings
2. Go to Appearance → Design → Navigation
3. Edit a navigation menu
4. Click the block settings menu (•••) on a navigation link
5. Verify it shows: Move up, Move down, Duplicate, Add before, Add after, and Remove
6. Verify Move up is disabled on the first item and Move down is disabled on the last item

### Testing Instructions for Keyboard

1. Follow the steps above using Tab/Shift+Tab to navigate to the ••• menu button
2. Press Enter/Space to open the menu
3. Use arrow keys to navigate menu items
4. Verify disabled items (Move up on first, Move down on last) are focusable but not activatable

### Screenshots
<img width="379" height="346" alt="Screenshot 2026-03-25 at 17 15 52" src="https://github.com/user-attachments/assets/f5350261-5991-4256-8877-9e4cff9f11a9" />
