### PR TITLE
Refactor Admin UI / Breadcrumbs to use DS components and design tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57669,7 +57669,6 @@
 			"version": "1.12.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 -   Increase page header vertical padding. [#77152](https://github.com/WordPress/gutenberg/pull/77152)
 
+### Internal
+
+-   `Breadcrumbs`: Migrate from `@wordpress/components` to `Link`, `Stack`, and `Text` from `@wordpress/ui`. [#77012](https://github.com/WordPress/gutenberg/pull/77012)
+
 ## 1.11.0 (2026-04-01)
 
 ### Bug Fixes

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase page header vertical padding. [#77152](https://github.com/WordPress/gutenberg/pull/77152)
 
+### Internal
+
+-   `Breadcrumbs`: Migrate from `@wordpress/components` to `Link`, `Stack`, and `Text` from `@wordpress/ui`. [#77012](https://github.com/WordPress/gutenberg/pull/77012)
+
 ## 1.11.0 (2026-04-01)
 
 ### Bug Fixes

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -45,7 +45,6 @@
 		"src/**/*.module.css"
 	],
 	"dependencies": {
-		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -74,7 +74,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 						<Text
 							variant="body-lg"
 							aria-hidden="true"
-							className="admin-ui-breadcrumbs__separator"
+							className={ styles.separator }
 						>
 							/
 						</Text>

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -71,6 +71,13 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 						>
 							{ item.label }
 						</Text>
+						<Text
+							variant="body-lg"
+							aria-hidden="true"
+							className="admin-ui-breadcrumbs__separator"
+						>
+							/
+						</Text>
 					</li>
 				) ) }
 				<li>

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -81,7 +81,6 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 							{ lastItem.label }
 						</Link>
 					) : (
-						/* eslint-disable jsx-a11y/heading-has-content */
 						<Text
 							variant="heading-lg"
 							render={ <h1 /> }
@@ -89,7 +88,6 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 						>
 							{ lastItem.label }
 						</Text>
-						/* eslint-enable jsx-a11y/heading-has-content */
 					) }
 				</li>
 			</Stack>

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -51,7 +51,11 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 	}
 
 	return (
-		<nav aria-label={ __( 'Breadcrumbs' ) }>
+		<Text
+			variant="body-lg"
+			render={ <nav /> }
+			aria-label={ __( 'Breadcrumbs' ) }
+		>
 			<Stack
 				render={ <ul /> }
 				direction="row"
@@ -89,7 +93,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 					) }
 				</li>
 			</Stack>
-		</nav>
+		</Text>
 	);
 };
 

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -3,11 +3,7 @@
  */
 import { Link as RouterLink } from '@wordpress/route';
 import { __ } from '@wordpress/i18n';
