### PR TITLE
ui/AlertDialog: better async confirm APIs, fully use base ui's `AlertDialog`

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Breaking Changes
 
 -   `Text`: Apply `margin: 0`, removing user-agent margins when the component renders as block-level elements (for example `p` or `h1`–`h6` via `render` prop) ([#76970](https://github.com/WordPress/gutenberg/pull/76970)).
+-   `AlertDialog`: Revise component API ([#76937](https://github.com/WordPress/gutenberg/pull/76937)):
+    -   `AlertDialog.Root`: moved `intent` prop to `AlertDialog.Popup`;
+    -   `AlertDialog.Popup`: moved `onConfirm` prop to `AlertDialog.Root` (now optional; supports async handlers, `{ close: false }` to keep the dialog open, and `{ error: '...' }` to display a built-in error message);
+    -   `AlertDialog.Popup`: removed `loading` prop (async flows are now handled internally via `Promise`-returning `onConfirm`);
+    -   `AlertDialog.Popup`: made `children` optional in favor of a new `description` prop, which describes the alert dialog semantically.
+
+### Internal
+
+-   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
 
 ### Bug Fixes
 

--- a/packages/ui/src/alert-dialog/context.tsx
+++ b/packages/ui/src/alert-dialog/context.tsx
@@ -1,14 +1,22 @@
 import { createContext } from '@wordpress/element';
-import type { RootProps } from './types';
 
-type Intent = NonNullable< RootProps[ 'intent' ] >;
+type Phase = 'idle' | 'pending' | 'closing';
 
 interface AlertDialogContextValue {
-	intent: Intent;
+	phase: Phase;
+	showSpinner: boolean;
+	errorMessage?: string;
+	confirm: () => Promise< void >;
 }
 
+const noop = async () => {};
+
 const AlertDialogContext = createContext< AlertDialogContextValue >( {
-	intent: 'default',
+	phase: 'idle',
+	showSpinner: false,
+	errorMessage: undefined,
+	confirm: noop,
 } );
 
 export { AlertDialogContext };
+export type { Phase };

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -1,56 +1,114 @@
+import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
+import clsx from 'clsx';
 import { forwardRef, useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+
 import { Button } from '../button';
-import * as Dialog from '../dialog';
+import dialogStyles from '../dialog/style.module.css';
+import { unlock } from '../lock-unlock';
+import { Stack } from '../stack';
+import { Text } from '../text';
 import { AlertDialogContext } from './context';
-import styles from './style.module.css';
+import alertDialogStyles from './style.module.css';
 import type { PopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const Popup = forwardRef< HTMLDivElement, PopupProps >(
 	function AlertDialogPopup(
 		{
+			className,
+			intent = 'default',
 			title,
+			description,
 			children,
-			onConfirm,
 			confirmButtonText = __( 'OK' ),
 			cancelButtonText = __( 'Cancel' ),
-			loading,
+			...props
 		},
 		ref
 	) {
-		const { intent } = useContext( AlertDialogContext );
+		const { phase, showSpinner, errorMessage, confirm } =
+			useContext( AlertDialogContext );
 
-		// When `loading` is provided, the consumer controls when the dialog
-		// closes (async flow). Use a plain Button so clicking confirm doesn't
-		// auto-close — the consumer sets `open={false}` after their operation.
-		const ConfirmButton = loading !== undefined ? Button : Dialog.Action;
+		const confirmClassName =
+			intent === 'irreversible'
+				? alertDialogStyles[ 'irreversible-action' ]
+				: undefined;
+
+		const buttonsDisabled = phase !== 'idle' || undefined;
 
 		return (
-			<Dialog.Popup ref={ ref }>
-				<Dialog.Header>
-					<Dialog.Title>{ title }</Dialog.Title>
-				</Dialog.Header>
-				{ children }
-				<Dialog.Footer>
-					<Dialog.Action
-						variant="minimal"
-						disabled={ loading || undefined }
+			<_AlertDialog.Portal>
+				<_AlertDialog.Backdrop className={ dialogStyles.backdrop } />
+				<ThemeProvider>
+					<_AlertDialog.Popup
+						ref={ ref }
+						className={ clsx(
+							dialogStyles.popup,
+							className,
+							dialogStyles[ 'is-medium' ]
+						) }
+						{ ...props }
 					>
-						{ cancelButtonText }
-					</Dialog.Action>
-					<ConfirmButton
-						className={
-							intent === 'irreversible'
-								? styles[ 'irreversible-action' ]
-								: undefined
-						}
-						onClick={ onConfirm }
-						loading={ loading }
-					>
-						{ confirmButtonText }
-					</ConfirmButton>
-				</Dialog.Footer>
-			</Dialog.Popup>
+						<Stack
+							direction="column"
+							gap="sm"
+							className={ alertDialogStyles.header }
+						>
+							<Text
+								variant="heading-xl"
+								render={ <_AlertDialog.Title /> }
+								className={ dialogStyles.title }
+							>
+								{ title }
+							</Text>
+							{ description && (
+								<Text
+									variant="body-md"
+									render={ <_AlertDialog.Description /> }
+								>
+									{ description }
+								</Text>
+							) }
+						</Stack>
+						{ children }
+						<Stack direction="column" gap="md">
+							<div className={ dialogStyles.footer }>
+								<_AlertDialog.Close
+									render={ <Button variant="minimal" /> }
+									disabled={ buttonsDisabled }
+								>
+									{ cancelButtonText }
+								</_AlertDialog.Close>
+								<Button
+									className={ confirmClassName }
+									onClick={ confirm }
+									loading={ showSpinner || undefined }
+									disabled={ buttonsDisabled }
+								>
+									{ confirmButtonText }
+								</Button>
+							</div>
+							{ errorMessage && (
+								<Text
+									variant="body-sm"
+									className={
+										alertDialogStyles[ 'error-message' ]
+									}
+								>
+									{ errorMessage }
+								</Text>
+							) }
+						</Stack>
+					</_AlertDialog.Popup>
+				</ThemeProvider>
+			</_AlertDialog.Portal>
 		);
 	}
 );

--- a/packages/ui/src/alert-dialog/root.tsx
+++ b/packages/ui/src/alert-dialog/root.tsx
@@ -1,7 +1,24 @@
 import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
-import { useMemo } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+
 import { AlertDialogContext } from './context';
+import type { Phase } from './context';
 import type { RootProps } from './types';
+
+function isThenable( value: unknown ): value is PromiseLike< unknown > {
+	return (
+		value !== null &&
+		value !== undefined &&
+		typeof ( value as PromiseLike< unknown > ).then === 'function'
+	);
+}
 
 /**
  * A dialog that requires a user response to proceed.
@@ -11,32 +28,193 @@ import type { RootProps } from './types';
  * The `AlertDialog.Trigger` is optional — the dialog can also be controlled
  * via `open` / `onOpenChange` props.
  *
- * ## Use cases
- *
- * - **Default intent**: Standard confirmation dialog for reversible actions.
- * - **Irreversible intent**: Confirmation dialog for irreversible actions that
- *   cannot be undone. The confirm button uses error/danger coloring.
- *
  * For use cases outside the standard confirm/cancel pattern, use the lower-level
  * `Dialog` component directly.
  *
- * See the [Destructive Actions guidelines](?path=/docs/design-system-patterns-destructive-actions--docs)
+ * See the [Destructive Actions guidelines](https://wordpress.github.io/gutenberg/?path=/docs/design-system-patterns-destructive-actions--docs)
  * for more details on when to use each pattern.
  */
 function Root( {
-	intent = 'default',
 	children,
-	open,
+	open: openProp,
 	onOpenChange,
 	defaultOpen,
+	onConfirm,
 }: RootProps ) {
-	const contextValue = useMemo( () => ( { intent } ), [ intent ] );
+	const [ internalOpen, setInternalOpen ] = useState( defaultOpen ?? false );
+
+	// Internal state machine for the confirm-and-close lifecycle.
+	//
+	// Phase transitions:
+	//
+	//   idle ──> pending ──> closing ──> idle
+	//           (confirm     (success,   (animation
+	//            clicked)     close)      complete)
+	//
+	//   idle ──> pending ──> idle
+	//           (confirm     (error, or
+	//            clicked)     {close:false})
+	//
+	//   idle ──> closing ──> idle
+	//           (cancel/     (animation
+	//            escape)      complete)
+	//
+	// `showSpinner` tracks whether the confirm button shows a loading
+	// indicator. It is orthogonal to `phase`:
+	//
+	//   Scenario                  | pending | closing
+	//   --------------------------+---------+---------
+	//   Sync onConfirm            | false   | false
+	//   Async onConfirm (success) | true    | true
+	//   Async onConfirm (error)   | true    | n/a (-> idle)
+	//   Cancel / Escape           | n/a     | false
+	//
+	// Buttons are disabled whenever phase !== 'idle'.
+	// Dismiss (Escape / Cancel) is blocked during 'pending'.
+	const [ phase, setPhase ] = useState< Phase >( 'idle' );
+	const [ showSpinner, setShowSpinner ] = useState( false );
+	const [ errorMessage, setErrorMessage ] = useState< string >();
+
+	const actionsRef = useRef< _AlertDialog.Root.Actions | null >( null );
+
+	const onConfirmRef = useRef( onConfirm );
+	onConfirmRef.current = onConfirm;
+
+	// Ref keeps phase accessible synchronously from callbacks that may
+	// run between a setState call and the subsequent React re-render.
+	const phaseRef = useRef( phase );
+	phaseRef.current = phase;
+
+	// Generation counter — safety net for the edge case where the component
+	// unmounts while an async confirm is in flight. Also incremented when
+	// the dialog finishes closing, so a stale promise settling after a
+	// dismiss+reopen cycle is silently discarded.
+	const confirmIdRef = useRef( 0 );
+
+	const effectiveOpen = openProp ?? internalOpen;
+
+	// Safety net: if the consumer keeps `open={true}` after a confirm
+	// (i.e. does not react to `onOpenChange`), the phase would be stuck
+	// at 'closing'. Detect the contradiction and reset to idle.
+	useEffect( () => {
+		if ( effectiveOpen && phase === 'closing' ) {
+			phaseRef.current = 'idle';
+			setPhase( 'idle' );
+			setShowSpinner( false );
+		}
+	}, [ effectiveOpen, phase ] );
+
+	const handleOpenChange = useCallback(
+		(
+			nextOpen: boolean,
+			eventDetails: _AlertDialog.Root.ChangeEventDetails
+		) => {
+			// Block dismiss while a confirm action is pending.
+			if ( ! nextOpen && phaseRef.current === 'pending' ) {
+				return;
+			}
+
+			if ( ! nextOpen && phaseRef.current === 'idle' ) {
+				phaseRef.current = 'closing';
+				setPhase( 'closing' );
+			}
+
+			setInternalOpen( nextOpen );
+			onOpenChange?.( nextOpen, eventDetails );
+		},
+		[ onOpenChange ]
+	);
+
+	const confirm = useCallback( async () => {
+		if ( phaseRef.current !== 'idle' ) {
+			return;
+		}
+
+		phaseRef.current = 'pending';
+		setPhase( 'pending' );
+		setErrorMessage( undefined );
+
+		const id = ++confirmIdRef.current;
+
+		try {
+			const rawResult = onConfirmRef.current?.();
+
+			// Show spinner only for async handlers (Promises).
+			// Sync handlers resolve in the same tick — no spinner needed.
+			if ( isThenable( rawResult ) ) {
+				setShowSpinner( true );
+			}
+
+			const result = await Promise.resolve( rawResult );
+
+			// Discard if the component unmounted or the dialog was
+			// dismissed and reopened while the promise was in flight.
+			if ( confirmIdRef.current !== id ) {
+				return;
+			}
+
+			// An error message implies the dialog should stay open.
+			if ( result?.error ) {
+				phaseRef.current = 'idle';
+				setPhase( 'idle' );
+				setShowSpinner( false );
+				setErrorMessage( result.error );
+				speak( result.error, 'assertive' );
+				return;
+			}
+
+			const shouldClose = result?.close !== false;
+
+			if ( shouldClose ) {
+				phaseRef.current = 'closing';
+				setPhase( 'closing' );
+				actionsRef.current?.close();
+			} else {
+				phaseRef.current = 'idle';
+				setPhase( 'idle' );
+				setShowSpinner( false );
+			}
+		} catch ( error ) {
+			if ( confirmIdRef.current !== id ) {
+				return;
+			}
+			phaseRef.current = 'idle';
+			setPhase( 'idle' );
+			setShowSpinner( false );
+			// eslint-disable-next-line no-console
+			console.error( error );
+		}
+	}, [] );
+
+	const handleOpenChangeComplete = useCallback( ( open: boolean ) => {
+		if ( ! open ) {
+			// Invalidate any in-flight async so a stale promise settling
+			// after dismiss+reopen doesn't close the new session.
+			confirmIdRef.current++;
+			phaseRef.current = 'idle';
+			setPhase( 'idle' );
+			setShowSpinner( false );
+			setErrorMessage( undefined );
+		}
+	}, [] );
+
+	const contextValue = useMemo(
+		() => ( {
+			phase,
+			showSpinner,
+			errorMessage,
+			confirm,
+		} ),
+		[ phase, showSpinner, errorMessage, confirm ]
+	);
 
 	return (
 		<_AlertDialog.Root
-			open={ open }
-			onOpenChange={ onOpenChange }
+			open={ effectiveOpen }
 			defaultOpen={ defaultOpen }
+			onOpenChange={ handleOpenChange }
+			onOpenChangeComplete={ handleOpenChangeComplete }
+			actionsRef={ actionsRef }
 		>
 			<AlertDialogContext.Provider value={ contextValue }>
 				{ children }

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -1,10 +1,10 @@
 import { Menu } from '@base-ui/react/menu';
-import { useState } from '@wordpress/element';
+import { useId, useState } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { action } from 'storybook/actions';
 import { fn } from 'storybook/test';
 
-import { AlertDialog } from '../..';
+import { AlertDialog, Text } from '../..';
 
 const meta: Meta< typeof AlertDialog.Root > = {
 	title: 'Design System/Components/AlertDialog',
@@ -14,6 +14,7 @@ const meta: Meta< typeof AlertDialog.Root > = {
 		'AlertDialog.Popup': AlertDialog.Popup,
 	},
 	argTypes: {
+		onConfirm: { action: fn() },
 		onOpenChange: { action: fn() },
 	},
 };
@@ -33,10 +34,8 @@ export const Default: Story = {
 				<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
 				<AlertDialog.Popup
 					title="Move to trash?"
-					onConfirm={ action( 'onConfirm' ) }
-				>
-					This post will be moved to trash. You can restore it later.
-				</AlertDialog.Popup>
+					description="This post will be moved to trash. You can restore it later."
+				/>
 			</>
 		),
 	},
@@ -48,38 +47,64 @@ export const Default: Story = {
  */
 export const Irreversible: Story = {
 	args: {
-		intent: 'irreversible',
 		children: (
 			<>
 				<AlertDialog.Trigger>Delete permanently</AlertDialog.Trigger>
 				<AlertDialog.Popup
+					intent="irreversible"
 					title="Delete permanently?"
-					onConfirm={ action( 'onConfirm' ) }
+					description="This action cannot be undone. All data will be lost."
 					confirmButtonText="Delete permanently"
-				>
-					This action cannot be undone. All data will be lost.
-				</AlertDialog.Popup>
+				/>
 			</>
 		),
 	},
 };
 
 /**
- * Example with custom button text for both confirm and cancel buttons.
+ * Example with custom button labels for both confirm and cancel buttons.
  */
-export const CustomButtonText: Story = {
+export const CustomLabels: Story = {
 	args: {
 		children: (
 			<>
 				<AlertDialog.Trigger>Send feedback</AlertDialog.Trigger>
 				<AlertDialog.Popup
 					title="Send feedback?"
-					onConfirm={ action( 'onConfirm' ) }
+					description="Your feedback helps us improve. Would you like to send it now?"
 					confirmButtonText="Send feedback"
 					cancelButtonText="Not now"
+				/>
+			</>
+		),
+	},
+};
+
+/**
+ * Use `children` to render custom content between the description and the
+ * action buttons. The `description` should be self-contained for
+ * accessibility (`aria-describedby`); `children` adds supplementary detail.
+ */
+export const WithCustomContent: Story = {
+	args: {
+		children: (
+			<>
+				<AlertDialog.Trigger>Remove pages</AlertDialog.Trigger>
+				<AlertDialog.Popup
+					title="Remove 3 pages?"
+					description="These pages will be moved to trash."
+					confirmButtonText="Delete pages"
 				>
-					Your feedback helps us improve. Would you like to send it
-					now?
+					<ul
+						style={ {
+							margin: 0,
+							paddingInlineStart: 'var(--wpds-dimension-gap-lg)',
+						} }
+					>
+						<Text render={ <li /> }>About us</Text>
+						<Text render={ <li /> }>Contact</Text>
+						<Text render={ <li /> }>Privacy policy</Text>
+					</ul>
 				</AlertDialog.Popup>
 			</>
 		),
@@ -117,10 +142,7 @@ const menuItemStyles: React.CSSProperties = {
  * component (not ready yet).
  */
 export const MenuTrigger: Story = {
-	args: {
-		intent: 'irreversible',
-	},
-	render: ( args ) => {
+	render: () => {
 		const [ menuOpen, setMenuOpen ] = useState( false );
 		return (
 			<>
@@ -132,7 +154,12 @@ export const MenuTrigger: Story = {
 								<Menu.Item style={ menuItemStyles }>
 									Edit
 								</Menu.Item>
-								<AlertDialog.Root { ...args }>
+								<AlertDialog.Root
+									onConfirm={ () => {
+										setMenuOpen( false );
+										action( 'onConfirm' )();
+									} }
+								>
 									<Menu.Item
 										render={
 											<AlertDialog.Trigger
@@ -147,16 +174,11 @@ export const MenuTrigger: Story = {
 									>
 										Delete...
 										<AlertDialog.Popup
+											intent="irreversible"
 											title="Delete permanently?"
-											onConfirm={ () => {
-												setMenuOpen( false );
-												action( 'onConfirm' )();
-											} }
+											description="This action cannot be undone. All data will be lost."
 											confirmButtonText="Delete permanently"
-										>
-											This action cannot be undone. All
-											data will be lost.
-										</AlertDialog.Popup>
+										/>
 									</Menu.Item>
 								</AlertDialog.Root>
 							</Menu.Popup>
@@ -168,55 +190,87 @@ export const MenuTrigger: Story = {
 	},
 };
 
+function sleep( ms: number ) {
+	return new Promise< void >( ( resolve ) => setTimeout( resolve, ms ) );
+}
+
 /**
- * Consumer-driven async confirm flow. The consumer uses controlled mode to
- * keep the dialog open while the async operation is in progress, and passes
- * `loading` to show a spinner on the confirm button and disable the cancel
- * button.
+ * Async confirm flow. The consumer returns a promise from `onConfirm`.
+ * The dialog automatically manages the pending state: buttons are disabled
+ * and a spinner appears on the confirm button. Toggle between success and
+ * failure to test both outcomes.
+ *
+ * On failure, the consumer catches the error and returns
+ * `{ close: false, error: '...' }`. The component displays the message
+ * below the action buttons and announces it to screen readers. The error
+ * is automatically cleared on the next confirm attempt or when the dialog
+ * reopens.
  */
 export const AsyncConfirm: Story = {
 	render: function AsyncConfirm( args ) {
-		const [ isOpen, setIsOpen ] = useState( false );
-		const [ isLoading, setIsLoading ] = useState( false );
+		const [ shouldFail, setShouldFail ] = useState( false );
+		const successId = useId();
+		const failureId = useId();
 
 		return (
 			<>
-				<button onClick={ () => setIsOpen( true ) }>
-					Delete permanently
-				</button>
+				<fieldset>
+					<legend>Async task outcome</legend>
+					<label htmlFor={ successId }>
+						<input
+							id={ successId }
+							type="radio"
+							name="async-outcome"
+							checked={ ! shouldFail }
+							onChange={ () => setShouldFail( false ) }
+						/>
+						Success (closes dialog)
+					</label>
+					<label
+						htmlFor={ failureId }
+						style={ { marginInlineStart: 12 } }
+					>
+						<input
+							id={ failureId }
+							type="radio"
+							name="async-outcome"
+							checked={ shouldFail }
+							onChange={ () => setShouldFail( true ) }
+						/>
+						Failure (dialog stays open, shows error)
+					</label>
+				</fieldset>
+				<br />
 				<AlertDialog.Root
 					{ ...args }
-					open={ isOpen }
-					onOpenChange={ ( open, eventDetails ) => {
-						if ( ! isLoading ) {
-							setIsOpen( open );
+					onConfirm={ async () => {
+						action( 'onConfirm' )();
+						try {
+							await sleep( 2000 );
+							if ( shouldFail ) {
+								throw new Error( 'Task failed' );
+							}
+						} catch {
+							return {
+								close: false,
+								error: 'Something went wrong. Please try again.',
+							};
 						}
-						args.onOpenChange?.( open, eventDetails );
+						return undefined;
 					} }
 				>
+					<AlertDialog.Trigger>
+						Delete permanently
+					</AlertDialog.Trigger>
 					<AlertDialog.Popup
+						intent="irreversible"
 						title="Delete permanently?"
-						loading={ isLoading }
-						onConfirm={ () => {
-							action( 'onConfirm' )();
-							setIsLoading( true );
-							new Promise< void >( ( resolve ) =>
-								setTimeout( resolve, 2000 )
-							).then( () => {
-								setIsLoading( false );
-								setIsOpen( false );
-							} );
-						} }
+						description="This action cannot be undone. All data will be lost."
 						confirmButtonText="Delete permanently"
-					>
-						This action cannot be undone. All data will be lost.
-					</AlertDialog.Popup>
+					/>
 				</AlertDialog.Root>
 			</>
 		);
-	},
-	args: {
-		intent: 'irreversible',
 	},
 };
 
@@ -242,11 +296,8 @@ export const Controlled: Story = {
 				>
 					<AlertDialog.Popup
 						title="Move to trash?"
-						onConfirm={ action( 'onConfirm' ) }
-					>
-						This post will be moved to trash. You can restore it
-						later.
-					</AlertDialog.Popup>
+						description="This post will be moved to trash. You can restore it later."
+					/>
 				</AlertDialog.Root>
 			</>
 		);

--- a/packages/ui/src/alert-dialog/style.module.css
+++ b/packages/ui/src/alert-dialog/style.module.css
@@ -1,5 +1,16 @@
 @layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
 
+@layer wp-ui-components {
+	.header {
+		margin-bottom: var(--wpds-dimension-gap-lg);
+	}
+
+	.error-message {
+		align-self: flex-end;
+		color: var(--wpds-color-fg-content-error);
+	}
+}
+
 @layer wp-ui-compositions {
 	.irreversible-action {
 		--wp-ui-button-background-color: var(--wpds-color-bg-interactive-error-strong);

--- a/packages/ui/src/alert-dialog/test/index.test.tsx
+++ b/packages/ui/src/alert-dialog/test/index.test.tsx
@@ -1,8 +1,24 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { speak } from '@wordpress/a11y';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createRef, useState } from '@wordpress/element';
+import { createRef } from '@wordpress/element';
 
 import * as AlertDialog from '..';
+import type { ConfirmResult } from '../types';
+
+jest.mock( '@wordpress/a11y', () => ( {
+	speak: jest.fn(),
+} ) );
+
+function createDeferred() {
+	let resolve!: ( value?: ConfirmResult ) => void;
+	let reject!: ( reason?: unknown ) => void;
+	const promise = new Promise< ConfirmResult >( ( res, rej ) => {
+		resolve = res;
+		reject = rej;
+	} );
+	return { promise, resolve, reject };
+}
 
 describe( 'AlertDialog', () => {
 	it( 'forwards ref', () => {
@@ -14,12 +30,8 @@ describe( 'AlertDialog', () => {
 				<AlertDialog.Trigger ref={ triggerRef }>
 					Open
 				</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					ref={ popupRef }
-					title="Test Title"
-					onConfirm={ jest.fn() }
-				>
-					Test message content
+				<AlertDialog.Popup ref={ popupRef } title="Test Title">
+					Content
 				</AlertDialog.Popup>
 			</AlertDialog.Root>
 		);
@@ -28,10 +40,10 @@ describe( 'AlertDialog', () => {
 		expect( popupRef.current ).toBeInstanceOf( HTMLDivElement );
 	} );
 
-	it( 'renders with title, message, and default buttons', async () => {
+	it( 'renders with title, children, and default buttons', async () => {
 		render(
 			<AlertDialog.Root open onOpenChange={ jest.fn() }>
-				<AlertDialog.Popup title="Test Title" onConfirm={ jest.fn() }>
+				<AlertDialog.Popup title="Test Title">
 					Test message content
 				</AlertDialog.Popup>
 			</AlertDialog.Root>
@@ -51,13 +63,27 @@ describe( 'AlertDialog', () => {
 		).toBeVisible();
 	} );
 
-	it( 'renders with role="alertdialog" for default intent', async () => {
+	it( 'renders description when provided', async () => {
 		render(
 			<AlertDialog.Root open onOpenChange={ jest.fn() }>
 				<AlertDialog.Popup
-					title="Default Dialog"
-					onConfirm={ jest.fn() }
+					title="Test Title"
+					description="This is a description"
 				>
+					Body content
+				</AlertDialog.Popup>
+			</AlertDialog.Root>
+		);
+
+		await waitFor( () => {
+			expect( screen.getByText( 'This is a description' ) ).toBeVisible();
+		} );
+	} );
+
+	it( 'renders with role="alertdialog" for default intent', async () => {
+		render(
+			<AlertDialog.Root open onOpenChange={ jest.fn() }>
+				<AlertDialog.Popup title="Default Dialog">
 					Content
 				</AlertDialog.Popup>
 			</AlertDialog.Root>
@@ -70,14 +96,10 @@ describe( 'AlertDialog', () => {
 
 	it( 'renders with role="alertdialog" for irreversible intent', async () => {
 		render(
-			<AlertDialog.Root
-				intent="irreversible"
-				open
-				onOpenChange={ jest.fn() }
-			>
+			<AlertDialog.Root open onOpenChange={ jest.fn() }>
 				<AlertDialog.Popup
+					intent="irreversible"
 					title="Irreversible Dialog"
-					onConfirm={ jest.fn() }
 				>
 					Content
 				</AlertDialog.Popup>
@@ -89,343 +111,15 @@ describe( 'AlertDialog', () => {
 		} );
 	} );
 
-	it( 'calls onConfirm and onOpenChange when confirm button is clicked', async () => {
-		const onConfirm = jest.fn();
-		const onOpenChange = jest.fn();
-
-		render(
-			<AlertDialog.Root open onOpenChange={ onOpenChange }>
-				<AlertDialog.Popup
-					title="Confirm Action"
-					onConfirm={ onConfirm }
-				>
-					Are you sure?
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect(
-				screen.getByRole( 'button', { name: 'OK' } )
-			).toBeVisible();
-		} );
-
-		await userEvent.click( screen.getByRole( 'button', { name: 'OK' } ) );
-
-		expect( onConfirm ).toHaveBeenCalledTimes( 1 );
-		expect( onOpenChange ).toHaveBeenCalledWith(
-			false,
-			expect.objectContaining( { reason: 'close-press' } )
-		);
-	} );
-
-	it( 'calls onOpenChange when cancel button is clicked', async () => {
-		const onConfirm = jest.fn();
-		const onOpenChange = jest.fn();
-
-		render(
-			<AlertDialog.Root open onOpenChange={ onOpenChange }>
-				<AlertDialog.Popup
-					title="Confirm Action"
-					onConfirm={ onConfirm }
-				>
-					Are you sure?
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect(
-				screen.getByRole( 'button', { name: 'Cancel' } )
-			).toBeVisible();
-		} );
-
-		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Cancel' } )
-		);
-
-		expect( onOpenChange ).toHaveBeenCalledWith(
-			false,
-			expect.objectContaining( { reason: 'close-press' } )
-		);
-		expect( onConfirm ).not.toHaveBeenCalled();
-	} );
-
-	it( 'calls onOpenChange on escape key for default intent', async () => {
-		const onOpenChange = jest.fn();
-
-		render(
-			<AlertDialog.Root open onOpenChange={ onOpenChange }>
-				<AlertDialog.Popup
-					title="Default Dialog"
-					onConfirm={ jest.fn() }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Default Dialog' ) ).toBeVisible();
-		} );
-
-		await userEvent.keyboard( '{Escape}' );
-
-		expect( onOpenChange ).toHaveBeenCalledWith(
-			false,
-			expect.objectContaining( { reason: 'escape-key' } )
-		);
-	} );
-
-	it( 'does not call onOpenChange on backdrop click for default intent', async () => {
-		const onOpenChange = jest.fn();
-
-		render(
-			<AlertDialog.Root open onOpenChange={ onOpenChange }>
-				<AlertDialog.Popup
-					title="Default Dialog"
-					onConfirm={ jest.fn() }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Default Dialog' ) ).toBeVisible();
-		} );
-
-		await userEvent.click( document.body );
-
-		expect( onOpenChange ).not.toHaveBeenCalled();
-	} );
-
-	it( 'renders with title, message, and default buttons for irreversible intent', async () => {
-		render(
-			<AlertDialog.Root
-				intent="irreversible"
-				open
-				onOpenChange={ jest.fn() }
-			>
-				<AlertDialog.Popup
-					title="Irreversible Dialog"
-					onConfirm={ jest.fn() }
-				>
-					Irreversible message content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Irreversible Dialog' ) ).toBeVisible();
-		} );
-
-		expect(
-			screen.getByText( 'Irreversible message content' )
-		).toBeVisible();
-		expect(
-			screen.queryByRole( 'button', { name: 'Close' } )
-		).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'OK' } ) ).toBeVisible();
-		expect(
-			screen.getByRole( 'button', { name: 'Cancel' } )
-		).toBeVisible();
-	} );
-
-	it( 'calls onOpenChange on escape key for irreversible intent', async () => {
-		const onOpenChange = jest.fn();
-
-		render(
-			<AlertDialog.Root
-				intent="irreversible"
-				open
-				onOpenChange={ onOpenChange }
-			>
-				<AlertDialog.Popup
-					title="Irreversible Dialog"
-					onConfirm={ jest.fn() }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Irreversible Dialog' ) ).toBeVisible();
-		} );
-
-		await userEvent.keyboard( '{Escape}' );
-
-		expect( onOpenChange ).toHaveBeenCalledWith(
-			false,
-			expect.objectContaining( { reason: 'escape-key' } )
-		);
-	} );
-
-	it( 'does not call onOpenChange on backdrop click for irreversible intent', async () => {
-		const onOpenChange = jest.fn();
-
-		render(
-			<AlertDialog.Root
-				intent="irreversible"
-				open
-				onOpenChange={ onOpenChange }
-			>
-				<AlertDialog.Popup
-					title="Irreversible Dialog"
-					onConfirm={ jest.fn() }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Irreversible Dialog' ) ).toBeVisible();
-		} );
-
-		await userEvent.click( document.body );
-
-		expect( onOpenChange ).not.toHaveBeenCalled();
-	} );
-
-	it( 'calls onOpenChange on cancel button click for irreversible intent', async () => {
-		const onOpenChange = jest.fn();
-		const onConfirm = jest.fn();
-
-		render(
-			<AlertDialog.Root
-				intent="irreversible"
-				open
-				onOpenChange={ onOpenChange }
-			>
-				<AlertDialog.Popup
-					title="Irreversible Dialog"
-					onConfirm={ onConfirm }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect(
-				screen.getByRole( 'button', { name: 'Cancel' } )
-			).toBeVisible();
-		} );
-
-		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Cancel' } )
-		);
-
-		expect( onOpenChange ).toHaveBeenCalledWith(
-			false,
-			expect.objectContaining( { reason: 'close-press' } )
-		);
-		expect( onConfirm ).not.toHaveBeenCalled();
-	} );
-
-	it( 'calls onConfirm and onOpenChange on confirm button click for irreversible intent', async () => {
-		const onOpenChange = jest.fn();
-		const onConfirm = jest.fn();
-
-		render(
-			<AlertDialog.Root
-				intent="irreversible"
-				open
-				onOpenChange={ onOpenChange }
-			>
-				<AlertDialog.Popup
-					title="Irreversible Dialog"
-					onConfirm={ onConfirm }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect(
-				screen.getByRole( 'button', { name: 'OK' } )
-			).toBeVisible();
-		} );
-
-		await userEvent.click( screen.getByRole( 'button', { name: 'OK' } ) );
-
-		expect( onConfirm ).toHaveBeenCalledTimes( 1 );
-		expect( onOpenChange ).toHaveBeenCalledWith(
-			false,
-			expect.objectContaining( { reason: 'close-press' } )
-		);
-	} );
-
-	it( 'disables both buttons when loading', async () => {
+	it( 'uses custom button labels', async () => {
 		render(
 			<AlertDialog.Root open onOpenChange={ jest.fn() }>
 				<AlertDialog.Popup
-					title="Loading Test"
-					onConfirm={ jest.fn() }
-					loading
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect(
-				screen.getByRole( 'button', { name: 'OK' } )
-			).toBeVisible();
-		} );
-
-		expect( screen.getByRole( 'button', { name: 'OK' } ) ).toHaveAttribute(
-			'aria-disabled',
-			'true'
-		);
-
-		expect(
-			screen.getByRole( 'button', { name: 'Cancel' } )
-		).toHaveAttribute( 'aria-disabled', 'true' );
-	} );
-
-	it( 'does not disable buttons when loading is false', async () => {
-		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
-				<AlertDialog.Popup
-					title="No Loading"
-					onConfirm={ jest.fn() }
-					loading={ false }
-				>
-					Content
-				</AlertDialog.Popup>
-			</AlertDialog.Root>
-		);
-
-		await waitFor( () => {
-			expect(
-				screen.getByRole( 'button', { name: 'OK' } )
-			).toBeVisible();
-		} );
-
-		expect(
-			screen.getByRole( 'button', { name: 'OK' } )
-		).not.toHaveAttribute( 'aria-disabled', 'true' );
-
-		expect(
-			screen.getByRole( 'button', { name: 'Cancel' } )
-		).not.toHaveAttribute( 'aria-disabled', 'true' );
-	} );
-
-	it( 'uses custom button text when provided', async () => {
-		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
-				<AlertDialog.Popup
-					title="Custom Text"
-					onConfirm={ jest.fn() }
+					title="Custom Labels"
 					confirmButtonText="Yes, do it"
 					cancelButtonText="No, go back"
 				>
-					Custom message
+					Content
 				</AlertDialog.Popup>
 			</AlertDialog.Root>
 		);
@@ -441,82 +135,11 @@ describe( 'AlertDialog', () => {
 		).toBeVisible();
 	} );
 
-	it( 'keeps dialog open when confirm is clicked with loading prop (async flow)', async () => {
-		function AsyncDialog() {
-			const [ isOpen, setIsOpen ] = useState( true );
-			const [ isLoading, setIsLoading ] = useState( false );
-
-			return (
-				<AlertDialog.Root
-					open={ isOpen }
-					onOpenChange={ ( open ) => {
-						if ( ! isLoading ) {
-							setIsOpen( open );
-						}
-					} }
-				>
-					<AlertDialog.Popup
-						title="Async Test"
-						loading={ isLoading }
-						onConfirm={ () => setIsLoading( true ) }
-					>
-						Content
-					</AlertDialog.Popup>
-				</AlertDialog.Root>
-			);
-		}
-
-		render( <AsyncDialog /> );
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Async Test' ) ).toBeVisible();
-		} );
-
-		await userEvent.click( screen.getByRole( 'button', { name: 'OK' } ) );
-
-		expect( screen.getByText( 'Async Test' ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'OK' } ) ).toHaveAttribute(
-			'aria-disabled',
-			'true'
-		);
-	} );
-
-	it( 'does not auto-close on confirm click when loading is false (manual-close mode)', async () => {
-		function ManualCloseDialog() {
-			const [ isOpen, setIsOpen ] = useState( true );
-
-			return (
-				<AlertDialog.Root
-					open={ isOpen }
-					onOpenChange={ ( open ) => setIsOpen( open ) }
-				>
-					<AlertDialog.Popup
-						title="Manual Close"
-						loading={ false }
-						onConfirm={ jest.fn() }
-					>
-						Content
-					</AlertDialog.Popup>
-				</AlertDialog.Root>
-			);
-		}
-
-		render( <ManualCloseDialog /> );
-
-		await waitFor( () => {
-			expect( screen.getByText( 'Manual Close' ) ).toBeVisible();
-		} );
-
-		await userEvent.click( screen.getByRole( 'button', { name: 'OK' } ) );
-
-		expect( screen.getByText( 'Manual Close' ) ).toBeVisible();
-	} );
-
 	it( 'opens dialog when Trigger is clicked', async () => {
 		render(
 			<AlertDialog.Root>
 				<AlertDialog.Trigger>Open</AlertDialog.Trigger>
-				<AlertDialog.Popup title="Trigger Test" onConfirm={ jest.fn() }>
+				<AlertDialog.Popup title="Trigger Test">
 					Dialog content
 				</AlertDialog.Popup>
 			</AlertDialog.Root>
@@ -533,5 +156,1300 @@ describe( 'AlertDialog', () => {
 		} );
 
 		expect( screen.getByText( 'Dialog content' ) ).toBeVisible();
+	} );
+
+	describe( 'sync confirm flow', () => {
+		it( 'calls onConfirm and closes on confirm click', async () => {
+			const onConfirm = jest.fn();
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Sync Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			expect( onConfirm ).toHaveBeenCalledTimes( 1 );
+			await waitFor( () => {
+				expect( onOpenChange ).toHaveBeenCalledWith(
+					false,
+					expect.objectContaining( {
+						reason: 'imperative-action',
+					} )
+				);
+			} );
+		} );
+
+		it( 'provides well-formed event details on confirm close', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ jest.fn() }
+				>
+					<AlertDialog.Popup title="Details Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect( onOpenChange ).toHaveBeenCalledWith(
+					false,
+					expect.objectContaining( {
+						reason: 'imperative-action',
+					} )
+				);
+			} );
+
+			const details = onOpenChange.mock.calls.find(
+				( [ open ]: [ boolean ] ) => ! open
+			)?.[ 1 ];
+
+			expect( details ).toBeDefined();
+			expect( typeof details.cancel ).toBe( 'function' );
+			expect( typeof details.allowPropagation ).toBe( 'function' );
+			expect( typeof details.preventUnmountOnClose ).toBe( 'function' );
+			expect( details.event ).toBeInstanceOf( Event );
+		} );
+
+		it( 'closes without onConfirm when no handler is provided', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root open onOpenChange={ onOpenChange }>
+					<AlertDialog.Popup title="No Handler">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect( onOpenChange ).toHaveBeenCalledWith(
+					false,
+					expect.objectContaining( {
+						reason: 'imperative-action',
+					} )
+				);
+			} );
+		} );
+	} );
+
+	describe( 'cancel and dismiss', () => {
+		it( 'closes on cancel click without calling onConfirm', async () => {
+			const onConfirm = jest.fn();
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Cancel Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'Cancel' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			);
+
+			expect( onOpenChange ).toHaveBeenCalledWith(
+				false,
+				expect.objectContaining( { reason: 'close-press' } )
+			);
+			expect( onConfirm ).not.toHaveBeenCalled();
+		} );
+
+		it( 'closes on escape key', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root open onOpenChange={ onOpenChange }>
+					<AlertDialog.Popup title="Escape Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Escape Test' ) ).toBeVisible();
+			} );
+
+			await userEvent.keyboard( '{Escape}' );
+
+			expect( onOpenChange ).toHaveBeenCalledWith(
+				false,
+				expect.objectContaining( { reason: 'escape-key' } )
+			);
+		} );
+
+		it( 'does not close on backdrop click', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root open onOpenChange={ onOpenChange }>
+					<AlertDialog.Popup title="Backdrop Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Backdrop Test' ) ).toBeVisible();
+			} );
+
+			await userEvent.click( document.body );
+
+			expect( onOpenChange ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'irreversible intent', () => {
+		it( 'renders title and buttons', async () => {
+			render(
+				<AlertDialog.Root open onOpenChange={ jest.fn() }>
+					<AlertDialog.Popup
+						intent="irreversible"
+						title="Irreversible Dialog"
+					>
+						Irreversible message content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Irreversible Dialog' )
+				).toBeVisible();
+			} );
+
+			expect(
+				screen.getByText( 'Irreversible message content' )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'button', { name: 'OK' } )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			).toBeVisible();
+		} );
+
+		it( 'closes on escape key', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root open onOpenChange={ onOpenChange }>
+					<AlertDialog.Popup
+						intent="irreversible"
+						title="Irreversible Dialog"
+					>
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Irreversible Dialog' )
+				).toBeVisible();
+			} );
+
+			await userEvent.keyboard( '{Escape}' );
+
+			expect( onOpenChange ).toHaveBeenCalledWith(
+				false,
+				expect.objectContaining( { reason: 'escape-key' } )
+			);
+		} );
+
+		it( 'does not close on backdrop click', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root open onOpenChange={ onOpenChange }>
+					<AlertDialog.Popup
+						intent="irreversible"
+						title="Irreversible Dialog"
+					>
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Irreversible Dialog' )
+				).toBeVisible();
+			} );
+
+			await userEvent.click( document.body );
+
+			expect( onOpenChange ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'async confirm flow', () => {
+		it( 'disables buttons while confirm is pending', async () => {
+			const deferred = createDeferred();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Async Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
+
+			await act( async () => {
+				deferred.resolve();
+			} );
+		} );
+
+		it( 'closes dialog when async confirm resolves', async () => {
+			const deferred = createDeferred();
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Async Resolve">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await act( async () => {
+				deferred.resolve();
+			} );
+
+			await waitFor( () => {
+				expect( onOpenChange ).toHaveBeenCalledWith(
+					false,
+					expect.objectContaining( {
+						reason: 'imperative-action',
+					} )
+				);
+			} );
+		} );
+
+		it( 're-enables buttons when async confirm rejects (task failure)', async () => {
+			const deferred = createDeferred();
+			const consoleSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation( () => {} );
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Async Reject">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			await act( async () => {
+				deferred.reject( new Error( 'Task failed' ) );
+			} );
+
+			// The error is caught and logged via console.error in Root.
+			await waitFor( () => {
+				expect( consoleSpy ).toHaveBeenCalledWith(
+					expect.objectContaining( { message: 'Task failed' } )
+				);
+			} );
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).not.toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			).not.toHaveAttribute( 'aria-disabled', 'true' );
+
+			expect( screen.getByText( 'Async Reject' ) ).toBeVisible();
+
+			// Throws do NOT render a visible error message.
+			expect(
+				screen.queryByText( 'Task failed' )
+			).not.toBeInTheDocument();
+
+			consoleSpy.mockRestore();
+		} );
+
+		it( 'keeps dialog open when confirm returns { close: false }', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ () => ( { close: false } ) }
+				>
+					<AlertDialog.Popup title="Keep Open">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).not.toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect( onOpenChange ).not.toHaveBeenCalledWith(
+				false,
+				expect.anything()
+			);
+			expect( screen.getByText( 'Keep Open' ) ).toBeVisible();
+		} );
+
+		it( 'keeps dialog open when async confirm returns { close: false }', async () => {
+			const deferred = createDeferred();
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Async Keep Open">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			await act( async () => {
+				deferred.resolve( { close: false } );
+			} );
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).not.toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect( onOpenChange ).not.toHaveBeenCalledWith(
+				false,
+				expect.anything()
+			);
+		} );
+
+		it( 'blocks dismiss while pending by default', async () => {
+			const deferred = createDeferred();
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Block Dismiss">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			await userEvent.keyboard( '{Escape}' );
+
+			expect( onOpenChange ).not.toHaveBeenCalledWith(
+				false,
+				expect.anything()
+			);
+
+			await act( async () => {
+				deferred.resolve();
+			} );
+		} );
+
+		it( 'ignores duplicate confirm clicks while pending', async () => {
+			const onConfirm = jest.fn(
+				() =>
+					new Promise< void >( () => {
+						// Never resolves
+					} )
+			);
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Double Click">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			expect( onConfirm ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'uncontrolled mode', () => {
+		it( 'renders dialog open when defaultOpen is true', async () => {
+			render(
+				<AlertDialog.Root defaultOpen>
+					<AlertDialog.Trigger>Open</AlertDialog.Trigger>
+					<AlertDialog.Popup title="Default Open">
+						Dialog content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'alertdialog' ) ).toBeVisible();
+			} );
+			expect( screen.getByText( 'Default Open' ) ).toBeVisible();
+			expect( screen.getByText( 'Dialog content' ) ).toBeVisible();
+		} );
+
+		it( 'allows closing and reopening after defaultOpen', async () => {
+			render(
+				<AlertDialog.Root defaultOpen>
+					<AlertDialog.Trigger>Open</AlertDialog.Trigger>
+					<AlertDialog.Popup title="Reopen Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'alertdialog' ) ).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'alertdialog' )
+				).not.toBeInTheDocument();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Open' } )
+			);
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'alertdialog' ) ).toBeVisible();
+			} );
+		} );
+
+		it( 'opens and closes via cancel', async () => {
+			const onConfirm = jest.fn();
+
+			render(
+				<AlertDialog.Root onConfirm={ onConfirm }>
+					<AlertDialog.Trigger>Open</AlertDialog.Trigger>
+					<AlertDialog.Popup title="Uncontrolled">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			expect( screen.queryByText( 'Content' ) ).not.toBeInTheDocument();
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Open' } )
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Uncontrolled' ) ).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.queryByText( 'Uncontrolled' )
+				).not.toBeInTheDocument();
+			} );
+		} );
+
+		it( 'closes and unmounts dialog via confirm click', async () => {
+			const onConfirm = jest.fn();
+
+			render(
+				<AlertDialog.Root onConfirm={ onConfirm }>
+					<AlertDialog.Trigger>Open</AlertDialog.Trigger>
+					<AlertDialog.Popup title="Uncontrolled Confirm">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Open' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Uncontrolled Confirm' )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			expect( onConfirm ).toHaveBeenCalledTimes( 1 );
+
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'alertdialog' )
+				).not.toBeInTheDocument();
+			} );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'does not error when unmounted during pending', async () => {
+			const deferred = createDeferred();
+
+			const { unmount } = render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Unmount Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			// Unmount while pending — should not throw
+			unmount();
+
+			// Resolve the deferred — should be a no-op after unmount
+			await act( async () => {
+				deferred.resolve();
+			} );
+		} );
+
+		it( 'controlled mode: recovers to idle when consumer keeps dialog open after confirm', async () => {
+			const onConfirm = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Deadlock Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			expect( onConfirm ).toHaveBeenCalledTimes( 1 );
+
+			// Consumer passes open={true} and does NOT update it in
+			// onOpenChange, so phase would be stuck at 'closing'.
+			// The safety-net useEffect should recover phase to 'idle'.
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).not.toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			).not.toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'recovers when onConfirm throws synchronously', async () => {
+			const onConfirm = jest.fn( () => {
+				throw new Error( 'Sync error' );
+			} );
+			const onOpenChange = jest.fn();
+			const consoleSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation( () => {} );
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Throw Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			// The error is caught and logged via console.error in Root.
+			await waitFor( () => {
+				expect( consoleSpy ).toHaveBeenCalledWith(
+					expect.objectContaining( { message: 'Sync error' } )
+				);
+			} );
+
+			// Dialog stays open and buttons return to idle
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).not.toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect( onOpenChange ).not.toHaveBeenCalledWith(
+				false,
+				expect.anything()
+			);
+			expect( screen.getByText( 'Throw Test' ) ).toBeVisible();
+
+			// Throws do NOT render a visible error message.
+			expect(
+				screen.queryByText( 'Sync error' )
+			).not.toBeInTheDocument();
+
+			consoleSpy.mockRestore();
+		} );
+
+		it( 'sets aria-describedby when description is provided', async () => {
+			render(
+				<AlertDialog.Root open onOpenChange={ jest.fn() }>
+					<AlertDialog.Popup
+						title="Describedby Test"
+						description="A helpful description"
+					>
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'alertdialog' ) ).toBeVisible();
+			} );
+
+			const dialog = screen.getByRole( 'alertdialog' );
+			expect( dialog ).toHaveAccessibleDescription(
+				'A helpful description'
+			);
+		} );
+
+		it( 'allows re-confirm after { close: false, error }', async () => {
+			const deferred = createDeferred();
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Error Retry">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			// First confirm — returns error
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await act( async () => {
+				deferred.resolve( {
+					close: false,
+					error: 'Validation failed',
+				} );
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Validation failed' ) ).toBeVisible();
+			} );
+
+			// Buttons are re-enabled, user can retry
+			expect(
+				screen.getByRole( 'button', { name: 'OK' } )
+			).not.toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'allows re-confirm after { close: false }', async () => {
+			let callCount = 0;
+			const onConfirm = jest.fn( (): { close: boolean } | undefined => {
+				callCount++;
+				if ( callCount === 1 ) {
+					return { close: false };
+				}
+				return undefined;
+			} );
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Retry Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			// First confirm — returns { close: false }
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).not.toHaveAttribute( 'aria-disabled', 'true' );
+			} );
+
+			expect( onOpenChange ).not.toHaveBeenCalledWith(
+				false,
+				expect.anything()
+			);
+
+			// Second confirm — returns void → should close
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect( onOpenChange ).toHaveBeenCalledWith(
+					false,
+					expect.objectContaining( {
+						reason: 'imperative-action',
+					} )
+				);
+			} );
+
+			expect( onConfirm ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+
+	describe( 'error handling', () => {
+		beforeEach( () => {
+			( speak as jest.Mock ).mockClear();
+		} );
+
+		it( 'displays error message when onConfirm returns { close: false, error }', async () => {
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => ( {
+						close: false,
+						error: 'Something went wrong.',
+					} ) }
+				>
+					<AlertDialog.Popup title="Error Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Something went wrong.' )
+				).toBeVisible();
+			} );
+		} );
+
+		it( 'displays error message from async onConfirm', async () => {
+			const deferred = createDeferred();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => deferred.promise }
+				>
+					<AlertDialog.Popup title="Async Error">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await act( async () => {
+				deferred.resolve( {
+					close: false,
+					error: 'Server error occurred.',
+				} );
+			} );
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Server error occurred.' )
+				).toBeVisible();
+			} );
+
+			// Buttons return to idle
+			expect(
+				screen.getByRole( 'button', { name: 'OK' } )
+			).not.toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'stays open when error is returned without explicit close: false', async () => {
+			const onOpenChange = jest.fn();
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ onOpenChange }
+					onConfirm={ () => ( { error: 'Implicit stay open.' } ) }
+				>
+					<AlertDialog.Popup title="Implicit Close">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Implicit stay open.' )
+				).toBeVisible();
+			} );
+
+			// Dialog stays open — onOpenChange(false) was not called
+			expect( onOpenChange ).not.toHaveBeenCalledWith(
+				false,
+				expect.anything()
+			);
+		} );
+
+		it( 'clears error message on next confirm attempt', async () => {
+			let callCount = 0;
+			const onConfirm = jest.fn( (): ConfirmResult => {
+				callCount++;
+				if ( callCount === 1 ) {
+					return {
+						close: false,
+						error: 'First attempt failed.',
+					};
+				}
+				return undefined;
+			} );
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ onConfirm }
+				>
+					<AlertDialog.Popup title="Clear Error">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			// First confirm — shows error
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'First attempt failed.' )
+				).toBeVisible();
+			} );
+
+			// Second confirm — error should be cleared
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.queryByText( 'First attempt failed.' )
+				).not.toBeInTheDocument();
+			} );
+		} );
+
+		it( 'clears error message when dialog reopens', async () => {
+			render(
+				<AlertDialog.Root
+					onConfirm={ () => ( {
+						close: false,
+						error: 'Persistent error.',
+					} ) }
+				>
+					<AlertDialog.Trigger>Open</AlertDialog.Trigger>
+					<AlertDialog.Popup title="Reopen Clear">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			// Open dialog
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Open' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			// Trigger error
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Persistent error.' ) ).toBeVisible();
+			} );
+
+			// Close via cancel
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'alertdialog' )
+				).not.toBeInTheDocument();
+			} );
+
+			// Reopen — error should be gone
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Open' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			expect(
+				screen.queryByText( 'Persistent error.' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'announces error message to screen readers via speak()', async () => {
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => ( {
+						close: false,
+						error: 'Announced error.',
+					} ) }
+				>
+					<AlertDialog.Popup title="Speak Test">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect( speak ).toHaveBeenCalledWith(
+					'Announced error.',
+					'assertive'
+				);
+			} );
+		} );
+
+		it( 'does not show error message when onConfirm throws', async () => {
+			const consoleSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation( () => {} );
+
+			render(
+				<AlertDialog.Root
+					open
+					onOpenChange={ jest.fn() }
+					onConfirm={ () => {
+						throw new Error( 'Unhandled throw' );
+					} }
+				>
+					<AlertDialog.Popup title="No Error Display">
+						Content
+					</AlertDialog.Popup>
+				</AlertDialog.Root>
+			);
+
+			await waitFor( () => {
+				expect(
+					screen.getByRole( 'button', { name: 'OK' } )
+				).toBeVisible();
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'OK' } )
+			);
+
+			await waitFor( () => {
+				expect( consoleSpy ).toHaveBeenCalledWith(
+					expect.objectContaining( { message: 'Unhandled throw' } )
+				);
+			} );
+
+			// No error message rendered — throws don't trigger the error UI
+			expect(
+				screen.queryByText( 'Unhandled throw' )
+			).not.toBeInTheDocument();
+			expect( speak ).not.toHaveBeenCalled();
+
+			consoleSpy.mockRestore();
+		} );
 	} );
 } );

