### PR TITLE
Button entity URL bindings via post-data/term-data args

### DIFF
--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -40,7 +40,19 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 		true
 	);
 
-	if ( $is_navigation_block ) {
+	$post_id = null;
+
+	if ( ! empty( $source_args['id'] ) ) {
+		$post_id = (int) $source_args['id'];
+		// get_post() resolves by ID alone; postType in args matches the editor contract
+		// (@wordpress/core-data needs postType + id) and allows validating the record.
+		if ( ! empty( $source_args['postType'] ) ) {
+			$actual_type = get_post_type( $post_id );
+			if ( ! $actual_type || $actual_type !== $source_args['postType'] ) {
+				return null;
+			}
+		}
+	} elseif ( $is_navigation_block ) {
 		// Navigation blocks: read from block attributes
 		$post_id = $block_instance->attributes['id'] ?? null;
 	} else {

--- a/lib/compat/wordpress-6.9/term-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/term-data-block-bindings.php
@@ -34,7 +34,17 @@ function gutenberg_block_bindings_term_data_get_value( array $source_args, $bloc
 		true
 	);
 
-	if ( $is_navigation_block ) {
+	$term_id  = null;
+	$taxonomy = '';
+
+	if ( ! empty( $source_args['id'] ) && ! empty( $source_args['taxonomy'] ) ) {
+		$term_id  = (int) $source_args['id'];
+		$taxonomy = $source_args['taxonomy'];
+		// Align with LinkControl / navigation attribute shorthand.
+		if ( 'tag' === $taxonomy ) {
+			$taxonomy = 'post_tag';
+		}
+	} elseif ( $is_navigation_block ) {
 		// Navigation blocks: read from block attributes
 		$term_id = $block_instance->attributes['id'] ?? null;
 		$type    = $block_instance->attributes['type'] ?? '';

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -197,15 +197,28 @@ function ButtonEdit( props ) {
 				metadata?.bindings?.url?.source
 			);
 
+			const urlBinding = metadata?.bindings?.url;
+			// Entity links store id/postType or taxonomy in binding args; the URL is
+			// updated via LinkControl (updateBlockBindings), not contextual setValues.
+			// canUserEditValue is false for args.id on these sources, which would hide
+			// the link UI—keep it available like Navigation Link.
+			const isEntityPostOrTermUrlBinding =
+				urlBinding &&
+				( urlBinding.source === 'core/post-data' ||
+					urlBinding.source === 'core/term-data' ) &&
+				urlBinding.args?.id !== undefined &&
+				urlBinding.args?.id !== null;
+
 			return {
 				createPageEntity: _settings.__experimentalCreatePageEntity,
 				userCanCreatePages: _settings.__experimentalUserCanCreatePages,
 				lockUrlControls:
-					!! metadata?.bindings?.url &&
+					!! urlBinding &&
+					! isEntityPostOrTermUrlBinding &&
 					! blockBindingsSource?.canUserEditValue?.( {
 						select,
 						context,
-						args: metadata?.bindings?.url?.args,
+						args: urlBinding?.args,
 					} ),
 			};
 		},

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -432,7 +432,8 @@ function ButtonEdit( props ) {
 									newValue?.id !== undefined &&
 									newValue?.id !== null &&
 									( newValue?.kind === 'post-type' ||
-										newValue?.kind === 'taxonomy' );
+										newValue?.kind === 'taxonomy' ||
+										newValue?.kind === 'media' );
 
 								const attrs = getUpdatedLinkAttributes( {
 									rel,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -47,6 +47,7 @@ import removeAnchorTag from '../utils/remove-anchor-tag';
 import { unlock } from '../lock-unlock';
 import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 import { getWidthClasses, isPercentageWidth } from './utils';
+import { useButtonUrlEntityBinding } from './use-button-url-entity-binding';
 
 const { HTMLElementControl } = unlock( blockEditorPrivateApis );
 
@@ -167,8 +168,15 @@ function ButtonEdit( props ) {
 	} );
 	const blockEditingMode = useBlockEditingMode();
 
+	const {
+		createBinding,
+		clearUrlBinding,
+		entityLinkControlProps,
+		hasEntityUrlBinding,
+	} = useButtonUrlEntityBinding( { clientId, metadata } );
+
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
-	const isURLSet = !! url;
+	const isURLSet = !! url || hasEntityUrlBinding;
 	const opensInNewTab = linkTarget === NEW_TAB_TARGET;
 	const nofollow = !! rel?.includes( NOFOLLOW_REL );
 	const isLinkTag = 'a' === TagName;
@@ -236,6 +244,7 @@ function ButtonEdit( props ) {
 	}
 
 	function unlink() {
+		clearUrlBinding();
 		setAttributes( {
 			url: undefined,
 			linkTarget: undefined,
@@ -253,8 +262,13 @@ function ButtonEdit( props ) {
 	// Memoize link value to avoid overriding the LinkControl's internal state.
 	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
 	const linkValue = useMemo(
-		() => ( { url, opensInNewTab, nofollow } ),
-		[ url, opensInNewTab, nofollow ]
+		() => ( {
+			url,
+			opensInNewTab,
+			nofollow,
+			...entityLinkControlProps,
+		} ),
+		[ url, opensInNewTab, nofollow, entityLinkControlProps ]
 	);
 
 	const useEnterRef = useEnter( { content: text, clientId } );
@@ -399,20 +413,29 @@ function ButtonEdit( props ) {
 					>
 						<LinkControl
 							value={ linkValue }
-							onChange={ ( {
-								url: newURL,
-								opensInNewTab: newOpensInNewTab,
-								nofollow: newNofollow,
-							} ) =>
-								setAttributes(
-									getUpdatedLinkAttributes( {
-										rel,
-										url: newURL,
-										opensInNewTab: newOpensInNewTab,
-										nofollow: newNofollow,
-									} )
-								)
-							}
+							handleEntities
+							onChange={ ( newValue ) => {
+								const isEntityLink =
+									newValue?.id !== undefined &&
+									newValue?.id !== null &&
+									( newValue?.kind === 'post-type' ||
+										newValue?.kind === 'taxonomy' );
+
+								const attrs = getUpdatedLinkAttributes( {
+									rel,
+									url: newValue?.url ?? '',
+									opensInNewTab: newValue?.opensInNewTab,
+									nofollow: newValue?.nofollow,
+								} );
+
+								if ( isEntityLink ) {
+									setAttributes( attrs );
+									createBinding( newValue );
+								} else {
+									clearUrlBinding();
+									setAttributes( attrs );
+								}
+							} }
 							onRemove={ () => {
 								unlink();
 								richTextRef.current?.focus();

--- a/packages/block-library/src/button/test/build-button-url-entity-binding.js
+++ b/packages/block-library/src/button/test/build-button-url-entity-binding.js
@@ -44,6 +44,26 @@ describe( 'buildButtonUrlEntityBinding', () => {
 		} );
 	} );
 
+	it( 'maps LinkControl media kind to core/post-data with postType attachment', () => {
+		expect(
+			buildButtonUrlEntityBinding( {
+				id: 68,
+				kind: 'media',
+				type: 'attachment',
+				url: 'https://example.com/wp-content/uploads/file.jpg',
+			} )
+		).toEqual( {
+			url: {
+				source: 'core/post-data',
+				args: {
+					field: 'link',
+					id: 68,
+					postType: 'attachment',
+				},
+			},
+		} );
+	} );
+
 	it( 'returns null for custom links without entity metadata', () => {
 		expect(
 			buildButtonUrlEntityBinding( { url: 'https://example.org' } )

--- a/packages/block-library/src/button/test/build-button-url-entity-binding.js
+++ b/packages/block-library/src/button/test/build-button-url-entity-binding.js
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import { buildButtonUrlEntityBinding } from '../use-button-url-entity-binding';
+
+describe( 'buildButtonUrlEntityBinding', () => {
+	it( 'builds core/post-data binding with postType in args', () => {
+		expect(
+			buildButtonUrlEntityBinding( {
+				id: 5,
+				kind: 'post-type',
+				type: 'page',
+				url: 'https://example.com',
+			} )
+		).toEqual( {
+			url: {
+				source: 'core/post-data',
+				args: {
+					field: 'link',
+					id: 5,
+					postType: 'page',
+				},
+			},
+		} );
+	} );
+
+	it( 'builds core/term-data binding and maps tag to post_tag', () => {
+		expect(
+			buildButtonUrlEntityBinding( {
+				id: 7,
+				kind: 'taxonomy',
+				type: 'tag',
+				url: 'https://example.com/tag/js',
+			} )
+		).toEqual( {
+			url: {
+				source: 'core/term-data',
+				args: {
+					field: 'link',
+					id: 7,
+					taxonomy: 'post_tag',
+				},
+			},
+		} );
+	} );
+
+	it( 'returns null for custom links without entity metadata', () => {
+		expect(
+			buildButtonUrlEntityBinding( { url: 'https://example.org' } )
+		).toBeNull();
+	} );
+} );

--- a/packages/block-library/src/button/use-button-url-entity-binding.js
+++ b/packages/block-library/src/button/use-button-url-entity-binding.js
@@ -18,11 +18,28 @@ import { useBlockBindingsUtils } from '@wordpress/block-editor';
 export function buildButtonUrlEntityBinding( linkValue ) {
 	const { id, kind, type: entitySlug } = linkValue;
 
-	if ( id === undefined || id === null || ! kind || ! entitySlug ) {
+	if ( id === undefined || id === null || ! kind ) {
 		return null;
 	}
 
+	// Media library results from fetchLinkSuggestions use kind `media` (not `post-type`).
+	if ( kind === 'media' ) {
+		return {
+			url: {
+				source: 'core/post-data',
+				args: {
+					field: 'link',
+					id,
+					postType: 'attachment',
+				},
+			},
+		};
+	}
+
 	if ( kind === 'post-type' ) {
+		if ( ! entitySlug ) {
+			return null;
+		}
 		return {
 			url: {
 				source: 'core/post-data',
@@ -36,6 +53,9 @@ export function buildButtonUrlEntityBinding( linkValue ) {
 	}
 
 	if ( kind === 'taxonomy' ) {
+		if ( ! entitySlug ) {
+			return null;
+		}
 		const taxonomy = entitySlug === 'tag' ? 'post_tag' : entitySlug;
 		return {
 			url: {
@@ -72,10 +92,18 @@ export function useButtonUrlEntityBinding( { clientId, metadata } ) {
 			urlBinding.source === 'core/post-data' &&
 			urlBinding.args.postType
 		) {
+			const postType = urlBinding.args.postType;
+			if ( postType === 'attachment' ) {
+				return {
+					id: urlBinding.args.id,
+					kind: 'media',
+					type: 'attachment',
+				};
+			}
 			return {
 				id: urlBinding.args.id,
 				kind: 'post-type',
-				type: urlBinding.args.postType,
+				type: postType,
 			};
 		}
 		if (

--- a/packages/block-library/src/button/use-button-url-entity-binding.js
+++ b/packages/block-library/src/button/use-button-url-entity-binding.js
@@ -1,0 +1,123 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+import { useBlockBindingsUtils } from '@wordpress/block-editor';
+
+/**
+ * Builds `metadata.bindings.url` from a LinkControl entity value.
+ *
+ * Entity identity is stored in binding args (not block attributes): `core/button`
+ * already uses the `type` attribute for the HTML `<button type>`, so we use
+ * `postType` in args for posts. `postType` is also required on the JS side because
+ * the core-data store resolves posts via getEditedEntityRecord( 'postType', slug, id ).
+ *
+ * @param {Object} linkValue LinkControl value including `id`, `kind`, and `type` (entity slug).
+ * @return {Object|null} Argument for `updateBlockBindings`, or null if not an entity link.
+ */
+export function buildButtonUrlEntityBinding( linkValue ) {
+	const { id, kind, type: entitySlug } = linkValue;
+
+	if ( id === undefined || id === null || ! kind || ! entitySlug ) {
+		return null;
+	}
+
+	if ( kind === 'post-type' ) {
+		return {
+			url: {
+				source: 'core/post-data',
+				args: {
+					field: 'link',
+					id,
+					postType: entitySlug,
+				},
+			},
+		};
+	}
+
+	if ( kind === 'taxonomy' ) {
+		const taxonomy = entitySlug === 'tag' ? 'post_tag' : entitySlug;
+		return {
+			url: {
+				source: 'core/term-data',
+				args: {
+					field: 'link',
+					id,
+					taxonomy,
+				},
+			},
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Block bindings helpers for Button entity URLs (post / term).
+ *
+ * @param {Object}           props
+ * @param {string}           props.clientId Block client id.
+ * @param {Object|undefined} props.metadata Block metadata (in attributes).
+ * @return {Object} Binding helpers and LinkControl entity props derived from args.
+ */
+export function useButtonUrlEntityBinding( { clientId, metadata } ) {
+	const { updateBlockBindings } = useBlockBindingsUtils( clientId );
+	const urlBinding = metadata?.bindings?.url;
+
+	const entityLinkControlProps = useMemo( () => {
+		if ( ! urlBinding?.args?.id ) {
+			return {};
+		}
+		if (
+			urlBinding.source === 'core/post-data' &&
+			urlBinding.args.postType
+		) {
+			return {
+				id: urlBinding.args.id,
+				kind: 'post-type',
+				type: urlBinding.args.postType,
+			};
+		}
+		if (
+			urlBinding.source === 'core/term-data' &&
+			urlBinding.args.taxonomy
+		) {
+			const taxonomy = urlBinding.args.taxonomy;
+			return {
+				id: urlBinding.args.id,
+				kind: 'taxonomy',
+				type: taxonomy === 'post_tag' ? 'tag' : taxonomy,
+			};
+		}
+		return {};
+	}, [ urlBinding ] );
+
+	const clearUrlBinding = useCallback( () => {
+		if ( metadata?.bindings?.url ) {
+			updateBlockBindings( { url: undefined } );
+		}
+	}, [ metadata?.bindings?.url, updateBlockBindings ] );
+
+	const createBinding = useCallback(
+		( linkValue ) => {
+			const binding = buildButtonUrlEntityBinding( linkValue );
+			if ( binding ) {
+				updateBlockBindings( binding );
+			}
+		},
+		[ updateBlockBindings ]
+	);
+
+	const hasEntityUrlBinding =
+		( urlBinding?.source === 'core/post-data' ||
+			urlBinding?.source === 'core/term-data' ) &&
+		urlBinding?.args?.id !== undefined &&
+		urlBinding?.args?.id !== null;
+
+	return {
+		createBinding,
+		clearUrlBinding,
+		entityLinkControlProps,
+		hasEntityUrlBinding,
+	};
+}

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -30,6 +30,17 @@ const postDataFields = [
 ];
 
 /**
+ * @param {Object} args Binding args.
+ * @return {string} Field key (`field` or legacy `key`).
+ */
+function getPostDataFieldKey( args ) {
+	if ( args?.field ) {
+		return args.field;
+	}
+	return args?.key ?? '';
+}
+
+/**
  * @type {WPBlockBindingsSource}
  */
 export default {
@@ -43,42 +54,56 @@ export default {
 		const blockName = getBlockName( clientId );
 		const isNavigationBlock = NAVIGATION_BLOCK_TYPES.includes( blockName );
 
-		let postId, postType;
-
-		if ( isNavigationBlock ) {
-			// Navigation blocks: read from block attributes
-			const blockAttributes = getBlockAttributes( clientId );
-			postId = blockAttributes?.id;
-			postType = blockAttributes?.type;
-		} else {
-			// All other blocks: use context
-			postId = context?.postId;
-			postType = context?.postType;
-		}
-
 		const { getEditedEntityRecord } = select( coreDataStore );
-		const entityDataValues = getEditedEntityRecord(
-			'postType',
-			postType,
-			postId
-		);
+
+		/**
+		 * Resolves which post record to use for a single binding. When `args.id`
+		 * and `args.postType` are set (e.g. Button block entity links), those
+		 * identify the post. `postType` is required in that path because the
+		 * `core-data` package stores posts under ( 'postType', postTypeSlug, id );
+		 * getEditedEntityRecord cannot look up a post by numeric id alone.
+		 *
+		 * @param {Object} binding Single attribute binding.
+		 * @return {Object|undefined} Edited entity record or undefined.
+		 */
+		const getEntityDataValuesForBinding = ( binding ) => {
+			const args = binding.args ?? {};
+			let postId;
+			let postType;
+
+			if ( args.id !== undefined && args.id !== null && args.postType ) {
+				postId = args.id;
+				postType = args.postType;
+			} else if ( isNavigationBlock ) {
+				const blockAttributes = getBlockAttributes( clientId );
+				postId = blockAttributes?.id;
+				postType = blockAttributes?.type;
+			} else {
+				postId = context?.postId;
+				postType = context?.postType;
+			}
+
+			return getEditedEntityRecord( 'postType', postType, postId );
+		};
 
 		const newValues = {};
 		for ( const [ attributeName, binding ] of Object.entries( bindings ) ) {
+			const fieldKey = getPostDataFieldKey( binding.args );
 			const postDataField = postDataFields.find(
-				( field ) => field.args.field === binding.args.field
+				( field ) => field.args.field === fieldKey
 			);
+
+			const entityDataValues = getEntityDataValuesForBinding( binding );
 
 			if ( ! postDataField ) {
 				// If the field is unknown, return the field name.
-				newValues[ attributeName ] = binding.args.field;
+				newValues[ attributeName ] = fieldKey;
 			} else if ( ! entityDataValues ) {
 				// If the entity data does not exist, return the field label.
 				newValues[ attributeName ] = postDataField.label;
 			} else {
 				// If the entity data exists, return the entity value.
-				newValues[ attributeName ] =
-					entityDataValues[ binding.args.field ];
+				newValues[ attributeName ] = entityDataValues[ fieldKey ];
 			}
 		}
 		return newValues;
@@ -95,7 +120,8 @@ export default {
 		}
 		const newData = {};
 		Object.values( bindings ).forEach( ( { args, newValue } ) => {
-			newData[ args.field ] = newValue;
+			const field = getPostDataFieldKey( args );
+			newData[ field ] = newValue;
 		} );
 
 		dispatch( coreDataStore ).editEntityRecord(
@@ -105,7 +131,7 @@ export default {
 			newData
 		);
 	},
-	canUserEditValue( { select, context } ) {
+	canUserEditValue( { select, context, args } ) {
 		const { getBlockName, getSelectedBlockClientId } =
 			select( blockEditorStore );
 		const clientId = getSelectedBlockClientId();
@@ -114,6 +140,12 @@ export default {
 		// Navigaton block types are read-only.
 		// See https://github.com/WordPress/gutenberg/pull/72165.
 		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
+			return false;
+		}
+
+		// Bindings that pin a specific post via args are not editable through
+		// contextual post editing (setValues still targets context post only).
+		if ( args?.id !== undefined && args?.id !== null ) {
 			return false;
 		}
 

--- a/packages/editor/src/bindings/term-data.js
+++ b/packages/editor/src/bindings/term-data.js
@@ -66,35 +66,63 @@ export default {
 		const blockName = getBlockName( clientId );
 		const isNavigationBlock = NAVIGATION_BLOCK_TYPES.includes( blockName );
 
-		let termDataValues;
+		/**
+		 * Resolves term data for one binding. When `args.id` and `args.taxonomy`
+		 * are set, those identify the term (same idea as post bindings: taxonomy
+		 * slug is required because getEntityRecord( 'taxonomy', taxonomy, id )
+		 * needs the taxonomy name, not just a numeric id.
+		 *
+		 * @param {Object} binding Single attribute binding.
+		 * @return {Object|undefined} Term record or context termData.
+		 */
+		const getTermDataForBinding = ( binding ) => {
+			const args = binding.args ?? {};
 
-		if ( isNavigationBlock ) {
-			// Navigation blocks: read from block attributes
-			const blockAttributes = getBlockAttributes( clientId );
-			const typeFromAttributes = blockAttributes?.type;
-			const taxonomy =
-				typeFromAttributes === 'tag' ? 'post_tag' : typeFromAttributes;
-			termDataValues = getEntityRecord(
-				'taxonomy',
-				taxonomy,
-				blockAttributes?.id
-			);
-		} else if ( context.termId && context.taxonomy ) {
-			// All other blocks: use context
-			termDataValues = getEntityRecord(
-				'taxonomy',
-				context.taxonomy,
-				context.termId
-			);
-		}
+			if ( args.id !== undefined && args.id !== null && args.taxonomy ) {
+				const taxonomy =
+					args.taxonomy === 'tag' ? 'post_tag' : args.taxonomy;
+				return getEntityRecord( 'taxonomy', taxonomy, args.id );
+			}
 
-		// Fall back to context termData if available.
-		if ( ! termDataValues && context?.termData && ! isNavigationBlock ) {
-			termDataValues = context.termData;
-		}
+			if ( isNavigationBlock ) {
+				const blockAttributes = getBlockAttributes( clientId );
+				const typeFromAttributes = blockAttributes?.type;
+				const taxonomy =
+					typeFromAttributes === 'tag'
+						? 'post_tag'
+						: typeFromAttributes;
+				return getEntityRecord(
+					'taxonomy',
+					taxonomy,
+					blockAttributes?.id
+				);
+			}
+
+			let termDataValues;
+			if ( context.termId && context.taxonomy ) {
+				termDataValues = getEntityRecord(
+					'taxonomy',
+					context.taxonomy,
+					context.termId
+				);
+			}
+
+			// Fall back to context termData if available (e.g. record not loaded yet).
+			if (
+				! termDataValues &&
+				context?.termData &&
+				! isNavigationBlock
+			) {
+				return context.termData;
+			}
+
+			return termDataValues;
+		};
 
 		const newValues = {};
 		for ( const [ attributeName, binding ] of Object.entries( bindings ) ) {
+			const termDataValues = getTermDataForBinding( binding );
+
 			const termDataField = termDataFields.find(
 				( field ) => field.args.field === binding.args.field
 			);
@@ -125,7 +153,7 @@ export default {
 		// Terms are typically not editable through block bindings in most contexts.
 		return false;
 	},
-	canUserEditValue( { select, context } ) {
+	canUserEditValue( { select, context, args } ) {
 		const { getBlockName, getSelectedBlockClientId } =
 			select( blockEditorStore );
 
@@ -135,6 +163,10 @@ export default {
 		// Navigaton block types are read-only.
 		// See https://github.com/WordPress/gutenberg/pull/72165.
 		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
+			return false;
+		}
+
+		if ( args?.id !== undefined && args?.id !== null ) {
 			return false;
 		}
 

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -142,6 +143,98 @@ describe( 'post-data bindings', () => {
 
 				expect( values.url ).toBe( 'https://example.com/page' );
 			} );
+		} );
+
+		describe( 'for blocks using binding args (e.g. core/button)', () => {
+			it( 'should resolve from args.id and args.postType instead of context', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/button',
+							getBlockAttributes: () => ( {} ),
+						};
+					}
+					return {
+						getEditedEntityRecord: ( kind, type, id ) => {
+							if (
+								kind === 'postType' &&
+								type === 'page' &&
+								id === 42
+							) {
+								return {
+									link: 'https://example.com/about',
+								};
+							}
+							return undefined;
+						},
+					};
+				};
+
+				const values = postDataBindings.getValues( {
+					select,
+					context: { postId: 1, postType: 'post' },
+					bindings: {
+						url: {
+							source: 'core/post-data',
+							args: {
+								field: 'link',
+								id: 42,
+								postType: 'page',
+							},
+						},
+					},
+					clientId: 'button-client',
+				} );
+
+				expect( values.url ).toBe( 'https://example.com/about' );
+			} );
+		} );
+	} );
+
+	describe( 'canUserEditValue', () => {
+		it( 'returns false when binding args pin a post via id', () => {
+			const select = ( store ) => {
+				if ( store === blockEditorStore ) {
+					return {
+						getSelectedBlockClientId: () => 'client1',
+						getBlockName: () => 'core/button',
+					};
+				}
+				return {};
+			};
+
+			expect(
+				postDataBindings.canUserEditValue( {
+					select,
+					context: { postId: 1, postType: 'post' },
+					args: { id: 99, postType: 'page', field: 'link' },
+				} )
+			).toBe( false );
+		} );
+
+		it( 'returns true when context allows editing and args do not pin an entity', () => {
+			const select = ( store ) => {
+				if ( store === blockEditorStore ) {
+					return {
+						getSelectedBlockClientId: () => 'client1',
+						getBlockName: () => 'core/paragraph',
+					};
+				}
+				if ( store === coreDataStore ) {
+					return {
+						canUser: () => true,
+					};
+				}
+				return {};
+			};
+
+			expect(
+				postDataBindings.canUserEditValue( {
+					select,
+					context: { postId: 1, postType: 'post' },
+					args: { field: 'date' },
+				} )
+			).toBe( true );
 		} );
 	} );
 

--- a/packages/editor/src/bindings/test/term-data.js
+++ b/packages/editor/src/bindings/test/term-data.js
@@ -301,6 +301,80 @@ describe( 'term-data bindings', () => {
 				expect( values.content ).toBe( 'JavaScript' );
 			} );
 		} );
+
+		describe( 'for blocks using binding args (e.g. core/button)', () => {
+			it( 'should resolve from args.id and args.taxonomy instead of context', () => {
+				const select = ( store ) => {
+					if ( store === blockEditorStore ) {
+						return {
+							getBlockName: () => 'core/button',
+							getBlockAttributes: () => ( {} ),
+						};
+					}
+					if ( store === coreDataStore ) {
+						return {
+							getEntityRecord: ( kind, taxonomy, termId ) => {
+								if (
+									kind === 'taxonomy' &&
+									taxonomy === 'category' &&
+									termId === 55
+								) {
+									return {
+										link: 'https://example.com/category/news',
+									};
+								}
+								return undefined;
+							},
+						};
+					}
+				};
+
+				const values = termDataBindings.getValues( {
+					select,
+					context: {
+						taxonomy: 'post_tag',
+						termId: 1,
+					},
+					bindings: {
+						url: {
+							source: 'core/term-data',
+							args: {
+								field: 'link',
+								id: 55,
+								taxonomy: 'category',
+							},
+						},
+					},
+					clientId: 'button-client',
+				} );
+
+				expect( values.url ).toBe(
+					'https://example.com/category/news'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'canUserEditValue', () => {
+		it( 'returns false when binding args pin a term via id', () => {
+			const select = ( store ) => {
+				if ( store === blockEditorStore ) {
+					return {
+						getSelectedBlockClientId: () => 'client1',
+						getBlockName: () => 'core/button',
+					};
+				}
+				return {};
+			};
+
+			expect(
+				termDataBindings.canUserEditValue( {
+					select,
+					context: { taxonomy: 'category', termId: 1 },
+					args: { id: 99, taxonomy: 'category', field: 'link' },
+				} )
+			).toBe( false );
+		} );
 	} );
 
 	describe( 'getFieldsList', () => {


### PR DESCRIPTION
Fixes #72314

## What

This pull request extends the `core/post-data` and `core/term-data` block binding sources so they can resolve values against a specific post or term when that entity is identified in binding `args` (numeric id plus `postType` for posts or `taxonomy` for terms, together with the bound field such as `link`). Resolution still falls back to the existing Navigation block attribute path, then to block context, when those args are not present.

It wires the Button block so entity links chosen in LinkControl use those sources: entity identity lives in `metadata.bindings.url.args`, not in new block attributes. The link UI remains usable so users can switch to another entity, unsync to a custom URL, or unlink; updates go through LinkControl and `updateBlockBindings`, not contextual `setValues`.

## Why

Navigation Link and Navigation Submenu already bind URLs to a specific entity, but the entity reference is stored in block attributes (`id`, `kind`, `type`, etc.) and the post/term sources rely on a dedicated exception for those blocks. Button cannot follow that pattern safely: it has no entity `id` attribute, and its `type` attribute is reserved for the HTML `button` element type, so overloading it for post type or taxonomy would be wrong.

Storing the entity reference in binding args matches the direction discussed in [Block Bindings Shape Concerns (#72426)](https://github.com/WordPress/gutenberg/issues/72426), including [this comment](https://github.com/WordPress/gutenberg/issues/72426#issuecomment-4146280560) on placing entity metadata in binding args rather than assuming every block defines an `id` attribute or introducing fragile composite attributes. This also addresses [Add dynamic URL resolution to Button Block (#72314)](https://github.com/WordPress/gutenberg/issues/72314).

## How

Editor and PHP compat layers apply a consistent precedence per binding: when `args` supply a post or term id and the discriminating slug, use that record; otherwise use the Navigation attribute branch, then context. Inline comments document why `postType` is required on the JavaScript side (core-data entity keys for `getEditedEntityRecord`) and how PHP can validate or resolve by id.

Button adds a small helper to build and clear URL bindings from LinkControl values, enables `handleEntities`, and avoids locking URL controls for post/term entity URL bindings so behavior stays aligned with Navigation Link for editing the link after it is set.

## Testing

1. Insert a Buttons block, set the inner Button to a link, and pick a page or post from suggestions; save and confirm the front-end `href`.
2. Pick a category or tag and confirm the term permalink resolves on save and on the front end.
3. Reopen the link popover: change to another entity, unsync to a custom URL, and unlink; confirm each path updates correctly.
4. Run unit tests: `npm run test:unit` for `packages/editor/src/bindings/test/post-data.js`, `packages/editor/src/bindings/test/term-data.js`, and `packages/block-library/src/button/test/build-button-url-entity-binding.js`.

Related: [#72426](https://github.com/WordPress/gutenberg/issues/72426)
