### PR TITLE
DataForm: Show tooltip in edit button in `panel` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - DataForm: support `isDisabled` field property. [#77090](https://github.com/WordPress/gutenberg/pull/77090)
 - DataViews/DataViewsPicker: simplify `defaultLayouts` property. [#77232](https://github.com/WordPress/gutenberg/pull/77232)
+- DataForm: Show tooltip in edit button in `panel` layout. [#77024](https://github.com/WordPress/gutenberg/pull/77024)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -157,7 +157,6 @@ export default function SummaryButton< Item >( {
 				<Button
 					className="dataforms-layouts-panel__field-trigger-icon"
 					label={ ariaLabel }
-					showTooltip={ false }
 					icon={ pencil }
 					size="small"
 					aria-expanded={ ariaExpanded }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from https://github.com/WordPress/gutenberg/pull/76934

There are cases when we use the `panel` DataForm layout with a field that its value is not required and we don't want to show a label. If it's empty, we end up with just the `edit`(pencil) icon button with no context about which this field is.

Adding the tooltip I think is the minimum. 


This might be useful for `excerpt` and `description` fields, if we end up **not** showing any labels.
 
## Testing Instructions
1. in storybook (`npm run storybook:dev`) - `?path=/story/dataviews-dataform--layout-panel`
2. Observe that the tooltip is shown
3. The issue is more obvious if you choose in storybook args the `labelPosition:none` and edit the title to empty it.



## Screenshots or screencast <!-- if applicable -->
<img width="300" height="410" alt="Screenshot 2026-04-03 at 1 31 40 PM" src="https://github.com/user-attachments/assets/0e9a33be-d54c-4352-b03d-49a703c5af04" />