-import {
-	__experimentalHeading as Heading,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
-import { Link } from '@wordpress/ui';
+import { Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -56,12 +52,11 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 
 	return (
 		<nav aria-label={ __( 'Breadcrumbs' ) }>
-			<HStack
-				as="ul"
+			<Stack
+				render={ <ul /> }
+				direction="row"
+				align="center"
 				className={ styles.list }
-				spacing={ 0 }
-				justify="flex-start"
-				alignment="center"
 			>
 				{ precedingItems.map( ( item, index ) => (
 					<li key={ index }>
@@ -82,12 +77,18 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 							{ lastItem.label }
 						</Link>
 					) : (
-						<Heading level={ 1 } truncate>
+						/* eslint-disable jsx-a11y/heading-has-content */
+						<Text
+							variant="heading-lg"
+							render={ <h1 /> }
+							className={ styles.current }
+						>
 							{ lastItem.label }
-						</Heading>
+						</Text>
+						/* eslint-enable jsx-a11y/heading-has-content */
 					) }
 				</li>
-			</HStack>
+			</Stack>
 		</nav>
 	);
 };

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -1,12 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { Link } from '@wordpress/route';
+import { Link as RouterLink } from '@wordpress/route';
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { Link } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -64,12 +65,22 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 			>
 				{ precedingItems.map( ( item, index ) => (
 					<li key={ index }>
-						<Link to={ item.to }>{ item.label }</Link>
+						<Link
+							render={ <RouterLink to={ item.to } /> }
+							tone="neutral"
+						>
+							{ item.label }
+						</Link>
 					</li>
 				) ) }
 				<li>
 					{ lastItem.to ? (
-						<Link to={ lastItem.to }>{ lastItem.label }</Link>
+						<Link
+							render={ <RouterLink to={ lastItem.to } /> }
+							tone="neutral"
+						>
+							{ lastItem.label }
+						</Link>
 					) : (
 						<Heading level={ 1 } truncate>
 							{ lastItem.label }

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -51,11 +51,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 	}
 
 	return (
-		<Text
-			variant="body-lg"
-			render={ <nav /> }
-			aria-label={ __( 'Breadcrumbs' ) }
-		>
+		<nav aria-label={ __( 'Breadcrumbs' ) }>
 			<Stack
 				render={ <ul /> }
 				direction="row"
@@ -64,22 +60,32 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 			>
 				{ precedingItems.map( ( item, index ) => (
 					<li key={ index }>
-						<Link
-							render={ <RouterLink to={ item.to } /> }
-							tone="neutral"
+						<Text
+							variant="body-lg"
+							render={
+								<Link
+									tone="neutral"
+									render={ <RouterLink to={ item.to } /> }
+								/>
+							}
 						>
 							{ item.label }
-						</Link>
+						</Text>
 					</li>
 				) ) }
 				<li>
 					{ lastItem.to ? (
-						<Link
-							render={ <RouterLink to={ lastItem.to } /> }
-							tone="neutral"
+						<Text
+							variant="body-lg"
+							render={
+								<Link
+									tone="neutral"
+									render={ <RouterLink to={ lastItem.to } /> }
+								/>
+							}
 						>
 							{ lastItem.label }
-						</Link>
+						</Text>
 					) : (
 						<Text
 							variant="heading-lg"
@@ -91,7 +97,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 					) }
 				</li>
 			</Stack>
-		</Text>
+		</nav>
 	);
 };
 

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -50,7 +50,11 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 	}
 
 	return (
-		<nav aria-label={ __( 'Breadcrumbs' ) }>
+		<Text
+			variant="body-lg"
+			render={ <nav /> }
+			aria-label={ __( 'Breadcrumbs' ) }
+		>
 			<Stack
 				render={ <ul /> }
 				direction="row"
@@ -88,7 +92,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 					) }
 				</li>
 			</Stack>
