### PR TITLE
Fix empty list block with anchor persisting after backspace deletion

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -346,7 +346,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 
 				if (
 					blockOrder.length === 1 &&
-					isUnmodifiedBlock( getBlock( firstClientId ) )
+					isUnmodifiedBlock( getBlock( firstClientId ), 'content' )
 				) {
 					removeBlock( _clientId );
 				} else if ( isTextualWrapper ) {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -391,10 +391,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 							}
 						}
 
-						if (
-							! getBlockOrder( _clientId ).length &&
-							isUnmodifiedBlock( getBlock( _clientId ) )
-						) {
+						if ( ! getBlockOrder( _clientId ).length ) {
 							removeBlock( _clientId, false );
 						}
 					} );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -391,7 +391,13 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 							}
 						}
 
-						if ( ! getBlockOrder( _clientId ).length ) {
+						if (
+							! getBlockOrder( _clientId ).length &&
+							isUnmodifiedBlock(
+								getBlock( _clientId ),
+								'content'
+							)
+						) {
 							removeBlock( _clientId, false );
 						}
 					} );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -2461,6 +2461,32 @@ test.describe( 'List (@firefox)', () => {
 		] );
 	} );
 
+	test( 'should remove an anchored list when deleting its last item', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/list',
+			attributes: { anchor: 'list' },
+			innerBlocks: [
+				{
+					name: 'core/list-item',
+					attributes: { content: 'x', anchor: 'item' },
+				},
+			],
+		} );
+
+		await editor.canvas.locator( '[data-type="core/list-item"]' ).click();
+		await page.keyboard.press( 'End' );
+		// Delete the text, then the emptied item: the anchors are not
+		// content, so the item and the list are removed together instead
+		// of the item being lifted out as a paragraph first.
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+
+		await expect.poll( editor.getBlocks ).toEqual( [] );
+	} );
+
 	test( 'should leave nested list intact when deleting the parent item', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -2469,15 +2469,29 @@ test.describe( 'List (@firefox)', () => {
 			name: 'core/list',
 			attributes: { anchor: 'list' },
 			innerBlocks: [
-				{
-					name: 'core/list-item',
-					attributes: { content: 'x', anchor: 'item' },
-				},
+				{ name: 'core/list-item', attributes: { anchor: 'item' } },
 			],
 		} );
+		// Inserting selects the list container; ArrowDown moves the caret
+		// into the sole empty item.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( 'x' );
 
-		await editor.canvas.locator( '[data-type="core/list-item"]' ).click();
-		await page.keyboard.press( 'End' );
+		// Typing lands in the sole item, verifying both the setup and the
+		// caret position.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				attributes: { anchor: 'list' },
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'x', anchor: 'item' },
+					},
+				],
+			},
+		] );
+
 		// Delete the text, then the emptied item: the anchors are not
 		// content, so the item and the list are removed together instead
 		// of the item being lifted out as a paragraph first.


### PR DESCRIPTION
## What?
Closes #76965

Fixes empty list block with anchor persisting in post content after deleting all list items via backspace.

## Why?

When `moveFirstItemUp` moves the last list-item out of a list block, it only removes the empty wrapper if `isUnmodifiedBlock` returns true. But when the list block has an anchor (or any non-default attribute like `ordered`, `reversed`, etc.), the check fails and the empty list block is left in the content. An empty text wrapper block with no inner blocks serves no purpose regardless of its attributes.

## How?

Removed the `isUnmodifiedBlock` condition from the empty wrapper cleanup in `moveFirstItemUp` (`packages/block-editor/src/components/block-list/block.js`). Now, when all inner blocks have been moved out of a text wrapper block, it is always removed.

## Testing Instructions

1. Create a new post
2. Add a List block with one list item
3. Open the block sidebar → Advanced → set an HTML anchor on the List block (e.g. `my-list`)
4. Select the list item → Advanced → set an HTML anchor on it too (e.g. `my-item`)
5. Type some text in the list item
6. Place cursor at the end and delete all text using Backspace
7. Continue pressing Backspace until the list block disappears and converts to a paragraph
8. Save the post
9. Refresh the editor
10. **Expected:** The empty list block does NOT reappear
11. **Before this fix:** The empty list block reappears on refresh

### Testing Instructions for Keyboard

Same as above — the entire flow uses keyboard (Backspace).

## Screenshots or screencast

|Before|After|
|-|-|
| Empty list block with anchor reappears on editor refresh | List block is fully removed after backspace deletion |

## Use of AI Tools
Chatgpt
