### PR TITLE
Text: Remove UA margins

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Text`: Apply `margin: 0`, removing user-agent margins when the component renders as block-level elements (for example `p` or `h1`–`h6` via `render` prop) ([#76970](https://github.com/WordPress/gutenberg/pull/76970)).
+
 ## 0.10.0 (2026-04-01)
 
 ### New Features

--- a/packages/ui/src/text/style.module.css
+++ b/packages/ui/src/text/style.module.css
@@ -1,6 +1,10 @@
 @layer wp-ui-utilities, wp-ui-components, wp-ui-compositions, wp-ui-overrides;
 
 @layer wp-ui-components {
+	.text {
+		margin: 0;
+	}
+
 	.heading-2xl {
 		font-family: var(--wpds-font-family-heading);
 		font-size: var(--wpds-font-size-2xl);

--- a/packages/ui/src/text/text.tsx
+++ b/packages/ui/src/text/text.tsx
@@ -17,7 +17,7 @@ export const Text = forwardRef< HTMLSpanElement, TextProps >( function Text(
 		defaultTagName: 'span',
 		ref,
 		props: mergeProps< 'span' >( props, {
-			className: clsx( styles[ variant ], className ),
+			className: clsx( styles.text, styles[ variant ], className ),
 		} ),
 	} );
 


### PR DESCRIPTION
## What?

Split from #76783.

Always apply `margin: 0` to the `Text` component, so block-level tags (`p`, `h1`–`h6`, etc.) no longer pick up user-agent margins when used via `render`.

## Why?

`Text` is meant to handle typography, not layout spacing. UA margins on `p` and headings made composition inconsistent with other primitives and pushed spacing responsibility in the wrong direction. Full discussion in https://github.com/WordPress/gutenberg/pull/76783#discussion_r2996271841.

## Testing Instructions

See "With Render Prop" story for the `Text` component in Storybook.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="902" height="448" alt="Text component rendered as heading and paragraph, before" src="https://github.com/user-attachments/assets/6a8dd8f1-23eb-4dc0-9974-a4e37ed1f31e" />|<img width="902" height="448" alt="Text component rendered as heading and paragraph, after" src="https://github.com/user-attachments/assets/f6020801-a27b-4d0b-a2bf-5520926a3a6e" />|


## Use of AI Tools

Composer 2 was used for a first draft of this PR description.