### PR TITLE
Site Editor > Quick Edit: add form config to endpoint

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -4,3 +4,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/76734
 * https://github.com/WordPress/gutenberg/pull/76622
 * https://github.com/WordPress/gutenberg/pull/76823
+* https://github.com/WordPress/gutenberg/pull/76953

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -83,59 +83,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$name = $request->get_param( 'name' );
 
 		// TODO: this data will come from a registry of view configs per entity.
-		$form            = array(
-			'layout' => array( 'type' => 'panel' ),
-			'fields' => array(
-				array(
-					'id'     => 'featured_media',
-					'layout' => array(
-						'type'          => 'regular',
-						'labelPosition' => 'none',
-					),
-				),
-				array(
-					'id'     => 'post-content-info',
-					'layout' => array(
-						'type'          => 'regular',
-						'labelPosition' => 'none',
-					),
-				),
-				array(
-					'id'       => 'status',
-					'label'    => __( 'Status', 'gutenberg' ),
-					'children' => array(
-						array(
-							'id'     => 'status',
-							'layout' => array(
-								'type'          => 'regular',
-								'labelPosition' => 'none',
-							),
-						),
-						'scheduled_date',
-						'password',
-					),
-				),
-				'author',
-				'date',
-				'slug',
-				'parent',
-				array(
-					'id'       => 'discussion',
-					'label'    => __( 'Discussion', 'gutenberg' ),
-					'children' => array(
-						array(
-							'id'     => 'comment_status',
-							'layout' => array(
-								'type'          => 'regular',
-								'labelPosition' => 'none',
-							),
-						),
-						'ping_status',
-					),
-				),
-				'template',
-			),
-		);
+		$form            = array();
 		$default_view    = array(
 			'type'       => 'table',
 			'filters'    => array(),
@@ -169,6 +117,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			$default_layouts = $this->get_default_layouts_for_page();
 			$default_view    = $this->get_default_view_for_page();
 			$view_list       = $this->get_view_list_for_page( $all_items_title, $default_layouts );
+			$form            = $this->get_form_for_page();
 		} elseif ( 'postType' === $kind && 'wp_block' === $name ) {
 			$default_layouts = $this->get_default_layouts_for_wp_block();
 			$default_view    = $this->get_default_view_for_wp_block( $default_layouts );
@@ -805,6 +754,62 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			),
 			'grid'  => array(),
 			'list'  => array(),
