### PR TITLE
Storybook: Fix "Default" cursor option in theming toolbar

### DIFF
--- a/storybook/addons/design-system-theme/manager.ts
+++ b/storybook/addons/design-system-theme/manager.ts
@@ -31,7 +31,7 @@ const COLOR_OPTIONS: ThemeOption[] = [
 ];
 
 const CURSOR_CONTROL_OPTIONS: ThemeOption[] = [
-	{ id: '', title: 'Default' },
+	{ id: 'default', title: 'Default' },
 	{ id: 'pointer', title: 'Pointer' },
 ];
 


### PR DESCRIPTION
## What?

Fixes a bug in the Storybook theming toolbar where the "Default" cursor option wasn't working properly.

## How?

Sets the Default option’s `id` to `'default'` so the global and decorator pass `cursor={{ control: 'default' }}` as intended.

## Testing Instructions

1. `npm run storybook:dev` and go to a Design System component story.
3. Open the **Theme** toolbar → **Cursor control**.
4. Choose **Default**: interactive controls that use `var(--wpds-cursor-control)` should use the normal arrow cursor.
5. Choose **Pointer**: they should use the pointer cursor again.

## Use of AI Tools

Composer 2