### PR TITLE
Components: Extract the autocomplete matcher into a separate function

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 -   `Button`: Hide focus outline on `:active` in High Contrast (forced colors) mode to provide visual click feedback ([#76833](https://github.com/WordPress/gutenberg/pull/76833)).
 
+### Internal
+
+-   `Autocomplete`: Extract matching logic into a standalone pure function ([#76957](https://github.com/WordPress/gutenberg/pull/76957)).
+
 ## 32.4.0 (2026-03-18)
 
 ### Bug Fixes

--- a/packages/components/src/autocomplete/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/get-autocomplete-match.ts
@@ -18,7 +18,7 @@ export function getAutocompleteMatch(
 	completers: WPCompleter[],
 	filteredOptionsLength: number,
 	isBackspacing: boolean,
-	textAfterSelection: string
+	getTextAfterSelection: () => string
 ): AutocompleteMatch | null {
 	if ( ! textContent ) {
 		return null;
@@ -50,7 +50,8 @@ export function getAutocompleteMatch(
 	);
 
 	// Prevent matching with an extremely long string, which causes
-	// the editor to slow-down significantly.
+	// the editor to slow-down significantly. Returning null here
+	// intentionally resets the autocompleter state in the caller.
 	if ( textWithoutTrigger.length > 50 ) {
 		return null;
 	}
@@ -74,7 +75,7 @@ export function getAutocompleteMatch(
 		allowContext &&
 		! allowContext(
 			textContent.slice( 0, triggerIndex ),
-			textAfterSelection
+			getTextAfterSelection()
 		)
 	) {
 		return null;

--- a/packages/components/src/autocomplete/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/get-autocomplete-match.ts
@@ -50,8 +50,10 @@ export function getAutocompleteMatch(
 	);
 
 	// Prevent matching with an extremely long string, which causes
-	// the editor to slow-down significantly. Returning null here
-	// intentionally resets the autocompleter state in the caller.
+	// the editor to slow-down significantly. This could happen, for
+	// example, if `matchingWhileBackspacing` is true and one of the
+	// "words" ends up being too long. Returning null here intentionally
+	// resets the autocompleter state in the caller.
 	if ( textWithoutTrigger.length > 50 ) {
 		return null;
 	}
@@ -61,9 +63,14 @@ export function getAutocompleteMatch(
 
 	// Allow matching when typing a trigger + the match string or when
 	// clicking in an existing trigger word on the page.
+	// E.g. "Some text @a" — "@a" is detected as a trigger word.
 	const hasOneTriggerWord = wordsFromTrigger.length === 1;
 
-	// Allow matching when backspacing near a trigger word (up to 3 words).
+	// Allow matching when backspacing near a trigger word (up to 3
+	// words from the trigger character). This lets us recover from a
+	// mismatch when backspacing while still imposing sane limits.
+	// E.g. "Some text @marcelo sekkkk" — backspacing "kkkk" re-shows
+	// the popup once the text matches again.
 	const matchingWhileBackspacing =
 		isBackspacing && wordsFromTrigger.length <= 3;
 

--- a/packages/components/src/autocomplete/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/get-autocomplete-match.ts
@@ -6,27 +6,13 @@ import removeAccents from 'remove-accents';
 /**
  * Internal dependencies
  */
-import { escapeRegExp } from '../utils/strings';
 import type { WPCompleter } from './types';
 
-export type AutocompleteMatch = {
+type AutocompleteMatch = {
 	completer: WPCompleter;
 	filterValue: string;
 };
 
-/**
- * Determines the best autocomplete match for the given text content.
- *
- * This is a pure function extracted from the useAutocomplete hook
- * to enable unit testing of the matching algorithm.
- *
- * @param textContent           The full text content up to the cursor.
- * @param completers            Available completers.
- * @param filteredOptionsLength Number of currently filtered options (0 = mismatch).
- * @param isBackspacing         Whether the user is currently backspacing.
- * @param textAfterSelection    Text content after the cursor.
- * @return The match result, or null if no match.
- */
 export function getAutocompleteMatch(
 	textContent: string,
 	completers: WPCompleter[],
@@ -39,38 +25,33 @@ export function getAutocompleteMatch(
 	}
 
 	// Find the completer with the highest triggerPrefix index in the
-	// textContent.
-	const completer = completers.reduce< WPCompleter | null >(
-		( lastTrigger, currentCompleter ) => {
-			const triggerIndex = textContent.lastIndexOf(
-				currentCompleter.triggerPrefix
-			);
-			const lastTriggerIndex =
-				lastTrigger !== null
-					? textContent.lastIndexOf( lastTrigger.triggerPrefix )
-					: -1;
+	// textContent. Compute lastIndexOf once per completer to avoid
+	// redundant lookups in the reduce accumulator.
+	let completer: WPCompleter | null = null;
+	let triggerIndex = -1;
 
-			return triggerIndex > lastTriggerIndex
-				? currentCompleter
-				: lastTrigger;
-		},
-		null
-	);
+	for ( const currentCompleter of completers ) {
+		const currentIndex = textContent.lastIndexOf(
+			currentCompleter.triggerPrefix
+		);
+		if ( currentIndex > triggerIndex ) {
+			completer = currentCompleter;
+			triggerIndex = currentIndex;
+		}
+	}
 
 	if ( ! completer ) {
 		return null;
 	}
 
 	const { allowContext, triggerPrefix } = completer;
-	const triggerIndex = textContent.lastIndexOf( triggerPrefix );
 	const textWithoutTrigger = textContent.slice(
 		triggerIndex + triggerPrefix.length
 	);
 
-	// This is a final barrier to prevent matching with an extremely long
-	// string, which causes the editor to slow-down significantly.
-	const tooDistantFromTrigger = textWithoutTrigger.length > 50;
-	if ( tooDistantFromTrigger ) {
+	// Prevent matching with an extremely long string, which causes
+	// the editor to slow-down significantly.
+	if ( textWithoutTrigger.length > 50 ) {
 		return null;
 	}
 
@@ -106,19 +87,8 @@ export function getAutocompleteMatch(
 		return null;
 	}
 
-	if ( ! /[\u0000-\uFFFF]*$/.test( textWithoutTrigger ) ) {
-		return null;
-	}
-
-	const safeTrigger = escapeRegExp( triggerPrefix );
-	const text = removeAccents( textContent );
-	const match = text
-		.slice( text.lastIndexOf( triggerPrefix ) )
-		.match( new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` ) );
-	const query = match && match[ 1 ];
-
 	return {
 		completer,
-		filterValue: query === null ? '' : query,
+		filterValue: removeAccents( textWithoutTrigger ),
 	};
 }

--- a/packages/components/src/autocomplete/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/get-autocomplete-match.ts
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import removeAccents from 'remove-accents';
+
+/**
+ * Internal dependencies
+ */
+import { escapeRegExp } from '../utils/strings';
+import type { WPCompleter } from './types';
+
+export type AutocompleteMatch = {
+	completer: WPCompleter;
+	filterValue: string;
+};
+
+/**
+ * Determines the best autocomplete match for the given text content.
+ *
+ * This is a pure function extracted from the useAutocomplete hook
+ * to enable unit testing of the matching algorithm.
+ *
+ * @param textContent           The full text content up to the cursor.
+ * @param completers            Available completers.
+ * @param filteredOptionsLength Number of currently filtered options (0 = mismatch).
+ * @param isBackspacing         Whether the user is currently backspacing.
+ * @param textAfterSelection    Text content after the cursor.
+ * @return The match result, or null if no match.
+ */
+export function getAutocompleteMatch(
+	textContent: string,
+	completers: WPCompleter[],
+	filteredOptionsLength: number,
+	isBackspacing: boolean,
+	textAfterSelection: string
+): AutocompleteMatch | null {
+	if ( ! textContent ) {
+		return null;
+	}
+
+	// Find the completer with the highest triggerPrefix index in the
+	// textContent.
+	const completer = completers.reduce< WPCompleter | null >(
+		( lastTrigger, currentCompleter ) => {
+			const triggerIndex = textContent.lastIndexOf(
+				currentCompleter.triggerPrefix
+			);
+			const lastTriggerIndex =
+				lastTrigger !== null
+					? textContent.lastIndexOf( lastTrigger.triggerPrefix )
+					: -1;
+
+			return triggerIndex > lastTriggerIndex
+				? currentCompleter
+				: lastTrigger;
+		},
+		null
+	);
+
+	if ( ! completer ) {
+		return null;
+	}
+
+	const { allowContext, triggerPrefix } = completer;
+	const triggerIndex = textContent.lastIndexOf( triggerPrefix );
+	const textWithoutTrigger = textContent.slice(
+		triggerIndex + triggerPrefix.length
+	);
+
+	// This is a final barrier to prevent matching with an extremely long
+	// string, which causes the editor to slow-down significantly.
+	const tooDistantFromTrigger = textWithoutTrigger.length > 50;
+	if ( tooDistantFromTrigger ) {
+		return null;
+	}
+
+	const mismatch = filteredOptionsLength === 0;
+	const wordsFromTrigger = textWithoutTrigger.split( /\s/ );
+
+	// Allow matching when typing a trigger + the match string or when
+	// clicking in an existing trigger word on the page.
+	const hasOneTriggerWord = wordsFromTrigger.length === 1;
+
+	// Allow matching when backspacing near a trigger word (up to 3 words).
+	const matchingWhileBackspacing =
+		isBackspacing && wordsFromTrigger.length <= 3;
+
+	if ( mismatch && ! ( matchingWhileBackspacing || hasOneTriggerWord ) ) {
+		return null;
+	}
+
+	if (
+		allowContext &&
+		! allowContext(
+			textContent.slice( 0, triggerIndex ),
+			textAfterSelection
+		)
+	) {
+		return null;
+	}
+
+	if (
+		/^\s/.test( textWithoutTrigger ) ||
+		/\s\s+$/.test( textWithoutTrigger )
+	) {
+		return null;
+	}
+
+	if ( ! /[\u0000-\uFFFF]*$/.test( textWithoutTrigger ) ) {
+		return null;
+	}
+
+	const safeTrigger = escapeRegExp( triggerPrefix );
+	const text = removeAccents( textContent );
+	const match = text
+		.slice( text.lastIndexOf( triggerPrefix ) )
+		.match( new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` ) );
+	const query = match && match[ 1 ];
+
+	return {
+		completer,
+		filterValue: query === null ? '' : query,
+	};
+}

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -225,18 +225,24 @@ export function useAutocomplete( {
 	}, [ record ] );
 
 	useEffect( () => {
-		const textAfterSelection = textContent
-			? getTextContent(
-					slice( record, undefined, getTextContent( record ).length )
-			  )
-			: '';
+		function getTextAfterSelection() {
+			return textContent
+				? getTextContent(
+						slice(
+							record,
+							undefined,
+							getTextContent( record ).length
+						)
+				  )
+				: '';
+		}
 
 		const match = getAutocompleteMatch(
 			textContent,
 			completers,
 			filteredOptions.length,
 			backspacingRef.current,
-			textAfterSelection
+			getTextAfterSelection
 		);
 
 		if ( ! match ) {

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import removeAccents from 'remove-accents';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -28,7 +23,7 @@ import { isAppleOS } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { getAutoCompleterUI } from './autocompleter-ui';
-import { escapeRegExp } from '../utils/strings';
+import { getAutocompleteMatch } from './get-autocomplete-match';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import type {
 	AutocompleteProps,
@@ -230,124 +225,28 @@ export function useAutocomplete( {
 	}, [ record ] );
 
 	useEffect( () => {
-		if ( ! textContent ) {
-			if ( autocompleter ) {
-				reset();
-			}
-			return;
-		}
+		const textAfterSelection = textContent
+			? getTextContent(
+					slice( record, undefined, getTextContent( record ).length )
+			  )
+			: '';
 
-		// Find the completer with the highest triggerPrefix index in the
-		// textContent.
-		const completer = completers.reduce< WPCompleter | null >(
-			( lastTrigger, currentCompleter ) => {
-				const triggerIndex = textContent.lastIndexOf(
-					currentCompleter.triggerPrefix
-				);
-				const lastTriggerIndex =
-					lastTrigger !== null
-						? textContent.lastIndexOf( lastTrigger.triggerPrefix )
-						: -1;
-
-				return triggerIndex > lastTriggerIndex
-					? currentCompleter
-					: lastTrigger;
-			},
-			null
+		const match = getAutocompleteMatch(
+			textContent,
+			completers,
+			filteredOptions.length,
+			backspacingRef.current,
+			textAfterSelection
 		);
 
-		if ( ! completer ) {
+		if ( ! match ) {
 			if ( autocompleter ) {
 				reset();
 			}
 			return;
 		}
 
-		const { allowContext, triggerPrefix } = completer;
-		const triggerIndex = textContent.lastIndexOf( triggerPrefix );
-		const textWithoutTrigger = textContent.slice(
-			triggerIndex + triggerPrefix.length
-		);
-
-		const tooDistantFromTrigger = textWithoutTrigger.length > 50; // 50 chars seems to be a good limit.
-		// This is a final barrier to prevent the effect from completing with
-		// an extremely long string, which causes the editor to slow-down
-		// significantly. This could happen, for example, if `matchingWhileBackspacing`
-		// is true and one of the "words" end up being too long. If that's the case,
-		// it will be caught by this guard.
-		if ( tooDistantFromTrigger ) {
-			return;
-		}
-
-		const mismatch = filteredOptions.length === 0;
-		const wordsFromTrigger = textWithoutTrigger.split( /\s/ );
-		// We need to allow the effect to run when not backspacing and if there
-		// was a mismatch. i.e when typing a trigger + the match string or when
-		// clicking in an existing trigger word on the page. We do that if we
-		// detect that we have one word from trigger in the current textual context.
-		//
-		// Ex.: "Some text @a" <-- "@a" will be detected as the trigger word and
-		// allow the effect to run. It will run until there's a mismatch.
-		const hasOneTriggerWord = wordsFromTrigger.length === 1;
-		// This is used to allow the effect to run when backspacing and if
-		// "touching" a word that "belongs" to a trigger. We consider a "trigger
-		// word" any word up to the limit of 3 from the trigger character.
-		// Anything beyond that is ignored if there's a mismatch. This allows
-		// us to "escape" a mismatch when backspacing, but still imposing some
-		// sane limits.
-		//
-		// Ex: "Some text @marcelo sekkkk" <--- "kkkk" caused a mismatch, but
-		// if the user presses backspace here, it will show the completion popup again.
-		const matchingWhileBackspacing =
-			backspacingRef.current && wordsFromTrigger.length <= 3;
-
-		if ( mismatch && ! ( matchingWhileBackspacing || hasOneTriggerWord ) ) {
-			if ( autocompleter ) {
-				reset();
-			}
-			return;
-		}
-
-		const textAfterSelection = getTextContent(
-			slice( record, undefined, getTextContent( record ).length )
-		);
-
-		if (
-			allowContext &&
-			! allowContext(
-				textContent.slice( 0, triggerIndex ),
-				textAfterSelection
-			)
-		) {
-			if ( autocompleter ) {
-				reset();
-			}
-			return;
-		}
-
-		if (
-			/^\s/.test( textWithoutTrigger ) ||
-			/\s\s+$/.test( textWithoutTrigger )
-		) {
-			if ( autocompleter ) {
-				reset();
-			}
-			return;
-		}
-
-		if ( ! /[\u0000-\uFFFF]*$/.test( textWithoutTrigger ) ) {
-			if ( autocompleter ) {
-				reset();
-			}
-			return;
-		}
-
-		const safeTrigger = escapeRegExp( completer.triggerPrefix );
-		const text = removeAccents( textContent );
-		const match = text
-			.slice( text.lastIndexOf( completer.triggerPrefix ) )
-			.match( new RegExp( `${ safeTrigger }([\u0000-\uFFFF]*)$` ) );
-		const query = match && match[ 1 ];
+		const { completer, filterValue: query } = match;
 
 		setAutocompleter( completer );
 		setAutocompleterUI( () =>
@@ -355,7 +254,7 @@ export function useAutocomplete( {
 				? getAutoCompleterUI( completer )
 				: AutocompleterUI
 		);
-		setFilterValue( query === null ? '' : query );
+		setFilterValue( query );
 		// We want to avoid introducing unexpected side effects.
 		// See https://github.com/WordPress/gutenberg/pull/41820
 	}, [ textContent ] );

--- a/packages/components/src/autocomplete/test/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/test/get-autocomplete-match.ts
@@ -28,6 +28,13 @@ describe( 'getAutocompleteMatch', () => {
 		).toBeNull();
 	} );
 
+	it( 'should return null when trigger prefix is not found in text', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		expect(
+			getAutocompleteMatch( 'no trigger here', completers, 1, false, '' )
+		).toBeNull();
+	} );
+
 	it( 'should match a simple trigger prefix', () => {
 		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
 		const result = getAutocompleteMatch(
@@ -221,4 +228,53 @@ describe( 'getAutocompleteMatch', () => {
 		expect( result ).not.toBeNull();
 		expect( result?.filterValue ).toBe( 'hello world' );
 	} );
+
+	it.each( [
+		{
+			text: 'café @user',
+			trigger: '@',
+			expected: 'user',
+			desc: 'accented text before trigger',
+		},
+		{
+			text: 'naïve /command',
+			trigger: '/',
+			expected: 'command',
+			desc: 'accented text before trigger (diaeresis)',
+		},
+		{
+			text: 'résumé @josé',
+			trigger: '@',
+			expected: 'jose',
+			desc: 'accents both before and after trigger',
+		},
+		{
+			text: '@café',
+			trigger: '@',
+			expected: 'cafe',
+			desc: 'accented text after trigger only',
+		},
+		{
+			text: 'a /héllo wörld',
+			trigger: '/',
+			expected: 'hello world',
+			desc: 'accented multi-word filter value',
+		},
+	] )(
+		'should handle accents correctly: $desc',
+		( { text, trigger, expected } ) => {
+			const completers = [
+				createCompleter( { triggerPrefix: trigger } ),
+			];
+			const result = getAutocompleteMatch(
+				text,
+				completers,
+				1,
+				false,
+				''
+			);
+			expect( result ).not.toBeNull();
+			expect( result?.filterValue ).toBe( expected );
+		}
+	);
 } );

--- a/packages/components/src/autocomplete/test/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/test/get-autocomplete-match.ts
@@ -1,0 +1,224 @@
+/**
+ * Internal dependencies
+ */
+import { getAutocompleteMatch } from '../get-autocomplete-match';
+import type { WPCompleter } from '../types';
+
+const createCompleter = (
+	overrides: Partial< WPCompleter > = {}
+): WPCompleter => ( {
+	name: 'test',
+	triggerPrefix: '/',
+	options: [],
+	getOptionLabel: ( option: any ) => option,
+	...overrides,
+} );
+
+describe( 'getAutocompleteMatch', () => {
+	it( 'should return null for empty text content', () => {
+		const completers = [ createCompleter() ];
+		expect(
+			getAutocompleteMatch( '', completers, 0, false, '' )
+		).toBeNull();
+	} );
+
+	it( 'should return null when no completers are provided', () => {
+		expect(
+			getAutocompleteMatch( 'some text /', [], 0, false, '' )
+		).toBeNull();
+	} );
+
+	it( 'should match a simple trigger prefix', () => {
+		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
+		const result = getAutocompleteMatch(
+			'some text /query',
+			completers,
+			1,
+			false,
+			''
+		);
+		expect( result ).toEqual( {
+			completer: completers[ 0 ],
+			filterValue: 'query',
+		} );
+	} );
+
+	it( 'should return empty filterValue when only trigger is typed', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		const result = getAutocompleteMatch(
+			'hello @',
+			completers,
+			1,
+			false,
+			''
+		);
+		expect( result ).toEqual( {
+			completer: completers[ 0 ],
+			filterValue: '',
+		} );
+	} );
+
+	it( 'should select the completer with the latest trigger index', () => {
+		const slashCompleter = createCompleter( {
+			name: 'slash',
+			triggerPrefix: '/',
+		} );
+		const atCompleter = createCompleter( {
+			name: 'at',
+			triggerPrefix: '@',
+		} );
+		const result = getAutocompleteMatch(
+			'/command some text @user',
+			[ slashCompleter, atCompleter ],
+			1,
+			false,
+			''
+		);
+		expect( result?.completer.name ).toBe( 'at' );
+	} );
+
+	it( 'should return null when text after trigger is too long (>50 chars)', () => {
+		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
+		const longText = '/' + 'a'.repeat( 51 );
+		expect(
+			getAutocompleteMatch( longText, completers, 1, false, '' )
+		).toBeNull();
+	} );
+
+	it( 'should match when text after trigger is exactly 50 chars', () => {
+		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
+		const text = '/' + 'a'.repeat( 50 );
+		const result = getAutocompleteMatch( text, completers, 1, false, '' );
+		expect( result ).not.toBeNull();
+		expect( result?.filterValue ).toBe( 'a'.repeat( 50 ) );
+	} );
+
+	it( 'should return null on mismatch with multiple words and no backspacing', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		// 4 words from trigger, mismatch (filteredOptionsLength=0), not backspacing
+		expect(
+			getAutocompleteMatch(
+				'text @one two three four',
+				completers,
+				0,
+				false,
+				''
+			)
+		).toBeNull();
+	} );
+
+	it( 'should still match on mismatch when there is only one trigger word', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		const result = getAutocompleteMatch(
+			'text @xyz',
+			completers,
+			0,
+			false,
+			''
+		);
+		expect( result ).not.toBeNull();
+		expect( result?.filterValue ).toBe( 'xyz' );
+	} );
+
+	it( 'should allow matching while backspacing within 3 words of trigger', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		const result = getAutocompleteMatch(
+			'text @one two three',
+			completers,
+			0,
+			true,
+			''
+		);
+		expect( result ).not.toBeNull();
+	} );
+
+	it( 'should NOT match while backspacing if more than 3 words from trigger', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		expect(
+			getAutocompleteMatch(
+				'text @one two three four',
+				completers,
+				0,
+				true,
+				''
+			)
+		).toBeNull();
+	} );
+
+	it( 'should return null when text after trigger starts with whitespace', () => {
+		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
+		expect(
+			getAutocompleteMatch( '/ query', completers, 1, false, '' )
+		).toBeNull();
+	} );
+
+	it( 'should return null when text after trigger ends with multiple spaces', () => {
+		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
+		expect(
+			getAutocompleteMatch( '/query  ', completers, 1, false, '' )
+		).toBeNull();
+	} );
+
+	it( 'should respect allowContext returning false', () => {
+		const completers = [
+			createCompleter( {
+				triggerPrefix: '@',
+				allowContext: () => false,
+			} ),
+		];
+		expect(
+			getAutocompleteMatch( 'text @user', completers, 1, false, '' )
+		).toBeNull();
+	} );
+
+	it( 'should pass correct before/after text to allowContext', () => {
+		const allowContext = jest.fn().mockReturnValue( true );
+		const completers = [
+			createCompleter( {
+				triggerPrefix: '@',
+				allowContext,
+			} ),
+		];
+		getAutocompleteMatch( 'before @user', completers, 1, false, 'after' );
+		expect( allowContext ).toHaveBeenCalledWith( 'before ', 'after' );
+	} );
+
+	it( 'should handle accented characters in filter value', () => {
+		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
+		const result = getAutocompleteMatch(
+			'text @café',
+			completers,
+			1,
+			false,
+			''
+		);
+		expect( result ).not.toBeNull();
+		expect( result?.filterValue ).toBe( 'cafe' );
+	} );
+
+	it( 'should handle special regex characters in trigger prefix', () => {
+		const completers = [ createCompleter( { triggerPrefix: '$$' } ) ];
+		const result = getAutocompleteMatch(
+			'text $$query',
+			completers,
+			1,
+			false,
+			''
+		);
+		expect( result ).not.toBeNull();
+		expect( result?.filterValue ).toBe( 'query' );
+	} );
+
+	it( 'should match with spaces in filter value (single space)', () => {
+		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
+		const result = getAutocompleteMatch(
+			'/hello world',
+			completers,
+			1,
+			false,
+			''
+		);
+		expect( result ).not.toBeNull();
+		expect( result?.filterValue ).toBe( 'hello world' );
+	} );
+} );

--- a/packages/components/src/autocomplete/test/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/test/get-autocomplete-match.ts
@@ -18,20 +18,26 @@ describe( 'getAutocompleteMatch', () => {
 	it( 'should return null for empty text content', () => {
 		const completers = [ createCompleter() ];
 		expect(
-			getAutocompleteMatch( '', completers, 0, false, '' )
+			getAutocompleteMatch( '', completers, 0, false, () => '' )
 		).toBeNull();
 	} );
 
 	it( 'should return null when no completers are provided', () => {
 		expect(
-			getAutocompleteMatch( 'some text /', [], 0, false, '' )
+			getAutocompleteMatch( 'some text /', [], 0, false, () => '' )
 		).toBeNull();
 	} );
 
 	it( 'should return null when trigger prefix is not found in text', () => {
 		const completers = [ createCompleter( { triggerPrefix: '@' } ) ];
 		expect(
-			getAutocompleteMatch( 'no trigger here', completers, 1, false, '' )
+			getAutocompleteMatch(
+				'no trigger here',
+				completers,
+				1,
+				false,
+				() => ''
+			)
 		).toBeNull();
 	} );
 
@@ -42,7 +48,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			1,
 			false,
-			''
+			() => ''
 		);
 		expect( result ).toEqual( {
 			completer: completers[ 0 ],
@@ -57,7 +63,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			1,
 			false,
-			''
+			() => ''
 		);
 		expect( result ).toEqual( {
 			completer: completers[ 0 ],
@@ -79,7 +85,7 @@ describe( 'getAutocompleteMatch', () => {
 			[ slashCompleter, atCompleter ],
 			1,
 			false,
-			''
+			() => ''
 		);
 		expect( result?.completer.name ).toBe( 'at' );
 	} );
@@ -88,14 +94,20 @@ describe( 'getAutocompleteMatch', () => {
 		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
 		const longText = '/' + 'a'.repeat( 51 );
 		expect(
-			getAutocompleteMatch( longText, completers, 1, false, '' )
+			getAutocompleteMatch( longText, completers, 1, false, () => '' )
 		).toBeNull();
 	} );
 
 	it( 'should match when text after trigger is exactly 50 chars', () => {
 		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
 		const text = '/' + 'a'.repeat( 50 );
-		const result = getAutocompleteMatch( text, completers, 1, false, '' );
+		const result = getAutocompleteMatch(
+			text,
+			completers,
+			1,
+			false,
+			() => ''
+		);
 		expect( result ).not.toBeNull();
 		expect( result?.filterValue ).toBe( 'a'.repeat( 50 ) );
 	} );
@@ -109,7 +121,7 @@ describe( 'getAutocompleteMatch', () => {
 				completers,
 				0,
 				false,
-				''
+				() => ''
 			)
 		).toBeNull();
 	} );
@@ -121,7 +133,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			0,
 			false,
-			''
+			() => ''
 		);
 		expect( result ).not.toBeNull();
 		expect( result?.filterValue ).toBe( 'xyz' );
@@ -134,7 +146,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			0,
 			true,
-			''
+			() => ''
 		);
 		expect( result ).not.toBeNull();
 	} );
@@ -147,7 +159,7 @@ describe( 'getAutocompleteMatch', () => {
 				completers,
 				0,
 				true,
-				''
+				() => ''
 			)
 		).toBeNull();
 	} );
@@ -155,14 +167,14 @@ describe( 'getAutocompleteMatch', () => {
 	it( 'should return null when text after trigger starts with whitespace', () => {
 		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
 		expect(
-			getAutocompleteMatch( '/ query', completers, 1, false, '' )
+			getAutocompleteMatch( '/ query', completers, 1, false, () => '' )
 		).toBeNull();
 	} );
 
 	it( 'should return null when text after trigger ends with multiple spaces', () => {
 		const completers = [ createCompleter( { triggerPrefix: '/' } ) ];
 		expect(
-			getAutocompleteMatch( '/query  ', completers, 1, false, '' )
+			getAutocompleteMatch( '/query  ', completers, 1, false, () => '' )
 		).toBeNull();
 	} );
 
@@ -174,7 +186,7 @@ describe( 'getAutocompleteMatch', () => {
 			} ),
 		];
 		expect(
-			getAutocompleteMatch( 'text @user', completers, 1, false, '' )
+			getAutocompleteMatch( 'text @user', completers, 1, false, () => '' )
 		).toBeNull();
 	} );
 
@@ -186,7 +198,13 @@ describe( 'getAutocompleteMatch', () => {
 				allowContext,
 			} ),
 		];
-		getAutocompleteMatch( 'before @user', completers, 1, false, 'after' );
+		getAutocompleteMatch(
+			'before @user',
+			completers,
+			1,
+			false,
+			() => 'after'
+		);
 		expect( allowContext ).toHaveBeenCalledWith( 'before ', 'after' );
 	} );
 
@@ -197,7 +215,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			1,
 			false,
-			''
+			() => ''
 		);
 		expect( result ).not.toBeNull();
 		expect( result?.filterValue ).toBe( 'cafe' );
@@ -210,7 +228,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			1,
 			false,
-			''
+			() => ''
 		);
 		expect( result ).not.toBeNull();
 		expect( result?.filterValue ).toBe( 'query' );
