### PR TITLE
DOM: Fix collapsed range boundary at line wraps Firefox bug

### DIFF
--- a/packages/dom/src/dom/compute-caret-rect.js
+++ b/packages/dom/src/dom/compute-caret-rect.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import getAdjacentCharRect from './get-adjacent-char-rect';
 import getRectangleFromRange from './get-rectangle-from-range';
 import { assertIsDefined } from '../utils/assert-is-defined';
 
@@ -20,23 +21,12 @@ export default function computeCaretRect( win ) {
 		return null;
 	}
 
-	// For collapsed selections inside text nodes, use the adjacent character's
-	// rect when available. This works around a Firefox bug where collapsed
-	// ranges at line-wrap boundaries report the previous line's position.
-	// See: https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
+	// Use adjacent character rect for collapsed ranges to work around
+	// Firefox bug 1014738.
 	if ( range.collapsed ) {
-		const { startContainer, startOffset } = range;
-		if (
-			startContainer.nodeType === startContainer.TEXT_NODE &&
-			startOffset < /** @type {Text} */ ( startContainer ).length
-		) {
-			const charRange = startContainer.ownerDocument.createRange();
-			charRange.setStart( startContainer, startOffset );
-			charRange.setEnd( startContainer, startOffset + 1 );
-			const charRect = getRectangleFromRange( charRange );
-			if ( charRect ) {
-				return charRect;
-			}
+		const charRect = getAdjacentCharRect( range );
+		if ( charRect ) {
+			return charRect;
 		}
 	}
 

--- a/packages/dom/src/dom/compute-caret-rect.js
+++ b/packages/dom/src/dom/compute-caret-rect.js
@@ -20,5 +20,25 @@ export default function computeCaretRect( win ) {
 		return null;
 	}
 
+	// For collapsed selections inside text nodes, use the adjacent character's
+	// rect when available. This works around a Firefox bug where collapsed
+	// ranges at line-wrap boundaries report the previous line's position.
+	// See: https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
+	if ( range.collapsed ) {
+		const { startContainer, startOffset } = range;
+		if (
+			startContainer.nodeType === startContainer.TEXT_NODE &&
+			startOffset < /** @type {Text} */ ( startContainer ).length
+		) {
+			const charRange = startContainer.ownerDocument.createRange();
+			charRange.setStart( startContainer, startOffset );
+			charRange.setEnd( startContainer, startOffset + 1 );
+			const charRect = getRectangleFromRange( charRange );
+			if ( charRect ) {
+				return charRect;
+			}
+		}
+	}
+
 	return getRectangleFromRange( range );
 }

--- a/packages/dom/src/dom/get-adjacent-char-rect.js
+++ b/packages/dom/src/dom/get-adjacent-char-rect.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import getRectangleFromRange from './get-rectangle-from-range';
+
+/**
+ * Get the rectangle of the character after the cursor for a collapsed range.
+ * This is more accurate than the collapsed range rect for determining the
+ * visual line, working around a Firefox bug where collapsed ranges at
+ * line-wrap boundaries report the previous line's position.
+ *
+ * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
+ *
+ * @param {Range} collapsedRange The collapsed range.
+ *
+ * @return {DOMRect|null} The next character's rectangle, or null.
+ */
+export default function getAdjacentCharRect( collapsedRange ) {
+	const { startContainer, startOffset } = collapsedRange;
+	if ( startContainer.nodeType !== startContainer.TEXT_NODE ) {
+		return null;
+	}
+	const textNode = /** @type {Text} */ ( startContainer );
+	if ( startOffset >= textNode.length ) {
+		return null;
+	}
+	const doc = startContainer.ownerDocument;
+	if ( ! doc ) {
+		return null;
+	}
+	const range = doc.createRange();
+	range.setStart( textNode, startOffset );
+	range.setEnd( textNode, startOffset + 1 );
+	return getRectangleFromRange( range );
+}

--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -11,26 +11,25 @@ import isInputOrTextArea from './is-input-or-text-area';
 import { scrollIfNoRange } from './scroll-if-no-range';
 
 /**
- * Get the rectangle of an adjacent character for a collapsed range. This is
- * more accurate than the collapsed range rect for determining the visual line,
- * working around a Firefox bug where collapsed ranges at line-wrap boundaries
- * report the previous line's position.
+ * Get the rectangle of the character after the cursor for a collapsed range.
+ * This is more accurate than the collapsed range rect for determining the
+ * visual line, working around a Firefox bug where collapsed ranges at
+ * line-wrap boundaries report the previous line's position.
  *
  * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
  *
  * @param {Range}    collapsedRange The collapsed range.
- * @param {boolean}  isReverse      Whether checking the top (true) or bottom (false) edge.
  * @param {Document} ownerDocument  The owner document.
  *
- * @return {DOMRect|null} The adjacent character's rectangle, or null.
+ * @return {DOMRect|null} The next character's rectangle, or null.
  */
