### PR TITLE
Connectors: account for mu-plugins when resolving plugin.file status

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -28,7 +28,8 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 	 *         env_var_name?: non-empty-string
 	 *     },
 	 *     plugin?: array{
-	 *         file: non-empty-string
+	 *         file: non-empty-string,
+	 *         is_active?: callable(): bool
 	 *     }
 	 * }
 	 */
@@ -99,6 +100,8 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *
 		 *         @type string $file The plugin's main file path relative to the plugins
 		 *                           directory (e.g. 'akismet/akismet.php' or 'hello.php').
+		 *         @type callable $is_active Optional callback to determine whether the plugin
+		 *                                   is active. Receives no arguments and must return bool.
 		 *     }
 		 * }
 		 * @return array|null The registered connector data on success, null on failure.
@@ -233,6 +236,20 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 
 			if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) && ! empty( $args['plugin']['file'] ) ) {
 				$connector['plugin'] = array( 'file' => $args['plugin']['file'] );
+
+				if ( isset( $args['plugin']['is_active'] ) ) {
+					if ( ! is_callable( $args['plugin']['is_active'] ) ) {
+						_doing_it_wrong(
+							__METHOD__,
+							/* translators: %s: Connector ID. */
+							sprintf( __( 'Connector "%s" plugin is_active must be callable.' ), esc_html( $id ) ),
+							'7.0.0'
+						);
+						return null;
+					}
+
+					$connector['plugin']['is_active'] = $args['plugin']['is_active'];
+				}
 			}
 
 			$this->registered_connectors[ $id ] = $connector;

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -524,9 +524,11 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		);
 
 		if ( ! empty( $connector_data['plugin']['file'] ) ) {
-			$file         = $connector_data['plugin']['file'];
-			$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $file );
-			$is_activated = $is_installed && is_plugin_active( $file );
+			$file                  = $connector_data['plugin']['file'];
+			$is_in_regular_plugins = file_exists( WP_PLUGIN_DIR . '/' . $file );
+			$is_in_mu_plugins      = file_exists( WPMU_PLUGIN_DIR . '/' . $file );
+			$is_installed          = $is_in_regular_plugins || $is_in_mu_plugins;
+			$is_activated          = $is_installed && ( $is_in_mu_plugins || is_plugin_active( $file ) );
 
 			$connector_out['plugin'] = array(
 				'file'        => $file,

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -31,7 +31,10 @@ function _gutenberg_connectors_init(): void {
 			'description'    => __( 'Protect your site from spam.', 'gutenberg' ),
 			'type'           => 'spam_filtering',
 			'plugin'         => array(
-				'file' => 'akismet/akismet.php',
+				'file'      => 'akismet/akismet.php',
+				'is_active' => function () {
+					return defined( 'AKISMET_VERSION' ) && class_exists( 'Akismet', false );
+				},
 			),
 			'authentication' => array(
 				'method'          => 'api_key',
@@ -524,11 +527,15 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		);
 
 		if ( ! empty( $connector_data['plugin']['file'] ) ) {
-			$file                  = $connector_data['plugin']['file'];
-			$is_in_regular_plugins = file_exists( WP_PLUGIN_DIR . '/' . $file );
-			$is_in_mu_plugins      = file_exists( WPMU_PLUGIN_DIR . '/' . $file );
-			$is_installed          = $is_in_regular_plugins || $is_in_mu_plugins;
-			$is_activated          = $is_installed && ( $is_in_mu_plugins || is_plugin_active( $file ) );
+			$file = $connector_data['plugin']['file'];
+
+			if ( ! empty( $connector_data['plugin']['is_active'] ) && is_callable( $connector_data['plugin']['is_active'] ) ) {
+				$is_activated = (bool) call_user_func( $connector_data['plugin']['is_active'] );
+				$is_installed = $is_activated;
+			} else {
+				$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $file );
+				$is_activated = $is_installed && is_plugin_active( $file );
+			}
 
 			$connector_out['plugin'] = array(
 				'file'        => $file,

--- a/lib/experimental/connectors/default-connectors.php
+++ b/lib/experimental/connectors/default-connectors.php
@@ -31,10 +31,7 @@ function _gutenberg_connectors_init(): void {
 			'description'    => __( 'Protect your site from spam.', 'gutenberg' ),
 			'type'           => 'spam_filtering',
 			'plugin'         => array(
-				'file'      => 'akismet/akismet.php',
-				'is_active' => function () {
-					return defined( 'AKISMET_VERSION' ) && class_exists( 'Akismet', false );
-				},
+				'file' => 'akismet/akismet.php',
 			),
 			'authentication' => array(
 				'method'          => 'api_key',
@@ -527,14 +524,22 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 		);
 
 		if ( ! empty( $connector_data['plugin']['file'] ) ) {
-			$file = $connector_data['plugin']['file'];
+			$file         = $connector_data['plugin']['file'];
+			$is_installed = false;
+			$is_activated = false;
 
 			if ( ! empty( $connector_data['plugin']['is_active'] ) && is_callable( $connector_data['plugin']['is_active'] ) ) {
 				$is_activated = (bool) call_user_func( $connector_data['plugin']['is_active'] );
-				$is_installed = $is_activated;
+			}
+
+			if ( ! $is_activated ) {
+				$is_activated = is_plugin_active( $file );
+			}
+
+			if ( $is_activated ) {
+				$is_installed = true;
 			} else {
 				$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $file );
-				$is_activated = $is_installed && is_plugin_active( $file );
 			}
 
 			$connector_out['plugin'] = array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76984 

This PR updates connector plugin status detection so connectors continue to appear when their plugin is installed as a must-use plugin.

## Why?
The connectors screen was checking plugin.file in the regular plugins directory only.
If a connector plugin was moved to mu-plugins and loaded via a mu-plugin bootstrap file, the connector could disappear even though the plugin was in use.

## How?
- For connector plugin.file, check both: WP_PLUGIN_DIR and WPMU_PLUGIN_DIR
- Mark plugin as activated when it is found in mu-plugins (mu-plugins are always loaded), or it is a regular plugin and is_plugin_active returns true.

## Testing Instructions
1. Start wordpress-develop trunk with Gutenberg plugin active from this branch.
2. Ensure Akismet exists in wp-content/plugins/akismet and is not activated.
3. Visit Settings > Connectors.
4. Confirm Akismet connector is shown.
5. Move Akismet to wp-content/mu-plugins/akismet.
6. Create wp-content/mu-plugins/a.php with:`<?php require_once __DIR__ . '/akismet/akismet.php';`
7. Reload Settings > Connectors.
8. Confirm Akismet connector is still shown.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before | After |
|---|---|
| <img width="1463" height="697" alt="Before Screenshot" src="https://github.com/user-attachments/assets/5b197b32-0154-48c2-9d40-5739485642c0" /> | <img width="1458" height="667" alt="After Screenshot" src="https://github.com/user-attachments/assets/0f76af42-46c1-456a-b32a-1bdf2082ab01" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
