### PR TITLE
RTC: Fix Block Hooks auto-inserted blocks duplication on collaboration

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -28,6 +28,7 @@ import {
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
+import { stripServerManagedMeta } from './utils/crdt';
 
 /**
  * Requests authors from the REST API.
@@ -247,13 +248,25 @@ export const getEntityRecord =
 										return;
 									}
 
+									// Shallow-clone the record and its meta so we
+									// don't mutate the cached selector result.
+									// Strip server-managed meta keys before saving —
+									// sending their (possibly stale) client values
+									// can overwrite what the server calculates
+									// during save (e.g. _wp_ignored_hooked_blocks).
+									const recordToSave = {
+										...editedRecord,
+										meta: { ...meta },
+									};
+									stripServerManagedMeta( recordToSave );
+
 									// Trigger a save to persist the CRDT document. The entity's
 									// pre-persist hooks will create the persisted CRDT document
 									// and apply it to the record's meta.
 									dispatch.saveEntityRecord(
 										kind,
 										name,
-										editedRecord
+										recordToSave
 									);
 								} );
 						},

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -76,7 +76,6 @@ export interface YPostRecord extends YMapRecord {
 
 export const POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE = '_crdt_document';
 
-// Post meta keys that should *not* be synced between peers via the CRDT doc.
 const disallowedPostMetaKeys = new Set< string >( [
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 ] );

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -76,10 +76,36 @@ export interface YPostRecord extends YMapRecord {
 
 export const POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE = '_crdt_document';
 
-// Post meta keys that should *not* be synced.
+// Post meta keys that should *not* be synced between peers via the CRDT doc.
 const disallowedPostMetaKeys = new Set< string >( [
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 ] );
+
+// Post meta keys that are server-managed and must not be sent by the client
+// during saves. Sending stale client values for these keys overwrites the
+// server's calculations (e.g. update_ignored_hooked_blocks_postmeta).
+const serverManagedPostMetaKeys = new Set< string >( [
+	'_wp_ignored_hooked_blocks',
+] );
+
+/**
+ * Remove server-managed meta keys from a record's meta object in place.
+ * These keys are calculated by the server during save and must not be
+ * overwritten by possibly stale client values.
+ *
+ * @param {Object} record An entity record with an optional `meta` property.
+ */
+export function stripServerManagedMeta(
+	record: Record< string, unknown >
+): void {
+	const meta = record.meta;
+	if ( ! meta || typeof meta !== 'object' ) {
+		return;
+	}
+	serverManagedPostMetaKeys.forEach( ( metaKey ) => {
+		delete ( meta as Record< string, unknown > )[ metaKey ];
+	} );
+}
 
 /**
  * Given a set of local changes to a generic entity record, apply those changes

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -59,6 +59,7 @@ import {
 	applyPostChangesToCRDTDoc,
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
+	stripServerManagedMeta,
 	type PostChanges,
 	type YPostRecord,
 } from '../crdt';
@@ -932,3 +933,34 @@ function addBlockToDoc(
 
 	return ytext;
 }
+
+describe( 'stripServerManagedMeta', () => {
+	it( 'should remove _wp_ignored_hooked_blocks from meta', () => {
+		const record = {
+			meta: {
+				_wp_ignored_hooked_blocks: '',
+				footnotes: '',
+			},
+		};
+		stripServerManagedMeta( record );
+		expect( record.meta ).toEqual( { footnotes: '' } );
+	} );
+
+	it( 'should be a no-op when the key is not present', () => {
+		const record = { meta: { footnotes: '' } };
+		stripServerManagedMeta( record );
+		expect( record.meta ).toEqual( { footnotes: '' } );
+	} );
+
+	it( 'should be a no-op when meta is null', () => {
+		const record = { meta: null };
+		stripServerManagedMeta( record );
+		expect( record.meta ).toBeNull();
+	} );
+
+	it( 'should be a no-op when meta is undefined', () => {
+		const record = {};
+		stripServerManagedMeta( record );
+		expect( record ).toEqual( {} );
+	} );
+} );

--- a/test/e2e/specs/editor/plugins/block-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/block-hooks.spec.js
@@ -3,13 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-/**
- * Internal dependencies
- */
-const {
-	setCollaboration,
-} = require( '../../editor/collaboration/fixtures/collaboration-utils' );
-
 const dummyBlocksContent = `<!-- wp:heading -->
 <h2 class="wp-block-heading">This is a dummy heading</h2>
 <!-- /wp:heading -->
@@ -72,12 +65,6 @@ test.describe( 'Block Hooks API', () => {
 				} else {
 					containerPost = postObject;
 				}
-
-				/**
-				 * Since the Block Hooks API relies on server-side rendering to insert
-				 * the hooked blocks, there is a fundamental incompatibility with RTC.
-				 */
-				await setCollaboration( requestUtils, false );
 			} );
 
 			test.afterAll( async ( { requestUtils } ) => {
@@ -87,7 +74,6 @@ test.describe( 'Block Hooks API', () => {
 
 				await requestUtils.deleteAllPosts();
 				await requestUtils.deleteAllBlocks();
-				await setCollaboration( requestUtils, true );
 			} );
 
 			test( `should insert hooked blocks into ${ name } on frontend`, async ( {
@@ -212,12 +198,6 @@ test.describe( 'Block Hooks API', () => {
 				} else {
 					containerPost = postObject;
 				}
-
-				/**
-				 * Since the Block Hooks API relies on server-side rendering to insert
-				 * the hooked blocks, there is a fundamental incompatibility with RTC.
-				 */
-				await setCollaboration( requestUtils, false );
 			} );
 
 			test.afterAll( async ( { requestUtils } ) => {
@@ -227,7 +207,6 @@ test.describe( 'Block Hooks API', () => {
 
 				await requestUtils.deleteAllPosts();
 				await requestUtils.deleteAllBlocks();
-				await setCollaboration( requestUtils, true );
 			} );
 
 			test( `should insert hooked blocks into ${ name } on frontend`, async ( {


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/76176

Fixes Block Hooks API auto-inserted blocks being duplicated on page refresh or when a collaborator joins an RTC session.

## Why?

When the CRDT persistence save fires, it sends the full edited record including `_wp_ignored_hooked_blocks` post meta back to the server. The server recalculates this meta on every save via `update_ignored_hooked_blocks_postmeta`, but the stale client value overwrites the server's calculation, causing hooked blocks to be re-inserted on each subsequent load.

## How?

1. **Strip server-managed meta before CRDT saves**: Added a `stripServerManagedMeta` utility that removes `_wp_ignored_hooked_blocks` from the record's meta before `saveEntityRecord` is called during CRDT persistence. The record is shallow-cloned first to avoid mutating the cached selector result.

2. **Remove the collaboration workaround in block hooks e2e tests**: The tests previously disabled collaboration entirely for block hooks tests with a comment noting "a fundamental incompatibility with RTC." Now that the root cause is fixed, that isn't required anymore.

## Testing Instructions

1. Create a new post and add a `core/heading` block and a `core/paragraph` block.
2. Publish or save the post, then close it.
3. Activate a plugin that registers blocks via the Block Hooks API (e.g. the Gutenberg Block Hooks test plugin from `packages/e2e-test/plugins`).
4. Reopen the post. The Block Hooks API auto-inserts its blocks.
5. Open the same post in a second browser window/tab to simulate a second collaborator joining.
6. Verify that hooked blocks are **not** duplicated in either window.
7. Refresh multiple times and confirm hooked blocks remain stable.

### Testing Instructions for Keyboard

N/A - no UI changes.

## Use of AI Tools

Claude Code (Claude Opus 4.6) was used to assist with cherry-picking commits, reviewing code, and creating this PR.