### PR TITLE
Fix: Preserve aspectRatio and scale when switching to wide/full align…

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -142,8 +142,6 @@ export function ImageEdit( {
 			setAttributes( {
 				width: undefined,
 				height: undefined,
-				aspectRatio: undefined,
-				scale: undefined,
 			} );
 		}
 	}, [ __unstableMarkNextChangeAsNotPersistent, align, setAttributes ] );


### PR DESCRIPTION
## What?
Fixes a bug where the `aspectRatio` and `scale` attributes of the Image Block 
are reset to `undefined` when switching alignment to Wide Width or Full Width.

Fixes #76697

## Why?
A `useEffect` in `edit.js` was introduced in #55954 to clear `width` and 
`height` pixel dimensions when switching to `wide` or `full` alignment — 
which is correct, since explicit pixel dimensions conflict with the 100% 
container width those alignments apply.

However, the same effect was also clearing `aspectRatio` and `scale`. These 
are CSS-based attributes (`aspect-ratio` and `object-fit`) that are fully 
compatible with wide/full alignment and should not be affected by the 
alignment change.

## How?
Removed `aspectRatio: undefined` and `scale: undefined` from the `setAttributes` 
call inside the `useEffect` that fires on `wide`/`full` alignment changes.

Only `width` and `height` (inline pixel dimensions) are now cleared, 
preserving the CSS-based aspect ratio and object-fit scale behavior.

**Before:**
```js
useEffect( () => {
    if ( [ 'wide', 'full' ].includes( align ) ) {
        __unstableMarkNextChangeAsNotPersistent();
        setAttributes( {
            width: undefined,
            height: undefined,
            aspectRatio: undefined,
            scale: undefined,
        } );
    }
}, [ __unstableMarkNextChangeAsNotPersistent, align, setAttributes ] );
```

**After:**
```js
useEffect( () => {
    if ( [ 'wide', 'full' ].includes( align ) ) {
        __unstableMarkNextChangeAsNotPersistent();
        setAttributes( {
            width: undefined,
            height: undefined,
        } );
    }
}, [ __unstableMarkNextChangeAsNotPersistent, align, setAttributes ] );
```

## Testing Instructions
1. Add a new Post
2. Add an Image Block and upload any image
3. In the sidebar, open the **Styles** tab
4. Set Aspect Ratio to **Square - 1:1**
5. Change Alignment to **Wide Width** or **Full Width** via the block toolbar
6. ✅ Confirm the Aspect Ratio dropdown still shows "Square - 1:1"
7. ✅ Confirm the image visually maintains the square crop
8. Switch between Content / Settings / Styles tabs
9. ✅ Confirm the Aspect Ratio dropdown does **not** reset to "Original"
10. Switch alignment back to **None**
11. ✅ Confirm aspect ratio is still preserved (regression check)

## Screenshots or screencast
<!-- Attach your before/after screen recordings here -->

As videos are larger than 10MB, uploaded into drive and gave public access
[https://drive.google.com/drive/folders/1R6Stkc4lsDSjUBT6Mj2IQ7Zg2cuFOmfO?usp=sharing](url)


