### PR TITLE
Command Palette: Search result scroll jumps and layout jitters

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -12,6 +12,7 @@ import {
 	useState,
 	useEffect,
 	useRef,
+	useLayoutEffect,
 	isValidElement,
 	Component,
 } from '@wordpress/element';
@@ -321,6 +322,33 @@ export function CommandMenu() {
 		[]
 	);
 	const { open, close } = useDispatch( commandsStore );
+	const listRef = useRef();
+
+	useLayoutEffect( () => {
+		if ( ! listRef.current ) {
+			return;
+		}
+
+		// cmdk occasionally evaluates and triggers its own scrollIntoView asynchronously
+		// so, we fire our forceScroll for next few frames.
+		let count = 0;
+		let animationFrameId;
+
+		const forceScroll = () => {
+			if ( listRef.current ) {
+				listRef.current.scrollTop = 0;
+			}
+			if ( count++ < 10 ) {
+				animationFrameId = window.requestAnimationFrame( forceScroll );
+			}
+		};
+
+		listRef.current.scrollTop = 0;
+
+		animationFrameId = window.requestAnimationFrame( forceScroll );
+
+		return () => window.cancelAnimationFrame( animationFrameId );
+	}, [ search, loadersLoading ] );
 
 	useEffect( () => {
 		registerShortcut( {
@@ -385,7 +413,10 @@ export function CommandMenu() {
 							setSearch={ setSearch }
 						/>
 					</div>
-					<Command.List label={ __( 'Command suggestions' ) }>
+					<Command.List
+						ref={ listRef }
+						label={ __( 'Command suggestions' ) }
+					>
 						{ search && ! loadersLoading && (
 							<Command.Empty>
 								{ __( 'No results found.' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77021

This is a solution for current Command Palette, before when we move away from `cmdk`, as mentioned [here](#76950).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR fixes a UI isssue in the Command Palette where the results list would unexpectedly scroll downward or "jitter" when filtering results.

The issue was caused by a conflict between cmdk’s internal scroll-into-view logic and the asynchronous nature of command loaders. When new results were injected or the search string changed, the library would attempt to center the active selection. If this happened while the DOM was still reconciling or the list height was shifting, it resulted in a "jump" that disoriented the user.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
To ensure a stable and "sticky" scroll position at the top of the list during filtering, added a `useLayoutEffect` hook in `CommandMenu` that targets the `[cmdk-list]` container. It synchronously resets `scrollTop` to 0 whenever the search state or `loadersLoading` state changes.

Because cmdk occasionally triggers its own scroll logic asynchronously (after the initial render), the reset logic uses an animation loop. This "guards" the scroll position for 10 frames (~160ms) to override any late-firing internal library scrolls.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Command Palette (e.g., via Cmd+K)
2. Type "t", the results updates, with selected result un the top.
3. Type "a", so the search term becomes "ta", the search results stay in the view. 
4. Complete typing the whole search term, "tags."

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before

https://github.com/user-attachments/assets/d27c8e1a-7c2a-4e7a-bc58-0eaf6ea1e8e6

#### After

https://github.com/user-attachments/assets/30c903cf-eed0-40c4-b03e-40d29d748f3b


## Use of AI Tools
Gemini 3.1 Pro and Claude Sonnet 4.6 were used for research.
 
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
