### PR TITLE
Remove unused catch block variables across the codebase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -579,5 +579,23 @@ module.exports = {
 				'@wordpress/use-recommended-components': 'off',
 			},
 		},
+		{
+			files: [ '**/*.js', '**/*.jsx', '**/*.mjs', '**/*.cjs' ],
+			rules: {
+				'no-unused-vars': [
+					'error',
+					{ ignoreRestSiblings: true, caughtErrors: 'all' },
+				],
+			},
+		},
+		{
+			files: [ '**/*.ts', '**/*.tsx' ],
+			rules: {
+				'@typescript-eslint/no-unused-vars': [
+					'error',
+					{ ignoreRestSiblings: true, caughtErrors: 'all' },
+				],
+			},
+		},
 	],
 };

--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -59,7 +59,7 @@ async function getDecFile( packagePath ) {
 	try {
 		await fs.access( decFile );
 		return decFile;
-	} catch ( err ) {
+	} catch {
 		console.error(
 			`Cannot access this declaration file. You may need to run tsc again: ${ decFile }`
 		);

--- a/packages/block-editor/src/components/block-draggable/test/helpers.native.js
+++ b/packages/block-editor/src/components/block-draggable/test/helpers.native.js
@@ -175,7 +175,7 @@ export const getDraggableChip = ( { getByTestId } ) => {
 	let draggableChip;
 	try {
 		draggableChip = getByTestId( 'draggable-chip' );
-	} catch ( e ) {
+	} catch {
 		// NOOP.
 	}
 	return draggableChip;

--- a/packages/block-editor/src/components/iframe/get-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/get-compatibility-styles.js
@@ -21,7 +21,7 @@ export function getCompatibilityStyles() {
 				// May fail for external styles.
 				// eslint-disable-next-line no-unused-expressions
 				styleSheet.cssRules;
-			} catch ( e ) {
+			} catch {
 				return accumulator;
 			}
 

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -100,7 +100,7 @@ export function useMediaCategories( rootClientId ) {
 							results = await category.fetch( {
 								per_page: 1,
 							} );
-						} catch ( e ) {
+						} catch {
 							// If the request fails, we shallow the error and just don't show
 							// the category, in order to not break the media tab.
 						}

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -99,7 +99,7 @@ const LinkControlSearchInput = forwardRef(
 					if ( suggestion?.url ) {
 						onSelect( suggestion );
 					}
-				} catch ( e ) {}
+				} catch {}
 				return;
 			}
 

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -46,7 +46,7 @@ export function parseDropEvent( event ) {
 			result,
 			JSON.parse( event.dataTransfer.getData( 'wp-blocks' ) )
 		);
-	} catch ( err ) {
+	} catch {
 		return result;
 	}
 

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -44,7 +44,7 @@ function hasSerializedBlocks( text ) {
 			return false;
 		}
 		return true;
