### PR TITLE
Commands: Fix useSelect warning in command palette

### DIFF
--- a/packages/commands/src/components/use-recent-commands.js
+++ b/packages/commands/src/components/use-recent-commands.js
@@ -18,6 +18,7 @@ import { unlock } from '../lock-unlock';
 
 const MAX_RECENTLY_SAVED = 30;
 const MAX_RECENTLY_DISPLAYED = 5;
+const EMPTY_ARRAY = [];
 const EMPTY_SET = new Set();
 
 export function recordUsage( name ) {
@@ -61,7 +62,7 @@ export function useRecentCommands() {
 		staticCommands,
 		contextualLoaders,
 		staticLoaders,
-		recentlyUsedNames,
+		recentlyUsedNames = EMPTY_ARRAY,
 	} = useSelect( ( select ) => {
 		const { getCommands, getCommandLoaders } = select( commandsStore );
 		return {
@@ -69,11 +70,10 @@ export function useRecentCommands() {
 			staticCommands: getCommands( false ),
 			contextualLoaders: getCommandLoaders( true ),
 			staticLoaders: getCommandLoaders( false ),
-			recentlyUsedNames:
-				select( preferencesStore ).get(
-					'core/commands',
-					'recentlyUsed'
-				) ?? [],
+			recentlyUsedNames: select( preferencesStore ).get(
+				'core/commands',
+				'recentlyUsed'
+			),
 		};
 	}, [] );
 


### PR DESCRIPTION
Follow-up on #75691

## What?

Fix the browser console warning that appears when opening the command palette:

```
The `useSelect` hook returns different values when called with the same state and parameters.
Non-equal value keys: recentlyUsedNames
```

<img width="1299" height="641" alt="image" src="https://github.com/user-attachments/assets/5bf72038-7109-4e60-afc7-d7d4aee621d0" />


## Why?

The `?? []` fallback inside `useSelect` creates a new empty array reference on every call when the `recentlyUsed` preference is `undefined`. This causes `useSelect`'s shallow equality check to fail, triggering unnecessary re-renders and the warning above.

## How?

- Moved the fallback outside of `useSelect` by using a module-level `EMPTY_ARRAY` constant as a stable default value in the destructuring assignment.

## Testing Instructions

First, execute the following code in the browser console.

```
wp.data.dispatch( 'core/preferences' ).set( 'core/commands', 'recentlyUsed', undefined );
```

1. Open the command palette.
2. Confirm the warning no longer appears in the browser console.

## Use of AI Tools

This PR was authored with assistance from Claude Code (Claude Opus 4.6).