### PR TITLE
Skip `is-layout-constrained` class on empty container blocks

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -891,7 +891,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
 		// Skip constrained layout class when no inner blocks exist to avoid affecting structural DOM children.
-		$is_contrained_without_children = 'is-layout-constrained' === $layout_classname && empty( $block['innerBlocks'] );
+		$has_inner_blocks = is_string( $block['innerContent'][0] ?? null ) && count( $block['innerContent'] ) > 1;
+		$is_contrained_without_children = 'is-layout-constrained' === $layout_classname && ! $has_inner_blocks;
 
 		if ( ! $is_contrained_without_children ) {
 			$class_names[] = sanitize_title( $layout_classname );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -890,7 +890,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
-		$class_names[] = sanitize_title( $layout_classname );
+		// Skip constrained layout class when no inner blocks exist to avoid affecting structural DOM children.
+		$is_contrained_without_children = 'is-layout-constrained' === $layout_classname && empty( $block['innerBlocks'] );
+
+		if ( ! $is_contrained_without_children ) {
+			$class_names[] = sanitize_title( $layout_classname );
+		}
 	}
 
 	/*

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -891,7 +891,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	if ( $layout_classname && is_string( $layout_classname ) ) {
 		// Skip constrained layout class when no inner blocks exist to avoid affecting structural DOM children.
-		$has_inner_blocks = is_string( $block['innerContent'][0] ?? null ) && count( $block['innerContent'] ) > 1;
+		$has_inner_blocks               = is_string( $block['innerContent'][0] ?? null ) && count( $block['innerContent'] ) > 1;
 		$is_contrained_without_children = 'is-layout-constrained' === $layout_classname && ! $has_inner_blocks;
 
 		if ( ! $is_contrained_without_children ) {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -497,7 +497,9 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						),
 						'innerHTML'    => '<div class="wp-block-group"></div>',
 						'innerContent' => array(
-							'<div class="wp-block-group"></div>',
+							'<div class="wp-block-group">',
+							null,
+							'</div>',
 						),
 					),
 				),

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -463,7 +463,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow"></div>',
 			),
-			'single wrapper block layout with constrained type' => array(
+			'single wrapper block layout with constrained type and no inner blocks' => array(
 				'args'            => array(
 					'block_content' => '<div class="wp-block-group"></div>',
 					'block'         => array(
@@ -474,6 +474,27 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 							),
 						),
 						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group"></div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group wp-block-group-is-layout-constrained"></div>',
+			),
+			'single wrapper block layout with constrained type and inner blocks' => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group"></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'constrained',
+							),
+						),
+						'innerBlocks'  => array(
+							array( 'blockName' => 'core/paragraph' ),
+						),
 						'innerHTML'    => '<div class="wp-block-group"></div>',
 						'innerContent' => array(
 							'<div class="wp-block-group"></div>',


### PR DESCRIPTION
## What?
Closes #76235 

Skip adding the `is-layout-constrained` class to container blocks that have no inner blocks.

## Why?
The constrained layout CSS selector targets all direct DOM children of the block wrapper. When a container block has no inner blocks, this selector incorrectly matches structural DOM children that are not inner blocks.

This causes the block to be constrained to content width instead of stretching full width when selected, breaking the WYSIWYG principle.

## How?
In `gutenberg_render_layout_support_flag`, skip adding `is-layout-constrained` when the block has no inner blocks. The guard is narrow and only applies to constrained layout while other layout types are unaffected.

## Testing Instructions
1. Create a new post and insert a Cover block
2. Give it a solid colour background and set alignment to full width
3. Open document overview and delete the inner Paragraph block, leaving the Cover empty
4. Save and view the post on the frontend
5. The Cover background should now stretch full width

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="2201" height="1061" alt="Screenshot 2026-04-02 at 9 29 08 PM" src="https://github.com/user-attachments/assets/67a584f2-cd43-4e09-980a-7538e8627fc5" />|<img width="2199" height="1061" alt="Screenshot 2026-04-02 at 9 30 02 PM" src="https://github.com/user-attachments/assets/d786eadc-6127-46dd-a333-3ed0506653f0" />|