+		);
+	}
+
+	private function get_form_for_page() {
+		return array(
+			'layout' => array( 'type' => 'panel' ),
+			'fields' => array(
+				array(
+					'id'     => 'featured_media',
+					'layout' => array(
+						'type'          => 'regular',
+						'labelPosition' => 'none',
+					),
+				),
+				array(
+					'id'     => 'post-content-info',
+					'layout' => array(
+						'type'          => 'regular',
+						'labelPosition' => 'none',
+					),
+				),
+				array(
+					'id'       => 'status',
+					'label'    => __( 'Status', 'gutenberg' ),
+					'children' => array(
+						array(
+							'id'     => 'status',
+							'layout' => array(
+								'type'          => 'regular',
+								'labelPosition' => 'none',
+							),
+						),
+						'scheduled_date',
+						'password',
+					),
+				),
+				'author',
+				'date',
+				'slug',
+				'parent',
+				array(
+					'id'       => 'discussion',
+					'label'    => __( 'Discussion', 'gutenberg' ),
+					'children' => array(
+						array(
+							'id'     => 'comment_status',
+							'layout' => array(
+								'type'          => 'regular',
+								'labelPosition' => 'none',
+							),
+						),
+						'ping_status',
+					),
+				),
+				'template',
+			),
 		);
 	}
 

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -558,6 +558,169 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	}
 
 	/**
+	 * Returns the schema for a form layout object as a discriminated union.
+	 *
+	 * Each variant is discriminated by a single-value enum on its `type` property,
+	 * matching the TypeScript Layout union in dataviews/src/types/dataform.ts.
+	 *
+	 * @return array Schema for a form layout object.
+	 */
+	private function get_form_layout_schema() {
+		return array(
+			'oneOf' => array(
+				// RegularLayout.
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'          => array(
+							'type' => 'string',
+							'enum' => array( 'regular' ),
+						),
+						'labelPosition' => array(
+							'type' => 'string',
+							'enum' => array( 'top', 'side', 'none' ),
+						),
+					),
+				),
+				// PanelLayout.
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'           => array(
+							'type' => 'string',
+							'enum' => array( 'panel' ),
+						),
+						'labelPosition'  => array(
+							'type' => 'string',
+							'enum' => array( 'top', 'side', 'none' ),
+						),
+						'openAs'         => array(
+							'oneOf' => array(
+								array(
+									'type' => 'string',
+									'enum' => array( 'dropdown', 'modal' ),
+								),
+								array(
+									'type'       => 'object',
+									'properties' => array(
+										'type'        => array(
+											'type' => 'string',
+											'enum' => array( 'dropdown', 'modal' ),
+										),
+										'applyLabel'  => array(
+											'type' => 'string',
+										),
+										'cancelLabel' => array(
+											'type' => 'string',
+										),
+									),
+								),
+							),
+						),
+						'summary'        => array(
+							'oneOf' => array(
+								array( 'type' => 'string' ),
+								array(
+									'type'  => 'array',
+									'items' => array(
+										'type' => 'string',
+									),
+								),
+							),
+						),
+						'editVisibility' => array(
+							'type' => 'string',
+							'enum' => array( 'always', 'on-hover' ),
+						),
+					),
+				),
+				// CardLayout.
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'          => array(
+							'type' => 'string',
+							'enum' => array( 'card' ),
+						),
+						'withHeader'    => array(
+							'type' => 'boolean',
+						),
+						'isOpened'      => array(
+							'type' => 'boolean',
+						),
+						'isCollapsible' => array(
+							'type' => 'boolean',
+						),
+						'summary'       => array(
+							'oneOf' => array(
+								array( 'type' => 'string' ),
+								array(
+									'type'  => 'array',
+									'items' => array(
+										'oneOf' => array(
+											array( 'type' => 'string' ),
+											array(
+												'type' => 'object',
+												'properties' => array(
+													'id' => array(
+														'type' => 'string',
+													),
+													'visibility' => array(
+														'type' => 'string',
+														'enum' => array( 'always', 'when-collapsed' ),
+													),
+												),
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+				// RowLayout.
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'      => array(
+							'type' => 'string',
+							'enum' => array( 'row' ),
+						),
+						'alignment' => array(
+							'type' => 'string',
+							'enum' => array( 'start', 'center', 'end' ),
+						),
+						'styles'    => array(
+							'type'                 => 'object',
+							'additionalProperties' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'flex' => array(
+										'type' => array( 'string', 'number' ),
+									),
+								),
+							),
+						),
+					),
+				),
+				// DetailsLayout.
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'    => array(
+							'type' => 'string',
+							'enum' => array( 'details' ),
+						),
+						'summary' => array(
+							'type' => 'string',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Returns the schema for a form field item (string or object).
 	 *
 	 * @return array Schema for a form field.
@@ -578,24 +741,16 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						'description' => array(
 							'type' => 'string',
 						),
-						'layout'      => array(
-							'type'       => 'object',
-							'properties' => array(
-								'type'          => array(
-									'type' => 'string',
-									'enum' => array( 'regular', 'panel', 'card', 'row', 'details' ),
-								),
-								'labelPosition' => array(
-									'type' => 'string',
-									'enum' => array( 'top', 'side', 'none' ),
-								),
-							),
-						),
+						'layout'      => $this->get_form_layout_schema(),
 						'children'    => array(
 							'type'  => 'array',
 							'items' => array(
 								'oneOf' => array(
 									array( 'type' => 'string' ),
+									// This object can have the shape of a form field itself,
+									// allowing for recursive nesting of form fields.
+									// There's no easy way to codify this recursion via the JSON Schema draft-04
+									// supported by the REST API.
 									array( 'type' => 'object' ),
 								),
 							),
@@ -613,19 +768,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 */
 	private function get_form_schema() {
 		return array(
-			'layout' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'type'          => array(
-						'type' => 'string',
-						'enum' => array( 'regular', 'panel', 'card', 'row', 'details' ),
-					),
-					'labelPosition' => array(
-						'type' => 'string',
-						'enum' => array( 'top', 'side', 'none' ),
-					),
-				),
-			),
+			'layout' => $this->get_form_layout_schema(),
 			'fields' => array(
 				'type'  => 'array',
 				'items' => $this->get_form_field_schema(),

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -757,7 +757,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		);
 	}
 
-	private function get_form_for_page() {
+	private function get_form_for_page(){
 		return array(
 			'layout' => array( 'type' => 'panel' ),
 			'fields' => array(
@@ -775,6 +775,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						'labelPosition' => 'none',
 					),
 				),
+				'excerpt',
 				array(
 					'id'       => 'status',
 					'label'    => __( 'Status', 'gutenberg' ),
@@ -788,12 +789,13 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						),
 						'scheduled_date',
 						'password',
+						'sticky',
 					),
 				),
-				'author',
 				'date',
 				'slug',
-				'parent',
+				'author',
+				'template',
 				array(
 					'id'       => 'discussion',
 					'label'    => __( 'Discussion', 'gutenberg' ),
@@ -808,7 +810,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						'ping_status',
 					),
 				),
