### PR TITLE
Focus utilities: Keep focus ring on aria-disabled buttons during :active

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Focus utilities: Keep focus ring visible on `aria-disabled` buttons during `:active` state ([#76896](https://github.com/WordPress/gutenberg/pull/76896)).
 -   `Card`: Add `overflow: clip` to `Card.Root` to prevent child content from overflowing rounded corners ([#76678](https://github.com/WordPress/gutenberg/pull/76678)).
 -   `CollapsibleCard`: do not animate the focus ring when expanding/collapsing the card ([#76459](https://github.com/WordPress/gutenberg/pull/76459)).
 

--- a/packages/ui/src/utils/css/focus.module.css
+++ b/packages/ui/src/utils/css/focus.module.css
@@ -22,9 +22,11 @@
 
 	.outset-ring--focus:focus,
 	.outset-ring--focus-except-active:focus:not(:active),
+	.outset-ring--focus-except-active:focus:active[aria-disabled="true"],
 	.outset-ring--focus-visible:focus-visible,
 	.outset-ring--focus-within:focus-within,
 	.outset-ring--focus-within-except-active:focus-within:not(:has(:active)),
+	.outset-ring--focus-within-except-active:focus-within:has(:active[aria-disabled="true"]),
 	.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
 	:focus-visible .outset-ring--focus-parent-visible {
 		outline-width: var(--wpds-border-width-focus);


### PR DESCRIPTION
## What?

Keep the focus ring visible on `aria-disabled` buttons when they enter the `:active` pseudo-state (e.g. when pressing Space).

## Why?

Buttons using `aria-disabled` (instead of native `disabled`) still receive the `:active` pseudo-state. The `:not(:active)` selector in `outset-ring--focus-except-active` was hiding the focus ring on Space press, giving a false impression that the button is interactive and responding to the click.

## How?

Add companion selectors that preserve the outline when `[aria-disabled="true"]` is active, for both the direct (`.outset-ring--focus-except-active`) and focus-within (`.outset-ring--focus-within-except-active`) variants.

## Testing Instructions

1. Run `npm run storybook:dev`
2. Open any story with a disabled-but-focusable button (e.g. `Dialog` with a `Dialog.Action` that has `loading={true}`)
3. Tab to the disabled button
4. Press and hold Space — verify the focus ring stays visible (it should not disappear)

### Unit tests

```bash
npm run test:unit -- packages/ui/src/dialog/test/index.test.tsx
```

## Use of AI Tools

Cursor + Claude Opus 4.6. All code was reviewed and validated by the author.