### PR TITLE
RTC: Fix notes not syncing between collaborative editors

### DIFF
--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -447,15 +447,19 @@ function poll(): void {
 				roomState.processAwarenessUpdate( room.awareness );
 
 				// If there is another collaborator on the primary entity,
-				// resume the queue for the next poll and increase polling
-				// frequency. We only check the primary room to avoid false
-				// positives from shared collection rooms (e.g. taxonomy/category).
+				// resume all room queues for the next poll and increase
+				// polling frequency. We only check the primary room to
+				// avoid false positives from shared collection rooms
+				// (e.g. taxonomy/category), but resume all queues so
+				// collection rooms (e.g. root/comment) can also sync.
 				if (
 					roomState.isPrimaryRoom &&
 					Object.keys( room.awareness ).length > 1
 				) {
 					hasCollaborators = true;
-					roomState.updateQueue.resume();
+					roomStates.forEach( ( state ) => {
+						state.updateQueue.resume();
+					} );
 				}
 
 				// Process each incoming update and collect any responses.

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -77,6 +77,17 @@ function createMockDoc( clientID = 1 ) {
 	return { clientID, on: jest.fn(), off: jest.fn() };
 }
 
+// Helper to extract the onDocUpdate callback registered via doc.on('updateV2', ...).
+function getOnDocUpdate( doc: ReturnType< typeof createMockDoc > ) {
+	const call = doc.on.mock.calls.find(
+		( args: unknown[] ) => args[ 0 ] === 'updateV2'
+	);
+	if ( ! call ) {
+		throw new Error( 'onDocUpdate not registered' );
+	}
+	return call[ 1 ] as ( update: Uint8Array, origin: unknown ) => void;
+}
+
 function createMockAwareness() {
 	return {
 		clientID: 1,
@@ -141,17 +152,6 @@ describe( 'polling-manager', () => {
 	} );
 
 	describe( 'document size limit', () => {
-		// Helper to extract the onDocUpdate callback registered via doc.on('updateV2', ...).
-		function getOnDocUpdate( doc: ReturnType< typeof createMockDoc > ) {
-			const call = doc.on.mock.calls.find(
-				( args: unknown[] ) => args[ 0 ] === 'updateV2'
-			);
-			if ( ! call ) {
-				throw new Error( 'onDocUpdate not registered' );
-			}
-			return call[ 1 ] as ( update: Uint8Array, origin: unknown ) => void;
-		}
-
 		it( 'emits document-size-limit-exceeded error when an update exceeds the size limit', async () => {
 			mockPostSyncUpdate.mockResolvedValue( syncResponse );
 
@@ -722,9 +722,7 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 
 			// Simulate a local doc update on the collection room (e.g., a note was saved).
-			const onDocUpdate = collectionDoc.on.mock.calls.find(
-				( args: unknown[] ) => args[ 0 ] === 'updateV2'
-			)![ 1 ] as ( update: Uint8Array, origin: unknown ) => void;
+			const onDocUpdate = getOnDocUpdate( collectionDoc );
 			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'local-origin' );
 
 			// Second poll: still no collaborators, collection room updates should be empty.

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -552,6 +552,259 @@ describe( 'polling-manager', () => {
 		} );
 	} );
 
+	describe( 'collaborator queue resumption', () => {
+		it( 'resumes non-primary room queues when collaborators are detected on primary room', async () => {
+			// First poll: primary room has collaborators, collection room has none.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 1,
+						awareness: {
+							1: { collaboratorInfo: { id: 100 } },
+							2: { collaboratorInfo: { id: 200 } },
+						},
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+
+			// Register primary room first (becomes isPrimaryRoom).
+			pollingManager.registerRoom( {
+				room: 'primary-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'collection-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			// First poll: detects collaborators on primary room, resumes all queues.
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			// Second poll: collection room queue should now be unpaused,
+			// so its initial sync_step1 update should be included.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 2,
+						awareness: {
+							1: { collaboratorInfo: { id: 100 } },
+							2: { collaboratorInfo: { id: 200 } },
+						},
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 2,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			// The second call should include non-empty updates for the collection room.
+			const secondCallPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
+			const collectionRoom = secondCallPayload.rooms.find(
+				( r: { room: string } ) => r.room === 'collection-room'
+			);
+			expect( collectionRoom!.updates.length ).toBeGreaterThan( 0 );
+		} );
+
+		it( 'does not resume non-primary room queues when no collaborators are detected', async () => {
+			// Only 1 client (self) — no collaborators.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 1,
+						awareness: { 1: { collaboratorInfo: { id: 100 } } },
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'primary-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'collection-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			// First poll: no collaborators.
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			// Second poll: collection room queue should still be paused.
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			const secondCallPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
+			const collectionRoom = secondCallPayload.rooms.find(
+				( r: { room: string } ) => r.room === 'collection-room'
+			);
+			expect( collectionRoom!.updates ).toEqual( [] );
+		} );
+
+		it( 'sends accumulated collection room updates after collaborator detection', async () => {
+			// First poll: no collaborators.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 1,
+						awareness: { 1: { collaboratorInfo: { id: 100 } } },
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+
+			const collectionDoc = createMockDoc( 2 );
+
+			pollingManager.registerRoom( {
+				room: 'primary-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			pollingManager.registerRoom( {
+				room: 'collection-room',
+				doc: collectionDoc,
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			// First poll: no collaborators, queues stay paused.
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			// Simulate a local doc update on the collection room (e.g., a note was saved).
+			const onDocUpdate = collectionDoc.on.mock.calls.find(
+				( args: unknown[] ) => args[ 0 ] === 'updateV2'
+			)![ 1 ] as ( update: Uint8Array, origin: unknown ) => void;
+			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'local-origin' );
+
+			// Second poll: still no collaborators, collection room updates should be empty.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 2,
+						awareness: { 1: { collaboratorInfo: { id: 100 } } },
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 2,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			const secondCallPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
+			const collectionRoomPoll2 = secondCallPayload.rooms.find(
+				( r: { room: string } ) => r.room === 'collection-room'
+			);
+			expect( collectionRoomPoll2!.updates ).toEqual( [] );
+
+			// Third poll: collaborator joins — queues should be resumed.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 3,
+						awareness: {
+							1: { collaboratorInfo: { id: 100 } },
+							2: { collaboratorInfo: { id: 200 } },
+						},
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 3,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			// Fourth poll: collection room should now send accumulated updates.
+			mockPostSyncUpdate.mockResolvedValue( {
+				rooms: [
+					{
+						room: 'primary-room',
+						end_cursor: 4,
+						awareness: {
+							1: { collaboratorInfo: { id: 100 } },
+							2: { collaboratorInfo: { id: 200 } },
+						},
+						updates: [],
+					},
+					{
+						room: 'collection-room',
+						end_cursor: 4,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 1000 );
+
+			const fourthCallPayload = mockPostSyncUpdate.mock.calls[ 3 ][ 0 ];
+			const collectionRoomPoll4 = fourthCallPayload.rooms.find(
+				( r: { room: string } ) => r.room === 'collection-room'
+			);
+			// Should include the initial sync_step1 update + the local update.
+			expect( collectionRoomPoll4!.updates.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
 	describe( 'visibility change', () => {
 		it( 'does not spawn a duplicate poll when a request is in-flight', () => {
 			// Keep the first postSyncUpdate pending so we can simulate

--- a/test/e2e/specs/editor/collaboration/collaboration-notes.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-notes.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - Notes Sync', () => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+	} );
+
+	test( 'User A adds a note, User B sees it', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Notes Sync Test',
+			status: 'draft',
+			content:
+				'<!-- wp:paragraph --><p>Block with note</p><!-- /wp:paragraph -->',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2 } = collaborationUtils;
+
+		// User A inserts a block and adds a note.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Note target block' },
+		} );
+
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		await page
+			.getByRole( 'textbox', { name: 'New note', exact: true } )
+			.fill( 'Hello from User A' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Add note', exact: true } )
+			.click();
+
+		// Verify the note appears locally for User A first.
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Hello from User A' } )
+		).toBeVisible();
+
+		// Wait for sync to propagate the block metadata and the
+		// collection save event to User B.
+		await collaborationUtils.waitForSyncCycle( page );
+		await collaborationUtils.waitForSyncCycle( page2 );
+
+		// Open the All Notes sidebar on User B's page.
+		const toggleButton = page2
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'All notes', exact: true } );
+
+		// The button may need a moment to appear after the note syncs.
+		await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
+		const isExpanded = await toggleButton.getAttribute( 'aria-expanded' );
+		if ( isExpanded === 'false' ) {
+			await toggleButton.click();
+		}
+
+		// User B should see the note from User A.
+		await expect(
+			page2
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Hello from User A' } )
+		).toBeVisible( { timeout: 10000 } );
+	} );
+
+	test( 'User B adds a note, User A sees it', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Notes Sync Test - B to A',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2 } = collaborationUtils;
+
+		// User A inserts a block so both users have content.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Shared paragraph' },
+		} );
+
+		// Wait for the block to sync to User B.
+		await collaborationUtils.waitForSyncCycle( page );
+		await collaborationUtils.waitForSyncCycle( page2 );
+
+		// User B clicks on the synced block in the canvas to select it.
+		const page2Editor = collaborationUtils.editor2;
+		await page2Editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Shared paragraph' } )
+			.click();
+
+		// User B adds a note using the block options menu.
+		await page2Editor.clickBlockOptionsMenuItem( 'Add note' );
+		await page2
+			.getByRole( 'textbox', { name: 'New note', exact: true } )
+			.fill( 'Note from User B' );
+		await page2
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Add note', exact: true } )
+			.click();
+
+		// Verify the note appears locally for User B.
+		await expect(
+			page2
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Note from User B' } )
+		).toBeVisible();
+
+		// Wait for sync cycles.
+		await collaborationUtils.waitForSyncCycle( page2 );
+		await collaborationUtils.waitForSyncCycle( page );
+
+		// Open notes sidebar on User A's page.
+		const toggleButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'All notes', exact: true } );
+		await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
+		const isExpanded = await toggleButton.getAttribute( 'aria-expanded' );
+		if ( isExpanded === 'false' ) {
+			await toggleButton.click();
+		}
+
+		// User A should see the note from User B.
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Note from User B' } )
+		).toBeVisible( { timeout: 10000 } );
+	} );
+
+	test( 'Note with reply syncs between users', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Notes Reply Sync Test',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2 } = collaborationUtils;
+
+		// User A inserts a block and adds a note with a reply.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Block for reply test' },
+		} );
+
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		await page
+			.getByRole( 'textbox', { name: 'New note', exact: true } )
+			.fill( 'Main note' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Add note', exact: true } )
+			.click();
+
+		// Wait for note to be saved before adding a reply.
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Main note' } )
+		).toBeVisible();
+
+		// Add a reply.
+		await page
+			.getByRole( 'textbox', { name: 'Reply to' } )
+			.fill( 'A reply to the note' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Reply', exact: true } )
+			.click();
+
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Reply added.' } )
+		).toBeVisible();
+
+		// Wait for sync cycles.
+		await collaborationUtils.waitForSyncCycle( page );
+		await collaborationUtils.waitForSyncCycle( page2 );
+
+		// Open notes sidebar on User B's page.
+		const toggleButton = page2
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'All notes', exact: true } );
+		await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
+		const isExpanded = await toggleButton.getAttribute( 'aria-expanded' );
+		if ( isExpanded === 'false' ) {
+			await toggleButton.click();
+		}
+
+		// User B should see the main note.
+		const thread = page2
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'treeitem', { name: 'Note: Main note' } );
+		await expect( thread ).toBeVisible( { timeout: 10000 } );
+
+		// Expand the thread to see the reply.
+		await thread.click();
+
+		// User B should see both the main note content and the reply.
+		await expect(
+			page2.locator( '.editor-collab-sidebar-panel__user-comment' ).last()
+		).toHaveText( 'A reply to the note', { timeout: 5000 } );
+	} );
+} );