--- a/packages/ui/src/alert-dialog/trigger.tsx
+++ b/packages/ui/src/alert-dialog/trigger.tsx
@@ -1,6 +1,6 @@
+import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
 import { forwardRef } from '@wordpress/element';
 
-import * as Dialog from '../dialog';
 import type { TriggerProps } from './types';
 
 /**
@@ -8,7 +8,7 @@ import type { TriggerProps } from './types';
  */
 const Trigger = forwardRef< HTMLButtonElement, TriggerProps >(
 	function AlertDialogTrigger( props, ref ) {
-		return <Dialog.Trigger ref={ ref } { ...props } />;
+		return <_AlertDialog.Trigger ref={ ref } { ...props } />;
 	}
 );
 

--- a/packages/ui/src/alert-dialog/types.ts
+++ b/packages/ui/src/alert-dialog/types.ts
@@ -1,7 +1,18 @@
 import type { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
 import type { ReactNode } from 'react';
 
-import type { TriggerProps as DialogTriggerProps } from '../dialog/types';
+import type { ComponentProps } from '../utils/types';
+
+/**
+ * The return type of `onConfirm`. Return `void` (or nothing) to auto-close
+ * the dialog after the confirm handler completes. Return `{ close: false }`
+ * to keep the dialog open (e.g. for validation errors).
+ *
+ * Return `{ error: '...' }` to display a built-in error message below the
+ * action buttons. When `error` is provided, the dialog stays open
+ * regardless of the `close` value.
+ */
+export type ConfirmResult = void | { close?: boolean; error?: string };
 
 export interface RootProps
 	extends Pick<
@@ -14,6 +25,43 @@ export interface RootProps
 	 */
 	children: ReactNode;
 
+	/**
+	 * Callback fired when the user confirms the action.
+	 *
+	 * - Synchronous handlers: the dialog closes immediately after the
+	 *   handler returns.
+	 * - Async handlers: the dialog enters a "pending" state (buttons
+	 *   disabled, spinner shown on the confirm button) until the promise
+	 *   settles.
+	 *
+	 * Return `{ close: false }` to keep the dialog open after the handler
+	 * completes (e.g. for server-side validation). Return `void` or
+	 * `{ close: true }` to close the dialog (the default).
+	 *
+	 * Return `{ error: '...' }` to show a built-in error message below
+	 * the action buttons. The dialog stays open regardless of the `close`
+	 * value. The error is announced to screen readers and is automatically
+	 * cleared on the next confirm attempt or when the dialog reopens.
+	 *
+	 * If the promise rejects (or the handler throws) without returning an
+	 * `error`, the dialog stays open and returns to idle without showing
+	 * a visible error message. The error is logged to the console.
+	 * To show a user-facing message on failure, catch the error and
+	 * return `{ close: false, error: '...' }`.
+	 */
+	onConfirm?: () => ConfirmResult | Promise< ConfirmResult >;
+}
+
+export interface TriggerProps extends ComponentProps< 'button' > {
+	/**
+	 * The content to be rendered inside the component.
+	 */
+	children?: ReactNode;
+}
+
+export interface PopupProps
+	extends ComponentProps< 'div' >,
+		Pick< _AlertDialog.Popup.Props, 'initialFocus' | 'finalFocus' > {
 	/**
 	 * The semantic intent of the dialog, which determines its styling.
 	 *
@@ -28,26 +76,27 @@ export interface RootProps
 	 * @default 'default'
 	 */
 	intent?: 'default' | 'irreversible';
-}
 
