### PR TITLE
Fields: Add `sticky` field

### DIFF
--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -48,6 +48,7 @@ const form = {
 				},
 				'scheduled_date',
 				'password',
+				'sticky',
 			],
 		},
 		'date',

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -39,6 +39,7 @@ import {
 	scheduledDateField,
 	formatField,
 	postContentInfoField,
+	stickyField,
 } from '@wordpress/fields';
 import {
 	altTextField,
@@ -285,6 +286,7 @@ export const registerPostTypeSchema =
 					postTypeConfig.supports?.editor &&
 					postContentInfoField,
 				passwordField,
+				postTypeConfig.slug === 'post' && stickyField,
 				postTypeConfig.supports?.editor &&
 					postTypeConfig.viewable &&
 					postPreviewField,

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -192,6 +192,10 @@ Slug field for BasePost.
 
 Status field for BasePost.
 
+### stickyField
+
+Sticky field for BasePost.
+
 ### templateField
 
 Template field for BasePost.

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -19,3 +19,4 @@ export { default as notesField } from './notes';
 export { default as excerptField } from './excerpt';
 export { default as formatField } from './format';
 export { default as postContentInfoField } from './post-content-info';
+export { default as stickyField } from './sticky';

--- a/packages/fields/src/fields/sticky/index.tsx
+++ b/packages/fields/src/fields/sticky/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+
+const stickyField: Field< BasePost > = {
+	id: 'sticky',
+	type: 'boolean',
+	label: __( 'Sticky' ),
+	description: __( 'Pin this post to the top of the blog.' ),
+	enableSorting: false,
+	enableHiding: false,
+	isVisible: ( item ) => !! item._links?.[ 'wp:action-sticky' ],
+	filterBy: false,
+};
+
+/**
+ * Sticky field for BasePost.
+ */
+export default stickyField;

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -54,6 +54,7 @@ export interface BasePost extends CommonPost {
 	ping_status?: 'open' | 'closed';
 	link?: string;
 	slug?: string;
+	sticky?: boolean;
 	permalink_template?: string;
 	date?: string;
 	modified?: string;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076

This PR adds a `sticky` field that is used in the `Editor Inspector: Use DataForm` experiment


Checks are the same with [PostStickyCheck](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/components/post-sticky/check.js) component.



## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment
2. Go to post in post-editor and click on the `Status` item in inspector controls.
3. Observe that the `sticky` field is editable and working as expected.


## Screenshots or screencast <!-- if applicable -->
<img width="584" height="435" alt="Screenshot 2026-03-31 at 12 24 56 PM" src="https://github.com/user-attachments/assets/09834d40-8ddb-4d45-a053-8c5e03c9b324" />
