### PR TITLE
BlockMover: Remove unused disabled button props

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -65,7 +65,6 @@ const BlockMoverButton = forwardRef(
 			? clientIds
 			: [ clientIds ];
 		const blocksCount = normalizedClientIds.length;
-		const { disabled } = props;
 
 		const {
 			blockType,
@@ -99,9 +98,7 @@ const BlockMoverButton = forwardRef(
 
 				return {
 					blockType: block ? getBlockType( block.name ) : null,
-					isDisabled:
-						disabled ||
-						( direction === 'up' ? isFirstBlock : isLastBlock ),
+					isDisabled: direction === 'up' ? isFirstBlock : isLastBlock,
 					rootClientId: blockRootClientId,
 					firstIndex: firstBlockIndex,
 					isFirst: isFirstBlock,

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -19,12 +19,7 @@ import BlockDraggable from '../block-draggable';
 import { BlockMoverUpButton, BlockMoverDownButton } from './button';
 import { store as blockEditorStore } from '../../store';
 
-function BlockMover( {
-	clientIds,
-	hideDragHandle,
-	isBlockMoverUpButtonDisabled,
-	isBlockMoverDownButtonDisabled,
-} ) {
+function BlockMover( { clientIds, hideDragHandle } ) {
 	const {
 		canMove,
 		rootClientId,
@@ -104,7 +99,6 @@ function BlockMover( {
 					<ToolbarItem>
 						{ ( itemProps ) => (
 							<BlockMoverUpButton
-								disabled={ isBlockMoverUpButtonDisabled }
 								clientIds={ clientIds }
 								{ ...itemProps }
 							/>
@@ -113,7 +107,6 @@ function BlockMover( {
 					<ToolbarItem>
 						{ ( itemProps ) => (
 							<BlockMoverDownButton
-								disabled={ isBlockMoverDownButtonDisabled }
 								clientIds={ clientIds }
 								{ ...itemProps }
 							/>


### PR DESCRIPTION
## What?
Remove dead code from `block-mover` introduced in #60054 (ce4940694).

The `block-selection-button.js` caller that passed `isBlockMoverUpButtonDisabled`/`isBlockMoverDownButtonDisabled` was removed in a later refactor, leaving these props and the `disabled` override in `button.js` unused.

## Testing Instructions
CI checks are passing.

## Use of AI Tools

None.