### PR TITLE
Reduce specificity of nav link default padding so global styles apply

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -27,9 +27,6 @@ $navigation-icon-size: 24px;
 	ul,
 	ul li {
 		list-style: none;
-
-		// Overrides generic ".entry-content li" styles on the front end.
-		padding: 0;
 	}
 
 	// Menu item container.
@@ -154,6 +151,11 @@ $navigation-icon-size: 24px;
 		--navigation-layout-justification-setting: space-between;
 		--navigation-layout-justify: space-between;
 	}
+}
+
+// Low specificity padding to not override global styles.
+:where(.wp-block-navigation) ul li {
+	padding: 0;
 }
 
 // Styles for submenu flyout.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes #76306

Default padding added in block library for Navigation Link has higher specificity than global styles, so these don't work.

It was originally added with that specificity to override generic list padding styles that themes might add under `.entry-content li` (see [here](https://github.com/WordPress/gutenberg/pull/29465#discussion_r585482209) for context). I had a quick look in [Veloria](https://veloria.dev/) and couldn't find any of those, which doesn't mean they don't exist, but it's not super likely themes will add a padding reset to `li` because user agents don't add padding to that element.

I guess we could remove it altogether, but in case anyone out there is relying on it this PR just lowers the rule specificity enough that it doesn't interfere with global styles.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some padding styles to core/navigation-link in theme.json under styles > blocks, like so:
```
"core/navigation-link": {
				"spacing": {
					"padding": {
						"top": "29px",
						"bottom": "33px"
					}
				}
			},
```
2. Add a Navigation block with links in it to a post, save and view the front end. The links should have the above defined padding applied.