### PR TITLE
Build: Replace stylelint with gale (~30x faster CSS linting)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7806,6 +7806,19 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@lyricalstring/gale": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@lyricalstring/gale/-/gale-0.1.4.tgz",
+			"integrity": "sha512-lfU6SZQgTse0rmTZRTvHXC5DxMotYFDDZQbEfpsub9+P79kbAxNWUM7xs4VFO5cqPSyy36PmGVd0scCgyLIVJQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"gale": "bin/gale"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@mdx-js/react": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
@@ -61566,6 +61579,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
+				"@lyricalstring/gale": "0.1.4",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",
@@ -61617,7 +61631,6 @@
 				"sass-loader": "^16.0.3",
 				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",
-				"stylelint": "^16.8.2",
 				"terser-webpack-plugin": "^5.3.10",
 				"url-loader": "^4.1.1",
 				"webpack": "^5.97.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7807,9 +7807,9 @@
 			}
 		},
 		"node_modules/@lyricalstring/gale": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@lyricalstring/gale/-/gale-0.1.4.tgz",
-			"integrity": "sha512-lfU6SZQgTse0rmTZRTvHXC5DxMotYFDDZQbEfpsub9+P79kbAxNWUM7xs4VFO5cqPSyy36PmGVd0scCgyLIVJQ==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@lyricalstring/gale/-/gale-0.1.5.tgz",
+			"integrity": "sha512-xnJF8AZILIDA28lCVmBawNwm8Q5tcEMD7rUtT7nghnk0IiFT2KIqlgP5zJX41FHNijRhZapyCzYL2S2DMJC0LQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -61579,7 +61579,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
-				"@lyricalstring/gale": "0.1.4",
+				"@lyricalstring/gale": "0.1.5",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
 				"@wordpress/babel-preset-default": "file:../babel-preset-default",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -34,7 +34,7 @@
 	},
 	"dependencies": {
 		"@babel/core": "7.25.7",
-		"@lyricalstring/gale": "0.1.4",
+		"@lyricalstring/gale": "0.1.5",
 		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 		"@svgr/webpack": "^8.0.1",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -34,6 +34,7 @@
 	},
 	"dependencies": {
 		"@babel/core": "7.25.7",
+		"@lyricalstring/gale": "0.1.4",
 		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 		"@svgr/webpack": "^8.0.1",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
@@ -85,7 +86,6 @@
 		"sass-loader": "^16.0.3",
 		"schema-utils": "^4.2.0",
 		"source-map-loader": "^3.0.0",
-		"stylelint": "^16.8.2",
 		"terser-webpack-plugin": "^5.3.10",
 		"url-loader": "^4.1.1",
 		"webpack": "^5.97.0",

--- a/packages/scripts/scripts/lint-style.js
+++ b/packages/scripts/scripts/lint-style.js
@@ -44,7 +44,7 @@ const defaultIgnoreArgs = ! hasIgnoredFiles
 	: [];
 
 const result = spawn(
-	resolveBin( 'stylelint' ),
+	resolveBin( '@lyricalstring/gale', { executable: 'gale' } ),
 	[
 		...defaultConfigArgs,
 		...defaultIgnoreArgs,


### PR DESCRIPTION
## What?

Replaces Stylelint with [Gale](https://github.com/LyricalString/gale) in `@wordpress/scripts`' `lint-style` command. Gale is a Rust-based drop-in replacement that reads the same `.stylelintrc` config and produces identical output — just ~30x faster.

## Why?

Gale produces byte-for-byte identical warnings to Stylelint v16 on this repo (0 false positives, 0 false negatives — verified with [differential testing](https://github.com/LyricalString/gale#differential-testing) against 22 real-world repos including Gutenberg). This speeds up `lint:css` with no behavioral changes.

## How?

Three changes:
- `packages/scripts/package.json`: `stylelint` dependency → `@lyricalstring/gale`
- `packages/scripts/scripts/lint-style.js`: `resolveBin('stylelint')` → `resolveBin('@lyricalstring/gale', { executable: 'gale' })`
- `package-lock.json`: updated by npm

Config files (`.stylelintrc`, `@wordpress/stylelint-config`, plugin packages) are untouched — Gale reads them natively.

## Testing Instructions

1. Run `npm run lint:css` — should produce the same lint output as before
2. Run `npx wp-scripts lint-style "packages/**/*.scss"` — should work identically

**Speed comparison (694 SCSS files):**

| Tool | Time |
|------|------|
| Stylelint | 5.65s |
| Gale | 0.19s |

### Testing Instructions for Keyboard

N/A — no UI changes.

## Use of AI Tools

This PR was authored with assistance from Claude Code (Anthropic). All changes were verified by running the actual lint scripts on the repo.