### PR TITLE
Fix pseudo selector block style rendering in the editor

### DIFF
--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -159,6 +159,13 @@ const BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS = {
 	typography: 'typography',
 };
 
+// The valid pseudo-selectors that can be used for blocks.
+// Keep in sync with WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS.
+const VALID_BLOCK_PSEUDO_SELECTORS: Record< string, string[] > = {
+	'core/button': [ ':hover', ':focus', ':focus-visible', ':active' ],
+	'core/navigation-link': [ ':hover', ':focus', ':focus-visible', ':active' ],
+};
+
 /**
  * Transform given preset tree into a set of preset class declarations.
  *
@@ -857,12 +864,23 @@ const STYLE_KEYS = [
 ];
 
 function pickStyleKeys( treeToPickFrom: any ): any {
+	return pickStyleAndPseudoKeys( treeToPickFrom );
+}
+
+function pickStyleAndPseudoKeys(
+	treeToPickFrom: any,
+	blockName?: string
+): any {
 	if ( ! treeToPickFrom ) {
 		return {};
 	}
 	const entries = Object.entries( treeToPickFrom );
-	const pickedEntries = entries.filter( ( [ key ] ) =>
-		STYLE_KEYS.includes( key )
+	const allowedPseudoSelectors = blockName
+		? VALID_BLOCK_PSEUDO_SELECTORS[ blockName ] ?? []
+		: [];
+	const pickedEntries = entries.filter(
+		( [ key ] ) =>
+			STYLE_KEYS.includes( key ) || allowedPseudoSelectors.includes( key )
 	);
 	// clone the style objects so that `getFeatureDeclarations` can remove consumed keys from it
 	const clonedEntries = pickedEntries.map( ( [ key, style ] ) => [
@@ -870,6 +888,92 @@ function pickStyleKeys( treeToPickFrom: any ): any {
 		JSON.parse( JSON.stringify( style ) ),
 	] );
 	return Object.fromEntries( clonedEntries );
+}
+
+function appendPseudoSelectorStyles(
+	styles: Record< string, any >,
+	selector: string,
+	ruleset: string,
+	featureSelectors:
+		| string
+		| Record< string, string | Record< string, string > >
+		| undefined,
+	treeSettings: Record< string, any > | undefined,
+	blockName: string | undefined,
+	styleVariationSelector?: string
+): string {
+	const pseudoSelectorStyles = Object.entries( styles ).filter( ( [ key ] ) =>
+		key.startsWith( ':' )
+	);
+
+	if ( ! pseudoSelectorStyles.length ) {
+		return ruleset;
+	}
+
+	pseudoSelectorStyles.forEach( ( [ pseudoKey, pseudoStyle ] ) => {
+		if ( ! pseudoStyle || typeof pseudoStyle !== 'object' ) {
+			return;
+		}
+
+		const remainingPseudoStyles = JSON.parse(
+			JSON.stringify( pseudoStyle )
+		);
+
+		if ( featureSelectors && typeof featureSelectors !== 'string' ) {
+			let pseudoFeatureDeclarations = getFeatureDeclarations(
+				featureSelectors,
+				remainingPseudoStyles
+			);
+
+			pseudoFeatureDeclarations = updateParagraphTextIndentSelector(
+				pseudoFeatureDeclarations,
+				treeSettings,
+				blockName
+			);
+
+			pseudoFeatureDeclarations = updateButtonWidthDeclarations(
+				pseudoFeatureDeclarations,
+				treeSettings
+			);
+
+			Object.entries( pseudoFeatureDeclarations ).forEach(
+				( [ baseSelector, declarations ] ) => {
+					if ( ! declarations.length ) {
+						return;
+					}
+					const pseudoFeatureSelector = appendToSelector(
+						baseSelector,
+						pseudoKey
+					);
+					const cssSelector = styleVariationSelector
+						? concatFeatureVariationSelectorString(
+								pseudoFeatureSelector,
+								styleVariationSelector
+						  )
+						: pseudoFeatureSelector;
+					const rules = declarations.join( ';' );
+					ruleset += `:root :where(${ cssSelector }){${ rules };}`;
+				}
+			);
+		}
+
+		const pseudoDeclarations = getStylesDeclarations(
+			remainingPseudoStyles
+		);
+
+		if ( ! pseudoDeclarations.length ) {
+			return;
+		}
+
+		const pseudoSelector = appendToSelector( selector, pseudoKey );
+		const pseudoRule = `:root :where(${ pseudoSelector }){${ pseudoDeclarations.join(
+			';'
+		) };}`;
+
+		ruleset += pseudoRule;
+	} );
+
+	return ruleset;
 }
 
 export const getNodesWithStyles = (
@@ -923,7 +1027,7 @@ export const getNodesWithStyles = (
 	// Iterate over blocks: they can have styles & elements.
 	Object.entries( tree.styles?.blocks ?? {} ).forEach(
 		( [ blockName, node ] ) => {
-			const blockStyles = pickStyleKeys( node );
+			const blockStyles = pickStyleAndPseudoKeys( node, blockName );
 			const typedNode = node as BlockNode;
 
 			// Store variation data for later processing, but don't add to nodes yet.
@@ -935,8 +1039,10 @@ export const getNodesWithStyles = (
 				Object.entries( typedNode.variations ).forEach(
 					( [ variationName, variation ] ) => {
 						const typedVariation = variation as BlockVariation;
-						variations[ variationName ] =
-							pickStyleKeys( typedVariation );
+						variations[ variationName ] = pickStyleAndPseudoKeys(
+							typedVariation,
+							blockName
+						);
 						if ( typedVariation?.css ) {
 							variations[ variationName ].css =
 								typedVariation.css;
@@ -1002,7 +1108,10 @@ export const getNodesWithStyles = (
 										: undefined;
 
 								const variationBlockStyleNodes =
-									pickStyleKeys( variationBlockStyles );
+									pickStyleAndPseudoKeys(
+										variationBlockStyles,
+										variationBlockName
+									);
 
 								if ( variationBlockStyles?.css ) {
 									variationBlockStyleNodes.css =
@@ -1558,6 +1667,17 @@ export const transformToStyles = (
 										`:root :where(${ styleVariationSelector })`
 									);
 								}
+
+								ruleset = appendPseudoSelectorStyles(
+									styleVariations,
+									styleVariationSelector as string,
+									ruleset,
+									featureSelectors,
+									tree.settings,
+									name,
+									styleVariationSelector as string
+								);
+
 								// Generate layout styles for the variation if it supports layout and has blockGap defined.
 								if (
 									hasLayoutSupport &&
@@ -1579,45 +1699,14 @@ export const transformToStyles = (
 					);
 				}
 
-				// Check for pseudo selector in `styles` and handle separately.
-				const pseudoSelectorStyles = Object.entries( styles ).filter(
-					( [ key ] ) => key.startsWith( ':' )
+				ruleset = appendPseudoSelectorStyles(
+					styles,
+					selector,
+					ruleset,
+					featureSelectors,
+					tree.settings,
+					name
 				);
-
-				if ( pseudoSelectorStyles?.length ) {
-					pseudoSelectorStyles.forEach(
-						( [ pseudoKey, pseudoStyle ] ) => {
-							const pseudoDeclarations =
-								getStylesDeclarations( pseudoStyle );
-
-							if ( ! pseudoDeclarations?.length ) {
-								return;
-							}
-
-							// `selector` may be provided in a form
-							// where block level selectors have sub element
-							// selectors appended to them as a comma separated
-							// string.
-							// e.g. `h1 a,h2 a,h3 a,h4 a,h5 a,h6 a`;
-							// Split and append pseudo selector to create
-							// the proper rules to target the elements.
-							const _selector = selector
-								.split( ',' )
-								.map( ( sel: string ) => sel + pseudoKey )
-								.join( ',' );
-
-							// As pseudo classes such as :hover, :focus etc. have class-level
-							// specificity, they must use the `:root :where()` wrapper. This.
-							// caps the specificity at `0-1-0` to allow proper nesting of variations
-							// and block type element styles.
-							const pseudoRule = `:root :where(${ _selector }){${ pseudoDeclarations.join(
-								';'
-							) };}`;
-
-							ruleset += pseudoRule;
-						}
-					);
-				}
 			}
 		);
 	}

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -652,6 +652,106 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'should handle block pseudo selectors', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							color: {
+								text: 'red',
+							},
+							':hover': {
+								color: {
+									text: 'blue',
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					blockGap: false,
+					blockStyles: true,
+					layoutStyles: false,
+					marginReset: false,
+					presets: false,
+					rootPadding: false,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.wp-block-button){color: red;}:root :where(.wp-block-button:hover){color: blue;}'
+			);
+		} );
+
+		it( 'should handle style variation pseudo selectors', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							variations: {
+								foo: {
+									color: {
+										text: 'green',
+									},
+									':hover': {
+										color: {
+											text: 'yellow',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button',
+					styleVariationSelectors: {
+						foo: '.is-style-foo.wp-block-button',
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					blockGap: false,
+					blockStyles: true,
+					layoutStyles: false,
+					marginReset: false,
+					presets: false,
+					rootPadding: false,
+					variationStyles: true,
+				}
+			);
+
+			expect( result ).toEqual(
+				':root :where(.is-style-foo.wp-block-button){color: green;}:root :where(.is-style-foo.wp-block-button:hover){color: yellow;}'
+			);
+		} );
+
 		it( 'should handle duotone filter', () => {
 			const tree = {
 				styles: {
@@ -944,7 +1044,7 @@ describe( 'global styles renderer', () => {
 		} );
 
 		it( 'should convert preset percentage width to calc() formula', () => {
-			const tree: GlobalStylesConfig = {
+			const tree = {
 				settings: {
 					blocks: {
 						'core/button': {
@@ -971,7 +1071,7 @@ describe( 'global styles renderer', () => {
 						},
 					},
 				},
-			};
+			} as unknown as GlobalStylesConfig;
 
 			const blockSelectors = {
 				'core/button': {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Noticed in testing #76491.

When defining hover/focus etc. states for blocks in global styles (currently enabled for Button blocks), the resulting styles aren't reflected in the editor. The original implementation in #71418 only added the logic for the front end. This PR adds the logic needed for the styles to render in the editor too.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Button block to a post or template
2. In global styles > blocks > Button, select "hover" from the state dropdown and add some styles
3. Hover over the Button in the editor and check the styles are applied.


## Screenshots or screencast <!-- if applicable -->
<img width="894" height="489" alt="Screenshot 2026-03-28 at 4 18 26 pm" src="https://github.com/user-attachments/assets/c04fc9d6-ab46-474c-b453-4375a81817be" />

## Use of AI Tools

Partially coded with copilot - I told it what to do and where to add it, and reviewed the resulting code.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
