### PR TITLE
wp-env: use dns lookup instead of resolve to test wp connection

### DIFF
--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -60,7 +60,7 @@ async function canAccessWPORG() {
 	if ( IS_OFFLINE !== undefined ) {
 		return IS_OFFLINE;
 	}
-	IS_OFFLINE = !! ( await dns.resolve( 'WordPress.org' ).catch( () => {} ) );
+	IS_OFFLINE = !! ( await dns.lookup( 'WordPress.org' ).catch( () => {} ) );
 	return IS_OFFLINE;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71095

Node's DNS resolver is very impatient and gives up instantly if the user network isn't ideal. This leads to a quick unwarranted exit during `wp-env start` 
That's why we switch to node's DNS lookup method instead which is more reliable across variable user network.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To allow the wp-env start command to work without errors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By using the right dns method.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Install wordpress env
2. run `wp-env start`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
This PR does not make UI level changes.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
