### PR TITLE
UI: Use Link component in details story example

### DIFF
--- a/packages/ui/src/form/stories/shared.tsx
+++ b/packages/ui/src/form/stories/shared.tsx
@@ -1,3 +1,5 @@
+import { Link } from '../..';
+
 export const WITH_DETAILS_DESCRIPTION = `\
 To add rich content (such as links) to the description, use the \`details\` prop.
 
@@ -11,9 +13,9 @@ so the readout is not unnecessarily verbose for screen reader users.`;
 export const DETAILS_EXAMPLE = (
 	<>
 		Details can include{ ' ' }
-		<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a">
+		<Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a">
 			links to more information
-		</a>{ ' ' }
+		</Link>{ ' ' }
 		and other semantic elements.
 	</>
 );


### PR DESCRIPTION
## What

Updates the shared `DETAILS_EXAMPLE` used in `WithDetails` stories to use the `Link` component instead of a plain `<a>` element.

## Why

The details story is meant to demonstrate rich content within the `details` prop. Using the design system's own `Link` component rather than a raw anchor tag better represents how consumers should compose these components together in practice.

## How

- Imported the `Link` component into `packages/ui/src/form/stories/shared.tsx`.
- Replaced the `<a>` element with `<Link>` in `DETAILS_EXAMPLE`.

## To test

- `npm run storybook`.
- Check the various 'With details' stories e.g. http://localhost:50240/?path=/story/design-system-components-form-inputcontrol--with-details.
- Note the consumption of `Link` rather than the plain `a`.