-function getAdjacentCharRect( collapsedRange, isReverse, ownerDocument ) {
+function getAdjacentCharRect( collapsedRange, ownerDocument ) {
 	const { startContainer, startOffset } = collapsedRange;
 	if ( startContainer.nodeType !== startContainer.TEXT_NODE ) {
 		return null;
 	}
 	const textNode = /** @type {Text} */ ( startContainer );
-	const offset = isReverse ? startOffset : startOffset - 1;
+	const offset = startOffset;
 	if ( offset < 0 || offset >= textNode.length ) {
 		return null;
 	}
@@ -150,8 +149,7 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 	// previous line's position.
 	const verticalRangeRect =
 		onlyVertical && isCollapsed
-			? getAdjacentCharRect( collapsedRange, isReverse, ownerDocument ) ??
-			  rangeRect
+			? getAdjacentCharRect( collapsedRange, ownerDocument ) ?? rangeRect
 			: rangeRect;
 
 	const verticalDiff =

--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -11,6 +11,36 @@ import isInputOrTextArea from './is-input-or-text-area';
 import { scrollIfNoRange } from './scroll-if-no-range';
 
 /**
+ * Get the rectangle of an adjacent character for a collapsed range. This is
+ * more accurate than the collapsed range rect for determining the visual line,
+ * working around a Firefox bug where collapsed ranges at line-wrap boundaries
+ * report the previous line's position.
+ *
+ * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
+ *
+ * @param {Range}    collapsedRange The collapsed range.
+ * @param {boolean}  isReverse      Whether checking the top (true) or bottom (false) edge.
+ * @param {Document} ownerDocument  The owner document.
+ *
+ * @return {DOMRect|null} The adjacent character's rectangle, or null.
+ */
+function getAdjacentCharRect( collapsedRange, isReverse, ownerDocument ) {
+	const { startContainer, startOffset } = collapsedRange;
+	if ( startContainer.nodeType !== startContainer.TEXT_NODE ) {
+		return null;
+	}
+	const textNode = /** @type {Text} */ ( startContainer );
+	const offset = isReverse ? startOffset : startOffset - 1;
+	if ( offset < 0 || offset >= textNode.length ) {
+		return null;
+	}
+	const range = ownerDocument.createRange();
+	range.setStart( textNode, offset );
+	range.setEnd( textNode, offset + 1 );
+	return getRectangleFromRange( range );
+}
+
+/**
  * Check whether the selection is at the edge of the container. Checks for
  * horizontal position by default. Set `onlyVertical` to true to check only
  * vertically.
@@ -113,7 +143,19 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 
 	const verticalSide = isReverse ? 'top' : 'bottom';
 	const horizontalSide = isReverseDir ? 'left' : 'right';
-	const verticalDiff = testRect[ verticalSide ] - rangeRect[ verticalSide ];
+
+	// For vertical edge checks on collapsed selections, use an adjacent
+	// character's rect instead of the collapsed range rect. This avoids a
+	// Firefox bug where collapsed ranges at line-wrap boundaries report the
+	// previous line's position.
+	const verticalRangeRect =
+		onlyVertical && isCollapsed
+			? getAdjacentCharRect( collapsedRange, isReverse, ownerDocument ) ??
+			  rangeRect
+			: rangeRect;
+
+	const verticalDiff =
+		testRect[ verticalSide ] - verticalRangeRect[ verticalSide ];
 	const horizontalDiff =
 		testRect[ horizontalSide ] - collapsedRangeRect[ horizontalSide ];
 

--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import getAdjacentCharRect from './get-adjacent-char-rect';
 import isRTL from './is-rtl';
 import getRangeHeight from './get-range-height';
 import getRectangleFromRange from './get-rectangle-from-range';
@@ -9,35 +10,6 @@ import hiddenCaretRangeFromPoint from './hidden-caret-range-from-point';
 import { assertIsDefined } from '../utils/assert-is-defined';
 import isInputOrTextArea from './is-input-or-text-area';
 import { scrollIfNoRange } from './scroll-if-no-range';
-
-/**
- * Get the rectangle of the character after the cursor for a collapsed range.
- * This is more accurate than the collapsed range rect for determining the
- * visual line, working around a Firefox bug where collapsed ranges at
- * line-wrap boundaries report the previous line's position.
- *
- * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1014738
- *
- * @param {Range}    collapsedRange The collapsed range.
- * @param {Document} ownerDocument  The owner document.
- *
- * @return {DOMRect|null} The next character's rectangle, or null.
- */
-function getAdjacentCharRect( collapsedRange, ownerDocument ) {
-	const { startContainer, startOffset } = collapsedRange;
-	if ( startContainer.nodeType !== startContainer.TEXT_NODE ) {
-		return null;
-	}
-	const textNode = /** @type {Text} */ ( startContainer );
-	const offset = startOffset;
-	if ( offset < 0 || offset >= textNode.length ) {
-		return null;
-	}
-	const range = ownerDocument.createRange();
-	range.setStart( textNode, offset );
-	range.setEnd( textNode, offset + 1 );
-	return getRectangleFromRange( range );
-}
 
 /**
  * Check whether the selection is at the edge of the container. Checks for
@@ -149,7 +121,7 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 	// previous line's position.
 	const verticalRangeRect =
 		onlyVertical && isCollapsed
-			? getAdjacentCharRect( collapsedRange, ownerDocument ) ?? rangeRect
+			? getAdjacentCharRect( collapsedRange ) ?? rangeRect
 			: rangeRect;
 
 	const verticalDiff =

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1040,7 +1040,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 <!-- /wp:paragraph -->` );
 	} );
 
-	test( 'should move to the start of the first line on ArrowUp (-firefox)', async ( {
+	test( 'should move to the start of the first line on ArrowUp', async ( {
 		page,
 		editor,
 	} ) => {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1074,6 +1074,44 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		).toHaveText( /^\.a+$/ );
 	} );
 
+	test( 'should move to the start of the first line on ArrowDown', async ( {
+		page,
+		editor,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a' );
+
+		async function getHeight() {
+			return await editor.canvas
+				.locator( ':root' )
+				.evaluate( () => document.activeElement.offsetHeight );
+		}
+
+		const height = await getHeight();
+
+		// Keep typing until the height of the element increases. We need two
+		// lines.
+		while ( height === ( await getHeight() ) ) {
+			await page.keyboard.type( 'a' );
+		}
+
+		// Move to the start of the second line.
+		await page.keyboard.press( 'ArrowLeft' );
+		// Move to the start of the first line.
+		await page.keyboard.press( 'ArrowUp' );
+		// Move to the title.
+		await page.keyboard.press( 'ArrowUp' );
+		// Move back down to the paragraph.
+		await page.keyboard.press( 'ArrowDown' );
+		// Insert a "." for testing.
+		await page.keyboard.type( '.' );
+
+		// Expect the "." to be added at the start of the paragraph
+		await expect(
+			editor.canvas.locator( 'role=document[name="Block: Paragraph"i]' )
+		).toHaveText( /^\.a+$/ );
+	} );
+
 	test( 'should vertically move the caret from corner to corner (-webkit)', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?
Closes #34215.
Alternative to #71205. Doesn't use browser check, which is usually a fragile fix.

Fixes a Firefox bug where arrow key navigation (both up and down) incorrectly jumps to the wrong block at line-wrap boundaries.

## Why?
Firefox reports the previous line's position for collapsed ranges at line wrap boundaries. This caused `isVerticalEdge` and `computeCaretRect` to misjudge which line the caret is on, leading to incorrect navigation.

This report is the closest I could find to the issue - https://bugzilla.mozilla.org/show_bug.cgi?id=1014738.

## How?
When the selection is collapsed inside a text node, we get the rect of the next character (offset to offset+1) instead of the collapsed range rect. This gives the correct visual line position. The logic is extracted into the `getAdjacentCharRect` method, reused by `computeCaretRect` and `isEdge`.

## Testing Instructions
1. Using Firefox.
2. Create a post and add some paragraphs that wrap.
3. Place a caret on the second line and try navigation with ArrowUp and ArrowDown.
4. The navigation should work as expected and not skip the lines. Matches the behavior of other browsers.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/feca25b5-d764-4b59-b301-b70e655f206b

**After**

https://github.com/user-attachments/assets/b109d36e-d2be-46a1-a8ff-ccad1a3970ec


## Use of AI Tools

Used Claude to validate possible solution (browser check, increased tolerance, etc). The solution is tested and reviewed by me.
