### PR TITLE
CollapsibleCard: Add HeaderDescription subcomponent

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - DataForm: Add `compact` configuration option to the `datetime` control. [#76905](https://github.com/WordPress/gutenberg/pull/76905)
 - DataViews: Field's description can accept ReactElements. [#76829](https://github.com/WordPress/gutenberg/pull/76829)
+- DataForm: Use `CollapsibleCard.HeaderDescription` for card layout header descriptions instead of manual `aria-describedby`.
 
 ## 13.1.0 (2026-03-18)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - DataForm: Add `compact` configuration option to the `datetime` control. [#76905](https://github.com/WordPress/gutenberg/pull/76905)
 - DataViews: Field's description can accept ReactElements. [#76829](https://github.com/WordPress/gutenberg/pull/76829)
-- DataForm: Use `CollapsibleCard.HeaderDescription` for card layout header descriptions instead of manual `aria-describedby`.
+- DataForm: Use `CollapsibleCard.HeaderDescription` for card layout header descriptions instead of manual `aria-describedby`. [#76867](https://github.com/WordPress/gutenberg/pull/76867)
 
 ## 13.1.0 (2026-03-18)
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -5,7 +5,6 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
-	useId,
 	useMemo,
 	useRef,
 	useState,
@@ -87,7 +86,6 @@ function isSummaryFieldVisible< Item >(
 function HeaderContent< Item >( {
 	data,
 	fields,
-	descriptionId,
 	label,
 	layout,
 	isOpen,
@@ -96,7 +94,6 @@ function HeaderContent< Item >( {
 }: {
 	data: Item;
 	fields: NormalizedField< Item >[];
-	descriptionId: string;
 	label: string | undefined;
 	layout: NormalizedCardLayout;
 	isOpen: boolean;
@@ -120,11 +117,7 @@ function HeaderContent< Item >( {
 		>
 			<Card.Title>{ label }</Card.Title>
 			{ ( hasBadge || hasSummary ) && (
-				<div
-					id={ descriptionId }
-					aria-hidden="true"
-					className="dataforms-layouts-card__field-header-content-description"
-				>
+				<CollapsibleCard.HeaderDescription className="dataforms-layouts-card__field-header-content-description">
 					{ hasBadge && <ValidationBadge validity={ validity } /> }
 					{ hasSummary && (
 						<div className="dataforms-layouts-card__field-summary">
@@ -137,7 +130,7 @@ function HeaderContent< Item >( {
 							) ) }
 						</div>
 					) }
-				</div>
+				</CollapsibleCard.HeaderDescription>
 			) }
 		</Stack>
 	);
@@ -208,7 +201,6 @@ export default function FormCardField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedCardLayout;
 	const contentRef = useRef< HTMLDivElement >( null );
-	const descriptionId = useId();
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -284,7 +276,6 @@ export default function FormCardField< Item >( {
 		<HeaderContent
 			data={ data }
 			fields={ fields }
-			descriptionId={ descriptionId }
 			label={ label }
 			layout={ layout }
 			isOpen={ isCollapsible ? !! isOpen : true }
@@ -300,7 +291,7 @@ export default function FormCardField< Item >( {
 				open={ isOpen }
 				onOpenChange={ handleOpenChange }
 			>
-				<CollapsibleCard.Header aria-describedby={ descriptionId }>
+				<CollapsibleCard.Header>
 					{ headerContent }
 				</CollapsibleCard.Header>
 				<CollapsibleCard.Content

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   Add `AlertDialog` primitive ([#76847](https://github.com/WordPress/gutenberg/pull/76847)).
 -   Add `InputControl` component ([#76653](https://github.com/WordPress/gutenberg/pull/76653)).
 -   `Dialog`: Expose `initialFocus` and `finalFocus` props on `Dialog.Popup` for custom focus management ([#76860](https://github.com/WordPress/gutenberg/pull/76860)).
--   `CollapsibleCard`: Add `HeaderDescription` subcomponent for supplementary header content with `aria-describedby` relationship.
+-   `CollapsibleCard`: Add `HeaderDescription` subcomponent for supplementary header content with `aria-describedby` relationship ([#76867](https://github.com/WordPress/gutenberg/pull/76867)).
 
 ### Bug Fixes
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Add `AlertDialog` primitive ([#76847](https://github.com/WordPress/gutenberg/pull/76847)).
 -   Add `InputControl` component ([#76653](https://github.com/WordPress/gutenberg/pull/76653)).
 -   `Dialog`: Expose `initialFocus` and `finalFocus` props on `Dialog.Popup` for custom focus management ([#76860](https://github.com/WordPress/gutenberg/pull/76860)).
+-   `CollapsibleCard`: Add `HeaderDescription` subcomponent for supplementary header content with `aria-describedby` relationship.
 
 ### Bug Fixes
 

--- a/packages/ui/src/collapsible-card/context.ts
+++ b/packages/ui/src/collapsible-card/context.ts
@@ -1,0 +1,7 @@
+import { createContext } from '@wordpress/element';
+
+export const HeaderDescriptionIdContext = createContext< {
+	setDescriptionId: ( id: string | undefined ) => void;
+} >( {
+	setDescriptionId: () => {},
+} );

--- a/packages/ui/src/collapsible-card/header-description.tsx
+++ b/packages/ui/src/collapsible-card/header-description.tsx
@@ -1,0 +1,43 @@
+import { forwardRef, useContext, useEffect, useId } from '@wordpress/element';
+import { HeaderDescriptionIdContext } from './context';
+import type { HeaderDescriptionProps } from './types';
+
+/**
+ * Secondary content placed in the collapsible card header that describes
+ * the trigger button via `aria-describedby`. Use it for supplementary
+ * information such as status badges or summary values.
+ *
+ * The content is visually rendered but marked `aria-hidden` so that
+ * assistive technologies consume it only through the `aria-describedby`
+ * relationship on the trigger, avoiding double announcements.
+ *
+ * Avoid interactive elements (buttons, links, inputs) inside this
+ * component — the entire header is the toggle trigger.
+ */
+export const HeaderDescription = forwardRef<
+	HTMLDivElement,
+	HeaderDescriptionProps
+>( function CollapsibleCardHeaderDescription(
+	{ children, className, ...restProps },
+	ref
+) {
+	const descriptionId = useId();
+	const { setDescriptionId } = useContext( HeaderDescriptionIdContext );
+
+	useEffect( () => {
+		setDescriptionId( descriptionId );
+		return () => setDescriptionId( undefined );
+	}, [ descriptionId, setDescriptionId ] );
+
+	return (
+		<div
+			ref={ ref }
+			id={ descriptionId }
+			aria-hidden="true"
+			className={ className }
+			{ ...restProps }
+		>
+			{ children }
+		</div>
+	);
+} );

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useMemo, useState } from '@wordpress/element';
 import { chevronDown } from '@wordpress/icons';
 import * as Card from '../card';
 import * as Collapsible from '../collapsible';
 import { Icon } from '../icon';
 import styles from './style.module.css';
 import focusStyles from '../utils/css/focus.module.css';
+import { HeaderDescriptionIdContext } from './context';
 import type { HeaderProps } from './types';
 
 /**
@@ -22,38 +23,54 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 		{ children, className, render, ...restProps },
 		ref
 	) {
+		const [ descriptionId, setDescriptionId ] = useState< string >();
+
+		const contextValue = useMemo(
+			() => ( { setDescriptionId } ),
+			[ setDescriptionId ]
+		);
+
 		return (
-			<Collapsible.Trigger
-				className={ clsx( styles.header, className ) }
-				render={
-					<Card.Header
-						ref={ ref }
-						render={ render }
-						{ ...restProps }
-					/>
-				}
-				nativeButton={ false }
-			>
-				<div className={ styles[ 'header-content' ] }>{ children }</div>
-				<div
-					className={ clsx( styles[ 'header-trigger-positioner' ] ) }
+			<HeaderDescriptionIdContext.Provider value={ contextValue }>
+				<Collapsible.Trigger
+					className={ clsx( styles.header, className ) }
+					render={
+						<Card.Header
+							ref={ ref }
+							render={ render }
+							{ ...restProps }
+						/>
+					}
+					nativeButton={ false }
+					aria-describedby={ descriptionId }
 				>
+					<div className={ styles[ 'header-content' ] }>
+						{ children }
+					</div>
 					<div
 						className={ clsx(
-							styles[ 'header-trigger-wrapper' ],
-							// While the interactive trigger element is the whole header,
-							// the focus ring will be displayed only on the icon to visually
-							// emulate it being the button.
-							focusStyles[ 'outset-ring--focus-parent-visible' ]
+							styles[ 'header-trigger-positioner' ]
 						) }
 					>
-						<Icon
-							icon={ chevronDown }
-							className={ styles[ 'header-trigger' ] }
-						/>
+						<div
+							className={ clsx(
+								styles[ 'header-trigger-wrapper' ],
+								// While the interactive trigger element is the whole header,
+								// the focus ring will be displayed only on the icon to visually
+								// emulate it being the button.
+								focusStyles[
+									'outset-ring--focus-parent-visible'
+								]
+							) }
+						>
+							<Icon
+								icon={ chevronDown }
+								className={ styles[ 'header-trigger' ] }
+							/>
+						</div>
 					</div>
-				</div>
-			</Collapsible.Trigger>
+				</Collapsible.Trigger>
+			</HeaderDescriptionIdContext.Provider>
 		);
 	}
 );

--- a/packages/ui/src/collapsible-card/index.ts
+++ b/packages/ui/src/collapsible-card/index.ts
@@ -1,5 +1,6 @@
 import { Root } from './root';
 import { Header } from './header';
+import { HeaderDescription } from './header-description';
 import { Content } from './content';
 
-export { Root, Header, Content };
+export { Root, Header, HeaderDescription, Content };

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import * as Card from '../../card';
 import * as CollapsibleCard from '../index';
+import { Stack } from '../../stack';
 
 /**
  * Temporary text component for story examples. This will be replaced by an
@@ -177,17 +178,19 @@ export const WithHeaderDescription: Story = {
 			{ ...restArgs }
 		>
 			<CollapsibleCard.Header>
-				<Card.Title>Settings</Card.Title>
-				<CollapsibleCard.HeaderDescription>
-					<span
-						style={ {
-							fontSize: 'var(--wpds-font-size-sm)',
-							color: 'var(--wpds-color-fg-content-neutral-weak)',
-						} }
-					>
-						3 items configured
-					</span>
-				</CollapsibleCard.HeaderDescription>
+				<Stack justify="space-between">
+					<Card.Title>Settings</Card.Title>
+					<CollapsibleCard.HeaderDescription>
+						<span
+							style={ {
+								fontSize: 'var(--wpds-font-size-sm)',
+								color: 'var(--wpds-color-fg-content-neutral-weak)',
+							} }
+						>
+							3 items configured
+						</span>
+					</CollapsibleCard.HeaderDescription>
+				</Stack>
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Text>

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -29,6 +29,7 @@ const meta: Meta< typeof CollapsibleCard.Root > = {
 	component: CollapsibleCard.Root,
 	subcomponents: {
 		'CollapsibleCard.Header': CollapsibleCard.Header,
+		'CollapsibleCard.HeaderDescription': CollapsibleCard.HeaderDescription,
 		'CollapsibleCard.Content': CollapsibleCard.Content,
 	},
 };
@@ -153,6 +154,49 @@ export const Stacked: Story = {
 				</CollapsibleCard.Root>
 			) ) }
 		</div>
+	),
+};
+
+/**
+ * A collapsible card with a `HeaderDescription` that provides supplementary
+ * information (e.g. status, summary) as an `aria-describedby` relationship.
+ */
+export const WithHeaderDescription: Story = {
+	// `defaultOpen` (uncontrolled) and `open` (controlled) should not be
+	// used together — disable the `open` control to avoid confusion.
+	argTypes: { open: { control: false } },
+	args: {
+		defaultOpen: true,
+	},
+	render: ( { open, defaultOpen, onOpenChange, disabled, ...restArgs } ) => (
+		<CollapsibleCard.Root
+			open={ open }
+			defaultOpen={ defaultOpen }
+			onOpenChange={ onOpenChange }
+			disabled={ disabled }
+			{ ...restArgs }
+		>
+			<CollapsibleCard.Header>
+				<Card.Title>Settings</Card.Title>
+				<CollapsibleCard.HeaderDescription>
+					<span
+						style={ {
+							fontSize: 'var(--wpds-font-size-sm)',
+							color: 'var(--wpds-color-fg-content-neutral-weak)',
+						} }
+					>
+						3 items configured
+					</span>
+				</CollapsibleCard.HeaderDescription>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Text>
+					The header description provides supplementary context to the
+					trigger button. Assistive technologies will announce the
+					description alongside the button label.
+				</Text>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	),
 };
 

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -268,7 +268,7 @@ describe( 'CollapsibleCard', () => {
 				</CollapsibleCard.Root>
 			);
 
-			expect( screen.getByText( 'Badge content' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Badge content' ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -178,4 +178,97 @@ describe( 'CollapsibleCard', () => {
 			).toBeVisible();
 		} );
 	} );
+
+	describe( 'HeaderDescription', () => {
+		it( 'sets aria-describedby on the trigger pointing to the description', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>Settings</Card.Title>
+						<CollapsibleCard.HeaderDescription data-testid="desc">
+							3 errors
+						</CollapsibleCard.HeaderDescription>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<p>Content</p>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			);
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Settings',
+			} );
+			const descriptionElement = screen.getByTestId( 'desc' );
+
+			expect( descriptionElement ).toHaveAttribute( 'id' );
+			expect( trigger ).toHaveAttribute(
+				'aria-describedby',
+				descriptionElement.id
+			);
+		} );
+
+		it( 'marks the description content as aria-hidden', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>Settings</Card.Title>
+						<CollapsibleCard.HeaderDescription data-testid="desc">
+							<span>Status: OK</span>
+						</CollapsibleCard.HeaderDescription>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			const descriptionWrapper = screen.getByTestId( 'desc' );
+			expect( descriptionWrapper ).toHaveAttribute(
+				'aria-hidden',
+				'true'
+			);
+		} );
+
+		it( 'does not set aria-describedby when HeaderDescription is absent', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>Title</Card.Title>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			const trigger = screen.getByRole( 'button', { name: 'Title' } );
+			expect( trigger ).not.toHaveAttribute( 'aria-describedby' );
+		} );
+
+		it( 'forwards ref on HeaderDescription', () => {
+			const descRef = createRef< HTMLDivElement >();
+
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>Title</Card.Title>
+						<CollapsibleCard.HeaderDescription ref={ descRef }>
+							Description
+						</CollapsibleCard.HeaderDescription>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			expect( descRef.current ).toBeInstanceOf( HTMLDivElement );
+		} );
+
+		it( 'renders description content visually', () => {
+			render(
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>Title</Card.Title>
+						<CollapsibleCard.HeaderDescription>
+							Badge content
+						</CollapsibleCard.HeaderDescription>
+					</CollapsibleCard.Header>
+				</CollapsibleCard.Root>
+			);
+
+			expect( screen.getByText( 'Badge content' ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/packages/ui/src/collapsible-card/types.ts
+++ b/packages/ui/src/collapsible-card/types.ts
@@ -37,6 +37,18 @@ export interface HeaderProps extends ComponentProps< 'div' > {
 	children?: ReactNode;
 }
 
+export interface HeaderDescriptionProps extends ComponentProps< 'div' > {
+	/**
+	 * Secondary content that describes the header trigger via
+	 * `aria-describedby`. Rendered visually but marked `aria-hidden`
+	 * so assistive technologies consume it only through the description
+	 * relationship, avoiding double announcements.
+	 *
+	 * Avoid interactive elements — the entire header is the toggle trigger.
+	 */
+	children?: ReactNode;
+}
+
 export interface ContentProps extends ComponentProps< 'div' > {
 	/**
 	 * The content to be rendered inside the collapsible content area.


### PR DESCRIPTION
## What?

Add a `CollapsibleCard.HeaderDescription` subcomponent to `@wordpress/ui` for supplementary header content (badges, summaries) with proper `aria-describedby` semantics. Refactor the DataForm card layout to use it.

Follow-up to #76282, based on the [discussion between @ciampo and @mirka](https://github.com/WordPress/gutenberg/pull/76282). Part of #76100.

## Why?

The manual `useId()` + `aria-hidden` + `aria-describedby` pattern used in #76282 is generic enough to belong in `CollapsibleCard` itself, so consumers don't have to wire it up every time.

## How?

`HeaderDescription` renders its children with `aria-hidden="true"` and an auto-generated ID. A React context communicates the ID to the parent `Header`, which sets `aria-describedby` on the trigger. When no `HeaderDescription` is present, `aria-describedby` is omitted.

The component does not apply any layout styles by default — consumers can pass a `className` to control how the description participates in the header layout (e.g. the DataForm card layout uses `display: contents`).

```jsx
<CollapsibleCard.Root>
  <CollapsibleCard.Header>
    <Card.Title>Settings</Card.Title>
    <CollapsibleCard.HeaderDescription>
      3 items configured
    </CollapsibleCard.HeaderDescription>
  </CollapsibleCard.Header>
  <CollapsibleCard.Content>
    <p>Content here</p>
  </CollapsibleCard.Content>
</CollapsibleCard.Root>
```

<details>
<summary>Implementation details</summary>

### New files (`@wordpress/ui`)
- **`collapsible-card/header-description.tsx`** — the subcomponent (`aria-hidden`, `useId`, no default layout styles)
- **`collapsible-card/context.ts`** — `HeaderDescriptionIdContext` for ID registration

### Modified files
- **`collapsible-card/header.tsx`** — provides context, conditionally sets `aria-describedby`
- **`collapsible-card/types.ts`** — added `HeaderDescriptionProps`
- **`collapsible-card/index.ts`** — exports `HeaderDescription`
- **`collapsible-card/test/index.test.tsx`** — 5 new tests
- **`collapsible-card/stories/index.story.tsx`** — `WithHeaderDescription` story

### DataForm card layout refactoring (`@wordpress/dataviews`)
- Replaced manual `useId()` + `aria-hidden` div + `aria-describedby` with `<CollapsibleCard.HeaderDescription>`
- The `display: contents` style remains in the DataForm's own SCSS, passed via `className`

</details>

## Testing Instructions

1. `CollapsibleCard` unit tests pass
2. Dataviews unit tests pass
3. Storybook: check the new `WithHeaderDescription` story and verify `aria-describedby` in dev tools
4. Storybook: check `DataForm / LayoutCard` collapsible cards still work

## AI Tooling

Cursor + Claude Opus 4.6
