### PR TITLE
Site Tagline: Fix block error when migrating deprecated textAlign attribute

### DIFF
--- a/packages/block-library/src/site-tagline/deprecated.js
+++ b/packages/block-library/src/site-tagline/deprecated.js
@@ -11,6 +11,7 @@ const v2 = {
 		},
 		level: {
 			type: 'number',
+			default: 0,
 		},
 		levelOptions: {
 			type: 'array',

--- a/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__site-tagline__deprecated-v2.json
@@ -3,6 +3,7 @@
 		"name": "core/site-tagline",
 		"isValid": true,
 		"attributes": {
+			"level": 0,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"style": {
 				"typography": {
@@ -16,6 +17,7 @@
 		"name": "core/site-tagline",
 		"isValid": true,
 		"attributes": {
+			"level": 0,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"style": {
 				"typography": {
@@ -29,6 +31,7 @@
 		"name": "core/site-tagline",
 		"isValid": true,
 		"attributes": {
+			"level": 0,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"style": {
 				"typography": {


### PR DESCRIPTION
Follow-up on #75690

## What?

Fix a React error (`<hundefined>`) in the Site Tagline block when it contains the deprecated `textAlign` attribute.

<img width="387" height="134" alt="image" src="https://github.com/user-attachments/assets/ab7ab836-f323-40eb-96ff-c022b91ad700" />


## Why?

When a Site Tagline block with the old `textAlign` attribute (e.g. `<!-- wp:site-tagline {"textAlign":"center"} /-->`) is parsed through the v2 deprecation path, the `level` attribute remains `undefined` because its `default: 0` was missing from the deprecated definition. This causes `h${undefined}` → `hundefined` to be rendered as a tag name, triggering a React error.

## How?

Added the missing `default: 0` for the `level` attribute in the v2 deprecated block definition.

## Testing Instructions

1. Open a page or post in the editor.
2. Switch to the Code Editor.
3. Insert the following markup:
   ```html
   <!-- wp:site-tagline {"textAlign":"center"} /-->
   ```
4. Switch back to the Visual Editor.
5. Verify that the Site Tagline block renders correctly without errors.

## Screenshot

### Before

https://github.com/user-attachments/assets/e23a7392-44e1-46b3-8567-c9dcd8ec0fef

### After

https://github.com/user-attachments/assets/a2cb71ea-c6ec-4c60-8fbb-4fc120a43365

## Use of AI Tools

Claude Code was used to assist with investigating the root cause and authoring this fix.