### PR TITLE
Fix failing 'WP_HTTP_Polling_Sync_Server' unit test

### DIFF
--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				foreach ( $existing_awareness as $entry ) {
 					if ( $client_id === $entry['client_id'] && $wp_user_id !== $entry['wp_user_id'] ) {
 						return new WP_Error(
-							'forbidden',
+							'rest_cannot_edit',
 							__( 'Client ID is already in use by another user.', 'gutenberg' ),
 							array( 'status' => 403 )
 						);


### PR DESCRIPTION
## What?
This is a follow-up to #76987.

PR fixes failing unit tests on the trunk for the previous major release. Update returned error to match what's [already in core](https://github.com/chriszarate/wordpress-develop/blob/fc8eb609af6d399e2f217ac94ad451ed3916b563/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php#L218-L228).

See: https://github.com/WordPress/gutenberg/actions/runs/23943246703/job/69834063213.


## Testing Instructions
We need to merge this for confirmation.