### PR TITLE
Font Library: Trim whitespace from font search input

### DIFF
--- a/packages/global-styles-ui/src/font-library/utils/filter-fonts.ts
+++ b/packages/global-styles-ui/src/font-library/utils/filter-fonts.ts
@@ -39,7 +39,7 @@ export default function filterFonts(
 				font.font_family_settings &&
 				font.font_family_settings.name
 					.toLowerCase()
-					.includes( search.toLowerCase() )
+					.includes( search.trim().toLowerCase() )
 		);
 	}
 

--- a/packages/global-styles-ui/src/font-library/utils/test/filter-fonts.test.ts
+++ b/packages/global-styles-ui/src/font-library/utils/test/filter-fonts.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import filterFonts from '../filter-fonts';
+
+const mockFonts = [
+	{
+		font_family_settings: {
+			name: 'Roboto',
+			slug: 'roboto',
+		},
+		categories: [ 'sans-serif' ],
+	},
+	{
+		font_family_settings: {
+			name: 'Open Sans',
+			slug: 'open-sans',
+		},
+		categories: [ 'sans-serif' ],
+	},
+	{
+		font_family_settings: {
+			name: 'Lora',
+			slug: 'lora',
+		},
+		categories: [ 'serif' ],
+	},
+];
+
+describe( 'filterFonts', () => {
+	it( 'should return all fonts when no filters are provided', () => {
+		const result = filterFonts( mockFonts, {} );
+		expect( result ).toEqual( mockFonts );
+	} );
+
+	it( 'should filter by search term', () => {
+		const result = filterFonts( mockFonts, { search: 'roboto' } );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].font_family_settings.name ).toBe( 'Roboto' );
+	} );
+
+	it( 'should filter by search term with trailing space', () => {
+		const result = filterFonts( mockFonts, { search: 'Roboto ' } );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].font_family_settings.name ).toBe( 'Roboto' );
+	} );
+
+	it( 'should filter by search term with leading space', () => {
+		const result = filterFonts( mockFonts, { search: ' Roboto' } );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].font_family_settings.name ).toBe( 'Roboto' );
+	} );
+
+	it( 'should filter by search term with leading and trailing spaces', () => {
+		const result = filterFonts( mockFonts, { search: ' Open Sans ' } );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].font_family_settings.name ).toBe( 'Open Sans' );
+	} );
+
+	it( 'should filter by category', () => {
+		const result = filterFonts( mockFonts, { category: 'serif' } );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].font_family_settings.name ).toBe( 'Lora' );
+	} );
+
+	it( 'should return all fonts when category is "all"', () => {
+		const result = filterFonts( mockFonts, { category: 'all' } );
+		expect( result ).toEqual( mockFonts );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes an issue where searching for a font name with leading or trailing spaces (e.g., "Roboto ") in the Font Library's Install Fonts tab returned no results. Adds `.trim()` to the search term before comparison, consistent with other search utilities in the codebase (`dataviews`, `block-library`, `editor`).

Closes #76866

## Test plan

- [ ] Open the Font Library
- [ ] Go to the "Install Fonts" tab
- [ ] Search for a font name with a trailing space (e.g., "Roboto ")
- [ ] Confirm results are displayed correctly
- [ ] Search with a leading space (e.g., " Roboto")
- [ ] Confirm results are displayed correctly
- [ ] Search without extra spaces to confirm normal behavior is unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)