### PR TITLE
React vendor script: avoid warning on createRoot

### DIFF
--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -12,22 +12,25 @@ const VENDORS_DIR = path.join( BUILD_DIR, 'vendors' );
 
 const VENDOR_SCRIPTS = [
 	{
-		name: 'react',
-		global: 'React',
 		handle: 'react',
+		global: 'React',
 		dependencies: [ 'wp-polyfill' ],
+		entrypoint: 'react',
 	},
 	{
-		name: 'react-dom',
-		global: 'ReactDOM',
 		handle: 'react-dom',
+		global: 'ReactDOM',
 		dependencies: [ 'react' ],
+		contents: [
+			'export * from "react-dom";',
+			'export { createRoot, hydrateRoot } from "react-dom/client";',
+		].join( '\n' ),
 	},
 	{
-		name: 'react/jsx-runtime',
-		global: 'ReactJSXRuntime',
 		handle: 'react-jsx-runtime',
+		global: 'ReactJSXRuntime',
 		dependencies: [ 'react' ],
+		entrypoint: 'react/jsx-runtime',
 	},
 ];
 
@@ -87,7 +90,7 @@ async function generateAssetFile( config ) {
  * @return {Promise<void>} Promise that resolves when all builds are finished.
  */
 async function bundleVendorScript( config ) {
-	const { name, global, handle } = config;
+	const { handle, global, entrypoint, contents } = config;
 
 	// Plugin that externalizes the `react` package.
 	const reactExternalPlugin = {
@@ -114,7 +117,6 @@ async function bundleVendorScript( config ) {
 	};
 
 	const esbuildOptions = {
-		entryPoints: [ name ],
 		bundle: true,
 		format: 'iife',
 		globalName: global,
@@ -122,6 +124,16 @@ async function bundleVendorScript( config ) {
 		platform: 'browser',
 		plugins: [ reactExternalPlugin ],
 	};
+
+	if ( entrypoint ) {
+		esbuildOptions.entryPoints = [ entrypoint ];
+	} else {
+		esbuildOptions.stdin = {
+			contents,
+			resolveDir: ROOT_DIR,
+			loader: 'js',
+		};
+	}
 
 	await Promise.all( [
 		esbuild.build( {
@@ -150,11 +162,11 @@ async function buildVendors() {
 			await bundleVendorScript( vendorConfig );
 			const buildTime = Date.now() - startTime;
 			console.log(
-				`   ✔ Bundled vendor ${ vendorConfig.name } (${ buildTime }ms)`
+				`   ✔ Bundled vendor ${ vendorConfig.handle } (${ buildTime }ms)`
 			);
 		} catch ( error ) {
 			console.error(
-				`   ✘ Failed to bundle vendor ${ vendorConfig.name }: ${ error.message }`
+				`   ✘ Failed to bundle vendor ${ vendorConfig.handle }: ${ error.message }`
 			);
 		}
 	}

--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -12,14 +12,15 @@ const VENDORS_DIR = path.join( BUILD_DIR, 'vendors' );
 
 const VENDOR_SCRIPTS = [
 	{
-		handle: 'react',
+		name: 'react',
 		global: 'React',
+		handle: 'react',
 		dependencies: [ 'wp-polyfill' ],
-		entrypoint: 'react',
 	},
 	{
-		handle: 'react-dom',
+		name: 'react-dom',
 		global: 'ReactDOM',
+		handle: 'react-dom',
 		dependencies: [ 'react' ],
 		contents: [
 			'export * from "react-dom";',
@@ -27,10 +28,10 @@ const VENDOR_SCRIPTS = [
 		].join( '\n' ),
 	},
 	{
-		handle: 'react-jsx-runtime',
+		name: 'react/jsx-runtime',
 		global: 'ReactJSXRuntime',
+		handle: 'react-jsx-runtime',
 		dependencies: [ 'react' ],
-		entrypoint: 'react/jsx-runtime',
 	},
 ];
 
@@ -90,7 +91,7 @@ async function generateAssetFile( config ) {
  * @return {Promise<void>} Promise that resolves when all builds are finished.
  */
 async function bundleVendorScript( config ) {
-	const { handle, global, entrypoint, contents } = config;
+	const { name, global, handle, contents } = config;
 
 	// Plugin that externalizes the `react` package.
 	const reactExternalPlugin = {
@@ -125,14 +126,14 @@ async function bundleVendorScript( config ) {
 		plugins: [ reactExternalPlugin ],
 	};
 
-	if ( entrypoint ) {
-		esbuildOptions.entryPoints = [ entrypoint ];
-	} else {
+	if ( contents ) {
 		esbuildOptions.stdin = {
 			contents,
 			resolveDir: ROOT_DIR,
 			loader: 'js',
 		};
+	} else {
+		esbuildOptions.entryPoints = [ name ];
 	}
 
 	await Promise.all( [


### PR DESCRIPTION
While working on #76811 and looking at @youknowriad's old Core patch in https://core.trac.wordpress.org/changeset/58775 I realized that our `react-dom` bundled vendor script has one little bug. It reexports `createRoot` directly from `react-dom`, not from the recommended `react-dom/client` package, and that triggers a warning:
```
Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".
```
The function is there, it works, but triggers a warning.

We usually don't see this because we typically use `createRoot` imported from `@wordpress/element`, where the reexport is done correctly, from `react-dom/client`.

This patch fixes that by providing explicit content string of the `react-dom` entrypoint.

**How to test:**
Build Gutenberg locally, load Gutenberg in browser, and then call this in console:
```js
ReactDOM.createRoot()
```
Before this PR you'll see a warning, after this PR the warning is no longer there.
