### PR TITLE
Fields: Tweak `excerpt` field

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -5,3 +5,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/76622
 * https://github.com/WordPress/gutenberg/pull/76823
 * https://github.com/WordPress/gutenberg/pull/76953
+* https://github.com/WordPress/gutenberg/pull/76903

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -777,7 +777,13 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						'labelPosition' => 'none',
 					),
 				),
-				'excerpt',
+				array(
+					'id'     => 'excerpt',
+					'layout' => array(
+						'type'          => 'panel',
+						'labelPosition' => 'top',
+					),
+				),
 				array(
 					'id'       => 'status',
 					'label'    => __( 'Status', 'gutenberg' ),

--- a/packages/fields/src/fields/excerpt/index.tsx
+++ b/packages/fields/src/fields/excerpt/index.tsx
@@ -38,7 +38,7 @@ const excerptField: Field< BasePost > = {
 			excerpt = decodeEntities( item.excerpt?.raw || '' );
 		}
 		return (
-			<Text align="left" numberOfLines={ 4 } truncate>
+			<Text align="left" numberOfLines={ 3 } truncate>
 				{ excerpt }
 			</Text>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/76829
See: https://github.com/WordPress/gutenberg/pull/76829#issuecomment-4154291970

This PR tweaks a bit the `excerpt` field design under the Editor Inspector: Use DataForm experiment.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Enable the Editor Inspector: Use DataForm experiment
2. Go to a post and play around with the new Excerpt field to see the different states (with/without excerpt)





|With excerpt|Without excerpt|
|-|-|
|<img width="299" height="176" alt="Screenshot 2026-03-30 at 2 40 37 PM" src="https://github.com/user-attachments/assets/aed0f824-c290-48ac-a669-1f5b5a9a56df" />|<img width="299" height="176" alt="Screenshot 2026-03-30 at 2 40 49 PM" src="https://github.com/user-attachments/assets/6829818e-caf6-4088-85f9-9b32163ce584" />|
