### PR TITLE
Paragraph: hide slash inserter placeholder in content-only editing mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2552,6 +2552,49 @@ export const hasInserterItems = ( state, rootClientId = null ) => {
 };
 
 /**
+ * Returns whether a block can use the slash command to insert or replace with
+ * another block type. Returns false when no other block type can be inserted
+ * in the same parent context — for example when the editor's allowedBlockTypes
+ * setting or a parent block's allowedBlocks setting restricts insertable types
+ * to only the current block, or when the block is inside a content-only section
+ * (unsynced pattern / templateLock:'contentOnly') where only content-role blocks
+ * are permitted and none are available.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Client ID of the block.
+ *
+ * @return {boolean} Whether the slash command can offer block replacements.
+ */
+export const __unstableHasSlashCommandReplacements = createSelector(
+	( state, clientId ) => {
+		const blockName = getBlockName( state, clientId );
+		if ( ! blockName ) {
+			return false;
+		}
+
+		const rootClientId = getBlockRootClientId( state, clientId );
+
+		// Return true as soon as we find any other insertable block type.
+		// canIncludeBlockTypeInInserter already accounts for content-only
+		// section restrictions (#76982) and allowedBlockTypes / parent
+		// allowedBlocks settings (#55378).
+		return getBlockTypes().some(
+			( blockType ) =>
+				blockType.name !== blockName &&
+				canIncludeBlockTypeInInserter( state, blockType, rootClientId )
+		);
+	},
+	( state, clientId ) => {
+		const rootClientId = getBlockRootClientId( state, clientId );
+		return [
+			getBlockName( state, clientId ),
+			getBlockTypes(),
+			...getInsertBlockTypeDependants()( state, rootClientId ),
+		];
+	}
+);
+
+/**
  * Returns the list of allowed inserter blocks for inner blocks children.
  *
  * @param {Object}  state        Editor state.

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4807,6 +4807,120 @@ describe( 'selectors', () => {
 			expect( canMoveBlock( state, 'child' ) ).toBe( true );
 		} );
 	} );
+
+	describe( '__unstableHasSlashCommandReplacements', () => {
+		const { __unstableHasSlashCommandReplacements } = selectors;
+
+		afterEach( async () => {
+			await dispatch( store ).resetBlocks( [] );
+			await dispatch( store ).updateSettings( {
+				allowedBlockTypes: undefined,
+			} );
+		} );
+
+		it( 'returns true when other block types can be inserted (default case)', async () => {
+			await dispatch( store ).resetBlocks( [
+				{
+					clientId: 'para',
+					name: 'core/test-block-a',
+					attributes: {},
+					innerBlocks: [],
+				},
+			] );
+
+			expect(
+				select( store ).__unstableHasSlashCommandReplacements( 'para' )
+			).toBe( true );
+		} );
+
+		it( 'returns false when allowedBlockTypes restricts to only the current block (#55378)', async () => {
+			await dispatch( store ).updateSettings( {
+				allowedBlockTypes: [ 'core/test-block-a' ],
+			} );
+			await dispatch( store ).resetBlocks( [
+				{
+					clientId: 'para',
+					name: 'core/test-block-a',
+					attributes: {},
+					innerBlocks: [],
+				},
+			] );
+
+			expect(
+				select( store ).__unstableHasSlashCommandReplacements( 'para' )
+			).toBe( false );
+		} );
+
+		it( 'returns false when parent allowedBlocks restricts to only the current block (#55378)', async () => {
+			// Use core/test-block-a as the container — no registered test block
+			// declares it as a required parent, so the allowedBlocks restriction
+			// is the only thing that controls insertion here.
+			await dispatch( store ).resetBlocks( [
+				{
+					clientId: 'container',
+					name: 'core/test-block-a',
+					attributes: {},
+					innerBlocks: [
+						{
+							clientId: 'para',
+							name: 'core/test-block-b',
+							attributes: {},
+							innerBlocks: [],
+						},
+					],
+				},
+			] );
+			await dispatch( store ).updateBlockListSettings( 'container', {
+				allowedBlocks: [ 'core/test-block-b' ],
+			} );
+
+			expect(
+				select( store ).__unstableHasSlashCommandReplacements( 'para' )
+			).toBe( false );
+		} );
+
+		it( 'returns false when paragraph is inside a content-only section (unsynced pattern) (#76982)', () => {
+			// A block with templateLock:'contentOnly' whose parent does NOT
+			// also have contentOnly is treated as a section block. Inside it,
+			// canIncludeBlockTypeInInserter returns false for any block type
+			// that isn't a content-role block — so the slash inserter would
+			// show nothing useful and the placeholder should not hint at it.
+			const state = {
+				blocks: {
+					byClientId: new Map( [
+						[ 'section', { name: 'core/test-block-b' } ],
+						[ 'para', { name: 'core/test-block-a' } ],
+					] ),
+					attributes: new Map( [
+						[ 'section', {} ],
+						[ 'para', {} ],
+					] ),
+					parents: new Map( [
+						[ 'section', '' ],
+						[ 'para', 'section' ],
+					] ),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'para' ] ],
+					] ),
+					blockEditingModes: new Map(),
+				},
+				blockListSettings: {
+					section: { templateLock: 'contentOnly' },
+				},
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				derivedBlockEditingModes: new Map(),
+				preferences: { insertUsage: {} },
+				editedContentOnlySection: null,
+			};
+
+			expect(
+				__unstableHasSlashCommandReplacements( state, 'para' )
+			).toBe( false );
+		} );
+	} );
 } );
 
 describe( 'getInserterItems with core blocks prioritization', () => {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -19,7 +19,9 @@ import {
 	useBlockProps,
 	useSettings,
 	useBlockEditingMode,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import { formatLTR } from '@wordpress/icons';
 /**
@@ -119,6 +121,20 @@ function ParagraphBlock( {
 		style: { direction },
 	} );
 	const blockEditingMode = useBlockEditingMode();
+	const isEmpty = RichText.isEmpty( content );
+	const hasSlashReplacements = useSelect(
+		( select ) =>
+			isEmpty &&
+			select( blockEditorStore ).__unstableHasSlashCommandReplacements(
+				clientId
+			),
+		[ clientId, isEmpty ]
+	);
+	const emptyAriaLabel = hasSlashReplacements
+		? __(
+				'Empty block; start writing or type forward slash to choose a block'
+		  )
+		: __( 'Empty block; start writing' );
 
 	return (
 		<>
@@ -152,14 +168,15 @@ function ParagraphBlock( {
 				onReplace={ onReplace }
 				onRemove={ onRemove }
 				aria-label={
-					RichText.isEmpty( content )
-						? __(
-								'Empty block; start writing or type forward slash to choose a block'
-						  )
-						: __( 'Block: Paragraph' )
+					isEmpty ? emptyAriaLabel : __( 'Block: Paragraph' )
 				}
-				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
+				data-empty={ isEmpty }
+				placeholder={
+					placeholder ||
+					( hasSlashReplacements
+						? __( 'Type / to choose a block' )
+						: __( 'Start writing…' ) )
+				}
 				data-custom-placeholder={ placeholder ? true : undefined }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations


### PR DESCRIPTION
(Maybe) fixes https://github.com/WordPress/gutenberg/issues/76982

(Maybe) fixes https://github.com/WordPress/gutenberg/issues/55378

## What

Fixes the paragraph block's placeholder text so it accurately reflects whether the slash inserter can actually offer alternative block types in a given context.


## Why
The placeholder "Type / to choose a block" was hardcoded regardless of context. This misled users in two situations:

- Inside unsynced patterns or `templateLock: "contentOnly"` blocks where no other block types can be inserted
- In editors where `allowedBlocks` settings restrict the inserter to only the paragraph block

The original fix in this PR keyed off `blockEditingMode`, which was too coarse — many content-only contexts (Quote, Cover, and other container blocks with `role: "content"`) legitimately support the slash inserter with multiple block types.


## How
Introduces a new private selector `__unstableHasSlashCommandReplacements` in the `block-editor` store that checks whether _any_ block type other than the current one can actually be inserted at the block's position.

It delegates to `canIncludeBlockTypeInInserter`, which already encodes the rules for:

- Global `allowedBlockTypes` restrictions 
- Parent block `allowedBlocks` settings
- Content-only section restrictions — blocks inside a non-content-role container (e.g. a plain Group with `templateLock: "contentOnly"`) cannot insert other types, but blocks inside a content-role container (e.g. Quote, Cover) can 
The selector is memoized via `createSelector` using `getBlockName`, `getBlockTypes`, and `getInsertBlockTypeDependants` as cache keys, so it only recomputes when something relevant actually changes.

In `paragraph/edit.js`, the `useSelect` call is gated behind an `isEmpty` check so that paragraphs with content never access the store at all, avoiding any subscription overhead during typing.

	
## Testing instructions
### Basic regression — default editor
1. Create a new post
2. Add a Paragraph block
3. Confirm the empty paragraph shows **"Type / to choose a block"**
4. Type `/` and confirm the block inserter opens normally

### Fix for #76982 — content-only pattern (no content-role container)

1. Create a new post
2. Insert any unsynced pattern that contains a paragraph (e.g. "Text" patterns), or add this block manually:
```html
<!-- wp:group {"templateLock":"contentOnly"} -->
<div class="wp-block-group">
  <!-- wp:paragraph -->
  <p>Hello</p>
  <!-- /wp:paragraph -->
</div>
<!-- /wp:group -->
```
3. Click into the paragraph and press Enter to create a new empty paragraph
4. Confirm the placeholder reads "Start writing…" (not "Type / to choose a block")
5. Confirm typing / does not open a useful block inserter

### Fix for #76982 — content-only container that is a content block (Quote, Cover)

1. Insert a Quote block
2. Click into the citation or an inner paragraph and press Enter to get a new empty paragraph
3. Confirm the placeholder still reads "Type / to choose a block"
4. Confirm typing / opens the inserter with relevant options (Heading, Image, etc.)
5. Repeat with a Cover block containing inner content.

### Fix for #55378 — allowedBlocks restricted to paragraph only

1. Insert a Group block
2. In the Block inspector → Advanced → Manage allowed blocks, deselect everything except Paragraph
3. Insert a Paragraph inside the Group
4. Confirm the placeholder reads "Start writing…"
5. Confirm typing / does not offer other block types


