### PR TITLE
Tooltip: Expose controlled props (open, defaultOpen, onOpenChange) on Root

### DIFF
--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from '@wordpress/element';
 import { formatBold, formatItalic } from '@wordpress/icons';
 import { Icon, Tooltip } from '../..';
 
@@ -79,6 +80,28 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
  * This is useful when you have multiple tooltips and want them to share
  * the same delay configuration.
  */
+/**
+ * Use the `open` and `onOpenChange` props to take full control over the
+ * tooltip's visibility. This example toggles the tooltip on click.
+ */
+export const Controlled: StoryObj< typeof Tooltip.Root > = {
+	render: () => {
+		const [ open, setOpen ] = useState( false );
+
+		return (
+			<>
+				<button onClick={ () => setOpen( ( v ) => ! v ) }>
+					Toggle tooltip
+				</button>
+				<Tooltip.Root open={ open } onOpenChange={ setOpen }>
+					<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+					<Tooltip.Popup>Save</Tooltip.Popup>
+				</Tooltip.Root>
+			</>
+		);
+	},
+};
+
 export const WithProvider: StoryObj< typeof Tooltip.Root > = {
 	render: () => (
 		<Tooltip.Provider delay={ 0 }>

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -65,6 +65,21 @@ describe( 'Tooltip', () => {
 		} );
 	} );
 
+	it( 'shows tooltip when controlled open', async () => {
+		render(
+			<TestProvider>
+				<Tooltip.Root open>
+					<Tooltip.Trigger>Hover me</Tooltip.Trigger>
+					<Tooltip.Popup>Tooltip content</Tooltip.Popup>
+				</Tooltip.Root>
+			</TestProvider>
+		);
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Tooltip content' ) ).toBeVisible();
+		} );
+	} );
+
 	it( 'does not show tooltip when disabled', async () => {
 		const user = userEvent.setup();
 

--- a/packages/ui/src/tooltip/types.ts
+++ b/packages/ui/src/tooltip/types.ts
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 import type { Tooltip } from '@base-ui/react/tooltip';
 import type { ComponentProps } from '../utils/types';
 
-export type RootProps = Pick< Tooltip.Root.Props, 'disabled' | 'children' >;
+export type RootProps = Pick<
+	Tooltip.Root.Props,
+	'disabled' | 'children' | 'open' | 'defaultOpen' | 'onOpenChange'
+>;
 
 export type ProviderProps = Pick<
 	Tooltip.Provider.Props,


### PR DESCRIPTION
## What?

Expose `open`, `defaultOpen`, and `onOpenChange` props on `Tooltip.Root` in `@wordpress/ui`.

## Why?

`Tooltip.Root` currently only exposes `disabled` and `children` from Base UI's `Tooltip.Root.Props`, which blocks consumers from building controlled or click-triggered tooltips. Base UI already supports these props and the `Root` component already spreads all props through, so this is purely a type widening. This follows the same pattern used by `AlertDialog.Root` and `Dialog.Root` in this codebase.

## How?

- Widened `RootProps` in `packages/ui/src/tooltip/types.ts` to pick `open`, `defaultOpen`, and `onOpenChange` in addition to the existing `disabled` and `children`.
- No runtime changes needed — `root.tsx` already spreads all props to the Base UI component.
- Added a unit test verifying the controlled `open` prop renders the tooltip without hover.
- Added a `Controlled` Storybook story demonstrating click-to-toggle usage.

## Testing Instructions

1. Run `npm run test:unit packages/ui/src/tooltip` — all tests pass, including the new controlled-open test.
2. Run `npx storybook dev` and navigate to **Tooltip > Controlled** — clicking the "Toggle tooltip" button should show/hide the tooltip.
3. Verify TypeScript compiles: `npx tsc -p packages/ui/tsconfig.json --noEmit`.

### Testing Instructions for Keyboard

1. Tab to the "Toggle tooltip" button in the Controlled story.
2. Press Enter/Space to toggle the tooltip visibility.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Claude Opus 4.6).