### PR TITLE
docs(create-block-interactive-template): document available variants in README

### DIFF
--- a/packages/create-block-interactive-template/README.md
+++ b/packages/create-block-interactive-template/README.md
@@ -12,6 +12,38 @@ npx @wordpress/create-block --template @wordpress/create-block-interactive-templ
 
 It requires at least WordPress 6.5 or Gutenberg 17.7.
 
+## Variants
+
+This template exposes three variants. Use the `--variant` flag to select one:
+
+### `default`
+
+The standard interactive block scaffold. Uses the Interactivity API to demonstrate reactive state, context, and DOM event handling.
+
+```bash
+npx @wordpress/create-block --template @wordpress/create-block-interactive-template --variant default
+```
+
+This is also the variant used when no `--variant` flag is provided.
+
+### `typescript`
+
+Same as `default` but the view script (`view.ts`) is written in TypeScript, with fully typed store state and context.
+
+```bash
+npx @wordpress/create-block --template @wordpress/create-block-interactive-template --variant typescript
+```
+
+### `client-side-navigation`
+
+Demonstrates client-side navigation powered by `@wordpress/interactivity-router`. The block renders a quote navigator whose Prev / Next links swap page content without a full reload. A client-side stopwatch running outside the router region proves that no full page reload occurred.
+
+```bash
+npx @wordpress/create-block --template @wordpress/create-block-interactive-template --variant client-side-navigation
+```
+
+This variant adds `@wordpress/interactivity-router` as an additional npm dependency.
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.


### PR DESCRIPTION
Closes #76827

Documents the three variants exposed by `@wordpress/create-block-interactive-template` in its README.

## Why?

The package has supported `default`, `typescript`, and `client-side-navigation` variants for some time, but the README only showed the base usage command with no mention
 of the `--variant` flag. Users had no way to discover TypeScript support or the client-side navigation demo without reading the package source.

## How?

Adds a `## Variants` section to the README with a subsection for each variant covering:
- what it demonstrates
- the exact `npx @wordpress/create-block` command to use it
- any notable extra dependencies (e.g. `@wordpress/interactivity-router` for `client-side-navigation`)

No code changes — documentation only.

## Testing Instructions

1. Open `packages/create-block-interactive-template/README.md`.
2. Verify a **Variants** section is present with subsections for `default`, `typescript`, and `client-side-navigation`.
3. Optionally, run each documented command and confirm the scaffolded block matches the description.

### Testing Instructions for Keyboard

N/A — documentation-only change, no UI affected.

## Use of AI Tools

This PR was drafted with the assistance of [Claude Code](https://claude.ai/code) (Anthropic). The content was reviewed and approved by the author.
