### PR TITLE
Buttons: Enable Fit / Grow / Fixed width controls using layout support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -101,7 +101,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Name:** core/button
 -	**Category:** design
 -	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
 
 ## Buttons

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -111,7 +111,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Allowed Blocks:** core/button
--	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), contentRole, interactivity (clientNavigation), layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Calendar
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -78,13 +78,6 @@
 				"text": true
 			}
 		},
-		"dimensions": {
-			"width": true,
-			"__experimentalSkipSerialization": [ "width" ],
-			"__experimentalDefaultControls": {
-				"width": true
-			}
-		},
 		"typography": {
 			"__experimentalSkipSerialization": [
 				"fontSize",

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -58,7 +58,8 @@
 			"allowInheriting": false,
 			"default": {
 				"type": "flex"
-			}
+			},
+			"allowSizingOnChildren": true
 		},
 		"interactivity": {
 			"clientNavigation": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #76531 

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, Button blocks inside a Buttons block do not expose the same sizing controls (Fit / Grow / Fixed) that are available when placed inside a Row block.

As a result users cannot proportionally size multiple buttons.

## How?
The PR sets "allowSizingOnChildren" to true & removes existing width control.

## Testing Instructions

1. Open a post or page in the editor
2. Insert a Buttons block
3. Add two or more Button blocks inside it
4. Select one of the Button blocks
5. Open the Settings sidebar

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="2938" height="1412" alt="image" src="https://github.com/user-attachments/assets/fd32f071-47ee-43d4-baf4-421454a09ff7" /> | <img width="2934" height="1414" alt="image" src="https://github.com/user-attachments/assets/8da371f5-e661-45ed-ac12-5c32ff11c896" /> |

