### PR TITLE
RTC: Fix "Edit as HTML" content reset during collaboration

### DIFF
--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -28,6 +28,13 @@ function BlockHTML( { clientId } ) {
 		[ clientId ]
 	);
 	const { updateBlock } = useDispatch( blockEditorStore );
+
+	// Derive block content as a primitive string so the effect only fires
+	// when the serialized content genuinely changes, not when the block
+	// object reference changes (which happens on every RESET_BLOCKS during
+	// RTC sync, even for unchanged blocks).
+	const blockContent = block ? getBlockContent( block ) : '';
+
 	const onChange = () => {
 		const blockType = getBlockType( block.name );
 
@@ -64,8 +71,8 @@ function BlockHTML( { clientId } ) {
 	};
 
 	useEffect( () => {
-		setHtml( getBlockContent( block ) );
-	}, [ block ] );
+		setHtml( blockContent );
+	}, [ blockContent ] );
 
 	return (
 		<TextareaAutosize

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	getBlockAttributes,
@@ -33,7 +33,10 @@ function BlockHTML( { clientId } ) {
 	// when the serialized content genuinely changes, not when the block
 	// object reference changes (which happens on every RESET_BLOCKS during
 	// RTC sync, even for unchanged blocks).
-	const blockContent = block ? getBlockContent( block ) : '';
+	const blockContent = useMemo(
+		() => ( block ? getBlockContent( block ) : '' ),
+		[ block ]
+	);
 
 	const onChange = () => {
 		const blockType = getBlockType( block.name );


### PR DESCRIPTION
## What?

Fixes the "Edit as HTML" block losing user input during real-time collaboration when another user makes any edit:

https://github.com/user-attachments/assets/88b8bb1e-c0e0-4bf9-8ab9-02141bab3b9f

*Changes in HTML mode are immediately reset when another user makes change to the document*

This is another block in the RTC `RESET_BLOCKS` saga (https://github.com/WordPress/gutenberg/pull/76980, https://github.com/WordPress/gutenberg/pull/76025), see this comment for a good explanation on this class of bugs: https://github.com/WordPress/gutenberg/pull/76980#issuecomment-4183779174.

## Why?

When two users are collaborating and one switches a block to "Edit as HTML" mode, every remote edit causes the HTML area to reset, discarding changes. This makes the HTML editing mode effectively unusable during collaboration.

The root cause is a `useEffect` in the `BlockHTML` component based on the `block` object. During RTC sync, `RESET_BLOCKS` rebuilds the block tree with new objects, even for blocks whose content hasn't changed. Since `useEffect` uses reference, it fired on every sync and calls `setHtml(getBlockContent(block))`, overwriting in-progress changes.

## How?

The fix precomputes block content as a string outside of the effect. `useEffect()` now depends on this string value rather than the block object reference. Since identical HTML strings are equal, the effect only fires when the block's serialized content genuinely changes. Peer edits to other blocks won't overwrite the text area, while edits to the same block still update it correctly:

https://github.com/user-attachments/assets/73b3d8c6-a629-4dab-9581-f50a573d8210

*Successfully typing in HTML mode during peer changes*

## Testing Instructions

This bug is difficult to test without real collaboration, because clicking out of the "Edit as HTML" box into another browser blur and commits content. The reproduction above and test steps below work best when tested on a live environment.

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Open the same post in two browser sessions with two different users.
3. In one session (User A), select a Paragraph block and open the block options menu (three dots) -> "Edit as HTML".
4. Type some changes in the HTML textarea (e.g. add `class="test"` to the element). Do not blur or click away.
5. In the other session (User B), make any edit in any block (e.g. type a character).
6. Verify that User A's HTML textarea still contains their typed changes. In `trunk`, this would reset the content of the edited HTML to the original state.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Discovery, root cause analysis, fix