### PR TITLE
Fix component naming and hook wrapper lint errors

### DIFF
--- a/packages/block-editor/src/components/block-list/block-crash-warning.js
+++ b/packages/block-editor/src/components/block-list/block-crash-warning.js
@@ -14,4 +14,6 @@ const warning = (
 	</Warning>
 );
 
-export default () => warning;
+export default function BlockCrashWarning() {
+	return warning;
+}

--- a/packages/block-editor/src/components/block-list/block-crash-warning.native.js
+++ b/packages/block-editor/src/components/block-list/block-crash-warning.native.js
@@ -16,4 +16,6 @@ const warning = (
 	/>
 );
 
-export default () => warning;
+export default function BlockCrashWarning() {
+	return warning;
+}

--- a/packages/components/src/higher-order/with-focus-outside/index.native.js
+++ b/packages/components/src/higher-order/with-focus-outside/index.native.js
@@ -12,26 +12,27 @@ import {
 } from '@wordpress/compose';
 
 export default createHigherOrderComponent(
-	( WrappedComponent ) => ( props ) => {
-		const [ handleFocusOutside, setHandleFocusOutside ] = useState();
-		const bindFocusOutsideHandler = useCallback(
-			( node ) =>
-				setHandleFocusOutside( () =>
-					node?.handleFocusOutside
-						? node.handleFocusOutside.bind( node )
-						: undefined
-				),
-			[]
-		);
+	( WrappedComponent ) =>
+		function WithFocusOutside( props ) {
+			const [ handleFocusOutside, setHandleFocusOutside ] = useState();
+			const bindFocusOutsideHandler = useCallback(
+				( node ) =>
+					setHandleFocusOutside( () =>
+						node?.handleFocusOutside
+							? node.handleFocusOutside.bind( node )
+							: undefined
+					),
+				[]
+			);
 
-		return (
-			<View { ...useFocusOutside( handleFocusOutside ) }>
-				<WrappedComponent
-					ref={ bindFocusOutsideHandler }
-					{ ...props }
-				/>
-			</View>
-		);
-	},
+			return (
+				<View { ...useFocusOutside( handleFocusOutside ) }>
+					<WrappedComponent
+						ref={ bindFocusOutsideHandler }
+						{ ...props }
+					/>
+				</View>
+			);
+		},
 	'withFocusOutside'
 );

--- a/packages/components/src/toolbar/toolbar-button/toolbar-button-container.native.js
+++ b/packages/components/src/toolbar/toolbar-button/toolbar-button-container.native.js
@@ -3,4 +3,6 @@
  */
 import { View } from 'react-native';
 
-export default ( props ) => <View>{ props.children }</View>;
+export default function ToolbarButtonContainer( props ) {
+	return <View>{ props.children }</View>;
+}

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -222,7 +222,7 @@ export default function useEntityRecord< RecordType >(
 	};
 }
 
-export function __experimentalUseEntityRecord(
+function useDeprecatedEntityRecord(
 	kind: string,
 	name: string,
 	recordId: any,
@@ -234,3 +234,5 @@ export function __experimentalUseEntityRecord(
 	} );
 	return useEntityRecord( kind, name, recordId, options );
 }
+
+export { useDeprecatedEntityRecord as __experimentalUseEntityRecord };

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -209,13 +209,12 @@ function useResourcePermissions< IdType = void >(
 
 export default useResourcePermissions;
 
-export function __experimentalUseResourcePermissions(
-	resource: string,
-	id?: unknown
-) {
+function useDeprecatedResourcePermissions( resource: string, id?: unknown ) {
 	deprecated( `wp.data.__experimentalUseResourcePermissions`, {
 		alternative: 'wp.data.useResourcePermissions',
 		since: '6.1',
 	} );
 	return useResourcePermissions( resource, id );
 }
+
+export { useDeprecatedResourcePermissions as __experimentalUseResourcePermissions };


### PR DESCRIPTION
## What?

Closes part of #76506

Fixes `react/display-name` and `react-hooks/rules-of-hooks` lint violations by making code changes instead of adding eslint-disable comments.

## Why?

Extracting these fixes from the main ESLint v10 upgrade PR (#76654) to reduce its diff size. All changes are backward-compatible with ESLint v8.

## How?

### Named function exports (fixes `react/display-name`)
Anonymous arrow function component exports lack a `displayName`, which makes debugging harder. Converted to named function declarations:
- `block-crash-warning.js` / `.native.js`: `() => warning` → `function BlockCrashWarning()`
- `toolbar-button-container.native.js`: `( props ) => <View>...` → `function ToolbarButtonContainer( props )`
- `with-focus-outside/index.native.js`: `( props ) => {` → `function WithFocusOutside( props ) {`

### Hook wrapper renames (fixes `react-hooks/rules-of-hooks`)
Deprecated `__experimental*` hook wrappers have names that don't match the `use*` convention, so `rules-of-hooks` flags hook calls inside them as violations. Renamed the internal function to `useDeprecated*` and re-exported with the original prefixed name:
- `useDeprecatedEntityRecord` as `__experimentalUseEntityRecord`
- `useDeprecatedResourcePermissions` as `__experimentalUseResourcePermissions`

No behavior change — all public APIs remain identical.

## Testing Instructions

1. `npm run lint:js` — no new errors
2. `npm run test:unit -- packages/core-data` — all tests pass

### Testing Instructions for Keyboard

N/A — no UI changes.

## Screenshots or screencast

N/A — code cleanup only.