-export type TriggerProps = DialogTriggerProps;
-
-export interface PopupProps {
 	/**
 	 * The title displayed in the dialog header. This serves as both the
-	 * visible heading and the accessible label for the dialog.
+	 * visible heading and the accessible label (`aria-labelledby`) for the
+	 * dialog. Must be a plain string to ensure a predictable accessible name.
 	 */
 	title: string;
 
 	/**
-	 * The message content displayed in the dialog body.
+	 * An optional description displayed below the title. Rendered using
+	 * Base UI's `AlertDialog.Description` for proper `aria-describedby`
+	 * association with the dialog. Must be a plain string to ensure a
+	 * predictable accessible description.
 	 */
-	children: ReactNode;
+	description?: string;
 
 	/**
-	 * Callback fired when the user confirms the action.
+	 * Optional body content displayed between the description and the
+	 * action buttons. Use for supplementary details or form fields.
 	 */
-	onConfirm: () => void;
+	children?: ReactNode;
 
 	/**
 	 * Custom text for the confirm button.
@@ -62,22 +111,4 @@ export interface PopupProps {
 	 * @default 'Cancel'
 	 */
 	cancelButtonText?: string;
-
-	/**
-	 * Whether the confirm action is in a loading state (e.g. an async
-	 * operation is in progress). When `true`, the confirm button shows a
-	 * spinner and the cancel button is disabled.
-	 *
-	 * **Important:** Passing this prop — even as `false` — opts into
-	 * manual-close mode: the confirm button will no longer auto-close the
-	 * dialog. The consumer is responsible for setting `open={false}` when
-	 * the operation completes. Omit the prop entirely for the default
-	 * auto-close-on-confirm behavior.
-	 *
-	 * To implement an async confirm flow, use controlled mode
-	 * (`open` / `onOpenChange`) and manage the loading state externally:
-	 * prevent closing in `onOpenChange` while loading, and set
-	 * `open={false}` once the operation completes.
-	 */
-	loading?: boolean;
 }


