### PR TITLE
Button: Add block bindings for entity URLs

### DIFF
--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -30,18 +30,23 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 	}
 
 	/*
-	 * BACKWARDS COMPATIBILITY: Hardcoded exception for navigation blocks.
-	 * Required for WordPress 6.9+ navigation blocks. DO NOT REMOVE.
+	 * Blocks that store entity references in their own attributes
+	 * rather than relying on block context.
 	 */
-	$block_name          = $block_instance->name ?? '';
-	$is_navigation_block = in_array(
+	$block_name                  = $block_instance->name ?? '';
+	$entity_attribute_block_types = array(
+		'core/navigation-link',
+		'core/navigation-submenu',
+		'core/button',
+	);
+	$reads_entity_from_attributes = in_array(
 		$block_name,
-		array( 'core/navigation-link', 'core/navigation-submenu' ),
+		$entity_attribute_block_types,
 		true
 	);
 
-	if ( $is_navigation_block ) {
-		// Navigation blocks: read from block attributes
+	if ( $reads_entity_from_attributes ) {
+		// These blocks store the entity ID in their own attributes.
 		$post_id = $block_instance->attributes['id'] ?? null;
 	} else {
 		// All other blocks: use context

--- a/lib/compat/wordpress-6.9/term-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/term-data-block-bindings.php
@@ -24,20 +24,25 @@ function gutenberg_block_bindings_term_data_get_value( array $source_args, $bloc
 	}
 
 	/*
-	 * BACKWARDS COMPATIBILITY: Hardcoded exception for navigation blocks.
-	 * Required for WordPress 6.9+ navigation blocks. DO NOT REMOVE.
+	 * Blocks that store entity references in their own attributes
+	 * rather than relying on block context.
 	 */
-	$block_name          = $block_instance->name ?? '';
-	$is_navigation_block = in_array(
+	$block_name                  = $block_instance->name ?? '';
+	$is_navigation_block         = in_array(
 		$block_name,
 		array( 'core/navigation-link', 'core/navigation-submenu' ),
 		true
 	);
+	$reads_entity_from_attributes = $is_navigation_block || 'core/button' === $block_name;
 
-	if ( $is_navigation_block ) {
-		// Navigation blocks: read from block attributes
+	if ( $reads_entity_from_attributes ) {
+		// These blocks store the entity ID in their own attributes.
 		$term_id = $block_instance->attributes['id'] ?? null;
-		$type    = $block_instance->attributes['type'] ?? '';
+		if ( $is_navigation_block ) {
+			$type = $block_instance->attributes['type'] ?? '';
+		} else {
+			$type = $block_instance->attributes['entityType'] ?? '';
+		}
 		// Map UI shorthand to taxonomy slug when using attributes.
 		$taxonomy = ( 'tag' === $type ) ? 'post_tag' : $type;
 	} else {

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -63,6 +63,15 @@
 		},
 		"gradient": {
 			"type": "string"
+		},
+		"id": {
+			"type": "number"
+		},
+		"kind": {
+			"type": "string"
+		},
+		"entityType": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -19,6 +19,7 @@ import {
 	RichText,
 	useBlockProps,
 	LinkControl,
+	useBlockBindingsUtils,
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
@@ -134,10 +135,19 @@ function ButtonEdit( props ) {
 		text,
 		url,
 		metadata,
+		id: entityId,
+		kind,
+		entityType,
 	} = attributes;
 	const width = style?.dimensions?.width;
 
 	useDeprecatedTextAlign( props );
+
+	const { updateBlockBindings } = useBlockBindingsUtils();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const hasEntityBinding =
+		!! metadata?.bindings?.url && !! entityId && kind !== 'custom';
 
 	const TagName = tagName || 'a';
 
@@ -236,10 +246,16 @@ function ButtonEdit( props ) {
 	}
 
 	function unlink() {
-		setAttributes( {
+		if ( hasEntityBinding ) {
+			updateBlockBindings( { url: undefined } );
+		}
+		updateBlockAttributes( clientId, {
 			url: undefined,
 			linkTarget: undefined,
 			rel: undefined,
+			id: undefined,
+			kind: undefined,
+			entityType: undefined,
 		} );
 		setIsEditingURL( false );
 	}
@@ -253,8 +269,15 @@ function ButtonEdit( props ) {
 	// Memoize link value to avoid overriding the LinkControl's internal state.
 	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
 	const linkValue = useMemo(
-		() => ( { url, opensInNewTab, nofollow } ),
-		[ url, opensInNewTab, nofollow ]
+		() => ( {
+			url,
+			opensInNewTab,
+			nofollow,
+			...( entityId
+				? { id: entityId, kind, type: entityType }
+				: {} ),
+		} ),
+		[ url, opensInNewTab, nofollow, entityId, kind, entityType ]
 	);
 
 	const useEnterRef = useEnter( { content: text, clientId } );
@@ -366,7 +389,8 @@ function ButtonEdit( props ) {
 			</div>
 			{ hasBlockControls && (
 				<BlockControls group="block">
-					{ isLinkTag && ! lockUrlControls && (
+					{ isLinkTag &&
+					( ! lockUrlControls || hasEntityBinding ) && (
 						<ToolbarButton
 							name="link"
 							icon={ ! isURLSet ? link : linkOff }
@@ -385,7 +409,7 @@ function ButtonEdit( props ) {
 			{ isLinkTag &&
 				isSelected &&
 				( isEditingURL || isURLSet ) &&
-				! lockUrlControls && (
+				( ! lockUrlControls || hasEntityBinding ) && (
 					<Popover
 						placement="bottom"
 						onClose={ () => {
@@ -403,16 +427,58 @@ function ButtonEdit( props ) {
 								url: newURL,
 								opensInNewTab: newOpensInNewTab,
 								nofollow: newNofollow,
-							} ) =>
-								setAttributes(
+								id: newId,
+								kind: newKind,
+								type: newEntityType,
+							} ) => {
+								const linkAttrs =
 									getUpdatedLinkAttributes( {
 										rel,
 										url: newURL,
 										opensInNewTab: newOpensInNewTab,
 										nofollow: newNofollow,
-									} )
-								)
-							}
+									} );
+
+								const isEntityLink =
+									!! newId &&
+									!! newKind &&
+									newKind !== 'custom';
+
+								if ( isEntityLink ) {
+									// Use updateBlockAttributes directly
+									// to bypass bound-attribute interception.
+									updateBlockAttributes( clientId, {
+										linkTarget: linkAttrs.linkTarget,
+										rel: linkAttrs.rel,
+										id: newId,
+										kind: newKind,
+										entityType: newEntityType,
+									} );
+									const source =
+										newKind === 'taxonomy'
+											? 'core/term-data'
+											: 'core/post-data';
+									updateBlockBindings( {
+										url: {
+											source,
+											args: { field: 'link' },
+										},
+									} );
+								} else {
+									// Custom URL: clear entity binding.
+									if ( hasEntityBinding ) {
+										updateBlockBindings( {
+											url: undefined,
+										} );
+									}
+									updateBlockAttributes( clientId, {
+										...linkAttrs,
+										id: undefined,
+										kind: undefined,
+										entityType: undefined,
+									} );
+								}
+							} }
 							onRemove={ () => {
 								unlink();
 								richTextRef.current?.focus();

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -5,7 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-// Navigation block types that use special handling for backwards compatibility
+// Block types that store entity references in their own attributes
+// rather than relying on block context.
+const ENTITY_ATTRIBUTE_BLOCK_TYPES = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+	'core/button',
+];
+
+// Navigation block types need special handling (read-only, use 'type' attribute).
 const NAVIGATION_BLOCK_TYPES = [
 	'core/navigation-link',
 	'core/navigation-submenu',
@@ -35,21 +43,20 @@ const postDataFields = [
 export default {
 	name: 'core/post-data',
 	getValues( { select, context, bindings, clientId } ) {
-		/*
-		 * BACKWARDS COMPATIBILITY: Hardcoded exception for navigation blocks.
-		 * Required for WordPress 6.9+ navigation blocks. DO NOT REMOVE.
-		 */
 		const { getBlockAttributes, getBlockName } = select( blockEditorStore );
 		const blockName = getBlockName( clientId );
-		const isNavigationBlock = NAVIGATION_BLOCK_TYPES.includes( blockName );
+		const readsEntityFromAttributes =
+			ENTITY_ATTRIBUTE_BLOCK_TYPES.includes( blockName );
 
 		let postId, postType;
 
-		if ( isNavigationBlock ) {
-			// Navigation blocks: read from block attributes
+		if ( readsEntityFromAttributes ) {
+			// These blocks store the entity ID in their own attributes.
 			const blockAttributes = getBlockAttributes( clientId );
 			postId = blockAttributes?.id;
-			postType = blockAttributes?.type;
+			postType = NAVIGATION_BLOCK_TYPES.includes( blockName )
+				? blockAttributes?.type
+				: blockAttributes?.entityType;
 		} else {
 			// All other blocks: use context
 			postId = context?.postId;
@@ -88,9 +95,8 @@ export default {
 
 		const blockName = getBlockName( clientId );
 
-		// Navigaton block types are read-only.
-		// See https://github.com/WordPress/gutenberg/pull/72165.
-		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
+		// Entity-attribute blocks are read-only for URL bindings.
+		if ( ENTITY_ATTRIBUTE_BLOCK_TYPES.includes( blockName ) ) {
 			return false;
 		}
 		const newData = {};
@@ -111,9 +117,9 @@ export default {
 		const clientId = getSelectedBlockClientId();
 		const blockName = getBlockName( clientId );
 
-		// Navigaton block types are read-only.
-		// See https://github.com/WordPress/gutenberg/pull/72165.
-		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
+		// Entity-attribute blocks manage their bindings through their
+		// own UI, not through direct value editing.
+		if ( ENTITY_ATTRIBUTE_BLOCK_TYPES.includes( blockName ) ) {
 			return false;
 		}
 

--- a/packages/editor/src/bindings/term-data.js
+++ b/packages/editor/src/bindings/term-data.js
@@ -5,7 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-// Navigation block types that use special handling for backwards compatibility
+// Block types that store entity references in their own attributes
+// rather than relying on block context.
+const ENTITY_ATTRIBUTE_BLOCK_TYPES = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+	'core/button',
+];
+
+// Navigation block types need special handling (use 'type' attribute).
 const NAVIGATION_BLOCK_TYPES = [
 	'core/navigation-link',
 	'core/navigation-submenu',
@@ -58,20 +66,21 @@ export default {
 	getValues( { select, context, bindings, clientId } ) {
 		const { getEntityRecord } = select( coreDataStore );
 
-		/*
-		 * BACKWARDS COMPATIBILITY: Hardcoded exception for navigation blocks.
-		 * Required for WordPress 6.9+ navigation blocks. DO NOT REMOVE.
-		 */
 		const { getBlockAttributes, getBlockName } = select( blockEditorStore );
 		const blockName = getBlockName( clientId );
-		const isNavigationBlock = NAVIGATION_BLOCK_TYPES.includes( blockName );
+		const readsEntityFromAttributes =
+			ENTITY_ATTRIBUTE_BLOCK_TYPES.includes( blockName );
 
 		let termDataValues;
 
-		if ( isNavigationBlock ) {
-			// Navigation blocks: read from block attributes
+		if ( readsEntityFromAttributes ) {
+			// These blocks store the entity ID in their own attributes.
 			const blockAttributes = getBlockAttributes( clientId );
-			const typeFromAttributes = blockAttributes?.type;
+			const isNavigationBlock =
+				NAVIGATION_BLOCK_TYPES.includes( blockName );
+			const typeFromAttributes = isNavigationBlock
+				? blockAttributes?.type
+				: blockAttributes?.entityType;
 			const taxonomy =
 				typeFromAttributes === 'tag' ? 'post_tag' : typeFromAttributes;
 			termDataValues = getEntityRecord(
@@ -89,7 +98,11 @@ export default {
 		}
 
 		// Fall back to context termData if available.
-		if ( ! termDataValues && context?.termData && ! isNavigationBlock ) {
+		if (
+			! termDataValues &&
+			context?.termData &&
+			! readsEntityFromAttributes
+		) {
 			termDataValues = context.termData;
 		}
 
@@ -132,9 +145,9 @@ export default {
 		const clientId = getSelectedBlockClientId();
 		const blockName = getBlockName( clientId );
 
-		// Navigaton block types are read-only.
-		// See https://github.com/WordPress/gutenberg/pull/72165.
-		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
+		// Entity-attribute blocks manage their bindings through their
+		// own UI, not through direct value editing.
+		if ( ENTITY_ATTRIBUTE_BLOCK_TYPES.includes( blockName ) ) {
 			return false;
 		}
 
@@ -156,14 +169,13 @@ export default {
 		const clientId = getSelectedBlockClientId();
 		const blockName = getBlockName( clientId );
 
-		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
-			// Navigation blocks: read from block attributes
+		if ( ENTITY_ATTRIBUTE_BLOCK_TYPES.includes( blockName ) ) {
+			// Entity-attribute blocks: read from block attributes
 			const blockAttributes = getBlockAttributes( clientId );
-			if (
-				! blockAttributes ||
-				! blockAttributes.id ||
-				! blockAttributes.type
-			) {
+			const typeAttr = NAVIGATION_BLOCK_TYPES.includes( blockName )
+				? blockAttributes?.type
+				: blockAttributes?.entityType;
+			if ( ! blockAttributes || ! blockAttributes.id || ! typeAttr ) {
 				return [];
 			}
 			return termDataFields;


### PR DESCRIPTION
## What?

Adds block bindings support to the Button block so that when a button links to an internal entity (post, page, or term), the URL is automatically bound via `core/post-data` or `core/term-data` and stays in sync if the entity's permalink changes.

## Why?

The Button block already had block bindings *registered* for its `url` attribute, but the binding was never actually created when linking to an internal entity. If a post's slug or permalink structure changed, button URLs would become stale. Navigation Link already solves this with entity bindings — this brings the same capability to buttons.

## How?

- **`button/block.json`**: Added `id`, `kind`, and `entityType` attributes to store entity reference info (avoiding collision with the existing `type` attribute which is used for HTML `<button type>`).
- **`button/edit.js`**: Updated LinkControl `onChange` to detect entity selections and create/clear bindings automatically. Uses `updateBlockAttributes` directly to bypass the bound-attribute interception in `setBoundAttributes`. The `unlink()` function also clears entity data and binding metadata. Link controls remain visible when entity-bound (overriding `lockUrlControls`).
- **PHP binding sources** (`post-data-block-bindings.php`, `term-data-block-bindings.php`): Added `core/button` to the list of blocks that read entity ID from their own attributes instead of block context.
- **JS binding sources** (`post-data.js`, `term-data.js`): Added `core/button` to the entity-attribute block types. For button blocks, reads `entityType` attribute (instead of `type`). Makes `setValues` and `canUserEditValue` return false for button (URL is read-only through the binding; edits go through the link picker).

## Testing Instructions

1. Open a post or page in the editor.
2. Insert a Buttons block, then select the inner Button block.
3. Click the Link toolbar button and search for an existing page or post.
4. Select the entity — verify the button's URL updates to the entity's permalink.
5. Save the post and inspect the block markup — it should include `"id"`, `"kind"`, `"entityType"` attributes and a `metadata.bindings.url` entry.
6. Change the linked page's slug in a separate tab, then reload the editor — the button URL should reflect the new permalink.
7. Click the Unlink button — verify the URL, entity attributes, and binding metadata are all cleared.
8. Link the button to a custom external URL — verify no binding is created.

### Testing Instructions for Keyboard

1. Select the Button block using keyboard navigation.
2. Press `Ctrl+K` / `Cmd+K` to open the link picker.
3. Type a page name, use arrow keys to select it, press Enter.
4. Press `Ctrl+Shift+K` / `Cmd+Shift+K` to unlink — verify binding is cleared.

## Use of AI Tools

This PR was authored with Claude Code (Claude Opus 4.6).