### PR DESCRIPTION
## What?

Fixes collaborative editing notes (block comments) not syncing between editors. When User A adds a note to a block, User B never sees it until they refresh the page.

## Why?

PR #76704 introduced the `isPrimaryRoom` concept to the HTTP polling manager to optimise collaborator detection — only the primary room (the post entity) is checked for awareness to avoid false positives from shared collection rooms like `taxonomy/category`.

However, the change accidentally restricted `updateQueue.resume()` to **only** the primary room's queue. Non-primary rooms — such as the `root/comment` collection room used for notes — had their update queues permanently paused. Since a paused queue's `get()` returns `[]`, CRDT save events from `markEntityAsSaved()` were never sent to the server, and notes never synced between editors.

## How?

When collaborators are detected on the primary room, resume **all** room queues instead of just the primary room's queue. This preserves the optimisation of only checking the primary room for collaborator awareness while ensuring collection rooms can also send their updates.

**The fix** (`packages/sync/src/providers/http-polling/polling-manager.ts`):

```diff
 if (
     roomState.isPrimaryRoom &&
     Object.keys( room.awareness ).length > 1
 ) {
     hasCollaborators = true;
-    roomState.updateQueue.resume();
+    roomStates.forEach( ( state ) => {
+        state.updateQueue.resume();
+    } );
 }
```

## Testing Instructions

1. Enable real-time collaboration in Settings → Writing.
2. Create or open a draft post in two different browser sessions (two different users).
3. Wait for both users to see each other's presence avatars.
4. In User A's editor, insert a paragraph block.
5. Select the paragraph block, open the block options menu (⋮), and click **Add note**.
6. Type a note and click **Add note**.
7. In User B's editor, click the **All notes** button in the top bar.
8. **Expected:** User B sees the note from User A within a few seconds.
9. Repeat in the other direction — User B adds a note, verify User A sees it.
