### PR TITLE
Connectors: Replace plugin.slug with plugin.file

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 	 *         env_var_name?: non-empty-string
 	 *     },
 	 *     plugin?: array{
-	 *         slug: non-empty-string
+	 *         file: non-empty-string
 	 *     }
 	 * }
 	 */
@@ -97,7 +97,8 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *     @type array  $plugin         {
 		 *         Optional. Plugin data for install/activate UI.
 		 *
-		 *         @type string $slug The WordPress.org plugin slug.
+		 *         @type string $file The plugin's main file path relative to the plugins
+		 *                           directory (e.g. 'akismet/akismet.php').
 		 *     }
 		 * }
 		 * @return array|null The registered connector data on success, null on failure.

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *         Optional. Plugin data for install/activate UI.
 		 *
 		 *         @type string $file The plugin's main file path relative to the plugins
-		 *                           directory (e.g. 'akismet/akismet.php').
+		 *                           directory (e.g. 'akismet/akismet.php' or 'hello.php').
 		 *     }
 		 * }
 		 * @return array|null The registered connector data on success, null on failure.
@@ -231,8 +231,8 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				}
 			}
 
-			if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {
-				$connector['plugin'] = $args['plugin'];
+			if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) && ! empty( $args['plugin']['file'] ) ) {
+				$connector['plugin'] = array( 'file' => $args['plugin']['file'] );
 			}
 
 			$this->registered_connectors[ $id ] = $connector;

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -373,8 +373,8 @@ add_filter( 'rest_post_dispatch', '_gutenberg_connectors_rest_settings_dispatch'
  * @access private
  */
 function _gutenberg_register_default_connector_settings(): void {
-	$ai_registry         = \WordPress\AiClient\AiClient::defaultRegistry();
-	$existing_settings   = get_registered_settings();
+	$ai_registry       = \WordPress\AiClient\AiClient::defaultRegistry();
+	$existing_settings = get_registered_settings();
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -529,7 +529,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 			$is_activated = $is_installed && is_plugin_active( $file );
 
 			$connector_out['plugin'] = array(
-				'pluginFile'  => str_ends_with( $file, '.php' ) ? substr( $file, 0, -4 ) : $file,
+				'file'        => str_ends_with( $file, '.php' ) ? substr( $file, 0, -4 ) : $file,
 				'isInstalled' => $is_installed,
 				'isActivated' => $is_activated,
 			);

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -529,7 +529,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 			$is_activated = $is_installed && is_plugin_active( $file );
 
 			$connector_out['plugin'] = array(
-				'file'        => str_ends_with( $file, '.php' ) ? substr( $file, 0, -4 ) : $file,
+				'file'        => $file,
 				'isInstalled' => $is_installed,
 				'isActivated' => $is_activated,
 			);

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -31,7 +31,7 @@ function _gutenberg_connectors_init(): void {
 			'description'    => __( 'Protect your site from spam.', 'gutenberg' ),
 			'type'           => 'spam_filtering',
 			'plugin'         => array(
-				'slug' => 'akismet',
+				'file' => 'akismet/akismet.php',
 			),
 			'authentication' => array(
 				'method'          => 'api_key',
@@ -92,7 +92,7 @@ function _gutenberg_register_default_ai_providers( WP_Connector_Registry $regist
 			'description'    => __( 'Text generation with Claude.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'plugin'         => array(
-				'slug' => 'ai-provider-for-anthropic',
+				'file' => 'ai-provider-for-anthropic/plugin.php',
 			),
 			'authentication' => array(
 				'method'          => 'api_key',
@@ -104,7 +104,7 @@ function _gutenberg_register_default_ai_providers( WP_Connector_Registry $regist
 			'description'    => __( 'Text and image generation with Gemini and Imagen.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'plugin'         => array(
-				'slug' => 'ai-provider-for-google',
+				'file' => 'ai-provider-for-google/plugin.php',
 			),
 			'authentication' => array(
 				'method'          => 'api_key',
@@ -116,7 +116,7 @@ function _gutenberg_register_default_ai_providers( WP_Connector_Registry $regist
 			'description'    => __( 'Text and image generation with GPT and Dall-E.', 'gutenberg' ),
 			'type'           => 'ai_provider',
 			'plugin'         => array(
-				'slug' => 'ai-provider-for-openai',
+				'file' => 'ai-provider-for-openai/plugin.php',
 			),
 			'authentication' => array(
 				'method'          => 'api_key',
@@ -373,12 +373,12 @@ add_filter( 'rest_post_dispatch', '_gutenberg_connectors_rest_settings_dispatch'
  * @access private
  */
 function _gutenberg_register_default_connector_settings(): void {
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
-		return;
-	}
-
-	$ai_registry       = \WordPress\AiClient\AiClient::defaultRegistry();
 	$existing_settings = get_registered_settings();
+
+	// Only load the AI registry if AiClient is available.
+	$ai_registry = class_exists( '\WordPress\AiClient\AiClient' )
+		? \WordPress\AiClient\AiClient::defaultRegistry()
+		: null;
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
@@ -391,9 +391,11 @@ function _gutenberg_register_default_connector_settings(): void {
 			continue;
 		}
 
-		// For AI providers, skip if the provider is not in the AI Client registry.
-		if ( 'ai_provider' === $connector_data['type'] && ! $ai_registry->hasProvider( $connector_id ) ) {
-			continue;
+		// For AI providers, skip if AI is unavailable or the provider is not registered.
+		if ( 'ai_provider' === $connector_data['type'] ) {
+			if ( null === $ai_registry || ! $ai_registry->hasProvider( $connector_id ) ) {
+				continue;
+			}
 		}
 
 		register_setting(
@@ -489,14 +491,8 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 
 	$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 
-	// Build a slug-to-file map for plugin installation status.
-	if ( ! function_exists( 'get_plugins' ) ) {
+	if ( ! function_exists( 'is_plugin_active' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-	$plugin_files_by_slug = array();
-	foreach ( array_keys( get_plugins() ) as $plugin_file ) {
-		$slug                          = str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
-		$plugin_files_by_slug[ $slug ] = $plugin_file;
 	}
 
 	$connectors = array();
@@ -533,18 +529,14 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 			'authentication' => $auth_out,
 		);
 
-		if ( ! empty( $connector_data['plugin']['slug'] ) ) {
-			$plugin_slug = $connector_data['plugin']['slug'];
-			$plugin_file = $plugin_files_by_slug[ $plugin_slug ] ?? null;
-
-			$is_installed = null !== $plugin_file;
-			$is_activated = $is_installed && is_plugin_active( $plugin_file );
+		if ( ! empty( $connector_data['plugin']['file'] ) ) {
+			$file         = $connector_data['plugin']['file'];
+			$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $file );
+			$is_activated = $is_installed && is_plugin_active( $file );
 
 			$connector_out['plugin'] = array(
-				'slug'        => $plugin_slug,
-				'pluginFile'  => $is_installed
-					? ( str_ends_with( $plugin_file, '.php' ) ? substr( $plugin_file, 0, -4 ) : $plugin_file )
-					: null,
+				'pluginFile'  => str_ends_with( $file, '.php' ) ? substr( $file, 0, -4 ) : $file,
+				'isInstalled' => $is_installed,
 				'isActivated' => $is_activated,
 			);
 		}

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -373,12 +373,8 @@ add_filter( 'rest_post_dispatch', '_gutenberg_connectors_rest_settings_dispatch'
  * @access private
  */
 function _gutenberg_register_default_connector_settings(): void {
-	$existing_settings = get_registered_settings();
-
-	// Only load the AI registry if AiClient is available.
-	$ai_registry = class_exists( '\WordPress\AiClient\AiClient' )
-		? \WordPress\AiClient\AiClient::defaultRegistry()
-		: null;
+	$ai_registry         = \WordPress\AiClient\AiClient::defaultRegistry();
+	$existing_settings   = get_registered_settings();
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
@@ -391,11 +387,9 @@ function _gutenberg_register_default_connector_settings(): void {
 			continue;
 		}
 
-		// For AI providers, skip if AI is unavailable or the provider is not registered.
-		if ( 'ai_provider' === $connector_data['type'] ) {
-			if ( null === $ai_registry || ! $ai_registry->hasProvider( $connector_id ) ) {
-				continue;
-			}
+		// For AI providers, skip if the provider is not in the AI Client registry.
+		if ( 'ai_provider' === $connector_data['type'] && ! $ai_registry->hasProvider( $connector_id ) ) {
+			continue;
 		}
 
 		register_setting(

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -16,7 +16,7 @@ export type ConnectorAuthentication =
 	| { method: 'none' };
 
 export interface ConnectorPlugin {
-	pluginFile: string;
+	file: string;
 	isInstalled: boolean;
 	isActivated: boolean;
 }

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -16,8 +16,8 @@ export type ConnectorAuthentication =
 	| { method: 'none' };
 
 export interface ConnectorPlugin {
-	slug: string;
-	pluginFile?: string | null;
+	pluginFile: string;
+	isInstalled: boolean;
 	isActivated: boolean;
 }
 

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -104,9 +104,10 @@ function ApiKeyConnector( {
 		authentication?.method === 'api_key' ? authentication : undefined;
 	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
-	const pluginSlug = plugin?.file?.includes( '/' )
-		? plugin.file.split( '/' )[ 0 ]
-		: plugin?.file;
+	const pluginFile = plugin?.file?.replace( /\.php$/, '' );
+	const pluginSlug = pluginFile?.includes( '/' )
+		? pluginFile.split( '/' )[ 0 ]
+		: pluginFile;
 
 	let helpLabel: string | undefined;
 	try {

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -31,8 +31,8 @@ interface ConnectorData {
 	logoUrl?: string;
 	type: string;
 	plugin?: {
-		slug: string;
-		pluginFile?: string | null;
+		pluginFile: string;
+		isInstalled: boolean;
 		isActivated: boolean;
 	};
 	authentication: NonNullable< ConnectorConfig[ 'authentication' ] >;
@@ -104,7 +104,9 @@ function ApiKeyConnector( {
 		authentication?.method === 'api_key' ? authentication : undefined;
 	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
-	const pluginSlug = plugin?.slug;
+	const pluginSlug = plugin?.pluginFile?.includes( '/' )
+		? plugin.pluginFile.split( '/' )[ 0 ]
+		: plugin?.pluginFile;
 
 	let helpLabel: string | undefined;
 	try {
@@ -130,10 +132,10 @@ function ApiKeyConnector( {
 		saveApiKey,
 		removeApiKey,
 	} = useConnectorPlugin( {
-		pluginSlug,
 		pluginFile: plugin?.pluginFile,
 		settingName,
 		connectorName: name,
+		isInstalled: plugin?.isInstalled,
 		isActivated: plugin?.isActivated,
 		keySource: auth?.keySource,
 		initialIsConnected: auth?.isConnected,

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -31,7 +31,7 @@ interface ConnectorData {
 	logoUrl?: string;
 	type: string;
 	plugin?: {
-		pluginFile: string;
+		file: string;
 		isInstalled: boolean;
 		isActivated: boolean;
 	};
@@ -104,9 +104,9 @@ function ApiKeyConnector( {
 		authentication?.method === 'api_key' ? authentication : undefined;
 	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
-	const pluginSlug = plugin?.pluginFile?.includes( '/' )
-		? plugin.pluginFile.split( '/' )[ 0 ]
-		: plugin?.pluginFile;
+	const pluginSlug = plugin?.file?.includes( '/' )
+		? plugin.file.split( '/' )[ 0 ]
+		: plugin?.file;
 
 	let helpLabel: string | undefined;
 	try {
@@ -132,7 +132,7 @@ function ApiKeyConnector( {
 		saveApiKey,
 		removeApiKey,
 	} = useConnectorPlugin( {
-		pluginFile: plugin?.pluginFile,
+		file: plugin?.file,
 		settingName,
 		connectorName: name,
 		isInstalled: plugin?.isInstalled,

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -12,7 +12,7 @@ import type { __experimentalApiKeySource as ApiKeySource } from '@wordpress/conn
 export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 
 interface UseConnectorPluginOptions {
-	pluginFile?: string;
+	file?: string;
 	settingName: string;
 	connectorName: string;
 	isInstalled?: boolean;
@@ -38,7 +38,7 @@ interface UseConnectorPluginReturn {
 }
 
 export function useConnectorPlugin( {
-	pluginFile: pluginFileFromServer,
+	file: pluginFileFromServer,
 	settingName,
 	connectorName,
 	isInstalled,

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -54,9 +54,10 @@ export function useConnectorPlugin( {
 	const [ pluginStatusOverride, setPluginStatusOverride ] =
 		useState< PluginStatus | null >( null );
 
-	const pluginSlug = pluginFileFromServer?.includes( '/' )
-		? pluginFileFromServer.split( '/' )[ 0 ]
-		: pluginFileFromServer;
+	const pluginBasename = pluginFileFromServer?.replace( /\.php$/, '' );
+	const pluginSlug = pluginBasename?.includes( '/' )
+		? pluginBasename.split( '/' )[ 0 ]
+		: pluginBasename;
 
 	const {
 		derivedPluginStatus,
@@ -94,12 +95,12 @@ export function useConnectorPlugin( {
 			const plugin = store.getEntityRecord(
 				'root',
 				'plugin',
-				pluginFileFromServer
+				pluginBasename
 			) as { plugin: string; status: string } | undefined;
 
 			const hasFinished = store.hasFinishedResolution(
 				'getEntityRecord',
-				[ 'root', 'plugin', pluginFileFromServer ]
+				[ 'root', 'plugin', pluginBasename ]
 			);
 
 			if ( ! hasFinished ) {
@@ -139,7 +140,7 @@ export function useConnectorPlugin( {
 				canInstallPlugins: canCreate,
 			};
 		},
-		[ pluginFileFromServer, settingName, isInstalled, isActivated ]
+		[ pluginBasename, settingName, isInstalled, isActivated ]
 	);
 
 	const pluginStatus = pluginStatusOverride ?? derivedPluginStatus;
@@ -202,7 +203,7 @@ export function useConnectorPlugin( {
 				'root',
 				'plugin',
 				{
-					plugin: pluginFileFromServer,
+					plugin: pluginBasename,
 					status: 'active',
 				},
 				{ throwOnError: true }

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -12,10 +12,10 @@ import type { __experimentalApiKeySource as ApiKeySource } from '@wordpress/conn
 export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 
 interface UseConnectorPluginOptions {
-	pluginSlug?: string;
-	pluginFile?: string | null;
+	pluginFile?: string;
 	settingName: string;
 	connectorName: string;
+	isInstalled?: boolean;
 	isActivated?: boolean;
 	keySource?: ApiKeySource;
 	initialIsConnected?: boolean;
@@ -38,10 +38,10 @@ interface UseConnectorPluginReturn {
 }
 
 export function useConnectorPlugin( {
-	pluginSlug,
 	pluginFile: pluginFileFromServer,
 	settingName,
 	connectorName,
+	isInstalled,
 	isActivated,
 	keySource = 'none',
 	initialIsConnected = false,
@@ -53,6 +53,10 @@ export function useConnectorPlugin( {
 	// Local override for immediate UI feedback after install/activate.
 	const [ pluginStatusOverride, setPluginStatusOverride ] =
 		useState< PluginStatus | null >( null );
+
+	const pluginSlug = pluginFileFromServer?.includes( '/' )
+		? pluginFileFromServer.split( '/' )[ 0 ]
+		: pluginFileFromServer;
 
 	const {
 		derivedPluginStatus,
@@ -72,7 +76,7 @@ export function useConnectorPlugin( {
 				name: 'plugin',
 			} );
 
-			if ( ! pluginSlug ) {
+			if ( ! pluginFileFromServer ) {
 				const hasLoaded = store.hasFinishedResolution(
 					'getEntityRecord',
 					[ 'root', 'site' ]
@@ -87,17 +91,15 @@ export function useConnectorPlugin( {
 				};
 			}
 
-			const pluginId = pluginFileFromServer ?? `${ pluginSlug }/plugin`;
-
 			const plugin = store.getEntityRecord(
 				'root',
 				'plugin',
-				pluginId
+				pluginFileFromServer
 			) as { plugin: string; status: string } | undefined;
 
 			const hasFinished = store.hasFinishedResolution(
 				'getEntityRecord',
-				[ 'root', 'plugin', pluginId ]
+				[ 'root', 'plugin', pluginFileFromServer ]
 			);
 
 			if ( ! hasFinished ) {
@@ -127,7 +129,7 @@ export function useConnectorPlugin( {
 			let status: PluginStatus = 'not-installed';
 			if ( isActivated ) {
 				status = 'active';
-			} else if ( pluginFileFromServer ) {
+			} else if ( isInstalled ) {
 				status = 'inactive';
 			}
 			return {
@@ -137,7 +139,7 @@ export function useConnectorPlugin( {
 				canInstallPlugins: canCreate,
 			};
 		},
-		[ pluginSlug, pluginFileFromServer, settingName, isActivated ]
+		[ pluginFileFromServer, settingName, isInstalled, isActivated ]
 	);
 
 	const pluginStatus = pluginStatusOverride ?? derivedPluginStatus;
@@ -191,7 +193,7 @@ export function useConnectorPlugin( {
 	};
 
 	const activatePlugin = async () => {
-		if ( ! pluginSlug ) {
+		if ( ! pluginFileFromServer ) {
 			return;
 		}
 		setIsBusy( true );
@@ -200,7 +202,7 @@ export function useConnectorPlugin( {
 				'root',
 				'plugin',
 				{
-					plugin: pluginFileFromServer ?? `${ pluginSlug }/plugin`,
+					plugin: pluginFileFromServer,
 					status: 'active',
 				},
 				{ throwOnError: true }


### PR DESCRIPTION
## Summary
- Replace `plugin.slug` with `plugin.file` (the full plugin file path, e.g. `akismet/akismet.php`) in connector registrations
- Simplify script module data: remove `get_plugins()` slug-to-file map, use `file_exists()` and `is_plugin_active()` directly
- Add `isInstalled` to the frontend plugin data; frontend derives slug from file path

## Test plan
- [ ] Verify connectors page loads and shows correct plugin status (installed/not installed/active)
- [ ] Verify install and activate flows still work for AI provider plugins
- [ ] Verify Akismet connector shows correct state