-	} catch ( err ) {
+	} catch {
 		// Parsing error, the text is not serialized blocks.
 		// (Even though that it technically won't happen)
 		return false;
@@ -153,7 +153,7 @@ export default function usePasteStyles() {
 				}
 
 				html = await window.navigator.clipboard.readText();
-			} catch ( error ) {
+			} catch {
 				// Possibly the permission is denied.
 				createErrorNotice(
 					__(

--- a/packages/block-editor/src/utils/pasting.js
+++ b/packages/block-editor/src/utils/pasting.js
@@ -55,7 +55,7 @@ export function getPasteEventData( { clipboardData } ) {
 	try {
 		plainText = clipboardData.getData( 'text/plain' );
 		html = clipboardData.getData( 'text/html' );
-	} catch ( error ) {
+	} catch {
 		// Some browsers like UC Browser paste plain text by default and
 		// don't support clipboardData at all, so allow default
 		// behaviour.

--- a/packages/block-library/src/cover/edit/color-utils.js
+++ b/packages/block-library/src/cover/edit/color-utils.js
@@ -92,7 +92,7 @@ export const getMediaColor = memoize( async ( url ) => {
 			crossOrigin: imgCrossOrigin,
 		} );
 		return color.hex;
-	} catch ( error ) {
+	} catch {
 		// If there's an error return the fallback color.
 		return DEFAULT_BACKGROUND_COLOR;
 	}

--- a/packages/block-library/src/cover/embed-video-utils.js
+++ b/packages/block-library/src/cover/embed-video-utils.js
@@ -189,7 +189,7 @@ export function getBackgroundVideoSrc( src ) {
 		}
 
 		return url.toString();
-	} catch ( error ) {
+	} catch {
 		// If URL parsing fails, return original src
 		return src;
 	}

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -28,9 +28,10 @@ import { requestPreview } from '@wordpress/react-native-bridge';
 /**
  * Internal dependencies
  */
+import { WebView } from 'react-native-webview';
+
 import * as paragraph from '../../paragraph';
 import * as embed from '..';
-import { WebView } from 'react-native-webview';
 
 // Override modal mock to prevent unmounting it when is not visible.
 // This is required to be able to trigger onClose and onDismiss events when
@@ -1114,7 +1115,7 @@ describe( 'Embed block', () => {
 			try {
 				mediaSettingsPanel =
 					await screen.findByText( 'Media settings' );
-			} catch ( e ) {
+			} catch {
 				// NOOP.
 			}
 

--- a/packages/block-library/src/file/utils/index.js
+++ b/packages/block-library/src/file/utils/index.js
@@ -54,7 +54,7 @@ const createActiveXObject = ( type ) => {
 	let ax;
 	try {
 		ax = new window.ActiveXObject( type );
-	} catch ( e ) {
+	} catch {
 		ax = undefined;
 	}
 	return ax;

--- a/packages/block-library/src/form/view.js
+++ b/packages/block-library/src/form/view.js
@@ -47,7 +47,7 @@ document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
 			} else {
 				redirectNotification( 'error' );
 			}
-		} catch ( error ) {
+		} catch {
 			redirectNotification( 'error' );
 		}
 	} );

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -103,7 +103,7 @@ export function LinkUIPageCreator( {
 
 				onPageCreated( pageLink );
 			}
-		} catch ( error ) {
+		} catch {
 			// Show error notice
 			createErrorNotice(
 				__( 'Failed to create page. Please try again.' ),

--- a/packages/block-library/src/navigation-link/shared/update-attributes.js
+++ b/packages/block-library/src/navigation-link/shared/update-attributes.js
@@ -34,7 +34,7 @@ const shouldSeverEntityLink = ( originalUrl, newUrl ) => {
 					? window.location.origin
 					: 'https://wordpress.org' );
 			return new URL( url, base );
-		} catch ( error ) {
+		} catch {
 			// If URL construction still fails, it's likely an invalid URL
 			// and we should sever the entity link
 			return null;

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -101,7 +101,7 @@ export function computeDisplayUrl( { linkUrl, homeUrl } = {} ) {
 			// Different host - this is an external link
 			isExternal = true;
 		}
-	} catch ( e ) {
+	} catch {
 		// URL parsing failed - treat as external (e.g. no homeUrl, or URL without protocol)
 		isExternal = true;
 	}

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -78,7 +78,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		if ( ! hasRecursionError && selectedPattern?.blocks ) {
 			try {
 				parsePatternDependencies( selectedPattern );
-			} catch ( error ) {
+			} catch {
 				setHasRecursionError( true );
 				return;
 			}

--- a/packages/block-serialization-default-parser/src/index.ts
+++ b/packages/block-serialization-default-parser/src/index.ts
@@ -366,7 +366,7 @@ function proceed(): boolean {
 function parseJSON( input: string ): Object | null {
 	try {
 		return JSON.parse( input );
-	} catch ( e ) {
+	} catch {
 		return null;
 	}
 }

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -372,7 +372,7 @@ export const phpTester = ( name, filename ) =>
 								'"attrs":{}'
 							)
 						);
-					} catch ( e ) {
+					} catch {
 						throw new Error(
 							'failed to parse JSON:\n' + process.stdout
 						);

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -110,7 +110,7 @@ export function fromDOM( domNodes ) {
 	for ( let i = 0; i < domNodes.length; i++ ) {
 		try {
 			result.push( node.fromDOM( domNodes[ i ] ) );
-		} catch ( error ) {
+		} catch {
 			// Simply ignore if DOM node could not be converted.
 		}
 	}

--- a/packages/blocks/src/api/node.js
+++ b/packages/blocks/src/api/node.js
@@ -139,7 +139,7 @@ export function matcher( selector ) {
 
 		try {
 			return fromDOM( match );
-		} catch ( error ) {
+		} catch {
 			return null;
 		}
 	};

--- a/packages/blocks/src/api/raw-handling/image-corrector.js
+++ b/packages/blocks/src/api/raw-handling/image-corrector.js
@@ -27,7 +27,7 @@ export default function imageCorrector( node ) {
 		// Can throw DOMException!
 		try {
 			decoded = atob( data );
-		} catch ( e ) {
+		} catch {
 			node.src = '';
 			return;
 		}

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -320,7 +320,7 @@ export function getBlockInnerHTML( block ) {
 				block.attributes,
 				block.innerBlocks
 			);
-		} catch ( error ) {}
+		} catch {}
 	}
 
 	return saveContent;

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -575,7 +575,7 @@ export function getNextNonWhitespaceToken( tokens ) {
 function getHTMLTokens( html, logger = createLogger() ) {
 	try {
 		return new Tokenizer( new DecodeEntityParser() ).tokenize( html );
-	} catch ( e ) {
+	} catch {
 		logger.warning( 'Malformed HTML detected: %s', html );
 	}
 

--- a/packages/components/src/mobile/utils/get-px-from-css-unit.native.js
+++ b/packages/components/src/mobile/utils/get-px-from-css-unit.native.js
@@ -26,7 +26,7 @@ function parseUnit( cssUnit ) {
 function calculate( expression ) {
 	try {
 		return Function( `'use strict'; return (${ expression })` )();
-	} catch ( err ) {
+	} catch {
 		return null;
 	}
 }

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -297,7 +297,7 @@ const Sandbox = forwardRef( function Sandbox(
 
 			try {
 				data = JSON.parse( data );
-			} catch ( e ) {
+			} catch {
 				return;
 			}
 

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -141,7 +141,7 @@ function SandBox( {
 	function isFrameAccessible() {
 		try {
 			return !! ref.current?.contentDocument?.body;
-		} catch ( e ) {
+		} catch {
 			return false;
 		}
 	}
@@ -232,7 +232,7 @@ function SandBox( {
 			if ( 'string' === typeof data ) {
 				try {
 					data = JSON.parse( data );
-				} catch ( e ) {}
+				} catch {}
 			}
 
 			// Update the state only if the message is formatted as we expect,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -578,7 +578,7 @@ export const getEntityRecords =
 
 				dispatch.__unstableReleaseStoreLock( lock );
 			} );
-		} catch ( e ) {
+		} catch {
 			dispatch.__unstableReleaseStoreLock( lock );
 		}
 	};
@@ -635,7 +635,7 @@ export const getEmbedPreview =
 				path: addQueryArgs( '/oembed/1.0/proxy', { url } ),
 			} );
 			dispatch.receiveEmbedPreview( url, embedProxyResponse );
-		} catch ( error ) {
+		} catch {
 			// Embed API 404s if the URL cannot be embedded, so we have to catch the error from the apiRequest here.
 			dispatch.receiveEmbedPreview( url, false );
 		}
@@ -706,7 +706,7 @@ export const canUser =
 				method: 'OPTIONS',
 				parse: false,
 			} );
-		} catch ( error ) {
+		} catch {
 			// Do nothing if our OPTIONS request comes back with an API error (4xx or
 			// 5xx). The previously determined isAllowed value will remain in the store.
 			return;
@@ -1077,7 +1077,7 @@ export const getRevisions =
 				entityConfig.supportsPagination && query.per_page !== -1;
 			try {
 				response = await apiFetch( { path, parse: ! isPaginated } );
-			} catch ( error ) {
+			} catch {
 				// Do nothing if our request comes back with an API error.
 				return;
 			}
@@ -1220,7 +1220,7 @@ export const getRevision =
 			let record;
 			try {
 				record = await apiFetch( { path } );
-			} catch ( error ) {
+			} catch {
 				// Do nothing if our request comes back with an API error.
 				return;
 			}
@@ -1257,7 +1257,7 @@ export const getRegisteredPostMeta =
 				path: `${ restNamespace }/${ restBase }/?context=edit`,
 				method: 'OPTIONS',
 			} );
