### PR TITLE
Fields: Fix `postContentInfoField` when there are edits

### DIFF
--- a/packages/fields/src/fields/post-content-info/index.ts
+++ b/packages/fields/src/fields/post-content-info/index.ts
@@ -7,10 +7,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { BasePost } from '../../types';
+import type { BasePostWithEditedEntity } from '../../types';
 import PostContentInfoView from './post-content-info-view';
 
-const postContentInfoField: Field< BasePost > = {
+const postContentInfoField: Field< BasePostWithEditedEntity > = {
 	label: __( 'Post content information' ),
 	id: 'post-content-info',
 	type: 'text',

--- a/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
+++ b/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
@@ -14,23 +14,21 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { BasePost } from '../../types';
+import type { BasePostWithEditedEntity } from '../../types';
 
 // Taken from packages/editor/src/components/time-to-read/index.js.
 const AVERAGE_READING_RATE = 189;
 
-export default function PostContentInfoView( { item }: { item: BasePost } ) {
-	// When a post is being edited, core-data stores content as a lazy
-	// serialization function rather than a string.
-	// @see `getEditedPostContent` selector - https://github.com/WordPress/gutenberg/blob/d9e01f6be913afa5ba3b88d2e1d36b4cf6f7982b/packages/editor/src/store/selectors.js#L919
-	const rawContent = item.content as
-		| BasePost[ 'content' ]
-		| ( ( record: any ) => string );
+export default function PostContentInfoView( {
+	item,
+}: {
+	item: BasePostWithEditedEntity;
+} ) {
 	let content = '';
-	if ( typeof rawContent === 'string' ) {
-		content = rawContent;
-	} else if ( typeof rawContent === 'function' ) {
-		content = rawContent( item );
+	if ( typeof item.content === 'string' ) {
+		content = item.content;
+	} else if ( typeof item.content === 'function' ) {
+		content = item.content( item );
 	}
 
 	/*

--- a/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
+++ b/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
@@ -20,10 +20,18 @@ import type { BasePost } from '../../types';
 const AVERAGE_READING_RATE = 189;
 
 export default function PostContentInfoView( { item }: { item: BasePost } ) {
-	const content =
-		typeof item.content === 'string'
-			? item.content
-			: item.content?.raw || '';
+	// When a post is being edited, core-data stores content as a lazy
+	// serialization function rather than a string.
+	// @see `getEditedPostContent` selector - https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/store/selectors.js#L919
+	const rawContent = item.content as
+		| BasePost[ 'content' ]
+		| ( ( record: any ) => string );
+	let content = '';
+	if ( typeof rawContent === 'string' ) {
+		content = rawContent;
+	} else if ( typeof rawContent === 'function' ) {
+		content = rawContent( item );
+	}
 
 	/*
 	 * translators: If your word count is based on single characters (e.g. East Asian characters),

--- a/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
+++ b/packages/fields/src/fields/post-content-info/post-content-info-view.tsx
@@ -22,7 +22,7 @@ const AVERAGE_READING_RATE = 189;
 export default function PostContentInfoView( { item }: { item: BasePost } ) {
 	// When a post is being edited, core-data stores content as a lazy
 	// serialization function rather than a string.
-	// @see `getEditedPostContent` selector - https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/store/selectors.js#L919
+	// @see `getEditedPostContent` selector - https://github.com/WordPress/gutenberg/blob/d9e01f6be913afa5ba3b88d2e1d36b4cf6f7982b/packages/editor/src/store/selectors.js#L919
 	const rawContent = item.content as
 		| BasePost[ 'content' ]
 		| ( ( record: any ) => string );

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -60,6 +60,12 @@ export interface BasePost extends CommonPost {
 	author?: number;
 }
 
+export interface BasePostWithEditedEntity extends Omit< BasePost, 'content' > {
+	content:
+		| BasePost[ 'content' ]
+		| ( ( record: BasePostWithEditedEntity ) => string );
+}
+
 export interface BasePostWithEmbeddedAuthor extends BasePost {
 	_embedded: EmbeddedAuthor;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed that post content field doesn't display the word count and reading time when we have the `Editor Inspector: Use DataForm` experiment enabled in inspector controls.

This happens because we the content of an edited entity is a [function](https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/hooks/use-entity-block-editor.js#L97) to avoid serialization before saving to avoid this possible expensive operation based on the content size, and the field wasn't checking for that case.

This PR fixes that by [following suite](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/store/selectors.js#L919) with the existing component (without the experiment). Existing behavior though and therefore this PR kind of defeat the purpose of trying to avoid the serialization. Should we consider handling this differently - not showing this info when there are edits? 🤔 

Noting that in order to see the post info while you're editing, you need to specifically change to the `post` tab, after selecting/creating a block. See below:


https://github.com/user-attachments/assets/58ef6c0c-2602-42f2-8498-37c90437aa99




## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment
2. Go to a post with some content and select a paragraph block
3. In inspector controls switch to `post` tab again
4. Start typing and observe that the wordcount is shown properly.

### Before


https://github.com/user-attachments/assets/84427edc-4050-40aa-9997-3b7754bdbac7



### After 



https://github.com/user-attachments/assets/d13822db-4405-41df-90fd-6d6828d748f7


