### PR TITLE
Ensure `@since` annotations are present in built files

### DIFF
--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -54,7 +54,11 @@ import {
 	getPhpReplacements,
 	renderTemplateToString,
 } from './php-generator.mjs';
-import { getPackageInfo, getPackageInfoFromFile } from './package-utils.mjs';
+import {
+	boolConfigVal,
+	getPackageInfo,
+	getPackageInfoFromFile,
+} from './package-utils.mjs';
 import { createWordpressExternalsPlugin } from './wordpress-externals-plugin.mjs';
 import {
 	getAllRoutes,
@@ -113,19 +117,6 @@ const HANDLE_PREFIX = WP_PLUGIN_CONFIG.handlePrefix || PACKAGE_NAMESPACE;
 const EXTERNAL_NAMESPACES = WP_PLUGIN_CONFIG.externalNamespaces || {};
 const PAGES = WP_PLUGIN_CONFIG.pages || [];
 
-/**
- * Interprets a configuration value as a boolean, where `"true"` and `"1"`
- * are considered true while all other values are false.
- *
- * @param {string|undefined} value The configuration value to interpret.
- * @return {boolean|undefined} Boolean interpretation of the given configuration value, or undefined if not set.
- */
-const boolConfigVal = ( value ) => {
-	if ( value === undefined ) {
-		return undefined;
-	}
-	return [ 'true', '1' ].includes( value.toLowerCase() );
-};
 
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -117,7 +117,6 @@ const HANDLE_PREFIX = WP_PLUGIN_CONFIG.handlePrefix || PACKAGE_NAMESPACE;
 const EXTERNAL_NAMESPACES = WP_PLUGIN_CONFIG.externalNamespaces || {};
 const PAGES = WP_PLUGIN_CONFIG.pages || [];
 
-
 const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
 		boolConfigVal( process.env.IS_GUTENBERG_PLUGIN ) ??

--- a/packages/wp-build/lib/package-utils.mjs
+++ b/packages/wp-build/lib/package-utils.mjs
@@ -65,6 +65,20 @@ function findPackageRoot( startDir ) {
 }
 
 /**
+ * Interprets a configuration value as a boolean, where `"true"` and `"1"`
+ * are considered true while all other values are false.
+ *
+ * @param {string|undefined} value The configuration value to interpret.
+ * @return {boolean|undefined} Boolean interpretation of the given configuration value, or undefined if not set.
+ */
+export const boolConfigVal = ( value ) => {
+	if ( value === undefined ) {
+		return undefined;
+	}
+	return [ 'true', '1' ].includes( value.toLowerCase() );
+};
+
+/**
  * Get package.json info using Node's module resolution.
  * Resolves packages from the appropriate context to support both workspace packages
  * and external dependencies in pnpm/yarn/npm workspaces.

--- a/packages/wp-build/lib/php-generator.mjs
+++ b/packages/wp-build/lib/php-generator.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 /**
  * Internal dependencies
  */
-import { getPackageInfoFromFile } from './package-utils.mjs';
+import { boolConfigVal, getPackageInfoFromFile } from './package-utils.mjs';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 
@@ -17,9 +17,13 @@ const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
  *
  * @param {string} rootDir           Root directory path.
  * @param {string} baseUrlExpression PHP expression for base URL (e.g. "includes_url( 'build' )").
- * @return {Promise<Record<string, string>>} Replacements object with {{PREFIX}}, {{VERSION}}, {{BASE_URL}}.
+ * @return {Promise<Record<string, string>>} Replacements object with {{PREFIX}}, {{VERSION}}, {{BASE_URL}}, {{SINCE_TAG}}.
  */
 export async function getPhpReplacements( rootDir, baseUrlExpression ) {
+	const isCoreBuild =
+		boolConfigVal( process.env.IS_WORDPRESS_CORE ) ??
+		boolConfigVal( process.env.npm_package_config_IS_WORDPRESS_CORE ) ??
+		false;
 	const rootPackageJson = getPackageInfoFromFile(
 		path.join( rootDir, 'package.json' )
 	);
@@ -35,6 +39,15 @@ export async function getPhpReplacements( rootDir, baseUrlExpression ) {
 		'{{PREFIX}}': name,
 		'{{VERSION}}': version,
 		'{{BASE_URL}}': baseUrlExpression,
+		/*
+		 * Inline @since annotations should be contextually accurate reflecting the correct WordPress or Gutenberg
+		 * version they were originally introduced.
+		 *
+		 * Until a more flexible approach can be created, @since annotations are set to 7.0.0 any time code is being
+		 * built for WordPress Core. Otherwise, the annotation is removed entirely.
+		 *
+		 */
+		'{{SINCE_TAG}}': isCoreBuild ? '\n * @since 7.0.0\n *' : '',
 	};
 }
 

--- a/packages/wp-build/templates/module-registration.php.template
+++ b/packages/wp-build/templates/module-registration.php.template
@@ -8,6 +8,7 @@
 
 /**
  * Register all script modules.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_register_script_modules() {
 	// Ensure this only runs once. wp_default_scripts can fire multiple times,

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -17,7 +17,7 @@ ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items = array();
 
 /**
  * Register a route for the {{PAGE_SLUG}}-wp-admin page.
- *
+ *{{SINCE_TAG}}
  * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
  * @param string|null $content_module Script module ID for content (stage/inspector).
  * @param string|null $route_module   Script module ID for route lifecycle hooks.
@@ -39,7 +39,7 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route( $path, $co
 /**
  * Register a menu item for the {{PAGE_SLUG}}-wp-admin page.
  * Note: Menu items are registered but not displayed in single-page mode.
- *
+ *{{SINCE_TAG}}
  * @param string $id        Menu item ID.
  * @param string $label     Display label.
  * @param string $to        Route path to navigate to.
@@ -63,7 +63,7 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_item( $id, $
 
 /**
  * Get all registered routes for the {{PAGE_SLUG}}-wp-admin page.
- *
+ *{{SINCE_TAG}}
  * @return array Array of route objects.
  */
 function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes() {
@@ -73,7 +73,7 @@ function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes() {
 
 /**
  * Get all registered menu items for the {{PAGE_SLUG}}-wp-admin page.
- *
+ *{{SINCE_TAG}}
  * @return array Array of menu item objects.
  */
 function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items() {
@@ -84,6 +84,7 @@ function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items() {
 /**
  * Preload REST API data for the {{PAGE_SLUG}}-wp-admin page.
  * Automatically called during page rendering.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
 	// Define paths to preload - same for all pages
@@ -114,7 +115,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_preload_data() {
 /**
  * Enqueue scripts and styles for the {{PAGE_SLUG}}-wp-admin page.
  * Hooked to admin_enqueue_scripts.
- *
+ *{{SINCE_TAG}}
  * @param string $hook_suffix The current admin page.
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suffix ) {
@@ -214,6 +215,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
  * Render the {{PAGE_SLUG}}-wp-admin page.
  * Call this function from add_menu_page or add_submenu_page.
  * This renders within the normal WordPress admin interface.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 	?>

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -14,7 +14,7 @@ ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items = array();
 
 /**
  * Register a route for the {{PAGE_SLUG}} page.
- *
+ *{{SINCE_TAG}}
  * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
  * @param string|null $content_module Script module ID for content (stage/inspector).
  * @param string|null $route_module   Script module ID for route lifecycle hooks.
@@ -35,7 +35,7 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route( $path, $content_mod
 
 /**
  * Register a menu item for the {{PAGE_SLUG}} page.
- *
+ *{{SINCE_TAG}}
  * @param string $id          Menu item ID.
  * @param string $label       Display label.
  * @param string $to          Route path to navigate to.
@@ -64,7 +64,7 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_menu_item( $id, $label, $t
 
 /**
  * Get all registered routes for the {{PAGE_SLUG}} page.
- *
+ *{{SINCE_TAG}}
  * @return array Array of route objects.
  */
 function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes() {
@@ -74,7 +74,7 @@ function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes() {
 
 /**
  * Get all registered menu items for the {{PAGE_SLUG}} page.
- *
+ *{{SINCE_TAG}}
  * @return array Array of menu item objects.
  */
 function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items() {
@@ -85,6 +85,7 @@ function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items() {
 /**
  * Preload REST API data for the {{PAGE_SLUG}} page.
  * Automatically called during page rendering.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data() {
 	// Define paths to preload - same for all pages
@@ -115,6 +116,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_preload_data() {
 /**
  * Render the {{PAGE_SLUG}} page.
  * Call this function from add_menu_page or add_submenu_page.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	// Load build constants
@@ -304,6 +306,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 /**
  * Intercept admin_init to render the page early.
  * This bypasses the default WordPress admin template.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_intercept_render() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/packages/wp-build/templates/routes-registration.php.template
+++ b/packages/wp-build/templates/routes-registration.php.template
@@ -34,7 +34,7 @@ foreach ( $routes_by_page as $page_slug => $page_routes ) {
 
 /**
  * Generic helper function to register routes for a page.
- *
+ *{{SINCE_TAG}}
  * @param array  $page_routes           Array of route data for the page.
  * @param string $register_function_name Name of the function to call for registering each route.
  */

--- a/packages/wp-build/templates/script-registration.php.template
+++ b/packages/wp-build/templates/script-registration.php.template
@@ -11,7 +11,7 @@
  * reassigning internal dependency properties of any script handle already
  * registered by that name. It does not deregister the original script, to
  * avoid losing inline scripts which may have been attached.
- *
+ *{{SINCE_TAG}}
  * @param WP_Scripts       $scripts   WP_Scripts instance.
  * @param string           $handle    Name of the script. Should be unique.
  * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
@@ -48,6 +48,7 @@ function {{PREFIX}}_override_script( $scripts, $handle, $src, $deps = array(), $
 
 /**
  * Register all package scripts.
+ *{{SINCE_TAG}}
  */
 function {{PREFIX}}_register_package_scripts( $scripts ) {
 	// Load build constants

--- a/packages/wp-build/templates/style-registration.php.template
+++ b/packages/wp-build/templates/style-registration.php.template
@@ -12,7 +12,7 @@
 /**
  * Registers a style according to `wp_register_style`. Honors this request by
  * deregistering any style by the same handler before registration.
- *
+ *{{SINCE_TAG}}
  * @param WP_Styles        $styles WP_Styles instance.
  * @param string           $handle Name of the stylesheet. Should be unique.
  * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
@@ -36,7 +36,7 @@ function {{PREFIX}}_override_style( $styles, $handle, $src, $deps = array(), $ve
 /**
  * Register all package styles (simple cases only).
  * Complex cases should be manually registered in lib/client-assets.php.
- *
+ *{{SINCE_TAG}}
  * @param WP_Styles $styles WP_Styles instance.
  */
 function {{PREFIX}}_register_package_styles( $styles ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The PHP functions maintained in `packages/wp-build/templates` and generated through the `wp-build` package lack `@since` annotations.

This is a short-term solution that ensures `@since 7.0.0` is present for all PHP functions when built for consumption by `wordpress-develop`.

This is a temporary fix for #76727.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Without `@since` annotations, the "New and updated in 7.0" page in the developer documentation will not include them (see the [6.9 version of this page](https://developer.wordpress.org/reference/since/6.9.0/)).

## How?
A `{{SINCE_TAG}}` token has been added so the script can replace it appropriately.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet 4.6
Used for: Created the initial first draft of the PR.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