-		</nav>
+		</Text>
 	);
 };
 

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -50,11 +50,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 	}
 
 	return (
-		<Text
-			variant="body-lg"
-			render={ <nav /> }
-			aria-label={ __( 'Breadcrumbs' ) }
-		>
+		<nav aria-label={ __( 'Breadcrumbs' ) }>
 			<Stack
 				render={ <ul /> }
 				direction="row"
@@ -63,22 +59,32 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 			>
 				{ precedingItems.map( ( item, index ) => (
 					<li key={ index }>
-						<Link
-							render={ <RouterLink to={ item.to } /> }
-							tone="neutral"
+						<Text
+							variant="body-lg"
+							render={
+								<Link
+									tone="neutral"
+									render={ <RouterLink to={ item.to } /> }
+								/>
+							}
 						>
 							{ item.label }
-						</Link>
+						</Text>
 					</li>
 				) ) }
 				<li>
 					{ lastItem.to ? (
-						<Link
-							render={ <RouterLink to={ lastItem.to } /> }
-							tone="neutral"
+						<Text
+							variant="body-lg"
+							render={
+								<Link
+									tone="neutral"
+									render={ <RouterLink to={ lastItem.to } /> }
+								/>
+							}
 						>
 							{ lastItem.label }
-						</Link>
+						</Text>
 					) : (
 						<Text
 							variant="heading-lg"
@@ -90,7 +96,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 					) }
 				</li>
 			</Stack>
-		</Text>
+		</nav>
 	);
 };
 

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -1,12 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { Link } from '@wordpress/route';
+import { Link as RouterLink } from '@wordpress/route';
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalHeading as Heading,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { Link } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -63,12 +64,22 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 			>
 				{ precedingItems.map( ( item, index ) => (
 					<li key={ index }>
-						<Link to={ item.to }>{ item.label }</Link>
+						<Link
+							render={ <RouterLink to={ item.to } /> }
+							tone="neutral"
+						>
+							{ item.label }
+						</Link>
 					</li>
 				) ) }
 				<li>
 					{ lastItem.to ? (
-						<Link to={ lastItem.to }>{ lastItem.label }</Link>
+						<Link
+							render={ <RouterLink to={ lastItem.to } /> }
+							tone="neutral"
+						>
+							{ lastItem.label }
+						</Link>
 					) : (
 						<Heading level={ 1 } truncate>
 							{ lastItem.label }

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -3,11 +3,7 @@
  */
 import { Link as RouterLink } from '@wordpress/route';
 import { __ } from '@wordpress/i18n';
-import {
-	__experimentalHeading as Heading,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
-import { Link } from '@wordpress/ui';
+import { Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -55,12 +51,11 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 
 	return (
 		<nav aria-label={ __( 'Breadcrumbs' ) }>
-			<HStack
-				as="ul"
+			<Stack
+				render={ <ul /> }
+				direction="row"
+				align="center"
 				className="admin-ui-breadcrumbs__list"
-				spacing={ 0 }
-				justify="flex-start"
-				alignment="center"
 			>
 				{ precedingItems.map( ( item, index ) => (
 					<li key={ index }>
@@ -81,12 +76,18 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 							{ lastItem.label }
 						</Link>
 					) : (
-						<Heading level={ 1 } truncate>
+						/* eslint-disable jsx-a11y/heading-has-content */
+						<Text
+							variant="heading-lg"
+							render={ <h1 /> }
+							className="admin-ui-breadcrumbs__current"
+						>
 							{ lastItem.label }
-						</Heading>
+						</Text>
+						/* eslint-enable jsx-a11y/heading-has-content */
 					) }
 				</li>
-			</HStack>
+			</Stack>
 		</nav>
 	);
 };

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -80,7 +80,6 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 							{ lastItem.label }
 						</Link>
 					) : (
-						/* eslint-disable jsx-a11y/heading-has-content */
 						<Text
 							variant="heading-lg"
 							render={ <h1 /> }
@@ -88,7 +87,6 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 						>
 							{ lastItem.label }
 						</Text>
-						/* eslint-enable jsx-a11y/heading-has-content */
 					) }
 				</li>
 			</Stack>

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -70,6 +70,13 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 						>
 							{ item.label }
 						</Text>
+						<Text
+							variant="body-lg"
+							aria-hidden="true"
+							className="admin-ui-breadcrumbs__separator"
+						>
+							/
+						</Text>
 					</li>
 				) ) }
 				<li>

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -1,8 +1,4 @@
 .list {
-	/* @TODO: use Text component from UI when available. */
-	font-family: var(--wpds-typography-font-family-heading);
-	font-size: var(--wpds-typography-font-size-lg);
-	line-height: var(--wpds-typography-line-height-lg);
 	list-style: none;
 	padding: 0;
 	margin: 0;

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -9,7 +9,6 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		margin: 0;
 	}
 
 	li:not(:last-child)::after {

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -8,11 +8,12 @@
 	margin: 0;
 	min-height: 32px;
 
-	/* @TODO: Remove once `Text` supports truncation natively. */
+	/* @TODO: Remove truncation styles once `Text` supports truncation natively. */
 	.current {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		margin: 0;
 	}
 
 	li:not(:last-child)::after {

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -11,10 +11,8 @@
 		white-space: nowrap;
 	}
 
-	li:not(:last-child)::after {
-		content: "/";
-		margin: 0 var(--wpds-dimension-gap-sm);
+	.admin-ui-breadcrumbs__separator {
 		color: var(--wpds-color-stroke-surface-neutral);
-		font-weight: var(--wpds-typography-font-weight-regular);
+		margin: 0 var(--wpds-dimension-gap-sm);
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -5,6 +5,19 @@
 	min-height: 32px;
 }
 
+/*
+ * Preceding items keep their intrinsic width; only the last (current) item
+ * is allowed to shrink so that the truncation styles on `.current` engage.
+ */
+.list > li {
+	flex-shrink: 0;
+}
+
+.list > li:last-child {
+	flex-shrink: 1;
+	min-width: 0;
+}
+
 /* @TODO: Remove truncation styles once `Text` supports truncation natively. */
 .current {
 	overflow: hidden;

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -2,7 +2,6 @@
 	/* @TODO: use Text component from UI when available. */
 	font-family: var(--wpds-typography-font-family-heading);
 	font-size: var(--wpds-typography-font-size-lg);
-	font-weight: var(--wpds-typography-font-weight-medium);
 	line-height: var(--wpds-typography-line-height-lg);
 	list-style: none;
 	padding: 0;
@@ -19,7 +18,7 @@
 	li:not(:last-child)::after {
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
-		color: var(--wpds-color-fg-content-neutral-weak);
+		color: var(--wpds-color-stroke-surface-neutral);
 		font-weight: var(--wpds-typography-font-weight-regular);
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -14,5 +14,6 @@
 	.admin-ui-breadcrumbs__separator {
 		color: var(--wpds-color-stroke-surface-neutral);
 		margin: 0 var(--wpds-dimension-gap-sm);
+		user-select: none;
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -15,6 +15,7 @@
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
 		color: var(--wpds-color-fg-content-neutral-weak);
+		font-weight: var(--wpds-font-weight-regular);
 	}
 
 	h1 {

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -7,19 +7,19 @@
 	list-style: none;
 	padding: 0;
 	margin: 0;
-	/* gap prop don't seem to be working properly. */
-	gap: 0;
 	min-height: 32px;
+
+	/* @TODO: Remove once `Text` supports truncation natively. */
+	.current {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 
 	li:not(:last-child)::after {
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
 		color: var(--wpds-color-fg-content-neutral-weak);
-		font-weight: var(--wpds-font-weight-regular);
-	}
-
-	h1 {
-		font-size: inherit;
-		line-height: inherit;
+		font-weight: var(--wpds-typography-font-weight-regular);
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -2,7 +2,8 @@
 	list-style: none;
 	padding: 0;
 	margin: 0;
-	min-height: 32px;
+	/* @TODO: Replace with a `size` token once that category exists in the theme package. */
+	min-height: calc(var(--wpds-dimension-base) * 8);
 }
 
 /*

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -14,6 +14,7 @@
 	li:not(:last-child)::after {
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
+		color: var(--wpds-color-fg-content-neutral-weak);
 	}
 
 	h1 {

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -3,17 +3,17 @@
 	padding: 0;
 	margin: 0;
 	min-height: 32px;
+}
 
-	/* @TODO: Remove truncation styles once `Text` supports truncation natively. */
-	.current {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
+/* @TODO: Remove truncation styles once `Text` supports truncation natively. */
+.current {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
 
-	.admin-ui-breadcrumbs__separator {
-		color: var(--wpds-color-stroke-surface-neutral);
-		margin: 0 var(--wpds-dimension-gap-sm);
-		user-select: none;
-	}
+.separator {
+	color: var(--wpds-color-stroke-surface-neutral);
+	margin: 0 var(--wpds-dimension-gap-sm);
+	user-select: none;
 }

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -9,7 +9,6 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		margin: 0;
 	}
 
 	li:not(:last-child)::after {

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -11,10 +11,8 @@
 		white-space: nowrap;
 	}
 
-	li:not(:last-child)::after {
-		content: "/";
-		margin: 0 var(--wpds-dimension-gap-sm);
+	.admin-ui-breadcrumbs__separator {
 		color: var(--wpds-color-stroke-surface-neutral);
-		font-weight: var(--wpds-typography-font-weight-regular);
+		margin: 0 var(--wpds-dimension-gap-sm);
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -14,5 +14,6 @@
 	.admin-ui-breadcrumbs__separator {
 		color: var(--wpds-color-stroke-surface-neutral);
 		margin: 0 var(--wpds-dimension-gap-sm);
+		user-select: none;
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -15,6 +15,7 @@
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
 		color: var(--wpds-color-fg-content-neutral-weak);
+		font-weight: var(--wpds-font-weight-regular);
 	}
 
 	h1 {

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -1,5 +1,3 @@
-@use "@wordpress/base-styles/variables";
-
 .admin-ui-breadcrumbs__list {
 	// @TODO: use Text component from UI when available.
 	font-family: var(--wpds-typography-font-family-heading);
@@ -15,7 +13,8 @@
 
 	li:not(:last-child)::after {
 		content: "/";
-		margin: 0 variables.$grid-unit-10;
+		margin: 0 var(--wpds-dimension-gap-sm);
+		color: var(--wpds-color-fg-content-neutral-weak);
 	}
 
 	h1 {

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -1,7 +1,6 @@
 .admin-ui-breadcrumbs__list {
 	font-family: var(--wpds-typography-font-family-heading);
 	font-size: var(--wpds-typography-font-size-lg);
-	font-weight: var(--wpds-typography-font-weight-medium);
 	line-height: var(--wpds-typography-line-height-lg);
 	list-style: none;
 	padding: 0;
@@ -18,7 +17,7 @@
 	li:not(:last-child)::after {
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
-		color: var(--wpds-color-fg-content-neutral-weak);
+		color: var(--wpds-color-stroke-surface-neutral);
 		font-weight: var(--wpds-typography-font-weight-regular);
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -1,7 +1,4 @@
 .admin-ui-breadcrumbs__list {
-	font-family: var(--wpds-typography-font-family-heading);
-	font-size: var(--wpds-typography-font-size-lg);
-	line-height: var(--wpds-typography-line-height-lg);
 	list-style: none;
 	padding: 0;
 	margin: 0;

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -1,5 +1,4 @@
 .admin-ui-breadcrumbs__list {
-	// @TODO: use Text component from UI when available.
 	font-family: var(--wpds-typography-font-family-heading);
 	font-size: var(--wpds-typography-font-size-lg);
 	font-weight: var(--wpds-typography-font-weight-medium);
@@ -7,19 +6,19 @@
 	list-style: none;
 	padding: 0;
 	margin: 0;
-	// gap prop don't seem to be working properly.
-	gap: 0;
 	min-height: 32px;
+
+	// @TODO: Remove once `Text` supports truncation natively.
+	.admin-ui-breadcrumbs__current {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 
 	li:not(:last-child)::after {
 		content: "/";
 		margin: 0 var(--wpds-dimension-gap-sm);
 		color: var(--wpds-color-fg-content-neutral-weak);
-		font-weight: var(--wpds-font-weight-regular);
-	}
-
-	h1 {
-		font-size: inherit;
-		line-height: inherit;
+		font-weight: var(--wpds-typography-font-weight-regular);
 	}
 }

--- a/packages/admin-ui/src/breadcrumbs/style.scss
+++ b/packages/admin-ui/src/breadcrumbs/style.scss
@@ -7,11 +7,12 @@
 	margin: 0;
 	min-height: 32px;
 
-	// @TODO: Remove once `Text` supports truncation natively.
+	// @TODO: Remove truncation styles once `Text` supports truncation natively.
 	.admin-ui-breadcrumbs__current {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		margin: 0;
 	}
 
 	li:not(:last-child)::after {

--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -27,8 +27,9 @@ ruleTester.run( 'use-recommended-components', rule, {
 
 		// Allowed @wordpress/ui components.
 		"import { Badge } from '@wordpress/ui';",
+		"import { Link } from '@wordpress/ui';",
 		"import { Stack } from '@wordpress/ui';",
-		"import { Badge, Stack } from '@wordpress/ui';",
+		"import { Badge, Link, Stack } from '@wordpress/ui';",
 	],
 
 	invalid: [

--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -29,7 +29,8 @@ ruleTester.run( 'use-recommended-components', rule, {
 		"import { Badge } from '@wordpress/ui';",
 		"import { Link } from '@wordpress/ui';",
 		"import { Stack } from '@wordpress/ui';",
-		"import { Badge, Link, Stack } from '@wordpress/ui';",
+		"import { Text } from '@wordpress/ui';",
+		"import { Badge, Link, Stack, Text } from '@wordpress/ui';",
 	],
 
 	invalid: [

--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -13,6 +13,7 @@ const ALLOWLIST = {
 			'Card',
 			'Collapsible',
 			'CollapsibleCard',
+			'Link',
 			'Stack',
 			'Text',
 			'VisuallyHidden',

--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -8,7 +8,7 @@
  */
 const ALLOWLIST = {
 	'@wordpress/ui': {
-		allowed: [ 'Badge', 'Stack', 'Text' ],
+		allowed: [ 'Badge', 'Link', 'Stack', 'Text' ],
 		message:
 			'`{{ name }}` from `{{ source }}` is not yet recommended for use in a WordPress environment.',
 	},

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1,9 +1,4 @@
 {
-	"packages/admin-ui/src/breadcrumbs/index.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
 	"packages/block-editor/src/components/background-image-control/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What
Refactors the Breadcrumbs component to use `Link`, `Stack`, and `Text` from `@wordpress/ui` instead of `HStack`, `Heading`, and the unstyled router `Link`. Drops the `@wordpress/base-styles` dependency from `@wordpress/admin-ui` entirely (no other styles in the package needed it), introduces an explicit, accessible separator element, fixes truncation behavior, and tidies up the stylesheet for the CSS modules era.

## Why
The Breadcrumbs component was relying on experimental components from `@wordpress/components` (`__experimentalHStack`, `__experimentalHeading`) and an unstyled router link. Migrating to `@wordpress/ui` aligns breadcrumbs with the design system, giving links consistent interactive styling via the `neutral` tone and typography via `Text` variants. It also resolves a longstanding TODO in the stylesheet about adopting the `Text` component, surfaces a couple of latent layout/styling bugs along the way, and removes a dependency that was no longer needed at the package level.

## How
- **Link**: Composes the UI `Link` (for styling) with the router `Link` (for navigation) using the `render` prop. Uses `tone="neutral"` for breadcrumb-appropriate link styling.
- **Stack**: Replaces `HStack` with `Stack direction="row"`, rendered as a `<ul>` via the `render` prop.
- **Text**: Replaces `Heading` with `Text variant="heading-lg"`, rendered as an `<h1>` via the `render` prop. Applied per-item so each breadcrumb gets the correct typography rather than relying on a single wrapping element.
- **Separator**: Replaces the CSS pseudo-element separator with an explicit `Text aria-hidden` element, uses a subdued `--wpds-color-stroke-surface-neutral` color, and disables text selection so the decorative `/` doesn't leak into copied selections.
- **Truncation**: Made the existing truncation styles on `.current` actually work — flex items default to `min-width: auto`, so the wrapping `<li>` was never shrinking. Added `min-width: 0` on the last `<li>` so the ellipsis can engage, and `flex-shrink: 0` on preceding items so their labels don't wrap to multiple lines in narrow containers.
- **Styles cleanup**: Un-nested `.current` and `.separator` from `.list` (CSS modules already scope class names), renamed `.admin-ui-breadcrumbs__separator` → `.separator` to match the `styles.separator` lookup in the component (the old name was returning `undefined`, leaving the separator unstyled), and replaced a hardcoded `min-height: 32px` with `calc(var(--wpds-dimension-base) * 8)` (with a `@TODO` to swap in a `size` token once that category exists).
- **Dependencies**: Removes `@wordpress/base-styles` from `packages/admin-ui/package.json` — nothing in the package imports it anymore.
- **ESLint**: Adds `Link` to the `use-recommended-components` allowlist for `@wordpress/ui` (with corresponding test updates), removes a now-unnecessary `heading-has-content` disable, and prunes the now-unused suppressions entry.

### Before
<img width="475" height="44" alt="Screenshot 2026-04-02 at 19 10 08" src="https://github.com/user-attachments/assets/fce0032a-0879-4fda-be19-08cf080adba9" />

### After
<img width="473" height="42" alt="Screenshot 2026-04-02 at 19 10 13" src="https://github.com/user-attachments/assets/36f57ee4-3e0c-4580-9881-abb0050eb017" />

## Use of AI Tools
Created with Cursor & Claude Opus 4.7