### PR TITLE
react-dom vendor script: remove __esModule flag

### DIFF
--- a/bin/packages/build-vendors.mjs
+++ b/bin/packages/build-vendors.mjs
@@ -23,8 +23,10 @@ const VENDOR_SCRIPTS = [
 		handle: 'react-dom',
 		dependencies: [ 'react' ],
 		contents: [
-			'export * from "react-dom";',
-			'export { createRoot, hydrateRoot } from "react-dom/client";',
+			'module.exports = {',
+			'  ...require("react-dom"),',
+			'  ...require("react-dom/client"),',
+			'};',
 		].join( '\n' ),
 	},
 	{


### PR DESCRIPTION
Followup to #76825 that fixes an issue reported in https://github.com/WordPress/gutenberg/pull/76825#issuecomment-4161007589 by @enricobattocchi.

The `react-dom` script has an unwanted `__esModule` flag. Some consumers expect such a module to have a `default` field, but our script doesn't have one. The entire module object is the default object, the CommonJS way.

This PR fixes that by converting the "synthetic" module to CommonJS. The original React modules are also all CJS.

**How to test:**
Load Gutenberg and look at `window.ReactDOM`. Before this patch, the object has an `__esModule` field. After this patch, the field is no longer there.