### PR TITLE
Build Tools: Update TypeScript to 6.0.2

### DIFF
--- a/bin/packages/check-build-type-declaration-files.js
+++ b/bin/packages/check-build-type-declaration-files.js
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`npx tsc --target esnext --moduleResolution node --noEmit --skipLibCheck "${ file }"`,
+			`npx tsc --ignoreConfig --target esnext --moduleResolution bundler --noEmit --skipLibCheck "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
 				"sprintf-js": "1.1.1",
 				"style-loader": "3.2.1",
 				"stylelint-plugin-logical-css": "^1.2.3",
-				"typescript": "5.9.3",
+				"typescript": "6.0.2",
 				"uuid": "9.0.1",
 				"wait-on": "8.0.1"
 			},
@@ -38901,6 +38901,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lerna/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/lerna/node_modules/universal-user-agent": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
@@ -54166,9 +54180,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"sprintf-js": "1.1.1",
 		"style-loader": "3.2.1",
 		"stylelint-plugin-logical-css": "^1.2.3",
-		"typescript": "5.9.3",
+		"typescript": "6.0.2",
 		"uuid": "9.0.1",
 		"wait-on": "8.0.1"
 	},

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -2,6 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"types": [ "style-imports" ],
 		"checkJs": false
 	},
 	"references": [

--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -43,7 +43,7 @@ underlying `grid` widget.
 
 ### `onChange`
 
- - Type: `(newValue: AlignmentMatrixControlValue) => void`
+ - Type: `((newValue: AlignmentMatrixControlValue) => void)`
  - Required: No
 
 A function that receives the updated alignment value.

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -77,7 +77,7 @@ If provided, renders `a` instead of `button`.
 
 ### `icon`
 
- - Type: `IconType`
+ - Type: `IconType | null`
  - Required: No
 
 If provided, renders an Icon component inside the button.

--- a/packages/components/src/calendar/utils/use-localization-props.ts
+++ b/packages/components/src/calendar/utils/use-localization-props.ts
@@ -10,7 +10,7 @@ import type { Modifiers, BaseProps } from '../types';
 
 function isLocaleRTL( localeCode: string ) {
 	const localeObj = new Intl.Locale( localeCode );
-	const direction = localeObj.getTextInfo?.()?.direction;
+	const direction = localeObj.getTextInfo?.().direction;
 	if ( direction ) {
 		return direction === 'rtl';
 	}

--- a/packages/components/src/calendar/utils/use-localization-props.ts
+++ b/packages/components/src/calendar/utils/use-localization-props.ts
@@ -10,10 +10,9 @@ import type { Modifiers, BaseProps } from '../types';
 
 function isLocaleRTL( localeCode: string ) {
 	const localeObj = new Intl.Locale( localeCode );
-	if ( 'getTextInfo' in localeObj ) {
-		// @ts-expect-error - getTextInfo is not typed yet
-		// see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
-		return localeObj.getTextInfo().direction === 'rtl';
+	const direction = localeObj.getTextInfo?.()?.direction;
+	if ( direction ) {
+		return direction === 'rtl';
 	}
 	return [
 		'ar', // Arabic

--- a/packages/components/src/form-file-upload/README.md
+++ b/packages/components/src/form-file-upload/README.md
@@ -48,7 +48,7 @@ Children are passed as children of `Button`.
 
 ### `icon`
 
- - Type: `IconType`
+ - Type: `IconType | null`
  - Required: No
 
 The icon to render in the default button.
@@ -65,7 +65,7 @@ Whether to allow multiple selection of files or not.
 
 ### `onChange`
 
- - Type: `ChangeEventHandler<HTMLInputElement>`
+ - Type: `ChangeEventHandler<HTMLInputElement> | undefined`
  - Required: Yes
 
 Callback function passed directly to the `input` file element.
@@ -95,7 +95,7 @@ an empty string in the `onClick` function.
 
 ### `render`
 
- - Type: `(arg: { openFileDialog: () => void; }) => ReactNode`
+ - Type: `((arg: { openFileDialog: () => void; }) => ReactNode)`
  - Required: No
 
 Optional callback function used to render the UI.

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -141,7 +141,7 @@ Only used when `asButtons` is not true.
 
 ### `onChange`
 
- - Type: `(currentGradient: string) => void`
+ - Type: `(currentGradient: string | undefined) => void`
  - Required: Yes
 
 The function called when a new gradient has been defined. It is passed to
@@ -149,7 +149,7 @@ the `currentGradient` as an argument.
 
 ### `value`
 
- - Type: `string`
+ - Type: `string | null`
  - Required: No
  - Default: `'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)'`
 

--- a/packages/components/src/icon/README.md
+++ b/packages/components/src/icon/README.md
@@ -16,7 +16,7 @@ import { wordpress } from '@wordpress/icons';
 
 ### `icon`
 
- - Type: `IconType`
+ - Type: `IconType | null`
  - Required: No
  - Default: `null`
 

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -19,7 +19,7 @@ component, and the `Menu.Popover` component.
 
 ### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | ... 516 more ... | ("view" & FunctionComponent<...>)`
+ - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | ... 517 more ...`
  - Required: No
 
 The HTML element or React component to render the component as.
@@ -57,7 +57,7 @@ override the `defaultOpen` prop.
 
 ### `onOpenChange`
 
- - Type: `(open: boolean) => void`
+ - Type: `((open: boolean) => void)`
  - Required: No
 
 A callback that gets called when the `open` state changes.

--- a/packages/components/src/tabs/README.md
+++ b/packages/components/src/tabs/README.md
@@ -19,7 +19,7 @@ It is responsible for managing the state of the tabs, and rendering one instance
 
 ### `activeTabId`
 
- - Type: `string`
+ - Type: `string | null`
  - Required: No
 
 The current active tab `id`. The active tab is the tab element within the
@@ -42,7 +42,7 @@ components as there are `Tabs.Tab` components.
 
 ### `defaultTabId`
 
- - Type: `string`
+ - Type: `string | null`
  - Required: No
 
 The id of the tab whose panel is currently visible.
@@ -56,7 +56,7 @@ provided (meaning the component will be used in "controlled" mode).
 
 ### `defaultActiveTabId`
 
- - Type: `string`
+ - Type: `string | null`
  - Required: No
 
 The tab id that should be active by default when the composite widget is
@@ -69,14 +69,14 @@ provided.
 
 ### `onSelect`
 
- - Type: `(selectedId: string) => void`
+ - Type: `((selectedId: string | null) => void)`
  - Required: No
 
 The function called when the `selectedTabId` changes.
 
 ### `onActiveTabIdChange`
 
- - Type: `(activeId: string) => void`
+ - Type: `((activeId: string | null) => void)`
  - Required: No
 
 A callback that gets called when the `activeTabId` state changes.
@@ -107,7 +107,7 @@ for more info.
 
 ### `selectedTabId`
 
- - Type: `string`
+ - Type: `string | null`
  - Required: No
 
 The id of the tab whose panel is currently visible.

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -118,7 +118,7 @@ If this property is added, an option will be added with this label to represent 
 
 ### `onChange`
 
- - Type: `(value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void`
+ - Type: `((value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void) | undefined`
  - Required: No
 
 A function that receives the value of the new option that is being selected as input.

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -5,8 +5,8 @@
 		"types": [
 			"gutenberg-env",
 			"gutenberg-test-env",
-			"css-modules",
-			"jest"
+			"jest",
+			"style-imports"
 		]
 	},
 	"references": [

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -2,7 +2,12 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "gutenberg-env", "gutenberg-test-env", "jest" ]
+		"types": [
+			"gutenberg-env",
+			"gutenberg-test-env",
+			"jest",
+			"style-imports"
+		]
 	},
 	"references": [
 		{ "path": "../components" },

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -2,6 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"types": [ "style-imports" ],
 		"checkJs": false
 	},
 	"references": [

--- a/packages/image-cropper/tsconfig.json
+++ b/packages/image-cropper/tsconfig.json
@@ -2,6 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"types": [ "style-imports" ],
 		"checkJs": false
 	},
 	"references": [

--- a/packages/lazy-editor/tsconfig.json
+++ b/packages/lazy-editor/tsconfig.json
@@ -2,6 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"types": [ "style-imports" ],
 		"checkJs": false
 	},
 	"references": [

--- a/packages/notices/tsconfig.json
+++ b/packages/notices/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "gutenberg-env" ],
+		"types": [ "gutenberg-env", "style-imports" ],
 		"checkJs": false
 	},
 	"references": [

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -3,7 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"moduleResolution": "bundler",
-		"types": [ "css-modules" ]
+		"types": [ "style-imports" ]
 	},
 	"files": [ "global.d.ts" ],
 	"references": [ { "path": "../element" }, { "path": "../private-apis" } ]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,8 +26,6 @@
 		/* Module Resolution Options */
 		"moduleResolution": "bundler",
 
-		/* This needs to be false so our types are possible to consume without setting this */
-		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
 		"typeRoots": [ "./typings", "./node_modules/@types" ],

--- a/typings/style-imports/index.d.ts
+++ b/typings/style-imports/index.d.ts
@@ -7,3 +7,6 @@ declare module '*.module.scss' {
 	const classes: { [ key: string ]: string };
 	export default classes;
 }
+
+declare module '*.css';
+declare module '*.scss';


### PR DESCRIPTION
## What?

Supersedes #77009

Update TypeScript from 5.9.3 to 6.0.2 and fix all resulting build issues.

## Why?

TypeScript 6 is the latest stable major version, bringing improved type checking (e.g. proper `Intl.Locale.getTextInfo()` typings), stricter side-effect import validation, and deprecation of legacy options.

## How?

1. **Bump TypeScript** from 5.9.3 to 6.0.2 in root `package.json`.
2. **Rename `typings/css-modules` → `typings/style-imports`** — add generic `*.css` and `*.scss` ambient module declarations alongside the existing `*.module.css`/`*.module.scss` declarations. TS6 introduces TS2882 which errors on side-effect stylesheet imports without type declarations. Updated all tsconfig references.
3. **Fix `use-localization-props.ts`** — TS6 now types `Intl.Locale.getTextInfo()`, making the `@ts-expect-error` directive unused (TS2578). Use optional chaining as a runtime fallback.
4. **Fix `check-build-type-declaration-files.js`** — add `--ignoreConfig` flag (TS6 TS5112) and switch `--moduleResolution` from deprecated `node10` to `bundler`.
5. **Remove deprecated `esModuleInterop: false`** from `tsconfig.base.json` — deprecated in TS6, default is already `false`.

## Testing Instructions

1. Run `npm run build` — should complete successfully.
2. Run `npx tsc --noEmit` — zero errors.
3. Open any package's `tsconfig.json` in an IDE — no deprecation warnings.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (claude-opus-4-6).