### PR DESCRIPTION
## What?

Follow-up to #76847.

Refactors `AlertDialog` to use Base UI's `AlertDialog` primitives directly (instead of wrapping `Dialog`), and redesigns the component API for cleaner async workflows and better accessibility.

## Why?

For two reasons: extend the underlying base ui `AlertDialog` more consistently, and improve the UX and DevX for async confirm flows. The three main changes are:

- **Simpler async confirm flows.** `onConfirm` now accepts a `Promise`-returning callback. **The component handles loading spinners, button disabling, and dismiss-blocking internally — no more manual state juggling**.
- **Built-in error handling.** Return `{ close: false, error: '...' }` from `onConfirm` to display an error message below the action buttons. The message is announced to screen readers via `speak()` and cleared automatically on the next confirm attempt or when the dialog reopens.
- **`description` prop for accessibility.** Rendered via Base UI's `AlertDialog.Description`, which wires up `aria-describedby` automatically.
- **Complete Base UI rewrite.** Removes the `Dialog` wrapper indirection by using Base UI's `AlertDialog` primitives directly.

## How?

<details>
<summary>Implementation notes</summary>

### Internal state machine

`Root` implements a three-phase state machine (`idle` → `pending` → `closing`) to manage the dialog lifecycle:

- **`idle`**: default state, buttons are interactive.
- **`pending`**: entered when `onConfirm` returns a Promise. Buttons are disabled, spinner shown on the confirm button. Dismiss is blocked (Escape key and Cancel button are disabled).
- **`closing`**: entered when the dialog starts its exit animation. Buttons stay disabled to prevent interactions during the animation. Reset to `idle` via Base UI's `onOpenChangeComplete`.

