### PR TITLE
Block Editor: Prevent Enter key from inserting paragraphs in contentOnly sections

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1747,11 +1747,18 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
-	// In content only mode, check if this container allows insertion.
-	// We need the `isParentSectionBlock` check because section blocks
-	// (synced patterns, contentOnly groups) have a `getBlockEditingMode`
-	// of 'default', not 'contentOnly' — the 'contentOnly' mode is only
-	// set on their *children*.
+	/*
+	 * In content only mode, check if this container allows insertion.
+	 * We need the `isParentSectionBlock` check because section blocks
+	 * (synced patterns, contentOnly groups) have a `getBlockEditingMode`
+	 * of 'default', not 'contentOnly' — the 'contentOnly' mode is only
+	 * set on their *children*.
+	 *
+	 * Also include `disabled` alongside `contentOnly`: structural inner blocks
+	 * (e.g. Column) inside a content-only section use `disabled` mode, and they
+	 * need the same default-block sibling rules so insertion stays aligned with
+	 * `canRemoveBlock`.
+	 */
 	if (
 		isWithinSection &&
 		( isParentSectionBlock ||
@@ -1764,8 +1771,11 @@ const canInsertBlockTypeUnmemoized = (
 		)
 	) {
 		const defaultBlockName = getDefaultBlockName();
-		// Allow inserting the default block anywhere that another default block already exists
-		// when in contentOnly mode.
+		/*
+		 * Allow inserting the default block anywhere that another default block already exists
+		 * when in contentOnly mode. The same sibling rule applies when the parent is `disabled`
+		 * within a content-only section (see the condition above).
+		 */
 		if ( blockName === defaultBlockName ) {
 			const existingBlocks = getBlockOrder( state, rootClientId );
 			const hasDefaultBlock = existingBlocks.some(

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1754,7 +1754,9 @@ const canInsertBlockTypeUnmemoized = (
 	// set on their *children*.
 	if (
 		isWithinSection &&
-		( isParentSectionBlock || blockEditingMode === 'contentOnly' ) &&
+		( isParentSectionBlock ||
+			blockEditingMode === 'contentOnly' ||
+			blockEditingMode === 'disabled' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			blockName,

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -565,4 +565,64 @@ test.describe( 'Content-only lock', () => {
 			).toBeVisible();
 		} );
 	} );
+
+	test( 'pressing Enter on a non-text block in a contentOnly section should not insert a paragraph', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// The Cover is nested inside a Column so that its parent has no
+		// templateLock of its own. This mirrors real patterns like
+		// Event RSVP where the Cover sits inside Columns > Column.
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>A paragraph</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:cover {"overlayColor":"black","isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
+<p>Cover content</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const coverBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Cover',
+		} );
+
+		// Select the content-locked group block first (enters section editing).
+		await editor.selectBlocks( groupBlock );
+
+		// Select the Cover block within the nested column.
+		await editor.selectBlocks( coverBlock );
+
+		// The Cover's parent Column should have exactly one child.
+		const initialBlocks = await editor.getBlocks();
+		const coverColumn =
+			initialBlocks[ 0 ].innerBlocks[ 0 ].innerBlocks[ 1 ];
+		const initialColumnChildren = coverColumn.innerBlocks.length;
+		expect( initialColumnChildren ).toBe( 1 );
+
+		// Press Enter on the selected Cover block.
+		await page.keyboard.press( 'Enter' );
+
+		// Verify no new paragraph was inserted in the Column.
+		const afterBlocks = await editor.getBlocks();
+		const afterColumn = afterBlocks[ 0 ].innerBlocks[ 0 ].innerBlocks[ 1 ];
+		expect( afterColumn.innerBlocks.length ).toBe( initialColumnChildren );
+	} );
 } );


### PR DESCRIPTION
Fixes a bug where pressing Enter on a non-text block (e.g. a Cover block) inside a contentOnly pattern inserts an empty paragraph that can't be removed.

See https://github.com/WordPress/gutenberg/pull/73222#issuecomment-4167310375

## Why?

When a block like Cover sits inside a nested container (Column) within a contentOnly pattern, pressing Enter inserts a paragraph via `insertAfterBlock`. The paragraph gets created because `canInsertBlockType` didn't consider containers with `disabled` editing mode when applying content-only insertion rules. 

The condition only matched `contentOnly` and section block parents, so the `disabled` Column fell through and the paragraph was allowed. But `canRemoveBlock` respects the Column's `disabled` editing mode, so the paragraph gets stuck.

## How?

Include `blockEditingMode === 'disabled'` in the content-only insertion check in `canInsertBlockType` so that disabled containers (like Column inside a contentOnly section) go through the same "has existing sibling paragraph" logic.

## Testing Instructions

1. Open the site editor, edit a page or template
2. Insert the "Event RSVP" pattern (from Twenty Twenty-Five)
3. Click the pattern to select it
4. Navigate to the Cover block (bottom-right area of the pattern) and select it
5. Press Enter
6. **Before:** An empty paragraph is inserted that can't be removed
7. **After:** Nothing happens, the pattern structure is preserved

Also verify normal editing still works:
- In a regular post, inserting blocks with Enter after a Cover still works
- Inside a contentOnly pattern, editing text in paragraphs and headings still works

## Screenshots

### How it worked before


https://github.com/user-attachments/assets/ac5f61dc-3691-4510-82cc-0c0c8381307f

### How it should work (this PR)


https://github.com/user-attachments/assets/03d3e33c-7d83-4f21-83ef-613b9642b5d9