### PR TITLE
UI `Text`: Mark as recommended

### DIFF
--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -11,16 +11,15 @@ This feature is still experimental. “Experimental” means this is an early im
 ```jsx
 import {
 	__experimentalDivider as Divider,
-	__experimentalText as Text,
 } from `@wordpress/components`;
 import { Stack } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<Stack direction="column" gap="lg">
-			<Text>Some text here</Text>
+			<span>Some text here</span>
 			<Divider />
-			<Text>Some more text here</Text>
+			<span>Some more text here</span>
 		</Stack>
 	);
 }

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -12,14 +12,13 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<HStack>
-			<Text>Code</Text>
-			<Text>is</Text>
-			<Text>Poetry</Text>
+			<span>Code</span>
+			<span>is</span>
+			<span>Poetry</span>
 		</HStack>
 	);
 }
@@ -86,16 +85,15 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<HStack>
-			<Text>Code</Text>
+			<span>Code</span>
 			<Spacer>
-				<Text>is</Text>
+				<span>is</span>
 			</Spacer>
-			<Text>Poetry</Text>
+			<span>Poetry</span>
 		</HStack>
 	);
 }
@@ -108,15 +106,14 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<HStack>
-			<Text>Code</Text>
+			<span>Code</span>
 			<Spacer />
-			<Text>is</Text>
-			<Text>Poetry</Text>
+			<span>is</span>
+			<span>Poetry</span>
 		</HStack>
 	);
 }

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -11,10 +11,8 @@ This feature is still experimental. “Experimental” means this is an early im
 `HStack` can render anything inside.
 
 ```jsx
-import {
-	__experimentalHStack as HStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
@@ -87,8 +85,8 @@ When a `Spacer` is used within an `HStack`, the `Spacer` adaptively expands to t
 import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
 } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
@@ -109,8 +107,8 @@ function Example() {
 import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
 } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (

--- a/packages/components/src/heading/stories/index.story.tsx
+++ b/packages/components/src/heading/stories/index.story.tsx
@@ -32,7 +32,7 @@ const meta: Meta< typeof Heading > = {
 		componentStatus: {
 			status: 'not-recommended',
 			whereUsed: 'global',
-			notes: 'Values are not aligned with the current design system. Use [typography tokens](?path=/docs/tokens-typography--page) from `@wordpress/base-styles` instead.',
+			notes: 'Use `Text` from `@wordpress/ui` instead, with the `render` prop set to the heading level element and the variant set to the visual heading size (e.g. `<Text render={ <h1 /> } variant="heading-2xl">`).',
 		},
 	},
 };

--- a/packages/components/src/text/stories/index.story.tsx
+++ b/packages/components/src/text/stories/index.story.tsx
@@ -33,7 +33,7 @@ const meta: Meta< typeof Text > = {
 		componentStatus: {
 			status: 'not-recommended',
 			whereUsed: 'global',
-			notes: 'Values are not aligned with the current design system. Use [typography tokens](?path=/docs/tokens-typography--page) from `@wordpress/base-styles` instead.',
+			notes: 'Use `Text` from `@wordpress/ui` instead.',
 		},
 	},
 };

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -11,10 +11,8 @@ This feature is still experimental. “Experimental” means this is an early im
 `VStack` can render anything inside.
 
 ```jsx
-import {
-	__experimentalText as Text,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
@@ -74,9 +72,9 @@ When a `Spacer` is used within an `VStack`, the `Spacer` adaptively expands to t
 ```jsx
 import {
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
@@ -96,9 +94,9 @@ function Example() {
 ```jsx
 import {
 	__experimentalSpacer as Spacer,
-	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -12,14 +12,13 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<VStack>
-			<Text>Code</Text>
-			<Text>is</Text>
-			<Text>Poetry</Text>
+			<span>Code</span>
+			<span>is</span>
+			<span>Poetry</span>
 		</VStack>
 	);
 }
@@ -74,16 +73,15 @@ import {
 	__experimentalSpacer as Spacer,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<VStack>
-			<Text>Code</Text>
+			<span>Code</span>
 			<Spacer>
-				<Text>is</Text>
+				<span>is</span>
 			</Spacer>
-			<Text>Poetry</Text>
+			<span>Poetry</span>
 		</VStack>
 	);
 }
@@ -96,15 +94,14 @@ import {
 	__experimentalSpacer as Spacer,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<VStack>
-			<Text>Code</Text>
+			<span>Code</span>
 			<Spacer />
-			<Text>is</Text>
-			<Text>Poetry</Text>
+			<span>is</span>
+			<span>Poetry</span>
 		</VStack>
 	);
 }

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -12,12 +12,11 @@ This feature is still experimental. “Experimental” means this is an early im
 
 ```jsx
 import { __experimentalView as View } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (
 		<View>
-			<Text>Code is Poetry</Text>
+			<span>Code is Poetry</span>
 		</View>
 	);
 }

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -11,10 +11,8 @@ This feature is still experimental. “Experimental” means this is an early im
 ## Usage
 
 ```jsx
-import {
-	__experimentalText as Text,
-	__experimentalView as View,
-} from '@wordpress/components';
+import { __experimentalView as View } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 
 function Example() {
 	return (

--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -8,7 +8,7 @@
  */
 const ALLOWLIST = {
 	'@wordpress/ui': {
-		allowed: [ 'Badge', 'Stack' ],
+		allowed: [ 'Badge', 'Stack', 'Text' ],
 		message:
 			'`{{ name }}` from `{{ source }}` is not yet recommended for use in a WordPress environment.',
 	},

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -17,6 +17,10 @@ export const Default: Story = {
 	},
 };
 
+/**
+ * Important: Setting the `variant` prop to a `heading` variant will not automatically render a heading element.
+ * Use the `render` prop to render a heading element with the appropriate level.
+ */
 export const AllVariants: Story = {
 	render: () => (
 		<Stack


### PR DESCRIPTION
## What?

Part of #76135 

Adds `Text` to the list of recommended components, and updates guidance for the old `Text`/`Heading` components to use the new `Text` instead.

Also removes the `Text` component from readme snippets where they're unnecessary.

## Why?

This should ultimately be enforced with the `use-recommended-components` lint rule. This PR is just a preliminary step to update the docs.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open **Components / Typography / Text** and **Components / Typography / Heading** and confirm the status note matches the new guidance.
3. Skim the updated README sections and confirm the code blocks read sensibly.

## Use of AI Tools

Composer 2