### PR TITLE
Site Editor > Patterns & Parts: generate sidebar from view config

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/76573
 * https://github.com/WordPress/gutenberg/pull/76734
 * https://github.com/WordPress/gutenberg/pull/76622
+* https://github.com/WordPress/gutenberg/pull/76823

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -863,30 +863,16 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		);
 
 		// Gather categories from the block pattern categories registry.
-		$categories = array();
-		$seen_names = array();
 		$registry   = WP_Block_Pattern_Categories_Registry::get_instance();
-		$registered = $registry->get_all_registered();
+		$categories = array();
 
-		foreach ( $registered as $category ) {
-			if ( ! isset( $seen_names[ $category['name'] ] ) ) {
-				$categories[]                    = array(
-					'name'  => $category['name'],
-					'label' => $category['label'],
-				);
-				$seen_names[ $category['name'] ] = true;
-			}
+		foreach ( $registry->get_all_registered() as $category ) {
+			$categories[ $category['name'] ] = $category['label'];
 		}
 
 		// Ensure "Uncategorized" is always included for patterns
 		// that have no category assigned.
-		if ( ! isset( $seen_names['uncategorized'] ) ) {
-			$categories[]                = array(
-				'name'  => 'uncategorized',
-				'label' => __( 'Uncategorized', 'gutenberg' ),
-			);
-			$seen_names['uncategorized'] = true;
-		}
+		$categories['uncategorized'] ??= __( 'Uncategorized', 'gutenberg' );
 
 		// Also gather user-created pattern categories (wp_pattern_category taxonomy).
 		$user_terms = get_terms(
@@ -898,28 +884,17 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 
 		if ( ! is_wp_error( $user_terms ) ) {
 			foreach ( $user_terms as $term ) {
-				if ( ! isset( $seen_names[ $term->slug ] ) ) {
-					$categories[]              = array(
-						'name'  => $term->slug,
-						'label' => $term->name,
-					);
-					$seen_names[ $term->slug ] = true;
-				}
+				$categories[ $term->slug ] = $term->name;
 			}
 		}
 
 		// Sort categories alphabetically by label.
-		usort(
-			$categories,
-			function ( $a, $b ) {
-				return strnatcasecmp( $a['label'], $b['label'] );
-			}
-		);
+		asort( $categories, SORT_NATURAL | SORT_FLAG_CASE );
 
-		foreach ( $categories as $category ) {
+		foreach ( $categories as $name => $label ) {
 			$view_list[] = array(
-				'title' => $category['label'],
-				'slug'  => $category['name'],
+				'title' => $label,
+				'slug'  => $name,
 			);
 		}
 

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -809,7 +809,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$areas = get_allowed_block_template_part_areas();
 
 		// Ensure default areas appear in a consistent order.
-		$preferred_order = array( 'header', 'footer', 'sidebar', 'uncategorized' );
+		$preferred_order = array( 'header', 'footer', 'sidebar', 'navigation-overlay', 'uncategorized' );
 		$ordered_areas   = array();
 		$remaining_areas = array();
 		foreach ( $areas as $area ) {

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -119,9 +119,11 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		} elseif ( 'postType' === $kind && 'wp_block' === $name ) {
 			$default_layouts = $this->get_default_layouts_for_wp_block();
 			$default_view    = $this->get_default_view_for_wp_block( $default_layouts );
+			$view_list       = $this->get_view_list_for_wp_block();
 		} elseif ( 'postType' === $kind && 'wp_template_part' === $name ) {
 			$default_layouts = $this->get_default_layouts_for_wp_template_part();
 			$default_view    = $this->get_default_view_for_wp_template_part( $default_layouts );
+			$view_list       = $this->get_view_list_for_wp_template_part();
 		} elseif ( 'postType' === $kind && 'wp_template' === $name ) {
 			$default_view    = $this->get_default_view_for_wp_template();
 			$default_layouts = $this->get_default_layouts_for_wp_template();
@@ -787,6 +789,141 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 
 		// Fail-safe to return a string should the original source ever fall through.
 		return '';
+	}
+
+	/**
+	 * Returns the view list for the wp_template_part post type.
+	 *
+	 * Builds entries from the registered template part areas (header, footer, etc.).
+	 *
+	 * @return array View list entries.
+	 */
+	private function get_view_list_for_wp_template_part() {
+		$view_list = array(
+			array(
+				'title' => __( 'All template parts', 'gutenberg' ),
+				'slug'  => 'all-parts',
+			),
+		);
+
+		$areas = get_allowed_block_template_part_areas();
+
+		// Ensure default areas appear in a consistent order.
+		$preferred_order = array( 'header', 'footer', 'sidebar', 'uncategorized' );
+		$ordered_areas   = array();
+		$remaining_areas = array();
+		foreach ( $areas as $area ) {
+			$position = array_search( $area['area'], $preferred_order, true );
+			if ( false !== $position ) {
+				$ordered_areas[ $position ] = $area;
+			} else {
+				$remaining_areas[] = $area;
+			}
+		}
+		ksort( $ordered_areas );
+		$areas = array_merge( array_values( $ordered_areas ), $remaining_areas );
+
+		foreach ( $areas as $area ) {
+			$view_list[] = array(
+				'title' => $area['label'],
+				'slug'  => $area['area'],
+				'view'  => array(
+					'filters' => array(
+						array(
+							'field'    => 'area',
+							'operator' => 'is',
+							'value'    => $area['area'],
+							'isLocked' => true,
+						),
+					),
+				),
+			);
+		}
+
+		return $view_list;
+	}
+
+	/**
+	 * Returns the view list for the wp_block (patterns) post type.
+	 *
+	 * Builds entries from registered block pattern categories and user pattern categories.
+	 *
+	 * @return array View list entries.
+	 */
+	private function get_view_list_for_wp_block() {
+		$view_list = array(
+			array(
+				'title' => __( 'All patterns', 'gutenberg' ),
+				'slug'  => 'all-patterns',
+			),
+			array(
+				'title' => __( 'My patterns', 'gutenberg' ),
+				'slug'  => 'my-patterns',
+			),
+		);
+
+		// Gather categories from the block pattern categories registry.
+		$categories = array();
+		$seen_names = array();
+		$registry   = WP_Block_Pattern_Categories_Registry::get_instance();
+		$registered = $registry->get_all_registered();
+
+		foreach ( $registered as $category ) {
+			if ( ! isset( $seen_names[ $category['name'] ] ) ) {
+				$categories[]                    = array(
+					'name'  => $category['name'],
+					'label' => $category['label'],
+				);
+				$seen_names[ $category['name'] ] = true;
+			}
+		}
+
+		// Ensure "Uncategorized" is always included for patterns
+		// that have no category assigned.
+		if ( ! isset( $seen_names['uncategorized'] ) ) {
+			$categories[]                = array(
+				'name'  => 'uncategorized',
+				'label' => __( 'Uncategorized', 'gutenberg' ),
+			);
+			$seen_names['uncategorized'] = true;
+		}
+
+		// Also gather user-created pattern categories (wp_pattern_category taxonomy).
+		$user_terms = get_terms(
+			array(
+				'taxonomy'   => 'wp_pattern_category',
+				'hide_empty' => false,
+			)
+		);
+
+		if ( ! is_wp_error( $user_terms ) ) {
+			foreach ( $user_terms as $term ) {
+				if ( ! isset( $seen_names[ $term->slug ] ) ) {
+					$categories[]              = array(
+						'name'  => $term->slug,
+						'label' => $term->name,
+					);
+					$seen_names[ $term->slug ] = true;
+				}
+			}
+		}
+
+		// Sort categories alphabetically by label.
+		usort(
+			$categories,
+			function ( $a, $b ) {
+				return strnatcasecmp( $a['label'], $b['label'] );
+			}
+		);
+
+		foreach ( $categories as $category ) {
+			$view_list[] = array(
+				'title' => $category['label'],
+				'slug'  => $category['name'],
+			);
+		}
+
+		return $view_list;
 	}
 
 	private function get_default_view_for_wp_template() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -5,7 +5,6 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
-import { useEntityRecords } from '@wordpress/core-data';
 import { getTemplatePartIcon } from '@wordpress/editor';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -23,37 +22,12 @@ import {
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	TEMPLATE_PART_ALL_AREAS_CATEGORY,
-	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 } from '../../utils/constants';
 import usePatternCategories from './use-pattern-categories';
+import useTemplatePartAreas from './use-template-part-areas';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
-
-function useTemplatePartCounts() {
-	const { records: templateParts, isResolving: isLoading } = useEntityRecords(
-		'postType',
-		TEMPLATE_PART_POST_TYPE,
-		{
-			per_page: -1,
-		}
-	);
-
-	const counts = useMemo( () => {
-		if ( ! templateParts ) {
-			return {};
-		}
-		const result = { [ TEMPLATE_PART_ALL_AREAS_CATEGORY ]: 0 };
-		templateParts.forEach( ( part ) => {
-			const area = part.area || TEMPLATE_PART_AREA_DEFAULT_CATEGORY;
-			result[ area ] = ( result[ area ] || 0 ) + 1;
-			result[ TEMPLATE_PART_ALL_AREAS_CATEGORY ] += 1;
-		} );
-		return result;
-	}, [ templateParts ] );
-
-	return { counts, isLoading };
-}
 
 function CategoriesGroup( {
 	templatePartViews,
@@ -121,7 +95,19 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 		name: PATTERN_TYPES.user,
 	} );
 
-	const { counts: templatePartCounts, isLoading } = useTemplatePartCounts();
+	const { templatePartAreas, isLoading, hasTemplateParts } =
+		useTemplatePartAreas();
+	const templatePartCounts = useMemo( () => {
+		const counts = { [ TEMPLATE_PART_ALL_AREAS_CATEGORY ]: 0 };
+		Object.entries( templatePartAreas ).forEach(
+			( [ area, { templateParts } ] ) => {
+				const count = templateParts?.length || 0;
+				counts[ area ] = count;
+				counts[ TEMPLATE_PART_ALL_AREAS_CATEGORY ] += count;
+			}
+		);
+		return counts;
+	}, [ templatePartAreas ] );
 	const { patternCategories } = usePatternCategories();
 	const patternCounts = useMemo( () => {
 		const counts = {};
@@ -131,8 +117,6 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 		return counts;
 	}, [ patternCategories ] );
 
-	const hasTemplateParts =
-		templatePartCounts[ TEMPLATE_PART_ALL_AREAS_CATEGORY ] > 0;
 	const hasPatterns = patternCounts[ PATTERN_DEFAULT_CATEGORY ] > 0;
 
 	return (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -25,8 +25,7 @@ import {
 	TEMPLATE_PART_ALL_AREAS_CATEGORY,
 	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 } from '../../utils/constants';
-import useThemePatterns from './use-theme-patterns';
-import usePatterns from '../page-patterns/use-patterns';
+import usePatternCategories from './use-pattern-categories';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -54,55 +53,6 @@ function useTemplatePartCounts() {
 	}, [ templateParts ] );
 
 	return { counts, isLoading };
-}
-
-function usePatternCounts() {
-	const themePatterns = useThemePatterns();
-	const { patterns: userPatterns, categories: userPatternCategories } =
-		usePatterns( PATTERN_TYPES.user );
-
-	const counts = useMemo( () => {
-		const result = {
-			[ PATTERN_DEFAULT_CATEGORY ]:
-				themePatterns.length + userPatterns.length,
-			'my-patterns': userPatterns.length,
-		};
-
-		// Count theme patterns per category.
-		themePatterns.forEach( ( pattern ) => {
-			pattern.categories?.forEach( ( cat ) => {
-				result[ cat ] = ( result[ cat ] || 0 ) + 1;
-			} );
-			if ( ! pattern.categories?.length ) {
-				result.uncategorized = ( result.uncategorized || 0 ) + 1;
-			}
-		} );
-
-		// Count user patterns per category.
-		userPatterns.forEach( ( pattern ) => {
-			pattern.wp_pattern_category?.forEach( ( catId ) => {
-				const category = userPatternCategories.find(
-					( cat ) => cat.id === catId
-				);
-				if ( category ) {
-					result[ category.name ] =
-						( result[ category.name ] || 0 ) + 1;
-				}
-			} );
-			if (
-				! pattern.wp_pattern_category?.length ||
-				! pattern.wp_pattern_category?.some( ( catId ) =>
-					userPatternCategories.find( ( cat ) => cat.id === catId )
-				)
-			) {
-				result.uncategorized = ( result.uncategorized || 0 ) + 1;
-			}
-		} );
-
-		return result;
-	}, [ themePatterns, userPatterns, userPatternCategories ] );
-
-	return counts;
 }
 
 function CategoriesGroup( {
@@ -172,7 +122,14 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 	} );
 
 	const { counts: templatePartCounts, isLoading } = useTemplatePartCounts();
-	const patternCounts = usePatternCounts();
+	const { patternCategories } = usePatternCategories();
+	const patternCounts = useMemo( () => {
+		const counts = {};
+		patternCategories.forEach( ( cat ) => {
+			counts[ cat.name ] = cat.count;
+		} );
+		return counts;
+	}, [ patternCategories ] );
 
 	const hasTemplateParts =
 		templatePartCounts[ TEMPLATE_PART_ALL_AREAS_CATEGORY ] > 0;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -5,10 +5,13 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
 import { getTemplatePartIcon } from '@wordpress/editor';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { file } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useViewConfig } from '@wordpress/views';
 
 /**
  * Internal dependencies
@@ -20,78 +23,127 @@ import {
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	TEMPLATE_PART_ALL_AREAS_CATEGORY,
+	TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 } from '../../utils/constants';
-import usePatternCategories from './use-pattern-categories';
-import useTemplatePartAreas from './use-template-part-areas';
+import useThemePatterns from './use-theme-patterns';
+import usePatterns from '../page-patterns/use-patterns';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
 
+function useTemplatePartCounts() {
+	const { records: templateParts, isResolving: isLoading } = useEntityRecords(
+		'postType',
+		TEMPLATE_PART_POST_TYPE,
+		{
+			per_page: -1,
+		}
+	);
+
+	const counts = useMemo( () => {
+		if ( ! templateParts ) {
+			return {};
+		}
+		const result = { [ TEMPLATE_PART_ALL_AREAS_CATEGORY ]: 0 };
+		templateParts.forEach( ( part ) => {
+			const area = part.area || TEMPLATE_PART_AREA_DEFAULT_CATEGORY;
+			result[ area ] = ( result[ area ] || 0 ) + 1;
+			result[ TEMPLATE_PART_ALL_AREAS_CATEGORY ] += 1;
+		} );
+		return result;
+	}, [ templateParts ] );
+
+	return { counts, isLoading };
+}
+
+function usePatternCounts() {
+	const themePatterns = useThemePatterns();
+	const { patterns: userPatterns, categories: userPatternCategories } =
+		usePatterns( PATTERN_TYPES.user );
+
+	const counts = useMemo( () => {
+		const result = {
+			[ PATTERN_DEFAULT_CATEGORY ]:
+				themePatterns.length + userPatterns.length,
+			'my-patterns': userPatterns.length,
+		};
+
+		// Count theme patterns per category.
+		themePatterns.forEach( ( pattern ) => {
+			pattern.categories?.forEach( ( cat ) => {
+				result[ cat ] = ( result[ cat ] || 0 ) + 1;
+			} );
+			if ( ! pattern.categories?.length ) {
+				result.uncategorized = ( result.uncategorized || 0 ) + 1;
+			}
+		} );
+
+		// Count user patterns per category.
+		userPatterns.forEach( ( pattern ) => {
+			pattern.wp_pattern_category?.forEach( ( catId ) => {
+				const category = userPatternCategories.find(
+					( cat ) => cat.id === catId
+				);
+				if ( category ) {
+					result[ category.name ] =
+						( result[ category.name ] || 0 ) + 1;
+				}
+			} );
+			if (
+				! pattern.wp_pattern_category?.length ||
+				! pattern.wp_pattern_category?.some( ( catId ) =>
+					userPatternCategories.find( ( cat ) => cat.id === catId )
+				)
+			) {
+				result.uncategorized = ( result.uncategorized || 0 ) + 1;
+			}
+		} );
+
+		return result;
+	}, [ themePatterns, userPatterns, userPatternCategories ] );
+
+	return counts;
+}
+
 function CategoriesGroup( {
-	templatePartAreas,
-	patternCategories,
+	templatePartViews,
+	patternViews,
+	templatePartCounts,
+	patternCounts,
 	currentCategory,
 	currentType,
 } ) {
-	const [ allPatterns, ...otherPatterns ] = patternCategories;
-
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-patterns__group">
-			<CategoryItem
-				key="all"
-				count={ Object.values( templatePartAreas )
-					.map( ( { templateParts } ) => templateParts?.length || 0 )
-					.reduce( ( acc, val ) => acc + val, 0 ) }
-				icon={ getTemplatePartIcon() } /* no name, so it provides the fallback icon */
-				label={ __( 'All template parts' ) }
-				id={ TEMPLATE_PART_ALL_AREAS_CATEGORY }
-				type={ TEMPLATE_PART_POST_TYPE }
-				isActive={
-					currentCategory === TEMPLATE_PART_ALL_AREAS_CATEGORY &&
-					currentType === TEMPLATE_PART_POST_TYPE
-				}
-			/>
-			{ Object.entries( templatePartAreas ).map(
-				( [ area, { label, templateParts, icon } ] ) => (
-					<CategoryItem
-						key={ area }
-						count={ templateParts?.length }
-						icon={ getTemplatePartIcon( icon ) }
-						label={ label }
-						id={ area }
-						type={ TEMPLATE_PART_POST_TYPE }
-						isActive={
-							currentCategory === area &&
-							currentType === TEMPLATE_PART_POST_TYPE
-						}
-					/>
-				)
-			) }
-			<div className="edit-site-sidebar-navigation-screen-patterns__divider" />
-			{ allPatterns && (
+			{ templatePartViews?.map( ( view ) => (
 				<CategoryItem
-					key={ allPatterns.name }
-					count={ allPatterns.count }
-					label={ allPatterns.label }
-					icon={ file }
-					id={ allPatterns.name }
-					type={ PATTERN_TYPES.user }
+					key={ view.slug }
+					count={ templatePartCounts[ view.slug ] }
+					icon={ getTemplatePartIcon(
+						view.slug === TEMPLATE_PART_ALL_AREAS_CATEGORY
+							? undefined
+							: view.slug
+					) }
+					label={ view.title }
+					id={ view.slug }
+					type={ TEMPLATE_PART_POST_TYPE }
 					isActive={
-						currentCategory === `${ allPatterns.name }` &&
-						currentType === PATTERN_TYPES.user
+						currentCategory === view.slug &&
+						currentType === TEMPLATE_PART_POST_TYPE
 					}
 				/>
-			) }
-			{ otherPatterns.map( ( category ) => (
+			) ) }
+			<div className="edit-site-sidebar-navigation-screen-patterns__divider" />
+			{ patternViews?.map( ( view ) => (
 				<CategoryItem
-					key={ category.name }
-					count={ category.count }
-					label={ category.label }
+					key={ view.slug }
+					count={ patternCounts[ view.slug ] }
+					label={ view.title }
 					icon={ file }
-					id={ category.name }
+					id={ view.slug }
 					type={ PATTERN_TYPES.user }
 					isActive={
-						currentCategory === `${ category.name }` &&
+						currentCategory === `${ view.slug }` &&
 						currentType === PATTERN_TYPES.user
 					}
 				/>
@@ -110,9 +162,21 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 			? PATTERN_DEFAULT_CATEGORY
 			: TEMPLATE_PART_ALL_AREAS_CATEGORY );
 
-	const { templatePartAreas, hasTemplateParts, isLoading } =
-		useTemplatePartAreas();
-	const { patternCategories, hasPatterns } = usePatternCategories();
+	const { view_list: templatePartViews } = useViewConfig( {
+		kind: 'postType',
+		name: TEMPLATE_PART_POST_TYPE,
+	} );
+	const { view_list: patternViews } = useViewConfig( {
+		kind: 'postType',
+		name: PATTERN_TYPES.user,
+	} );
+
+	const { counts: templatePartCounts, isLoading } = useTemplatePartCounts();
+	const patternCounts = usePatternCounts();
+
+	const hasTemplateParts =
+		templatePartCounts[ TEMPLATE_PART_ALL_AREAS_CATEGORY ] > 0;
+	const hasPatterns = patternCounts[ PATTERN_DEFAULT_CATEGORY ] > 0;
 
 	return (
 		<SidebarNavigationScreen
@@ -133,8 +197,10 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 								</ItemGroup>
 							) }
 							<CategoriesGroup
-								templatePartAreas={ templatePartAreas }
-								patternCategories={ patternCategories }
+								templatePartViews={ templatePartViews }
+								patternViews={ patternViews }
+								templatePartCounts={ templatePartCounts }
+								patternCounts={ patternCounts }
 								currentCategory={ currentCategory }
 								currentType={ postType }
 							/>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76544
Backported at https://github.com/WordPress/wordpress-develop/pull/11272

## What?
                                                                             
Refactor Site Editor > Patterns sidebar to source its category list from the server, using `useViewConfig` hook's `view_list`. This aligns with how the Templates and Pages sidebars already work, and it continues work from https://github.com/WordPress/gutenberg/pull/76734

## Why?

See https://github.com/WordPress/gutenberg/issues/76544

## How?

PHP:

- Added `get_view_list_for_wp_template_part` — returns "All template parts" plus one entry per registered area (header, footer, sidebar, etc.).
- Added `get_view_list_for_wp_block` — returns "All patterns", "My patterns", plus one entry per category from WP_Block_Pattern_Categories_Registry and wp_pattern_category taxonomy terms, sorted alphabetically.

JS:

- Replaced useTemplatePartAreas() and usePatternCategories() with two useViewConfig() calls (one per post type) as the source for the sidebar list.
- Added hooks to count the number of items in each category.
                                                                                                                                                                                                                                                                                                                                                                          
## Testing Instructions

  1. Open the site editor and navigate to Patterns in the left sidebar.
  2. Verify that template part areas (All template parts, Header, Footer, General) appear with correct counts and icons.
  3. Verify that pattern categories (All patterns, My patterns, About, Banners, etc.) appear with correct counts and icons.
  4. Click on different categories and verify the content area updates correctly.
  5. Verify the divider between template parts and patterns is still present.
  6. Verify the loading state ("Loading items…") and empty state ("No items found") still work.

## Use of AI Tools

This PR and summary were authored with assistance from Claude Code (Claude Opus 4.6).
