### PR TITLE
Build: Fix import map ordering in wp-build page template

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1184,10 +1184,21 @@ async function generatePagesPhp( pageData, replacements ) {
 			),
 		] );
 
-		// Generate empty loader.js (dummy module for dependencies)
+		// Generate loader.js — boots the page using the config global set
+		// by the classic prerequisites script. Runs as a module so the
+		// import map is guaranteed to be in the DOM.
+		const pageSlugUnderscore = page.slug.replace( /-/g, '_' );
 		await writeFile(
 			path.join( BUILD_DIR, 'pages', page.slug, 'loader.js' ),
-			'// Empty module loader for page dependencies\n'
+			[
+				`import { initSinglePage } from '@wordpress/boot';`,
+				``,
+				`const config = window.__wpBuildPageConfig_${ pageSlugUnderscore };`,
+				`if ( config ) {`,
+				`\tinitSinglePage( config );`,
+				`}`,
+				``,
+			].join( '\n' )
 		);
 	} );
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -148,18 +148,24 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 	if ( file_exists( $asset_file ) ) {
 		$asset = require $asset_file;
 
-		// This script serves two purposes:
-		// 1. It ensures all the globals that are made available to the modules are loaded.
-		// 2. It initializes the boot module as an inline script.
+		// Ensure classic-script dependencies (globals) are loaded.
+		// Boot config is passed as a global because import() inside a
+		// classic inline script runs before the import map is in the DOM.
+		// The loader module reads it after the import map is available.
 		wp_register_script( '{{PAGE_SLUG}}-wp-admin-prerequisites', '', $asset['dependencies'], $asset['version'], true );
 
-		// Add inline script to initialize the app using initSinglePage (no menuItems)
 		wp_add_inline_script(
 			'{{PAGE_SLUG}}-wp-admin-prerequisites',
 			sprintf(
-				'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "%s", routes: %s}));',
-				'{{PAGE_SLUG}}-wp-admin-app',
-				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+				'window.__wpBuildPageConfig_%s = %s;',
+				'{{PAGE_SLUG_UNDERSCORE}}',
+				wp_json_encode(
+					array(
+						'mountId' => '{{PAGE_SLUG}}-wp-admin-app',
+						'routes'  => $routes,
+					),
+					JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
+				)
 			)
 		);
 
@@ -196,7 +202,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 			}
 		}
 
-		// Dummy script module to ensure dependencies are loaded
+		// Loader module — reads the page config global and boots the app.
 		wp_register_script_module(
 			'{{PAGE_SLUG}}-wp-admin',
 			$build_constants['build_url'] . 'pages/{{PAGE_SLUG}}/loader.js',


### PR DESCRIPTION
## Description

The `page-wp-admin.php` template generated by `@wordpress/build` uses `import("@wordpress/boot")` inside a classic inline script (`wp_add_inline_script`). This is incorrect: `import()` with a bare specifier requires the import map to already be in the DOM.

In `admin_print_footer_scripts`, both `_wp_footer_scripts` and `print_import_map` are registered at priority 10, but `_wp_footer_scripts` comes first in registration order. The classic inline script therefore always appears before the import map in the HTML output.

This works by accident in most environments — browsers typically defer the specifier resolution to a microtask, by which point the import map has been parsed. But any plugin that changes execution timing (e.g. converting scripts to \`type="module"\` via \`script_loader_tag\`) breaks it:

\`\`\`
TypeError: Failed to resolve module specifier '@wordpress/boot'
\`\`\`

This affects all wp-build pages: Forms, Font Library, Connectors.

## Fix

Two changes:

1. **Template** (`page-wp-admin.php.template`): The inline script no longer calls `import()`. Instead it sets the boot config as a plain global (`window.__wpBuildBootConfig`).

2. **Loader** (`build.mjs`): The previously empty `loader.js` stub now contains the actual boot code — it imports `@wordpress/boot` and calls `initSinglePage` with the config from the global. Since `loader.js` is a registered script module, it executes after the import map by definition.

## Testing

1. Build a project that uses `@wordpress/build` with a `wp-admin` page layout
2. Install [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/)
3. Navigate to the wp-build page — should render normally
4. Check console — no module specifier errors
5. With Gutenberg plugin active, also test `/wp-admin/themes.php?page=font-library-wp-admin` and `/wp-admin/options-general.php?page=options-connectors-wp-admin`