-		} catch ( error ) {
+		} catch {
 			// Do nothing if the request comes back with an API error.
 			return;
 		}

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -118,7 +118,7 @@ const getOutputAssets = async ( outputAssetsPath ) => {
 const externalTemplateExists = async ( templateName ) => {
 	try {
 		await command( `npm view ${ templateName }` );
-	} catch ( error ) {
+	} catch {
 		return false;
 	}
 	return true;

--- a/packages/data/src/plugins/persistence/index.ts
+++ b/packages/data/src/plugins/persistence/index.ts
@@ -94,7 +94,7 @@ export function createPersistenceInterface(
 			} else {
 				try {
 					data = JSON.parse( persisted );
-				} catch ( error ) {
+				} catch {
 					// Similarly, should any error be thrown during parse of
 					// the string (malformed JSON), fall back to empty object.
 					data = {};

--- a/packages/data/src/plugins/persistence/storage/default.ts
+++ b/packages/data/src/plugins/persistence/storage/default.ts
@@ -13,7 +13,7 @@ try {
 	storage = window.localStorage;
 	storage.setItem( '__wpDataTestLocalStorage', '' );
 	storage.removeItem!( '__wpDataTestLocalStorage' );
-} catch ( error ) {
+} catch {
 	storage = objectStorage;
 }
 

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -21,7 +21,7 @@ const testStore = {
 async function resolve( registry, selector ) {
 	try {
 		await registry.resolveSelect( 'store' )[ selector ]();
-	} catch ( e ) {}
+	} catch {}
 }
 
 describe( 'getIsResolving', () => {

--- a/packages/data/src/registry.ts
+++ b/packages/data/src/registry.ts
@@ -261,7 +261,7 @@ export function createRegistry(
 				unlock( store.store ).registerPrivateSelectors(
 					unlock( parent ).privateSelectorsOf( name )
 				);
-			} catch ( e ) {
+			} catch {
 				// unlock() throws if store.store was not locked.
 				// The error indicates there's nothing to do here so let's
 				// ignore it.
@@ -389,7 +389,7 @@ export function createRegistry(
 		privateActionsOf: ( name: string ) => {
 			try {
 				return unlock( stores[ name ].store ).privateActions;
-			} catch ( e ) {
+			} catch {
 				// unlock() throws an error the store was not locked – this means
 				// there no private actions are available
 				return {};
@@ -398,7 +398,7 @@ export function createRegistry(
 		privateSelectorsOf: ( name: string ) => {
 			try {
 				return unlock( stores[ name ].store ).privateSelectors;
-			} catch ( e ) {
+			} catch {
 				return {};
 			}
 		},

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -598,7 +598,7 @@ function getVariableTypeAnnotation( declarationToken ) {
 
 	try {
 		return getTypeAnnotation( resolvedToken.typeAnnotation.typeAnnotation );
-	} catch ( e ) {
+	} catch {
 		// Assume it's a fully undocumented variable, there's nothing we can do about that but fail silently.
 	}
 }

--- a/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
+++ b/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
@@ -40,7 +40,7 @@ export default function inputFieldHasUncollapsedSelection( element ) {
 			// when not null, compare the two points
 			selectionStart !== selectionEnd
 		);
-	} catch ( error ) {
+	} catch {
 		// This is Safari's way of saying that the input type doesn't implement
 		// selection, so we default to true.
 		return true;

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -76,7 +76,7 @@ export async function visitSiteEditor(
 				// doesn't make it under the default timeout value.
 				timeout: 60_000,
 			} );
-		} catch ( error ) {
+		} catch {
 			// If the canvas loader is already disappeared, skip the waiting.
 			await this.page
 				.getByRole( 'region', { name: 'Editor content' } )

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -153,7 +153,7 @@ const test = base.extend<
 			await page.evaluate( () => {
 				window.localStorage.clear();
 			} );
-		} catch ( error ) {
+		} catch {
 			// noop.
 		}
 

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
@@ -23,7 +23,7 @@ const { callbacks } = store( 'test/generator-scope', {
 			let value = yield Promise.resolve( 1 );
 			try {
 				value = yield Promise.reject( 2 );
-			} catch ( e ) {
+			} catch {
 				value = yield Promise.resolve( 3 );
 			}
 			getContext().result = value;

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
@@ -34,7 +34,7 @@ const { state } = store( 'router', {
 
 			try {
 				yield actions.navigate( e.target.href, { force, timeout } );
-			} catch ( error ) {
+			} catch {
 				state.status = 'fail';
 			}
 

--- a/packages/edit-site/src/components/more-menu/site-export.js
+++ b/packages/edit-site/src/components/more-menu/site-export.js
@@ -49,7 +49,7 @@ export default function SiteExport() {
 			let error = {};
 			try {
 				error = await errorResponse.json();
-			} catch ( e ) {}
+			} catch {}
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message

--- a/packages/editor/src/components/collaborators-overlay/cursor-dom-utils.ts
+++ b/packages/editor/src/components/collaborators-overlay/cursor-dom-utils.ts
@@ -67,7 +67,7 @@ const getOffsetPositionInBlock = (
 
 	try {
 		cursorRange.setStart( node, offset );
-	} catch ( error ) {
+	} catch {
 		return null;
 	}
 

--- a/packages/editor/src/components/collaborators-overlay/timing-utils.ts
+++ b/packages/editor/src/components/collaborators-overlay/timing-utils.ts
@@ -13,7 +13,7 @@ export function setDelayedInterval( callback: () => void, delayMs: number ) {
 	const runner = () => {
 		try {
 			callback();
-		} catch ( error ) {
+		} catch {
 			// Do nothing
 		}
 

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -26,7 +26,7 @@ function getContent() {
 		// content serialization throughout the lifetime of a non-erroring
 		// application.
 		return select( editorStore ).getEditedPostContent();
-	} catch ( error ) {}
+	} catch {}
 }
 
 function CopyButton( { text, children, variant = 'secondary' } ) {

--- a/packages/editor/src/components/error-boundary/index.native.js
+++ b/packages/editor/src/components/error-boundary/index.native.js
@@ -34,7 +34,7 @@ function getContent() {
 		// content serialization throughout the lifetime of a non-erroring
 		// application.
 		return select( editorStore ).getEditedPostContent();
-	} catch ( error ) {}
+	} catch {}
 }
 
 function CopyButton( {

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -124,7 +124,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		try {
 			plainText = clipboardData.getData( 'text/plain' );
 			html = clipboardData.getData( 'text/html' );
-		} catch ( error ) {
+		} catch {
 			// Some browsers like UC Browser paste plain text by default and
 			// don't support clipboardData at all, so allow default
 			// behaviour.

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -61,7 +61,7 @@ module.exports = async function loadConfig(
 	if ( customConfigPath ) {
 		try {
 			await fs.stat( configFilePath );
-		} catch ( error ) {
+		} catch {
 			throw new ValidationError(
 				`Config file not found: ${ configFilePath }`
 			);

--- a/packages/env/lib/config/parse-source-string.js
+++ b/packages/env/lib/config/parse-source-string.js
@@ -106,7 +106,7 @@ function parseSourceString( sourceString, { cacheDirectoryPath } ) {
 				basename,
 			};
 		}
-	} catch ( err ) {}
+	} catch {}
 
 	const gitHubFields = sourceString.match(
 		/^([^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?$/

--- a/packages/env/lib/runtime/docker/wordpress.js
+++ b/packages/env/lib/runtime/docker/wordpress.js
@@ -64,7 +64,7 @@ async function configureWordPress( environment, config, spinner ) {
 			spinner,
 			config.debug
 		);
-	} catch ( err ) {
+	} catch {
 		// Ignore error.
 	}
 

--- a/packages/env/lib/runtime/playground/index.js
+++ b/packages/env/lib/runtime/playground/index.js
@@ -327,7 +327,7 @@ class PlaygroundRuntime {
 			try {
 				const pidContent = await fs.readFile( pidFile, 'utf8' );
 				pid = parseInt( pidContent.trim(), 10 );
-			} catch ( error ) {
+			} catch {
 				// PID file doesn't exist or can't be read
 				spinner.text = 'Stopped WordPress Playground.';
 				return;
@@ -350,7 +350,7 @@ class PlaygroundRuntime {
 				} catch {
 					// Process group already terminated
 				}
-			} catch ( error ) {
+			} catch {
 				// Process group doesn't exist or already terminated
 			}
 

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -51,7 +51,10 @@ module.exports = {
 		'no-unreachable': 'error',
 		'no-unsafe-negation': 'error',
 		'no-unused-expressions': 'error',
-		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
+		'no-unused-vars': [
+			'error',
+			{ ignoreRestSiblings: true, caughtErrors: 'all' },
+		],
 		'no-useless-return': 'error',
 		'no-whitespace-before-property': 'error',
 		'no-with': 'error',

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -51,10 +51,7 @@ module.exports = {
 		'no-unreachable': 'error',
 		'no-unsafe-negation': 'error',
 		'no-unused-expressions': 'error',
-		'no-unused-vars': [
-			'error',
-			{ ignoreRestSiblings: true, caughtErrors: 'all' },
-		],
+		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
 		'no-useless-return': 'error',
 		'no-whitespace-before-property': 'error',
 		'no-with': 'error',

--- a/packages/eslint-plugin/configs/jshint.js
+++ b/packages/eslint-plugin/configs/jshint.js
@@ -9,7 +9,10 @@ module.exports = {
 		'no-trailing-spaces': 'error',
 		'no-undef': 'error',
 		'no-unused-expressions': 'error',
-		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
+		'no-unused-vars': [
+			'error',
+			{ ignoreRestSiblings: true, caughtErrors: 'all' },
+		],
 		'one-var': [ 'error', 'always' ],
 		quotes: [ 'error', 'single' ],
 		'wrap-iife': [ 'error', 'any' ],

--- a/packages/eslint-plugin/configs/jshint.js
+++ b/packages/eslint-plugin/configs/jshint.js
@@ -9,10 +9,7 @@ module.exports = {
 		'no-trailing-spaces': 'error',
 		'no-undef': 'error',
 		'no-unused-expressions': 'error',
-		'no-unused-vars': [
-			'error',
-			{ ignoreRestSiblings: true, caughtErrors: 'all' },
-		],
+		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
 		'one-var': [ 'error', 'always' ],
 		quotes: [ 'error', 'single' ],
 		'wrap-iife': [ 'error', 'any' ],

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -62,10 +62,7 @@ if ( isPackageInstalled( 'typescript' ) ) {
 				'no-unused-vars': 'off',
 				'@typescript-eslint/no-unused-vars': [
 					'error',
-					{
-						ignoreRestSiblings: true,
-						caughtErrors: 'all',
-					},
+					{ ignoreRestSiblings: true },
 				],
 				// no-shadow doesn't work correctly in TS, so let's use a TS-dedicated version instead.
 				'no-shadow': 'off',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -62,7 +62,10 @@ if ( isPackageInstalled( 'typescript' ) ) {
 				'no-unused-vars': 'off',
 				'@typescript-eslint/no-unused-vars': [
 					'error',
-					{ ignoreRestSiblings: true },
+					{
+						ignoreRestSiblings: true,
+						caughtErrors: 'all',
+					},
 				],
 				// no-shadow doesn't work correctly in TS, so let's use a TS-dedicated version instead.
 				'no-shadow': 'off',

--- a/packages/eslint-plugin/utils/is-package-installed.js
+++ b/packages/eslint-plugin/utils/is-package-installed.js
@@ -9,7 +9,7 @@ const isPackageInstalled = ( packageName ) => {
 		if ( require.resolve( packageName ) ) {
 			return true;
 		}
-	} catch ( error ) {}
+	} catch {}
 	return false;
 };
 

--- a/packages/global-styles-engine/src/preview-state-styles.ts
+++ b/packages/global-styles-engine/src/preview-state-styles.ts
@@ -36,7 +36,7 @@ export function generatePreviewStateStyles(
 		const [ generatedStyles ] = generateGlobalStyles( previewConfig, [] );
 
 		return generatedStyles.map( ( style ) => style.css ).join( '\n' );
-	} catch ( error ) {
+	} catch {
 		// If generation fails, return empty string to avoid breaking previews
 		return '';
 	}

--- a/packages/global-styles-ui/src/font-library/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library/font-collection.tsx
@@ -210,7 +210,7 @@ function FontCollection( { slug }: { slug: string } ) {
 					} )
 				);
 			}
-		} catch ( error ) {
+		} catch {
 			// If any of the fonts fail to download,
 			// show an error notice and stop the request from being sent.
 			setNotice( {

--- a/packages/global-styles-ui/src/font-library/upload-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/upload-fonts.tsx
@@ -131,7 +131,7 @@ function UploadFonts() {
 			const buffer = await readFileAsArrayBuffer( file );
 			await font.fromDataBuffer( buffer, 'font' );
 			return true;
-		} catch ( error ) {
+		} catch {
 			return false;
 		}
 	}

--- a/packages/icons/lib/validate-collection.cjs
+++ b/packages/icons/lib/validate-collection.cjs
@@ -16,7 +16,7 @@ async function validateCollection() {
 
 	try {
 		await stat( manifestPath );
-	} catch ( error ) {
+	} catch {
 		throw new Error(
 			`Could not find icons manifest at '${ manifestPath }'`
 		);

--- a/packages/interactivity-router/src/assets/dynamic-importmap/fetch.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/fetch.ts
@@ -42,7 +42,7 @@ export async function fetchModule(
 	let res: Response;
 	try {
 		res = await fetch( url, fetchOpts );
-	} catch ( e ) {
+	} catch {
 		throw Error( `Network error${ fetching( url, parent ) }.` );
 	}
 	if ( ! res.ok ) {

--- a/packages/interactivity-router/src/assets/dynamic-importmap/resolver.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/resolver.ts
@@ -22,7 +22,7 @@ function isURL( url: string ) {
 	try {
 		new URL( url );
 		return true;
-	} catch ( _ ) {
+	} catch {
 		return false;
 	}
 }

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -90,7 +90,7 @@ const parseRegionAttribute = ( region: Element ) => {
 	try {
 		const { id, attachTo } = JSON.parse( value );
 		return { id, attachTo };
-	} catch ( e ) {
+	} catch {
 		return { id: value };
 	}
 };
@@ -169,7 +169,7 @@ const fetchPage = async ( url: string, { html }: { html: string } ) => {
 		}
 		const dom = new window.DOMParser().parseFromString( html, 'text/html' );
 		return await preparePage( url, dom );
-	} catch ( e ) {
+	} catch {
 		return false;
 	}
 };

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -782,7 +782,7 @@ export default () => {
 								? ''
 								: result;
 						return;
-					} catch ( err ) {}
+					} catch {}
 				}
 				/*
 				 * aria- and data- attributes have no boolean representation.
@@ -858,7 +858,7 @@ export default () => {
 				}
 				element.props.children =
 					typeof result === 'object' ? null : result.toString();
-			} catch ( e ) {
+			} catch {
 				element.props.children = null;
 			}
 		} );

--- a/packages/interactivity/src/proxies/test/state-proxy.ts
+++ b/packages/interactivity/src/proxies/test/state-proxy.ts
@@ -919,7 +919,7 @@ describe( 'Interactivity API', () => {
 						let tag = 'No scope';
 						try {
 							tag = getContext< any >().tag;
-						} catch ( e ) {}
+						} catch {}
 						return `${ tag }: ${ this.number }`;
 					},
 				} );

--- a/packages/interactivity/src/test/utils.ts
+++ b/packages/interactivity/src/test/utils.ts
@@ -196,7 +196,7 @@ describe( 'Interactivity API', () => {
 						namespace: getNamespace(),
 					} );
 					a = yield Promise.reject( new Error( 'CatchMe' ) );
-				} catch ( e ) {
+				} catch {
 					steps.push( {
 						scope: getScope(),
 						namespace: getNamespace(),

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -401,7 +401,7 @@ export const warn = ( message: string ): void => {
 		// A consumer can use 'pause on caught exceptions'
 		try {
 			throw Error( message );
-		} catch ( e ) {
+		} catch {
 			// Do nothing.
 		}
 		logged.add( message );

--- a/packages/list-reusable-blocks/src/utils/import.js
+++ b/packages/list-reusable-blocks/src/utils/import.js
@@ -19,7 +19,7 @@ async function importReusableBlock( file ) {
 	let parsedContent;
 	try {
 		parsedContent = JSON.parse( fileContent );
-	} catch ( e ) {
+	} catch {
 		throw new Error( 'Invalid JSON file' );
 	}
 	if (

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -57,7 +57,7 @@ export const createPatternFromFile =
 		let parsedContent;
 		try {
 			parsedContent = JSON.parse( fileContent );
-		} catch ( e ) {
+		} catch {
 			throw new Error( 'Invalid JSON file' );
 		}
 		if (

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -111,7 +111,7 @@ const setupDriver = async () => {
 					'Detected Android device running Android %s',
 					androidVersion
 				);
-			} catch ( error ) {
+			} catch {
 				// Ignore error.
 			}
 		} else {
@@ -692,7 +692,7 @@ const clickIfClickable = async (
 
 	try {
 		return await element.click();
-	} catch ( error ) {
+	} catch {
 		if ( iteration >= maxIteration ) {
 			// eslint-disable-next-line no-console
 			console.error(

--- a/packages/react-native-editor/bin/extract-files-from-sourcemap.js
+++ b/packages/react-native-editor/bin/extract-files-from-sourcemap.js
@@ -40,14 +40,14 @@ if ( require.main === module ) {
 	}
 	try {
 		fs.accessSync( mapFile );
-	} catch ( err ) {
+	} catch {
 		// eslint-disable-next-line no-console
 		console.error( `Map file "${ mapFile } doesn't exist.` );
 		process.exit( 1 );
 	}
 	try {
 		fs.accessSync( targetDir );
-	} catch ( err ) {
+	} catch {
 		// eslint-disable-next-line no-console
 		console.error( `Target directory "${ targetDir }"" doesn't exist.` );
 		process.exit( 1 );
@@ -74,7 +74,7 @@ if ( require.main === module ) {
 		try {
 			fs.accessSync( file );
 			return true;
-		} catch ( error ) {
+		} catch {
 			return false;
 		}
 	} );
@@ -87,7 +87,7 @@ if ( require.main === module ) {
 				.replace( '.ts', '.js' );
 			try {
 				fs.accessSync( compiledFile );
-			} catch ( error ) {
+			} catch {
 				// eslint-disable-next-line no-console
 				console.warn(
 					`Couldn't find matching build file for Typescript file "${ compiledFile }".`

--- a/packages/react-native-editor/i18n-cache/index.js
+++ b/packages/react-native-editor/i18n-cache/index.js
@@ -76,7 +76,7 @@ const fetchTranslation = ( locale ) => {
 				locale,
 				inCache: true,
 			} );
-		} catch ( error ) {
+		} catch {
 			// translation not found, let's fetch it
 		}
 	}

--- a/packages/report-flaky-tests/src/markdown.ts
+++ b/packages/report-flaky-tests/src/markdown.ts
@@ -37,7 +37,7 @@ const metaData = {
 			if ( matched ) {
 				return JSON.parse( matched[ 1 ] );
 			}
-		} catch ( error ) {
+		} catch {
 			// Ignore errors.
 		}
 		return undefined;

--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -40,7 +40,7 @@ let loadConfig = null;
 try {
 	// First, try to load the package installed from among the optional peerDependencies.
 	loadConfig = require( '@wordpress/env/lib/config' ).loadConfig;
-} catch ( error ) {
+} catch {
 	// eslint-disable-next-line no-console
 	console.log(
 		'Notice: Could not find @wordpress/env package. Using WP_BASE_URL environment variable or else the default http://localhost:8889 URL for tests.'

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -272,7 +272,7 @@ function getWebpackEntryPoints( buildType ) {
 				// at which point they are completely empty and therefore not valid JSON
 				try {
 					parsedBlockJson = JSON.parse( fileContents );
-				} catch ( error ) {
+				} catch {
 					warn(
 						`Not scanning "${ blockMetadataFile.replace(
 							fromProjectRoot( sep ),
@@ -402,7 +402,7 @@ function getPhpFilePaths( context, props ) {
 		let parsedBlockJson;
 		try {
 			parsedBlockJson = JSON.parse( readFileSync( blockMetadataFile ) );
-		} catch ( error ) {
+		} catch {
 			warn(
 				`Not scanning "${ blockMetadataFile.replace(
 					fromProjectRoot( sep ),

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -207,7 +207,7 @@ export function camelCaseJoin( strings: string[] ): string {
 export function safeDecodeURI( uri: string ): string {
 	try {
 		return decodeURI( uri );
-	} catch ( uriError ) {
+	} catch {
 		return uri;
 	}
 }

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -96,7 +96,7 @@ export function deserializeCrdtDoc(
 		ydoc.clientID = pseudoRandomID();
 
 		return ydoc;
-	} catch ( e ) {
+	} catch {
 		return null;
 	}
 }

--- a/packages/url/src/get-filename.ts
+++ b/packages/url/src/get-filename.ts
@@ -22,7 +22,7 @@ export function getFilename( url: string ): string | void {
 		filename = new URL( url, 'http://example.com' ).pathname
 			.split( '/' )
 			.pop();
-	} catch ( error ) {}
+	} catch {}
 
 	if ( filename ) {
 		return filename;

--- a/packages/url/src/get-query-string.ts
+++ b/packages/url/src/get-query-string.ts
@@ -14,7 +14,7 @@ export function getQueryString( url: string ): string | void {
 	let query;
 	try {
 		query = new URL( url, 'http://example.com' ).search.substring( 1 );
-	} catch ( error ) {}
+	} catch {}
 
 	if ( query ) {
 		return query;

--- a/packages/url/src/safe-decode-uri-component.ts
+++ b/packages/url/src/safe-decode-uri-component.ts
@@ -9,7 +9,7 @@
 export function safeDecodeURIComponent( uriComponent: string ): string {
 	try {
 		return decodeURIComponent( uriComponent );
-	} catch ( uriComponentError ) {
+	} catch {
 		return uriComponent;
 	}
 }

--- a/packages/url/src/safe-decode-uri.ts
+++ b/packages/url/src/safe-decode-uri.ts
@@ -14,7 +14,7 @@
 export function safeDecodeURI( uri: string ): string {
 	try {
 		return decodeURI( uri );
-	} catch ( uriError ) {
+	} catch {
 		return uri;
 	}
 }

--- a/packages/warning/src/index.ts
+++ b/packages/warning/src/index.ts
@@ -43,7 +43,7 @@ export default function warning( message: string ): void {
 	// https://github.com/facebook/react/issues/4216
 	try {
 		throw Error( message );
-	} catch ( x ) {
+	} catch {
 		// Do nothing.
 	}
 	logged.add( message );

--- a/packages/wp-build/lib/route-utils.mjs
+++ b/packages/wp-build/lib/route-utils.mjs
@@ -22,7 +22,7 @@ export function getAllRoutes( rootDir ) {
 		return readdirSync( routesPath, { withFileTypes: true } )
 			.filter( ( dirent ) => dirent.isDirectory() )
 			.map( ( dirent ) => dirent.name );
-	} catch ( error ) {
+	} catch {
 		// Routes directory doesn't exist, return empty array
 		return [];
 	}

--- a/test/e2e/specs/admin/font-library.spec.js
+++ b/test/e2e/specs/admin/font-library.spec.js
@@ -93,7 +93,7 @@ test.describe( 'Font Library', () => {
 					// Attempt to load the font - this will throw or return empty array if not available.
 					const fonts = await document.fonts.load( '16px "Exo 2"' );
 					return fonts.length > 0;
-				} catch ( error ) {
+				} catch {
 					return false;
 				}
 			} );

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -374,7 +374,7 @@ test.describe( 'Cover', () => {
 				trial: true,
 				timeout: 1000, // This test will always take 1 second to run.
 			} );
-		} catch ( error ) {
+		} catch {
 			isClickable = false;
 		}
 

--- a/test/integration/fixtures/utils.js
+++ b/test/integration/fixtures/utils.js
@@ -9,7 +9,7 @@ const FIXTURES_DIR = path.join( __dirname, 'blocks' );
 function readFixtureFile( fixturesDir, filename ) {
 	try {
 		return fs.readFileSync( path.join( fixturesDir, filename ), 'utf8' );
-	} catch ( err ) {
+	} catch {
 		return null;
 	}
 }

--- a/test/native/matchers/utils.js
+++ b/test/native/matchers/utils.js
@@ -20,7 +20,7 @@ export class ReactElementTypeError extends Error {
 		let withType = '';
 		try {
 			withType = printWithType( 'Received', received, printReceived );
-		} catch ( e ) {}
+		} catch {}
 		this.message = [
 			matcherHint(
 				`${ context.isNot ? '.not' : '' }.${ matcherFn.name }`,

--- a/test/unit/config/matchers/to-match-style-diff-snapshot.js
+++ b/test/unit/config/matchers/to-match-style-diff-snapshot.js
@@ -21,7 +21,7 @@ const getStyleRulesForElement = ( element, styleSheets ) => {
 					found.push( rule.style );
 				}
 			} );
-		} catch ( e ) {}
+		} catch {}
 
 		return [ ...matchingRules, ...found ];
 	}, [] );


### PR DESCRIPTION
## What?

Extracted from https://github.com/WordPress/gutenberg/pull/76654#issuecomment-4169268916

Removes unused error variables from `catch` blocks across 71 files, using ES2019 optional catch binding (`catch { ... }` instead of `catch (error) { ... }`).

## Why?

ESLint v10 changes the `no-unused-vars` rule default for `caughtErrors` from `"none"` to `"all"`, which flags unused catch block variables as errors. Extracting this mechanical cleanup into a separate PR reduces the size of the main ESLint v10 upgrade PR (#76654) and makes it easier to review.

## How?

Purely mechanical transformation: every `catch (error)`, `catch (e)`, `catch (err)` where the variable is unused is converted to `catch`. No behavior change.

## Testing Instructions

1. `npm run lint:js` — should pass (no new errors introduced).
2. `npm run test:unit` — all tests should pass (no runtime behavior change).

### Testing Instructions for Keyboard

N/A — no UI changes.

## Screenshots or screencast

N/A — code cleanup only.