### PR TITLE
Build Tools: Remove deprecated `esModuleInterop: false` from tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,8 +26,6 @@
 		/* Module Resolution Options */
 		"moduleResolution": "bundler",
 
-		/* This needs to be false so our types are possible to consume without setting this */
-		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
 		"typeRoots": [ "./typings", "./node_modules/@types" ],


### PR DESCRIPTION
## What?

Remove the deprecated `esModuleInterop: false` setting from `tsconfig.base.json`.

## Why?

The `esModuleInterop=false` option is [deprecated in TypeScript 6.0](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/) and will stop functioning in TypeScript 7.0, producing a warning in the IDE. Removing it now eliminates the warning while keeping the same default behavior (`false`). `allowSyntheticDefaultImports: true` already handles default imports for type-checking.

## How?

Removed the `esModuleInterop: false` line and its associated comment from `tsconfig.base.json`.

## Testing Instructions

1. Run `npm run build` — should complete successfully.
2. Open any package's `tsconfig.json` in an IDE — the deprecation warning should be gone.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (claude-opus-4-6).