### PR TITLE
RTC: Fix core/table cell merging

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -23,14 +23,14 @@ interface BlockAttributes {
 	[ key: string ]: unknown;
 }
 
-interface BlockAttributeType {
+interface BlockAttributeSchema {
 	role?: string;
 	type?: string;
-	query?: Record< string, BlockAttributeType >;
+	query?: Record< string, BlockAttributeSchema >;
 }
 
 interface BlockType {
-	attributes?: Record< string, BlockAttributeType >;
+	attributes?: Record< string, BlockAttributeSchema >;
 	name: string;
 }
 
@@ -134,7 +134,7 @@ function makeBlocksSerializable( blocks: Block[] ): Block[] {
  * @return The value with rich-text strings replaced by RichTextData.
  */
 function deserializeAttributeValue(
-	schema: BlockAttributeType | undefined,
+	schema: BlockAttributeSchema | undefined,
 	value: unknown
 ): unknown {
 	if ( schema?.type === 'rich-text' && typeof value === 'string' ) {
@@ -184,7 +184,7 @@ export function deserializeBlockAttributes( blocks: Block[] ): Block[] {
 		const newAttributes = { ...attributes };
 
 		for ( const [ key, value ] of Object.entries( attributes ) ) {
-			const schema = getBlockAttributeType( name, key );
+			const schema = getBlockAttributeSchema( name, key );
 
 			if ( schema ) {
 				newAttributes[ key ] = deserializeAttributeValue(
@@ -255,14 +255,89 @@ function createNewYAttributeValue(
 	blockName: string,
 	attributeName: string,
 	attributeValue: unknown
-): Y.Text | unknown {
-	const isRichText = isRichTextAttribute( blockName, attributeName );
+): Y.Text | Y.Array< unknown > | Y.Map< unknown > | unknown {
+	const schema = getBlockAttributeSchema( blockName, attributeName );
+	return createYValueFromSchema( schema, attributeValue );
+}
 
-	if ( isRichText ) {
-		return new Y.Text( attributeValue?.toString() ?? '' );
+/**
+ * Recursively create the appropriate Y.js type for a value based on its
+ * block-attribute schema.
+ *
+ * - `rich-text`          -> Y.Text
+ * - `array`  with query  -> Y.Array of Y.Maps
+ * - `object` with query  -> Y.Map
+ * - anything else        -> plain value (unchanged)
+ *
+ * @param schema The attribute type definition.
+ * @param value  The plain JS value to convert.
+ * @return A Y.js type or the original value.
+ */
+function createYValueFromSchema(
+	schema: BlockAttributeSchema | undefined,
+	value: unknown
+): Y.Text | Y.Array< unknown > | Y.Map< unknown > | unknown {
+	if ( ! schema ) {
+		return value;
 	}
 
-	return attributeValue;
+	if ( schema.type === 'rich-text' ) {
+		return new Y.Text( value?.toString() ?? '' );
+	}
+
+	if ( schema.type === 'array' && schema.query && Array.isArray( value ) ) {
+		const query = schema.query;
+		const yArray = new Y.Array< Y.Map< unknown > >();
+
+		yArray.insert(
+			0,
+			value.map( ( item ) => createYMapFromQuery( query, item ) )
+		);
+
+		return yArray;
+	}
+
+	if ( schema.type === 'object' && schema.query && isRecord( value ) ) {
+		return createYMapFromQuery( schema.query, value );
+	}
+
+	return value;
+}
+
+/**
+ * Type guard that narrows `unknown` to `Record< string, unknown >`.
+ *
+ * @param value Value to check.
+ * @return True if `value` is a non-null, non-array object.
+ */
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+/**
+ * Create a Y.Map from a plain object, using a query schema to decide which
+ * properties should become nested Y.js types (Y.Text, Y.Array, Y.Map).
+ *
+ * @param query The query schema defining the properties.
+ * @param obj   The plain object to convert.
+ * @return A Y.Map with typed values.
+ */
+function createYMapFromQuery(
+	query: Record< string, BlockAttributeSchema >,
+	obj: unknown
+): Y.Map< unknown > {
+	if ( ! isRecord( obj ) ) {
+		return new Y.Map();
+	}
+
+	const entries: [ string, unknown ][] = Object.entries( obj ).map(
+		( [ key, val ] ): [ string, unknown ] => {
+			const subSchema = query[ key ];
+			return [ key, createYValueFromSchema( subSchema, val ) ];
+		}
+	);
+
+	return new Y.Map( entries );
 }
 
 function createNewYBlock( block: Block ): YBlock {
@@ -499,11 +574,140 @@ export function mergeCrdtBlocks(
 }
 
 /**
- * Update a single attribute on a Yjs block attributes map (currentAttributes).
+ * Merge an incoming plain array into an existing Y.Array in-place.
  *
- * For rich-text attributes that already exist as Y.Text instances, the update
- * is applied as a delta merge so that concurrent edits are preserved. All
- * other attributes are replaced wholesale via `createNewYAttributeValue`.
+ * When the array length is unchanged (stable structure), each element is
+ * merged individually via `mergeYMapValues`, preserving concurrent edits to
+ * different elements. When the length changes (structural edit such as row
+ * insertion/deletion), the Y.Array is rebuilt from scratch.
+ *
+ * @param yArray         The existing Y.Array to update.
+ * @param newValue       The new plain array to merge into the Y.Array.
+ * @param schema         The attribute schema (must have `query`).
+ * @param cursorPosition The local cursor position for rich-text delta merges.
+ */
+function mergeYArray(
+	yArray: Y.Array< unknown >,
+	newValue: unknown[],
+	schema: BlockAttributeSchema,
+	cursorPosition: number | null
+): void {
+	if ( ! schema.query ) {
+		return;
+	}
+
+	const query = schema.query;
+
+	if ( yArray.length === newValue.length ) {
+		// Same length: update each element in-place.
+		for ( let i = 0; i < newValue.length; i++ ) {
+			const currentElement = yArray.get( i );
+			const newElement = newValue[ i ];
+
+			if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+				mergeYMapValues(
+					currentElement,
+					newElement,
+					query,
+					cursorPosition
+				);
+			}
+		}
+	} else {
+		// Structure changed: rebuild the Y.Array.
+		yArray.delete( 0, yArray.length );
+		yArray.insert(
+			0,
+			newValue.map( ( item ) => createYMapFromQuery( query, item ) )
+		);
+	}
+}
+
+/**
+ * Merge a single value into a Y.Map entry, using the attribute schema to
+ * decide how to merge.
+ *
+ * If the current value is already a matching Y.js type (Y.Text, Y.Array,
+ * Y.Map), the update is merged in-place so concurrent edits are preserved.
+ * Otherwise the value is replaced wholesale.
+ *
+ * @param schema         The attribute type definition for this value.
+ * @param newVal         The new value to merge into the Y.Map entry.
+ * @param yMap           The Y.Map that owns this entry.
+ * @param key            The key of this entry in the Y.Map.
+ * @param cursorPosition The local cursor position for rich-text delta merges.
+ */
+function mergeYValue(
+	schema: BlockAttributeSchema | undefined,
+	newVal: unknown,
+	yMap: Y.Map< unknown >,
+	key: string,
+	cursorPosition: number | null
+): void {
+	const currentVal = yMap.get( key );
+	if (
+		schema?.type === 'rich-text' &&
+		typeof newVal === 'string' &&
+		currentVal instanceof Y.Text
+	) {
+		mergeRichTextUpdate( currentVal, newVal, cursorPosition );
+	} else if (
+		schema?.type === 'array' &&
+		schema.query &&
+		Array.isArray( newVal ) &&
+		currentVal instanceof Y.Array
+	) {
+		mergeYArray( currentVal, newVal, schema, cursorPosition );
+	} else if (
+		schema?.type === 'object' &&
+		schema.query &&
+		isRecord( newVal ) &&
+		currentVal instanceof Y.Map
+	) {
+		mergeYMapValues( currentVal, newVal, schema.query, cursorPosition );
+	} else {
+		const newYValue = createYValueFromSchema( schema, newVal );
+
+		// Replace if the schema created a new Y type (newYValue !== newVal means
+		// createYValueFromSchema wrapped the value, so the current value is the
+		// wrong type and needs upgrading) or if the raw value changed.
+		if ( newYValue !== newVal || ! fastDeepEqual( currentVal, newVal ) ) {
+			yMap.set( key, newYValue );
+		}
+	}
+}
+
+/**
+ * Merge an incoming plain object into an existing Y.Map in-place, using
+ * the query schema to decide how each property should be merged.
+ *
+ * Properties present in the Y.Map but absent from `newObj` are deleted.
+ *
+ * @param yMap           The existing Y.Map to update.
+ * @param newObj         The new plain object to merge into the Y.Map.
+ * @param query          The query schema defining property types.
+ * @param cursorPosition The local cursor position for rich-text delta merges.
+ */
+function mergeYMapValues(
+	yMap: Y.Map< unknown >,
+	newObj: Record< string, unknown >,
+	query: Record< string, BlockAttributeSchema >,
+	cursorPosition: number | null
+): void {
+	for ( const [ key, newVal ] of Object.entries( newObj ) ) {
+		mergeYValue( query[ key ], newVal, yMap, key, cursorPosition );
+	}
+
+	// Delete properties absent from the incoming object.
+	for ( const key of yMap.keys() ) {
+		if ( ! newObj.hasOwnProperty( key ) ) {
+			yMap.delete( key );
+		}
+	}
+}
+
+/**
+ * Update a single attribute on a Yjs block attributes map (currentAttributes).
  *
  * @param blockName         The block type name, e.g. 'core/paragraph'.
  * @param attributeName     The name of the attribute to update, e.g. 'content'.
@@ -518,28 +722,22 @@ function updateYBlockAttribute(
 	currentAttributes: YBlockAttributes,
 	cursorPosition: number | null
 ): void {
-	const isRichText = isRichTextAttribute( blockName, attributeName );
-	const currentAttribute = currentAttributes.get( attributeName );
+	const schema = getBlockAttributeSchema( blockName, attributeName );
 
-	if (
-		isRichText &&
-		'string' === typeof attributeValue &&
-		currentAttributes.has( attributeName ) &&
-		currentAttribute instanceof Y.Text
-	) {
-		// Rich text values are stored as persistent Y.Text instances.
-		// Update the value with a delta in place.
-		mergeRichTextUpdate( currentAttribute, attributeValue, cursorPosition );
-	} else {
-		currentAttributes.set(
-			attributeName,
-			createNewYAttributeValue( blockName, attributeName, attributeValue )
-		);
-	}
+	mergeYValue(
+		schema,
+		attributeValue,
+		currentAttributes,
+		attributeName,
+		cursorPosition
+	);
 }
 
 // Cached block attribute types, populated once from getBlockTypes().
-let cachedBlockAttributeTypes: Map< string, Map< string, BlockAttributeType > >;
+let cachedBlockAttributeSchemas: Map<
+	string,
+	Map< string, BlockAttributeSchema >
+>;
 
 /**
  * Get the attribute type definition for a block attribute.
@@ -548,18 +746,18 @@ let cachedBlockAttributeTypes: Map< string, Map< string, BlockAttributeType > >;
  * @param attributeName The name of the attribute, e.g. 'content'.
  * @return The type definition of the attribute.
  */
-function getBlockAttributeType(
+function getBlockAttributeSchema(
 	blockName: string,
 	attributeName: string
-): BlockAttributeType | undefined {
-	if ( ! cachedBlockAttributeTypes ) {
+): BlockAttributeSchema | undefined {
+	if ( ! cachedBlockAttributeSchemas ) {
 		// Parse the attributes for all blocks once.
-		cachedBlockAttributeTypes = new Map();
+		cachedBlockAttributeSchemas = new Map();
 
 		for ( const blockType of getBlockTypes() as BlockType[] ) {
-			cachedBlockAttributeTypes.set(
+			cachedBlockAttributeSchemas.set(
 				blockType.name,
-				new Map< string, BlockAttributeType >(
+				new Map< string, BlockAttributeSchema >(
 					Object.entries( blockType.attributes ?? {} ).map(
 						( [ name, definition ] ) => {
 							const { role, type, query } = definition;
@@ -571,7 +769,7 @@ function getBlockAttributeType(
 		}
 	}
 
-	return cachedBlockAttributeTypes.get( blockName )?.get( attributeName );
+	return cachedBlockAttributeSchemas.get( blockName )?.get( attributeName );
 }
 
 /**
@@ -587,20 +785,24 @@ function isExpectedAttributeType(
 	attributeName: string,
 	attributeValue: unknown
 ): boolean {
-	const expectedAttributeType = getBlockAttributeType(
-		blockName,
-		attributeName
-	)?.type;
+	const schema = getBlockAttributeSchema( blockName, attributeName );
 
-	if ( expectedAttributeType === 'rich-text' ) {
+	if ( schema?.type === 'rich-text' ) {
 		return attributeValue instanceof Y.Text;
 	}
 
-	if ( expectedAttributeType === 'string' ) {
+	if ( schema?.type === 'string' ) {
 		return typeof attributeValue === 'string';
 	}
 
-	// No other types comparisons use special logic.
+	if ( schema?.type === 'array' && schema.query ) {
+		return attributeValue instanceof Y.Array;
+	}
+
+	if ( schema?.type === 'object' && schema.query ) {
+		return attributeValue instanceof Y.Map;
+	}
+
 	return true;
 }
 
@@ -613,22 +815,8 @@ function isExpectedAttributeType(
  * @return True if the attribute is local, false otherwise.
  */
 function isLocalAttribute( blockName: string, attributeName: string ): boolean {
-	return 'local' === getBlockAttributeType( blockName, attributeName )?.role;
-}
-
-/**
- * Given a block name and attribute key, return true if the attribute is rich-text typed.
- *
- * @param blockName     The name of the block, e.g. 'core/paragraph'.
- * @param attributeName The name of the attribute to check, e.g. 'content'.
- * @return True if the attribute is rich-text typed, false otherwise.
- */
-function isRichTextAttribute(
-	blockName: string,
-	attributeName: string
-): boolean {
 	return (
-		'rich-text' === getBlockAttributeType( blockName, attributeName )?.type
+		'local' === getBlockAttributeSchema( blockName, attributeName )?.role
 	);
 }
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -611,6 +611,17 @@ function mergeYArray(
 					query,
 					cursorPosition
 				);
+			} else {
+				// Element is the wrong type (e.g. partial migration) or the
+				// incoming value is not an object. Rebuild the entire array.
+				yArray.delete( 0, yArray.length );
+				yArray.insert(
+					0,
+					newValue.map( ( item ) =>
+						createYMapFromQuery( query, item )
+					)
+				);
+				return;
 			}
 		}
 	} else {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -483,8 +483,16 @@ export function mergeCrdtBlocks(
 								currentAttribute
 							);
 
+							// Y types (Y.Text, Y.Array, Y.Map) cannot be
+							// compared with fastDeepEqual against plain values.
+							// Delegate to mergeYValue which handles no-op
+							// detection at the edges.
+							const isYType =
+								currentAttribute instanceof Y.AbstractType;
+
 							const isAttributeChanged =
 								! isExpectedType ||
+								isYType ||
 								! fastDeepEqual(
 									currentAttribute,
 									attributeValue
@@ -679,9 +687,9 @@ function mergeYValue(
 	} else {
 		const newYValue = createYValueFromSchema( schema, newVal );
 
-		// Replace if the schema created a new Y type (newYValue !== newVal means
-		// createYValueFromSchema wrapped the value, so the current value is the
-		// wrong type and needs upgrading) or if the raw value changed.
+		// If createYValueFromSchema wrapped the value into a Y type, the
+		// current value is the wrong type and needs upgrading. Otherwise,
+		// only replace if the raw value actually changed.
 		if ( newYValue !== newVal || ! fastDeepEqual( currentVal, newVal ) ) {
 			yMap.set( key, newYValue );
 		}

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -711,7 +711,7 @@ function mergeYMapValues(
 
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
-		if ( ! newObj.hasOwnProperty( key ) ) {
+		if ( ! Object.hasOwn( newObj, key ) ) {
 			yMap.delete( key );
 		}
 	}

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -43,9 +43,42 @@ jest.mock( '@wordpress/blocks', () => ( {
 			attributes: {
 				hasFixedLayout: { type: 'boolean' },
 				caption: { type: 'rich-text' },
-				head: { type: 'array' },
-				body: { type: 'array' },
-				foot: { type: 'array' },
+				head: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+				body: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
+				foot: {
+					type: 'array',
+					query: {
+						cells: {
+							type: 'array',
+							query: {
+								content: { type: 'rich-text' },
+								tag: { type: 'string' },
+							},
+						},
+					},
+				},
 			},
 		},
 	],
@@ -1159,7 +1192,8 @@ describe( 'crdt-blocks', () => {
 
 			const block = yblocks2.get( 0 );
 			const attrs = block.get( 'attributes' ) as YBlockAttributes;
-			const body = attrs.get( 'body' ) as {
+			const bodyYArray = attrs.get( 'body' ) as Y.Array< unknown >;
+			const body = bodyYArray.toJSON() as {
 				cells: { content: string; tag: string }[];
 			}[];
 
@@ -1218,14 +1252,16 @@ describe( 'crdt-blocks', () => {
 			const block = yblocks2.get( 0 );
 			const attrs = block.get( 'attributes' ) as YBlockAttributes;
 
-			const head = attrs.get( 'head' ) as {
+			const headYArray = attrs.get( 'head' ) as Y.Array< unknown >;
+			const head = headYArray.toJSON() as {
 				cells: { content: string }[];
 			}[];
 			expect( head[ 0 ].cells[ 0 ].content ).toBe(
 				'<strong>Header</strong>'
 			);
 
-			const body = attrs.get( 'body' ) as {
+			const bodyYArray = attrs.get( 'body' ) as Y.Array< unknown >;
+			const body = bodyYArray.toJSON() as {
 				cells: { content: string }[];
 			}[];
 			expect( body[ 0 ].cells[ 0 ].content ).toBe(
@@ -1233,6 +1269,334 @@ describe( 'crdt-blocks', () => {
 			);
 
 			doc2.destroy();
+		} );
+
+		it( 'stores table body as nested Y types (Y.Array of Y.Maps with Y.Text)', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						hasFixedLayout: true,
+						body: [
+							{
+								cells: [
+									{
+										content:
+											RichTextData.fromPlainText( 'A1' ),
+										tag: 'td',
+									},
+									{
+										content:
+											RichTextData.fromPlainText( 'B1' ),
+										tag: 'td',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' );
+
+			// body should be a Y.Array, not a plain array.
+			expect( body ).toBeInstanceOf( Y.Array );
+
+			// Each row should be a Y.Map.
+			const row = ( body as Y.Array< unknown > ).get( 0 );
+			expect( row ).toBeInstanceOf( Y.Map );
+
+			// Each row's cells should be a Y.Array.
+			const cells = ( row as Y.Map< unknown > ).get( 'cells' );
+			expect( cells ).toBeInstanceOf( Y.Array );
+
+			// Each cell should be a Y.Map with Y.Text content.
+			const cell = ( cells as Y.Array< unknown > ).get( 0 );
+			expect( cell ).toBeInstanceOf( Y.Map );
+
+			const content = ( cell as Y.Map< unknown > ).get(
+				'content'
+			) as Y.Text;
+			expect( content ).toBeInstanceOf( Y.Text );
+			expect( content.toString() ).toBe( 'A1' );
+
+			// tag should be a plain string value.
+			expect( ( cell as Y.Map< unknown > ).get( 'tag' ) ).toBe( 'td' );
+		} );
+
+		it( 'merges table cell edits in-place without replacing sibling cells', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			// Grab the Y.Text for cell B2 before the update.
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row1 = body.get( 1 ) as Y.Map< unknown >;
+			const cells1 = row1.get( 'cells' ) as Y.Array< unknown >;
+			const cellB2 = cells1.get( 1 ) as Y.Map< unknown >;
+			const b2Text = cellB2.get( 'content' ) as Y.Text;
+
+			// Edit only cell A1.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1-edited', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			// The Y.Text for B2 should be the exact same object (identity).
+			const bodyAfter = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row1After = bodyAfter.get( 1 ) as Y.Map< unknown >;
+			const cells1After = row1After.get( 'cells' ) as Y.Array< unknown >;
+			const cellB2After = cells1After.get( 1 ) as Y.Map< unknown >;
+			const b2TextAfter = cellB2After.get( 'content' ) as Y.Text;
+
+			expect( b2TextAfter ).toBe( b2Text );
+			expect( b2TextAfter.toString() ).toBe( 'B2' );
+
+			// Cell A1 should be updated.
+			const row0After = bodyAfter.get( 0 ) as Y.Map< unknown >;
+			const cells0After = row0After.get( 'cells' ) as Y.Array< unknown >;
+			const cellA1After = cells0After.get( 0 ) as Y.Map< unknown >;
+			const a1Content = cellA1After.get( 'content' ) as Y.Text;
+			expect( a1Content.toString() ).toBe( 'A1-edited' );
+		} );
+
+		it( 'rebuilds Y.Array when row count changes (structural edit)', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			// Add a second row.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+
+			expect( body.length ).toBe( 2 );
+
+			const row1 = body.get( 1 ) as Y.Map< unknown >;
+			const cells = ( row1.get( 'cells' ) as Y.Array< unknown > ).get(
+				0
+			) as Y.Map< unknown >;
+			const a2Content = cells.get( 'content' ) as Y.Text;
+			expect( a2Content.toString() ).toBe( 'A2' );
+		} );
+
+		it( 'concurrent cell edits on different cells are both preserved', () => {
+			// Simulate two users editing different cells in the same table.
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			// Set up doc1 (User A).
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Set up doc2 (User B) by syncing initial state.
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			// User A edits cell A1.
+			const userABlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1-userA', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			mergeCrdtBlocks( yblocks, userABlocks, null );
+
+			// User B edits cell B1 (concurrently, before syncing A's change).
+			const userBBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1-userB', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			mergeCrdtBlocks( yblocks2, userBBlocks, null );
+
+			// Sync: apply each other's changes.
+			const updateA = Y.encodeStateAsUpdate( doc );
+			const updateB = Y.encodeStateAsUpdate( doc2 );
+			Y.applyUpdate( doc2, updateA );
+			Y.applyUpdate( doc, updateB );
+
+			// Both docs should have both edits preserved.
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				const attrs = checkBlocks
+					.get( 0 )
+					.get( 'attributes' ) as YBlockAttributes;
+				const body = (
+					attrs.get( 'body' ) as Y.Array< unknown >
+				 ).toJSON() as { cells: { content: string }[] }[];
+
+				expect( body[ 0 ].cells[ 0 ].content ).toBe( 'A1-userA' );
+				expect( body[ 0 ].cells[ 1 ].content ).toBe( 'B1-userB' );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'migrates plain array to Y.Array on first update', () => {
+			// Manually set up a block with a plain array body (old format).
+			const block = new Y.Map() as unknown as YBlock;
+			block.set( 'name' as any, 'core/table' );
+			block.set( 'clientId' as any, 'table-migration' );
+			block.set( 'innerBlocks' as any, new Y.Array() );
+
+			const attrs = new Y.Map();
+			attrs.set( 'hasFixedLayout', true );
+			// Store body as a plain array (pre-migration format).
+			attrs.set( 'body', [
+				{ cells: [ { content: 'old', tag: 'td' } ] },
+			] );
+			block.set( 'attributes' as any, attrs );
+
+			doc.transact( () => {
+				yblocks.push( [ block ] );
+			} );
+
+			// The body is currently a plain array.
+			expect( attrs.get( 'body' ) ).not.toBeInstanceOf( Y.Array );
+
+			// Now merge blocks, which should trigger migration.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						hasFixedLayout: true,
+						body: [
+							{
+								cells: [ { content: 'migrated', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			// After migration, body should be a Y.Array.
+			const bodyAfter = attrs.get( 'body' );
+			expect( bodyAfter ).toBeInstanceOf( Y.Array );
+
+			const bodyJson = ( bodyAfter as Y.Array< unknown > ).toJSON() as {
+				cells: { content: string }[];
+			}[];
+			expect( bodyJson[ 0 ].cells[ 0 ].content ).toBe( 'migrated' );
 		} );
 	} );
 

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -39,6 +39,18 @@ jest.mock( '@wordpress/blocks', () => ( {
 			},
 		},
 		{
+			name: 'core/test-object-query',
+			attributes: {
+				metadata: {
+					type: 'object',
+					query: {
+						title: { type: 'rich-text' },
+						value: { type: 'string' },
+					},
+				},
+			},
+		},
+		{
 			name: 'core/table',
 			attributes: {
 				hasFixedLayout: { type: 'boolean' },
@@ -1685,6 +1697,321 @@ describe( 'crdt-blocks', () => {
 			expect( cellAfter.get( 'tag' ) ).toBe( 'th' );
 			expect( cellAfter.get( 'scope' ) ).toBe( 'col' );
 			expect( cellAfter.get( 'align' ) ).toBe( 'center' );
+		} );
+
+		it( 'deletes removed properties from Y.Map cells', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{
+										content: 'Header',
+										tag: 'th',
+										scope: 'col',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row = body.get( 0 ) as Y.Map< unknown >;
+			const cells = row.get( 'cells' ) as Y.Array< unknown >;
+			const cell = cells.get( 0 ) as Y.Map< unknown >;
+
+			// Scope should exist initially.
+			expect( cell.get( 'scope' ) ).toBe( 'col' );
+
+			// Update without the scope property.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{
+										content: 'Header',
+										tag: 'th',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const cellAfter = (
+				(
+					( attrs.get( 'body' ) as Y.Array< unknown > ).get(
+						0
+					) as Y.Map< unknown >
+				 ).get( 'cells' ) as Y.Array< unknown >
+			 ).get( 0 ) as Y.Map< unknown >;
+
+			// Scope should be deleted.
+			expect( cellAfter.get( 'scope' ) ).toBeUndefined();
+			// Other properties should remain.
+			expect( cellAfter.get( 'tag' ) ).toBe( 'th' );
+			expect( ( cellAfter.get( 'content' ) as Y.Text ).toString() ).toBe(
+				'Header'
+			);
+		} );
+
+		it( 'rebuilds Y.Array when element is wrong type (partial migration)', () => {
+			// Manually set up a block with a Y.Array whose elements are
+			// plain values instead of Y.Maps (simulating a partial migration).
+			const block = new Y.Map() as unknown as YBlock;
+			block.set( 'name' as any, 'core/table' );
+			block.set( 'clientId' as any, 'table-partial' );
+			block.set( 'innerBlocks' as any, new Y.Array() );
+
+			const attrs = new Y.Map();
+			// Create a Y.Array with a plain object element (not a Y.Map).
+			const bodyArray = new Y.Array();
+			bodyArray.insert( 0, [
+				{ cells: [ { content: 'plain', tag: 'td' } ] },
+			] );
+			attrs.set( 'body', bodyArray );
+			block.set( 'attributes' as any, attrs );
+
+			doc.transact( () => {
+				yblocks.push( [ block ] );
+			} );
+
+			// The element should be a plain object, not a Y.Map.
+			expect( bodyArray.get( 0 ) ).not.toBeInstanceOf( Y.Map );
+
+			// Merge, which should detect the wrong type and rebuild.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'rebuilt', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const bodyAfter = attrs.get( 'body' ) as Y.Array< unknown >;
+			expect( bodyAfter ).toBeInstanceOf( Y.Array );
+
+			// After rebuild, elements should be proper Y.Maps.
+			const row = bodyAfter.get( 0 );
+			expect( row ).toBeInstanceOf( Y.Map );
+
+			const cells = ( row as Y.Map< unknown > ).get(
+				'cells'
+			) as Y.Array< unknown >;
+			const cell = cells.get( 0 ) as Y.Map< unknown >;
+			expect( cell ).toBeInstanceOf( Y.Map );
+			expect( ( cell.get( 'content' ) as Y.Text ).toString() ).toBe(
+				'rebuilt'
+			);
+		} );
+	} );
+
+	describe( 'object+query attributes', () => {
+		it( 'creates Y.Map for object+query attributes with Y.Text sub-values', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/test-object-query',
+					attributes: {
+						metadata: {
+							title: 'Hello',
+							value: 'world',
+						},
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const metadata = attrs.get( 'metadata' );
+
+			// Should be a Y.Map, not a plain object.
+			expect( metadata ).toBeInstanceOf( Y.Map );
+
+			const metadataMap = metadata as Y.Map< unknown >;
+
+			// title is rich-text, so it should be Y.Text.
+			expect( metadataMap.get( 'title' ) ).toBeInstanceOf( Y.Text );
+			expect( ( metadataMap.get( 'title' ) as Y.Text ).toString() ).toBe(
+				'Hello'
+			);
+
+			// value is a plain string, so it should remain a string.
+			expect( metadataMap.get( 'value' ) ).toBe( 'world' );
+		} );
+
+		it( 'merges object+query attribute in-place preserving Y.Map identity', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/test-object-query',
+					attributes: {
+						metadata: {
+							title: 'Original',
+							value: 'v1',
+						},
+					},
+					innerBlocks: [],
+					clientId: 'obj-query-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const metadataBefore = attrs.get( 'metadata' ) as Y.Map< unknown >;
+			const titleBefore = metadataBefore.get( 'title' ) as Y.Text;
+
+			// Update the metadata.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/test-object-query',
+					attributes: {
+						metadata: {
+							title: 'Updated',
+							value: 'v2',
+						},
+					},
+					innerBlocks: [],
+					clientId: 'obj-query-1',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const metadataAfter = attrs.get( 'metadata' ) as Y.Map< unknown >;
+
+			// The Y.Map should be the same object (in-place merge).
+			expect( metadataAfter ).toBe( metadataBefore );
+
+			// The Y.Text for title should be the same object (merged in-place).
+			const titleAfter = metadataAfter.get( 'title' ) as Y.Text;
+			expect( titleAfter ).toBe( titleBefore );
+			expect( titleAfter.toString() ).toBe( 'Updated' );
+
+			// Plain value should be updated.
+			expect( metadataAfter.get( 'value' ) ).toBe( 'v2' );
+		} );
+
+		it( 'deletes removed properties from object+query Y.Map', () => {
+			const blocks: Block[] = [
+				{
+					name: 'core/test-object-query',
+					attributes: {
+						metadata: {
+							title: 'Keep',
+							value: 'remove-me',
+						},
+					},
+					innerBlocks: [],
+					clientId: 'obj-query-2',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, blocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const metadata = attrs.get( 'metadata' ) as Y.Map< unknown >;
+			expect( metadata.get( 'value' ) ).toBe( 'remove-me' );
+
+			// Update without the value property.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/test-object-query',
+					attributes: {
+						metadata: {
+							title: 'Keep',
+						},
+					},
+					innerBlocks: [],
+					clientId: 'obj-query-2',
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( metadata.get( 'value' ) ).toBeUndefined();
+			expect( ( metadata.get( 'title' ) as Y.Text ).toString() ).toBe(
+				'Keep'
+			);
+		} );
+
+		it( 'upgrades plain value to Y.Map when schema requires it', () => {
+			// Manually set up a block with a plain object attribute
+			// where the schema expects object+query (Y.Map).
+			const block = new Y.Map() as unknown as YBlock;
+			block.set( 'name' as any, 'core/test-object-query' );
+			block.set( 'clientId' as any, 'obj-upgrade' );
+			block.set( 'innerBlocks' as any, new Y.Array() );
+
+			const attrs = new Y.Map();
+			// Store metadata as a plain object (pre-migration).
+			attrs.set( 'metadata', { title: 'plain', value: 'old' } );
+			block.set( 'attributes' as any, attrs );
+
+			doc.transact( () => {
+				yblocks.push( [ block ] );
+			} );
+
+			// metadata should be a plain object currently.
+			expect( attrs.get( 'metadata' ) ).not.toBeInstanceOf( Y.Map );
+
+			// Merge, which should upgrade to Y.Map.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/test-object-query',
+					attributes: {
+						metadata: {
+							title: 'upgraded',
+							value: 'new',
+						},
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const metadataAfter = attrs.get( 'metadata' );
+			expect( metadataAfter ).toBeInstanceOf( Y.Map );
+
+			const metadataMap = metadataAfter as Y.Map< unknown >;
+			expect( metadataMap.get( 'title' ) ).toBeInstanceOf( Y.Text );
+			expect( ( metadataMap.get( 'title' ) as Y.Text ).toString() ).toBe(
+				'upgraded'
+			);
+			expect( metadataMap.get( 'value' ) ).toBe( 'new' );
 		} );
 	} );
 

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -51,6 +51,8 @@ jest.mock( '@wordpress/blocks', () => ( {
 							query: {
 								content: { type: 'rich-text' },
 								tag: { type: 'string' },
+								scope: { type: 'string' },
+								align: { type: 'string' },
 							},
 						},
 					},
@@ -63,6 +65,8 @@ jest.mock( '@wordpress/blocks', () => ( {
 							query: {
 								content: { type: 'rich-text' },
 								tag: { type: 'string' },
+								scope: { type: 'string' },
+								align: { type: 'string' },
 							},
 						},
 					},
@@ -75,6 +79,8 @@ jest.mock( '@wordpress/blocks', () => ( {
 							query: {
 								content: { type: 'rich-text' },
 								tag: { type: 'string' },
+								scope: { type: 'string' },
+								align: { type: 'string' },
 							},
 						},
 					},
@@ -1597,6 +1603,88 @@ describe( 'crdt-blocks', () => {
 				cells: { content: string }[];
 			}[];
 			expect( bodyJson[ 0 ].cells[ 0 ].content ).toBe( 'migrated' );
+		} );
+
+		it( 'preserves non-rich-text cell properties alongside Y.Text content', () => {
+			const tableBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{
+										content: 'Header',
+										tag: 'th',
+										scope: 'col',
+										align: 'center',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, tableBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row = body.get( 0 ) as Y.Map< unknown >;
+			const cells = row.get( 'cells' ) as Y.Array< unknown >;
+			const cell = cells.get( 0 ) as Y.Map< unknown >;
+
+			// Rich-text content should be Y.Text.
+			const content = cell.get( 'content' ) as Y.Text;
+			expect( content ).toBeInstanceOf( Y.Text );
+			expect( content.toString() ).toBe( 'Header' );
+
+			// Plain string properties should be stored as-is.
+			expect( cell.get( 'tag' ) ).toBe( 'th' );
+			expect( cell.get( 'scope' ) ).toBe( 'col' );
+			expect( cell.get( 'align' ) ).toBe( 'center' );
+
+			// Update only the content, verify other properties remain.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{
+										content: 'Updated Header',
+										tag: 'th',
+										scope: 'col',
+										align: 'center',
+									},
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			const cellAfter = (
+				(
+					( attrs.get( 'body' ) as Y.Array< unknown > ).get(
+						0
+					) as Y.Map< unknown >
+				 ).get( 'cells' ) as Y.Array< unknown >
+			 ).get( 0 ) as Y.Map< unknown >;
+
+			expect( ( cellAfter.get( 'content' ) as Y.Text ).toString() ).toBe(
+				'Updated Header'
+			);
+			expect( cellAfter.get( 'tag' ) ).toBe( 'th' );
+			expect( cellAfter.get( 'scope' ) ).toBe( 'col' );
+			expect( cellAfter.get( 'align' ) ).toBe( 'center' );
 		} );
 	} );
 

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -9,7 +9,7 @@ import { Y } from '@wordpress/sync';
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 /**
- * Mock getBlockTypes so isRichTextAttribute can identify rich-text attrs.
+ * Mock getBlockTypes so CRDT merging can identify rich-text attributes.
  */
 jest.mock( '@wordpress/blocks', () => {
 	const actual = jest.requireActual( '@wordpress/blocks' ) as Record<


### PR DESCRIPTION
## What?

This is a bit risky of a change for late-stage 7.0, so it's intended for post-7.0 merging into Gutenberg. Part of the overall work in https://github.com/WordPress/gutenberg/issues/76915.

Closes https://github.com/WordPress/gutenberg/issues/76908:

https://github.com/user-attachments/assets/ac876d51-5b0d-444d-9b50-e7fa688ef1bd

*Users can not add simultaneous updates to separate cells of the same table*

---

This PR changes how query block attributes like a table `body` are stored in the CRDT document. This gives each table cell its own independent `Y.Text`, so two users editing different cells no longer overwrite each other:

https://github.com/user-attachments/assets/0b338846-3704-4904-b1f7-280b3cab26ff

*Demonstration of correct cell data merging in `core/table`*

## Why?

Previously, the entire table `body` was stored as a single opaque value in the block's `Y.Map`:

```
Y.Map (block attributes)
  └─ "body" → plain JS array   ← entire value replaced on any cell edit
       [
         { cells: [{ content: "A1", tag: "td" }, { content: "B1", tag: "td" }] },
         { cells: [{ content: "A2", tag: "td" }, { content: "B2", tag: "td" }] }
       ]
```

Any cell edit (e.g. modifying "A1") replaced the whole `body` array. With slower HTTP polling, two users typing in different cells of the same table can easily overlap on updates, and Yjs would silently discard one user's edit as `body` is a big non-Y-type blob.

Note that this is related but different from #76597. That PR fixed nested `RichTextData` instances inside table cells that were accidentally being serialized to empty data. This PR improves in a different direction by restructuring the whole table layout in the CRDT to nested Yjs types.

## How?

Previously, we only cared about top-level block `RichText` attributes into `Y.Text`, but other attribute types would get serialized into the CRDT as-is. The change uses the existing `query` property in block attribute schemas to recursively create nested Yjs types. For a table `body` attribute, the new structure looks like this:

**After (deep Yjs types):**
```
Y.Map (block attributes)
  └─ "body" → Y.Array
       ├─ [0] Y.Map (row)
       │    └─ "cells" → Y.Array
       │         ├─ [0] Y.Map (cell)
       │         │    ├─ "content" → Y.Text("A1")   ← independent Y.Text entry
       │         │    └─ "tag" → "td"
       │         └─ [1] Y.Map (cell)
       │              ├─ "content" → Y.Text("B1")   ← independent Y.Text entry
       │              └─ "tag" → "td"
       └─ [1] Y.Map (row)
            └─ "cells" → Y.Array
                 ├─ [0] Y.Map (cell)
                 │    ├─ "content" → Y.Text("A2")
                 │    └─ "tag" → "td"
                 └─ [1] Y.Map (cell)
                      ├─ "content" → Y.Text("B2")
                      └─ "tag" → "td"
```

With this structure, User A editing cell A1 and User B editing cell B2 write to different Y.Text instances, and Yjs can merge them correctly.

To get started reading the code, the best entry point is `updateYBlockAttribute()`, which calls into `mergeYValue()`. This function handles merging or creating new Y values. Previously `updateYBlockAttribute()` only reacted to top-level `Y.Text` values, but now `mergeYValue()` recurses into schema definitions to create the right Y types for internal arrays and objects.

Any block attribute with `type: 'array'` or `type: 'object'` and a `query` schema definition gets nested Y types automatically. This change also affects [`core/gallery` images](https://github.com/WordPress/gutenberg/blob/802e9e0f9343f1a44b5198df61d57e44d9ff6037/packages/block-library/src/gallery/block.json#L13-L56), though table is the much more important case.

For structural changes (adding/removing rows), the Y.Array is rebuilt from scratch as a fallback. This means a concurrent cell edit during a structural change could still conflict, but these are infrequent and should be a reasonable fallback.

This is also related to https://github.com/WordPress/gutenberg/issues/76812, because we can't render cursors without `Y.Text` instances for table cells. The changes in here should allow for fixing #76812.

## Testing Instructions

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Create a post with a table block (e.g. 2 columns, 2 rows). Add some text to each cell.
3. Open the same post in a second browser tab.
4. In tab 1, edit a cell in row 1. In window 2, edit a different cell in row 2.
5. Verify both edits appear in both windows within a few seconds without overwriting each other.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Implementation of nested Y.js types for array/object block attributes
