### PR TITLE
Connectors: Update help text from 'reset' to 'manage'

### DIFF
--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -142,7 +142,7 @@ export function DefaultConnectorSettings( {
 						sprintf(
 							/* translators: %s: Link to provider settings. */
 							__(
-								'Your API key is stored securely. You can reset it at %s'
+								'Your API key is stored securely. You can manage it at %s'
 							),
 							'<a></a>'
 						),


### PR DESCRIPTION
## Summary
- Updates the connector settings help text from "You can reset it at" to "You can manage it at" for a more accurate description of the linked action. As not all connectors may allow resetting.

## Test plan
- [ ] Open the Connectors settings page
- [ ] Connect a provider with an API key
- [ ] Verify the help text reads "You can manage it at {link}"