### PR TITLE
RTC: Predefined retry schedules for disconnect dialog, make more lenient

### DIFF
--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -239,15 +239,12 @@ export function SyncConnectionErrorModal() {
 		connectionStatus && 'error' in connectionStatus
 			? connectionStatus?.error
 			: undefined;
-	const manualRetry =
-		connectionStatus &&
-		'canManuallyRetry' in connectionStatus &&
-		connectionStatus.canManuallyRetry
-			? () => {
-					onManualRetry();
-					retrySyncConnection();
-			  }
-			: undefined;
+	const manualRetry = showModal
+		? () => {
+				onManualRetry();
+				retrySyncConnection();
+		  }
+		: undefined;
 	const messages = getSyncErrorMessages( error );
 
 	return (

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -39,7 +39,7 @@ const INITIAL_DISCONNECTED_DEBOUNCE_MS = 20000;
 
 // Debounce time for showing the disconnect dialog after the initial connection,
 // allowing brief network interruptions and automatic retries to resolve.
-const DISCONNECTED_DEBOUNCE_MS = 30000;
+const DISCONNECTED_DEBOUNCE_MS = 25000;
 
 export interface SyncConnectionErrorModalProps {
 	description: string; // Modal description.

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -208,6 +208,9 @@ export function SyncConnectionErrorModal() {
 		useRetryCountdown( connectionStatus );
 
 	const isConnected = 'connected' === connectionStatus?.status;
+	const [ firstDisconnectTime, setFirstDisconnectTime ] = useState<
+		number | null
+	>( null );
 
 	// Set hasInitialized after a debounce to give extra time on initial load.
 	useEffect( () => {
@@ -218,18 +221,34 @@ export function SyncConnectionErrorModal() {
 		return () => clearTimeout( timeout );
 	}, [] );
 
+	// Track when the disconnection first started.
 	useEffect( () => {
 		if ( isConnected ) {
+			setFirstDisconnectTime( null );
 			setShowModal( false );
 			return;
 		}
 
-		const timeout = setTimeout( () => {
-			setShowModal( true );
-		}, DISCONNECTED_DEBOUNCE_MS );
-
-		return () => clearTimeout( timeout );
+		setFirstDisconnectTime( ( prev ) => prev ?? Date.now() );
 	}, [ isConnected ] );
+
+	// Show the modal after a retry failure once the debounce period has
+	// elapsed. This ensures the modal appears right after a failed retry
+	// rather than in the middle of a retry cycle.
+	useEffect( () => {
+		if (
+			isConnected ||
+			! firstDisconnectTime ||
+			connectionStatus?.status !== 'disconnected'
+		) {
+			return;
+		}
+
+		const elapsed = Date.now() - firstDisconnectTime;
+		if ( elapsed >= DISCONNECTED_DEBOUNCE_MS ) {
+			setShowModal( true );
+		}
+	}, [ connectionStatus, firstDisconnectTime, isConnected ] );
 
 	if ( ! isCollaborationEnabled || ! hasInitialized || ! showModal ) {
 		return null;

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -203,8 +203,6 @@ export function SyncConnectionErrorModal() {
 	const { onManualRetry, secondsRemaining } =
 		useRetryCountdown( connectionStatus );
 
-	const isConnected = 'connected' === connectionStatus?.status;
-
 	// Set hasInitialized after a debounce to give extra time on initial load.
 	useEffect( () => {
 		const timeout = setTimeout( () => {
@@ -218,7 +216,7 @@ export function SyncConnectionErrorModal() {
 	// This naturally fires only after a failed retry (status = 'disconnected'),
 	// not mid-cycle (status = 'connecting').
 	useEffect( () => {
-		if ( isConnected ) {
+		if ( 'connected' === connectionStatus?.status ) {
 			setShowModal( false );
 			return;
 		}
@@ -229,7 +227,7 @@ export function SyncConnectionErrorModal() {
 		) {
 			setShowModal( true );
 		}
-	}, [ connectionStatus, isConnected ] );
+	}, [ connectionStatus ] );
 
 	if ( ! isCollaborationEnabled || ! hasInitialized || ! showModal ) {
 		return null;
@@ -239,12 +237,10 @@ export function SyncConnectionErrorModal() {
 		connectionStatus && 'error' in connectionStatus
 			? connectionStatus?.error
 			: undefined;
-	const manualRetry = showModal
-		? () => {
-				onManualRetry();
-				retrySyncConnection();
-		  }
-		: undefined;
+	const manualRetry = () => {
+		onManualRetry();
+		retrySyncConnection();
+	};
 	const messages = getSyncErrorMessages( error );
 
 	return (

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -39,7 +39,7 @@ const INITIAL_DISCONNECTED_DEBOUNCE_MS = 20000;
 
 // Debounce time for showing the disconnect dialog after the initial connection,
 // allowing brief network interruptions and automatic retries to resolve.
-const DISCONNECTED_DEBOUNCE_MS = 25000;
+const DISCONNECTED_DEBOUNCE_MS = 16000;
 
 export interface SyncConnectionErrorModalProps {
 	description: string; // Modal description.

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -37,9 +37,9 @@ const { retrySyncConnection } = unlock( coreDataPrivateApis );
 // Debounce time for initial disconnected status to allow connection to establish.
 const INITIAL_DISCONNECTED_DEBOUNCE_MS = 20000;
 
-// Debounce time for showing the disconnect dialog after the intial connection,
-// allowing brief network interruptions to resolve.
-const DISCONNECTED_DEBOUNCE_MS = 8000;
+// Debounce time for showing the disconnect dialog after the initial connection,
+// allowing brief network interruptions and automatic retries to resolve.
+const DISCONNECTED_DEBOUNCE_MS = 30000;
 
 export interface SyncConnectionErrorModalProps {
 	description: string; // Modal description.

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -37,10 +37,6 @@ const { retrySyncConnection } = unlock( coreDataPrivateApis );
 // Debounce time for initial disconnected status to allow connection to establish.
 const INITIAL_DISCONNECTED_DEBOUNCE_MS = 20000;
 
-// Debounce time for showing the disconnect dialog after the initial connection,
-// allowing brief network interruptions and automatic retries to resolve.
-const DISCONNECTED_DEBOUNCE_MS = 16000;
-
 export interface SyncConnectionErrorModalProps {
 	description: string; // Modal description.
 	error?: ConnectionError; // Error object with a `code` property.
@@ -208,9 +204,6 @@ export function SyncConnectionErrorModal() {
 		useRetryCountdown( connectionStatus );
 
 	const isConnected = 'connected' === connectionStatus?.status;
-	const [ firstDisconnectTime, setFirstDisconnectTime ] = useState<
-		number | null
-	>( null );
 
 	// Set hasInitialized after a debounce to give extra time on initial load.
 	useEffect( () => {
@@ -221,34 +214,22 @@ export function SyncConnectionErrorModal() {
 		return () => clearTimeout( timeout );
 	}, [] );
 
-	// Track when the disconnection first started.
+	// Show the modal once the retry schedule is exhausted. Hide it on reconnect.
+	// This naturally fires only after a failed retry (status = 'disconnected'),
+	// not mid-cycle (status = 'connecting').
 	useEffect( () => {
 		if ( isConnected ) {
-			setFirstDisconnectTime( null );
 			setShowModal( false );
 			return;
 		}
 
-		setFirstDisconnectTime( ( prev ) => prev ?? Date.now() );
-	}, [ isConnected ] );
-
-	// Show the modal after a retry failure once the debounce period has
-	// elapsed. This ensures the modal appears right after a failed retry
-	// rather than in the middle of a retry cycle.
-	useEffect( () => {
 		if (
-			isConnected ||
-			! firstDisconnectTime ||
-			connectionStatus?.status !== 'disconnected'
+			connectionStatus?.status === 'disconnected' &&
+			connectionStatus.backgroundRetriesFailed
 		) {
-			return;
-		}
-
-		const elapsed = Date.now() - firstDisconnectTime;
-		if ( elapsed >= DISCONNECTED_DEBOUNCE_MS ) {
 			setShowModal( true );
 		}
-	}, [ connectionStatus, firstDisconnectTime, isConnected ] );
+	}, [ connectionStatus, isConnected ] );
 
 	if ( ! isCollaborationEnabled || ! hasInitialized || ! showModal ) {
 		return null;

--- a/packages/editor/src/components/sync-connection-error-modal/use-retry-countdown.ts
+++ b/packages/editor/src/components/sync-connection-error-modal/use-retry-countdown.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import type { ConnectionStatus } from '@wordpress/core-data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 interface UseRetryCountdownResult {
 	onManualRetry: () => void;
@@ -13,6 +13,7 @@ export function useRetryCountdown(
 	connectionStatus?: ConnectionStatus | null
 ): UseRetryCountdownResult {
 	const [ secondsRemaining, setSecondsRemaining ] = useState< number >();
+	const hasRetriedRef = useRef( false );
 
 	useEffect( () => {
 		if ( ! connectionStatus ) {
@@ -22,6 +23,7 @@ export function useRetryCountdown(
 		// Only clear countdown when explicitly connected.
 		if ( 'connected' === connectionStatus.status ) {
 			setSecondsRemaining( undefined );
+			hasRetriedRef.current = false;
 			return;
 		}
 
@@ -37,21 +39,55 @@ export function useRetryCountdown(
 
 		const { willAutoRetryInMs: retryInMs } = connectionStatus;
 		const retryAt = Date.now() + retryInMs;
-		setSecondsRemaining( Math.ceil( retryInMs / 1000 ) );
 
-		const intervalId = setInterval( () => {
-			const remaining = Math.ceil( ( retryAt - Date.now() ) / 1000 );
-			setSecondsRemaining( Math.max( 0, remaining ) );
-			if ( remaining <= 0 ) {
-				clearInterval( intervalId );
+		// After a retry attempt (manual or automatic), show "Retrying..."
+		// for 500ms before starting the next countdown. Skip the delay on
+		// the very first disconnect so the countdown starts immediately.
+		const isSubsequentRetry = hasRetriedRef.current;
+		hasRetriedRef.current = true;
+
+		if ( isSubsequentRetry ) {
+			setSecondsRemaining( 0 );
+		}
+
+		let countdownIntervalId: ReturnType< typeof setInterval > | null = null;
+
+		const startCountdown = () => {
+			setSecondsRemaining( Math.ceil( ( retryAt - Date.now() ) / 1000 ) );
+
+			countdownIntervalId = setInterval( () => {
+				const remaining = Math.ceil( ( retryAt - Date.now() ) / 1000 );
+				setSecondsRemaining( Math.max( 0, remaining ) );
+
+				if ( remaining <= 0 && countdownIntervalId ) {
+					clearInterval( countdownIntervalId );
+				}
+			}, 1000 );
+		};
+
+		const retryingDelayId = isSubsequentRetry
+			? setTimeout( startCountdown, 500 )
+			: null;
+
+		if ( ! retryingDelayId ) {
+			startCountdown();
+		}
+
+		return () => {
+			if ( retryingDelayId ) {
+				clearTimeout( retryingDelayId );
 			}
-		}, 1000 );
 
-		return () => clearInterval( intervalId );
+			if ( countdownIntervalId ) {
+				clearInterval( countdownIntervalId );
+			}
+		};
 	}, [ connectionStatus ] );
 
 	return {
-		onManualRetry: () => setSecondsRemaining( 0 ),
+		onManualRetry: () => {
+			setSecondsRemaining( 0 );
+		},
 		secondsRemaining,
 	};
 }

--- a/packages/editor/src/components/sync-connection-error-modal/use-retry-countdown.ts
+++ b/packages/editor/src/components/sync-connection-error-modal/use-retry-countdown.ts
@@ -43,10 +43,10 @@ export function useRetryCountdown(
 		// After a retry attempt (manual or automatic), show "Retrying..."
 		// for 500ms before starting the next countdown. Skip the delay on
 		// the very first disconnect so the countdown starts immediately.
-		const isSubsequentRetry = hasRetriedRef.current;
+		const hasRetried = hasRetriedRef.current;
 		hasRetriedRef.current = true;
 
-		if ( isSubsequentRetry ) {
+		if ( hasRetried ) {
 			setSecondsRemaining( 0 );
 		}
 
@@ -65,7 +65,7 @@ export function useRetryCountdown(
 			}, 1000 );
 		};
 
-		const retryingDelayId = isSubsequentRetry
+		const retryingDelayId = hasRetried
 			? setTimeout( startCountdown, 500 )
 			: null;
 

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -4,8 +4,10 @@
 import { applyFilters } from '@wordpress/hooks';
 
 export const DEFAULT_CLIENT_LIMIT_PER_ROOM = 3;
-// Retry delays after consecutive poll failures. The disconnect dialog shows
-// after all retries are exhausted, then retries continue at DISCONNECT_DIALOG_RETRY_MS.
+
+// Retry delays after poll failures.
+// The disconnect dialog shows after all retries are exhausted, then retries
+// continue at DISCONNECT_DIALOG_RETRY_MS.
 export const ERROR_RETRY_DELAYS_SOLO_MS = [
 	2000, 4000, 8000, 12000,
 	// Solo: 26s total retry time solo before dialog
@@ -14,7 +16,14 @@ export const ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS = [
 	1000, 2000, 4000, 8000,
 	// With collaborators: 15s total retry time before dialog
 ];
+
+// How often to automatically retry the connection when in the disconnect dialog.
 export const DISCONNECT_DIALOG_RETRY_MS = 30000;
+
+// When a user manually retries on the disconnection dialog, the amount of time
+// until the next automatic retry attempt.
+export const MANUAL_RETRY_INTERVAL_MS = 15000;
+
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 
 export const POLLING_INTERVAL_IN_MS = applyFilters(

--- a/packages/sync/src/providers/http-polling/config.ts
+++ b/packages/sync/src/providers/http-polling/config.ts
@@ -4,7 +4,17 @@
 import { applyFilters } from '@wordpress/hooks';
 
 export const DEFAULT_CLIENT_LIMIT_PER_ROOM = 3;
-export const MAX_ERROR_BACKOFF_IN_MS = 30 * 1000; // 30 seconds
+// Retry delays after consecutive poll failures. The disconnect dialog shows
+// after all retries are exhausted, then retries continue at DISCONNECT_DIALOG_RETRY_MS.
+export const ERROR_RETRY_DELAYS_SOLO_MS = [
+	2000, 4000, 8000, 12000,
+	// Solo: 26s total retry time solo before dialog
+];
+export const ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS = [
+	1000, 2000, 4000, 8000,
+	// With collaborators: 15s total retry time before dialog
+];
+export const DISCONNECT_DIALOG_RETRY_MS = 30000;
 export const MAX_UPDATE_SIZE_IN_BYTES = 1 * 1024 * 1024; // 1 MB
 
 export const POLLING_INTERVAL_IN_MS = applyFilters(

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -18,11 +18,13 @@ import * as syncProtocol from 'y-protocols/sync';
  */
 import {
 	DEFAULT_CLIENT_LIMIT_PER_ROOM,
-	MAX_ERROR_BACKOFF_IN_MS,
+	ERROR_RETRY_DELAYS_SOLO_MS,
+	ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS,
 	MAX_UPDATE_SIZE_IN_BYTES,
 	POLLING_INTERVAL_IN_MS,
 	POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS,
 	POLLING_INTERVAL_BACKGROUND_TAB_IN_MS,
+	DISCONNECT_DIALOG_RETRY_MS,
 } from './config';
 import { ConnectionError, ConnectionErrorCode } from '../../errors';
 import type { ConnectionStatus } from '../../types';
@@ -300,6 +302,7 @@ function checkConnectionLimit(
 }
 
 let areListenersRegistered = false;
+let consecutiveFailures = 0;
 let hasCheckedConnectionLimit = false;
 let hasCollaborators = false;
 let isActiveBrowser = 'visible' === document.visibilityState;
@@ -415,6 +418,7 @@ function poll(): void {
 			const { rooms } = await postSyncUpdate( payload );
 
 			// Emit 'connected' status.
+			consecutiveFailures = 0;
 			roomStates.forEach( ( state ) => {
 				state.onStatusChange( { status: 'connected' } );
 			} );
@@ -499,11 +503,16 @@ function poll(): void {
 				pollInterval = POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
 			}
 		} catch ( error ) {
-			// Exponential backoff on error: increase the backoff time, up to max
-			pollInterval = Math.min(
-				pollInterval * 1.5,
-				MAX_ERROR_BACKOFF_IN_MS
-			);
+			// Use the explicit retry delay schedule for backoff.
+			consecutiveFailures++;
+			const retrySchedule = hasCollaborators
+				? ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS
+				: ERROR_RETRY_DELAYS_SOLO_MS;
+			if ( consecutiveFailures <= retrySchedule.length ) {
+				pollInterval = retrySchedule[ consecutiveFailures - 1 ];
+			} else {
+				pollInterval = DISCONNECT_DIALOG_RETRY_MS;
+			}
 
 			// Recover from the failed request. We don't know whether the server stored
 			// our updates before the error occurred (e.g. a network timeout after a
@@ -542,10 +551,15 @@ function poll(): void {
 			// due to page unload (e.g. during a refresh) to avoid briefly
 			// flashing the disconnect dialog before the new page loads.
 			if ( ! isUnloadPending ) {
+				const backgroundRetriesFailed =
+					consecutiveFailures > retrySchedule.length;
+
 				roomStates.forEach( ( state ) => {
 					state.onStatusChange( {
 						status: 'disconnected',
 						canManuallyRetry: true,
+						consecutiveFailures,
+						backgroundRetriesFailed,
 						willAutoRetryInMs: pollInterval,
 					} );
 				} );
@@ -724,7 +738,7 @@ function unregisterRoom( room: string ): void {
  * the backoff interval is reset so the next scheduled poll fires sooner.
  */
 function retryNow(): void {
-	pollInterval = POLLING_INTERVAL_IN_MS * 2;
+	consecutiveFailures = 0;
 
 	if ( pollingTimeoutId ) {
 		clearTimeout( pollingTimeoutId );

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -499,9 +499,9 @@ function poll(): void {
 				pollInterval = POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
 			}
 		} catch ( error ) {
-			// Exponential backoff on error: double the backoff time, up to max
+			// Exponential backoff on error: increase the backoff time, up to max
 			pollInterval = Math.min(
-				pollInterval * 2,
+				pollInterval * 1.5,
 				MAX_ERROR_BACKOFF_IN_MS
 			);
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -25,6 +25,7 @@ import {
 	POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS,
 	POLLING_INTERVAL_BACKGROUND_TAB_IN_MS,
 	DISCONNECT_DIALOG_RETRY_MS,
+	MANUAL_RETRY_INTERVAL_MS,
 } from './config';
 import { ConnectionError, ConnectionErrorCode } from '../../errors';
 import type { ConnectionStatus } from '../../types';
@@ -304,6 +305,7 @@ function checkConnectionLimit(
 let areListenersRegistered = false;
 let consecutiveFailures = 0;
 let hasCheckedConnectionLimit = false;
+let isManualRetry = false;
 let hasCollaborators = false;
 let isActiveBrowser = 'visible' === document.visibilityState;
 let isPolling = false;
@@ -419,6 +421,7 @@ function poll(): void {
 
 			// Emit 'connected' status.
 			consecutiveFailures = 0;
+			isManualRetry = false;
 			roomStates.forEach( ( state ) => {
 				state.onStatusChange( { status: 'connected' } );
 			} );
@@ -512,6 +515,12 @@ function poll(): void {
 				pollInterval = retrySchedule[ consecutiveFailures - 1 ];
 			} else {
 				pollInterval = DISCONNECT_DIALOG_RETRY_MS;
+			}
+
+			// After a manual retry, use a shorter interval for one cycle.
+			if ( isManualRetry ) {
+				pollInterval = MANUAL_RETRY_INTERVAL_MS;
+				isManualRetry = false;
 			}
 
 			// Recover from the failed request. We don't know whether the server stored
@@ -736,10 +745,12 @@ function unregisterRoom( room: string ): void {
 /**
  * Immediately retry the sync connection by cancelling any pending
  * timeout and triggering a new poll. If the retry fails, the next
- * auto-retry uses the current backoff interval rather than restarting
- * the fast schedule, keeping the UI calm when the dialog is visible.
+ * auto-retry waits 15s (MANUAL_RETRY_INTERVAL_MS) instead of the
+ * usual 30s, then falls back to 30s for subsequent auto-retries.
  */
 function retryNow(): void {
+	isManualRetry = true;
+
 	if ( pollingTimeoutId ) {
 		clearTimeout( pollingTimeoutId );
 		pollingTimeoutId = null;

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -729,13 +729,14 @@ function unregisterRoom( room: string ): void {
 		);
 		areListenersRegistered = false;
 		hasCheckedConnectionLimit = false;
+		consecutiveFailures = 0;
 	}
 }
 
 /**
- * Immediately retry the sync connection by cancelling any pending backoff
- * timeout and triggering a new poll. If a request is already in-flight,
- * the backoff interval is reset so the next scheduled poll fires sooner.
+ * Immediately retry the sync connection by cancelling any pending
+ * timeout and triggering a new poll. Resets the failure counter so
+ * the retry schedule starts fresh.
  */
 function retryNow(): void {
 	consecutiveFailures = 0;

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -735,12 +735,11 @@ function unregisterRoom( room: string ): void {
 
 /**
  * Immediately retry the sync connection by cancelling any pending
- * timeout and triggering a new poll. Resets the failure counter so
- * the retry schedule starts fresh.
+ * timeout and triggering a new poll. If the retry fails, the next
+ * auto-retry uses the current backoff interval rather than restarting
+ * the fast schedule, keeping the UI calm when the dialog is visible.
  */
 function retryNow(): void {
-	consecutiveFailures = 0;
-
 	if ( pollingTimeoutId ) {
 		clearTimeout( pollingTimeoutId );
 		pollingTimeoutId = null;

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -860,8 +860,8 @@ describe( 'polling-manager', () => {
 				responseWithCollaborator
 			);
 
-			// Error handler doubled the interval: min(1000 * 2, 30000) = 2000.
-			await jest.advanceTimersByTimeAsync( 2000 );
+			// First failure with collaborators: retry in 1000ms (schedule[0]).
+			await jest.advanceTimersByTimeAsync( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const thirdCallPayload = mockPostSyncUpdate.mock
@@ -906,8 +906,9 @@ describe( 'polling-manager', () => {
 			expect( secondCallPayload.rooms[ 0 ].updates ).toHaveLength( 0 );
 
 			// Third poll: succeed — should still have no updates (no compaction queued).
+			// First failure solo: retry in 2000ms (schedule[0]).
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
-			await jest.advanceTimersByTimeAsync( 8000 );
+			await jest.advanceTimersByTimeAsync( 2000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const thirdCallPayload = mockPostSyncUpdate.mock

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -80,6 +80,12 @@ export interface ConnectionStatusDisconnected {
 	/** Whether the error condition is retryable via user action. */
 	canManuallyRetry?: boolean;
 
+	/** Number of consecutive poll failures since the last successful connection. */
+	consecutiveFailures?: number;
+
+	/** Whether the background retry schedule has been exhausted without a successful connection. */
+	backgroundRetriesFailed?: boolean;
+
 	/** Milliseconds until the next automatic retry attempt (triggered by the provider). */
 	willAutoRetryInMs?: number;
 }


### PR DESCRIPTION
## What?

This PR replaces the exponential backoff and debounce for the disconnect dialog with predefined retry schedules. The dialog now waits through a fixed list of retry times before showing, with separate schedules for solo and collaborative editing. After the dialog appears, retries continue in the background at 30s intervals.

Additionally, the disconnect dialog adds a "Retrying..." state so it's clearer when a connection attempt is being made (even if it fails immediately):

![disconnect-retrying-state](https://github.com/user-attachments/assets/b81ec8f9-b1fb-41f9-a762-3c8234306d8f)

## Why?

The previous system used exponential back-off (`pollInterval * 2`, capped at 30s) and ran a time-based debounce depending on the number of collaborators. The two mechanisms interacted in ways that made changes like https://github.com/WordPress/gutenberg/pull/76704 difficult to reason about.

Even though we increased both the poll interval and disconnect debounce by 4x, the exponential math worked out so just one failed request could cause a disconnect dialog:

```
Previous behavior (4s base poll interval, 2x backoff, 8s debounce):

t=0s:  Fail. Next retry in 8s  (4 * 2)
t=8s:  Retry.                  <- debounce fires at the same time, modal flashes
```

Because the backoff multiplied the base polling interval, the behavior was different in solo mode, and not in a useful way. **Solo editing had fewer retries** before showing the dialog, even though solo users are the least likely to hit CRDT conflicts from a brief disconnect. Collaborative editing had more retries, despite being the mode where stale state matters most. Adjusting either the backoff multiplier or the debounce timer required recalculating the tables for both modes to make sure the timing still made sense.

Predefined retry schedules fix all of this by making the timing readable at a glance. Each mode has its own array of delays, and you can see exactly when each retry happens and when the dialog appears without doing any math.

## How?

The exponential backoff in the polling manager is replaced with two explicit retry delay arrays in config:

```ts
export const ERROR_RETRY_DELAYS_SOLO_MS = [
	2000, 4000, 8000, 12000,
	// Solo: 26s total retry time solo before dialog
];

export const ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS = [
	1000, 2000, 4000, 8000,
	// With collaborators: 15s total retry time before dialog
];

export const DISCONNECT_DIALOG_RETRY_MS = 30000;
```

These have been selected sort of arbitrarily, but gives more time for solo connections to reconnect.

Additionally, we no longer will show the dialog mid-cycle. Previously the dialog debounce timer made it so that we might show a dialog mid-cycle with a few seconds left before another retry. Instead, ensure we've just seen a failure before showing the dialog.

Here's the new behavior for both modes:


```
Solo editing (26s before dialog):

t=0s   Fail.  Retry in 2s.
t=2s   Fail.  Retry in 4s.
t=6s   Fail.  Retry in 8s.
t=14s  Fail.  Retry in 12s.
t=26s  Fail.  Dialog shows.  Retry forever in 30s.
```

---

```
Collaborative editing (15s before dialog):

t=0s   Fail.  Retry in 1s.
t=1s   Fail.  Retry in 2s.
t=3s   Fail.  Retry in 4s.
t=7s   Fail.  Retry in 8s.
t=15s  Fail.  Dialog shows.  Retry forever in 30s.
```

## Testing Instructions

Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.

**Solo editing (dialog after ~26s):**

1. Open a post in a single browser tab.
3. In DevTools, go to the Network tab and switch to "Offline" for about 15 seconds, then switch back to "Online". Verify the disconnect dialog does not appear.
4. Switch to "Offline" for 30+ seconds. Verify the disconnect dialog appears with a retry countdown.
5. Click "Retry" in the dialog. Verify it retries (and fails)
6. Switch back to "Online" and click "Retry". Verify the dialog dismisses when the connection recovers.

**Collaborative editing (dialog after ~15s):**

1. Open the same post in two browser tabs so there are multiple collaborators.
2. In one tab, switch to "Offline" for about 10 seconds, then switch back to "Online". Verify the disconnect dialog does not appear.
3. Switch to "Offline" for 20+ seconds. Verify the disconnect dialog appears sooner than in solo mode.
4. Click "Retry" in the dialog. Verify it retries (and fails)
5. Switch back to "Online" and click "Retry". Verify the dialog dismisses when the connection recovers.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Reviewing the previous disconnect timing logic, designing the fixed retry schedule, and implementing the changes