### PR TITLE
Shortcode: Fix parsing when attribute values contain brackets

### DIFF
--- a/packages/shortcode/README.md
+++ b/packages/shortcode/README.md
@@ -78,6 +78,11 @@ Generate a RegExp to identify a shortcode.
 
 The base regex is functionally equivalent to the one found in `get_shortcode_regex()` in `wp-includes/shortcodes.php`.
 
+Differences from the PHP regex:
+
+-   The closing shortcode tag is captured as group 6 (used by `fromMatch`).
+-   Quoted attribute values may contain `]` (e.g. `text="[Click here]"`).
+
 Capture groups:
 
 1.  An extra `[` to allow for escaping shortcodes with double `[[]]`

--- a/packages/shortcode/src/index.ts
+++ b/packages/shortcode/src/index.ts
@@ -129,6 +129,11 @@ export function string( options: ShortcodeOptions ): string {
  * The base regex is functionally equivalent to the one found in
  * `get_shortcode_regex()` in `wp-includes/shortcodes.php`.
  *
+ * Differences from the PHP regex:
+ *
+ * - The closing shortcode tag is captured as group 6 (used by `fromMatch`).
+ * - Quoted attribute values may contain `]` (e.g. `text="[Click here]"`).
+ *
  * Capture groups:
  *
  * 1. An extra `[` to allow for escaping shortcodes with double `[[]]`
@@ -144,10 +149,44 @@ export function string( options: ShortcodeOptions ): string {
  * @return Shortcode RegExp.
  */
 export function regexp( tag: string ): RegExp {
+	// Not a closing bracket, forward slash, or quote.
+	const ATTR_CHARS = '[^\\]\\/\'"]*';
+	// A double- or single-quoted string (may contain `]`).
+	const QUOTED_STRING = '(?:"[^"]*"|\'[^\']*\')';
+	// Characters and quoted strings, but not an unquoted `]` or `/`.
+	const ATTR_SEGMENT = ATTR_CHARS + '(?:' + QUOTED_STRING + ATTR_CHARS + ')*';
+
 	return new RegExp(
-		'\\[(\\[?)(' +
+		'\\[' + // Opening bracket.
+			'(\\[?)' + // 1: Optional second opening bracket for escaping shortcodes: [[tag]].
+			'(' +
 			tag +
-			')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)',
+			')' + // 2: Shortcode name.
+			'(?![\\w-])' + // Not followed by word character or hyphen.
+			'(' + // 3: Unroll the loop: Inside the opening shortcode tag.
+			ATTR_SEGMENT + // Not a closing bracket or forward slash (respects quoted strings).
+			'(?:' +
+			'\\/(?!\\])' + // A forward slash not followed by a closing bracket.
+			ATTR_SEGMENT + // Not a closing bracket or forward slash (respects quoted strings).
+			')*?' +
+			')' +
+			'(?:' +
+			'(\\/)' + // 4: Self closing tag...
+			'\\]' + // ...and closing bracket.
+			'|' +
+			'\\]' + // Closing bracket.
+			'(?:' +
+			'(' + // 5: Unroll the loop: Optionally, anything between the opening and closing shortcode tags.
+			'[^\\[]*' + // Not an opening bracket.
+			'(?:' +
+			'\\[(?!\\/\\2\\])' + // An opening bracket not followed by the closing shortcode tag.
+			'[^\\[]*' + // Not an opening bracket.
+			')*' +
+			')' +
+			'(\\[\\/\\2\\])' + // 6: Closing shortcode tag.
+			')?' +
+			')' +
+			'(\\]?)', // 7: Optional second closing bracket for escaping shortcodes: [[tag]].
 		'g'
 	);
 }

--- a/packages/shortcode/src/test/index.ts
+++ b/packages/shortcode/src/test/index.ts
@@ -88,6 +88,15 @@ describe( 'shortcode', () => {
 			expect( result?.index ).toBe( 31 );
 		} );
 
+		it( 'should find the shortcode when attribute values contain brackets', () => {
+			const result = next(
+				'foo',
+				'this has the [foo param="[value]" bar="baz"] shortcode'
+			);
+			expect( result?.shortcode.attrs.named.param ).toBe( '[value]' );
+			expect( result?.shortcode.attrs.named.bar ).toBe( 'baz' );
+		} );
+
 		it( 'should not find shortcodes that are not full matches', () => {
 			const result1 = next( 'foo', 'this has the [foobar] shortcode' );
 			expect( result1 ).toBe( undefined );

--- a/test/e2e/specs/editor/blocks/shortcode.spec.js
+++ b/test/e2e/specs/editor/blocks/shortcode.spec.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Shortcode', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should convert classic block content with a shortcode', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/freeform',
+			attributes: {
+				content: '<p>[my_shortcode param="foo"]</p>',
+			},
+		} );
+		await editor.clickBlockToolbarButton( 'Convert to blocks' );
+
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Shortcode',
+			} )
+		).toBeVisible();
+	} );
+
+	test( 'should convert shortcode with brackets in quoted attribute values', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/freeform',
+			attributes: {
+				content:
+					'<p>[my_shortcode param="foo" link_text="[Click here]" bar="baz"]</p>',
+			},
+		} );
+
+		await editor.clickBlockToolbarButton( 'Convert to blocks' );
+
+		// Should produce a single shortcode block, not an HTML block.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Shortcode',
+			} )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Custom HTML',
+			} )
+		).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
## What?
Closes #8937.

PR fixes a bug with the shortcode parser when values contain brackets. I've also updated `RegExp` to be more readable, similar to [`get_shortcode_regex()`](https://developer.wordpress.org/reference/functions/get_shortcode_regex/).

This change diverges the regex from the PHP equivalent a bit, but is required to correctly convert shortcodes.

## Why?
Previously, the regex would split the shortcode at the first `]` inside a quoted value, causing incorrect block conversion

## Testing Instructions
1. Create a post.
2. Add a Classic block with a shortcode that contains a parameter with bracketed text - `[my_shortcode param="foo" link_text="[Click here]" bar="baz"]`.
3. Try converting Classic to blocks.
4. A shortcode block should be generated correctly.

This is now covered by e2e tests.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Used Claude to update `RegExp`, it's better at it than me. Reviewed and tested changes manually.
