### PR TITLE
RTC: Isolate sync update failures to prevent full disconnect

### DIFF
--- a/packages/sync/src/providers/http-polling/http-polling-provider.ts
+++ b/packages/sync/src/providers/http-polling/http-polling-provider.ts
@@ -111,17 +111,28 @@ class HttpPollingProvider extends ObservableV2< HttpPollingEvents > {
 	/**
 	 * Log debug messages if debugging is enabled.
 	 *
-	 * @param message The debug message
-	 * @param debug   Additional debug information
+	 * @param message    The debug message
+	 * @param debug      Additional debug information
+	 * @param errorLevel The console method to use for logging
+	 * @param force      Whether to force logging regardless of debug setting
 	 */
-	protected log = ( message: string, debug: object = {} ): void => {
-		if ( this.options.debug ) {
-			// eslint-disable-next-line no-console
-			console.log( `[${ this.constructor.name }]: ${ message }`, {
-				room: this.options.room,
-				...debug,
-			} );
+	protected log = (
+		message: string,
+		debug: object = {},
+		errorLevel: 'log' | 'warn' | 'error' = 'log',
+		force = false
+	): void => {
+		if ( ! this.options.debug && ! force ) {
+			return;
 		}
+
+		// eslint-disable-next-line no-console
+		const logFn = console[ errorLevel ] || console.log;
+
+		logFn( `[${ this.constructor.name }]: ${ message }`, {
+			room: this.options.room,
+			...debug,
+		} );
 	};
 
 	/**

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -45,7 +45,12 @@ import {
 
 const POLLING_MANAGER_ORIGIN = 'polling-manager';
 
-type LogFunction = ( message: string, debug?: object ) => void;
+type LogFunction = (
+	message: string,
+	debug?: object,
+	errorLevel?: 'error' | 'log' | 'warn',
+	force?: boolean
+) => void;
 
 interface PollingManager {
 	registerRoom: ( options: RegisterRoomOptions ) => void;
@@ -463,11 +468,23 @@ function poll(): void {
 				}
 
 				// Process each incoming update and collect any responses.
-				const responseUpdates = room.updates
-					.map( ( update ) => roomState.processDocUpdate( update ) )
-					.filter( ( update ): update is SyncUpdate =>
-						Boolean( update )
-					);
+				const responseUpdates: SyncUpdate[] = [];
+				for ( const update of room.updates ) {
+					try {
+						const response = roomState.processDocUpdate( update );
+						if ( response ) {
+							responseUpdates.push( response );
+						}
+					} catch ( error ) {
+						roomState.log(
+							'Failed to apply sync update',
+							{ error, update },
+							'error',
+							true // force
+						);
+					}
+				}
+
 				roomState.updateQueue.addBulk( responseUpdates );
 
 				// Respond to compaction requests from server. The server asks only one
@@ -531,10 +548,9 @@ function poll(): void {
 
 				state.log(
 					'Error posting sync update, will retry with backoff',
-					{
-						error,
-						nextPoll: pollInterval,
-					}
+					{ error, nextPoll: pollInterval },
+					'error',
+					true // force
 				);
 			}
 


### PR DESCRIPTION
## What?

Isolate sync update failures to prevent full disconnect. Add additional logging on failure.

Related: https://github.com/wordpress/gutenberg/pull/76304

## Why?

A single malformed or incompatible sync update (e.g., a v1-format update from an older client applied via `Y.applyUpdateV2`) crashes the entire poll cycle, disconnecting all rooms and triggering the disconnect modal.

## How?

- Wrap each update in a try/catch so failures are logged and skipped, allowing the remaining updates and rooms to process normally.
- Enhance the `log()` helper to support `errorLevel` and `force` parameters so sync update failures are always logged to console (even with debug mode off), making these issues visible in production.

## Testing Instructions

1. Check out this PR.
2. Settings > Writing > Enable real-time collaboration.
3. Open a post for editing.
4. Use WP-CLI to store a corrupted sync update. This command assumes local `wp-env`, do not run on production site:
   ```sh
   npm run wp-env run cli wp --allow-root eval '
   $room    = "taxonomy/wp_pattern_category";
   $storage = new WP_Sync_Post_Meta_Storage();

   // Valid Yjs v1 update that sets state.version on a fresh client.
   // This will fail when the client tries to apply it with Y.applyUpdateV2().
   $storage->add_update( $room, array(
      "client_id" => 999999999,
      "type"      => "update",
      "data"      => "AQGz2b2CBQAoAQVzdGF0ZQd2ZXJzaW9uAX0BAA==",
   ) );

   echo "Injected v1 update into room: " . $room . "\\n";'
   ```  
5. Wait for additional polling cycle to complete (~5s).
6. Observe an error logged to the console, but no disconnect modal.

Clean-up command:
```sh
npm run wp-env run cli wp --allow-root eval '                                      ~/c/w/g/hyderabad 
  global $wpdb;
  $room_hash = md5( "taxonomy/wp_pattern_category" );
  $post = get_posts( array(
      "post_type" => "wp_sync_storage",
      "name"      => $room_hash,
      "fields"    => "ids",
      "posts_per_page" => 1,
  ) );
  if ( $post ) {
      $wpdb->delete( $wpdb->postmeta, array(
          "post_id"  => $post[0],
          "meta_key" => "wp_sync_update_data",
      ) );
      echo "Cleared all sync updates for taxonomy/wp_pattern_category\\n";
  }'
```