### PR TITLE
RTC: Remove stale wp_enable_real_time_collaboration option check

### DIFF
--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -146,12 +146,6 @@ function gutenberg_inject_real_time_collaboration_setting() {
 		return;
 	}
 
-	// Temporary check to bridge the short time when this is change is merged in
-	// Gutenberg but not in core.
-	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
-		return;
-	}
-
 	// Disable real-time collaboration on the site editor.
 	$enabled = true;
 	if (

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -448,10 +448,6 @@ export async function setCollaboration(
 
 	formData[ optionName ] = optionValue;
 
-	// Temporary addition to bridge the short time when this is change is merged in
-	// Gutenberg but not in core.
-	formData.wp_enable_real_time_collaboration = optionValue;
-
 	await requestUtils.request.post( '/wp-admin/options.php', {
 		form: formData,
 		failOnStatusCode: true,


### PR DESCRIPTION
## What?

Removes the stale `wp_enable_real_time_collaboration` option check that prevents collaborative editing from working.

## Why?

The migration in `lib/upgrade.php` deletes the old `wp_enable_real_time_collaboration` option and consolidates into `wp_collaboration_enabled`. But `gutenberg_inject_real_time_collaboration_setting()` still gates on the deleted option, so `window._wpCollaborationEnabled` is never set. This causes the editor to show the post lock takeover modal instead of starting a collaborative session.

## How?

- Remove the stale `get_option( 'wp_enable_real_time_collaboration' )` check from `collaboration.php`. The first check on `wp_collaboration_enabled` is sufficient.
- Remove the matching line in the e2e test helper that was also setting the deleted option.

## Testing Instructions

1. Enable RTC (Settings > Writing > Collaboration)
2. Log in as **User A** in one browser, open a post
3. Log in as **User B** in another browser, open the same post
4. Verify **User B** enters a collaborative session (no post lock takeover modal)
5. Disable RTC and verify the classic lock modal appears again

### Testing Instructions for Keyboard

No UI changes. The fix affects whether the lock modal or collaboration session is started.
