### PR TITLE
POC: Modern Comments Admin Page

### DIFF
--- a/lib/experimental/pages/comments.php
+++ b/lib/experimental/pages/comments.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Comments Admin Page - Replaces the core Comments admin page with a modern DataViews-based UI.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Register the Comments admin page, replacing Core's edit-comments.php.
+ */
+function gutenberg_register_comments_admin_page() {
+	// Remove Core's comments menu item.
+	remove_menu_page( 'edit-comments.php' );
+
+	// Register the new comments page under the same top-level position.
+	add_menu_page(
+		__( 'Comments', 'gutenberg' ),
+		__( 'Comments', 'gutenberg' ),
+		'moderate_comments',
+		'comments-admin-wp-admin',
+		'gutenberg_comments_admin_wp_admin_render_page',
+		'dashicons-admin-comments',
+		25 // Same position as the original Comments menu.
+	);
+}
+add_action( 'admin_menu', 'gutenberg_register_comments_admin_page', 11 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -129,6 +129,7 @@ require __DIR__ . '/experimental/script-modules.php';
 require __DIR__ . '/experimental/pages/site-editor.php';
 require __DIR__ . '/experimental/extensible-site-editor.php';
 require __DIR__ . '/experimental/fonts/load.php';
+require __DIR__ . '/experimental/pages/comments.php';
 if ( class_exists( '\WordPress\AiClient\AiClient' ) ) {
 	require __DIR__ . '/experimental/connectors/load.php';
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 			},
 			"font-library",
 			"options-connectors",
-			"guidelines"
+			"guidelines",
+			"comments-admin"
 		]
 	},
 	"config": {

--- a/routes/comments-home/package.json
+++ b/routes/comments-home/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@wordpress/comments-home-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/",
+		"page": [
+			"comments-admin"
+		]
+	},
+	"dependencies": {
+		"@wordpress/route": "file:../../packages/route"
+	}
+}

--- a/routes/comments-home/route.ts
+++ b/routes/comments-home/route.ts
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+/**
+ * Route configuration for comments home redirect.
+ */
+export const route = {
+	beforeLoad: () => {
+		throw redirect( {
+			throw: true,
+			to: '/all',
+		} );
+	},
+};