A safety-net `useEffect` detects the contradictory state of the dialog being open while phase is stuck at `closing` (e.g. when a controlled consumer keeps `open={true}` after confirm) and resets to `idle`.

### Spinner detection

The spinner is shown immediately when `onConfirm` returns a thenable (detected via `isThenable`). Synchronous handlers skip the spinner entirely.

### Imperative close via `actionsRef`

When `onConfirm` resolves successfully, the dialog is closed imperatively via Base UI's `actionsRef.current.close()`. This generates real `ChangeEventDetails` with proper `cancel()`, `allowPropagation()`, and `preventUnmountOnClose()` methods — no synthetic event fabrication needed.

### `onConfirm` placement

`onConfirm` lives on `Root` (the state machine owner).

### `intent` moved to `Popup`

The `intent` prop only affects the confirm button's styling, so it was moved from `Root` to `Popup` to eliminate unnecessary context forwarding.

### Error handling

Two error paths are supported:

- **Explicit error message:** Return `{ close: false, error: '...' }` from `onConfirm`. The component renders the message below the action buttons, announces it to screen readers via `speak()`, and clears it on the next confirm attempt or when the dialog reopens.
- **Unhandled throw / rejection:** When `onConfirm` throws (or the promise rejects) without returning an `error`, the dialog stays open and returns to `idle`. The error is logged to `console.error` but no visible message is shown — the component recovers gracefully.

