### PR TITLE
compose/useDialog: add `stopPropagation()` to Escape handler

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `useDialog`: Add `event.stopPropagation()` to the Escape key handler to prevent the event from bubbling to parent overlays.
+
 ## 7.42.0 (2026-03-18)
 
 ### New Features

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `useDialog`: Add `event.stopPropagation()` to the Escape key handler to prevent the event from bubbling to parent overlays.
+-   `useDialog`: Add `event.stopPropagation()` to the Escape key handler to prevent the event from bubbling to parent overlays ([#76861](https://github.com/WordPress/gutenberg/pull/76861)).
 
 ## 7.42.0 (2026-03-18)
 

--- a/packages/compose/src/hooks/use-dialog/index.ts
+++ b/packages/compose/src/hooks/use-dialog/index.ts
@@ -99,6 +99,7 @@ function useDialog( options: DialogOptions ): useDialogReturn {
 				currentOptions.current?.onClose
 			) {
 				event.preventDefault();
+				event.stopPropagation();
 				currentOptions.current.onClose();
 			}
 		} );

--- a/packages/compose/src/hooks/use-dialog/test/index.tsx
+++ b/packages/compose/src/hooks/use-dialog/test/index.tsx
@@ -126,9 +126,7 @@ describe( 'useDialog', () => {
 
 		render( <NestedDialogs /> );
 
-		pressEscapeOn(
-			screen.getByRole( 'button', { name: 'Focusable' } )
-		);
+		pressEscapeOn( screen.getByRole( 'button', { name: 'Focusable' } ) );
 
 		expect( innerOnClose ).toHaveBeenCalledTimes( 1 );
 		expect( outerOnClose ).not.toHaveBeenCalled();

--- a/packages/compose/src/hooks/use-dialog/test/index.tsx
+++ b/packages/compose/src/hooks/use-dialog/test/index.tsx
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useDialog from '..';
+
+function Dialog( { onClose }: { onClose?: () => void } ) {
+	const [ ref, props ] = useDialog( {
+		onClose,
+		focusOnMount: false,
+	} );
+
+	return (
+		<div ref={ ref } { ...props } role="dialog" aria-label="Test dialog">
+			<p>Dialog content</p>
+			<button>Inside</button>
+		</div>
+	);
+}
+
+function pressEscapeOn( element: HTMLElement ) {
+	fireEvent.keyDown( element, { keyCode: 27, key: 'Escape' } );
+}
+
+describe( 'useDialog', () => {
+	it( 'should call onClose when Escape is pressed', () => {
+		const onClose = jest.fn();
+
+		render( <Dialog onClose={ onClose } /> );
+
+		pressEscapeOn( screen.getByRole( 'dialog' ) );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not call onClose when Escape is pressed if defaultPrevented', () => {
+		const onClose = jest.fn();
+
+		render( <Dialog onClose={ onClose } /> );
+
+		const dialog = screen.getByRole( 'dialog' );
+		const event = new KeyboardEvent( 'keydown', {
+			keyCode: 27,
+			bubbles: true,
+			cancelable: true,
+		} );
+		event.preventDefault();
+		dialog.dispatchEvent( event );
+
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should stop Escape event from propagating to parent elements', () => {
+		const onClose = jest.fn();
+		const parentKeyDownHandler = jest.fn();
+
+		render(
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+			<div onKeyDown={ parentKeyDownHandler }>
+				<Dialog onClose={ onClose } />
+			</div>
+		);
+
+		pressEscapeOn( screen.getByRole( 'button', { name: 'Inside' } ) );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+		expect( parentKeyDownHandler ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should let Escape propagate when there is no onClose handler', () => {
+		const parentKeyDownHandler = jest.fn();
+
+		render(
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+			<div onKeyDown={ parentKeyDownHandler }>
+				<Dialog />
+			</div>
+		);
+
+		pressEscapeOn( screen.getByRole( 'button', { name: 'Inside' } ) );
+
+		expect( parentKeyDownHandler ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should close only the innermost dialog when nested', () => {
+		const outerOnClose = jest.fn();
+		const innerOnClose = jest.fn();
+
+		function NestedDialogs() {
+			const [ outerRef, outerProps ] = useDialog( {
+				onClose: outerOnClose,
+				focusOnMount: false,
+			} );
+			const [ innerRef, innerProps ] = useDialog( {
+				onClose: innerOnClose,
+				focusOnMount: false,
+			} );
+
+			return (
+				<div
+					ref={ outerRef }
+					{ ...outerProps }
+					role="dialog"
+					aria-label="Outer"
+				>
+					<div
+						ref={ innerRef }
+						{ ...innerProps }
+						role="dialog"
+						aria-label="Inner"
+					>
+						<button>Focusable</button>
+					</div>
+				</div>
+			);
+		}
+
+		render( <NestedDialogs /> );
+
+		pressEscapeOn(
+			screen.getByRole( 'button', { name: 'Focusable' } )
+		);
+
+		expect( innerOnClose ).toHaveBeenCalledTimes( 1 );
+		expect( outerOnClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not call onClose for non-Escape keys', () => {
+		const onClose = jest.fn();
+
+		render( <Dialog onClose={ onClose } /> );
+
+		const dialog = screen.getByRole( 'dialog' );
+
+		fireEvent.keyDown( dialog, { keyCode: 13, key: 'Enter' } );
+		fireEvent.keyDown( dialog, { keyCode: 65, key: 'a' } );
+		fireEvent.keyDown( dialog, { keyCode: 9, key: 'Tab' } );
+
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/compose/src/hooks/use-dialog/test/index.tsx
+++ b/packages/compose/src/hooks/use-dialog/test/index.tsx
@@ -22,6 +22,11 @@ function Dialog( { onClose }: { onClose?: () => void } ) {
 	);
 }
 
+// `useDialog` currently detects the Escape key via the deprecated `keyCode`
+// property (`event.keyCode === 27`). In jsdom, `userEvent.keyboard('[Escape]')`
+// does not set `keyCode` to 27, so we use `fireEvent` to control the event
+// shape. Once the hook is updated to use `event.key === 'Escape'`, these tests
+// should be rewritten to use `userEvent` for more realistic event simulation.
 function pressEscapeOn( element: HTMLElement ) {
 	fireEvent.keyDown( element, { keyCode: 27, key: 'Escape' } );
 }


### PR DESCRIPTION
## What?

Part of https://github.com/WordPress/gutenberg/pull/76487
Extracted from https://github.com/WordPress/gutenberg/pull/76837

Add `event.stopPropagation()` to the Escape key handler in the `useDialog` hook from `@wordpress/compose`.

## Why?

When a legacy Popover (which uses `useDialog` internally) is rendered inside a Base UI `Dialog`, pressing Escape currently bubbles up and closes both the Popover **and** the parent Dialog in a single keystroke.

This happens because the Popover's keydown handler calls `event.preventDefault()` but not `event.stopPropagation()`, so the Escape event continues to propagate up the DOM tree where Base UI's Dialog picks it up and also dismisses itself.

The expected behavior is that Escape closes only the innermost overlay — pressing Escape once should close the Popover, and pressing it a second time should close the Dialog.

## How?

Added `event.stopPropagation()` immediately after `event.preventDefault()` in the `closeOnEscapeRef` callback within `useDialog`. This prevents the Escape keydown event from bubbling past the Popover to parent overlay listeners.

```ts
if (
  event.keyCode === ESCAPE &&
  !event.defaultPrevented &&
  currentOptions.current?.onClose
) {
  event.preventDefault();
  event.stopPropagation(); // <-- added
  currentOptions.current.onClose();
}
```

<details>
<summary>Regression risk assessment</summary>

### The `stopPropagation()` only fires when `onClose` is provided

The guard clause (`currentOptions.current?.onClose`) ensures that if no `onClose` handler is set (e.g., the DataViews dropdown), the Escape event still propagates normally — no behavior change.

### Legacy Modal already checks `defaultPrevented`

The `@wordpress/components` Modal's `handleEscapeKeyDown` already checks `!event.defaultPrevented`, so the existing `preventDefault()` call already prevents it from double-closing. However, `stopPropagation()` adds a stronger guarantee — the event never even reaches the Modal's handler. All 27 Modal unit tests still pass, including the nested modal Escape stacking test.

### All 91 Popover tests still pass

Confirming no regression for the primary consumer of `useDialog`.

### Base UI Dialog doesn't check `defaultPrevented`

It listens for Escape independently. This is precisely the scenario the fix addresses: without `stopPropagation()`, a Popover inside a Base UI Dialog would see both close on a single Escape. With it, only the innermost overlay closes.

### Nested `useDialog` instances work correctly

If the inner dialog has `onClose`, it handles Escape and stops propagation so the outer dialog doesn't fire. If the inner dialog has no `onClose`, the event propagates naturally to the outer one.

</details>

## Testing Instructions

1. Open any screen that has a Popover inside a Dialog/Modal (e.g., a dropdown inside a modal).
2. Open the Popover (e.g., click a dropdown trigger inside the modal).
3. Press Escape.
4. Verify the Popover closes but the Dialog remains open.
5. Press Escape again.
6. Verify the Dialog now closes.

### Testing Instructions for Keyboard

Same as above — the entire test is keyboard-driven.

## Use of AI Tools

Cursor + Claude Opus 4.6
