### PR TITLE
Connectors: Hide Akismet unless already installed

### DIFF
--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -239,7 +239,8 @@ export function registerDefaultConnectors() {
 	const sanitize = ( s: string ) => s.replace( /[^a-z0-9-_]/gi, '-' );
 
 	for ( const [ connectorId, data ] of Object.entries( connectors ) ) {
-		// Hide Akismet unless it is already installed.
+		// Special case: Hide Akismet unless it is already installed.
+		// See https://core.trac.wordpress.org/ticket/65012
 		if ( connectorId === 'akismet' && ! data.plugin?.isInstalled ) {
 			continue;
 		}

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -239,6 +239,11 @@ export function registerDefaultConnectors() {
 	const sanitize = ( s: string ) => s.replace( /[^a-z0-9-_]/gi, '-' );
 
 	for ( const [ connectorId, data ] of Object.entries( connectors ) ) {
+		// Hide Akismet unless it is already installed.
+		if ( connectorId === 'akismet' && ! data.plugin?.isInstalled ) {
+			continue;
+		}
+
 		const { authentication } = data;
 
 		const connectorName = sanitize( connectorId );

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -6,7 +6,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const SETTINGS_PAGE_PATH = 'options-general.php';
 const CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
 
-const AI_CONNECTORS = [
+const CONNECTORS = [
 	{
 		slug: 'ai-provider-for-openai',
 		name: 'OpenAI',
@@ -21,15 +21,6 @@ const AI_CONNECTORS = [
 		slug: 'ai-provider-for-google',
 		name: 'Google',
 		description: 'Text and image generation with Gemini and Imagen.',
-	},
-];
-
-const CONNECTORS = [
-	...AI_CONNECTORS,
-	{
-		slug: 'akismet',
-		name: 'Akismet Anti-Spam',
-		description: 'Protect your site from spam.',
 	},
 ];
 
@@ -383,28 +374,6 @@ test.describe( 'Connectors', () => {
 				testProviderCard.getByRole( 'button', { name: 'Cancel' } )
 			).not.toBeFocused();
 		} );
-	} );
-
-	test( 'should display Akismet connector with install button', async ( {
-		page,
-		admin,
-	} ) => {
-		await admin.visitAdminPage( SETTINGS_PAGE_PATH, CONNECTORS_PAGE_QUERY );
-
-		const card = page.locator( '.connector-item--akismet' );
-		await expect( card ).toBeVisible();
-
-		const heading = card.getByRole( 'heading', {
-			name: 'Akismet Anti-Spam',
-			level: 2,
-		} );
-		await expect( heading ).toBeVisible();
-		await expect(
-			card.getByText( 'Protect your site from spam.' )
-		).toBeVisible();
-
-		const button = card.getByRole( 'button', { name: 'Install' } );
-		await expect( button ).toBeVisible();
 	} );
 
 	test( 'should display the AI plugin callout banner with install button', async ( {


### PR DESCRIPTION
## Summary
- Skip registering the Akismet connector on the connectors screen when its plugin is not installed on the site.

## Test plan
- [ ] Load the connectors screen with Akismet **not** installed — it should not appear.
- [ ] Load the connectors screen with Akismet installed (active or inactive) — it should appear as normal.