### PR TITLE
Add some typing to block-editor utils

### DIFF
--- a/packages/block-editor/src/utils/object.ts
+++ b/packages/block-editor/src/utils/object.ts
@@ -3,12 +3,16 @@
  * new object. Treats nullish initial values as empty objects. Clones any
  * nested objects. Supports arrays, too.
  *
- * @param {Object}              object Object to set a value in.
- * @param {number|string|Array} path   Path in the object to modify.
- * @param {*}                   value  New value to set.
- * @return {Object} Cloned object with the new value set.
+ * @param object Object to set a value in.
+ * @param path   Path in the object to modify.
+ * @param value  New value to set.
+ * @return Cloned object with the new value set.
  */
-export function setImmutably( object, path, value ) {
+export function setImmutably(
+	object: Object,
+	path: string | number | ( string | number )[],
+	value: any
+) {
 	// Normalize path
 	path = Array.isArray( path ) ? [ ...path ] : [ path ];
 
@@ -20,10 +24,13 @@ export function setImmutably( object, path, value ) {
 	// Traverse object from root to leaf, shallowly cloning at each level
 	let prev = object;
 	for ( const key of path ) {
+		// @ts-expect-error
 		const lvl = prev[ key ];
+		// @ts-expect-error
 		prev = prev[ key ] = Array.isArray( lvl ) ? [ ...lvl ] : { ...lvl };
 	}
 
+	// @ts-expect-error
 	prev[ leaf ] = value;
 
 	return object;
@@ -31,20 +38,27 @@ export function setImmutably( object, path, value ) {
 
 /**
  * Helper util to return a value from a certain path of the object.
+ *
  * Path is specified as either:
  * - a string of properties, separated by dots, for example: "x.y".
  * - an array of properties, for example `[ 'x', 'y' ]`.
+ *
  * You can also specify a default value in case the result is nullish.
  *
- * @param {Object}       object       Input object.
- * @param {string|Array} path         Path to the object property.
- * @param {*}            defaultValue Default value if the value at the specified path is nullish.
- * @return {*} Value of the object property at the specified path.
+ * @param object       Input object.
+ * @param path         Path to the object property.
+ * @param defaultValue Default value if the value at the specified path is nullish.
+ * @return Value of the object property at the specified path.
  */
-export const getValueFromObjectPath = ( object, path, defaultValue ) => {
+export const getValueFromObjectPath = (
+	object: Object,
+	path: string | string[],
+	defaultValue?: any
+) => {
 	const arrayPath = Array.isArray( path ) ? path : path.split( '.' );
 	let value = object;
 	arrayPath.forEach( ( fieldName ) => {
+		// @ts-expect-error
 		value = value?.[ fieldName ];
 	} );
 	return value ?? defaultValue;
@@ -58,9 +72,10 @@ export const getValueFromObjectPath = ( object, path, defaultValue ) => {
  *
  * @return {Object[]} Array of objects with unique values for the specified property.
  */
-export function uniqByProperty( array, property ) {
+export function uniqByProperty( array: Object[], property: string ): Object[] {
 	const seen = new Set();
 	return array.filter( ( item ) => {
+		// @ts-expect-error
 		const value = item[ property ];
 		return seen.has( value ) ? false : seen.add( value );
 	} );

--- a/packages/block-editor/src/utils/object.ts
+++ b/packages/block-editor/src/utils/object.ts
@@ -67,10 +67,9 @@ export const getValueFromObjectPath = (
 /**
  * Helper util to filter out objects with duplicate values for a given property.
  *
- * @param {Object[]} array    Array of objects to filter.
- * @param {string}   property Property to filter unique values by.
- *
- * @return {Object[]} Array of objects with unique values for the specified property.
+ * @param array    Array of objects to filter.
+ * @param property Property to filter unique values by.
+ * @return  Array of objects with unique values for the specified property.
  */
 export function uniqByProperty( array: Object[], property: string ): Object[] {
 	const seen = new Set();

--- a/packages/block-editor/src/utils/pasting.js
+++ b/packages/block-editor/src/utils/pasting.js
@@ -48,9 +48,16 @@ function removeCharsetMetaTag( html ) {
 	return html;
 }
 
+/**
+ * @param {ClipboardEvent} param0
+ */
 export function getPasteEventData( { clipboardData } ) {
 	let plainText = '';
 	let html = '';
+
+	if ( ! clipboardData ) {
+		return;
+	}
 
 	try {
 		plainText = clipboardData.getData( 'text/plain' );

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -39,6 +39,10 @@
 	// NOTE: This package is being progressively typed. You are encouraged to
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.
-	"files": [ "src/components/block-context/index.js", "src/utils/dom.js" ],
+	"files": [
+		"src/components/block-context/index.js",
+		"src/utils/dom.js",
+		"src/utils/pasting.js"
+	],
 	"include": []
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
This continues the effort of typing more of the @wordpress/block-editor package. I worked on two particular files in the src/utils subfolder: object.js and pasting.js

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Potentially improve code quality with more typing in @wordpress/block-editor. Additionally the tsconfig.json for the package says the package is being slowly typed so I figured I'd help :smile: 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I noticed that the src/utils/object.js file is mostly the same as similar utils file in the  [global-styles-engine](https://github.com/wwahammy/gutenberg/blob/60a9c8ec8a81ca4c7a9025776fd80080bc8ed27e/packages/global-styles-engine/src/utils/object.ts). Given that I figured I'd migrate the file straight to ts so I can reuse the code.

Typing the src/utils/pasting.js file required two small changes to the getPasteEventData function: 

1. I needed to set the type of the param to a ClipboardEvent.
2. I needed to add a guard statement for ClipboardEvent is null. If you read the code, the try block will technically catch that situation but TS doesn't realize that. I don't love the use of a guard statement so if there's a better option, I'm for it but it does work. Additionally, pasting is not that common of an event so a single if statement isn't going to have much if any effect on performance.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Likely none required, only one functional change, a redundant null check.

## Use of AI Tools
None.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
