### PR TITLE
RTC: Add optional `shouldSync` function to entity sync config

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -17,6 +17,7 @@ import { PostEditorAwareness } from './awareness/post-editor-awareness';
 import { getSyncManager } from './sync';
 import {
 	applyPostChangesToCRDTDoc,
+	defaultCollectionSyncConfig,
 	defaultSyncConfig,
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
@@ -141,6 +142,7 @@ export const rootEntitiesConfig = [
 		plural: 'comments',
 		label: __( 'Comment' ),
 		supportsPagination: true,
+		syncConfig: defaultCollectionSyncConfig,
 	},
 	{
 		name: 'menu',
@@ -237,14 +239,7 @@ export const rootEntitiesConfig = [
 		plural: 'icons',
 		key: 'name',
 	},
-].map( ( entity ) => {
-	const syncEnabledRootEntities = new Set( [ 'comment' ] );
-
-	if ( syncEnabledRootEntities.has( entity.name ) ) {
-		entity.syncConfig = defaultSyncConfig;
-	}
-	return entity;
-} );
+];
 
 export const deprecatedEntities = {
 	root: {

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -11,6 +11,8 @@ import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import {
 	type CRDTDoc,
 	type ObjectData,
+	type ObjectID,
+	type ObjectType,
 	type SyncConfig,
 	Y,
 } from '@wordpress/sync';
@@ -426,6 +428,19 @@ export const defaultSyncConfig: SyncConfig = {
 	applyChangesToCRDTDoc: defaultApplyChangesToCRDTDoc,
 	createAwareness: ( ydoc: CRDTDoc ) => new BaseAwareness( ydoc ),
 	getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
+};
+
+/**
+ * This default collection sync config can be used to sync entity collections
+ * (e.g., block comments) where we are not interested in merging changes at the
+ * individual record level, but instead want to replace the entire collection
+ * when changes are detected.
+ */
+export const defaultCollectionSyncConfig: SyncConfig = {
+	applyChangesToCRDTDoc: () => {},
+	getChangesFromCRDTDoc: () => ( {} ),
+	shouldSync: ( _: ObjectType, objectId: ObjectID | null ) =>
+		null === objectId,
 };
 
 /**

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -115,7 +115,7 @@ describe( 'defaultCollectionSyncConfig', () => {
 			defaultCollectionSyncConfig.shouldSync?.( 'comment', '123' )
 		).toBe( false );
 		expect(
-			defaultCollectionSyncConfig.shouldSync?.( 'comment', 456 )
+			defaultCollectionSyncConfig.shouldSync?.( 'comment', 'foo' )
 		).toBe( false );
 	} );
 } );

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -57,6 +57,7 @@ import { RichTextData } from '@wordpress/rich-text';
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
 import {
 	applyPostChangesToCRDTDoc,
+	defaultCollectionSyncConfig,
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 	type PostChanges,
@@ -81,6 +82,43 @@ const defaultSyncedProperties = new Set< string >( [
 	'tags',
 	'title',
 ] );
+
+describe( 'defaultCollectionSyncConfig', () => {
+	it( 'has no-op applyChangesToCRDTDoc', () => {
+		const doc = new Y.Doc();
+		// Should not throw and return undefined.
+		expect(
+			defaultCollectionSyncConfig.applyChangesToCRDTDoc( doc, {
+				title: 'test',
+			} )
+		).toBeUndefined();
+		doc.destroy();
+	} );
+
+	it( 'has getChangesFromCRDTDoc that returns empty object', () => {
+		const doc = new Y.Doc();
+		const result = defaultCollectionSyncConfig.getChangesFromCRDTDoc( doc, {
+			title: 'test',
+		} );
+		expect( result ).toEqual( {} );
+		doc.destroy();
+	} );
+
+	it( 'shouldSync returns true when objectId is null (collection)', () => {
+		expect(
+			defaultCollectionSyncConfig.shouldSync?.( 'comment', null )
+		).toBe( true );
+	} );
+
+	it( 'shouldSync returns false when objectId is provided (individual record)', () => {
+		expect(
+			defaultCollectionSyncConfig.shouldSync?.( 'comment', '123' )
+		).toBe( false );
+		expect(
+			defaultCollectionSyncConfig.shouldSync?.( 'comment', 456 )
+		).toBe( false );
+	} );
+} );
 
 describe( 'crdt', () => {
 	let doc: Y.Doc;

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -323,7 +323,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		}
 
 		if ( false === syncConfig.shouldSync?.( objectType, null ) ) {
-			log( 'loadEntity', 'shouldSync false, skipping', entityId );
+			log( 'loadCollection', 'shouldSync false, skipping', entityId );
 			return; // Sync config indicates that this entity should not be synced.
 		}
 

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -170,6 +170,11 @@ export function createSyncManager( debug = false ): SyncManager {
 			return; // Already bootstrapped.
 		}
 
+		if ( false === syncConfig.shouldSync?.( objectType, objectId ) ) {
+			log( 'loadEntity', 'shouldSync false, skipping', entityId );
+			return; // Sync config indicates that this entity should not be synced.
+		}
+
 		log( 'loadEntity', 'loading', entityId );
 
 		handlers = {
@@ -315,6 +320,11 @@ export function createSyncManager( debug = false ): SyncManager {
 		if ( collectionStates.has( objectType ) ) {
 			log( 'loadCollection', 'already loaded', entityId );
 			return; // Already loaded.
+		}
+
+		if ( false === syncConfig.shouldSync?.( objectType, null ) ) {
+			log( 'loadEntity', 'shouldSync false, skipping', entityId );
+			return; // Sync config indicates that this entity should not be synced.
 		}
 
 		log( 'loadCollection', 'loading', entityId );

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -587,6 +587,138 @@ describe( 'SyncManager', () => {
 		} );
 	} );
 
+	describe( 'shouldSync', () => {
+		it( 'skips loading entity when shouldSync returns false', async () => {
+			const manager = createSyncManager();
+
+			mockSyncConfig.shouldSync = jest.fn( () => false );
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			expect( mockSyncConfig.shouldSync ).toHaveBeenCalledWith(
+				'post',
+				'123'
+			);
+			expect(
+				mockSyncConfig.applyChangesToCRDTDoc
+			).not.toHaveBeenCalled();
+			expect( mockProviderCreator ).not.toHaveBeenCalled();
+		} );
+
+		it( 'loads entity when shouldSync returns true', async () => {
+			const manager = createSyncManager();
+
+			mockSyncConfig.shouldSync = jest.fn( () => true );
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			expect( mockSyncConfig.shouldSync ).toHaveBeenCalledWith(
+				'post',
+				'123'
+			);
+			expect(
+				mockSyncConfig.applyChangesToCRDTDoc
+			).toHaveBeenCalledTimes( 1 );
+			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'loads entity when shouldSync is not defined', async () => {
+			const manager = createSyncManager();
+
+			delete mockSyncConfig.shouldSync;
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			expect(
+				mockSyncConfig.applyChangesToCRDTDoc
+			).toHaveBeenCalledTimes( 1 );
+			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'skips loading collection when shouldSync returns false', async () => {
+			const manager = createSyncManager();
+
+			mockSyncConfig.shouldSync = jest.fn( () => false );
+
+			const mockCollectionHandlers = {
+				onStatusChange: jest.fn(),
+				refetchRecords: jest.fn( async () => Promise.resolve() ),
+			};
+
+			await manager.loadCollection(
+				mockSyncConfig,
+				'comment',
+				mockCollectionHandlers
+			);
+
+			expect( mockSyncConfig.shouldSync ).toHaveBeenCalledWith(
+				'comment',
+				null
+			);
+			expect( mockProviderCreator ).not.toHaveBeenCalled();
+		} );
+
+		it( 'loads collection when shouldSync returns true', async () => {
+			const manager = createSyncManager();
+
+			mockSyncConfig.shouldSync = jest.fn( () => true );
+
+			const mockCollectionHandlers = {
+				onStatusChange: jest.fn(),
+				refetchRecords: jest.fn( async () => Promise.resolve() ),
+			};
+
+			await manager.loadCollection(
+				mockSyncConfig,
+				'comment',
+				mockCollectionHandlers
+			);
+
+			expect( mockSyncConfig.shouldSync ).toHaveBeenCalledWith(
+				'comment',
+				null
+			);
+			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'loads collection when shouldSync is not defined', async () => {
+			const manager = createSyncManager();
+
+			delete mockSyncConfig.shouldSync;
+
+			const mockCollectionHandlers = {
+				onStatusChange: jest.fn(),
+				refetchRecords: jest.fn( async () => Promise.resolve() ),
+			};
+
+			await manager.loadCollection(
+				mockSyncConfig,
+				'comment',
+				mockCollectionHandlers
+			);
+
+			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
 	describe( 'CRDT doc observation', () => {
 		it( 'edits the local entity record when remote updates arrive', async () => {
 			// Capture the Y.Doc from provider creator.

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -144,6 +144,10 @@ export interface SyncConfig {
 		editedRecord: ObjectData
 	) => ObjectData;
 	getPersistedCRDTDoc?: ( record: ObjectData ) => string | null;
+	shouldSync?: (
+		objectType: ObjectType,
+		objectId: ObjectID | null
+	) => boolean;
 }
 
 export interface SyncManager {


### PR DESCRIPTION

## What?

Add optional `shouldSync` function to entity sync config to control whether an entity or entity collection should be synced.

Closes https://github.com/WordPress/gutenberg/issues/76932

## Why?

In #76932, @mmtr notes that when a `core/comments` block is added to a post with existing comments, each comment is loaded for syncing, even though there is no possibility of collaborating on those comments. This contributes to unnecessary resource usage: additional WebSocket connections (if using a WebSocket provider) or additional database storage (if using the default polling provider).

The root cause is that the `comment` entity is used for both regular post comments and block comments. By enabling sync for block comments, we also enable syncing for regular post comments.

It might be ideal to represent block comments as a separate entity (e.g., `blockComment`) that targets the same REST API endpoint as `comment`. However, this would require changes both to the block comments feature as well as the permissions system.

An alternative approach, taken in this PR, is to add an optional `shouldSync` function to the entity sync config, allowing it to control whether specific entities or entity collections should be loaded. This will probably find utility in other circumstances. Often, we want to sync individual entities but not the collection, or vice versa. We might also want a way to sync specific entity subtypes while excluding others.

## How?

Add an optional `shouldSync` function to the entity sync config. If it is present and returns `false`, the entity or collection are not synced.

## Testing Instructions

1. Check out this PR.
2. Settings > Writing > Enable real-time collaboration.
3. Find a post with comments (e.g., post `1` / "Hello world") and open it for editing.
4. Add a Comments block.
5. Inspect the network requests to `/wp-json/wp-sync/v1/updates`.
6. Confirm that the request payload does not include a room for `root/comment:n` where `n` is the comment ID.
