### PR TITLE
Preferences: Hide collaboration options when RTC is not enabled

### DIFF
--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -55,20 +55,26 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 
 function PreferencesModalContents( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const showBlockBreadcrumbsOption = useSelect(
+	const { showBlockBreadcrumbsOption, showCollaborationOptions } = useSelect(
 		( select ) => {
 			const { getEditorSettings } = select( editorStore );
 			const { get } = select( preferencesStore );
 			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
 			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );
-			return (
-				! isDistractionFreeEnabled &&
-				isLargeViewport &&
-				isRichEditingEnabled
-			);
+			return {
+				showBlockBreadcrumbsOption:
+					! isDistractionFreeEnabled &&
+					isLargeViewport &&
+					isRichEditingEnabled,
+				showCollaborationOptions:
+					select(
+						editorStore
+					).isCollaborationEnabledForCurrentPost(),
+			};
 		},
 		[ isLargeViewport ]
 	);
+
 	const { setIsListViewOpened, setIsInserterOpened } =
 		useDispatch( editorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
@@ -120,24 +126,30 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									) }
 									label={ __( 'Show starter patterns' ) }
 								/>
-								<PreferenceToggleControl
-									scope="core"
-									featureName="showCollaborationCursor"
-									help={ __(
-										'Show your own avatar inside blocks during collaborative editing sessions.'
-									) }
-									label={ __( 'Show avatar in blocks' ) }
-								/>
-								<PreferenceToggleControl
-									scope="core"
-									featureName="showCollaborationNotifications"
-									help={ __(
-										'Show notifications when collaborators join, leave, or save the post.'
-									) }
-									label={ __(
-										'Show collaboration notifications'
-									) }
-								/>
+								{ showCollaborationOptions && (
+									<>
+										<PreferenceToggleControl
+											scope="core"
+											featureName="showCollaborationCursor"
+											help={ __(
+												'Show your own avatar inside blocks during collaborative editing sessions.'
+											) }
+											label={ __(
+												'Show avatar in blocks'
+											) }
+										/>
+										<PreferenceToggleControl
+											scope="core"
+											featureName="showCollaborationNotifications"
+											help={ __(
+												'Show notifications when collaborators join, leave, or save the post.'
+											) }
+											label={ __(
+												'Show collaboration notifications'
+											) }
+										/>
+									</>
+								) }
 							</PreferencesModalSection>
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }
@@ -350,6 +362,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 			].filter( Boolean ),
 		[
 			showBlockBreadcrumbsOption,
+			showCollaborationOptions,
 			extraSections,
 			setIsInserterOpened,
 			setIsListViewOpened,

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -57,7 +57,8 @@ function PreferencesModalContents( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { showBlockBreadcrumbsOption, showCollaborationOptions } = useSelect(
 		( select ) => {
-			const { getEditorSettings } = select( editorStore );
+			const { getEditorSettings, isCollaborationEnabledForCurrentPost } =
+				select( editorStore );
 			const { get } = select( preferencesStore );
 			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
 			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );
@@ -67,9 +68,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 					isLargeViewport &&
 					isRichEditingEnabled,
 				showCollaborationOptions:
-					select(
-						editorStore
-					).isCollaborationEnabledForCurrentPost(),
+					isCollaborationEnabledForCurrentPost(),
 			};
 		},
 		[ isLargeViewport ]


### PR DESCRIPTION
Closes https://core.trac.wordpress.org/ticket/64949

## What?

Hide the RTC-related preference controls when RTC is not enabled for the current post.

## Why?

These preference toggles are irrelevant in that context and may confuse users.

## How?

Use the `isCollaborationEnabledForCurrentPost()` selector to conditionally render the two collaboration components.

## Testing Instructions

1. Disable RTC in Settings > Writing > uncheck "Enable real-time collaboration".
2. Open a post.
3. Open the Preferences modal4. Verify that "Show avatar in blocks" and "Show collaboration notifications" options are not visible.
5. Enable RTC again.
6. Open Preferences again and verify the two options are visible.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Claude Opus 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)