### PR TITLE
Fix: Flaky RichText format e2e test

### DIFF
--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -104,7 +104,9 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 		pageUtils,
 	} ) => {
-		await page.keyboard.press( 'Enter' );
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'primary+b' );


### PR DESCRIPTION
## What?
Closes #48529.

PR fixes flaky `should not highlight more than one format` e2e test. Based on the traces, typing occurred within the title fields, and the test failed. Using the default appender ensures the test is tied inside the block. This matches the pattern of other tests.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/editor/various/rich-text.spec.js
```