### PR TITLE
Block Editor: Hide Duplicate/Add before/Add after for templateLock contentOnly blocks

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -29,6 +29,7 @@ export default function BlockActions( {
 				getBlocksByClientId,
 				getDirectInsertBlock,
 				canRemoveBlocks,
+				getTemplateLock,
 			} = select( blockEditorStore );
 
 			const blocks = getBlocksByClientId( clientIds );
@@ -40,15 +41,19 @@ export default function BlockActions( {
 			const directInsertBlock = rootClientId
 				? getDirectInsertBlock( rootClientId )
 				: null;
+			const isParentTemplateLockContentOnly =
+				getTemplateLock( rootClientId ) === 'contentOnly';
 
 			return {
 				canRemove: canRemoveBlocks( clientIds ),
-				canInsertBlock: blocks.every( ( block ) => {
-					return (
-						( canInsertDefaultBlock || !! directInsertBlock ) &&
-						canInsertBlockType( block.name, rootClientId )
-					);
-				} ),
+				canInsertBlock:
+					! isParentTemplateLockContentOnly &&
+					blocks.every( ( block ) => {
+						return (
+							( canInsertDefaultBlock || !! directInsertBlock ) &&
+							canInsertBlockType( block.name, rootClientId )
+						);
+					} ),
 				canCopyStyles: blocks.every( ( block ) => {
 					return (
 						!! block &&
@@ -56,13 +61,15 @@ export default function BlockActions( {
 							hasBlockSupport( block.name, 'typography' ) )
 					);
 				} ),
-				canDuplicate: blocks.every( ( block ) => {
-					return (
-						!! block &&
-						hasBlockSupport( block.name, 'multiple', true ) &&
-						canInsertBlockType( block.name, rootClientId )
-					);
-				} ),
+				canDuplicate:
+					! isParentTemplateLockContentOnly &&
+					blocks.every( ( block ) => {
+						return (
+							!! block &&
+							hasBlockSupport( block.name, 'multiple', true ) &&
+							canInsertBlockType( block.name, rootClientId )
+						);
+					} ),
 			};
 		},
 		[ clientIds, getDefaultBlockName ]

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -174,7 +174,8 @@ const getQuickActionsCommands = () =>
 			canRemoveBlocks,
 			isBlockHiddenAnywhere,
 		} = unlock( useSelect( blockEditorStore ) );
-		const { getBlockEditingMode } = useSelect( blockEditorStore );
+		const { getBlockEditingMode, getTemplateLock } =
+			useSelect( blockEditorStore );
 		const { getDefaultBlockName, getGroupingBlockName } =
 			useSelect( blocksStore );
 
@@ -236,10 +237,12 @@ const getQuickActionsCommands = () =>
 			);
 		} );
 		const canRemove = canRemoveBlocks( clientIds );
+		const isParentTemplateLockContentOnly =
+			getTemplateLock( rootClientId ) === 'contentOnly';
 
 		const commands = [];
 
-		if ( canDuplicate ) {
+		if ( canDuplicate && ! isParentTemplateLockContentOnly ) {
 			commands.push( {
 				name: 'duplicate',
 				label: __( 'Duplicate' ),
@@ -248,7 +251,7 @@ const getQuickActionsCommands = () =>
 			} );
 		}
 
-		if ( canInsertDefaultBlock ) {
+		if ( canInsertDefaultBlock && ! isParentTemplateLockContentOnly ) {
 			commands.push(
 				{
 					name: 'add-before',


### PR DESCRIPTION


## What

Hides "Duplicate", "Add before", and "Add after" from the block options menu and command palette when a block is inside a parent with `templateLock: "contentOnly"`.

Fixes #76881

## Why

- insert before/after buttons silently bail and do nothing
- duplicate block, arguably, goes against intended restrictions


## How

`getTemplateLock` is called on the parent block inside `BlockSettingsDropdown` and `useQuickActionsCommands`. When it returns `'contentOnly'`, Duplicate, Add before, and Add after are hidden.

This targets `templateLock` specifically and does not affect unsynced patterns: they enter `contentOnly` editing mode via `metadata.patternName`, not `templateLock`, so `getTemplateLock` returns `false` for them and their menu items are unaffected.

## Testing Instructions

See https://github.com/WordPress/gutenberg/issues/76881 for bug description and test HTML.

1. Open the Site Editor and create or edit a template part.
2. Add a Group block with `"templateLock": "contentOnly"` and    `"lock": { "move": true, "remove": true }`.
3. Add a Paragraph block inside the Group.
4. Save and reload. Select the Paragraph block.
5. Open the Options menu (⋮) in the block toolbar.
   - **Expected:** "Duplicate", "Add before", and "Add after" are not present.
   - **Expected:** "Add note" and other items still appear.
6. Open the command palette (`Cmd+K` / `Ctrl+K`) with the Paragraph selected.
   - **Expected:** "Duplicate", "Add before", and "Add after" are not listed.
7. Create an unsynced pattern containing a Paragraph block.
8. In the editor, select the Paragraph inside the unsynced pattern.
9. Open the Options menu (⋮).
   - **Expected:** "Add before" and "Add after" are still present and functional.


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/3115000e-c00f-49a9-b69b-b782b09414d4



### After


https://github.com/user-attachments/assets/754d6607-9f3d-4179-92b0-b846cd03cdae



## Use of AI Tools

Claude code developed this PR under instruction.