The recommended consumer pattern is to catch known errors and return `{ close: false, error }`, letting unexpected errors fall through to the throw path (see the `AsyncConfirm` story).

</details>

<details>
<summary>API comparison: trunk vs this PR</summary>

### `AlertDialog.Root`

| Prop | Trunk | This PR |
|---|---|---|
| `open` | ✅ | ✅ |
| `onOpenChange` | ✅ | ✅ |
| `defaultOpen` | ✅ | ✅ |
| `intent` | ✅ | ❌ Moved to `Popup` |
| `onConfirm` | ❌ | ✅ New (optional; supports async, `{ close: false }`, and `{ error: '...' }`) |

### `AlertDialog.Popup`

| Prop | Trunk | This PR |
|---|---|---|
| `title` | `string` (required) | `string` (required) |
| `children` | `ReactNode` (required) | `ReactNode` (optional) |
| `description` | ❌ | ✅ New (`string`, wires `aria-describedby`) |
| `intent` | ❌ | ✅ Moved from `Root` |
| `onConfirm` | ✅ (required) | ❌ Moved to `Root` |
| `confirmButtonText` | `string` | `string` |
| `cancelButtonText` | `string` | `string` |
| `loading` | ✅ (consumer-managed) | ❌ Removed |
| `initialFocus` | ❌ | ✅ New |
| `finalFocus` | ❌ | ✅ New |

