### PR TITLE
Icon: Fix center alignment in the editor for classic themes

### DIFF
--- a/packages/block-library/src/icon/editor.scss
+++ b/packages/block-library/src/icon/editor.scss
@@ -1,6 +1,11 @@
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/colors" as *;
 
+.wp-block[data-align="center"] > .wp-block-icon {
+	display: flex;
+	justify-content: center;
+}
+
 // Style for the icon library modal.
 .wp-block-icon__inserter {
 	padding: 0 $grid-unit-30;

--- a/packages/block-library/src/icon/style.scss
+++ b/packages/block-library/src/icon/style.scss
@@ -2,16 +2,13 @@
  * Editor and frontend styles for the Icon Block.
  */
 
-.wp-block[data-align="center"] > .wp-block-icon {
-	text-align: center;
-}
-
 /* Icon Block styles. */
 .wp-block-icon {
 	line-height: 0;
 
 	&.aligncenter {
-		text-align: center;
+		display: flex;
+		justify-content: center;
 	}
 
 	svg {

--- a/packages/block-library/src/icon/style.scss
+++ b/packages/block-library/src/icon/style.scss
@@ -2,13 +2,16 @@
  * Editor and frontend styles for the Icon Block.
  */
 
+.wp-block[data-align="center"] > .wp-block-icon {
+	text-align: center;
+}
+
 /* Icon Block styles. */
 .wp-block-icon {
 	line-height: 0;
 
 	&.aligncenter {
-		display: flex;
-		justify-content: center;
+		text-align: center;
 	}
 
 	svg {


### PR DESCRIPTION
## What?

Fix the Icon block's center alignment in the editor when using classic themes.

## Why?

I noticed that the center alignment for the icon block is not working on some classic themes.

The `aligncenter` styles were [already defined in `style.scss`](https://github.com/WordPress/gutenberg/blob/edea48874020260864566378c431f682fc094d7d/packages/block-library/src/icon/style.scss#L9-L12). However, in classic themes that don't support layout, the editor wraps aligned blocks in an additional `<div>` element, and the `aligncenter` class is not added to the block element:

```html
<div class="wp-block" data-align="center">
  <figure class="wp-block-icon">
    <svg>...</svg>
  </figure>
</div>
```

## How?

Add an editor-specific rule in `editor.scss` targeting `.wp-block[data-align="center"] > .wp-block-icon`.

Note that, similar to the frontend, flex layout is used instead of text-align. This is because some themes apply `display:block` to SVG elements. If an SVG element is a block element, text-align will not work ([e.g., in Twenty Twenty](https://github.com/WordPress/wordpress-develop/blob/42531603c6a57bf9c6e13c126f4057a927aad344/src/wp-content/themes/twentytwenty/style.css#L623-L627)).


## Testing Instructions

1. Activate Twenty Twenty. This is precisely the theme that is causing the current problem.
2. Open a post or page in the editor.
3. Insert an Icon block.
4. Change the alignment to Center.
5. Verify the icon is correctly centered in the editor.
6. Save and view the post on the frontend — verify the icon is also centered there.

## Screenshots or screencast

### Before

<img width="1013" height="460" alt="image" src="https://github.com/user-attachments/assets/93c90f6c-8eca-4c2d-9a89-5bf0f4c62ff0" />

### After

<img width="986" height="466" alt="image" src="https://github.com/user-attachments/assets/be74af7c-a6f3-4690-8444-c1a5bdccc81c" />

## Use of AI Tools

This PR was developed with assistance from Claude Code (claude-sonnet-4-6).