### PR TITLE
Block Editor: Display shortcuts for moving blocks via tooltips

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -12,6 +12,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
+import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -145,6 +146,11 @@ const BlockMoverButton = forwardRef(
 					onClick={ isDisabled ? null : onClick }
 					disabled={ isDisabled }
 					accessibleWhenDisabled
+					shortcut={
+						direction === 'up'
+							? displayShortcut.secondary( 't' )
+							: displayShortcut.secondary( 'y' )
+					}
 				/>
 				<VisuallyHidden id={ descriptionId }>
 					{ getBlockMoverDescription(


### PR DESCRIPTION
## What?
Closes #51647.

PR adds shortcuts display via tooltips for selected block mover actions.

## Why?
A recent [conversation on X](https://x.com/iansvo/status/2039380451647713686) led me to this rabbit hole. Hopefully, this will make shortcuts more discoverable.

## Testing Instructions
1. Create a post.
2. Add a couple of blocks.
3. Hover or focus block mover toolbar buttons.
4. Confirm that the shortcut is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="771" height="283" alt="CleanShot 2026-04-02 at 09 41 43" src="https://github.com/user-attachments/assets/b76b5ad2-ff1f-445c-baf6-5d17fd055840" />


## Use of AI Tools

None.