### PR TITLE
List Item: Disable edit as HTML support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -483,7 +483,7 @@ An individual item within a list. ([Source](https://github.com/WordPress/gutenbe
 -	**Category:** text
 -	**Parent:** core/list
 -	**Allowed Blocks:** core/list
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~, ~~html~~
 -	**Attributes:** content, placeholder
 
 ## Login/out

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -21,6 +21,7 @@
 	},
 	"supports": {
 		"anchor": true,
+		"html": false,
 		"className": false,
 		"splitting": true,
 		"__experimentalBorder": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close #76851

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
> Editing these wrapper blocks in HTML directly is fragile and prone to breaking the users' content. HTML editing should be left to leaf-blocks.

https://github.com/WordPress/gutenberg/pull/11785#issue-380011111

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a Post or Page.
2. Insert a List block.
3. Confirm "Edit as HTML" action isn't available in block Options.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="682" height="561" alt="before" src="https://github.com/user-attachments/assets/5e252d2b-cef8-4c92-993f-e2f5ae349b70" /> | <img width="680" height="530" alt="after" src="https://github.com/user-attachments/assets/c79752cd-c378-4fc0-bc6b-2be773c25bff" /> |
