### PR TITLE
Latest Comments: Fix v1 block deprecation

### DIFF
--- a/packages/block-library/src/latest-comments/deprecated.js
+++ b/packages/block-library/src/latest-comments/deprecated.js
@@ -23,6 +23,39 @@ const v1 = {
 			default: true,
 		},
 	},
+	supports: {
+		align: true,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		html: false,
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
 	isEligible( attributes ) {
 		return attributes?.displayExcerpt === false;
 	},


### PR DESCRIPTION
Follow-up to #72665

## What?

This PR fixes v1 block deprecation for the Latest Comments block by adding the missing `supports` definition.

## Why?

The v1 block deprecation was missing the `supports` property. Without it, styles such as color and font size are lost during block migration from v1.

https://github.com/user-attachments/assets/2293cb94-5c89-4726-89c9-8bd271722619

## Testing Instructions

1. Start up a WordPress 6.9 environment. Using [Playground](https://playground.wordpress.net/) would be the easiest way.
2 Insert a Latest Comments block and apply colors and font size.
3. **Disable the "Display excerpt" settings**. This setting is required for the v1 migration to run.
4. Copy the block.
5. Paste the block into the content in your local Gutenberg environment.
6. Confirm the block migrates correctly.

## Screenshots

https://github.com/user-attachments/assets/6a67cd08-7e4b-4052-be46-3bdf774f3dab


## Use of AI Tools

This PR was authored with the assistance of Claude Code (AI).