### PR TITLE
RTC: Restore on failed request with compaction update

### DIFF
--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -505,14 +505,30 @@ function poll(): void {
 				MAX_ERROR_BACKOFF_IN_MS
 			);
 
-			// Restore updates to queues on failure so they can be retried.
+			// Recover from the failed request. We don't know whether the server stored
+			// our updates before the error occurred (e.g. a network timeout after a
+			// successful write). Re-sending the same updates via restore() would
+			// duplicate them on the server and cause unbounded storage growth.
+			//
+			// Instead, for rooms that had outgoing updates, replace the queue with a
+			// single compaction (full document state). This is idempotent: if the
+			// server already stored the updates, the compaction safely supersedes
+			// them; if it didn't, the compaction includes them. Updates not seen by
+			// this client are preserved in both cases.
 			for ( const room of payload.rooms ) {
 				if ( ! roomStates.has( room.room ) ) {
 					continue;
 				}
 
 				const state = roomStates.get( room.room )!;
-				state.updateQueue.restore( room.updates );
+
+				if ( room.updates.length > 0 && state.endCursor > 0 ) {
+					state.updateQueue.clear();
+					state.updateQueue.add( state.createCompactionUpdate() );
+				} else if ( room.updates.length > 0 ) {
+					state.updateQueue.restore( room.updates );
+				}
+
 				state.log(
 					'Error posting sync update, will retry with backoff',
 					{

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -803,6 +803,123 @@ describe( 'polling-manager', () => {
 		} );
 	} );
 
+	describe( 'error recovery', () => {
+		it( 'replaces queued updates with a compaction after a poll error', async () => {
+			// First poll: succeed with collaborators to resume the queue.
+			const responseWithCollaborator = {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: { 1: {}, 2: {} },
+						updates: [],
+					},
+				],
+			};
+			mockPostSyncUpdate.mockResolvedValueOnce(
+				responseWithCollaborator
+			);
+
+			const doc = createMockDoc( 1 );
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			// Flush the initial poll (queue is paused, so no updates sent).
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Add a document update (queue is now resumed due to collaborators).
+			const onDocUpdate = getOnDocUpdate( doc );
+			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'user' );
+
+			// Second poll: fail with a network error.
+			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'timeout' ) );
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// Verify the second poll included the queued updates (sync_step1 + doc update).
+			const secondCallPayload = mockPostSyncUpdate.mock
+				.calls[ 1 ][ 0 ] as {
+				rooms: Array< {
+					updates: Array< { type: string } >;
+				} >;
+			};
+			expect(
+				secondCallPayload.rooms[ 0 ].updates.length
+			).toBeGreaterThan( 0 );
+
+			// Third poll: succeed — verify it sends a compaction instead of
+			// restoring the same updates.
+			mockPostSyncUpdate.mockResolvedValueOnce(
+				responseWithCollaborator
+			);
+
+			// Error handler doubled the interval: min(1000 * 2, 30000) = 2000.
+			await jest.advanceTimersByTimeAsync( 2000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			const thirdCallPayload = mockPostSyncUpdate.mock
+				.calls[ 2 ][ 0 ] as {
+				rooms: Array< {
+					updates: Array< { type: string } >;
+				} >;
+			};
+			const retryUpdates = thirdCallPayload.rooms[ 0 ].updates;
+			expect( retryUpdates ).toHaveLength( 1 );
+			expect( retryUpdates[ 0 ].type ).toBe( 'compaction' );
+		} );
+
+		it( 'does not queue a compaction for rooms with no outgoing updates', async () => {
+			// First poll succeeds (no collaborators, queue stays paused).
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Second poll: fail (no updates were sent because queue is paused).
+			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'timeout' ) );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// Verify no updates were sent on the failed poll.
+			const secondCallPayload = mockPostSyncUpdate.mock
+				.calls[ 1 ][ 0 ] as {
+				rooms: Array< {
+					updates: Array< { type: string } >;
+				} >;
+			};
+			expect( secondCallPayload.rooms[ 0 ].updates ).toHaveLength( 0 );
+
+			// Third poll: succeed — should still have no updates (no compaction queued).
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+			await jest.advanceTimersByTimeAsync( 8000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			const thirdCallPayload = mockPostSyncUpdate.mock
+				.calls[ 2 ][ 0 ] as {
+				rooms: Array< {
+					updates: Array< { type: string } >;
+				} >;
+			};
+			expect( thirdCallPayload.rooms[ 0 ].updates ).toHaveLength( 0 );
+		} );
+	} );
+
 	describe( 'visibility change', () => {
 		it( 'does not spawn a duplicate poll when a request is in-flight', () => {
 			// Keep the first postSyncUpdate pending so we can simulate


### PR DESCRIPTION

## What?

When an RTC polling request fails, convert queued updates into a compaction update instead of replaying them.

## Why?

In at least one instance, we have observed a cascading failure that results in thousands of duplicate updates, eventually resulting in OOM errors. This appears to happen when the server request fails _after_ it successfully writes the provided updates—either because of an unknown code failure or because of a timeout or other transport issue.

When this happens, the client detects the failure and restores the updates to the queue. The exact same updates are then sent on the following poll request.

If this pattern repeats, updates are continuously duplicated leading to unbounded growth of sync data and eventual OOM errors.

## How?

Instead of blindly replaying updates on failure, we must accept the possibility that the updates were successful. 

This PR replaces the queue `restore()` strategy with compaction: instead of re-sending the updates, the client encodes its full document state as a single compaction update and clears the queue. This is safe because:

- If the server stored the original updates before the error, the compaction supersedes them.
- If it didn’t, the compaction contains the same state.
- Sending the same compaction multiple times is idempotent (Yjs CRDT merge).

When `endCursor` is still `0` (no successful poll yet), we fall back to `restore()` since the queue only contains the initial `sync_step1` update and there’s no meaningful document state to compact. Additionally, compaction updates require an `endCursor` so that they target existing updates.

In theory, it's still possible for this issue to manifest on the very first poll request that contains updates, but the risk should be dramatically reduced.