--- a/routes/comments/actions.tsx
+++ b/routes/comments/actions.tsx
@@ -48,7 +48,7 @@ export const approveComment: Action< CommentWithPermissions > = {
 			await Promise.all(
 				items.map( async ( item ) => {
 					await editEntityRecord( 'root', 'comment', item.id, {
-						status: 'approve',
+						status: 'approved',
 					} );
 					await saveEditedEntityRecord( 'root', 'comment', item.id, {
 						throwOnError: true,
@@ -87,7 +87,7 @@ export const unapproveComment: Action< CommentWithPermissions > = {
 	isPrimary: true,
 	supportsBulk: true,
 	isEligible( item ) {
-		return item.status === COMMENT_STATUSES.APPROVE;
+		return item.status === COMMENT_STATUSES.APPROVED;
 	},
 	async callback( items, { registry } ) {
 		const { editEntityRecord, saveEditedEntityRecord } =
@@ -204,7 +204,7 @@ export const restoreComment: Action< CommentWithPermissions > = {
 			await Promise.all(
 				items.map( async ( item ) => {
 					await editEntityRecord( 'root', 'comment', item.id, {
-						status: 'approve',
+						status: 'approved',
 					} );
 					await saveEditedEntityRecord( 'root', 'comment', item.id, {
 						throwOnError: true,

--- a/routes/comments/actions.tsx
+++ b/routes/comments/actions.tsx
@@ -1,0 +1,401 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import {
+	check,
+	cancelCircleFilled,
+	trash,
+	backup,
+	bug,
+} from '@wordpress/icons';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { CommentWithPermissions } from './types';
+import { COMMENT_STATUSES } from './types';
+
+/**
+ * Approve a pending comment.
+ */
+export const approveComment: Action< CommentWithPermissions > = {
+	id: 'approve-comment',
+	label: __( 'Approve' ),
+	icon: check,
+	isPrimary: true,
+	supportsBulk: true,
+	isEligible( item ) {
+		return (
+			item.status === COMMENT_STATUSES.HOLD && item.permissions?.update
+		);
+	},
+	async callback( items, { registry } ) {
+		const { editEntityRecord, saveEditedEntityRecord } =
+			registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		try {
+			await Promise.all(
+				items.map( async ( item ) => {
+					await editEntityRecord( 'root', 'comment', item.id, {
+						status: 'approve',
+					} );
+					await saveEditedEntityRecord( 'root', 'comment', item.id, {
+						throwOnError: true,
+					} );
+				} )
+			);
+			let successMessage;
+			if ( items.length === 1 ) {
+				successMessage = __( 'Comment approved.' );
+			} else {
+				successMessage = sprintf(
+					/* translators: %d: The number of comments. */
+					__( '%d comments approved.' ),
+					items.length
+				);
+			}
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'approve-comment-action',
+			} );
+		} catch {
+			createErrorNotice( __( 'An error occurred while approving.' ), {
+				type: 'snackbar',
+			} );
+		}
+	},
+};
+
+/**
+ * Unapprove (hold) an approved comment.
+ */
+export const unapproveComment: Action< CommentWithPermissions > = {
+	id: 'unapprove-comment',
+	label: __( 'Unapprove' ),
+	icon: cancelCircleFilled,
+	isPrimary: true,
+	supportsBulk: true,
+	isEligible( item ) {
+		return (
+			item.status === COMMENT_STATUSES.APPROVE && item.permissions?.update
+		);
+	},
+	async callback( items, { registry } ) {
+		const { editEntityRecord, saveEditedEntityRecord } =
+			registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		try {
+			await Promise.all(
+				items.map( async ( item ) => {
+					await editEntityRecord( 'root', 'comment', item.id, {
+						status: 'hold',
+					} );
+					await saveEditedEntityRecord( 'root', 'comment', item.id, {
+						throwOnError: true,
+					} );
+				} )
+			);
+			let successMessage;
+			if ( items.length === 1 ) {
+				successMessage = __( 'Comment unapproved.' );
+			} else {
+				successMessage = sprintf(
+					/* translators: %d: The number of comments. */
+					__( '%d comments unapproved.' ),
+					items.length
+				);
+			}
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'unapprove-comment-action',
+			} );
+		} catch {
+			createErrorNotice( __( 'An error occurred while unapproving.' ), {
+				type: 'snackbar',
+			} );
+		}
+	},
+};
+
+/**
+ * Mark comment as spam.
+ */
+export const spamComment: Action< CommentWithPermissions > = {
+	id: 'spam-comment',
+	label: __( 'Mark as Spam' ),
+	icon: bug,
+	supportsBulk: true,
+	isEligible( item ) {
+		return (
+			item.status !== COMMENT_STATUSES.SPAM &&
+			item.status !== COMMENT_STATUSES.TRASH &&
+			item.permissions?.update
+		);
+	},
+	async callback( items, { registry } ) {
+		const { editEntityRecord, saveEditedEntityRecord } =
+			registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		try {
+			await Promise.all(
+				items.map( async ( item ) => {
+					await editEntityRecord( 'root', 'comment', item.id, {
+						status: 'spam',
+					} );
+					await saveEditedEntityRecord( 'root', 'comment', item.id, {
+						throwOnError: true,
+					} );
+				} )
+			);
+			let successMessage;
+			if ( items.length === 1 ) {
+				successMessage = __( 'Comment marked as spam.' );
+			} else {
+				successMessage = sprintf(
+					/* translators: %d: The number of comments. */
+					__( '%d comments marked as spam.' ),
+					items.length
+				);
+			}
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'spam-comment-action',
+			} );
+		} catch {
+			createErrorNotice(
+				__( 'An error occurred while marking as spam.' ),
+				{ type: 'snackbar' }
+			);
+		}
+	},
+};
+
+/**
+ * Restore comment from spam or trash back to its previous status (approved).
+ */
+export const restoreComment: Action< CommentWithPermissions > = {
+	id: 'restore-comment',
+	label: __( 'Restore' ),
+	icon: backup,
+	isPrimary: true,
+	supportsBulk: true,
+	isEligible( item ) {
+		return (
+			( item.status === COMMENT_STATUSES.SPAM ||
+				item.status === COMMENT_STATUSES.TRASH ) &&
+			item.permissions?.update
+		);
+	},
+	async callback( items, { registry } ) {
+		const { editEntityRecord, saveEditedEntityRecord } =
+			registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		try {
+			await Promise.all(
+				items.map( async ( item ) => {
+					await editEntityRecord( 'root', 'comment', item.id, {
+						status: 'approve',
+					} );
+					await saveEditedEntityRecord( 'root', 'comment', item.id, {
+						throwOnError: true,
+					} );
+				} )
+			);
+			let successMessage;
+			if ( items.length === 1 ) {
+				successMessage = __( 'Comment restored.' );
+			} else {
+				successMessage = sprintf(
+					/* translators: %d: The number of comments. */
+					__( '%d comments restored.' ),
+					items.length
+				);
+			}
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'restore-comment-action',
+			} );
+		} catch {
+			createErrorNotice( __( 'An error occurred while restoring.' ), {
+				type: 'snackbar',
+			} );
+		}
+	},
+};
+
+/**
+ * Move comment to trash (soft delete).
+ */
+export const trashComment: Action< CommentWithPermissions > = {
+	id: 'trash-comment',
+	label: __( 'Move to Trash' ),
+	icon: trash,
+	supportsBulk: true,
+	isEligible( item ) {
+		return (
+			item.status !== COMMENT_STATUSES.TRASH && item.permissions?.delete
+		);
+	},
+	async callback( items, { registry } ) {
+		const { deleteEntityRecord } = registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		try {
+			await Promise.all(
+				items.map( ( item ) =>
+					deleteEntityRecord(
+						'root',
+						'comment',
+						item.id,
+						{},
+						{
+							throwOnError: true,
+						}
+					)
+				)
+			);
+			let successMessage;
+			if ( items.length === 1 ) {
+				successMessage = __( 'Comment moved to trash.' );
+			} else {
+				successMessage = sprintf(
+					/* translators: %d: The number of comments. */
+					__( '%d comments moved to trash.' ),
+					items.length
+				);
+			}
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'trash-comment-action',
+			} );
+		} catch {
+			createErrorNotice(
+				__( 'An error occurred while moving to trash.' ),
+				{ type: 'snackbar' }
+			);
+		}
+	},
+};
+
+/**
+ * Permanently delete a comment (only available in Trash view).
+ */
+export const deleteComment: Action< CommentWithPermissions > = {
+	id: 'delete-comment',
+	label: __( 'Delete Permanently' ),
+	icon: trash,
+	isDestructive: true,
+	supportsBulk: true,
+	hideModalHeader: true,
+	isEligible( item ) {
+		return (
+			item.status === COMMENT_STATUSES.TRASH && item.permissions?.delete
+		);
+	},
+	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+		const [ isBusy, setIsBusy ] = useState( false );
+		const { deleteEntityRecord } = useDispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			useDispatch( noticesStore );
+
+		let confirmMessage;
+		if ( items.length === 1 ) {
+			confirmMessage = __(
+				'Are you sure you want to permanently delete this comment?'
+			);
+		} else {
+			confirmMessage = sprintf(
+				/* translators: %d: The number of comments. */
+				__(
+					'Are you sure you want to permanently delete %d comments?'
+				),
+				items.length
+			);
+		}
+
+		return (
+			<VStack spacing="5">
+				<Text>{ confirmMessage }</Text>
+				<HStack justify="right">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ closeModal }
+						disabled={ isBusy }
+						accessibleWhenDisabled
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isDestructive
+						onClick={ async () => {
+							setIsBusy( true );
+							try {
+								await Promise.all(
+									items.map( ( item ) =>
+										deleteEntityRecord(
+											'root',
+											'comment',
+											item.id,
+											{ force: true },
+											{ throwOnError: true }
+										)
+									)
+								);
+								let successMessage;
+								if ( items.length === 1 ) {
+									successMessage = __(
+										'Comment permanently deleted.'
+									);
+								} else {
+									successMessage = sprintf(
+										/* translators: %d: The number of comments. */
+										__(
+											'%d comments permanently deleted.'
+										),
+										items.length
+									);
+								}
+								createSuccessNotice( successMessage, {
+									type: 'snackbar',
+									id: 'delete-comment-action',
+								} );
+								onActionPerformed?.( items );
+							} catch {
+								createErrorNotice(
+									__( 'An error occurred while deleting.' ),
+									{ type: 'snackbar' }
+								);
+							}
+							setIsBusy( false );
+							closeModal?.();
+						} }
+						isBusy={ isBusy }
+						disabled={ isBusy }
+						accessibleWhenDisabled
+					>
+						{ __( 'Delete Permanently' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		);
+	},
+};

--- a/routes/comments/actions.tsx
+++ b/routes/comments/actions.tsx
@@ -132,7 +132,7 @@ export const unapproveComment: Action< CommentWithPermissions > = {
  */
 export const spamComment: Action< CommentWithPermissions > = {
 	id: 'spam-comment',
-	label: __( 'Mark as Spam' ),
+	label: __( 'Spam' ),
 	icon: bug,
 	supportsBulk: true,
 	isEligible( item ) {
@@ -238,7 +238,7 @@ export const restoreComment: Action< CommentWithPermissions > = {
  */
 export const trashComment: Action< CommentWithPermissions > = {
 	id: 'trash-comment',
-	label: __( 'Move to Trash' ),
+	label: __( 'Trash' ),
 	icon: trash,
 	supportsBulk: true,
 	isEligible( item ) {
@@ -290,7 +290,7 @@ export const trashComment: Action< CommentWithPermissions > = {
  */
 export const deleteComment: Action< CommentWithPermissions > = {
 	id: 'delete-comment',
-	label: __( 'Delete Permanently' ),
+	label: __( 'Delete' ),
 	icon: trash,
 	isDestructive: true,
 	supportsBulk: true,
@@ -382,7 +382,7 @@ export const deleteComment: Action< CommentWithPermissions > = {
 						disabled={ isBusy }
 						accessibleWhenDisabled
 					>
-						{ __( 'Delete Permanently' ) }
+						{ __( 'Delete' ) }
 					</Button>
 				</HStack>
 			</VStack>

--- a/routes/comments/actions.tsx
+++ b/routes/comments/actions.tsx
@@ -37,9 +37,7 @@ export const approveComment: Action< CommentWithPermissions > = {
 	isPrimary: true,
 	supportsBulk: true,
 	isEligible( item ) {
-		return (
-			item.status === COMMENT_STATUSES.HOLD && item.permissions?.update
-		);
+		return item.status === COMMENT_STATUSES.HOLD;
 	},
 	async callback( items, { registry } ) {
 		const { editEntityRecord, saveEditedEntityRecord } =
@@ -89,9 +87,7 @@ export const unapproveComment: Action< CommentWithPermissions > = {
 	isPrimary: true,
 	supportsBulk: true,
 	isEligible( item ) {
-		return (
-			item.status === COMMENT_STATUSES.APPROVE && item.permissions?.update
-		);
+		return item.status === COMMENT_STATUSES.APPROVE;
 	},
 	async callback( items, { registry } ) {
 		const { editEntityRecord, saveEditedEntityRecord } =
@@ -142,8 +138,7 @@ export const spamComment: Action< CommentWithPermissions > = {
 	isEligible( item ) {
 		return (
 			item.status !== COMMENT_STATUSES.SPAM &&
-			item.status !== COMMENT_STATUSES.TRASH &&
-			item.permissions?.update
+			item.status !== COMMENT_STATUSES.TRASH
 		);
 	},
 	async callback( items, { registry } ) {
@@ -196,9 +191,8 @@ export const restoreComment: Action< CommentWithPermissions > = {
 	supportsBulk: true,
 	isEligible( item ) {
 		return (
-			( item.status === COMMENT_STATUSES.SPAM ||
-				item.status === COMMENT_STATUSES.TRASH ) &&
-			item.permissions?.update
+			item.status === COMMENT_STATUSES.SPAM ||
+			item.status === COMMENT_STATUSES.TRASH
 		);
 	},
 	async callback( items, { registry } ) {
@@ -248,9 +242,7 @@ export const trashComment: Action< CommentWithPermissions > = {
 	icon: trash,
 	supportsBulk: true,
 	isEligible( item ) {
-		return (
-			item.status !== COMMENT_STATUSES.TRASH && item.permissions?.delete
-		);
+		return item.status !== COMMENT_STATUSES.TRASH;
 	},
 	async callback( items, { registry } ) {
 		const { deleteEntityRecord } = registry.dispatch( coreStore );
@@ -304,9 +296,7 @@ export const deleteComment: Action< CommentWithPermissions > = {
 	supportsBulk: true,
 	hideModalHeader: true,
 	isEligible( item ) {
-		return (
-			item.status === COMMENT_STATUSES.TRASH && item.permissions?.delete
-		);
+		return item.status === COMMENT_STATUSES.TRASH;
 	},
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -59,11 +59,14 @@ export const contentField: Field< CommentWithPermissions > = {
 	enableGlobalSearch: true,
 	enableSorting: false,
 	render: ( { item } ) => {
-		const stripped =
-			item.content?.rendered?.replace( /<[^>]+>/g, '' ) || '';
-		const text = decodeEntities( stripped );
+		// Replace block-level closing tags with spaces to preserve word boundaries.
+		const spaced =
+			item.content?.rendered?.replace( /<\/(p|div|br\s*\/?)>/gi, ' ' ) ||
+			'';
+		const stripped = spaced.replace( /<[^>]+>/g, '' );
+		const text = decodeEntities( stripped ).trim();
 		const truncated =
-			text.length > 120 ? text.substring( 0, 120 ) + '...' : text;
+			text.length > 200 ? text.substring( 0, 200 ) + '...' : text;
 		return <span>{ truncated }</span>;
 	},
 };
@@ -108,7 +111,7 @@ function PostFieldView( { item }: { item: CommentWithPermissions } ) {
  */
 export const postField: Field< CommentWithPermissions > = {
 	id: 'post',
-	label: __( 'Post' ),
+	label: __( 'In Response To' ),
 	type: 'integer',
 	enableSorting: false,
 	render: PostFieldView,
@@ -150,7 +153,7 @@ export const postField: Field< CommentWithPermissions > = {
  */
 export const dateField: Field< CommentWithPermissions > = {
 	id: 'date',
-	label: __( 'Date' ),
+	label: __( 'Submitted on' ),
 	type: 'datetime',
 	render: ( { item } ) => {
 		const dateFormat = getSettings().formats.date;

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -74,14 +74,20 @@ function PostFieldView( { item }: { item: CommentWithPermissions } ) {
 			if ( ! item.post ) {
 				return null;
 			}
-			const post = select( coreStore ).getEntityRecord(
-				'postType',
-				'post',
-				item.post,
-				{ _fields: 'title' }
-			);
-			return ( post as { title?: { rendered?: string } } )?.title
-				?.rendered;
+			// Try 'post' first, then 'page' as fallback.
+			for ( const type of [ 'post', 'page' ] ) {
+				const post = select( coreStore ).getEntityRecord(
+					'postType',
+					type,
+					item.post,
+					{ _fields: 'title' }
+				);
+				if ( post ) {
+					return ( post as { title?: { rendered?: string } } )?.title
+						?.rendered;
+				}
+			}
+			return null;
 		},
 		[ item.post ]
 	);
@@ -90,7 +96,11 @@ function PostFieldView( { item }: { item: CommentWithPermissions } ) {
 		return <span>{ __( '(No post)' ) }</span>;
 	}
 
-	return <span>{ postTitle || `Post #${ item.post }` }</span>;
+	return (
+		<span>
+			{ postTitle ? decodeEntities( postTitle ) : `#${ item.post }` }
+		</span>
+	);
 }
 
 /**
@@ -103,24 +113,32 @@ export const postField: Field< CommentWithPermissions > = {
 	enableSorting: false,
 	render: PostFieldView,
 	getElements: async () => {
-		const posts =
-			( await resolveSelect( coreStore ).getEntityRecords(
-				'postType',
-				'post',
-				{
+		// Fetch posts and pages that have comments.
+		const results = await Promise.all(
+			[ 'post', 'page' ].map( ( type ) =>
+				resolveSelect( coreStore ).getEntityRecords( 'postType', type, {
 					per_page: 100,
 					_fields: 'id,title',
 					orderby: 'title',
 					order: 'asc',
 					status: 'publish',
-				}
-			) ) ?? [];
-		return ( posts as { id: number; title: { rendered: string } }[] ).map(
-			( { id, title } ) => ( {
-				value: id,
-				label: decodeEntities( title.rendered ) || `Post #${ id }`,
-			} )
+				} )
+			)
 		);
+		const allPosts = results.flat().filter( Boolean ) as {
+			id: number;
+			title: { rendered: string };
+		}[];
+		return allPosts
+			.sort( ( a, b ) =>
+				decodeEntities( a.title.rendered ).localeCompare(
+					decodeEntities( b.title.rendered )
+				)
+			)
+			.map( ( { id, title } ) => ( {
+				value: id,
+				label: decodeEntities( title.rendered ) || `#${ id }`,
+			} ) );
 	},
 	filterBy: {
 		operators: [ 'is' ],

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -175,7 +175,7 @@ export const statusField: Field< CommentWithPermissions > = {
 	type: 'text',
 	enableSorting: false,
 	elements: [
-		{ value: COMMENT_STATUSES.APPROVE, label: __( 'Approved' ) },
+		{ value: COMMENT_STATUSES.APPROVED, label: __( 'Approved' ) },
 		{ value: COMMENT_STATUSES.HOLD, label: __( 'Pending' ) },
 		{ value: COMMENT_STATUSES.SPAM, label: __( 'Spam' ) },
 		{ value: COMMENT_STATUSES.TRASH, label: __( 'Trash' ) },

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import type { Field } from '@wordpress/dataviews';
 
 /**
@@ -63,20 +65,40 @@ export const contentField: Field< CommentWithPermissions > = {
 	},
 };
 
+function PostFieldView( { item }: { item: CommentWithPermissions } ) {
+	const postTitle = useSelect(
+		( select ) => {
+			if ( ! item.post ) {
+				return null;
+			}
+			const post = select( coreStore ).getEntityRecord(
+				'postType',
+				'post',
+				item.post,
+				{ _fields: 'title' }
+			);
+			return ( post as { title?: { rendered?: string } } )?.title
+				?.rendered;
+		},
+		[ item.post ]
+	);
+
+	if ( ! item.post ) {
+		return <span>{ __( '(No post)' ) }</span>;
+	}
+
+	return <span>{ postTitle || `Post #${ item.post }` }</span>;
+}
+
 /**
  * Post field — displays the title of the post the comment is on.
- * Uses the `post` field (post ID) from the comment entity.
  */
 export const postField: Field< CommentWithPermissions > = {
 	id: 'post',
 	label: __( 'In Response To' ),
 	type: 'integer',
 	enableSorting: false,
-	render: ( { item } ) => {
-		// The post ID is available; a richer implementation would resolve the post title.
-		// For now, display a link placeholder with the post ID.
-		return <span>{ `Post #${ item.post }` }</span>;
-	},
+	render: PostFieldView,
 	filterBy: {
 		operators: [ 'is' ],
 	},

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useSelect } from '@wordpress/data';
+import { useSelect, resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { Field } from '@wordpress/dataviews';
 
@@ -98,10 +98,30 @@ function PostFieldView( { item }: { item: CommentWithPermissions } ) {
  */
 export const postField: Field< CommentWithPermissions > = {
 	id: 'post',
-	label: __( 'In Response To' ),
+	label: __( 'Post' ),
 	type: 'integer',
 	enableSorting: false,
 	render: PostFieldView,
+	getElements: async () => {
+		const posts =
+			( await resolveSelect( coreStore ).getEntityRecords(
+				'postType',
+				'post',
+				{
+					per_page: 100,
+					_fields: 'id,title',
+					orderby: 'title',
+					order: 'asc',
+					status: 'publish',
+				}
+			) ) ?? [];
+		return ( posts as { id: number; title: { rendered: string } }[] ).map(
+			( { id, title } ) => ( {
+				value: id,
+				label: decodeEntities( title.rendered ) || `Post #${ id }`,
+			} )
+		);
+	},
 	filterBy: {
 		operators: [ 'is' ],
 	},

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -1,0 +1,123 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { CommentWithPermissions } from './types';
+import { COMMENT_STATUSES } from './types';
+
+/**
+ * Author name field — displays the comment author's name.
+ */
+export const authorNameField: Field< CommentWithPermissions > = {
+	id: 'author_name',
+	label: __( 'Author' ),
+	type: 'text',
+	enableGlobalSearch: true,
+	render: ( { item } ) => {
+		const avatarUrl =
+			item.author_avatar_urls?.[ '48' ] ||
+			item.author_avatar_urls?.[ '24' ];
+		return (
+			<div
+				style={ {
+					display: 'flex',
+					alignItems: 'center',
+					gap: '8px',
+				} }
+			>
+				{ avatarUrl && (
+					<img
+						src={ avatarUrl }
+						alt=""
+						width={ 24 }
+						height={ 24 }
+						style={ { borderRadius: '50%' } }
+					/>
+				) }
+				<span>{ item.author_name || __( 'Anonymous' ) }</span>
+			</div>
+		);
+	},
+};
+
+/**
+ * Comment content field — displays a truncated preview of the comment.
+ */
+export const contentField: Field< CommentWithPermissions > = {
+	id: 'content',
+	label: __( 'Comment' ),
+	type: 'text',
+	enableGlobalSearch: true,
+	enableSorting: false,
+	render: ( { item } ) => {
+		const text = item.content?.rendered?.replace( /<[^>]+>/g, '' ) || '';
+		const truncated =
+			text.length > 120 ? text.substring( 0, 120 ) + '...' : text;
+		return <span>{ truncated }</span>;
+	},
+};
+
+/**
+ * Post field — displays the title of the post the comment is on.
+ * Uses the `post` field (post ID) from the comment entity.
+ */
+export const postField: Field< CommentWithPermissions > = {
+	id: 'post',
+	label: __( 'In Response To' ),
+	type: 'integer',
+	enableSorting: false,
+	render: ( { item } ) => {
+		// The post ID is available; a richer implementation would resolve the post title.
+		// For now, display a link placeholder with the post ID.
+		return <span>{ `Post #${ item.post }` }</span>;
+	},
+	filterBy: {
+		operators: [ 'is' ],
+	},
+};
+
+/**
+ * Date field — displays the comment date.
+ */
+export const dateField: Field< CommentWithPermissions > = {
+	id: 'date',
+	label: __( 'Date' ),
+	type: 'datetime',
+	render: ( { item } ) => {
+		const dateFormat = getSettings().formats.date;
+		const commentDate = getDate( item.date );
+		return (
+			<time dateTime={ item.date }>
+				{ dateI18n( dateFormat, commentDate ) }
+			</time>
+		);
+	},
+	filterBy: {
+		operators: [ 'before', 'after' ],
+	},
+};
+
+/**
+ * Status field — displays the comment status as a label.
+ */
+export const statusField: Field< CommentWithPermissions > = {
+	id: 'status',
+	label: __( 'Status' ),
+	type: 'text',
+	enableSorting: false,
+	elements: [
+		{ value: COMMENT_STATUSES.APPROVE, label: __( 'Approved' ) },
+		{ value: COMMENT_STATUSES.HOLD, label: __( 'Pending' ) },
+		{ value: COMMENT_STATUSES.SPAM, label: __( 'Spam' ) },
+		{ value: COMMENT_STATUSES.TRASH, label: __( 'Trash' ) },
+	],
+	filterBy: {
+		operators: [ 'is' ],
+	},
+};

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -167,6 +167,24 @@ export const dateField: Field< CommentWithPermissions > = {
 };
 
 /**
+ * Type field — allows filtering by comment type (comment, pingback, trackback).
+ */
+export const typeField: Field< CommentWithPermissions > = {
+	id: 'type',
+	label: __( 'Type' ),
+	type: 'text',
+	enableSorting: false,
+	elements: [
+		{ value: 'comment', label: __( 'Comments' ) },
+		{ value: 'pingback', label: __( 'Pingbacks' ) },
+		{ value: 'trackback', label: __( 'Trackbacks' ) },
+	],
+	filterBy: {
+		operators: [ 'is' ],
+	},
+};
+
+/**
  * Status field — displays the comment status as a label.
  */
 export const statusField: Field< CommentWithPermissions > = {

--- a/routes/comments/fields.tsx
+++ b/routes/comments/fields.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { Field } from '@wordpress/dataviews';
@@ -58,7 +59,9 @@ export const contentField: Field< CommentWithPermissions > = {
 	enableGlobalSearch: true,
 	enableSorting: false,
 	render: ( { item } ) => {
-		const text = item.content?.rendered?.replace( /<[^>]+>/g, '' ) || '';
+		const stripped =
+			item.content?.rendered?.replace( /<[^>]+>/g, '' ) || '';
+		const text = decodeEntities( stripped );
 		const truncated =
 			text.length > 120 ? text.substring( 0, 120 ) + '...' : text;
 		return <span>{ truncated }</span>;

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -127,7 +127,7 @@ function CommentInspector() {
 
 			{ /* Post reference */ }
 			<HStack>
-				<Text weight="bold">{ __( 'In Response To:' ) }</Text>
+				<Text weight="bold">{ __( 'Post:' ) }</Text>
 				<Text>{ postTitle || `Post #${ comment.post }` }</Text>
 			</HStack>
 

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -28,7 +28,7 @@ const STATUS_LABELS: Record< string, string > = {
 };
 
 function CommentInspector() {
-	const searchParams = useSearch( { from: '/comments/$status' } );
+	const searchParams = useSearch( { from: '/$status' } );
 	const commentIds = useMemo(
 		() => searchParams.commentIds ?? [],
 		[ searchParams.commentIds ]

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -21,7 +21,7 @@ import type { CommentWithPermissions } from './types';
 import { COMMENT_STATUSES } from './types';
 
 const STATUS_LABELS: Record< string, string > = {
-	[ COMMENT_STATUSES.APPROVE ]: __( 'Approved' ),
+	[ COMMENT_STATUSES.APPROVED ]: __( 'Approved' ),
 	[ COMMENT_STATUSES.HOLD ]: __( 'Pending' ),
 	[ COMMENT_STATUSES.SPAM ]: __( 'Spam' ),
 	[ COMMENT_STATUSES.TRASH ]: __( 'Trash' ),

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -1,26 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useSearch, useNavigate } from '@wordpress/route';
-import { useMemo, useEffect, useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSearch } from '@wordpress/route';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as noticesStore } from '@wordpress/notices';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import {
-	check,
-	cancelCircleFilled,
-	bug,
-	trash,
-	backup,
-	chevronUp,
-	chevronDown,
-	closeSmall,
-} from '@wordpress/icons';
-import {
-	Button,
-	Tooltip,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -40,84 +27,22 @@ const STATUS_LABELS: Record< string, string > = {
 	[ COMMENT_STATUSES.TRASH ]: __( 'Trash' ),
 };
 
-/**
- * Navigate to a specific comment by updating URL search params.
- *
- * @param commentId    The comment ID to select.
- * @param searchParams Current search params object.
- * @param navigate     The navigate function from the router.
- */
-function selectComment(
-	commentId: string,
-	searchParams: Record< string, unknown >,
-	navigate: ReturnType< typeof useNavigate >
-) {
-	navigate( {
-		search: {
-			...searchParams,
-			commentIds: [ commentId ],
-		},
-	} );
-}
-
-/**
- * Clear the comment selection.
- *
- * @param searchParams Current search params object.
- * @param navigate     The navigate function from the router.
- */
-function clearSelection(
-	searchParams: Record< string, unknown >,
-	navigate: ReturnType< typeof useNavigate >
-) {
-	navigate( {
-		search: {
-			...searchParams,
-			commentIds: undefined,
-		},
-	} );
-}
-
 function CommentInspector() {
 	const searchParams = useSearch( { from: '/$status' } );
-	const navigate = useNavigate();
-
 	const commentIds = useMemo(
 		() => searchParams.commentIds ?? [],
 		[ searchParams.commentIds ]
 	);
 
-	const visibleIds: string[] = useMemo(
-		() => searchParams.visibleIds ?? [],
-		[ searchParams.visibleIds ]
-	);
-
-	const currentId = commentIds.length === 1 ? commentIds[ 0 ] : null;
-
-	// Determine prev/next comment IDs based on the visible list order.
-	const { prevId, nextId } = useMemo( () => {
-		if ( ! currentId || visibleIds.length === 0 ) {
-			return { prevId: null, nextId: null };
-		}
-		const idx = visibleIds.indexOf( currentId );
-		if ( idx === -1 ) {
-			return { prevId: null, nextId: null };
-		}
-		return {
-			prevId: idx > 0 ? visibleIds[ idx - 1 ] : null,
-			nextId: idx < visibleIds.length - 1 ? visibleIds[ idx + 1 ] : null,
-		};
-	}, [ currentId, visibleIds ] );
-
 	const { comment, postTitle } = useSelect(
 		( select ) => {
-			if ( ! currentId ) {
+			if ( commentIds.length !== 1 ) {
 				return { comment: null, postTitle: null };
 			}
 			const commentRecord = select( coreStore ).getEntityRecord(
 				'root',
 				'comment',
-				Number( currentId )
+				Number( commentIds[ 0 ] )
 			) as CommentWithPermissions | undefined;
 
 			let resolvedPostTitle = null;
@@ -135,189 +60,12 @@ function CommentInspector() {
 
 			return { comment: commentRecord, postTitle: resolvedPostTitle };
 		},
-		[ currentId ]
+		[ commentIds ]
 	);
-
-	const { editEntityRecord, saveEditedEntityRecord, deleteEntityRecord } =
-		useDispatch( coreStore );
-	const { createSuccessNotice, createErrorNotice } =
-		useDispatch( noticesStore );
-
-	/**
-	 * Auto-advance to the next (or previous) comment after an action.
-	 * If no comments remain, clear the selection.
-	 */
-	const autoAdvance = useCallback( () => {
-		if ( nextId ) {
-			selectComment( nextId, searchParams, navigate );
-		} else if ( prevId ) {
-			selectComment( prevId, searchParams, navigate );
-		} else {
-			clearSelection( searchParams, navigate );
-		}
-	}, [ nextId, prevId, searchParams, navigate ] );
-
-	/**
-	 * Change the comment status and auto-advance.
-	 *
-	 * @param newStatus The new status to set on the comment.
-	 * @param label     Human-readable label for the notice message.
-	 */
-	const changeStatus = useCallback(
-		async ( newStatus: string, label: string ) => {
-			if ( ! currentId ) {
-				return;
-			}
-			try {
-				await editEntityRecord(
-					'root',
-					'comment',
-					Number( currentId ),
-					{ status: newStatus }
-				);
-				await saveEditedEntityRecord(
-					'root',
-					'comment',
-					Number( currentId ),
-					{ throwOnError: true }
-				);
-				createSuccessNotice( label, {
-					type: 'snackbar',
-				} );
-				autoAdvance();
-			} catch {
-				createErrorNotice(
-					__( 'An error occurred. Please try again.' ),
-					{ type: 'snackbar' }
-				);
-			}
-		},
-		[
-			currentId,
-			editEntityRecord,
-			saveEditedEntityRecord,
-			createSuccessNotice,
-			createErrorNotice,
-			autoAdvance,
-		]
-	);
-
-	/**
-	 * Move comment to trash and auto-advance.
-	 */
-	const handleTrash = useCallback( async () => {
-		if ( ! currentId ) {
-			return;
-		}
-		try {
-			await deleteEntityRecord(
-				'root',
-				'comment',
-				Number( currentId ),
-				{},
-				{ throwOnError: true }
-			);
-			createSuccessNotice( __( 'Comment moved to trash.' ), {
-				type: 'snackbar',
-			} );
-			autoAdvance();
-		} catch {
-			createErrorNotice(
-				__( 'An error occurred while moving to trash.' ),
-				{ type: 'snackbar' }
-			);
-		}
-	}, [
-		currentId,
-		deleteEntityRecord,
-		createSuccessNotice,
-		createErrorNotice,
-		autoAdvance,
-	] );
-
-	const handleApprove = useCallback(
-		() => changeStatus( 'approve', __( 'Comment approved.' ) ),
-		[ changeStatus ]
-	);
-
-	const handleUnapprove = useCallback(
-		() => changeStatus( 'hold', __( 'Comment unapproved.' ) ),
-		[ changeStatus ]
-	);
-
-	const handleSpam = useCallback(
-		() => changeStatus( 'spam', __( 'Comment marked as spam.' ) ),
-		[ changeStatus ]
-	);
-
-	const handleRestore = useCallback(
-		() => changeStatus( 'approve', __( 'Comment restored.' ) ),
-		[ changeStatus ]
-	);
-
-	const goToPrevious = useCallback( () => {
-		if ( prevId ) {
-			selectComment( prevId, searchParams, navigate );
-		}
-	}, [ prevId, searchParams, navigate ] );
-
-	const goToNext = useCallback( () => {
-		if ( nextId ) {
-			selectComment( nextId, searchParams, navigate );
-		}
-	}, [ nextId, searchParams, navigate ] );
-
-	const handleClose = useCallback( () => {
-		clearSelection( searchParams, navigate );
-	}, [ searchParams, navigate ] );
-
-	// Keyboard navigation
-	useEffect( () => {
-		if ( ! currentId ) {
-			return;
-		}
-
-		/**
-		 * Handle keydown events for comment navigation.
-		 *
-		 * @param event The keyboard event.
-		 */
-		function onKeyDown( event: KeyboardEvent ) {
-			// Do not intercept when focus is inside an input or textarea.
-			const tag = ( event.target as HTMLElement )?.tagName;
-			if ( tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' ) {
-				return;
-			}
-
-			switch ( event.key ) {
-				case 'ArrowUp':
-					event.preventDefault();
-					if ( prevId ) {
-						selectComment( prevId, searchParams, navigate );
-					}
-					break;
-				case 'ArrowDown':
-					event.preventDefault();
-					if ( nextId ) {
-						selectComment( nextId, searchParams, navigate );
-					}
-					break;
-				case 'Escape':
-					event.preventDefault();
-					clearSelection( searchParams, navigate );
-					break;
-			}
-		}
-
-		window.addEventListener( 'keydown', onKeyDown );
-		return () => {
-			window.removeEventListener( 'keydown', onKeyDown );
-		};
-	}, [ currentId, prevId, nextId, searchParams, navigate ] );
 
 	if ( ! comment ) {
 		return (
-			<VStack spacing="4" className="comments-inspector">
+			<VStack spacing="4" style={ { padding: '16px' } }>
 				<Text>
 					{ commentIds.length === 0
 						? __( 'Select a comment to view details.' )
@@ -333,216 +81,91 @@ function CommentInspector() {
 		comment.author_avatar_urls?.[ '96' ] ||
 		comment.author_avatar_urls?.[ '48' ];
 
-	const status = comment.status;
-
-	// Determine which action buttons to show based on comment status.
-	// Permission checks are omitted because the page requires moderate_comments.
-	const isApproved = status === COMMENT_STATUSES.APPROVE;
-	const isPending = status === COMMENT_STATUSES.HOLD;
-	const isSpam = status === COMMENT_STATUSES.SPAM;
-	const isTrashed = status === COMMENT_STATUSES.TRASH;
-
-	// Position indicator (e.g., "3 of 12")
-	const currentIndex = visibleIds.indexOf( currentId ?? '' );
-	const positionLabel =
-		currentIndex !== -1 && visibleIds.length > 0
-			? `${ currentIndex + 1 } / ${ visibleIds.length }`
-			: '';
-
 	return (
-		<div className="comments-inspector">
-			{ /* Header: actions + navigation */ }
-			<div className="comments-inspector__header">
-				<div className="comments-inspector__actions">
-					{ /* Approve button: show for pending, spam, trash */ }
-					{ ( isPending || isSpam || isTrashed ) && (
-						<Tooltip
-							text={
-								isSpam || isTrashed
-									? __( 'Restore' )
-									: __( 'Approve' )
-							}
-						>
-							<Button
-								icon={ isSpam || isTrashed ? backup : check }
-								label={
-									isSpam || isTrashed
-										? __( 'Restore' )
-										: __( 'Approve' )
-								}
-								onClick={
-									isSpam || isTrashed
-										? handleRestore
-										: handleApprove
-								}
-								size="compact"
-							/>
-						</Tooltip>
+		<VStack spacing="4" style={ { padding: '16px' } }>
+			{ /* Author section */ }
+			<HStack alignment="top" spacing="3">
+				{ avatarUrl && (
+					<img
+						src={ avatarUrl }
+						alt=""
+						width={ 48 }
+						height={ 48 }
+						style={ { borderRadius: '50%', flexShrink: 0 } }
+					/>
+				) }
+				<VStack spacing="1">
+					<Heading level={ 4 }>
+						{ comment.author_name || __( 'Anonymous' ) }
+					</Heading>
+					{ comment.author_email && (
+						<Text variant="muted">{ comment.author_email }</Text>
 					) }
-					{ /* Unapprove button: show for approved comments */ }
-					{ isApproved && (
-						<Tooltip text={ __( 'Unapprove' ) }>
-							<Button
-								icon={ cancelCircleFilled }
-								label={ __( 'Unapprove' ) }
-								onClick={ handleUnapprove }
-								size="compact"
-							/>
-						</Tooltip>
-					) }
-					{ /* Spam button: show for non-spam, non-trash */ }
-					{ ! isSpam && ! isTrashed && (
-						<Tooltip text={ __( 'Mark as Spam' ) }>
-							<Button
-								icon={ bug }
-								label={ __( 'Mark as Spam' ) }
-								onClick={ handleSpam }
-								size="compact"
-							/>
-						</Tooltip>
-					) }
-					{ /* Trash button: show for non-trash */ }
-					{ ! isTrashed && (
-						<Tooltip text={ __( 'Move to Trash' ) }>
-							<Button
-								icon={ trash }
-								label={ __( 'Move to Trash' ) }
-								onClick={ handleTrash }
-								size="compact"
-								isDestructive
-							/>
-						</Tooltip>
-					) }
-				</div>
-
-				<div className="comments-inspector__navigation">
-					{ positionLabel && (
-						<Text variant="muted" size="small">
-							{ positionLabel }
-						</Text>
-					) }
-					<Tooltip text={ __( 'Previous comment' ) }>
-						<Button
-							icon={ chevronUp }
-							label={ __( 'Previous comment' ) }
-							onClick={ goToPrevious }
-							disabled={ ! prevId }
-							size="compact"
-							accessibleWhenDisabled
-						/>
-					</Tooltip>
-					<Tooltip text={ __( 'Next comment' ) }>
-						<Button
-							icon={ chevronDown }
-							label={ __( 'Next comment' ) }
-							onClick={ goToNext }
-							disabled={ ! nextId }
-							size="compact"
-							accessibleWhenDisabled
-						/>
-					</Tooltip>
-					<Tooltip text={ __( 'Close' ) }>
-						<Button
-							icon={ closeSmall }
-							label={ __( 'Close' ) }
-							onClick={ handleClose }
-							size="compact"
-						/>
-					</Tooltip>
-				</div>
-			</div>
-
-			{ /* Body */ }
-			<div className="comments-inspector__body">
-				<VStack spacing="4">
-					{ /* Author section */ }
-					<HStack alignment="top" spacing="3">
-						{ avatarUrl && (
-							<img
-								src={ avatarUrl }
-								alt=""
-								width={ 48 }
-								height={ 48 }
-								style={ {
-									borderRadius: '50%',
-									flexShrink: 0,
-								} }
-							/>
-						) }
-						<VStack spacing="1">
-							<Heading level={ 4 }>
-								{ comment.author_name || __( 'Anonymous' ) }
-							</Heading>
-							{ comment.author_email && (
-								<Text variant="muted">
-									{ comment.author_email }
-								</Text>
-							) }
-							{ comment.author_url && (
-								<Text variant="muted">
-									{ comment.author_url }
-								</Text>
-							) }
-						</VStack>
-					</HStack>
-
-					{ /* Status badge */ }
-					<HStack>
-						<Text weight="bold">{ __( 'Status:' ) }</Text>
-						<Text>
-							{ STATUS_LABELS[ comment.status ] ||
-								comment.status }
-						</Text>
-					</HStack>
-
-					{ /* Date */ }
-					<HStack>
-						<Text weight="bold">{ __( 'Date:' ) }</Text>
-						<Text>
-							<time dateTime={ comment.date }>
-								{ dateI18n( dateFormat, commentDate ) }
-							</time>
-						</Text>
-					</HStack>
-
-					{ /* Post reference */ }
-					<HStack>
-						<Text weight="bold">{ __( 'In Response To:' ) }</Text>
-						<Text>{ postTitle || `Post #${ comment.post }` }</Text>
-					</HStack>
-
-					{ /* Comment content */ }
-					<VStack spacing="2">
-						<Heading level={ 5 }>{ __( 'Comment' ) }</Heading>
-						<div
-							className="comments-inspector__content-rendered"
-							dangerouslySetInnerHTML={ {
-								__html: comment.content?.rendered || '',
-							} }
-						/>
-					</VStack>
-
-					{ /* View comment link */ }
-					{ comment.link && (
-						<a
-							href={ comment.link }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{ __( 'View Comment' ) }
-						</a>
-					) }
-
-					{ /* Author IP (for moderation context) */ }
-					{ comment.author_ip && (
-						<HStack>
-							<Text weight="bold">{ __( 'IP Address:' ) }</Text>
-							<Text variant="muted">{ comment.author_ip }</Text>
-						</HStack>
+					{ comment.author_url && (
+						<Text variant="muted">{ comment.author_url }</Text>
 					) }
 				</VStack>
-			</div>
-		</div>
+			</HStack>
+
+			{ /* Status */ }
+			<HStack>
+				<Text weight="bold">{ __( 'Status:' ) }</Text>
+				<Text>
+					{ STATUS_LABELS[ comment.status ] || comment.status }
+				</Text>
+			</HStack>
+
+			{ /* Date */ }
+			<HStack>
+				<Text weight="bold">{ __( 'Date:' ) }</Text>
+				<Text>
+					<time dateTime={ comment.date }>
+						{ dateI18n( dateFormat, commentDate ) }
+					</time>
+				</Text>
+			</HStack>
+
+			{ /* Post reference */ }
+			<HStack>
+				<Text weight="bold">{ __( 'In Response To:' ) }</Text>
+				<Text>{ postTitle || `Post #${ comment.post }` }</Text>
+			</HStack>
+
+			{ /* Comment content */ }
+			<VStack spacing="2">
+				<Heading level={ 5 }>{ __( 'Comment' ) }</Heading>
+				<div
+					dangerouslySetInnerHTML={ {
+						__html: comment.content?.rendered || '',
+					} }
+					style={ {
+						padding: '12px',
+						background: '#f0f0f0',
+						borderRadius: '4px',
+						lineHeight: 1.6,
+					} }
+				/>
+			</VStack>
+
+			{ /* View comment link */ }
+			{ comment.link && (
+				<a
+					href={ comment.link }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ __( 'View Comment' ) }
+				</a>
+			) }
+
+			{ /* Author IP */ }
+			{ comment.author_ip && (
+				<HStack>
+					<Text weight="bold">{ __( 'IP Address:' ) }</Text>
+					<Text variant="muted">{ comment.author_ip }</Text>
+				</HStack>
+			) }
+		</VStack>
 	);
 }
 

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -1,0 +1,146 @@
+/**
+ * WordPress dependencies
+ */
+import { useSearch } from '@wordpress/route';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { CommentWithPermissions } from './types';
+import { COMMENT_STATUSES } from './types';
+
+const STATUS_LABELS: Record< string, string > = {
+	[ COMMENT_STATUSES.APPROVE ]: __( 'Approved' ),
+	[ COMMENT_STATUSES.HOLD ]: __( 'Pending' ),
+	[ COMMENT_STATUSES.SPAM ]: __( 'Spam' ),
+	[ COMMENT_STATUSES.TRASH ]: __( 'Trash' ),
+};
+
+function CommentInspector() {
+	const searchParams = useSearch( { from: '/comments/$status' } );
+	const commentIds = useMemo(
+		() => searchParams.commentIds ?? [],
+		[ searchParams.commentIds ]
+	);
+
+	const comment = useSelect(
+		( select ) => {
+			if ( commentIds.length !== 1 ) {
+				return null;
+			}
+			return select( coreStore ).getEntityRecord(
+				'root',
+				'comment',
+				Number( commentIds[ 0 ] )
+			) as CommentWithPermissions | undefined;
+		},
+		[ commentIds ]
+	);
+
+	if ( ! comment ) {
+		return (
+			<VStack spacing="4" style={ { padding: '16px' } }>
+				<Text>
+					{ commentIds.length === 0
+						? __( 'Select a comment to view details.' )
+						: __( 'Select a single comment to view details.' ) }
+				</Text>
+			</VStack>
+		);
+	}
+
+	const dateFormat = getSettings().formats.datetime;
+	const commentDate = getDate( comment.date );
+	const avatarUrl =
+		comment.author_avatar_urls?.[ '96' ] ||
+		comment.author_avatar_urls?.[ '48' ];
+
+	return (
+		<VStack spacing="4" style={ { padding: '16px' } }>
+			{ /* Author section */ }
+			<HStack alignment="top" spacing="3">
+				{ avatarUrl && (
+					<img
+						src={ avatarUrl }
+						alt=""
+						width={ 48 }
+						height={ 48 }
+						style={ { borderRadius: '50%', flexShrink: 0 } }
+					/>
+				) }
+				<VStack spacing="1">
+					<Heading level={ 4 }>
+						{ comment.author_name || __( 'Anonymous' ) }
+					</Heading>
+					{ comment.author_email && (
+						<Text variant="muted">{ comment.author_email }</Text>
+					) }
+					{ comment.author_url && (
+						<Text variant="muted">{ comment.author_url }</Text>
+					) }
+				</VStack>
+			</HStack>
+
+			{ /* Status badge */ }
+			<HStack>
+				<Text weight="bold">{ __( 'Status:' ) }</Text>
+				<Text>
+					{ STATUS_LABELS[ comment.status ] || comment.status }
+				</Text>
+			</HStack>
+
+			{ /* Date */ }
+			<HStack>
+				<Text weight="bold">{ __( 'Date:' ) }</Text>
+				<Text>
+					<time dateTime={ comment.date }>
+						{ dateI18n( dateFormat, commentDate ) }
+					</time>
+				</Text>
+			</HStack>
+
+			{ /* Post reference */ }
+			<HStack>
+				<Text weight="bold">{ __( 'In Response To:' ) }</Text>
+				<Text>{ `Post #${ comment.post }` }</Text>
+			</HStack>
+
+			{ /* Comment content */ }
+			<VStack spacing="2">
+				<Heading level={ 5 }>{ __( 'Comment' ) }</Heading>
+				<div
+					dangerouslySetInnerHTML={ {
+						__html: comment.content?.rendered || '',
+					} }
+					style={ {
+						padding: '12px',
+						background: '#f0f0f0',
+						borderRadius: '4px',
+						lineHeight: 1.6,
+					} }
+				/>
+			</VStack>
+
+			{ /* Author IP (for moderation context) */ }
+			{ comment.author_ip && (
+				<HStack>
+					<Text weight="bold">{ __( 'IP Address:' ) }</Text>
+					<Text variant="muted">{ comment.author_ip }</Text>
+				</HStack>
+			) }
+		</VStack>
+	);
+}
+
+export const inspector = CommentInspector;

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -1,13 +1,26 @@
 /**
  * WordPress dependencies
  */
-import { useSearch } from '@wordpress/route';
-import { useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSearch, useNavigate } from '@wordpress/route';
+import { useMemo, useEffect, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import {
+	check,
+	cancelCircleFilled,
+	bug,
+	trash,
+	backup,
+	chevronUp,
+	chevronDown,
+	closeSmall,
+} from '@wordpress/icons';
+import {
+	Button,
+	Tooltip,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -27,22 +40,84 @@ const STATUS_LABELS: Record< string, string > = {
 	[ COMMENT_STATUSES.TRASH ]: __( 'Trash' ),
 };
 
+/**
+ * Navigate to a specific comment by updating URL search params.
+ *
+ * @param commentId    The comment ID to select.
+ * @param searchParams Current search params object.
+ * @param navigate     The navigate function from the router.
+ */
+function selectComment(
+	commentId: string,
+	searchParams: Record< string, unknown >,
+	navigate: ReturnType< typeof useNavigate >
+) {
+	navigate( {
+		search: {
+			...searchParams,
+			commentIds: [ commentId ],
+		},
+	} );
+}
+
+/**
+ * Clear the comment selection.
+ *
+ * @param searchParams Current search params object.
+ * @param navigate     The navigate function from the router.
+ */
+function clearSelection(
+	searchParams: Record< string, unknown >,
+	navigate: ReturnType< typeof useNavigate >
+) {
+	navigate( {
+		search: {
+			...searchParams,
+			commentIds: undefined,
+		},
+	} );
+}
+
 function CommentInspector() {
 	const searchParams = useSearch( { from: '/$status' } );
+	const navigate = useNavigate();
+
 	const commentIds = useMemo(
 		() => searchParams.commentIds ?? [],
 		[ searchParams.commentIds ]
 	);
 
+	const visibleIds: string[] = useMemo(
+		() => searchParams.visibleIds ?? [],
+		[ searchParams.visibleIds ]
+	);
+
+	const currentId = commentIds.length === 1 ? commentIds[ 0 ] : null;
+
+	// Determine prev/next comment IDs based on the visible list order.
+	const { prevId, nextId } = useMemo( () => {
+		if ( ! currentId || visibleIds.length === 0 ) {
+			return { prevId: null, nextId: null };
+		}
+		const idx = visibleIds.indexOf( currentId );
+		if ( idx === -1 ) {
+			return { prevId: null, nextId: null };
+		}
+		return {
+			prevId: idx > 0 ? visibleIds[ idx - 1 ] : null,
+			nextId: idx < visibleIds.length - 1 ? visibleIds[ idx + 1 ] : null,
+		};
+	}, [ currentId, visibleIds ] );
+
 	const { comment, postTitle } = useSelect(
 		( select ) => {
-			if ( commentIds.length !== 1 ) {
+			if ( ! currentId ) {
 				return { comment: null, postTitle: null };
 			}
 			const commentRecord = select( coreStore ).getEntityRecord(
 				'root',
 				'comment',
-				Number( commentIds[ 0 ] )
+				Number( currentId )
 			) as CommentWithPermissions | undefined;
 
 			let resolvedPostTitle = null;
@@ -60,12 +135,189 @@ function CommentInspector() {
 
 			return { comment: commentRecord, postTitle: resolvedPostTitle };
 		},
-		[ commentIds ]
+		[ currentId ]
 	);
+
+	const { editEntityRecord, saveEditedEntityRecord, deleteEntityRecord } =
+		useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	/**
+	 * Auto-advance to the next (or previous) comment after an action.
+	 * If no comments remain, clear the selection.
+	 */
+	const autoAdvance = useCallback( () => {
+		if ( nextId ) {
+			selectComment( nextId, searchParams, navigate );
+		} else if ( prevId ) {
+			selectComment( prevId, searchParams, navigate );
+		} else {
+			clearSelection( searchParams, navigate );
+		}
+	}, [ nextId, prevId, searchParams, navigate ] );
+
+	/**
+	 * Change the comment status and auto-advance.
+	 *
+	 * @param newStatus The new status to set on the comment.
+	 * @param label     Human-readable label for the notice message.
+	 */
+	const changeStatus = useCallback(
+		async ( newStatus: string, label: string ) => {
+			if ( ! currentId ) {
+				return;
+			}
+			try {
+				await editEntityRecord(
+					'root',
+					'comment',
+					Number( currentId ),
+					{ status: newStatus }
+				);
+				await saveEditedEntityRecord(
+					'root',
+					'comment',
+					Number( currentId ),
+					{ throwOnError: true }
+				);
+				createSuccessNotice( label, {
+					type: 'snackbar',
+				} );
+				autoAdvance();
+			} catch {
+				createErrorNotice(
+					__( 'An error occurred. Please try again.' ),
+					{ type: 'snackbar' }
+				);
+			}
+		},
+		[
+			currentId,
+			editEntityRecord,
+			saveEditedEntityRecord,
+			createSuccessNotice,
+			createErrorNotice,
+			autoAdvance,
+		]
+	);
+
+	/**
+	 * Move comment to trash and auto-advance.
+	 */
+	const handleTrash = useCallback( async () => {
+		if ( ! currentId ) {
+			return;
+		}
+		try {
+			await deleteEntityRecord(
+				'root',
+				'comment',
+				Number( currentId ),
+				{},
+				{ throwOnError: true }
+			);
+			createSuccessNotice( __( 'Comment moved to trash.' ), {
+				type: 'snackbar',
+			} );
+			autoAdvance();
+		} catch {
+			createErrorNotice(
+				__( 'An error occurred while moving to trash.' ),
+				{ type: 'snackbar' }
+			);
+		}
+	}, [
+		currentId,
+		deleteEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+		autoAdvance,
+	] );
+
+	const handleApprove = useCallback(
+		() => changeStatus( 'approve', __( 'Comment approved.' ) ),
+		[ changeStatus ]
+	);
+
+	const handleUnapprove = useCallback(
+		() => changeStatus( 'hold', __( 'Comment unapproved.' ) ),
+		[ changeStatus ]
+	);
+
+	const handleSpam = useCallback(
+		() => changeStatus( 'spam', __( 'Comment marked as spam.' ) ),
+		[ changeStatus ]
+	);
+
+	const handleRestore = useCallback(
+		() => changeStatus( 'approve', __( 'Comment restored.' ) ),
+		[ changeStatus ]
+	);
+
+	const goToPrevious = useCallback( () => {
+		if ( prevId ) {
+			selectComment( prevId, searchParams, navigate );
+		}
+	}, [ prevId, searchParams, navigate ] );
+
+	const goToNext = useCallback( () => {
+		if ( nextId ) {
+			selectComment( nextId, searchParams, navigate );
+		}
+	}, [ nextId, searchParams, navigate ] );
+
+	const handleClose = useCallback( () => {
+		clearSelection( searchParams, navigate );
+	}, [ searchParams, navigate ] );
+
+	// Keyboard navigation
+	useEffect( () => {
+		if ( ! currentId ) {
+			return;
+		}
+
+		/**
+		 * Handle keydown events for comment navigation.
+		 *
+		 * @param event The keyboard event.
+		 */
+		function onKeyDown( event: KeyboardEvent ) {
+			// Do not intercept when focus is inside an input or textarea.
+			const tag = ( event.target as HTMLElement )?.tagName;
+			if ( tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' ) {
+				return;
+			}
+
+			switch ( event.key ) {
+				case 'ArrowUp':
+					event.preventDefault();
+					if ( prevId ) {
+						selectComment( prevId, searchParams, navigate );
+					}
+					break;
+				case 'ArrowDown':
+					event.preventDefault();
+					if ( nextId ) {
+						selectComment( nextId, searchParams, navigate );
+					}
+					break;
+				case 'Escape':
+					event.preventDefault();
+					clearSelection( searchParams, navigate );
+					break;
+			}
+		}
+
+		window.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			window.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [ currentId, prevId, nextId, searchParams, navigate ] );
 
 	if ( ! comment ) {
 		return (
-			<VStack spacing="4" style={ { padding: '16px' } }>
+			<VStack spacing="4" className="comments-inspector">
 				<Text>
 					{ commentIds.length === 0
 						? __( 'Select a comment to view details.' )
@@ -81,91 +333,217 @@ function CommentInspector() {
 		comment.author_avatar_urls?.[ '96' ] ||
 		comment.author_avatar_urls?.[ '48' ];
 
+	const status = comment.status;
+	const canUpdate = comment.permissions?.update;
+	const canDelete = comment.permissions?.delete;
+
+	// Determine which action buttons to show based on comment status.
+	const isApproved = status === COMMENT_STATUSES.APPROVE;
+	const isPending = status === COMMENT_STATUSES.HOLD;
+	const isSpam = status === COMMENT_STATUSES.SPAM;
+	const isTrashed = status === COMMENT_STATUSES.TRASH;
+
+	// Position indicator (e.g., "3 of 12")
+	const currentIndex = visibleIds.indexOf( currentId ?? '' );
+	const positionLabel =
+		currentIndex !== -1 && visibleIds.length > 0
+			? `${ currentIndex + 1 } / ${ visibleIds.length }`
+			: '';
+
 	return (
-		<VStack spacing="4" style={ { padding: '16px' } }>
-			{ /* Author section */ }
-			<HStack alignment="top" spacing="3">
-				{ avatarUrl && (
-					<img
-						src={ avatarUrl }
-						alt=""
-						width={ 48 }
-						height={ 48 }
-						style={ { borderRadius: '50%', flexShrink: 0 } }
-					/>
-				) }
-				<VStack spacing="1">
-					<Heading level={ 4 }>
-						{ comment.author_name || __( 'Anonymous' ) }
-					</Heading>
-					{ comment.author_email && (
-						<Text variant="muted">{ comment.author_email }</Text>
+		<div className="comments-inspector">
+			{ /* Header: actions + navigation */ }
+			<div className="comments-inspector__header">
+				<div className="comments-inspector__actions">
+					{ /* Approve button: show for pending, spam, trash */ }
+					{ ( isPending || isSpam || isTrashed ) && canUpdate && (
+						<Tooltip
+							text={
+								isSpam || isTrashed
+									? __( 'Restore' )
+									: __( 'Approve' )
+							}
+						>
+							<Button
+								icon={ isSpam || isTrashed ? backup : check }
+								label={
+									isSpam || isTrashed
+										? __( 'Restore' )
+										: __( 'Approve' )
+								}
+								onClick={
+									isSpam || isTrashed
+										? handleRestore
+										: handleApprove
+								}
+								size="compact"
+							/>
+						</Tooltip>
 					) }
-					{ comment.author_url && (
-						<Text variant="muted">{ comment.author_url }</Text>
+					{ /* Unapprove button: show for approved comments */ }
+					{ isApproved && canUpdate && (
+						<Tooltip text={ __( 'Unapprove' ) }>
+							<Button
+								icon={ cancelCircleFilled }
+								label={ __( 'Unapprove' ) }
+								onClick={ handleUnapprove }
+								size="compact"
+							/>
+						</Tooltip>
+					) }
+					{ /* Spam button: show for non-spam, non-trash */ }
+					{ ! isSpam && ! isTrashed && canUpdate && (
+						<Tooltip text={ __( 'Mark as Spam' ) }>
+							<Button
+								icon={ bug }
+								label={ __( 'Mark as Spam' ) }
+								onClick={ handleSpam }
+								size="compact"
+							/>
+						</Tooltip>
+					) }
+					{ /* Trash button: show for non-trash */ }
+					{ ! isTrashed && canDelete && (
+						<Tooltip text={ __( 'Move to Trash' ) }>
+							<Button
+								icon={ trash }
+								label={ __( 'Move to Trash' ) }
+								onClick={ handleTrash }
+								size="compact"
+								isDestructive
+							/>
+						</Tooltip>
+					) }
+				</div>
+
+				<div className="comments-inspector__navigation">
+					{ positionLabel && (
+						<Text variant="muted" size="small">
+							{ positionLabel }
+						</Text>
+					) }
+					<Tooltip text={ __( 'Previous comment' ) }>
+						<Button
+							icon={ chevronUp }
+							label={ __( 'Previous comment' ) }
+							onClick={ goToPrevious }
+							disabled={ ! prevId }
+							size="compact"
+							accessibleWhenDisabled
+						/>
+					</Tooltip>
+					<Tooltip text={ __( 'Next comment' ) }>
+						<Button
+							icon={ chevronDown }
+							label={ __( 'Next comment' ) }
+							onClick={ goToNext }
+							disabled={ ! nextId }
+							size="compact"
+							accessibleWhenDisabled
+						/>
+					</Tooltip>
+					<Tooltip text={ __( 'Close' ) }>
+						<Button
+							icon={ closeSmall }
+							label={ __( 'Close' ) }
+							onClick={ handleClose }
+							size="compact"
+						/>
+					</Tooltip>
+				</div>
+			</div>
+
+			{ /* Body */ }
+			<div className="comments-inspector__body">
+				<VStack spacing="4">
+					{ /* Author section */ }
+					<HStack alignment="top" spacing="3">
+						{ avatarUrl && (
+							<img
+								src={ avatarUrl }
+								alt=""
+								width={ 48 }
+								height={ 48 }
+								style={ {
+									borderRadius: '50%',
+									flexShrink: 0,
+								} }
+							/>
+						) }
+						<VStack spacing="1">
+							<Heading level={ 4 }>
+								{ comment.author_name || __( 'Anonymous' ) }
+							</Heading>
+							{ comment.author_email && (
+								<Text variant="muted">
+									{ comment.author_email }
+								</Text>
+							) }
+							{ comment.author_url && (
+								<Text variant="muted">
+									{ comment.author_url }
+								</Text>
+							) }
+						</VStack>
+					</HStack>
+
+					{ /* Status badge */ }
+					<HStack>
+						<Text weight="bold">{ __( 'Status:' ) }</Text>
+						<Text>
+							{ STATUS_LABELS[ comment.status ] ||
+								comment.status }
+						</Text>
+					</HStack>
+
+					{ /* Date */ }
+					<HStack>
+						<Text weight="bold">{ __( 'Date:' ) }</Text>
+						<Text>
+							<time dateTime={ comment.date }>
+								{ dateI18n( dateFormat, commentDate ) }
+							</time>
+						</Text>
+					</HStack>
+
+					{ /* Post reference */ }
+					<HStack>
+						<Text weight="bold">{ __( 'In Response To:' ) }</Text>
+						<Text>{ postTitle || `Post #${ comment.post }` }</Text>
+					</HStack>
+
+					{ /* Comment content */ }
+					<VStack spacing="2">
+						<Heading level={ 5 }>{ __( 'Comment' ) }</Heading>
+						<div
+							className="comments-inspector__content-rendered"
+							dangerouslySetInnerHTML={ {
+								__html: comment.content?.rendered || '',
+							} }
+						/>
+					</VStack>
+
+					{ /* View comment link */ }
+					{ comment.link && (
+						<a
+							href={ comment.link }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ __( 'View Comment' ) }
+						</a>
+					) }
+
+					{ /* Author IP (for moderation context) */ }
+					{ comment.author_ip && (
+						<HStack>
+							<Text weight="bold">{ __( 'IP Address:' ) }</Text>
+							<Text variant="muted">{ comment.author_ip }</Text>
+						</HStack>
 					) }
 				</VStack>
-			</HStack>
-
-			{ /* Status badge */ }
-			<HStack>
-				<Text weight="bold">{ __( 'Status:' ) }</Text>
-				<Text>
-					{ STATUS_LABELS[ comment.status ] || comment.status }
-				</Text>
-			</HStack>
-
-			{ /* Date */ }
-			<HStack>
-				<Text weight="bold">{ __( 'Date:' ) }</Text>
-				<Text>
-					<time dateTime={ comment.date }>
-						{ dateI18n( dateFormat, commentDate ) }
-					</time>
-				</Text>
-			</HStack>
-
-			{ /* Post reference */ }
-			<HStack>
-				<Text weight="bold">{ __( 'In Response To:' ) }</Text>
-				<Text>{ postTitle || `Post #${ comment.post }` }</Text>
-			</HStack>
-
-			{ /* Comment content */ }
-			<VStack spacing="2">
-				<Heading level={ 5 }>{ __( 'Comment' ) }</Heading>
-				<div
-					dangerouslySetInnerHTML={ {
-						__html: comment.content?.rendered || '',
-					} }
-					style={ {
-						padding: '12px',
-						background: '#f0f0f0',
-						borderRadius: '4px',
-						lineHeight: 1.6,
-					} }
-				/>
-			</VStack>
-
-			{ /* View comment link */ }
-			{ comment.link && (
-				<a
-					href={ comment.link }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{ __( 'View Comment' ) }
-				</a>
-			) }
-
-			{ /* Author IP (for moderation context) */ }
-			{ comment.author_ip && (
-				<HStack>
-					<Text weight="bold">{ __( 'IP Address:' ) }</Text>
-					<Text variant="muted">{ comment.author_ip }</Text>
-				</HStack>
-			) }
-		</VStack>
+			</div>
+		</div>
 	);
 }
 

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -34,16 +34,31 @@ function CommentInspector() {
 		[ searchParams.commentIds ]
 	);
 
-	const comment = useSelect(
+	const { comment, postTitle } = useSelect(
 		( select ) => {
 			if ( commentIds.length !== 1 ) {
-				return null;
+				return { comment: null, postTitle: null };
 			}
-			return select( coreStore ).getEntityRecord(
+			const commentRecord = select( coreStore ).getEntityRecord(
 				'root',
 				'comment',
 				Number( commentIds[ 0 ] )
 			) as CommentWithPermissions | undefined;
+
+			let resolvedPostTitle = null;
+			if ( commentRecord?.post ) {
+				const post = select( coreStore ).getEntityRecord(
+					'postType',
+					'post',
+					commentRecord.post,
+					{ _fields: 'title' }
+				);
+				resolvedPostTitle = (
+					post as { title?: { rendered?: string } }
+				 )?.title?.rendered;
+			}
+
+			return { comment: commentRecord, postTitle: resolvedPostTitle };
 		},
 		[ commentIds ]
 	);
@@ -113,7 +128,7 @@ function CommentInspector() {
 			{ /* Post reference */ }
 			<HStack>
 				<Text weight="bold">{ __( 'In Response To:' ) }</Text>
-				<Text>{ `Post #${ comment.post }` }</Text>
+				<Text>{ postTitle || `Post #${ comment.post }` }</Text>
 			</HStack>
 
 			{ /* Comment content */ }
@@ -131,6 +146,17 @@ function CommentInspector() {
 					} }
 				/>
 			</VStack>
+
+			{ /* View comment link */ }
+			{ comment.link && (
+				<a
+					href={ comment.link }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ __( 'View Comment' ) }
+				</a>
+			) }
 
 			{ /* Author IP (for moderation context) */ }
 			{ comment.author_ip && (

--- a/routes/comments/inspector.tsx
+++ b/routes/comments/inspector.tsx
@@ -334,10 +334,9 @@ function CommentInspector() {
 		comment.author_avatar_urls?.[ '48' ];
 
 	const status = comment.status;
-	const canUpdate = comment.permissions?.update;
-	const canDelete = comment.permissions?.delete;
 
 	// Determine which action buttons to show based on comment status.
+	// Permission checks are omitted because the page requires moderate_comments.
 	const isApproved = status === COMMENT_STATUSES.APPROVE;
 	const isPending = status === COMMENT_STATUSES.HOLD;
 	const isSpam = status === COMMENT_STATUSES.SPAM;
@@ -356,7 +355,7 @@ function CommentInspector() {
 			<div className="comments-inspector__header">
 				<div className="comments-inspector__actions">
 					{ /* Approve button: show for pending, spam, trash */ }
-					{ ( isPending || isSpam || isTrashed ) && canUpdate && (
+					{ ( isPending || isSpam || isTrashed ) && (
 						<Tooltip
 							text={
 								isSpam || isTrashed
@@ -381,7 +380,7 @@ function CommentInspector() {
 						</Tooltip>
 					) }
 					{ /* Unapprove button: show for approved comments */ }
-					{ isApproved && canUpdate && (
+					{ isApproved && (
 						<Tooltip text={ __( 'Unapprove' ) }>
 							<Button
 								icon={ cancelCircleFilled }
@@ -392,7 +391,7 @@ function CommentInspector() {
 						</Tooltip>
 					) }
 					{ /* Spam button: show for non-spam, non-trash */ }
-					{ ! isSpam && ! isTrashed && canUpdate && (
+					{ ! isSpam && ! isTrashed && (
 						<Tooltip text={ __( 'Mark as Spam' ) }>
 							<Button
 								icon={ bug }
@@ -403,7 +402,7 @@ function CommentInspector() {
 						</Tooltip>
 					) }
 					{ /* Trash button: show for non-trash */ }
-					{ ! isTrashed && canDelete && (
+					{ ! isTrashed && (
 						<Tooltip text={ __( 'Move to Trash' ) }>
 							<Button
 								icon={ trash }

--- a/routes/comments/package.json
+++ b/routes/comments/package.json
@@ -12,6 +12,7 @@
 		"@wordpress/compose": "file:../../packages/compose",
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/date": "file:../../packages/date",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",

--- a/routes/comments/package.json
+++ b/routes/comments/package.json
@@ -3,8 +3,10 @@
 	"version": "1.0.0",
 	"private": true,
 	"route": {
-		"path": "/comments/$status",
-		"page": "site-editor-v2"
+		"path": "/$status",
+		"page": [
+			"comments-admin"
+		]
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",

--- a/routes/comments/package.json
+++ b/routes/comments/package.json
@@ -17,6 +17,7 @@
 		"@wordpress/date": "file:../../packages/date",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/notices": "file:../../packages/notices",

--- a/routes/comments/package.json
+++ b/routes/comments/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/api-fetch": "file:../../packages/api-fetch",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/compose": "file:../../packages/compose",
 		"@wordpress/core-data": "file:../../packages/core-data",

--- a/routes/comments/package.json
+++ b/routes/comments/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@wordpress/comments",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/comments/$status",
+		"page": "site-editor-v2"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/compose": "file:../../packages/compose",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/icons": "file:../../packages/icons",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/private-apis": "file:../../packages/private-apis",
+		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/views": "file:../../packages/views"
+	}
+}

--- a/routes/comments/route.ts
+++ b/routes/comments/route.ts
@@ -10,4 +10,7 @@ export const route = {
 	title: async () => {
 		return __( 'Comments' );
 	},
+	inspector: ( { search }: { search: { commentIds?: string[] } } ) => {
+		return !! ( search?.commentIds?.length === 1 );
+	},
 };

--- a/routes/comments/route.ts
+++ b/routes/comments/route.ts
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Route configuration for comments list.
+ */
+export const route = {
+	title: async () => {
+		return __( 'Comments' );
+	},
+};

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -8,7 +8,7 @@ import { Page } from '@wordpress/admin-ui';
 import type { View } from '@wordpress/dataviews';
 import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import { useMemo, useCallback, useEffect } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -158,23 +158,6 @@ function CommentsList() {
 
 	// Selection from URL
 	const selection = searchParams.commentIds ?? [];
-
-	// Store visible comment IDs in URL so the inspector can navigate between them.
-	useEffect( () => {
-		if ( ! comments || comments.length === 0 ) {
-			return;
-		}
-		const orderedIds = comments.map( ( c ) => c.id.toString() );
-		const currentVisibleIds = searchParams.visibleIds ?? [];
-		if ( orderedIds.join( ',' ) !== currentVisibleIds.join( ',' ) ) {
-			navigate( {
-				search: {
-					...searchParams,
-					visibleIds: orderedIds,
-				},
-			} );
-		}
-	}, [ comments, searchParams, navigate ] );
 
 	return (
 		<Page

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -58,10 +58,10 @@ function getItemId( item: CommentWithPermissions ) {
 
 function CommentsList() {
 	const { status: statusSlug = 'all' } = useParams( {
-		from: '/comments/$status',
+		from: '/$status',
 	} );
 	const navigate = useNavigate();
-	const searchParams = useSearch( { from: '/comments/$status' } );
+	const searchParams = useSearch( { from: '/$status' } );
 
 	// View state management
 	const activeViewOverrides = useMemo(
@@ -150,7 +150,7 @@ function CommentsList() {
 	const handleTabChange = useCallback(
 		( newStatus: string ) => {
 			navigate( {
-				to: `/comments/${ newStatus }`,
+				to: `/${ newStatus }`,
 			} );
 		},
 		[ navigate ]

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -55,10 +55,15 @@ const { Tabs } = unlock( componentsPrivateApis );
 
 /**
  * Fetch lightweight comment counts for each status tab.
+ * Re-fetches whenever refreshKey changes (e.g. after moderation actions).
  *
  * @param currentUserId The current user's ID, used for the "mine" count.
+ * @param refreshKey    A value that changes when counts should be re-fetched.
  */
-function useCommentCounts( currentUserId: number | undefined ) {
+function useCommentCounts(
+	currentUserId: number | undefined,
+	refreshKey: unknown
+) {
 	const [ counts, setCounts ] = useState< Record< string, number > >( {} );
 
 	useEffect( () => {
@@ -102,7 +107,7 @@ function useCommentCounts( currentUserId: number | undefined ) {
 				( newCounts.approve ?? 0 ) + ( newCounts.hold ?? 0 );
 			setCounts( newCounts );
 		} );
-	}, [ currentUserId ] );
+	}, [ currentUserId, refreshKey ] );
 
 	return counts;
 }
@@ -150,8 +155,6 @@ function CommentsList() {
 			 )?.id,
 		[]
 	);
-	const counts = useCommentCounts( currentUserId );
-
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'root',
 		name: 'comment',
@@ -185,6 +188,9 @@ function CommentsList() {
 		isResolving,
 		hasResolved,
 	} = useEntityRecordsWithPermissions( 'root', 'comment', queryArgs );
+
+	// Re-fetch counts whenever the current list total changes (after moderation).
+	const counts = useCommentCounts( currentUserId, totalItems );
 
 	// Fields — hide status column when viewing a specific status tab
 	const fields = useMemo( () => {

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -6,10 +6,15 @@ import { useView } from '@wordpress/views';
 import { DataViews } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
 import type { View } from '@wordpress/dataviews';
-import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import {
+	privateApis as coreDataPrivateApis,
+	store as coreStore,
+} from '@wordpress/core-data';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -29,6 +34,7 @@ import {
 	postField,
 	dateField,
 	statusField,
+	typeField,
 } from './fields';
 import {
 	approveComment,
@@ -46,6 +52,60 @@ import './style.scss';
 
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
+
+/**
+ * Fetch lightweight comment counts for each status tab.
+ *
+ * @param currentUserId The current user's ID, used for the "mine" count.
+ */
+function useCommentCounts( currentUserId: number | undefined ) {
+	const [ counts, setCounts ] = useState< Record< string, number > >( {} );
+
+	useEffect( () => {
+		const statuses = [ 'approve', 'hold', 'spam', 'trash' ];
+		const fetches = statuses.map( ( status ) =>
+			apiFetch( {
+				path: `/wp/v2/comments?status=${ status }&per_page=1`,
+				parse: false,
+			} ).then( ( response: Response ) => ( {
+				status,
+				total: parseInt(
+					response.headers.get( 'X-WP-Total' ) || '0',
+					10
+				),
+			} ) )
+		);
+
+		// Fetch "mine" count if we have a user ID.
+		if ( currentUserId ) {
+			fetches.push(
+				apiFetch( {
+					path: `/wp/v2/comments?author=${ currentUserId }&per_page=1`,
+					parse: false,
+				} ).then( ( response: Response ) => ( {
+					status: 'mine',
+					total: parseInt(
+						response.headers.get( 'X-WP-Total' ) || '0',
+						10
+					),
+				} ) )
+			);
+		}
+
+		Promise.all( fetches ).then( ( results ) => {
+			const newCounts: Record< string, number > = {};
+			results.forEach( ( { status, total } ) => {
+				newCounts[ status ] = total;
+			} );
+			// "all" = approve + hold (matching classic WP behavior).
+			newCounts.all =
+				( newCounts.approve ?? 0 ) + ( newCounts.hold ?? 0 );
+			setCounts( newCounts );
+		} );
+	}, [ currentUserId ] );
+
+	return counts;
+}
 
 /**
  * Return a stable string ID for a comment item.
@@ -81,6 +141,17 @@ function CommentsList() {
 		[ searchParams, navigate ]
 	);
 
+	const currentUserId = useSelect(
+		( select ) =>
+			(
+				select( coreStore ).getCurrentUser() as
+					| { id?: number }
+					| undefined
+			 )?.id,
+		[]
+	);
+	const counts = useCommentCounts( currentUserId );
+
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'root',
 		name: 'comment',
@@ -100,7 +171,13 @@ function CommentsList() {
 	};
 
 	// Build query and fetch comments
-	const queryArgs = useMemo( () => viewToQuery( view ), [ view ] );
+	const queryArgs = useMemo( () => {
+		const args = viewToQuery( view );
+		if ( statusSlug === 'mine' && currentUserId ) {
+			args.author = currentUserId;
+		}
+		return args;
+	}, [ view, statusSlug, currentUserId ] );
 	const {
 		records: comments,
 		totalItems,
@@ -117,6 +194,7 @@ function CommentsList() {
 			postField,
 			dateField,
 			statusField,
+			typeField,
 		];
 		return allFields
 			.filter( ( field ) => {
@@ -171,6 +249,8 @@ function CommentsList() {
 						{ STATUS_TABS.map( ( tab ) => (
 							<Tabs.Tab tabId={ tab.slug } key={ tab.slug }>
 								{ tab.label }
+								{ counts[ tab.slug ] !== undefined &&
+									` (${ counts[ tab.slug ] })` }
 							</Tabs.Tab>
 						) ) }
 					</Tabs.TabList>

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useParams, useNavigate, useSearch } from '@wordpress/route';
+import { useParams, useNavigate, useSearch, Link } from '@wordpress/route';
 import { useView } from '@wordpress/views';
 import { DataViews } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
@@ -216,6 +216,24 @@ function CommentsList() {
 						},
 					} );
 				} }
+				renderItemLink={ ( {
+					item,
+					...props
+				}: {
+					item: CommentWithPermissions;
+				} ) => (
+					<Link
+						to={ `/${ statusSlug }` }
+						search={ {
+							...searchParams,
+							commentIds: [ item.id.toString() ],
+						} }
+						{ ...props }
+						onClick={ ( event: React.MouseEvent ) => {
+							event.stopPropagation();
+						} }
+					/>
+				) }
 			/>
 		</Page>
 	);

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -8,7 +8,7 @@ import { Page } from '@wordpress/admin-ui';
 import type { View } from '@wordpress/dataviews';
 import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -159,21 +159,40 @@ function CommentsList() {
 	// Selection from URL
 	const selection = searchParams.commentIds ?? [];
 
+	// Store visible comment IDs in URL so the inspector can navigate between them.
+	useEffect( () => {
+		if ( ! comments || comments.length === 0 ) {
+			return;
+		}
+		const orderedIds = comments.map( ( c ) => c.id.toString() );
+		const currentVisibleIds = searchParams.visibleIds ?? [];
+		if ( orderedIds.join( ',' ) !== currentVisibleIds.join( ',' ) ) {
+			navigate( {
+				search: {
+					...searchParams,
+					visibleIds: orderedIds,
+				},
+			} );
+		}
+	}, [ comments, searchParams, navigate ] );
+
 	return (
 		<Page
 			title={ __( 'Comments' ) }
 			className="comments-page"
 			hasPadding={ false }
 		>
-			<Tabs onSelect={ handleTabChange } selectedTabId={ statusSlug }>
-				<Tabs.TabList>
-					{ STATUS_TABS.map( ( tab ) => (
-						<Tabs.Tab tabId={ tab.slug } key={ tab.slug }>
-							{ tab.label }
-						</Tabs.Tab>
-					) ) }
-				</Tabs.TabList>
-			</Tabs>
+			<div className="comments-page__tabs-wrapper">
+				<Tabs onSelect={ handleTabChange } selectedTabId={ statusSlug }>
+					<Tabs.TabList>
+						{ STATUS_TABS.map( ( tab ) => (
+							<Tabs.Tab tabId={ tab.slug } key={ tab.slug }>
+								{ tab.label }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+				</Tabs>
+			</div>
 			<DataViews
 				data={ comments }
 				fields={ fields }

--- a/routes/comments/stage.tsx
+++ b/routes/comments/stage.tsx
@@ -1,0 +1,205 @@
+/**
+ * WordPress dependencies
+ */
+import { useParams, useNavigate, useSearch } from '@wordpress/route';
+import { useView } from '@wordpress/views';
+import { DataViews } from '@wordpress/dataviews';
+import { Page } from '@wordpress/admin-ui';
+import type { View } from '@wordpress/dataviews';
+import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { useMemo, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import {
+	DEFAULT_VIEW,
+	DEFAULT_LAYOUTS,
+	getActiveViewOverridesForTab,
+	viewToQuery,
+} from './view-utils';
+import { STATUS_TABS } from './types';
+import type { CommentWithPermissions } from './types';
+import {
+	authorNameField,
+	contentField,
+	postField,
+	dateField,
+	statusField,
+} from './fields';
+import {
+	approveComment,
+	unapproveComment,
+	spamComment,
+	trashComment,
+	restoreComment,
+	deleteComment,
+} from './actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+const { Tabs } = unlock( componentsPrivateApis );
+
+/**
+ * Return a stable string ID for a comment item.
+ *
+ * @param item The comment record.
+ */
+function getItemId( item: CommentWithPermissions ) {
+	return item.id.toString();
+}
+
+function CommentsList() {
+	const { status: statusSlug = 'all' } = useParams( {
+		from: '/comments/$status',
+	} );
+	const navigate = useNavigate();
+	const searchParams = useSearch( { from: '/comments/$status' } );
+
+	// View state management
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverridesForTab( statusSlug ),
+		[ statusSlug ]
+	);
+
+	const handleQueryParamsChange = useCallback(
+		( params: { page?: number; search?: string } ) => {
+			navigate( {
+				search: {
+					...searchParams,
+					...params,
+				},
+			} );
+		},
+		[ searchParams, navigate ]
+	);
+
+	const { view, isModified, updateView, resetToDefault } = useView( {
+		kind: 'root',
+		name: 'comment',
+		slug: 'default',
+		defaultView: DEFAULT_VIEW,
+		activeViewOverrides,
+		queryParams: searchParams,
+		onChangeQueryParams: handleQueryParamsChange,
+	} );
+
+	const onChangeView = ( newView: View ) => {
+		updateView( newView );
+	};
+
+	const onReset = () => {
+		resetToDefault();
+	};
+
+	// Build query and fetch comments
+	const queryArgs = useMemo( () => viewToQuery( view ), [ view ] );
+	const {
+		records: comments,
+		totalItems,
+		totalPages,
+		isResolving,
+		hasResolved,
+	} = useEntityRecordsWithPermissions( 'root', 'comment', queryArgs );
+
+	// Fields — hide status column when viewing a specific status tab
+	const fields = useMemo( () => {
+		const allFields = [
+			authorNameField,
+			contentField,
+			postField,
+			dateField,
+			statusField,
+		];
+		return allFields
+			.filter( ( field ) => {
+				if ( field.id === 'status' && statusSlug !== 'all' ) {
+					return false;
+				}
+				return true;
+			} )
+			.map( ( field ) => {
+				// Disable status filtering since we use tabs
+				if ( field.id === 'status' ) {
+					return { ...field, filterBy: false };
+				}
+				return field;
+			} );
+	}, [ statusSlug ] );
+
+	// Actions — context-sensitive based on current tab
+	const actions = useMemo( () => {
+		return [
+			approveComment,
+			unapproveComment,
+			spamComment,
+			trashComment,
+			restoreComment,
+			deleteComment,
+		];
+	}, [] );
+
+	// Tab change handler
+	const handleTabChange = useCallback(
+		( newStatus: string ) => {
+			navigate( {
+				to: `/comments/${ newStatus }`,
+			} );
+		},
+		[ navigate ]
+	);
+
+	// Selection from URL
+	const selection = searchParams.commentIds ?? [];
+
+	return (
+		<Page
+			title={ __( 'Comments' ) }
+			className="comments-page"
+			hasPadding={ false }
+		>
+			<Tabs onSelect={ handleTabChange } selectedTabId={ statusSlug }>
+				<Tabs.TabList>
+					{ STATUS_TABS.map( ( tab ) => (
+						<Tabs.Tab tabId={ tab.slug } key={ tab.slug }>
+							{ tab.label }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.TabList>
+			</Tabs>
+			<DataViews
+				data={ comments }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				actions={ actions }
+				isLoading={ isResolving || ! hasResolved }
+				paginationInfo={ {
+					totalItems,
+					totalPages,
+				} }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ getItemId }
+				selection={ selection }
+				onReset={ isModified ? onReset : false }
+				onChangeSelection={ ( items: string[] ) => {
+					navigate( {
+						search: {
+							...searchParams,
+							commentIds: items.length > 0 ? items : undefined,
+						},
+					} );
+				} }
+			/>
+		</Page>
+	);
+}
+
+export const stage = CommentsList;

--- a/routes/comments/style.scss
+++ b/routes/comments/style.scss
@@ -1,0 +1,10 @@
+.comments-page {
+	.dataviews-wrapper {
+		// Ensure content column doesn't overflow
+		[data-field-id="content"] {
+			max-width: 400px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+}

--- a/routes/comments/style.scss
+++ b/routes/comments/style.scss
@@ -16,38 +16,3 @@
 		}
 	}
 }
-
-.comments-inspector {
-	padding: $grid-unit-20;
-
-	&__header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding-bottom: $grid-unit-20;
-		border-bottom: 1px solid $gray-100;
-		margin-bottom: $grid-unit-20;
-	}
-
-	&__actions {
-		display: flex;
-		gap: $grid-unit-10;
-	}
-
-	&__navigation {
-		display: flex;
-		gap: $grid-unit-05;
-		align-items: center;
-	}
-
-	&__body {
-		overflow-y: auto;
-	}
-
-	&__content-rendered {
-		padding: $grid-unit-15;
-		background: $gray-100;
-		border-radius: $radius-medium;
-		line-height: 1.6;
-	}
-}

--- a/routes/comments/style.scss
+++ b/routes/comments/style.scss
@@ -1,3 +1,11 @@
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
+
+.comments-page__tabs-wrapper {
+	border-bottom: 1px solid $gray-100;
+	padding: 0 $grid-unit-30;
+}
+
 .comments-page {
 	.dataviews-wrapper {
 		// Ensure content column doesn't overflow
@@ -6,5 +14,40 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
+	}
+}
+
+.comments-inspector {
+	padding: $grid-unit-20;
+
+	&__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding-bottom: $grid-unit-20;
+		border-bottom: 1px solid $gray-100;
+		margin-bottom: $grid-unit-20;
+	}
+
+	&__actions {
+		display: flex;
+		gap: $grid-unit-10;
+	}
+
+	&__navigation {
+		display: flex;
+		gap: $grid-unit-05;
+		align-items: center;
+	}
+
+	&__body {
+		overflow-y: auto;
+	}
+
+	&__content-rendered {
+		padding: $grid-unit-15;
+		background: $gray-100;
+		border-radius: $radius-medium;
+		line-height: 1.6;
 	}
 }

--- a/routes/comments/types.ts
+++ b/routes/comments/types.ts
@@ -24,6 +24,7 @@ export const COMMENT_STATUSES = {
 
 export const STATUS_TABS = [
 	{ slug: 'all', label: 'All' },
+	{ slug: 'mine', label: 'Mine' },
 	{ slug: 'approve', label: 'Approved' },
 	{ slug: 'hold', label: 'Pending' },
 	{ slug: 'spam', label: 'Spam' },

--- a/routes/comments/types.ts
+++ b/routes/comments/types.ts
@@ -17,7 +17,7 @@ export type CommentWithPermissions = Comment< 'edit' > & {
  */
 export const COMMENT_STATUSES = {
 	HOLD: 'hold',
-	APPROVE: 'approve',
+	APPROVED: 'approved',
 	SPAM: 'spam',
 	TRASH: 'trash',
 } as const;

--- a/routes/comments/types.ts
+++ b/routes/comments/types.ts
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import type { Comment } from '@wordpress/core-data';
+
+export type CommentWithPermissions = Comment< 'edit' > & {
+	permissions: {
+		delete: boolean;
+		update: boolean;
+	};
+};
+
+/**
+ * Comment status values used by the WP REST API.
+ * 'hold' = pending/unapproved, 'approve' = approved,
+ * 'spam' and 'trash' are self-explanatory.
+ */
+export const COMMENT_STATUSES = {
+	HOLD: 'hold',
+	APPROVE: 'approve',
+	SPAM: 'spam',
+	TRASH: 'trash',
+} as const;
+
+export const STATUS_TABS = [
+	{ slug: 'all', label: 'All' },
+	{ slug: 'approve', label: 'Approved' },
+	{ slug: 'hold', label: 'Pending' },
+	{ slug: 'spam', label: 'Spam' },
+	{ slug: 'trash', label: 'Trash' },
+] as const;

--- a/routes/comments/view-utils.ts
+++ b/routes/comments/view-utils.ts
@@ -9,14 +9,14 @@ export const DEFAULT_VIEW: View = {
 		field: 'date',
 		direction: 'desc' as const,
 	},
-	fields: [ 'content', 'post', 'date' ],
+	fields: [ 'post', 'date' ],
 	titleField: 'author_name',
+	descriptionField: 'content',
 	perPage: 20,
 };
 
 export const DEFAULT_LAYOUTS = {
 	table: {},
-	list: {},
 };
 
 type ActiveViewOverrides = {

--- a/routes/comments/view-utils.ts
+++ b/routes/comments/view-utils.ts
@@ -78,10 +78,9 @@ export function viewToQuery( view: View ) {
 	);
 	if ( statusFilter ) {
 		result.status = statusFilter.value;
-	} else {
-		// Default: show all non-trash comments
-		result.status = 'approve,hold,spam';
 	}
+	// When no status filter is set (the "All" tab), omit the status param.
+	// The REST API defaults to approved comments for authenticated users.
 
 	const postFilter = view.filters?.find(
 		( filter ) => filter.field === 'post'

--- a/routes/comments/view-utils.ts
+++ b/routes/comments/view-utils.ts
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import type { View, Filter } from '@wordpress/dataviews';
+
+export const DEFAULT_VIEW: View = {
+	type: 'table' as const,
+	sort: {
+		field: 'date',
+		direction: 'desc' as const,
+	},
+	fields: [ 'author_name', 'content', 'post', 'date' ],
+	titleField: 'author_name',
+	descriptionField: 'content',
+	perPage: 20,
+};
+
+export const DEFAULT_LAYOUTS = {
+	table: {},
+	list: {},
+};
+
+type ActiveViewOverrides = {
+	filters?: Filter[];
+	layout?: Record< string, unknown >;
+};
+
+export function getActiveViewOverridesForTab(
+	slug: string
+): ActiveViewOverrides {
+	if ( slug === 'all' ) {
+		return {};
+	}
+	return {
+		filters: [
+			{
+				field: 'status',
+				operator: 'is',
+				value: slug,
+			},
+		],
+	};
+}
+
+/**
+ * Convert a DataViews view object to WP REST API query parameters
+ * for the /wp/v2/comments endpoint.
+ *
+ * @param view The current DataViews view state.
+ */
+export function viewToQuery( view: View ) {
+	const result: Record< string, any > = {};
+
+	// Pagination
+	if ( view.perPage !== undefined ) {
+		result.per_page = view.perPage;
+	}
+	if ( view.page !== undefined ) {
+		result.page = view.page;
+	}
+
+	// Search
+	if ( view.search ) {
+		result.search = view.search;
+	}
+
+	// Sorting
+	if ( view.sort?.field ) {
+		result.orderby = view.sort.field;
+	}
+	if ( view.sort?.direction ) {
+		result.order = view.sort.direction;
+	}
+
+	// Filters
+	const statusFilter = view.filters?.find(
+		( filter ) => filter.field === 'status'
+	);
+	if ( statusFilter ) {
+		result.status = statusFilter.value;
+	} else {
+		// Default: show all non-trash comments
+		result.status = 'approve,hold,spam';
+	}
+
+	const postFilter = view.filters?.find(
+		( filter ) => filter.field === 'post'
+	);
+	if ( postFilter ) {
+		result.post = postFilter.value;
+	}
+
+	const dateFilter = view.filters?.find(
+		( filter ) => filter.field === 'date'
+	);
+	if ( dateFilter?.value ) {
+		if ( dateFilter.operator === 'before' ) {
+			result.before = dateFilter.value;
+		} else if ( dateFilter.operator === 'after' ) {
+			result.after = dateFilter.value;
+		}
+	}
+
+	return result;
+}

--- a/routes/comments/view-utils.ts
+++ b/routes/comments/view-utils.ts
@@ -9,9 +9,8 @@ export const DEFAULT_VIEW: View = {
 		field: 'date',
 		direction: 'desc' as const,
 	},
-	fields: [ 'author_name', 'content', 'post', 'date' ],
+	fields: [ 'content', 'post', 'date' ],
 	titleField: 'author_name',
-	descriptionField: 'content',
 	perPage: 20,
 };
 

--- a/routes/comments/view-utils.ts
+++ b/routes/comments/view-utils.ts
@@ -27,7 +27,7 @@ type ActiveViewOverrides = {
 export function getActiveViewOverridesForTab(
 	slug: string
 ): ActiveViewOverrides {
-	if ( slug === 'all' ) {
+	if ( slug === 'all' || slug === 'mine' ) {
 		return {};
 	}
 	return {
@@ -86,6 +86,20 @@ export function viewToQuery( view: View ) {
 	);
 	if ( postFilter ) {
 		result.post = postFilter.value;
+	}
+
+	const typeFilter = view.filters?.find(
+		( filter ) => filter.field === 'type'
+	);
+	if ( typeFilter ) {
+		result.type = typeFilter.value;
+	}
+
+	const authorFilter = view.filters?.find(
+		( filter ) => filter.field === 'author'
+	);
+	if ( authorFilter ) {
+		result.author = authorFilter.value;
 	}
 
 	const dateFilter = view.filters?.find(


### PR DESCRIPTION
## Summary

Proof of concept for a modern Comments admin page that replaces `wp-admin/edit-comments.php` using the new `routes/` routing infrastructure and `@wordpress/dataviews`.

- **DataViews-powered list** with table/list layout, pagination, sorting, search, and filtering
- **Status tabs** (All / Approved / Pending / Spam / Trash)
- **Built-in moderation actions** via DataViews: Approve, Unapprove, Mark as Spam, Move to Trash, Restore, Delete Permanently — with bulk support
- **Inspector panel** for viewing comment details (author, content, post, date, IP)
- **Standalone admin page** registered via `@wordpress/boot`, replacing the core Comments menu item
- **Post title resolution** in both list and inspector views

Inspired by [Jetpack Forms](https://github.com/Automattic/jetpack-forms) response management UX, built on the routing foundation from #70862.

### New files
```
routes/comments/          — Main comments route (stage, inspector, fields, actions, styles)
routes/comments-home/     — Redirect route (/ → /all)
lib/experimental/pages/comments.php — PHP admin page registration
```

## Test plan

- [ ] `npm run build` completes successfully
- [ ] Navigate to Comments in wp-admin sidebar — loads the new DataViews page
- [ ] Verify status tabs filter comments correctly
- [ ] Test row-level actions (approve, spam, trash) via three-dot menu
- [ ] Test bulk selection and bulk actions
- [ ] Click a comment title to open inspector panel
- [ ] Verify post titles resolve in list and inspector

🧪 To generate test data: `npm run wp-env run cli -- wp eval-file /var/www/html/wp-content/plugins/gutenberg/scripts/generate-test-comments.php`

## Video demo

https://github.com/user-attachments/assets/f627e8c8-4db3-4460-b771-7fb7e1aaffb1

## Open questions

I want @WordPress/gutenberg-design to check this out as the current UX feels just okay. In particular, the quick edit panel view of a single comment frankly looks and feels rough to me. As we think about expanding our foundational items, I felt like this would be a good stress test to see what we can do and perhaps what we can update in a future release. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)