-				'template',
+				'parent',
+				'format',
 			),
 		);
 	}

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -83,6 +83,59 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$name = $request->get_param( 'name' );
 
 		// TODO: this data will come from a registry of view configs per entity.
+		$quick_edit_form = array(
+			'layout' => array( 'type' => 'panel' ),
+			'fields' => array(
+				array(
+					'id'     => 'featured_media',
+					'layout' => array(
+						'type'          => 'regular',
+						'labelPosition' => 'none',
+					),
+				),
+				array(
+					'id'     => 'post-content-info',
+					'layout' => array(
+						'type'          => 'regular',
+						'labelPosition' => 'none',
+					),
+				),
+				array(
+					'id'       => 'status',
+					'label'    => __( 'Status', 'gutenberg' ),
+					'children' => array(
+						array(
+							'id'     => 'status',
+							'layout' => array(
+								'type'          => 'regular',
+								'labelPosition' => 'none',
+							),
+						),
+						'scheduled_date',
+						'password',
+					),
+				),
+				'author',
+				'date',
+				'slug',
+				'parent',
+				array(
+					'id'       => 'discussion',
+					'label'    => __( 'Discussion', 'gutenberg' ),
+					'children' => array(
+						array(
+							'id'     => 'comment_status',
+							'layout' => array(
+								'type'          => 'regular',
+								'labelPosition' => 'none',
+							),
+						),
+						'ping_status',
+					),
+				),
+				'template',
+			),
+		);
 		$default_view    = array(
 			'type'       => 'table',
 			'filters'    => array(),
@@ -136,6 +189,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'default_view'    => $default_view,
 			'default_layouts' => $default_layouts,
 			'view_list'       => $view_list,
+			'quick_edit_form' => $quick_edit_form,
 		);
 
 		return rest_ensure_response( $response );
@@ -269,6 +323,12 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 							),
 						),
 					),
+				),
+				'quick_edit_form' => array(
+					'description' => __( 'Default quick edit form configuration.', 'gutenberg' ),
+					'type'        => 'object',
+					'readonly'    => true,
+					'properties'  => $this->get_form_schema(),
 				),
 			),
 		);
@@ -493,6 +553,82 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					'type' => 'string',
 					'enum' => array( 'compact', 'balanced', 'comfortable' ),
 				),
