### PR TITLE
Block visibility badge: use canvas iframe for viewport detection

### DIFF
--- a/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
@@ -60,7 +60,8 @@ export default function ViewportVisibilityInfo( { clientId } ) {
 	// Get the block's DOM element to derive the canvas iframe window,
 	// so viewport detection matches the actual block rendering context.
 	const blockElement = useBlockElement( clientId );
-	const canvasView = blockElement?.ownerDocument?.defaultView;
+	const rawCanvasView = blockElement?.ownerDocument?.defaultView;
+	const canvasView = rawCanvasView === null ? undefined : rawCanvasView;
 
 	const { isBlockCurrentlyHidden, currentViewport } = useBlockVisibility( {
 		blockVisibility: currentBlockVisibility,

--- a/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-visibility-info.js
@@ -17,6 +17,7 @@ import { unseen } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
 import useBlockVisibility from './use-block-visibility';
+import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import { deviceTypeKey } from '../../store/private-keys';
 import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
 
@@ -56,10 +57,15 @@ export default function ViewportVisibilityInfo( { clientId } ) {
 		[ clientId ]
 	);
 
-	// Use hook to get current viewport and if block is currently hidden (accurate viewport detection)
+	// Get the block's DOM element to derive the canvas iframe window,
+	// so viewport detection matches the actual block rendering context.
+	const blockElement = useBlockElement( clientId );
+	const canvasView = blockElement?.ownerDocument?.defaultView;
+
 	const { isBlockCurrentlyHidden, currentViewport } = useBlockVisibility( {
 		blockVisibility: currentBlockVisibility,
 		deviceType: selectedDeviceType,
+		view: canvasView,
 	} );
 
 	/*


### PR DESCRIPTION
## Summary

Fixes #76730

The hidden block badge in the inspector sidebar was using the browser window width to detect the current viewport. But blocks in the canvas use the iframe window width. When the browser window is narrow, the badge could say "Block is hidden on Desktop" even though the canvas is rendering at a different size.

This passes the canvas iframe's window to `useBlockVisibility` via `useBlockElement`, matching what `use-block-props` and `block-list/block.js` already do.

## Test plan

- Create a new page. Add a paragraph and set it to hidden on Mobile and Tablet (desktop-only).
- Shrink your browser window or zoom in (`Cmd + +`).
- Click the block. The badge should reflect the canvas viewport, not the browser window.
- Try other combos: tablet-only, mobile-only. The badge should stay accurate.
- Switch device preview (Mobile/Tablet) in the toolbar. Badge should follow.

https://github.com/user-attachments/assets/b97eee8f-3067-4e6a-9ae1-f5d690ceb1b3


