### PR TITLE
Button: hide focus outline on :active for click feedback in forced-colors mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,10 @@
 -   `CustomGradientPicker`: Add state persistence when switching between Linear and Radial Gradient ([#76595](https://github.com/WordPress/gutenberg/pull/76595)).
 -   `Button`: fix focus styles in High Contrast (forced colors) mode ([#76719](https://github.com/WordPress/gutenberg/pull/76719)).
 
+### Enhancements
+
+-   `Button`: Hide focus outline on `:active` in High Contrast (forced colors) mode to provide visual click feedback ([#76833](https://github.com/WordPress/gutenberg/pull/76833)).
+
 ## 32.4.0 (2026-03-18)
 
 ### Bug Fixes

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -391,6 +391,14 @@
 		}
 	}
 
+	// Hide focus outline on :active to provide click feedback in forced-colors
+	// mode, where box-shadow is not visible. Higher specificity (0,3,0)
+	// ensures this wins over variant outline declarations. Placed after
+	// .is-pressed to also win by source order at equal specificity (0,3,0).
+	&:focus:active {
+		outline: none;
+	}
+
 	svg {
 		fill: currentColor;
 		outline: none;


### PR DESCRIPTION
## What?

Follow up to #76719.

Hide the focus `outline` during `:active` state on the `Button` component to provide visual click feedback in forced-colors (High Contrast) mode.

## Why?

In forced-colors mode, `box-shadow` is not rendered — the `outline` is the only visible focus indicator. Without hiding it on `:active`, clicking a focused button produces no visual feedback ([discussed here](https://github.com/WordPress/gutenberg/pull/76719#discussion_r2967845518)).

## How?

Added a single `&:focus:active { outline: none; }` rule after the `.is-pressed` block.

This approach was [suggested by @t-hamano](https://github.com/WordPress/gutenberg/pull/76833#pullrequestreview-2789218038) as a simpler alternative to the original `&:focus:not(:active)` approach, which re-exposed a regression from #75346 (the default browser outline would appear during the `:focus:active` state, since no outline rule covered it).

<details>
<summary>Implementation details</summary>

### Why `&:focus:active` instead of `&:focus:not(:active)`?

With `&:focus:not(:active)`, the `:focus:active` state has **no** outline rule covering it, so the browser's default outline leaks through — the exact issue fixed in #75346.

With `&:focus:active { outline: none; }`, the existing `&:focus { outline: 3px solid transparent; }` rule remains untouched, and the new rule explicitly removes the outline only during the click. No gaps in coverage.

### Specificity

`&:focus:active` compiles to `.components-button:focus:active` with specificity `0,3,0`, which:
- Is **higher** than `&:focus` (`0,2,0`) and variant outline declarations like `.is-primary` (`0,2,0`), so it naturally overrides them.
- **Equals** `.is-pressed &:focus` (`0,3,0`), but wins by **source order** since it's placed after the `.is-pressed` block.

### Comparison with `@wordpress/ui` Button

The `@wordpress/ui` Button already uses `:focus:not(:active)` for its outline via the shared `outset-ring--focus-except-active` utility class. After this change, both buttons have the same visual behavior: the focus indicator hides on `:active` for click feedback in all modes.

</details>

## Testing Instructions

1. Load the Button examples on Storybook (`npm run storybook:dev`)
2. Enable forced-colors mode (browser DevTools → Rendering → Emulate CSS media feature `forced-colors: active`)
3. Focus a button (keyboard or mouse)
4. Click it — the thick focus outline should briefly disappear during the click, then reappear
5. Repeat for Primary, Secondary, Tertiary, Link, and Pressed variants
6. **Regression check**: verify that no default browser outline appears during the `:focus:active` state (the issue from #75346)

### Testing Instructions for Keyboard

1. Same setup as above (Storybook + forced-colors emulation)
2. Tab to focus a button — thick outline should appear
3. Press Enter/Space — outline should briefly hide during keypress, then return

## Screenshots or screencast

https://github.com/user-attachments/assets/82d7f1f0-0495-49fb-806d-a77d0f12adea

## Use of AI Tools

Cursor + Claude Opus 4.6