### PR TITLE
Storybook: Fix E2E subpath exports and add CI build smoke test

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -39,7 +39,6 @@ jobs:
 
             - name: Build E2E Storybook
               env:
-                  NODE_OPTIONS: --max-old-space-size=8192
                   NODE_ENV: test
               run: npm run storybook:e2e:build
 

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -37,6 +37,12 @@ jobs:
                   NODE_ENV: test
               run: npm run storybook:build
 
+            - name: Build E2E Storybook
+              env:
+                  NODE_OPTIONS: --max-old-space-size=8192
+                  NODE_ENV: test
+              run: npm run storybook:e2e:build
+
             - name: Install test-runner and Playwright dependencies
               run: |
                   npm install --no-save @storybook/test-runner@0.24.2

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
 		"storybook:build": "npm run --workspace @wordpress/storybook storybook:build",
 		"storybook:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && npm run --workspace @wordpress/storybook storybook:dev\"",
 		"storybook:e2e:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && npm run --workspace @wordpress/storybook-playwright storybook:dev\"",
+		"storybook:e2e:build": "npm run --workspace @wordpress/storybook-playwright storybook:build",
 		"test": "npm-run-all lint test:unit",
 		"test:create-block": "bash ./bin/test-create-block.sh",
 		"test:e2e": "npm run --workspace @wordpress/e2e-tests-playwright test:e2e",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -19,6 +19,10 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"exports": {
+		"./main": "./main.ts",
+		"./preview": "./preview.jsx"
+	},
 	"devDependencies": {
 		"@storybook/addon-a11y": "^10.2.8",
 		"@storybook/addon-docs": "^10.2.8",

--- a/test/storybook-playwright/package.json
+++ b/test/storybook-playwright/package.json
@@ -31,6 +31,7 @@
 		"access": "public"
 	},
 	"scripts": {
+		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c ./storybook -o ./build",
 		"storybook:dev": "storybook dev -c ./storybook -p 50241",
 		"test:e2e": "playwright test --config playwright.config.ts"
 	}

--- a/test/storybook-playwright/package.json
+++ b/test/storybook-playwright/package.json
@@ -31,7 +31,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c ./storybook -o ./build",
+		"storybook:build": "storybook build -c ./storybook -o ./build",
 		"storybook:dev": "storybook dev -c ./storybook -p 50241",
 		"test:e2e": "playwright test --config playwright.config.ts"
 	}


### PR DESCRIPTION
## What?

Adds `exports` on `@wordpress/storybook` for `./main` and `./preview` so Node can resolve the paths used by the Playwright Storybook app (`storybook:e2e:dev` / `test/storybook-playwright`).

Also adds a static build for that app (`storybook:e2e:build`) and runs it in the existing Storybook CI workflow right after the main Storybook build.

## Why?

Storybook 10 evaluates `main.ts` with a TS loader, but bare imports like `@wordpress/storybook/main` still go through normal package resolution. Without `exports`, Node looks for a file named `main` with no extension and fails (`ERR_MODULE_NOT_FOUND`). The CI step catches similar breakages before they land.

## Testing Instructions

`npm run storybook:e2e:dev` and confirm Storybook starts.

The CI test will test the `npm run storybook:e2e:build` case.

## Use of AI Tools

Cursor was used to trace the Storybook/Node resolution error, add the `exports` and CI wiring, and to draft this description.