+			),
+		);
+	}
+
+	/**
+	 * Returns the schema for a form field item (string or object).
+	 *
+	 * @return array Schema for a form field.
+	 */
+	private function get_form_field_schema() {
+		return array(
+			'oneOf' => array(
+				array( 'type' => 'string' ),
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'          => array(
+							'type' => 'string',
+						),
+						'label'       => array(
+							'type' => 'string',
+						),
+						'description' => array(
+							'type' => 'string',
+						),
+						'layout'      => array(
+							'type'       => 'object',
+							'properties' => array(
+								'type'          => array(
+									'type' => 'string',
+									'enum' => array( 'regular', 'panel', 'card', 'row', 'details' ),
+								),
+								'labelPosition' => array(
+									'type' => 'string',
+									'enum' => array( 'top', 'side', 'none' ),
+								),
+							),
+						),
+						'children'    => array(
+							'type'  => 'array',
+							'items' => array(
+								'oneOf' => array(
+									array( 'type' => 'string' ),
+									array( 'type' => 'object' ),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Returns the schema for the form configuration object.
+	 *
+	 * @return array Schema properties for the form configuration.
+	 */
+	private function get_form_schema() {
+		return array(
+			'layout' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'type'          => array(
+						'type' => 'string',
+						'enum' => array( 'regular', 'panel', 'card', 'row', 'details' ),
+					),
+					'labelPosition' => array(
+						'type' => 'string',
+						'enum' => array( 'top', 'side', 'none' ),
+					),
+				),
+			),
+			'fields' => array(
+				'type'  => 'array',
+				'items' => $this->get_form_field_schema(),
 			),
 		);
 	}

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -118,7 +118,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			$default_view    = $this->get_default_view_for_page();
 			$view_list       = $this->get_view_list_for_page( $all_items_title, $default_layouts );
 			$form            = $this->get_form_for_page();
-		} elseif ( 'postType' === $kind && 'post' === $name) {
+		} elseif ( 'postType' === $kind && 'post' === $name ) {
 			$form = $this->get_form_for_page();
 		} elseif ( 'postType' === $kind && 'wp_block' === $name ) {
 			$default_layouts = $this->get_default_layouts_for_wp_block();
@@ -759,7 +759,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		);
 	}
 
-	private function get_form_for_page(){
+	private function get_form_for_page() {
 		return array(
 			'layout' => array( 'type' => 'panel' ),
 			'fields' => array(

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -83,7 +83,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$name = $request->get_param( 'name' );
 
 		// TODO: this data will come from a registry of view configs per entity.
-		$quick_edit_form = array(
+		$form            = array(
 			'layout' => array( 'type' => 'panel' ),
 			'fields' => array(
 				array(
@@ -189,7 +189,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'default_view'    => $default_view,
 			'default_layouts' => $default_layouts,
 			'view_list'       => $view_list,
-			'quick_edit_form' => $quick_edit_form,
+			'form'            => $form,
 		);
 
 		return rest_ensure_response( $response );
@@ -324,8 +324,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 						),
 					),
 				),
-				'quick_edit_form' => array(
-					'description' => __( 'Default quick edit form configuration.', 'gutenberg' ),
+				'form'            => array(
+					'description' => __( 'Default form configuration.', 'gutenberg' ),
 					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => $this->get_form_schema(),

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -118,6 +118,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			$default_view    = $this->get_default_view_for_page();
 			$view_list       = $this->get_view_list_for_page( $all_items_title, $default_layouts );
 			$form            = $this->get_form_for_page();
+		} elseif ( 'postType' === $kind && 'post' === $name) {
+			$form = $this->get_form_for_page();
 		} elseif ( 'postType' === $kind && 'wp_block' === $name ) {
 			$default_layouts = $this->get_default_layouts_for_wp_block();
 			$default_view    = $this->get_default_view_for_wp_block( $default_layouts );

--- a/package-lock.json
+++ b/package-lock.json
@@ -60180,6 +60180,7 @@
 				"@wordpress/server-side-render": "file:../server-side-render",
 				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",
+				"@wordpress/views": "file:../views",
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/wordcount": "file:../wordcount",
 				"change-case": "^4.1.2",

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -343,6 +343,7 @@ export function getViewConfig(
 			default_view: undefined,
 			default_layouts: undefined,
 			view_list: undefined,
+			quick_edit_form: undefined,
 		}
 	);
 }

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -343,7 +343,7 @@ export function getViewConfig(
 			default_view: undefined,
 			default_layouts: undefined,
 			view_list: undefined,
-			quick_edit_form: undefined,
+			form: undefined,
 		}
 	);
 }

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -60,6 +60,7 @@ export default function PostList( { postType } ) {
 		default_view: defaultView,
 		default_layouts: defaultLayouts,
 		view_list: viewList,
+		quick_edit_form: quickEditForm,
 	} = useViewConfig( {
 		kind: 'postType',
 		name: postType,
@@ -339,6 +340,7 @@ export default function PostList( { postType } ) {
 						postType={ postType }
 						postId={ selection }
 						closeModal={ closeQuickEditModal }
+						quickEditForm={ quickEditForm }
 					/>
 				) }
 		</Page>

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -60,7 +60,7 @@ export default function PostList( { postType } ) {
 		default_view: defaultView,
 		default_layouts: defaultLayouts,
 		view_list: viewList,
-		quick_edit_form: quickEditForm,
+		form: quickEditForm,
 	} = useViewConfig( {
 		kind: 'postType',
 		name: postType,

--- a/packages/edit-site/src/components/post-list/quick-edit-modal.js
+++ b/packages/edit-site/src/components/post-list/quick-edit-modal.js
@@ -22,7 +22,12 @@ const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
 
 const fieldsWithBulkEditSupport = [ 'status', 'date', 'author', 'discussion' ];
 
-export function QuickEditModal( { postType, postId, closeModal } ) {
+export function QuickEditModal( {
+	postType,
+	postId,
+	closeModal,
+	quickEditForm,
+} ) {
 	const isBulk = postId.length > 1;
 
 	const [ localEdits, setLocalEdits ] = useState( {} );
@@ -93,61 +98,21 @@ export function QuickEditModal( { postType, postId, closeModal } ) {
 	);
 
 	const form = useMemo( () => {
-		const allFields = [
-			{
-				id: 'featured_media',
-				layout: {
-					type: 'regular',
-					labelPosition: 'none',
-				},
-			},
-			{
-				id: 'post-content-info',
-				layout: { type: 'regular', labelPosition: 'none' },
-			},
-			{
-				id: 'status',
-				label: __( 'Status' ),
-				children: [
-					{
-						id: 'status',
-						layout: { type: 'regular', labelPosition: 'none' },
-					},
-					'scheduled_date',
-					'password',
-				],
-			},
-			'author',
-			'date',
-			'slug',
-			'parent',
-			{
-				id: 'discussion',
-				label: __( 'Discussion' ),
-				children: [
-					{
-						id: 'comment_status',
-						layout: { type: 'regular', labelPosition: 'none' },
-					},
-					'ping_status',
-				],
-			},
-			'template',
-		];
-
+		if ( ! quickEditForm ) {
+			return { layout: { type: 'panel' }, fields: [] };
+		}
+		if ( ! isBulk ) {
+			return quickEditForm;
+		}
 		return {
-			layout: {
-				type: 'panel',
-			},
-			fields: isBulk
-				? allFields.filter( ( field ) =>
-						fieldsWithBulkEditSupport.includes(
-							typeof field === 'string' ? field : field.id
-						)
-				  )
-				: allFields,
+			...quickEditForm,
+			fields: ( quickEditForm.fields ?? [] ).filter( ( field ) =>
+				fieldsWithBulkEditSupport.includes(
+					typeof field === 'string' ? field : field.id
+				)
+			),
 		};
-	}, [ isBulk ] );
+	}, [ isBulk, quickEditForm ] );
 
 	const onChange = ( edits ) => {
 		const currentData = { ...record, ...localEdits };

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -101,6 +101,7 @@
 		"@wordpress/server-side-render": "file:../server-side-render",
 		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",
+		"@wordpress/views": "file:../views",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
 		"change-case": "^4.1.2",

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -7,6 +7,7 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { DataForm } from '@wordpress/dataviews';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
+import { useViewConfig } from '@wordpress/views';
 
 /**
  * Internal dependencies
@@ -18,58 +19,7 @@ import PostTrash from '../post-trash';
 import usePostFields from '../post-fields';
 import { usePostTemplatePanelMode } from '../post-template/hooks';
 
-const form = {
-	layout: {
-		type: 'panel',
-	},
-	fields: [
-		{
-			id: 'featured_media',
-			layout: {
-				type: 'regular',
-				labelPosition: 'none',
-			},
-		},
-		{
-			id: 'post-content-info',
-			layout: {
-				type: 'regular',
-				labelPosition: 'none',
-			},
-		},
-		'excerpt',
-		{
-			id: 'status',
-			label: __( 'Status' ),
-			children: [
-				{
-					id: 'status',
-					layout: { type: 'regular', labelPosition: 'none' },
-				},
-				'scheduled_date',
-				'password',
-				'sticky',
-			],
-		},
-		'date',
-		'slug',
-		'author',
-		'template',
-		{
-			id: 'discussion',
-			label: __( 'Discussion' ),
-			children: [
-				{
-					id: 'comment_status',
-					layout: { type: 'regular', labelPosition: 'none' },
-				},
-				'ping_status',
-			],
-		},
-		'parent',
-		'format',
-	],
-};
+const EMPTY_FORM = { layout: { type: 'panel' }, fields: [] };
 
 export default function DataFormPostSummary( { onActionPerformed } ) {
 	const { postType, postId } = useSelect( ( select ) => {
@@ -79,6 +29,11 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 			postId: getCurrentPostId(),
 		};
 	}, [] );
+	const { form: formConfig } = useViewConfig( {
+		kind: 'postType',
+		name: postType,
+	} );
+	const form = formConfig ?? EMPTY_FORM;
 	const record = useSelect(
 		( select ) => {
 			if ( ! postType || ! postId ) {

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -37,6 +37,7 @@
 		{ "path": "../rich-text" },
 		{ "path": "../url" },
 		{ "path": "../upload-media" },
+		{ "path": "../views" },
 		{ "path": "../warning" },
 		{ "path": "../wordcount" }
 	]

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import type { View, SupportedLayouts } from '@wordpress/dataviews';
+import type { View, SupportedLayouts, Form } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
@@ -29,6 +29,7 @@ export function useViewConfig( {
 	default_view: View;
 	default_layouts: SupportedLayouts;
 	view_list: Array< any >;
+	quick_edit_form: Form | undefined;
 } {
 	return useSelect(
 		( select ) => {

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -29,7 +29,7 @@ export function useViewConfig( {
 	default_view: View;
 	default_layouts: SupportedLayouts;
 	view_list: Array< any >;
-	quick_edit_form: Form | undefined;
+	form: Form | undefined;
 } {
 	return useSelect(
 		( select ) => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76544
Backported at https://github.com/WordPress/wordpress-develop/pull/11272

## What?                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                        
  Migrates the quick edit form configuration from a hardcoded JavaScript definition to the wp/v2/view-config REST API endpoint.                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                        
##  Why?                                                                                                                                                                                                                                                                                                  

See https://github.com/WordPress/gutenberg/issues/76544
                                                                                                                                                                                                                                                                                                          
##  How?                                                                                                                                                                                                                                                                                                  
                                                        
  - Added a `form` property to the view-config REST endpoint response in the PHP controller, containing the form layout (panel) and fields list.                                                                                                                                               
                                                                                                                                                     
##  Testing Instructions                                                                                                                                                                                                                                                                                  
                                                        
  1. Open the Site Editor > Pages screen.
  2. Select a post and open the quick edit modal — verify all fields render as before (featured media, status group, author, date, slug, parent, discussion group, template).
  3. Select multiple posts and open quick edit — verify only bulk-supported fields appear (status, date, author, discussion).                                                                                                                                                                           
  4. Verify the REST response at /wp/v2/view-config?kind=postType&name=page includes a `form` key with layout and fields.                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                        
##  Use of AI Tools                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                        
  Claude Code (Claude Opus 4.6) was used to assist with implementation, code exploration, etc.                                                                                                                                                                                                  
  
## Follow-ups

Update backport PR at https://github.com/WordPress/wordpress-develop/pull/11272