@@ -223,7 +241,7 @@ describe( 'getAutocompleteMatch', () => {
 			completers,
 			1,
 			false,
-			''
+			() => ''
 		);
 		expect( result ).not.toBeNull();
 		expect( result?.filterValue ).toBe( 'hello world' );
@@ -271,7 +289,7 @@ describe( 'getAutocompleteMatch', () => {
 				completers,
 				1,
 				false,
-				''
+				() => ''
 			);
 			expect( result ).not.toBeNull();
 			expect( result?.filterValue ).toBe( expected );


### PR DESCRIPTION
## What?
Closes #30969.
Alternative to #71417. Pure matcher function; tests without benchmarking; perf tests already track this. Return types.

PR extracts autocomplete matching logic into a standalone pure function.

## Why?
The matching algorithm was buried inside a `useEffect`, making it untestable in isolation. Also simplifies by removing dead code (no-op unicode regex, unnecessary `escapeRegExp` + regex construction).

This should make it easier to fix and test cases like #61919.

## How?
* New `getAutocompleteMatch()` takes text content, completers, and a few flags.
* Replaces regex-based query extraction with a simple `slice()` + `removeAccents()`. Improves upon #48327.
* A minor behavior change. The "extremely long string" now will reset the autocompleter. This is more of an internal improvement, shouldn't affect users.
* Adds 24 unit tests covering most of the edge cases.

## Testing Instructions
1. Open a post or a page.
2. Smoke test the autocompleters.
3. They should work as before.

The `test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js` covers most of the cases.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Claude did most of the grunt work. I reviewed and validated results.
