### PR TITLE
UI/Dialog: Expose initialFocus and finalFocus on Dialog.Popup

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 -   Add `InputControl` component ([#76653](https://github.com/WordPress/gutenberg/pull/76653)).
+-   `Dialog`: Expose `initialFocus` and `finalFocus` props on `Dialog.Popup` for custom focus management.
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 
 -   Add `InputControl` component ([#76653](https://github.com/WordPress/gutenberg/pull/76653)).
--   `Dialog`: Expose `initialFocus` and `finalFocus` props on `Dialog.Popup` for custom focus management.
+-   `Dialog`: Expose `initialFocus` and `finalFocus` props on `Dialog.Popup` for custom focus management ([#76860](https://github.com/WordPress/gutenberg/pull/76860)).
 
 ### Bug Fixes
 

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -18,7 +18,14 @@ const ThemeProvider: typeof ThemeProviderType =
  * Uses a portal to render outside the DOM hierarchy.
  */
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
-	{ className, size = 'medium', children, ...props },
+	{
+		className,
+		size = 'medium',
+		initialFocus,
+		finalFocus,
+		children,
+		...props
+	},
 	ref
 ) {
 	return (
@@ -32,6 +39,8 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 						className,
 						styles[ `is-${ size }` ]
 					) }
+					initialFocus={ initialFocus }
+					finalFocus={ finalFocus }
 					{ ...props }
 				>
 					<DialogValidationProvider>

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -22,7 +22,9 @@ export interface TriggerProps extends ComponentProps< 'button' > {
 	children?: ReactNode;
 }
 
-export interface PopupProps extends ComponentProps< 'div' > {
+export interface PopupProps
+	extends ComponentProps< 'div' >,
+		Pick< _Dialog.Popup.Props, 'initialFocus' | 'finalFocus' > {
 	/**
 	 * The content to be rendered inside the component.
 	 */


### PR DESCRIPTION
## What?

Expose (forward) the Base UI's `initialFocus` and `finalFocus` props on the `@wordpress/ui` `Dialog.Popup` component.

## Why?

Consumers of `Dialog.Popup` need to customize which element receives focus when the dialog opens or closes. For example, action modals in `@wordpress/dataviews` need to focus the first input in the content area (skipping the header close icon) or focus a specific content element.

Without these props, consumers must resort to workarounds like disabling Dialog's focus management entirely and using separate hooks, leading to potential timing conflicts.

## How?

Forwarded the props to the underlying Base UI dialog, use original Base UI types.

## Testing Instructions

1. Open a Storybook instance (`npm run storybook`).
2. Navigate to the Dialog stories.
3. Verify dialogs still focus correctly by default (first tabbable element).
4. (Optional) Add a story with `initialFocus={false}` and verify focus does not move on open.

### Testing Instructions for Keyboard

1. Open a dialog using keyboard (Enter/Space on trigger).
2. Verify focus lands inside the dialog.
3. Close the dialog (Escape or close button).
4. Verify focus returns to the trigger element.

## Use of AI Tools

Cursor + Claude Opus 4.6