### PR TITLE
docs: Update setup instructions for Interactivity Router to include -variant flag

### DIFF
--- a/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/client-side-navigation.md
@@ -29,10 +29,10 @@ This approach offers several benefits:
 
 ## Getting started with the Interactivity Router
 
-The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. If you are starting a new project, the easiest way to get set up is using the [`@wordpress/create-block-interactive-template`](https://www.npmjs.com/package/@wordpress/create-block-interactive-template) scaffolding tool, which creates a block with the Interactivity API already configured:
+The `@wordpress/interactivity-router` package is bundled with WordPress Core since version 6.5. If you are starting a new project, the easiest way to get set up is using the [`@wordpress/create-block-interactive-template`](https://www.npmjs.com/package/@wordpress/create-block-interactive-template) scaffolding tool with the `--variant client-side-navigation` flag, which creates a block with the Interactivity API and the router already configured:
 
 ```bash
-npx @wordpress/create-block@latest my-interactive-block --template @wordpress/create-block-interactive-template
+npx @wordpress/create-block@latest my-interactive-block --template @wordpress/create-block-interactive-template --variant client-side-navigation
 ```
 
 Whether you are working with a block or a classic theme, adding client-side navigation involves the same steps:


### PR DESCRIPTION
Updates the "Getting started with the Interactivity Router" section in the client-side navigation core concepts doc to recommend the `--variant client-side-navigation` scaffold variant.

## Why?

`@wordpress/create-block-interactive-template` now ships a dedicated `client-side-navigation` variant that scaffolds a block with `@wordpress/interactivity-router` already wired up. The existing docs pointed to the base template command, which doesn't include the router setup — developers reading the client-side navigation guide would benefit from starting with the variant that matches their intent.

## How?

Updated the scaffold command in the "Getting started with the Interactivity Router" section of `core-concepts/client-side-navigation.md` to include `--variant client-side-navigation`, and updated the surrounding prose to reflect that the variant includes both the Interactivity API and the router pre-configured.

## Testing Instructions

1. Read through the [Client-Side Navigation core concept doc](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/client-side-navigation/).
2. Verify the scaffold command in the "Getting started with the Interactivity Router" section includes `--variant client-side-navigation`.
3. Optionally, run the updated command locally and confirm the scaffolded block includes router configuration out of the box.

### Testing Instructions for Keyboard

No UI changes — documentation only.

## Screenshots or screencast

N/A — documentation-only change.

## Use of AI Tools

This PR was drafted with Claude Code assistance. The content was reviewed and is the author's responsibility.