### PR TITLE
Migrate lightweight Github workflows to ubuntu-slim

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
     type-related-labels:
-        runs-on: 'ubuntu-24.04'
+        runs-on: 'ubuntu-slim'
         if: ${{ github.event.pull_request.state == 'open' }}
         permissions:
             pull-requests: write

--- a/.github/workflows/notify-slack-on-label.yml
+++ b/.github/workflows/notify-slack-on-label.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     notify:
         if: ${{ github.event.label.name == 'Needs Testing' }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         permissions: {}
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL }}

--- a/.github/workflows/pr-labeling-automation.yml
+++ b/.github/workflows/pr-labeling-automation.yml
@@ -12,7 +12,7 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-slim
         steps:
             - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
               with:

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
     # - Removes the props-bot label, if necessary.
     props-bot:
         name: Generate a list of props
-        runs-on: 'ubuntu-24.04'
+        runs-on: 'ubuntu-slim'
         permissions:
             # The action needs permission `write` permission for PRs in order to add a comment.
             pull-requests: write


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
This PR migrates a few of the Github actions workflows to the ubuntu-slim sized runner

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Github [created](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) a lower performance runner for lightweight operations. This should reduce power usage of developing the Gutenberg project. While perhaps not a vital change, given the number of times these runners run on Gutenberg, it's not an insignificant change.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Simply changed runners for lightweight operations to ubuntu-slim.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Does the CI run? If so, we're good.

## Use of AI Tools

Nope.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
