### PR TITLE
Cover block: fix embed video background Error 153 in editor

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useEffect, useMemo, useRef } from '@wordpress/element';
-import { Placeholder, Spinner } from '@wordpress/components';
+import { Placeholder, SandBox, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {
 	withColors,
@@ -49,7 +49,7 @@ import {
 	DEFAULT_OVERLAY_COLOR,
 } from './color-utils';
 import { DEFAULT_MEDIA_SIZE_SLUG } from '../constants';
-import { getIframeSrc, getBackgroundVideoSrc } from '../embed-video-utils';
+import { getBackgroundEmbedHtml } from '../embed-video-utils';
 
 function getInnerBlocksTemplate( attributes ) {
 	return [
@@ -365,23 +365,15 @@ function CoverEdit( {
 		[ url, backgroundType ]
 	);
 
-	// Compute embedSrc on-the-fly from embed preview for editor display
-	const embedSrc = useMemo( () => {
+	// Compute embed HTML for editor display via SandBox
+	const embedHtml = useMemo( () => {
 		if (
 			backgroundType !== EMBED_VIDEO_BACKGROUND_TYPE ||
 			! embedPreview?.html
 		) {
 			return null;
 		}
-
-		// Extract iframe src from embed HTML
-		const iframeSrc = getIframeSrc( embedPreview.html );
-		if ( ! iframeSrc ) {
-			return null;
-		}
-
-		// Modify the src to add background video parameters (provider auto-detected)
-		return getBackgroundVideoSrc( iframeSrc );
+		return getBackgroundEmbedHtml( embedPreview.html );
 	}, [ embedPreview, backgroundType ] );
 
 	const isUploadingMedia = isTemporaryMedia( id, url );
@@ -668,21 +660,22 @@ function CoverEdit( {
 						style={ mediaStyle }
 					/>
 				) }
-				{ isEmbedVideoBackground && embedSrc && (
+				{ isEmbedVideoBackground && embedHtml && (
 					<div
 						ref={ mediaElement }
 						className="wp-block-cover__video-background wp-block-cover__embed-background"
 						style={ mediaStyle }
 					>
-						<iframe
-							src={ embedSrc }
+						<SandBox
+							html={ embedHtml }
 							title="Background video"
-							frameBorder="0"
-							allow="autoplay; fullscreen"
+							styles={ [
+								'iframe{position:fixed;top:0;left:0;width:100%;height:100%;}',
+							] }
 						/>
 					</div>
 				) }
-				{ isEmbedVideoBackground && ! embedSrc && isFetchingEmbed && (
+				{ isEmbedVideoBackground && ! embedHtml && isFetchingEmbed && (
 					<Spinner />
 				) }
 

--- a/packages/block-library/src/cover/embed-video-utils.js
+++ b/packages/block-library/src/cover/embed-video-utils.js
@@ -74,18 +74,20 @@ function findVideoEmbedProvider( url ) {
 }
 
 /**
- * Extracts iframe src from embed HTML.
+ * Modifies embed HTML to use background video parameters.
  *
- * @param {string} html The embed HTML.
- * @return {string|null} The iframe src URL or null if not found.
+ * @param {string} html The original embed HTML.
+ * @return {string|null} The modified embed HTML, or null if not possible.
  */
-export function getIframeSrc( html ) {
-	if ( ! html ) {
+export function getBackgroundEmbedHtml( html ) {
+	const srcMatch = html?.match( /src=["']([^"']+)["']/ );
+	if ( ! srcMatch ) {
 		return null;
 	}
 
-	const srcMatch = html.match( /src=["']([^"']+)["']/ );
-	return srcMatch ? srcMatch[ 1 ] : null;
+	const iframeSrc = srcMatch[ 1 ];
+	const backgroundSrc = getBackgroundVideoSrc( iframeSrc );
+	return html.replace( iframeSrc, backgroundSrc );
 }
 
 /**


### PR DESCRIPTION
Fixes #76902

## What?

Fixes an issue where using a YouTube URL as a cover block embed video background displays Error 153 in the editor.

<img width="717" height="522" alt="571247394-be309861-dd12-4dfb-b80d-7cec1e06751e" src="https://github.com/user-attachments/assets/53b149c0-f521-400d-9c27-cde47d270e7f" />

## Why?

To be honest, we don't know the exact cause. It seems to be related to the referrer. Similar to the Embed block, using the `Sandbox` component seems to resolve the issue.

The following are the AI's findings.

> When the cover block renders the YouTube `<iframe>` directly inside the editor canvas, YouTube's player can detect the WordPress admin URL (e.g. `/wp-admin/post.php?...`) as the parent document's URL — either via the `Referer` HTTP header or `document.referrer` inside the iframe. YouTube may treat admin URLs as an unauthorized embedding context and respond with Error 153.
> 
> By contrast, the embed block and the Custom HTML block both use the `SandBox` component for editor previews. `SandBox` injects content via `document.write()` into an `about:blank` iframe. Because `about:blank` has no HTTP origin, the `Referer` header is empty when YouTube loads — which YouTube appears to accept without error.

## Testing Instructions

1. Insert a Cover block and embed a YouTube video.
4. Confirm the Cover block shows the embedded video as background.

These are the URLs I used for testing.

- YouTube: https://www.youtube.com/watch?v=U_DF4-23C8Q
- Vimeo: https://vimeo.com/1086925006
- Videpress: https://videopress.com/v/Ygmx4akX
- WordPress.tv: https://wordpress.tv/2025/12/03/state-of-the-word-2025/

I was  unable to test the following two providers correctly.

- animoto: couldn't find any public video
- tiktok: It showed "Access Denied" when embedding


## Use of AI Tools

This PR was developed with the assistance of Claude Code (claude-sonnet-4-6).

## Screenshot

<img width="1104" height="608" alt="image" src="https://github.com/user-attachments/assets/6eb1d1ac-50c4-4d2a-aec9-29aea5bb7465" />
