### PR TITLE
Core Data: remove offset param from stableKey, use pagination logic

### DIFF
--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -15,14 +15,11 @@ import { withWeakMapCache, getNormalizedCommaSeparable } from '../utils';
  *
  * @property {number}      page      The query page (1-based index, default 1).
  * @property {number}      perPage   Items per page for query (default 10).
- * @property {?number}     offset    Absolute item offset (default undefined).
- * @property {string}      stableKey An encoded stable string of all non-
- *                                   pagination, non-fields query parameters.
- * @property {?(string[])} fields    Target subset of fields to derive from
- *                                   item objects.
- * @property {?(number[])} include   Specific item IDs to include.
- * @property {string}      context   Scope under which the request is made;
- *                                   determines returned fields in response.
+ * @property {?number}     offset    Absolute item offset (default null).
+ * @property {string}      stableKey An encoded stable string of all non-pagination, non-fields query parameters.
+ * @property {?(string[])} fields    Target subset of fields to derive from item objects (default null).
+ * @property {?(number[])} include   Specific item IDs to include (default null).
+ * @property {string}      context   Scope under which the request is made; determines returned fields in response.
  */
 
 /**

--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -65,21 +65,19 @@ export function getQueryParts( query ) {
 				parts.perPage = Number( value );
 				break;
 
+			case 'offset': {
+				const numericOffset = Number( value );
+				if ( Number.isFinite( numericOffset ) ) {
+					parts.offset = numericOffset;
+				}
+				break;
+			}
+
 			case 'context':
 				parts.context = value;
 				break;
 
 			default:
-				// Extract offset for use in pagination calculations while
-				// still including it in the stableKey (different offsets
-				// produce different result sets).
-				if ( key === 'offset' ) {
-					const numericOffset = Number( value );
-					if ( Number.isFinite( numericOffset ) ) {
-						parts.offset = numericOffset;
-					}
-				}
-
 				// While in theory, we could exclude "_fields" from the stableKey
 				// because two request with different fields have the same results
 				// We're not able to ensure that because the server can decide to omit

--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -15,8 +15,7 @@ import { withWeakMapCache, getNormalizedCommaSeparable } from '../utils';
  *
  * @property {number}      page      The query page (1-based index, default 1).
  * @property {number}      perPage   Items per page for query (default 10).
- * @property {number}      offset    Absolute item offset (default undefined).
- *                                   When present, also encoded into stableKey.
+ * @property {?number}     offset    Absolute item offset (default undefined).
  * @property {string}      stableKey An encoded stable string of all non-
  *                                   pagination, non-fields query parameters.
  * @property {?(string[])} fields    Target subset of fields to derive from
@@ -43,7 +42,7 @@ export function getQueryParts( query ) {
 		stableKey: '',
 		page: 1,
 		perPage: 10,
-		offset: undefined,
+		offset: null,
 		fields: null,
 		include: null,
 		context: 'default',

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -30,31 +30,31 @@ function getContextFromAction( action ) {
  * Returns a merged array of item IDs, given details of the received paginated
  * items. The array is sparse-like with `undefined` entries where holes exist.
  *
- * @param {?Array<number>}   itemIds     Original item IDs (default empty array).
- * @param {number[]}         nextItemIds Item IDs to merge.
- * @param {number}           page        Page of items merged.
- * @param {number|undefined} offset      Offset of items merged.
- * @param {number}           perPage     Number of items per page.
+ * @param {number[]|undefined} itemIds          Original item IDs (default empty array).
+ * @param {number[]}           nextItemIds      Item IDs to merge.
+ * @param {Object}             options          Options object.
+ * @param {number}             [options.page]   Page of items merged.
+ * @param {number}             [options.offset] Offset of items merged.
+ * @param {number}             options.perPage  Number of items per page.
  *
  * @return {number[]} Merged array of item IDs.
  */
 export function getMergedItemIds(
-	itemIds,
+	itemIds = [],
 	nextItemIds,
-	page,
-	offset,
-	perPage
+	{ page, offset, perPage } = {}
 ) {
-	const receivedAllIds = ( page === 1 || offset === 0 ) && perPage === -1;
-	if ( receivedAllIds ) {
+	// If the query is unbounded, then `nextItemIds` is a complete replacement.
+	if ( perPage === -1 ) {
 		return nextItemIds;
 	}
-	const nextItemIdsStartIndex = offset ?? ( page - 1 ) * perPage;
+
+	const nextItemIdsStartIndex = offset ?? ( ( page ?? 1 ) - 1 ) * perPage;
 
 	// If later page has already been received, default to the larger known
 	// size of the existing array, else calculate as extending the existing.
 	const size = Math.max(
-		itemIds?.length ?? 0,
+		itemIds.length,
 		nextItemIdsStartIndex + nextItemIds.length
 	);
 
@@ -67,9 +67,11 @@ export function getMergedItemIds(
 		// a page could receive fewer than what was previously stored.
 		const isInNextItemsRange =
 			i >= nextItemIdsStartIndex && i < nextItemIdsStartIndex + perPage;
-		mergedItemIds[ i ] = isInNextItemsRange
-			? nextItemIds[ i - nextItemIdsStartIndex ]
-			: itemIds?.[ i ];
+		if ( isInNextItemsRange ) {
+			mergedItemIds[ i ] = nextItemIds[ i - nextItemIdsStartIndex ];
+		} else {
+			mergedItemIds[ i ] = itemIds[ i ];
+		}
 	}
 
 	return mergedItemIds;
@@ -251,11 +253,13 @@ const receiveQueries = compose( [
 
 	return {
 		itemIds: getMergedItemIds(
-			state?.itemIds || [],
+			state.itemIds,
 			action.items.map( ( item ) => item?.[ key ] ).filter( Boolean ),
-			action.page,
-			action.offset,
-			action.perPage
+			{
+				page: action.page,
+				offset: action.offset,
+				perPage: action.perPage,
+			}
 		),
 		meta: action.meta,
 	};

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -30,19 +30,26 @@ function getContextFromAction( action ) {
  * Returns a merged array of item IDs, given details of the received paginated
  * items. The array is sparse-like with `undefined` entries where holes exist.
  *
- * @param {?Array<number>} itemIds     Original item IDs (default empty array).
- * @param {number[]}       nextItemIds Item IDs to merge.
- * @param {number}         page        Page of items merged.
- * @param {number}         perPage     Number of items per page.
+ * @param {?Array<number>}   itemIds     Original item IDs (default empty array).
+ * @param {number[]}         nextItemIds Item IDs to merge.
+ * @param {number}           page        Page of items merged.
+ * @param {number|undefined} offset      Offset of items merged.
+ * @param {number}           perPage     Number of items per page.
  *
  * @return {number[]} Merged array of item IDs.
  */
-export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
-	const receivedAllIds = page === 1 && perPage === -1;
+export function getMergedItemIds(
+	itemIds,
+	nextItemIds,
+	page,
+	offset,
+	perPage
+) {
+	const receivedAllIds = ( page === 1 || offset === 0 ) && perPage === -1;
 	if ( receivedAllIds ) {
 		return nextItemIds;
 	}
-	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
+	const nextItemIdsStartIndex = offset ?? ( page - 1 ) * perPage;
 
 	// If later page has already been received, default to the larger known
 	// size of the existing array, else calculate as extending the existing.
@@ -247,6 +254,7 @@ const receiveQueries = compose( [
 			state?.itemIds || [],
 			action.items.map( ( item ) => item?.[ key ] ).filter( Boolean ),
 			action.page,
+			action.offset,
 			action.perPage
 		),
 		meta: action.meta,

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -42,14 +42,15 @@ function getContextFromAction( action ) {
 export function getMergedItemIds(
 	itemIds = [],
 	nextItemIds,
-	{ page, offset, perPage } = {}
+	// The defaults for `page` and `perPage` are the same as in `getQueryParts`.
+	{ page = 1, offset, perPage = 10 } = {}
 ) {
 	// If the query is unbounded, then `nextItemIds` is a complete replacement.
 	if ( perPage === -1 ) {
 		return nextItemIds;
 	}
 
-	const nextItemIdsStartIndex = offset ?? ( ( page ?? 1 ) - 1 ) * perPage;
+	const nextItemIdsStartIndex = offset ?? ( page - 1 ) * perPage;
 
 	// If later page has already been received, default to the larger known
 	// size of the existing array, else calculate as extending the existing.

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -47,7 +47,8 @@ function getQueriedItemsUncached( state, query ) {
 		return null;
 	}
 
-	const startOffset = perPage === -1 ? 0 : ( page - 1 ) * perPage;
+	const startOffset =
+		perPage === -1 ? 0 : queryOffset ?? ( page - 1 ) * perPage;
 	const endOffset =
 		perPage === -1
 			? itemIds.length
@@ -59,19 +60,8 @@ function getQueriedItemsUncached( state, query ) {
 	if ( perPage !== -1 && itemIds.length < startOffset + perPage ) {
 		const totalItems =
 			state.queries[ context ][ stableKey ].meta?.totalItems;
-		if ( Number.isFinite( totalItems ) ) {
-			// For offset-based queries, totalItems (from X-WP-Total)
-			// reflects the global count of all matching items, not the
-			// count remaining after the offset. The number of items
-			// available for this query is (totalItems - offset), so a
-			// partial last page is expected and valid.
-			const effectiveTotal =
-				queryOffset !== undefined
-					? totalItems - queryOffset
-					: totalItems;
-			if ( itemIds.length < effectiveTotal ) {
-				return null;
-			}
+		if ( Number.isFinite( totalItems ) && itemIds.length < totalItems ) {
+			return null;
 		}
 	}
 

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -124,7 +124,7 @@ describe( 'getQueryParts', () => {
 		} );
 	} );
 
-	it( 'extracts offset and includes it in stableKey', () => {
+	it( 'extracts offset and excludes it from stableKey', () => {
 		const parts = getQueryParts( {
 			per_page: 50,
 			offset: 100,
@@ -135,7 +135,7 @@ describe( 'getQueryParts', () => {
 			page: 1,
 			perPage: 50,
 			offset: 100,
-			stableKey: 'offset=100',
+			stableKey: '',
 			fields: null,
 			include: null,
 		} );

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -11,7 +11,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 2,
 			perPage: 2,
-			offset: undefined,
+			offset: null,
 			stableKey: '',
 			fields: null,
 			include: null,
@@ -29,7 +29,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: 10,
-			offset: undefined,
+			offset: null,
 			stableKey: 'include=1',
 			fields: null,
 			include: [ 1 ],
@@ -45,7 +45,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: 10,
-			offset: undefined,
+			offset: null,
 			stableKey: '%3F=%26&b=2',
 			fields: null,
 			include: null,
@@ -59,7 +59,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: 10,
-			offset: undefined,
+			offset: null,
 			stableKey: 'a%5B0%5D=1&a%5B1%5D=2',
 			fields: null,
 			include: null,
@@ -75,7 +75,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: 10,
-			offset: undefined,
+			offset: null,
 			stableKey: 'b=2',
 			fields: null,
 			include: null,
@@ -89,7 +89,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: -1,
-			offset: undefined,
+			offset: null,
 			stableKey: 'b=2',
 			fields: null,
 			include: null,
@@ -103,7 +103,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: 10,
-			offset: undefined,
+			offset: null,
 			stableKey: '_fields=id%2Ctitle',
 			fields: [ 'id', 'title' ],
 			include: null,
@@ -116,7 +116,7 @@ describe( 'getQueryParts', () => {
 		expect( parts ).toEqual( {
 			page: 1,
 			perPage: 10,
-			offset: undefined,
+			offset: null,
 			stableKey: '',
 			include: null,
 			fields: null,
@@ -147,6 +147,6 @@ describe( 'getQueryParts', () => {
 			offset: 'abc',
 		} );
 
-		expect( parts.offset ).toBeUndefined();
+		expect( parts.offset ).toBeNull();
 	} );
 } );

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -222,6 +222,51 @@ describe( 'reducer', () => {
 		} );
 	} );
 
+	it( 'receives a sparse subset of items at given offsets', () => {
+		const original = deepFreeze( {
+			items: { default: {} },
+			queries: {},
+			itemIsComplete: { default: {} },
+		} );
+		const state = [
+			{
+				type: 'RECEIVE_ITEMS',
+				query: { offset: 1, per_page: 2 },
+				items: [
+					{ id: 2, name: 'def' },
+					{ id: 3, name: 'ghi' },
+				],
+			},
+			{
+				type: 'RECEIVE_ITEMS',
+				query: { offset: 4, per_page: 2 },
+				items: [
+					{ id: 5, name: 'mno' },
+					{ id: 6, name: 'pqr' },
+				],
+			},
+		].reduce( reducer, original );
+
+		expect( state ).toEqual( {
+			items: {
+				default: {
+					2: { id: 2, name: 'def' },
+					3: { id: 3, name: 'ghi' },
+					5: { id: 5, name: 'mno' },
+					6: { id: 6, name: 'pqr' },
+				},
+			},
+			itemIsComplete: {
+				default: { 2: true, 3: true, 5: true, 6: true },
+			},
+			queries: {
+				default: {
+					'': { itemIds: [ undefined, 2, 3, undefined, 5, 6 ] },
+				},
+			},
+		} );
+	} );
+
 	it( 'deletes an item', () => {
 		const kind = 'root';
 		const name = 'menu';

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -11,7 +11,10 @@ import { removeItems } from '../actions';
 
 describe( 'getMergedItemIds', () => {
 	it( 'should receive a page', () => {
-		const result = getMergedItemIds( [], [ 4, 5, 6 ], 2, undefined, 3 );
+		const result = getMergedItemIds( [], [ 4, 5, 6 ], {
+			page: 2,
+			perPage: 3,
+		} );
 
 		expect( result ).toEqual( [
 			undefined,
@@ -32,64 +35,68 @@ describe( 'getMergedItemIds', () => {
 			5,
 			6,
 		] );
-		const result = getMergedItemIds(
-			original,
-			[ 1, 2, 3 ],
-			1,
-			undefined,
-			3
-		);
+		const result = getMergedItemIds( original, [ 1, 2, 3 ], {
+			page: 1,
+			perPage: 3,
+		} );
 
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6 ] );
 	} );
 
 	it( 'should replace with new page', () => {
 		const original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
-		const result = getMergedItemIds(
-			original,
-			[ 'replaced', 5, 6 ],
-			2,
-			undefined,
-			3
-		);
+		const result = getMergedItemIds( original, [ 'replaced', 5, 6 ], {
+			page: 2,
+			perPage: 3,
+		} );
 
 		expect( result ).toEqual( [ 1, 2, 3, 'replaced', 5, 6 ] );
 	} );
 
 	it( 'should append a new partial page', () => {
 		const original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
-		const result = getMergedItemIds( original, [ 7 ], 3, undefined, 3 );
+		const result = getMergedItemIds( original, [ 7 ], {
+			page: 3,
+			perPage: 3,
+		} );
 
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 	} );
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const result = getMergedItemIds( original, [ 1, 3 ], 1, undefined, -1 );
+		const result = getMergedItemIds( original, [ 1, 3 ], {
+			page: 1,
+			perPage: -1,
+		} );
 
 		expect( result ).toEqual( [ 1, 3 ] );
 	} );
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const result = getMergedItemIds(
-			original,
-			[ 1, 3, 4 ],
-			1,
-			undefined,
-			-1
-		);
+		const result = getMergedItemIds( original, [ 1, 3, 4 ], {
+			page: 1,
+			perPage: -1,
+		} );
 
 		expect( result ).toEqual( [ 1, 3, 4 ] );
 	} );
+
 	it( 'should update a page properly if less items are provided than previously stored', () => {
 		let original = deepFreeze( [ 1, 2, 3 ] );
-		let result = getMergedItemIds( original, [ 1, 2 ], 1, undefined, 3 );
+		let result = getMergedItemIds( original, [ 1, 2 ], {
+			page: 1,
+			perPage: 3,
+		} );
 
 		expect( result ).toEqual( [ 1, 2 ] );
 
 		original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
-		result = getMergedItemIds( original, [ 9 ], 2, undefined, 2 );
+		result = getMergedItemIds( original, [ 9 ], {
+			page: 2,
+			perPage: 2,
+		} );
 
 		expect( result ).toEqual( [ 1, 2, 9, undefined, 5, 6 ] );
 	} );

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -11,7 +11,7 @@ import { removeItems } from '../actions';
 
 describe( 'getMergedItemIds', () => {
 	it( 'should receive a page', () => {
-		const result = getMergedItemIds( [], [ 4, 5, 6 ], 2, 3 );
+		const result = getMergedItemIds( [], [ 4, 5, 6 ], 2, undefined, 3 );
 
 		expect( result ).toEqual( [
 			undefined,
@@ -32,46 +32,64 @@ describe( 'getMergedItemIds', () => {
 			5,
 			6,
 		] );
-		const result = getMergedItemIds( original, [ 1, 2, 3 ], 1, 3 );
+		const result = getMergedItemIds(
+			original,
+			[ 1, 2, 3 ],
+			1,
+			undefined,
+			3
+		);
 
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6 ] );
 	} );
 
 	it( 'should replace with new page', () => {
 		const original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
-		const result = getMergedItemIds( original, [ 'replaced', 5, 6 ], 2, 3 );
+		const result = getMergedItemIds(
+			original,
+			[ 'replaced', 5, 6 ],
+			2,
+			undefined,
+			3
+		);
 
 		expect( result ).toEqual( [ 1, 2, 3, 'replaced', 5, 6 ] );
 	} );
 
 	it( 'should append a new partial page', () => {
 		const original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
-		const result = getMergedItemIds( original, [ 7 ], 3, 3 );
+		const result = getMergedItemIds( original, [ 7 ], 3, undefined, 3 );
 
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 	} );
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
+		const result = getMergedItemIds( original, [ 1, 3 ], 1, undefined, -1 );
 
 		expect( result ).toEqual( [ 1, 3 ] );
 	} );
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const result = getMergedItemIds( original, [ 1, 3, 4 ], 1, -1 );
+		const result = getMergedItemIds(
+			original,
+			[ 1, 3, 4 ],
+			1,
+			undefined,
+			-1
+		);
 
 		expect( result ).toEqual( [ 1, 3, 4 ] );
 	} );
 	it( 'should update a page properly if less items are provided than previously stored', () => {
 		let original = deepFreeze( [ 1, 2, 3 ] );
-		let result = getMergedItemIds( original, [ 1, 2 ], 1, 3 );
+		let result = getMergedItemIds( original, [ 1, 2 ], 1, undefined, 3 );
 
 		expect( result ).toEqual( [ 1, 2 ] );
 
 		original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
-		result = getMergedItemIds( original, [ 9 ], 2, 2 );
+		result = getMergedItemIds( original, [ 9 ], 2, undefined, 2 );
 
 		expect( result ).toEqual( [ 1, 2, 9, undefined, 5, 6 ] );
 	} );

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -286,13 +286,10 @@ describe( 'getQueriedItems', () => {
 			queries: {
 				default: {
 					'': {
-						itemIds: getMergedItemIds(
-							[],
-							[ 101, 102, 103 ],
-							undefined,
-							100,
-							50
-						),
+						itemIds: getMergedItemIds( [], [ 101, 102, 103 ], {
+							offset: 100,
+							perPage: 50,
+						} ),
 						meta: { totalItems: 103 },
 					},
 				},
@@ -322,13 +319,10 @@ describe( 'getQueriedItems', () => {
 			queries: {
 				default: {
 					'': {
-						itemIds: getMergedItemIds(
-							[],
-							[ 51, 52 ],
-							undefined,
-							50,
-							50
-						),
+						itemIds: getMergedItemIds( [], [ 51, 52 ], {
+							offset: 50,
+							perPage: 50,
+						} ),
 						meta: { totalItems: 200 },
 					},
 				},
@@ -362,13 +356,10 @@ describe( 'getQueriedItems', () => {
 			queries: {
 				default: {
 					'': {
-						itemIds: getMergedItemIds(
-							[],
-							[ 4, 5, 6, 7, 8 ],
-							undefined,
-							3,
-							10
-						),
+						itemIds: getMergedItemIds( [], [ 4, 5, 6, 7, 8 ], {
+							offset: 3,
+							perPage: 10,
+						} ),
 						meta: { totalItems: 50 },
 					},
 				},
@@ -428,7 +419,10 @@ describe( 'getQueriedItems', () => {
 			queries: {
 				default: {
 					'': {
-						itemIds: getMergedItemIds( [], [], undefined, 84, 7 ),
+						itemIds: getMergedItemIds( [], [], {
+							offset: 84,
+							perPage: 7,
+						} ),
 						meta: { totalItems: 84 },
 					},
 				},

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getQueriedItems } from '../selectors';
+import { getMergedItemIds } from '../reducer';
 
 describe( 'getQueriedItems', () => {
 	it( 'should return null if requesting but no item IDs', () => {
@@ -284,8 +285,14 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'offset=100': {
-						itemIds: [ 101, 102, 103 ],
+					'': {
+						itemIds: getMergedItemIds(
+							[],
+							[ 101, 102, 103 ],
+							undefined,
+							100,
+							50
+						),
 						meta: { totalItems: 103 },
 					},
 				},
@@ -314,8 +321,14 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'offset=50': {
-						itemIds: [ 51, 52 ],
+					'': {
+						itemIds: getMergedItemIds(
+							[],
+							[ 51, 52 ],
+							undefined,
+							50,
+							50
+						),
 						meta: { totalItems: 200 },
 					},
 				},
@@ -348,8 +361,14 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'offset=3': {
-						itemIds: [ 4, 5, 6, 7, 8 ],
+					'': {
+						itemIds: getMergedItemIds(
+							[],
+							[ 4, 5, 6, 7, 8 ],
+							undefined,
+							3,
+							10
+						),
 						meta: { totalItems: 50 },
 					},
 				},
@@ -379,7 +398,7 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'offset=0': {
+					'': {
 						itemIds: [ 1, 2 ],
 						meta: { totalItems: 5 },
 					},
@@ -408,8 +427,8 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'offset=84': {
-						itemIds: [],
+					'': {
+						itemIds: getMergedItemIds( [], [], undefined, 84, 7 ),
 						meta: { totalItems: 84 },
 					},
 				},


### PR DESCRIPTION
Followup to #76613 that removes `offset` from `stableKey` and treats it as a new pagination parameter, on par with `page` and `per_page`. The query results for different offsets are merged into one big array with `getMergedItemIds`.

I'm not sure how to test it. There are unit tests, but they test isolated parts of the entire process (the selectors, the reducer). @andrewserong Do we already have a UI feature that uses the infinite scroll with `offset`, so that it could be tested there, end to end?
