### PR TITLE
DataViews: Fix wrapper height resolution in flex layouts

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 - DataViews: Restore the original 24px gap on the default-density grid (had drifted to 32px during the token migration). [#75204](https://github.com/WordPress/gutenberg/pull/75204)
 - DataForms: Restore the original 24px minimum height on panel-layout fields (trigger, label, control) (had drifted to 32px during the token migration). [#75204](https://github.com/WordPress/gutenberg/pull/75204)
 - DataViews: Restore the original 28px end-padding on resettable filter chips (had drifted to 32px during the token migration). [#75204](https://github.com/WordPress/gutenberg/pull/75204)
+- DataViews: Fix wrapper height not resolving in flex layouts, enabling proper internal scrolling. [#76945](https://github.com/WordPress/gutenberg/pull/76945)
 
 ### Code Quality
 
@@ -57,10 +58,6 @@
 
 - DataViews: Use intersectionObserver to improve performance by unloading invisible items. Change how infinite scroll is enabled to require only 2 view properties: `infiniteScrollEnabled` and `startPosition`. [#74378](https://github.com/WordPress/gutenberg/pull/74378)
 - DataForm: The card layout now uses `Card` and `CollapsibleCard` from `@wordpress/ui` instead of `Card`, `CardHeader`, and `CardBody` from `@wordpress/components`. This changes the card's visual appearance (spacing, typography, and removal of the header/content separator). Custom CSS targeting `.components-card__body` within DataViews has been removed. Consumers wrapping DataViews or DataForm in a card should migrate to the `Card` and `CollapsibleCard` components from `@wordpress/ui`. [#76282](https://github.com/WordPress/gutenberg/pull/76282)
-
-### Bug Fixes
-
-- DataViews: Fix wrapper height not resolving in flex layouts, enabling proper internal scrolling. [#76945](https://github.com/WordPress/gutenberg/pull/76945)
 
 ### Enhancements
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -58,6 +58,10 @@
 - DataViews: Use intersectionObserver to improve performance by unloading invisible items. Change how infinite scroll is enabled to require only 2 view properties: `infiniteScrollEnabled` and `startPosition`. [#74378](https://github.com/WordPress/gutenberg/pull/74378)
 - DataForm: The card layout now uses `Card` and `CollapsibleCard` from `@wordpress/ui` instead of `Card`, `CardHeader`, and `CardBody` from `@wordpress/components`. This changes the card's visual appearance (spacing, typography, and removal of the header/content separator). Custom CSS targeting `.components-card__body` within DataViews has been removed. Consumers wrapping DataViews or DataForm in a card should migrate to the `Card` and `CollapsibleCard` components from `@wordpress/ui`. [#76282](https://github.com/WordPress/gutenberg/pull/76282)
 
+### Bug Fixes
+
+- DataViews: Fix wrapper height not resolving in flex layouts, enabling proper internal scrolling. [#76945](https://github.com/WordPress/gutenberg/pull/76945)
+
 ### Enhancements
 
 - DataForm: Add `compact` configuration option to the `datetime` control. [#76905](https://github.com/WordPress/gutenberg/pull/76905)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -7,6 +7,10 @@
 - DataViews: Use intersectionObserver to improve performance by unloading invisible items. Change how infinite scroll is enabled to require only 2 view properties: `infiniteScrollEnabled` and `startPosition`. [#74378](https://github.com/WordPress/gutenberg/pull/74378)
 - DataForm: The card layout now uses `Card` and `CollapsibleCard` from `@wordpress/ui` instead of `Card`, `CardHeader`, and `CardBody` from `@wordpress/components`. This changes the card's visual appearance (spacing, typography, and removal of the header/content separator). Custom CSS targeting `.components-card__body` within DataViews has been removed. Consumers wrapping DataViews or DataForm in a card should migrate to the `Card` and `CollapsibleCard` components from `@wordpress/ui`. [#76282](https://github.com/WordPress/gutenberg/pull/76282)
 
+### Bug Fixes
+
+- DataViews: Fix wrapper height not resolving in flex layouts, enabling proper internal scrolling. [#76945](https://github.com/WordPress/gutenberg/pull/76945)
+
 ### Enhancements
 
 - DataForm: Add `compact` configuration option to the `datetime` control. [#76905](https://github.com/WordPress/gutenberg/pull/76905)

--- a/packages/dataviews/src/dataviews/style.scss
+++ b/packages/dataviews/src/dataviews/style.scss
@@ -13,6 +13,8 @@
 .dataviews-wrapper,
 .dataviews-picker-wrapper {
 	height: 100%;
+	flex-grow: 1;
+	min-height: 0;
 	box-sizing: border-box;
 	scroll-padding-bottom: calc(var(--wpds-dimension-base) * 16);
 	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */

--- a/packages/dataviews/src/dataviews/style.scss
+++ b/packages/dataviews/src/dataviews/style.scss
@@ -15,6 +15,8 @@
 .dataviews-wrapper,
 .dataviews-picker-wrapper {
 	height: 100%;
+	flex-grow: 1;
+	min-height: 0;
 	box-sizing: border-box;
 	scroll-padding-bottom: $grid-unit-80;
 	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */


### PR DESCRIPTION
## What?
Closes #76944

Adds `flex-grow: 1` and `min-height: 0` to `.dataviews-wrapper` / `.dataviews-picker-wrapper` so the wrapper correctly fills available space in flex layout parents.

## Why?

`.dataviews-wrapper` uses `height: 100%` which doesn't resolve to a definite value when the parent container gets its height from `flex-grow` rather than an explicit `height` property. This causes `.dataviews-layout__container`'s `overflow: auto` to never activate, so the table grows to full content height and overflows its container instead of scrolling.

## How?

Added two CSS properties to the existing `.dataviews-wrapper` / `.dataviews-picker-wrapper` rule:

- `flex-grow: 1` — fills the parent's remaining space in flex layouts
- `min-height: 0` — overrides the default `min-height: auto` so the element can shrink below its content height

The existing `height: 100%` is preserved for non-flex contexts.

## Testing Instructions

1. Place a `<DataViews>` component inside a flex column container where the parent uses `flex-grow: 1` (not an explicit `height`) — for example, inside the `@wordpress/admin-ui` `Page` component, where `.admin-ui-page__content` uses `flex-grow: 1`
2. Add enough data rows to exceed the available space
3. Verify the table scrolls internally via `.dataviews-layout__container`
4. Verify DataViews still works correctly in non-flex contexts (e.g. Site Editor pages list)

### Testing Instructions for Keyboard

No keyboard-specific changes — this is a CSS-only fix affecting scroll containment.

## Screenshots or screencast

N/A — layout/scrolling behavior fix, not a visual change.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Claude Opus 4.6). The change was reviewed and validated by a human contributor.