### PR TITLE
Fields: Add `excerpt` field

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -7,6 +7,10 @@
 - DataViews: Use intersectionObserver to improve performance by unloading invisible items. Change how infinite scroll is enabled to require only 2 view properties: `infiniteScrollEnabled` and `startPosition`. [#74378](https://github.com/WordPress/gutenberg/pull/74378)
 - DataForm: The card layout now uses `Card` and `CollapsibleCard` from `@wordpress/ui` instead of `Card`, `CardHeader`, and `CardBody` from `@wordpress/components`. This changes the card's visual appearance (spacing, typography, and removal of the header/content separator). Custom CSS targeting `.components-card__body` within DataViews has been removed. Consumers wrapping DataViews or DataForm in a card should migrate to the `Card` and `CollapsibleCard` components from `@wordpress/ui`. [#76282](https://github.com/WordPress/gutenberg/pull/76282)
 
+### Enhancements
+
+- DataViews: Field's description can accept ReactElements. [#76829](https://github.com/WordPress/gutenberg/pull/76829)
+
 ## 13.1.0 (2026-03-18)
 
 ### Enhancements

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ReactElement } from 'react';
+
+/**
  * Internal dependencies
  */
 import type { Field, FieldValidity } from './field-api';
@@ -143,7 +148,7 @@ export type NormalizedSummaryField =
 export type FormField = {
 	id: string;
 	label?: string;
-	description?: string;
+	description?: string | ReactElement;
 	layout?: Layout;
 	children?: Array< FormField | string >;
 };
@@ -151,7 +156,7 @@ export type NormalizedFormField = {
 	id: string;
 	layout: NormalizedLayout;
 	label?: string;
-	description?: string;
+	description?: string | ReactElement;
 	children?: NormalizedFormField[];
 };
 

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { ReactElement } from 'react';
-
-/**
  * Internal dependencies
  */
 import type { Field, FieldValidity } from './field-api';
@@ -148,7 +143,7 @@ export type NormalizedSummaryField =
 export type FormField = {
 	id: string;
 	label?: string;
-	description?: string | ReactElement;
+	description?: string;
 	layout?: Layout;
 	children?: Array< FormField | string >;
 };
@@ -156,7 +151,7 @@ export type NormalizedFormField = {
 	id: string;
 	layout: NormalizedLayout;
 	label?: string;
-	description?: string | ReactElement;
+	description?: string;
 	children?: NormalizedFormField[];
 };
 

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -200,7 +200,7 @@ export type Field< Item > = {
 	/**
 	 * A description of the field.
 	 */
-	description?: string;
+	description?: string | ReactElement;
 
 	/**
 	 * Placeholder for the field.

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -38,6 +38,7 @@ const form = {
 				labelPosition: 'none',
 			},
 		},
+		'excerpt',
 		{
 			id: 'status',
 			label: __( 'Status' ),

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -268,8 +268,6 @@ export const registerPostTypeSchema =
 				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
 					scheduledDateField,
 				slugField,
-				// There are special cases where we want to label the excerpt as a description.
-				// So for now skip registering the excerpt field for some post types.
 				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
 					postTypeConfig.supports?.excerpt &&
 					excerptField,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -19,6 +19,7 @@ import {
 	resetPost,
 	deletePost,
 	duplicateTemplatePart,
+	excerptField,
 	featuredImageField,
 	dateField,
 	parentField,
@@ -267,6 +268,11 @@ export const registerPostTypeSchema =
 				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
 					scheduledDateField,
 				slugField,
+				// There are special cases where we want to label the excerpt as a description.
+				// So for now skip registering the excerpt field for some post types.
+				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
+					postTypeConfig.supports?.excerpt &&
+					excerptField,
 				postTypeConfig.supports?.[ 'page-attributes' ] && parentField,
 				postTypeConfig.supports?.comments && commentStatusField,
 				postTypeConfig.supports?.trackbacks && pingStatusField,

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -63,6 +63,10 @@ Duplicate action for BasePost.
 
 Duplicate action for TemplatePart.
 
+### excerptField
+
+Excerpt field for BasePost.
+
 ### exportPattern
 
 Export action as JSON for Pattern.

--- a/packages/fields/src/fields/excerpt/index.tsx
+++ b/packages/fields/src/fields/excerpt/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+import {
+	ExternalLink,
+	__experimentalText as Text,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+
+const excerptField: Field< BasePost > = {
+	id: 'excerpt',
+	type: 'text',
+	label: __( 'Excerpt' ),
+	placeholder: __( 'Add an excerpt' ),
+	description: (
+		<ExternalLink
+			href={ __(
+				'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt'
+			) }
+		>
+			{ __( 'Learn more about manual excerpts' ) }
+		</ExternalLink>
+	),
+	render: ( { item } ) => {
+		let excerpt;
+		if ( typeof item.excerpt === 'string' ) {
+			excerpt = !! item.excerpt
+				? decodeEntities( item.excerpt )
+				: __( 'Add an excerpt' );
+		} else {
+			excerpt = decodeEntities( item.excerpt?.raw || '' );
+		}
+		return (
+			<Text align="left" numberOfLines={ 4 } truncate>
+				{ excerpt }
+			</Text>
+		);
+	},
+	Edit: {
+		control: 'textarea',
+		rows: 4,
+	},
+	enableSorting: false,
+	filterBy: false,
+};
+
+/**
+ * Excerpt field for BasePost.
+ */
+export default excerptField;

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -16,5 +16,6 @@ export { default as dateField } from './date';
 export { default as scheduledDateField } from './date/scheduled';
 export { default as authorField } from './author';
 export { default as notesField } from './notes';
+export { default as excerptField } from './excerpt';
 export { default as formatField } from './format';
 export { default as postContentInfoField } from './post-content-info';

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -127,6 +127,7 @@ export interface PostType {
 	supports?: {
 		'page-attributes'?: boolean;
 		title?: boolean;
+		excerpt?: boolean;
 		revisions?: boolean;
 		author?: string;
 		thumbnail?: string;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/76238
Which is part of: https://github.com/WordPress/gutenberg/issues/76076

## Notes
1. DataForm `panel` layout overrides the color on hover of the field's view component. In this case `Text` has its own styles and the DataForm style is not applied on `hover`. This seems like an issue we should discuss for DataForm in general
2. If we apply the `panel` layout for `excerpt` without a label and updating the value of the field to a placeholder like text (like `Add an excerpt`) is closer to what we have in trunk without the experiment but the problem is there is no clear indication that this field is an excerpt. In trunk we show an `edit excerpt` button below which is clear. This needs input from @WordPress/gutenberg-design 

## Testing Instructions
1. Enable the Editor Inspector: Use DataForm experiment
3. Go to a post and play around with the `excerpt`


## Screenshots or screencast <!-- if applicable -->
<img width="464" height="519" alt="Screenshot 2026-03-26 at 12 55 20 PM" src="https://github.com/user-attachments/assets/38a0b653-a95c-4720-845c-63d2b262cb48" />
<img width="560" height="519" alt="Screenshot 2026-03-26 at 12 55 29 PM" src="https://github.com/user-attachments/assets/5785e9a1-535d-42ed-9736-b819d375238d" />
