### PR TITLE
RTC: Add filterable flag for meta box RTC compatibility

### DIFF
--- a/backport-changelog/7.0/11566.md
+++ b/backport-changelog/7.0/11566.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/11566
+
+* https://github.com/WordPress/gutenberg/pull/76939

--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -124,6 +124,18 @@ _Returns_
 
 -   `Object`: Preferences Object.
 
+### getRtcCompatibleMetaBoxIds
+
+Returns the list of meta box IDs marked as compatible with real-time collaboration via the add_meta_box() \_\_rtc_compatible_meta_box compatibility flag.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string[]`: List of RTC-compatible meta box IDs.
+
 ### hasMetaBoxes
 
 Returns true if the post is using Meta Boxes
@@ -471,6 +483,14 @@ Returns an action object used to open/close the list view.
 _Parameters_
 
 -   _isOpen_ `boolean`: A boolean representing whether the list view should be opened or closed.
+
+### setRtcCompatibleMetaBoxIds
+
+Stores the IDs of meta boxes marked as compatible with real-time collaboration via the \_\_rtc_compatible_meta_box flag on the server.
+
+_Parameters_
+
+-   _ids_ `string[]`: Meta box IDs that are RTC-compatible.
 
 ### showBlockTypes
 

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
 
 		$rtc_compatible_ids = array();
 
-		foreach ( $wp_meta_boxes[ $screen_id ] as $location => $priorities ) {
+		foreach ( $wp_meta_boxes[ $screen_id ] as $priorities ) {
 			foreach ( $priorities as $priority_boxes ) {
 				foreach ( (array) $priority_boxes as $meta_box ) {
 					if ( false === $meta_box || ! $meta_box['title'] ) {

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -64,6 +64,13 @@ if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
 			} );';
 
 			wp_add_inline_script( 'wp-edit-post', $script );
+
+			// If wp-edit-post is output earlier in <head>, the inline script
+			// needs to be manually printed. This mirrors the same fallback
+			// used by WordPress core for setAvailableMetaBoxesPerLocation.
+			if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
+				printf( "<script>\n%s\n</script>\n", trim( $script ) );
+			}
 		}
 
 		return $wp_meta_boxes;

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Adds support for the __rtc_compatible_meta_box flag in add_meta_box().
+ *
+ * Plugin authors can mark their meta boxes as compatible with real-time
+ * collaboration by passing '__rtc_compatible_meta_box' => true in the
+ * $callback_args parameter of add_meta_box(). Users can also add this
+ * flag to third-party meta boxes via the filter_block_editor_meta_boxes hook.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
+	/**
+	 * Reads the __rtc_compatible_meta_box flag from registered meta boxes
+	 * and injects the compatibility data into the block editor via inline script.
+	 *
+	 * Hooks into filter_block_editor_meta_boxes at a late priority so that it
+	 * runs after any developer filters that add the flag to third-party meta boxes.
+	 *
+	 * @param array $wp_meta_boxes Global meta box state.
+	 * @return array Unmodified meta box state.
+	 */
+	function gutenberg_inject_rtc_compatible_meta_boxes( $wp_meta_boxes ) {
+		global $current_screen;
+
+		if ( ! $current_screen || ! wp_is_collaboration_enabled() ) {
+			return $wp_meta_boxes;
+		}
+
+		$screen_id = $current_screen->id;
+
+		if ( ! isset( $wp_meta_boxes[ $screen_id ] ) ) {
+			return $wp_meta_boxes;
+		}
+
+		$rtc_compatible_ids = array();
+
+		foreach ( $wp_meta_boxes[ $screen_id ] as $location => $priorities ) {
+			foreach ( $priorities as $priority_boxes ) {
+				foreach ( (array) $priority_boxes as $meta_box ) {
+					if ( false === $meta_box || ! $meta_box['title'] ) {
+						continue;
+					}
+
+					// Skip back-compat meta boxes (they won't appear in the block editor).
+					if ( isset( $meta_box['args']['__back_compat_meta_box'] )
+						&& $meta_box['args']['__back_compat_meta_box'] ) {
+						continue;
+					}
+
+					if ( isset( $meta_box['args']['__rtc_compatible_meta_box'] )
+						&& $meta_box['args']['__rtc_compatible_meta_box'] ) {
+						$rtc_compatible_ids[] = $meta_box['id'];
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $rtc_compatible_ids ) ) {
+			// Meta boxes are registered during admin_head, which fires after
+			// admin_enqueue_scripts where the editor instance is created. This
+			// means the compatibility data cannot be added to editor settings
+			// directly. Instead, we inject an inline script that dispatches
+			// into the store once the block editor has finished loading.
+			$script = 'window._wpLoadBlockEditor.then( function() {
+				wp.data.dispatch( \'core/edit-post\' ).setRtcCompatibleMetaBoxIds( '
+				. wp_json_encode( array_values( array_unique( $rtc_compatible_ids ) ) )
+				. ' );
+			} );';
+
+			wp_add_inline_script( 'wp-edit-post', $script );
+		}
+
+		return $wp_meta_boxes;
+	}
+
+	add_filter( 'filter_block_editor_meta_boxes', 'gutenberg_inject_rtc_compatible_meta_boxes', 100 );
+}

--- a/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.0/meta-box-rtc-compat.php
@@ -43,12 +43,6 @@ if ( ! function_exists( 'gutenberg_inject_rtc_compatible_meta_boxes' ) ) {
 						continue;
 					}
 
-					// Skip back-compat meta boxes (they won't appear in the block editor).
-					if ( isset( $meta_box['args']['__back_compat_meta_box'] )
-						&& $meta_box['args']['__back_compat_meta_box'] ) {
-						continue;
-					}
-
 					if ( isset( $meta_box['args']['__rtc_compatible_meta_box'] )
 						&& $meta_box['args']['__rtc_compatible_meta_box'] ) {
 						$rtc_compatible_ids[] = $meta_box['id'];

--- a/lib/load.php
+++ b/lib/load.php
@@ -119,6 +119,7 @@ require __DIR__ . '/compat/wordpress-7.0/blocks.php';
 require __DIR__ . '/compat/wordpress-7.0/kses.php';
 require __DIR__ . '/compat/wordpress-7.0/media.php';
 require __DIR__ . '/compat/wordpress-7.0/command-palette.php';
+require __DIR__ . '/compat/wordpress-7.0/meta-box-rtc-compat.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/e2e-tests/plugins/meta-box-rtc-compatible.php
+++ b/packages/e2e-tests/plugins/meta-box-rtc-compatible.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, RTC Compatible Meta Box
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-rtc-compatible-meta-box
+ */
+
+/**
+ * Renders the RTC-compatible test meta box.
+ */
+function gutenberg_test_rtc_compatible_meta_box_render() {
+	echo 'RTC Compatible Meta Box';
+}
+
+/**
+ * Registers a meta box marked as compatible with real-time collaboration.
+ */
+function gutenberg_test_rtc_compatible_meta_box_add() {
+	add_meta_box(
+		'gutenberg-test-rtc-compatible-meta-box',
+		'RTC Compatible Test Meta Box',
+		'gutenberg_test_rtc_compatible_meta_box_render',
+		'post',
+		'normal',
+		'high',
+		array( '__rtc_compatible_meta_box' => true )
+	);
+}
+add_action( 'add_meta_boxes', 'gutenberg_test_rtc_compatible_meta_box_add' );

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -1,0 +1,192 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { RegistryProvider, createRegistry } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useMetaBoxInitialization } from '../use-meta-box-initialization';
+import { STORE_NAME } from '../../../store/constants';
+
+// Mock unlock to be an identity function so private actions are directly accessible.
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: ( value ) => value,
+} ) );
+
+const storeConfig = {
+	actions: {
+		forceUpdate: jest.fn( () => ( { type: 'FORCE_UPDATE' } ) ),
+	},
+	reducer: ( state = {}, action ) =>
+		action.type === 'FORCE_UPDATE' ? { ...state } : state,
+};
+
+const setCollaborationSupported = jest.fn( () => ( {
+	type: 'SET_COLLABORATION_SUPPORTED',
+} ) );
+
+const initializeMetaBoxes = jest.fn( () => ( {
+	type: 'META_BOXES_INITIALIZED',
+} ) );
+
+function createMockStores( {
+	isEditorReady = true,
+	isCollaborationEnabled = true,
+	metaBoxes = [],
+} = {} ) {
+	return {
+		'core/editor': {
+			...storeConfig,
+			selectors: {
+				__unstableIsEditorReady: jest.fn( () => isEditorReady ),
+				isCollaborationEnabledForCurrentPost: jest.fn(
+					() => isCollaborationEnabled
+				),
+			},
+		},
+		core: {
+			...storeConfig,
+			actions: {
+				...storeConfig.actions,
+				setCollaborationSupported,
+			},
+		},
+		[ STORE_NAME ]: {
+			...storeConfig,
+			actions: {
+				...storeConfig.actions,
+				initializeMetaBoxes,
+			},
+			selectors: {
+				getAllMetaBoxes: jest.fn( () => metaBoxes ),
+			},
+		},
+	};
+}
+
+function TestComponent( { enabled } ) {
+	useMetaBoxInitialization( enabled );
+	return null;
+}
+
+function renderHook( registry, enabled = true ) {
+	return render(
+		<RegistryProvider value={ registry }>
+			<TestComponent enabled={ enabled } />
+		</RegistryProvider>
+	);
+}
+
+describe( 'useMetaBoxInitialization', () => {
+	afterEach( () => {
+		setCollaborationSupported.mockClear();
+		initializeMetaBoxes.mockClear();
+		removeFilter(
+			'editor.incompatibleRtcMetaBoxes',
+			'test/use-meta-box-initialization'
+		);
+	} );
+
+	it( 'disables collaboration when metaboxes are present', () => {
+		const mockStores = createMockStores( {
+			metaBoxes: [
+				{ id: 'my-metabox', title: 'My Meta Box' },
+				{ id: 'another-metabox', title: 'Another' },
+			],
+		} );
+		const registry = createRegistry( mockStores );
+
+		renderHook( registry );
+
+		expect( initializeMetaBoxes ).toHaveBeenCalled();
+		expect( setCollaborationSupported ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'does not disable collaboration when filter removes all metabox IDs', () => {
+		addFilter(
+			'editor.incompatibleRtcMetaBoxes',
+			'test/use-meta-box-initialization',
+			() => []
+		);
+
+		const mockStores = createMockStores( {
+			metaBoxes: [
+				{ id: 'my-metabox', title: 'My Meta Box' },
+				{ id: 'another-metabox', title: 'Another' },
+			],
+		} );
+		const registry = createRegistry( mockStores );
+
+		renderHook( registry );
+
+		expect( initializeMetaBoxes ).toHaveBeenCalled();
+		expect( setCollaborationSupported ).not.toHaveBeenCalled();
+	} );
+
+	it( 'disables collaboration when filter keeps some metabox IDs', () => {
+		addFilter(
+			'editor.incompatibleRtcMetaBoxes',
+			'test/use-meta-box-initialization',
+			( ids ) => ids.filter( ( id ) => id !== 'compatible-metabox' )
+		);
+
+		const mockStores = createMockStores( {
+			metaBoxes: [
+				{ id: 'compatible-metabox', title: 'Compatible' },
+				{ id: 'incompatible-metabox', title: 'Incompatible' },
+			],
+		} );
+		const registry = createRegistry( mockStores );
+
+		renderHook( registry );
+
+		expect( setCollaborationSupported ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'does not disable collaboration when filter removes the only metabox ID', () => {
+		addFilter(
+			'editor.incompatibleRtcMetaBoxes',
+			'test/use-meta-box-initialization',
+			( ids ) => ids.filter( ( id ) => id !== 'compatible-metabox' )
+		);
+
+		const mockStores = createMockStores( {
+			metaBoxes: [ { id: 'compatible-metabox', title: 'Compatible' } ],
+		} );
+		const registry = createRegistry( mockStores );
+
+		renderHook( registry );
+
+		expect( setCollaborationSupported ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not disable collaboration when there are no metaboxes', () => {
+		const mockStores = createMockStores( {
+			metaBoxes: [],
+		} );
+		const registry = createRegistry( mockStores );
+
+		renderHook( registry );
+
+		expect( setCollaborationSupported ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not disable collaboration when collaboration is not enabled', () => {
+		const mockStores = createMockStores( {
+			isCollaborationEnabled: false,
+			metaBoxes: [ { id: 'my-metabox', title: 'My Meta Box' } ],
+		} );
+		const registry = createRegistry( mockStores );
+
+		renderHook( registry );
+
+		expect( setCollaborationSupported ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -93,7 +93,7 @@ describe( 'useMetaBoxInitialization', () => {
 		setCollaborationSupported.mockClear();
 		initializeMetaBoxes.mockClear();
 		removeFilter(
-			'editor.incompatibleRtcMetaBoxes',
+			'editor.rtcIncompatibleMetaBoxes',
 			'test/use-meta-box-initialization'
 		);
 	} );
@@ -115,7 +115,7 @@ describe( 'useMetaBoxInitialization', () => {
 
 	it( 'does not disable collaboration when filter removes all metabox IDs', () => {
 		addFilter(
-			'editor.incompatibleRtcMetaBoxes',
+			'editor.rtcIncompatibleMetaBoxes',
 			'test/use-meta-box-initialization',
 			() => []
 		);
@@ -136,7 +136,7 @@ describe( 'useMetaBoxInitialization', () => {
 
 	it( 'disables collaboration when filter keeps some metabox IDs', () => {
 		addFilter(
-			'editor.incompatibleRtcMetaBoxes',
+			'editor.rtcIncompatibleMetaBoxes',
 			'test/use-meta-box-initialization',
 			( ids ) => ids.filter( ( id ) => id !== 'compatible-metabox' )
 		);
@@ -156,7 +156,7 @@ describe( 'useMetaBoxInitialization', () => {
 
 	it( 'does not disable collaboration when filter removes the only metabox ID', () => {
 		addFilter(
-			'editor.incompatibleRtcMetaBoxes',
+			'editor.rtcIncompatibleMetaBoxes',
 			'test/use-meta-box-initialization',
 			( ids ) => ids.filter( ( id ) => id !== 'compatible-metabox' )
 		);

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -39,6 +39,7 @@ function createMockStores( {
 	isEditorReady = true,
 	isCollaborationEnabled = true,
 	metaBoxes = [],
+	rtcCompatibleIds = [],
 } = {} ) {
 	return {
 		'core/editor': {
@@ -65,6 +66,7 @@ function createMockStores( {
 			},
 			selectors: {
 				getAllMetaBoxes: jest.fn( () => metaBoxes ),
+				getRtcCompatibleMetaBoxIds: jest.fn( () => rtcCompatibleIds ),
 				hasMetaBoxes: jest.fn( () => metaBoxes.length > 0 ),
 				getActiveMetaBoxLocations: jest.fn( () =>
 					metaBoxes.length > 0 ? [ 'normal' ] : []
@@ -111,13 +113,10 @@ describe( 'useMetaBoxInitialization', () => {
 	it( 'does not disable collaboration when all metaboxes are rtcCompatible', () => {
 		const mockStores = createMockStores( {
 			metaBoxes: [
-				{ id: 'my-metabox', title: 'My Meta Box', rtcCompatible: true },
-				{
-					id: 'another-metabox',
-					title: 'Another',
-					rtcCompatible: true,
-				},
+				{ id: 'my-metabox', title: 'My Meta Box' },
+				{ id: 'another-metabox', title: 'Another' },
 			],
+			rtcCompatibleIds: [ 'my-metabox', 'another-metabox' ],
 		} );
 		const registry = createRegistry( mockStores );
 
@@ -130,13 +129,10 @@ describe( 'useMetaBoxInitialization', () => {
 	it( 'disables collaboration when some metaboxes lack rtcCompatible', () => {
 		const mockStores = createMockStores( {
 			metaBoxes: [
-				{
-					id: 'compatible-metabox',
-					title: 'Compatible',
-					rtcCompatible: true,
-				},
+				{ id: 'compatible-metabox', title: 'Compatible' },
 				{ id: 'incompatible-metabox', title: 'Incompatible' },
 			],
+			rtcCompatibleIds: [ 'compatible-metabox' ],
 		} );
 		const registry = createRegistry( mockStores );
 
@@ -147,13 +143,8 @@ describe( 'useMetaBoxInitialization', () => {
 
 	it( 'does not disable collaboration when the only metabox is rtcCompatible', () => {
 		const mockStores = createMockStores( {
-			metaBoxes: [
-				{
-					id: 'compatible-metabox',
-					title: 'Compatible',
-					rtcCompatible: true,
-				},
-			],
+			metaBoxes: [ { id: 'compatible-metabox', title: 'Compatible' } ],
+			rtcCompatibleIds: [ 'compatible-metabox' ],
 		} );
 		const registry = createRegistry( mockStores );
 

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -66,6 +66,10 @@ function createMockStores( {
 			},
 			selectors: {
 				getAllMetaBoxes: jest.fn( () => metaBoxes ),
+				hasMetaBoxes: jest.fn( () => metaBoxes.length > 0 ),
+				getActiveMetaBoxLocations: jest.fn( () =>
+					metaBoxes.length > 0 ? [ 'normal' ] : []
+				),
 			},
 		},
 	};

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -6,7 +6,6 @@ import { render } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
-import { addFilter, removeFilter } from '@wordpress/hooks';
 import { RegistryProvider, createRegistry } from '@wordpress/data';
 
 /**
@@ -92,10 +91,6 @@ describe( 'useMetaBoxInitialization', () => {
 	afterEach( () => {
 		setCollaborationSupported.mockClear();
 		initializeMetaBoxes.mockClear();
-		removeFilter(
-			'editor.rtcIncompatibleMetaBoxes',
-			'test/use-meta-box-initialization'
-		);
 	} );
 
 	it( 'disables collaboration when metaboxes are present', () => {
@@ -113,17 +108,15 @@ describe( 'useMetaBoxInitialization', () => {
 		expect( setCollaborationSupported ).toHaveBeenCalledWith( false );
 	} );
 
-	it( 'does not disable collaboration when filter removes all metabox IDs', () => {
-		addFilter(
-			'editor.rtcIncompatibleMetaBoxes',
-			'test/use-meta-box-initialization',
-			() => []
-		);
-
+	it( 'does not disable collaboration when all metaboxes are rtcCompatible', () => {
 		const mockStores = createMockStores( {
 			metaBoxes: [
-				{ id: 'my-metabox', title: 'My Meta Box' },
-				{ id: 'another-metabox', title: 'Another' },
+				{ id: 'my-metabox', title: 'My Meta Box', rtcCompatible: true },
+				{
+					id: 'another-metabox',
+					title: 'Another',
+					rtcCompatible: true,
+				},
 			],
 		} );
 		const registry = createRegistry( mockStores );
@@ -134,16 +127,14 @@ describe( 'useMetaBoxInitialization', () => {
 		expect( setCollaborationSupported ).not.toHaveBeenCalled();
 	} );
 
-	it( 'disables collaboration when filter keeps some metabox IDs', () => {
-		addFilter(
-			'editor.rtcIncompatibleMetaBoxes',
-			'test/use-meta-box-initialization',
-			( ids ) => ids.filter( ( id ) => id !== 'compatible-metabox' )
-		);
-
+	it( 'disables collaboration when some metaboxes lack rtcCompatible', () => {
 		const mockStores = createMockStores( {
 			metaBoxes: [
-				{ id: 'compatible-metabox', title: 'Compatible' },
+				{
+					id: 'compatible-metabox',
+					title: 'Compatible',
+					rtcCompatible: true,
+				},
 				{ id: 'incompatible-metabox', title: 'Incompatible' },
 			],
 		} );
@@ -154,15 +145,15 @@ describe( 'useMetaBoxInitialization', () => {
 		expect( setCollaborationSupported ).toHaveBeenCalledWith( false );
 	} );
 
-	it( 'does not disable collaboration when filter removes the only metabox ID', () => {
-		addFilter(
-			'editor.rtcIncompatibleMetaBoxes',
-			'test/use-meta-box-initialization',
-			( ids ) => ids.filter( ( id ) => id !== 'compatible-metabox' )
-		);
-
+	it( 'does not disable collaboration when the only metabox is rtcCompatible', () => {
 		const mockStores = createMockStores( {
-			metaBoxes: [ { id: 'compatible-metabox', title: 'Compatible' } ],
+			metaBoxes: [
+				{
+					id: 'compatible-metabox',
+					title: 'Compatible',
+					rtcCompatible: true,
+				},
+			],
 		} );
 		const registry = createRegistry( mockStores );
 

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -49,14 +49,17 @@ export const useMetaBoxInitialization = ( enabled ) => {
 
 			// Disable real-time collaboration when legacy meta boxes are detected.
 			// Meta boxes marked with __rtc_compatible_meta_box on the server
-			// will have rtcCompatible set to true in the store.
+			// have their IDs stored via setRtcCompatibleMetaBoxIds().
 			if ( isCollaborationEnabled ) {
 				const allMetaBoxes = registry
 					.select( editPostStore )
 					.getAllMetaBoxes();
+				const rtcCompatibleIds = registry
+					.select( editPostStore )
+					.getRtcCompatibleMetaBoxIds();
 
 				const hasIncompatibleMetaBoxes = allMetaBoxes.some(
-					( metaBox ) => ! metaBox.rtcCompatible
+					( metaBox ) => ! rtcCompatibleIds.includes( metaBox.id )
 				);
 
 				if ( hasIncompatibleMetaBoxes ) {

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
@@ -18,25 +18,29 @@ import { unlock } from '../../lock-unlock';
  * @param { boolean } enabled
  */
 export const useMetaBoxInitialization = ( enabled ) => {
-	const { isEnabledAndEditorReady, isCollaborationEnabled, hasMetaBoxes } =
-		useSelect(
-			( select ) => ( {
-				isEnabledAndEditorReady:
-					enabled && select( editorStore ).__unstableIsEditorReady(),
-				isCollaborationEnabled:
-					select(
-						editorStore
-					).isCollaborationEnabledForCurrentPost(),
-				hasMetaBoxes: enabled
-					? select( editPostStore ).hasMetaBoxes()
-					: false,
-			} ),
-			[ enabled ]
-		);
-
-	// Read allMetaBoxes via the registry instead of useSelect to avoid
-	// referential instability from getAllMetaBoxes() returning a new array.
-	const registry = useRegistry();
+	const {
+		isEnabledAndEditorReady,
+		isCollaborationEnabled,
+		hasMetaBoxes,
+		allMetaBoxes,
+		rtcCompatibleIds,
+	} = useSelect(
+		( select ) => ( {
+			isEnabledAndEditorReady:
+				enabled && select( editorStore ).__unstableIsEditorReady(),
+			isCollaborationEnabled:
+				select( editorStore ).isCollaborationEnabledForCurrentPost(),
+			hasMetaBoxes: enabled
+				? select( editPostStore ).hasMetaBoxes()
+				: false,
+			allMetaBoxes: enabled
+				? select( editPostStore ).getAllMetaBoxes()
+				: [],
+			rtcCompatibleIds:
+				select( editPostStore ).getRtcCompatibleMetaBoxIds(),
+		} ),
+		[ enabled ]
+	);
 	const { setCollaborationSupported } = unlock( useDispatch( coreStore ) );
 
 	const { initializeMetaBoxes } = useDispatch( editPostStore );
@@ -51,13 +55,6 @@ export const useMetaBoxInitialization = ( enabled ) => {
 			// Meta boxes marked with __rtc_compatible_meta_box on the server
 			// have their IDs stored via setRtcCompatibleMetaBoxIds().
 			if ( isCollaborationEnabled ) {
-				const allMetaBoxes = registry
-					.select( editPostStore )
-					.getAllMetaBoxes();
-				const rtcCompatibleIds = registry
-					.select( editPostStore )
-					.getRtcCompatibleMetaBoxIds();
-
 				const hasIncompatibleMetaBoxes = allMetaBoxes.some(
 					( metaBox ) => ! rtcCompatibleIds.includes( metaBox.id )
 				);
@@ -73,6 +70,7 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		isCollaborationEnabled,
 		setCollaborationSupported,
 		hasMetaBoxes,
-		registry,
+		allMetaBoxes,
+		rtcCompatibleIds,
 	] );
 };

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
@@ -19,7 +19,7 @@ import { unlock } from '../../lock-unlock';
  * @param { boolean } enabled
  */
 export const useMetaBoxInitialization = ( enabled ) => {
-	const { isEnabledAndEditorReady, isCollaborationEnabled, allMetaBoxes } =
+	const { isEnabledAndEditorReady, isCollaborationEnabled, hasMetaBoxes } =
 		useSelect(
 			( select ) => ( {
 				isEnabledAndEditorReady:
@@ -28,13 +28,16 @@ export const useMetaBoxInitialization = ( enabled ) => {
 					select(
 						editorStore
 					).isCollaborationEnabledForCurrentPost(),
-				allMetaBoxes: enabled
-					? select( editPostStore ).getAllMetaBoxes()
-					: [],
+				hasMetaBoxes: enabled
+					? select( editPostStore ).hasMetaBoxes()
+					: false,
 			} ),
 			[ enabled ]
 		);
 
+	// Read allMetaBoxes via the registry instead of useSelect to avoid
+	// referential instability from getAllMetaBoxes() returning a new array.
+	const registry = useRegistry();
 	const { setCollaborationSupported } = unlock( useDispatch( coreStore ) );
 
 	const { initializeMetaBoxes } = useDispatch( editPostStore );
@@ -47,6 +50,9 @@ export const useMetaBoxInitialization = ( enabled ) => {
 
 			// Disable real-time collaboration when legacy meta boxes are detected.
 			if ( isCollaborationEnabled ) {
+				const allMetaBoxes = registry
+					.select( editPostStore )
+					.getAllMetaBoxes();
 				const metaBoxIds = allMetaBoxes.map( ( { id } ) => id );
 
 				/**
@@ -74,6 +80,7 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		initializeMetaBoxes,
 		isCollaborationEnabled,
 		setCollaborationSupported,
-		allMetaBoxes,
+		hasMetaBoxes,
+		registry,
 	] );
 };

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -66,7 +66,7 @@ export const useMetaBoxInitialization = ( enabled ) => {
 				 * @param {string[]} metaBoxIds Array of all active metabox IDs.
 				 */
 				const incompatibleIds = applyFilters(
-					'editor.incompatibleRtcMetaBoxes',
+					'editor.rtcIncompatibleMetaBoxes',
 					metaBoxIds
 				);
 

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -18,18 +19,26 @@ import { unlock } from '../../lock-unlock';
  * @param { boolean } enabled
  */
 export const useMetaBoxInitialization = ( enabled ) => {
-	const { isEnabledAndEditorReady, isCollaborationEnabled } = useSelect(
-		( select ) => ( {
-			isEnabledAndEditorReady:
-				enabled && select( editorStore ).__unstableIsEditorReady(),
-			isCollaborationEnabled:
-				select( editorStore ).isCollaborationEnabledForCurrentPost(),
-		} ),
-		[ enabled ]
-	);
+	const { isEnabledAndEditorReady, isCollaborationEnabled, allMetaBoxes } =
+		useSelect(
+			( select ) => ( {
+				isEnabledAndEditorReady:
+					enabled && select( editorStore ).__unstableIsEditorReady(),
+				isCollaborationEnabled:
+					select(
+						editorStore
+					).isCollaborationEnabledForCurrentPost(),
+				allMetaBoxes: enabled
+					? select( editPostStore ).getAllMetaBoxes()
+					: [],
+			} ),
+			[ enabled ]
+		);
+
 	const { setCollaborationSupported } = unlock( useDispatch( coreStore ) );
 
 	const { initializeMetaBoxes } = useDispatch( editPostStore );
+
 	// The effect has to rerun when the editor is ready because initializeMetaBoxes
 	// will noop until then.
 	useEffect( () => {
@@ -38,7 +47,26 @@ export const useMetaBoxInitialization = ( enabled ) => {
 
 			// Disable real-time collaboration when legacy meta boxes are detected.
 			if ( isCollaborationEnabled ) {
-				setCollaborationSupported( false );
+				const metaBoxIds = allMetaBoxes.map( ( { id } ) => id );
+
+				/**
+				 * Filters the list of metabox IDs considered incompatible
+				 * with real-time collaboration.
+				 *
+				 * Developers can remove known-working metabox IDs from this
+				 * array, or return an empty array to ignore all metabox
+				 * incompatibility.
+				 *
+				 * @param {string[]} metaBoxIds Array of all active metabox IDs.
+				 */
+				const incompatibleIds = applyFilters(
+					'editor.incompatibleRtcMetaBoxes',
+					metaBoxIds
+				);
+
+				if ( incompatibleIds.length > 0 ) {
+					setCollaborationSupported( false );
+				}
 			}
 		}
 	}, [
@@ -46,5 +74,6 @@ export const useMetaBoxInitialization = ( enabled ) => {
 		initializeMetaBoxes,
 		isCollaborationEnabled,
 		setCollaborationSupported,
+		allMetaBoxes,
 	] );
 };

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -5,7 +5,6 @@ import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -49,28 +48,18 @@ export const useMetaBoxInitialization = ( enabled ) => {
 			initializeMetaBoxes();
 
 			// Disable real-time collaboration when legacy meta boxes are detected.
+			// Meta boxes marked with __rtc_compatible_meta_box on the server
+			// will have rtcCompatible set to true in the store.
 			if ( isCollaborationEnabled ) {
 				const allMetaBoxes = registry
 					.select( editPostStore )
 					.getAllMetaBoxes();
-				const metaBoxIds = allMetaBoxes.map( ( { id } ) => id );
 
-				/**
-				 * Filters the list of metabox IDs considered incompatible
-				 * with real-time collaboration.
-				 *
-				 * Developers can remove known-working metabox IDs from this
-				 * array, or return an empty array to ignore all metabox
-				 * incompatibility.
-				 *
-				 * @param {string[]} metaBoxIds Array of all active metabox IDs.
-				 */
-				const incompatibleIds = applyFilters(
-					'editor.rtcIncompatibleMetaBoxes',
-					metaBoxIds
+				const hasIncompatibleMetaBoxes = allMetaBoxes.some(
+					( metaBox ) => ! metaBox.rtcCompatible
 				);
 
-				if ( incompatibleIds.length > 0 ) {
+				if ( hasIncompatibleMetaBoxes ) {
 					setCollaborationSupported( false );
 				}
 			}

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -278,6 +278,19 @@ export function setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 }
 
 /**
+ * Stores the IDs of meta boxes marked as compatible with real-time collaboration
+ * via the __rtc_compatible_meta_box flag on the server.
+ *
+ * @param {string[]} ids Meta box IDs that are RTC-compatible.
+ */
+export function setRtcCompatibleMetaBoxIds( ids ) {
+	return {
+		type: 'SET_RTC_COMPATIBLE_META_BOX_IDS',
+		ids,
+	};
+}
+
+/**
  * Update a metabox.
  */
 export const requestMetaBoxUpdates =

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -83,10 +83,28 @@ function metaBoxesInitialized( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer tracking meta box IDs marked as compatible with real-time collaboration
+ * via the add_meta_box() __rtc_compatible_meta_box compatibility flag.
+ *
+ * @param {string[]} state  Previous state.
+ * @param {Object}   action Action Object.
+ *
+ * @return {string[]} Updated state.
+ */
+export function rtcCompatibleMetaBoxIds( state = [], action ) {
+	switch ( action.type ) {
+		case 'SET_RTC_COMPATIBLE_META_BOX_IDS':
+			return action.ids;
+	}
+	return state;
+}
+
 const metaBoxes = combineReducers( {
 	isSaving: isSavingMetaBoxes,
 	locations: metaBoxLocations,
 	initialized: metaBoxesInitialized,
+	rtcCompatibleIds: rtcCompatibleMetaBoxIds,
 } );
 
 export default combineReducers( {

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -425,6 +425,18 @@ export const getAllMetaBoxes = createSelector(
 );
 
 /**
+ * Returns the list of meta box IDs marked as compatible with real-time
+ * collaboration via the add_meta_box() __rtc_compatible_meta_box compatibility flag.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string[]} List of RTC-compatible meta box IDs.
+ */
+export function getRtcCompatibleMetaBoxIds( state ) {
+	return state.metaBoxes.rtcCompatibleIds;
+}
+
+/**
  * Returns true if the post is using Meta Boxes
  *
  * @param {Object} state Global application state

--- a/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
@@ -7,99 +7,173 @@ import { SECOND_USER } from './fixtures/collaboration-utils';
 const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
 
 test.describe( 'Collaboration with meta boxes', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activatePlugin( 'gutenberg-test-plugin-meta-box' );
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin( 'gutenberg-test-plugin-meta-box' );
-	} );
-
-	test( 'shows post-locked modal when meta boxes disable collaboration', async ( {
-		collaborationUtils,
-		requestUtils,
-		admin,
-		editor,
-		page,
-	} ) => {
-		// Create a draft post.
-		const post = await requestUtils.createPost( {
-			title: 'Meta Box Lock Test',
-			status: 'draft',
-			date_gmt: new Date().toISOString(),
-		} );
-
-		// User 1 (admin) opens the post.
-		await admin.visitAdminPage(
-			'post.php',
-			`post=${ post.id }&action=edit`
-		);
-		await editor.setPreferences( 'core/edit-post', {
-			welcomeGuide: false,
-			fullscreenMode: false,
-		} );
-
-		// Wait for collaboration runtime and entity record to be ready.
-		await collaborationUtils.waitForEntityReady( page );
-
-		// Wait for meta boxes to initialize and disable collaboration.
-		// collaborationSupported starts as true, then the meta box hook
-		// sets it to false once meta boxes are detected.
-		await page.waitForFunction(
-			() =>
-				window?.wp?.data
-					?.select( 'core/editor' )
-					?.isCollaborationEnabledForCurrentPost?.() === false,
-			{ timeout: 15000 }
-		);
-
-		// Set up second browser context for User 2.
-		const secondContext = await admin.browser.newContext( {
-			baseURL: BASE_URL,
-		} );
-		const page2 = await secondContext.newPage();
-
-		try {
-			// Log in the second user.
-			await page2.goto( '/wp-login.php' );
-			await page2.locator( '#user_login' ).fill( SECOND_USER.username );
-			await page2.locator( '#user_pass' ).fill( SECOND_USER.password );
-			await page2.getByRole( 'button', { name: 'Log In' } ).click();
-			await page2.waitForURL( '**/wp-admin/**' );
-
-			// User 2 navigates to the same post.
-			await page2.goto(
-				`/wp-admin/post.php?post=${ post.id }&action=edit`
+	test.describe( 'incompatible meta boxes', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-plugin-meta-box'
 			);
+		} );
 
-			// Wait for wp.data to be available on User 2's page.
-			await page2.waitForFunction(
-				() => window?.wp?.data && window?.wp?.blocks,
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-plugin-meta-box'
+			);
+		} );
+
+		test( 'shows post-locked modal when meta boxes disable collaboration', async ( {
+			collaborationUtils,
+			requestUtils,
+			admin,
+			editor,
+			page,
+		} ) => {
+			// Create a draft post.
+			const post = await requestUtils.createPost( {
+				title: 'Meta Box Lock Test',
+				status: 'draft',
+				date_gmt: new Date().toISOString(),
+			} );
+
+			// User 1 (admin) opens the post.
+			await admin.visitAdminPage(
+				'post.php',
+				`post=${ post.id }&action=edit`
+			);
+			await editor.setPreferences( 'core/edit-post', {
+				welcomeGuide: false,
+				fullscreenMode: false,
+			} );
+
+			// Wait for collaboration runtime and entity record to be ready.
+			await collaborationUtils.waitForEntityReady( page );
+
+			// Wait for meta boxes to initialize and disable collaboration.
+			// collaborationSupported starts as true, then the meta box hook
+			// sets it to false once meta boxes are detected.
+			await page.waitForFunction(
+				() =>
+					window?.wp?.data
+						?.select( 'core/editor' )
+						?.isCollaborationEnabledForCurrentPost?.() === false,
 				{ timeout: 15000 }
 			);
 
-			// Assert the post-locked modal appears.
-			// Because collaboration is disabled (meta boxes), WordPress
-			// falls back to standard post-locking. User 2 sees the
-			// "This post is already being edited" modal.
+			// Set up second browser context for User 2.
+			const secondContext = await admin.browser.newContext( {
+				baseURL: BASE_URL,
+			} );
+			const page2 = await secondContext.newPage();
+
+			try {
+				// Log in the second user.
+				await page2.goto( '/wp-login.php' );
+				await page2
+					.locator( '#user_login' )
+					.fill( SECOND_USER.username );
+				await page2
+					.locator( '#user_pass' )
+					.fill( SECOND_USER.password );
+				await page2.getByRole( 'button', { name: 'Log In' } ).click();
+				await page2.waitForURL( '**/wp-admin/**' );
+
+				// User 2 navigates to the same post.
+				await page2.goto(
+					`/wp-admin/post.php?post=${ post.id }&action=edit`
+				);
+
+				// Wait for wp.data to be available on User 2's page.
+				await page2.waitForFunction(
+					() => window?.wp?.data && window?.wp?.blocks,
+					{ timeout: 15000 }
+				);
+
+				// Assert the post-locked modal appears.
+				// Because collaboration is disabled (meta boxes), WordPress
+				// falls back to standard post-locking. User 2 sees the
+				// "This post is already being edited" modal.
+				const modal = page2.getByRole( 'dialog', {
+					name: 'This post is already being edited',
+				} );
+				await expect( modal ).toBeVisible( { timeout: 15000 } );
+
+				// Assert the explanation about meta box incompatibility.
+				await expect(
+					modal.getByText(
+						'Because this post uses plugins that aren\u2019t compatible with real-time collaboration, only one person can edit at a time.'
+					)
+				).toBeVisible();
+
+				// Assert the "Take over" option is available.
+				await expect(
+					modal.getByRole( 'link', { name: 'Take over' } )
+				).toBeVisible();
+			} finally {
+				await secondContext.close();
+			}
+		} );
+	} );
+
+	test.describe( 'RTC-compatible meta boxes', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-plugin-rtc-compatible-meta-box'
+			);
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-plugin-rtc-compatible-meta-box'
+			);
+		} );
+
+		test( 'does not disable collaboration when all meta boxes are RTC-compatible', async ( {
+			collaborationUtils,
+			requestUtils,
+			admin,
+			editor,
+			page,
+		} ) => {
+			// Create a draft post.
+			const post = await requestUtils.createPost( {
+				title: 'RTC Compatible Meta Box Test',
+				status: 'draft',
+				date_gmt: new Date().toISOString(),
+			} );
+
+			// User 1 (admin) opens the post.
+			await admin.visitAdminPage(
+				'post.php',
+				`post=${ post.id }&action=edit`
+			);
+			await editor.setPreferences( 'core/edit-post', {
+				welcomeGuide: false,
+				fullscreenMode: false,
+			} );
+
+			// Wait for collaboration runtime and entity record to be ready.
+			await collaborationUtils.waitForEntityReady( page );
+
+			// Verify collaboration remains enabled. The RTC-compatible meta
+			// box should not trigger the incompatibility lock-out.
+			await page.waitForFunction(
+				() =>
+					window?.wp?.data
+						?.select( 'core/editor' )
+						?.isCollaborationEnabledForCurrentPost?.() === true,
+				{ timeout: 15000 }
+			);
+
+			// Verify a second user can join without seeing the lock modal.
+			const { page: page2 } = await collaborationUtils.joinUser(
+				post.id,
+				SECOND_USER
+			);
+
+			// The post-locked modal should not appear.
 			const modal = page2.getByRole( 'dialog', {
 				name: 'This post is already being edited',
 			} );
-			await expect( modal ).toBeVisible( { timeout: 15000 } );
-
-			// Assert the explanation about meta box incompatibility.
-			await expect(
-				modal.getByText(
-					'Because this post uses plugins that aren\u2019t compatible with real-time collaboration, only one person can edit at a time.'
-				)
-			).toBeVisible();
-
-			// Assert the "Take over" option is available.
-			await expect(
-				modal.getByRole( 'link', { name: 'Take over' } )
-			).toBeVisible();
-		} finally {
-			await secondContext.close();
-		}
+			await expect( modal ).not.toBeVisible();
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/76940.

Previously, the presence of any legacy meta box would unconditionally disable collaboration support with a modal:

<img width="575" height="335" alt="image" src="https://github.com/user-attachments/assets/38a6dc54-ac58-414e-83a4-04f858571abb" />

---

This PR adds a server-side `__rtc_compatible_meta_box` [compatibility flag for `add_meta_box()`](https://make.wordpress.org/core/2018/11/07/meta-box-compatibility-flags/), consistent with the existing `__back_compat_meta_box` and `__block_editor_compatible_meta_box` flags.

## Why?

Some meta box plugins are safe to use alongside real-time collaboration, but there was no way to indicate this. The existing check meant that any meta box would force the editor into single-user lock mode.

This change gives plugin authors the ability to mark their meta boxes as compatible so collaboration stays enabled. Site administrators can also add the flag to third-party meta boxes via the existing `filter_block_editor_meta_boxes` PHP hook, without waiting for plugin authors to update.

## How?

On the PHP side, a new `filter_block_editor_meta_boxes` callback reads the `__rtc_compatible_meta_box` flag from each meta box's args and passes the compatible IDs to the client via inline script.

On the JS side, a new `setRtcCompatibleMetaBoxIds` action in the `core/edit-post` store receives these IDs. `useMetaBoxInitialization` then checks each active meta box against this list, and only disables collaboration if any meta box is missing from it.

Plugin authors can mark their meta box as RTC-compatible directly:

```php
add_meta_box(
    'my-metabox-id',
    'My Meta Box',
    'my_metabox_render',
    'post',
    'normal',
    'default',
    array( '__rtc_compatible_meta_box' => true ) // <- The compatibility flag
);
```

Alternatively, plugin users can mark an existing third-party meta box as compatible using the `filter_block_editor_meta_boxes` hook:

```php
add_filter( 'filter_block_editor_meta_boxes', function ( $wp_meta_boxes ) {
    // Mark 'some-plugin-metabox' as RTC-compatible.
    foreach ( $wp_meta_boxes as $screen_id => $locations ) {
        foreach ( $locations as $location => $priorities ) {
            foreach ( $priorities as $priority => $boxes ) {
                if ( isset( $boxes['some-plugin-metabox'] ) ) {
                    $wp_meta_boxes[ $screen_id ][ $location ][ $priority ]['some-plugin-metabox']['args']['__rtc_compatible_meta_box'] = true;
                }
            }
        }
    }

    return $wp_meta_boxes;
} );
```

---

For a YOLO mode to disable all metaboxes from triggering the warning (not recommended), this code can be used for testing:

```php
add_filter( 'filter_block_editor_meta_boxes', function ( $wp_meta_boxes ) {
    // Not recommended! Mark all meta boxes as RTC-compatible.
    foreach ( $wp_meta_boxes as $screen_id => $locations ) {
        foreach ( $locations as $location => $priorities ) {
            foreach ( $priorities as $priority => $boxes ) {
                foreach ( $boxes as $box_id => $box ) {
                    // Warning! Enabling meta boxes may result in metabox content data loss.
                    $wp_meta_boxes[ $screen_id ][ $location ][ $priority ][ $box_id ]['args']['__rtc_compatible_meta_box'] = true;
                }
            }
        }
    }

    return $wp_meta_boxes;
} );
```

## Testing Instructions

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Add and activate a plugin that registers a metabox (e.g. Yoast SEO).
3. As one user, open a new post and save a draft.
4. As another user (ensure it's an actual other user, not the same user on another tab) open the same post. You should see an incompatibility message:

    <img width="1269" height="734" alt="metabox-incompatibility" src="https://github.com/user-attachments/assets/b58ad2d1-9df3-4458-9267-539ef103016a" />

5. In a PHP file (e.g. `gutenberg.php`), add this code to exclude Yoast SEO's metabox (ID `wpseo_meta`) from the list:

    ```php
    add_filter( 'filter_block_editor_meta_boxes', function ( $wp_meta_boxes ) {
        // Mark 'wpseo_meta' as RTC-compatible.
        foreach ( $wp_meta_boxes as $screen_id => $locations ) {
            foreach ( $locations as $location => $priorities ) {
                foreach ( $priorities as $priority => $boxes ) {
                    if ( isset( $boxes['wpseo_meta'] ) ) {
                        $wp_meta_boxes[ $screen_id ][ $location ][ $priority ]['wpseo_meta']['args']['__rtc_compatible_meta_box'] = true;
                    }
                }
            }
        }

        return $wp_meta_boxes;
    } );

    ```

7. Reload the post as the second user who previously had the pop-up modal. Ensure the modal no longer shows.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Implementation, unit tests
