### PR TITLE
Experiment: Add revisions panel to templates, template parts and patterns

### DIFF
--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -12,7 +12,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { authorField } from '@wordpress/fields';
 
@@ -26,10 +25,44 @@ import { unlock } from '../../lock-unlock';
 const { Badge } = unlock( componentsPrivateApis );
 const DAY_IN_MILLISECONDS = 86400000;
 const EMPTY_ARRAY = [];
-const POST_TYPES_USING_MODIFIED_DATE = [ 'wp_template', 'wp_template_part' ];
 const defaultLayouts = { activity: {} };
 const noop = () => {};
 const paginationInfo = {};
+const view = {
+	type: 'activity',
+	titleField: 'date',
+	fields: [ 'author' ],
+	layout: { density: 'compact' },
+};
+const fields = [
+	{
+		id: 'date',
+		label: __( 'Date' ),
+		render: ( { item, field } ) => {
+			const dateNowInMs = getDate( null ).getTime();
+			const _value = field.getValue( { item } );
+			const date = getDate( _value ?? null );
+			const displayDate =
+				dateNowInMs - date.getTime() > DAY_IN_MILLISECONDS
+					? dateI18n(
+							getSettings().formats.datetimeAbbreviated,
+							date
+					  )
+					: humanTimeDiff( date );
+			return (
+				<time
+					className="editor-post-revisions-panel__revision-date"
+					dateTime={ _value }
+				>
+					{ displayDate }
+				</time>
+			);
+		},
+		enableSorting: false,
+		enableHiding: false,
+	},
+	authorField,
+];
 
 function PostRevisionsPanelContent() {
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
@@ -39,7 +72,6 @@ function PostRevisionsPanelContent() {
 		revisionKey,
 		isLoading,
 		lastRevisionId,
-		dateField,
 	} = useSelect( ( select ) => {
 		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
 		const { getCurrentPostRevisionsCount, getCurrentPostLastRevisionId } =
@@ -49,14 +81,11 @@ function PostRevisionsPanelContent() {
 		const _postType = getCurrentPostType();
 		const entityConfig = getEntityConfig( 'postType', _postType );
 		const _revisionKey = entityConfig?.revisionKey || 'id';
-		const _dateField = POST_TYPES_USING_MODIFIED_DATE.includes( _postType )
-			? 'modified'
-			: 'date';
 		const revisionsQuery = {
 			per_page: 3,
 			orderby: 'date',
 			order: 'desc',
-			_fields: `${ _revisionKey },${ _dateField },author`,
+			_fields: `${ _revisionKey },date,author`,
 		};
 		const query = [
 			'postType',
@@ -70,51 +99,9 @@ function PostRevisionsPanelContent() {
 			lastRevisionId: getCurrentPostLastRevisionId(),
 			revisions: _revisions,
 			revisionKey: _revisionKey,
-			dateField: _dateField,
 			isLoading: isResolving( 'getRevisions', query ),
 		};
 	}, [] );
-	const view = useMemo(
-		() => ( {
-			type: 'activity',
-			titleField: dateField,
-			fields: [ 'author' ],
-			layout: { density: 'compact' },
-		} ),
-		[ dateField ]
-	);
-	const fields = useMemo(
-		() => [
-			{
-				id: dateField,
-				label: __( 'Date' ),
-				render: ( { item, field } ) => {
-					const dateNowInMs = getDate( null ).getTime();
-					const _value = field.getValue( { item } );
-					const date = getDate( _value ?? null );
-					const displayDate =
-						dateNowInMs - date.getTime() > DAY_IN_MILLISECONDS
-							? dateI18n(
-									getSettings().formats.datetimeAbbreviated,
-									date
-							  )
-							: humanTimeDiff( date );
-					return (
-						<time
-							className="editor-post-revisions-panel__revision-date"
-							dateTime={ _value }
-						>
-							{ displayDate }
-						</time>
-					);
-				},
-				enableSorting: false,
-				enableHiding: false,
-			},
-			authorField,
-		],
-		[ dateField ]
-	);
 	return (
 		<PanelBody
 			title={

--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -88,9 +88,10 @@ function PostRevisionsPanelContent() {
 			{
 				id: dateField,
 				label: __( 'Date' ),
-				render: ( { item } ) => {
+				render: ( { item, field } ) => {
 					const dateNowInMs = getDate( null ).getTime();
-					const date = getDate( item[ dateField ] ?? null );
+					const _value = field.getValue( { item } );
+					const date = getDate( _value ?? null );
 					const displayDate =
 						dateNowInMs - date.getTime() > DAY_IN_MILLISECONDS
 							? dateI18n(
@@ -101,7 +102,7 @@ function PostRevisionsPanelContent() {
 					return (
 						<time
 							className="editor-post-revisions-panel__revision-date"
-							dateTime={ item[ dateField ] }
+							dateTime={ _value }
 						>
 							{ displayDate }
 						</time>

--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -12,6 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { authorField } from '@wordpress/fields';
 
@@ -26,79 +27,94 @@ const { Badge } = unlock( componentsPrivateApis );
 const DAY_IN_MILLISECONDS = 86400000;
 const EMPTY_ARRAY = [];
 
-const REVISIONS_QUERY = {
-	per_page: 3,
-	orderby: 'date',
-	order: 'desc',
-	context: 'embed',
-	_fields: 'id,date,author',
-};
+// TODO: This should be updated with `wp_template_part` when we expand the experiment.
+const POST_TYPES_USING_MODIFIED_DATE = [ 'wp_template' ];
 const defaultLayouts = { activity: {} };
-const view = {
-	type: 'activity',
-	titleField: 'date',
-	fields: [ 'author' ],
-	layout: {
-		density: 'compact',
-	},
-};
-const fields = [
-	{
-		id: 'date',
-		label: __( 'Date' ),
-		render: ( { item } ) => {
-			const dateNowInMs = getDate( null ).getTime();
-			const date = getDate( item.date ?? null );
-			const displayDate =
-				dateNowInMs - date.getTime() > DAY_IN_MILLISECONDS
-					? dateI18n(
-							getSettings().formats.datetimeAbbreviated,
-							date
-					  )
-					: humanTimeDiff( date );
-			return (
-				<time
-					className="editor-post-revisions-panel__revision-date"
-					dateTime={ item.date }
-				>
-					{ displayDate }
-				</time>
-			);
-		},
-		enableSorting: false,
-		enableHiding: false,
-	},
-	authorField,
-];
 const noop = () => {};
 const paginationInfo = {};
 
 function PostRevisionsPanelContent() {
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
-	const { revisionsCount, revisions, isLoading, lastRevisionId } = useSelect(
-		( select ) => {
-			const { getCurrentPostId, getCurrentPostType } =
-				select( editorStore );
-			const {
-				getCurrentPostRevisionsCount,
-				getCurrentPostLastRevisionId,
-			} = select( editorStore );
-			const { getRevisions, isResolving } = select( coreStore );
-			const query = [
-				'postType',
-				getCurrentPostType(),
-				getCurrentPostId(),
-				REVISIONS_QUERY,
-			];
-			const _revisions = getRevisions( ...query );
-			return {
-				revisionsCount: getCurrentPostRevisionsCount(),
-				lastRevisionId: getCurrentPostLastRevisionId(),
-				revisions: _revisions,
-				isLoading: isResolving( 'getRevisions', query ),
-			};
-		},
-		[]
+	const {
+		revisionsCount,
+		revisions,
+		revisionKey,
+		isLoading,
+		lastRevisionId,
+		dateField,
+	} = useSelect( ( select ) => {
+		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
+		const { getCurrentPostRevisionsCount, getCurrentPostLastRevisionId } =
+			select( editorStore );
+		const { getRevisions, getEntityConfig, isResolving } =
+			select( coreStore );
+		const _postType = getCurrentPostType();
+		const entityConfig = getEntityConfig( 'postType', _postType );
+		const _revisionKey = entityConfig?.revisionKey || 'id';
+		const _dateField = POST_TYPES_USING_MODIFIED_DATE.includes( _postType )
+			? 'modified'
+			: 'date';
+		const revisionsQuery = {
+			per_page: 3,
+			orderby: 'date',
+			order: 'desc',
+			_fields: `${ _revisionKey },${ _dateField },author`,
+		};
+		const query = [
+			'postType',
+			_postType,
+			getCurrentPostId(),
+			revisionsQuery,
+		];
+		const _revisions = getRevisions( ...query );
+		return {
+			revisionsCount: getCurrentPostRevisionsCount(),
+			lastRevisionId: getCurrentPostLastRevisionId(),
+			revisions: _revisions,
+			revisionKey: _revisionKey,
+			dateField: _dateField,
+			isLoading: isResolving( 'getRevisions', query ),
+		};
+	}, [] );
+	const view = useMemo(
+		() => ( {
+			type: 'activity',
+			titleField: dateField,
+			fields: [ 'author' ],
+			layout: { density: 'compact' },
+		} ),
+		[ dateField ]
+	);
+	const fields = useMemo(
+		() => [
+			{
+				id: dateField,
+				label: __( 'Date' ),
+				render: ( { item } ) => {
+					const dateNowInMs = getDate( null ).getTime();
+					const date = getDate( item[ dateField ] ?? null );
+					const displayDate =
+						dateNowInMs - date.getTime() > DAY_IN_MILLISECONDS
+							? dateI18n(
+									getSettings().formats.datetimeAbbreviated,
+									date
+							  )
+							: humanTimeDiff( date );
+					return (
+						<time
+							className="editor-post-revisions-panel__revision-date"
+							dateTime={ item[ dateField ] }
+						>
+							{ displayDate }
+						</time>
+					);
+				},
+				enableSorting: false,
+				enableHiding: false,
+			},
+			authorField,
+		],
+		[ dateField ]
 	);
 	return (
 		<PanelBody
@@ -121,10 +137,10 @@ function PostRevisionsPanelContent() {
 					isLoading={ isLoading }
 					paginationInfo={ paginationInfo }
 					defaultLayouts={ defaultLayouts }
-					getItemId={ ( item ) => item.id }
+					getItemId={ ( item ) => item[ revisionKey ] }
 					isItemClickable={ () => true }
 					onClickItem={ ( item ) => {
-						setCurrentRevisionId( item.id );
+						setCurrentRevisionId( item[ revisionKey ] );
 					} }
 				>
 					<DataViews.Layout />

--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -26,9 +26,7 @@ import { unlock } from '../../lock-unlock';
 const { Badge } = unlock( componentsPrivateApis );
 const DAY_IN_MILLISECONDS = 86400000;
 const EMPTY_ARRAY = [];
-
-// TODO: This should be updated with `wp_template_part` when we expand the experiment.
-const POST_TYPES_USING_MODIFIED_DATE = [ 'wp_template' ];
+const POST_TYPES_USING_MODIFIED_DATE = [ 'wp_template', 'wp_template_part' ];
 const defaultLayouts = { activity: {} };
 const noop = () => {};
 const paginationInfo = {};

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -112,7 +112,13 @@ const SidebarContent = ( {
 				<PluginDocumentSettingPanel.Slot />
 				<TemplateContentPanel />
 				{ window?.__experimentalDataFormInspector &&
-					[ 'post', 'page', 'wp_template' ].includes( postType ) && (
+					[
+						'post',
+						'page',
+						'wp_template',
+						'wp_template_part',
+						'wp_block',
+					].includes( postType ) && (
 						<>
 							<TemplateActionsPanel />
 							<PostRevisionsPanel />

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -112,7 +112,7 @@ const SidebarContent = ( {
 				<PluginDocumentSettingPanel.Slot />
 				<TemplateContentPanel />
 				{ window?.__experimentalDataFormInspector &&
-					[ 'post', 'page' ].includes( postType ) && (
+					[ 'post', 'page', 'wp_template' ].includes( postType ) && (
 						<>
 							<TemplateActionsPanel />
 							<PostRevisionsPanel />

--- a/packages/editor/src/components/sidebar/post-revision-summary.js
+++ b/packages/editor/src/components/sidebar/post-revision-summary.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	ExternalLink,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -15,7 +20,6 @@ import { PostContentInformationUI } from '../post-content-information';
 import RevisionFieldsDiffPanel from '../revision-fields-diff';
 import PostPanelSection from '../post-panel-section';
 import PostCardPanel from '../post-card-panel';
-import { OpenRevisionsClassicScreen } from './post-summary';
 
 export default function PostRevisionSummary() {
 	const { revisionId, postId, postContent } = useSelect( ( select ) => {
@@ -40,7 +44,13 @@ export default function PostRevisionSummary() {
 						<PostContentInformationUI postContent={ postContent } />
 						<RevisionCreatedPanel />
 					</VStack>
-					<OpenRevisionsClassicScreen revisionId={ revisionId } />
+					<ExternalLink
+						href={ addQueryArgs( 'revision.php', {
+							revision: revisionId,
+						} ) }
+					>
+						{ __( 'Open classic revisions screen' ) }
+					</ExternalLink>
 					<RevisionAuthorPanel />
 				</VStack>
 			</PostPanelSection>

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -1,13 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalVStack as VStack,
-	ExternalLink,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -40,18 +35,6 @@ import PostTrash from '../post-trash';
  * Module Constants
  */
 const PANEL_NAME = 'post-status';
-
-export function OpenRevisionsClassicScreen( { revisionId } ) {
-	return (
-		<ExternalLink
-			href={ addQueryArgs( 'revision.php', {
-				revision: revisionId,
-			} ) }
-		>
-			{ __( 'Open classic revisions screen' ) }
-		</ExternalLink>
-	);
-}
 
 export default function PostSummary( { onActionPerformed } ) {
 	const postType = useSelect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076
Extracted from: https://github.com/WordPress/gutenberg/pull/76934

In the linked PR I'm working on expanding the `Editor Inspector: Use DataForm` experiment to other post types (focusing on templates so far). This PR adds the revisions panel (under the experiment) for `templates, template parts and patterns`.

Noting that in this PR revisions are shown both in the post summary and the experimental panel, but it's fine for now in order to iterate with smaller PRs.


## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment
2. Edit a template either through site editor or in post editor by clicking to edit the current template
3. Observe that the revisions panel is rendered properly (if there are revisions to show) for templates
4. Do the same for template parts and patterns with revisions
5. Ensure that the revisions panel is working properly as before for posts/pages

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


### Site editor template editing


https://github.com/user-attachments/assets/f8faa330-2e5c-4e70-87b2-5cc3c6f30a97



### Post editor template editing

https://github.com/user-attachments/assets/f1e95077-9380-4956-9cf8-0c0d4900dccb