### Async confirm flow comparison

| | Trunk | This PR |
|---|---|---|
| **Setup** | Controlled mode, manage `loading` state | Return a `Promise` from `onConfirm` |
| **Button disabling** | Consumer passes `loading` prop | Automatic |
| **Spinner** | Consumer passes `loading` prop | Automatic for async handlers |
| **Dismiss blocking** | Consumer blocks in `onOpenChange` | Automatic (always blocked during pending) |
| **Error handling** | Consumer manages everything | `{ error: '...' }` → built-in message + `speak()`. Throws → stays open, `console.error` |
| **Close control** | Consumer sets `open={false}` | Automatic, or `{ close: false }` to keep open |

</details>

## Testing Instructions

```bash
npm run test:unit -- --testPathPattern="packages/ui/src/alert-dialog" --no-coverage
```

All 40 tests pass.

### Storybook

1. `npm run storybook:dev`
2. Navigate to **Design System / Components / AlertDialog**
3. Verify all stories: Default, Irreversible, CustomLabels, WithCustomContent, MenuTrigger, AsyncConfirm, Controlled
4. In **AsyncConfirm**, use the radio toggle to test success (dialog closes) and failure (dialog stays open with error message)

### Testing Instructions for Keyboard

1. Open any AlertDialog story in Storybook
2. Tab to the trigger button, press Enter to open
3. Verify focus moves into the dialog
4. Tab between Cancel and confirm buttons
5. Press Escape to dismiss — verify dialog closes
6. In AsyncConfirm, press Enter on confirm — verify buttons become disabled and spinner appears
7. After async completes, verify focus returns to the trigger


## Screen recording


https://github.com/user-attachments/assets/484cf187-2b3f-4c70-aa55-3cb7d2a265b9



## Use of AI Tools

Cursor with Claude Opus 4.6



