### PR TITLE
DOM: Prefer standard `caretPositionFromPoint` over deprecated `caretRangeFromPoint`

### DIFF
--- a/packages/dom/src/dom/caret-range-from-point.js
+++ b/packages/dom/src/dom/caret-range-from-point.js
@@ -1,41 +1,38 @@
 /**
- * Polyfill.
  * Get a collapsed range for a given point.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/caretRangeFromPoint
+ * Prefers the standard `caretPositionFromPoint` API and falls back to the
+ * non-standard, WebKit-originated `caretRangeFromPoint` for older browsers.
  *
- * @param {DocumentMaybeWithCaretPositionFromPoint} doc The document of the range.
- * @param {number}                                  x   Horizontal position within the current viewport.
- * @param {number}                                  y   Vertical position within the current viewport.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint
+ *
+ * @param {Document} doc The document of the range.
+ * @param {number}   x   Horizontal position within the current viewport.
+ * @param {number}   y   Vertical position within the current viewport.
  *
  * @return {Range | null} The best range for the given point.
  */
 export default function caretRangeFromPoint( doc, x, y ) {
+	if ( doc.caretPositionFromPoint ) {
+		const point = doc.caretPositionFromPoint( x, y );
+
+		// If x or y are negative, outside viewport, or there is no text entry node.
+		// https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint
+		if ( ! point ) {
+			return null;
+		}
+
+		const range = doc.createRange();
+
+		range.setStart( point.offsetNode, point.offset );
+		range.collapse( true );
+
+		return range;
+	}
+
 	if ( doc.caretRangeFromPoint ) {
 		return doc.caretRangeFromPoint( x, y );
 	}
 
-	if ( ! doc.caretPositionFromPoint ) {
-		return null;
-	}
-
-	const point = doc.caretPositionFromPoint( x, y );
-
-	// If x or y are negative, outside viewport, or there is no text entry node.
-	// https://developer.mozilla.org/en-US/docs/Web/API/Document/caretRangeFromPoint
-	if ( ! point ) {
-		return null;
-	}
-
-	const range = doc.createRange();
-
-	range.setStart( point.offsetNode, point.offset );
-	range.collapse( true );
-
-	return range;
+	return null;
 }
-
-/**
- * @typedef {{caretPositionFromPoint?: (x: number, y: number)=> CaretPosition | null} & Document } DocumentMaybeWithCaretPositionFromPoint
- * @typedef {{ readonly offset: number; readonly offsetNode: Node; getClientRect(): DOMRect | null; }} CaretPosition
- */


### PR DESCRIPTION
## What?
Noticed while investigating #34215.

PR modenizes `caretRangeFromPoint` DOM helper. Changes: The `caretPositionFromPoint` is baseline available and recommended over the deprecated `caretRangeFromPoint`. See: https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint

- Flip API priority in `caretRangeFromPoint()` to try the standard `document.caretPositionFromPoint` first, falling back to the deprecated WebKit-originated `document.caretRangeFromPoint` for older browsers
- Return type (`Range | null`) and function signature unchanged — no caller changes needed
- Remove unused `DocumentMaybeWithCaretPositionFromPoint` and `CaretPosition` typedefs

## Testing Instructions
The writing flow e2e tests should cover this refactoring.

## Use of AI Tools

Used Cluade to validate the idea, reviewed and tested manually.
