### PR TITLE
Card: Set default foreground color on root

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Card`: Set default foreground color on `Card.Root` so content and `currentColor` icons (for example the `CollapsibleCard` chevron) are themeable by default ([#77013](https://github.com/WordPress/gutenberg/pull/77013)).
+
 ## 0.10.0 (2026-04-01)
 
 ### New Features

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -12,6 +12,7 @@
 		border-radius: var(--wpds-border-radius-lg);
 		overflow: clip;
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
+		color: var(--wpds-color-fg-content-neutral);
 	}
 
 	/* Padding is applied to the individual header/content elements to enable
@@ -40,6 +41,5 @@
 
 	.title {
 		margin: 0;
-		color: var(--wpds-color-fg-content-neutral);
 	}
 }


### PR DESCRIPTION
## What?

Sets `color: var(--wpds-color-fg-content-neutral)` on `Card`’s root element and removes the same declaration from `Card.Title` so everything contained inherits from the root.

## Why?

Only `Card.Title` had an explicit content foreground token. Anything else in the card that relies on `currentColor` (for example the caret icon in `CollapsibleCard`’s header) inherited `color` from ancestors outside the card, which often stayed light-theme in dark mode. The card already sets a theme-aware background on the root; pairing default text color there keeps header and body copy, and decorative icons, aligned with the design tokens.

## Testing Instructions

1. See Storybook for `CollapsibleCard`.
1. Use the theming toolbar to switch light / dark.
1. Confirm title, body text, and the collapsible chevron use readable foreground on the card surface in both modes.