### PR TITLE
Paragraph: Dynamically change placeholder based on available blocks

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -12,6 +12,7 @@ import {
 	ToggleControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import {
 	BlockControls,
 	InspectorControls,
@@ -19,6 +20,7 @@ import {
 	useBlockProps,
 	useSettings,
 	useBlockEditingMode,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { getBlockSupport } from '@wordpress/blocks';
 import { formatLTR } from '@wordpress/icons';
@@ -45,6 +47,31 @@ function ParagraphRTLControl( { direction, setDirection } ) {
 
 function hasDropCapDisabled( align ) {
 	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
+}
+
+function RichTextWrapper( { clientId, blockEditingMode, children } ) {
+	// This wrapper checks whether the slash inserter is available in the current
+	// context and passes the result to children to dynamically adjust the
+	// placeholder text.
+	// Please do not add a useSelect call to the paragraph block unconditionally.
+	// Every useSelect added to a (frequently used) block will degrade load and
+	// type performance. This wrapper is only rendered when the block is selected
+	// or empty, keeping the store subscription cost minimal.
+	const isOnlyParagraphAllowed = useSelect(
+		( select ) => {
+			const { getBlockRootClientId, getInserterItems } =
+				select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+			const items = getInserterItems( rootClientId );
+			return items.length === 1 && items[ 0 ].name === 'core/paragraph';
+		},
+		[ clientId ]
+	);
+
+	const isSlashInserterDisabled =
+		blockEditingMode === 'contentOnly' || isOnlyParagraphAllowed;
+
+	return children( isSlashInserterDisabled );
 }
 
 function DropCapControl( { clientId, attributes, setAttributes, name } ) {
@@ -120,6 +147,21 @@ function ParagraphBlock( {
 	} );
 	const blockEditingMode = useBlockEditingMode();
 
+	const richTextProps = {
+		identifier: 'content',
+		tagName: 'p',
+		...blockProps,
+		value: content,
+		onChange: ( newContent ) => setAttributes( { content: newContent } ),
+		onMerge: mergeBlocks,
+		onReplace,
+		onRemove,
+		'data-empty': RichText.isEmpty( content ),
+		'data-custom-placeholder': placeholder ? true : undefined,
+		__unstableEmbedURLOnPaste: true,
+		__unstableAllowPrefixTransformations: true,
+	};
+
 	return (
 		<>
 			{ blockEditingMode === 'default' && (
@@ -140,30 +182,51 @@ function ParagraphBlock( {
 					setAttributes={ setAttributes }
 				/>
 			) }
-			<RichText
-				identifier="content"
-				tagName="p"
-				{ ...blockProps }
-				value={ content }
-				onChange={ ( newContent ) =>
-					setAttributes( { content: newContent } )
-				}
-				onMerge={ mergeBlocks }
-				onReplace={ onReplace }
-				onRemove={ onRemove }
-				aria-label={
-					RichText.isEmpty( content )
-						? __(
+			{ isSingleSelected || RichText.isEmpty( content ) ? (
+				<RichTextWrapper
+					clientId={ clientId }
+					blockEditingMode={ blockEditingMode }
+				>
+					{ ( isSlashInserterDisabled ) => {
+						let ariaLabel;
+						if ( ! RichText.isEmpty( content ) ) {
+							ariaLabel = __( 'Block: Paragraph' );
+						} else if ( isSlashInserterDisabled ) {
+							ariaLabel = __( 'Empty block; start writing' );
+						} else {
+							ariaLabel = __(
 								'Empty block; start writing or type forward slash to choose a block'
-						  )
-						: __( 'Block: Paragraph' )
-				}
-				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
-				data-custom-placeholder={ placeholder ? true : undefined }
-				__unstableEmbedURLOnPaste
-				__unstableAllowPrefixTransformations
-			/>
+							);
+						}
+						return (
+							<RichText
+								{ ...richTextProps }
+								aria-label={ ariaLabel }
+								placeholder={
+									placeholder ||
+									( isSlashInserterDisabled
+										? __( 'Start writing…' )
+										: __( 'Type / to choose a block' ) )
+								}
+							/>
+						);
+					} }
+				</RichTextWrapper>
+			) : (
+				<RichText
+					{ ...richTextProps }
+					aria-label={
+						RichText.isEmpty( content )
+							? __(
+									'Empty block; start writing or type forward slash to choose a block'
+							  )
+							: __( 'Block: Paragraph' )
+					}
+					placeholder={
+						placeholder || __( 'Type / to choose a block' )
+					}
+				/>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
## What?

Alternatives to #76988

- Attempting to dynamically change placeholder and aria-label for paragraph blocks without sacrificing performance.
- The hook is triggered only when a block is selected or its content is empty, checking if the slash inserter should be enabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
