### PR TITLE
Style Book: Fix missing styles for classic themes in stylebook route

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/stylebook.js
+++ b/packages/edit-site/src/components/site-editor-routes/stylebook.js
@@ -33,12 +33,18 @@ export const stylebookRoute = {
 		},
 		preview( { siteData } ) {
 			return isClassicThemeWithStyleBookSupport( siteData ) ? (
-				<StyleBookPreview isStatic />
+				<StyleBookPreview
+					isStatic
+					settings={ siteData.editorSettings }
+				/>
 			) : undefined;
 		},
 		mobile( { siteData } ) {
 			return isClassicThemeWithStyleBookSupport( siteData ) ? (
-				<StyleBookPreview isStatic />
+				<StyleBookPreview
+					isStatic
+					settings={ siteData.editorSettings }
+				/>
 			) : undefined;
 		},
 	},

--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -375,6 +375,7 @@ function StyleBook(
  * @param {Function} props.onPathChange Callback when the path changes.
  * @param {Object}   props.userConfig   User configuration.
  * @param {boolean}  props.isStatic     Whether the stylebook is static or clickable.
+ * @param {Object}   props.settings     Optional editor settings to use instead of the editor store settings.
  * @return {Object} Style Book Preview component.
  */
 export const StyleBookPreview = ( {
@@ -382,11 +383,14 @@ export const StyleBookPreview = ( {
 	isStatic = false,
 	path,
 	onPathChange,
+	settings: settingsProp,
 } ) => {
 	const editorSettings = useSelect(
 		( select ) => select( editorStore ).getEditorSettings(),
 		[]
 	);
+
+	const baseSettings = settingsProp ?? editorSettings;
 
 	const canUserUploadMedia = useSelect(
 		( select ) =>
@@ -400,10 +404,10 @@ export const StyleBookPreview = ( {
 	// Update block editor settings because useMultipleOriginColorsAndGradients fetch colours from there.
 	useEffect( () => {
 		dispatch( blockEditorStore ).updateSettings( {
-			...editorSettings,
+			...baseSettings,
 			mediaUpload: canUserUploadMedia ? uploadMedia : undefined,
 		} );
-	}, [ editorSettings, canUserUploadMedia ] );
+	}, [ baseSettings, canUserUploadMedia ] );
 
 	const [ internalPath, setInternalPath ] = useState( '/' );
 	const section = path ?? internalPath;
@@ -529,14 +533,14 @@ export const StyleBookPreview = ( {
 
 	const settings = useMemo(
 		() => ( {
-			...editorSettings,
+			...baseSettings,
 			styles:
 				! isObjectEmpty( globalStyles ) && ! isObjectEmpty( userConfig )
 					? globalStyles
-					: editorSettings.styles,
+					: baseSettings.styles,
 			isPreviewMode: true,
 		} ),
-		[ globalStyles, editorSettings, userConfig ]
+		[ globalStyles, baseSettings, userConfig ]
 	);
 
 	return (

--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -386,11 +386,9 @@ export const StyleBookPreview = ( {
 	settings: settingsProp,
 } ) => {
 	const editorSettings = useSelect(
-		( select ) => select( editorStore ).getEditorSettings(),
-		[]
+		( select ) => settingsProp ?? select( editorStore ).getEditorSettings(),
+		[ settingsProp ]
 	);
-
-	const baseSettings = settingsProp ?? editorSettings;
 
 	const canUserUploadMedia = useSelect(
 		( select ) =>
@@ -404,10 +402,10 @@ export const StyleBookPreview = ( {
 	// Update block editor settings because useMultipleOriginColorsAndGradients fetch colours from there.
 	useEffect( () => {
 		dispatch( blockEditorStore ).updateSettings( {
-			...baseSettings,
+			...editorSettings,
 			mediaUpload: canUserUploadMedia ? uploadMedia : undefined,
 		} );
-	}, [ baseSettings, canUserUploadMedia ] );
+	}, [ editorSettings, canUserUploadMedia ] );
 
 	const [ internalPath, setInternalPath ] = useState( '/' );
 	const section = path ?? internalPath;
@@ -533,14 +531,14 @@ export const StyleBookPreview = ( {
 
 	const settings = useMemo(
 		() => ( {
-			...baseSettings,
+			...editorSettings,
 			styles:
 				! isObjectEmpty( globalStyles ) && ! isObjectEmpty( userConfig )
 					? globalStyles
-					: baseSettings.styles,
+					: editorSettings.styles,
 			isPreviewMode: true,
 		} ),
-		[ globalStyles, baseSettings, userConfig ]
+		[ globalStyles, editorSettings, userConfig ]
 	);
 
 	return (


### PR DESCRIPTION
Fixes #76826

## What?

Fix the Style Book not applying any styles when opened via the stylebook route with a classic theme

## Why?

When `StyleBookPreview` was moved from `edit-site` to `editor` package in #72681, [the settings source changed from `siteEditorStore.getSettings()` to `editorStore.getEditorSettings()`](https://github.com/WordPress/gutenberg/pull/72681/changes#diff-183511823cbdb27735b9754cbc1f56d137e587bb7e741b7041792bb0cd7814a9R386-R389). For the classic theme stylebook route, no post is being edited, so `EditorProvider` is not rendered and `editorStore.editorSettings` is never initialized with the theme's styles — resulting in a completely unstyled Style Book.

## How?

- Add an optional `settings` prop to `StyleBookPreview` that takes precedence over `editorStore.getEditorSettings()` when provided.
- In the stylebook route, pass `siteData.editorSettings` (from `editSiteStore.getSettings()`, which contains the theme styles) to `StyleBookPreview`.

## Testing Instructions

1. Activate a classic theme (e.g., Twenty Twenty-One)
2. Navigate to Appearance > Design > Styles.
3. Verify that the Style Book displays with styles properly applied.

## Screenshots

### Before

<img width="1324" height="674" alt="image" src="https://github.com/user-attachments/assets/19a1cfa3-aaf0-40a3-8f29-365088ccaf24" />


### After

<img width="1319" height="672" alt="image" src="https://github.com/user-attachments/assets/5b347d99-81b2-44cf-a7d4-07ef97d64614" />

## Use of AI Tools

Claude Code was used to investigate the regression and implement the fix.