### PR TITLE
Fix: restore editor canvas padding in classic themes

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -14,8 +14,11 @@
 // Themes with theme.json can control this themselves.
 // For full-wide blocks, we compensate for the base padding.
 // These margins should match the padding value above.
-html :where(.editor-styles-wrapper) {
+.editor-styles-wrapper {
 	padding: 8px;
+}
+
+html :where(.editor-styles-wrapper) {
 	.block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {
 		margin-left: -8px;
 		margin-right: -8px;


### PR DESCRIPTION
## What?
Closes #76863

This PR restores the expected `8px` padding around the editor canvas when using classic themes. In WordPress 7.0 / Gutenberg, the padding defined in `html :where(.editor-styles-wrapper)` can be overridden by `body { padding: 0 }` introduced by global styles. As a result, the editor content touches the canvas edges.

## Why?
Classic themes expect the editor canvas to have a default `8px` padding. When this padding is overridden, the text appears flush with the edges of the editor iframe, which negatively affects the editing experience and makes the editor visually inconsistent with previous versions.

## How?
This change moves the padding declaration from `html :where(.editor-styles-wrapper)` to `.editor-styles-wrapper`. Applying the padding directly to `.editor-styles-wrapper` ensures it cannot be unintentionally overridden by global styles affecting the `body`. The existing full-width block margin compensation logic remains unchanged.

## Testing Instructions
1. Activate a classic theme (for example, Twenty Twenty).
2. Open the WordPress post editor.
3. Narrow the browser width or switch to tablet view.
4. Insert a paragraph or heading block.

Expected result: The editor canvas should display `8px` padding around the content instead of the text touching the edges.

### Testing Instructions for Keyboard
1. Open the editor using the keyboard.
2. Insert blocks and navigate between them using `Tab` and arrow keys.
3. Verify the editor layout and spacing remain correct and no visual regressions occur.