### PR TITLE
Post Featured Image: Add UI toggle for using first image from post

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -245,7 +245,10 @@ export default function PostFeaturedImageEdit( {
 					media={ media }
 				/>
 			</InspectorControls>
-			{ ( featuredImage || isDescendentOfQueryLoop || ! postId || ! storedFeaturedImage ) && (
+			{ ( featuredImage || 
+                isDescendentOfQueryLoop || 
+                ! postId || 
+                ! storedFeaturedImage ) && (
 				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -258,6 +258,7 @@ export default function PostFeaturedImageEdit( {
 								linkTarget: '_self',
 								rel: '',
 								sizeSlug: DEFAULT_MEDIA_SIZE_SLUG,
+								useFirstImageFromPost: false,
 							} );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -245,7 +245,7 @@ export default function PostFeaturedImageEdit( {
 					media={ media }
 				/>
 			</InspectorControls>
-			{ ( featuredImage || isDescendentOfQueryLoop || ! postId ) && (
+			{ ( featuredImage || isDescendentOfQueryLoop || ! postId || ! storedFeaturedImage ) && (
 				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }
@@ -357,6 +357,32 @@ export default function PostFeaturedImageEdit( {
 									setAttributes( { sizeSlug: nextSizeSlug } )
 								}
 							/>
+						) }
+						{ ! storedFeaturedImage && (
+							<ToolsPanelItem
+								label={ __( 'Use first image from post' ) }
+								isShownByDefault
+								hasValue={ () => !! useFirstImageFromPost }
+								onDeselect={ () =>
+									setAttributes( {
+										useFirstImageFromPost: false,
+									} )
+								}
+							>
+								<ToggleControl
+									label={ __( 'Use first image from post' ) }
+									help={ __(
+										'Use the first image in the post content as the featured image.'
+									) }
+									onChange={ () =>
+										setAttributes( {
+											useFirstImageFromPost:
+												! useFirstImageFromPost,
+										} )
+									}
+									checked={ useFirstImageFromPost }
+								/>
+							</ToolsPanelItem>
 						) }
 					</ToolsPanel>
 				</InspectorControls>

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -245,10 +245,10 @@ export default function PostFeaturedImageEdit( {
 					media={ media }
 				/>
 			</InspectorControls>
-			{ ( featuredImage || 
-                isDescendentOfQueryLoop || 
-                ! postId || 
-                ! storedFeaturedImage ) && (
+			{ ( featuredImage ||
+				isDescendentOfQueryLoop ||
+				! postId ||
+				! storedFeaturedImage ) && (
 				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -364,7 +364,9 @@ export default function PostFeaturedImageEdit( {
 						) }
 						{ ! storedFeaturedImage && (
 							<ToolsPanelItem
-								label={ __( 'Feature the first image from the post' ) }
+								label={ __(
+									'Feature the first image from the post'
+								) }
 								isShownByDefault
 								hasValue={ () => !! useFirstImageFromPost }
 								onDeselect={ () =>
@@ -374,7 +376,9 @@ export default function PostFeaturedImageEdit( {
 								}
 							>
 								<ToggleControl
-									label={ __( 'Feature the first image from the post' ) }
+									label={ __(
+										'Feature the first image from the post'
+									) }
 									help={ __(
 										'Use the first image in the post content as the featured image if no featured image is set.'
 									) }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -365,7 +365,7 @@ export default function PostFeaturedImageEdit( {
 						{ ! storedFeaturedImage && (
 							<ToolsPanelItem
 								label={ __(
-									'Feature the first image from the post'
+									'Feature the first image'
 								) }
 								isShownByDefault
 								hasValue={ () => !! useFirstImageFromPost }
@@ -377,10 +377,10 @@ export default function PostFeaturedImageEdit( {
 							>
 								<ToggleControl
 									label={ __(
-										'Feature the first image from the post'
+										'Feature the first image'
 									) }
 									help={ __(
-										'Use the first image in the post content as the featured image if no featured image is set.'
+										'Use the first image in the post content as the featured image.'
 									) }
 									onChange={ () =>
 										setAttributes( {

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -363,7 +363,7 @@ export default function PostFeaturedImageEdit( {
 						) }
 						{ ! storedFeaturedImage && (
 							<ToolsPanelItem
-								label={ __( 'Use first image from post' ) }
+								label={ __( 'Feature the first image from the post' ) }
 								isShownByDefault
 								hasValue={ () => !! useFirstImageFromPost }
 								onDeselect={ () =>
@@ -373,9 +373,9 @@ export default function PostFeaturedImageEdit( {
 								}
 							>
 								<ToggleControl
-									label={ __( 'Use first image from post' ) }
+									label={ __( 'Feature the first image from the post' ) }
 									help={ __(
-										'Use the first image in the post content as the featured image.'
+										'Use the first image in the post content as the featured image if no featured image is set.'
 									) }
 									onChange={ () =>
 										setAttributes( {

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -362,7 +362,7 @@ export default function PostFeaturedImageEdit( {
 								}
 							/>
 						) }
-						{ ! storedFeaturedImage && (
+						{ isDescendentOfQueryLoop && ! storedFeaturedImage && (
 							<ToolsPanelItem
 								label={ __(
 									'Feature the first image'


### PR DESCRIPTION
## What?

Follow up to #56573

Adds a UI toggle to the Post Featured Image block for the `useFirstImageFromPost` attribute that was added in #56573 but not exposed in the editor.

## Why?

PR #56573 added the ability to fall back to the first image in a post's content when no featured image is set, but the setting was only available by editing block markup directly. This makes the feature discoverable and usable from the block's settings panel.

## How?

- Added a "Use first image from post" `ToggleControl` inside a `ToolsPanelItem` in the block's inspector settings panel.
- The toggle is only shown when no featured image is explicitly set (`!storedFeaturedImage`), since it's a fallback behavior.
- Removed the conditional that hid the entire settings panel when no image was present, so the toggle is accessible even before a featured image is assigned.
- Added `useFirstImageFromPost` to the panel's `resetAll` handler.

## Testing Instructions

1. Create a new post and add an Image block with an image.
2. Add a Post Featured Image block (e.g., via the Site Editor in a template).
3. Do **not** set a featured image on the post.
4. Select the Post Featured Image block and open the Settings panel in the sidebar.
5. Verify the "Use first image from post" toggle is visible.
6. Enable the toggle — the first image from the post content should now appear as the featured image.
7. Set an actual featured image on the post — the toggle should disappear from the settings panel.
8. Remove the featured image — the toggle should reappear.

### Testing Instructions for Keyboard

1. Tab to the Post Featured Image block to select it.
2. Use the keyboard to navigate to the Settings panel in the sidebar inspector.
3. Tab to the "Use first image from post" toggle and press Space to enable/disable it.
4. Verify the toggle is focusable and operable via keyboard.

### Screenshots
<img width="352" height="521" alt="Screenshot 2026-03-26 at 10 35 07" src="https://github.com/user-attachments/assets/e29ed67b-f526-4800-aba9-e37909205544" />




## Use of AI Tools

This PR was authored with Claude Code (Claude Opus 4.6).