### PR TITLE
RTC: Explore suggested edits

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./schemas/json/wp-env.json",
 	"testsEnvironment": false,
-	"core": "WordPress/WordPress",
+	"core": "WordPress/WordPress#6.9.4",
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"phpmyadminPort": 9000

--- a/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php
@@ -236,6 +236,12 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 				$entity_name = $object_parts[0];
 				$object_id   = $object_parts[1] ?? null;
 
+				if ( str_ends_with( $object_id, ':suggestions' ) {
+					// Handle the special case of suggestions rooms, which inherit the same
+					// permissions as the main entity room.
+					$object_id = str_replace( ':suggestions', '', $object_id );
+				}
+
 				if ( ! $this->can_user_sync_entity_type( $entity_kind, $entity_name, $object_id ) ) {
 					return new WP_Error(
 						'rest_cannot_edit',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -21,6 +21,7 @@ import {
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from './utils/crdt';
+import { stripSuggestionMarkup } from './utils/strip-suggestion-markup';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
@@ -315,6 +316,19 @@ export const prePersistPostType = async (
 		}
 	}
 
+	// Strip suggestion markup from content before saving to the REST API.
+	// Suggestion annotations (<ins>/<del>) are ephemeral editor state that
+	// should not persist to the database.
+	if ( edits.content ) {
+		const rawContent =
+			typeof edits.content === 'string'
+				? edits.content
+				: edits.content?.raw;
+		if ( rawContent && rawContent.includes( 'wp-suggestion-' ) ) {
+			newEdits.content = stripSuggestionMarkup( rawContent );
+		}
+	}
+
 	// Add meta for persisted CRDT document.
 	if ( persistedRecord ) {
 		const objectType = `postType/${ name }`;
@@ -447,11 +461,12 @@ async function loadPostTypeEntities() {
 			 * @param {import('@wordpress/sync').ObjectData} editedRecord
 			 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
 			 */
-			getChangesFromCRDTDoc: ( crdtDoc, editedRecord ) =>
+			getChangesFromCRDTDoc: ( crdtDoc, editedRecord, am ) =>
 				getPostChangesFromCRDTDoc(
 					crdtDoc,
 					editedRecord,
-					syncedProperties
+					syncedProperties,
+					am
 				),
 
 			/**

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -7,6 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { STORE_NAME } from './name';
+import { getSyncManager } from './sync';
 
 /**
  * Returns an action object used in signalling that the registered post meta
@@ -172,6 +173,44 @@ export const setCollaborationSupported =
 	( supported ) =>
 	( { dispatch } ) => {
 		dispatch( { type: 'SET_COLLABORATION_SUPPORTED', supported } );
+	};
+
+/**
+ * Sets the suggestion mode for a given entity.
+ *
+ * @param {string} objectType Object type (e.g. `postType/post`).
+ * @param {string} objectId   Object ID.
+ * @param {string} mode       The suggestion mode ('editing' or 'suggesting').
+ */
+export const setSuggestionMode =
+	( objectType, objectId, mode ) =>
+	( { dispatch } ) => {
+		getSyncManager()?.setSuggestionMode( objectType, objectId, mode );
+		dispatch( { type: 'SET_SUGGESTION_MODE', objectType, objectId, mode } );
+	};
+
+/**
+ * Accepts all pending suggestions for a given entity.
+ *
+ * @param {string} objectType Object type (e.g. `postType/post`).
+ * @param {string} objectId   Object ID.
+ */
+export const acceptAllSuggestions =
+	( objectType, objectId ) =>
+	() => {
+		getSyncManager()?.acceptAllSuggestions( objectType, objectId );
+	};
+
+/**
+ * Rejects all pending suggestions for a given entity.
+ *
+ * @param {string} objectType Object type (e.g. `postType/post`).
+ * @param {string} objectId   Object ID.
+ */
+export const rejectAllSuggestions =
+	( objectType, objectId ) =>
+	() => {
+		getSyncManager()?.rejectAllSuggestions( objectType, objectId );
 	};
 
 /**

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -325,6 +325,36 @@ export function isCollaborationSupported( state: State ): boolean {
 }
 
 /**
+ * Returns the current suggestion mode for the given entity.
+ *
+ * The mode is read from the sync manager but the `state.suggestionModes`
+ * reducer is included as a dependency so that `useSelect` re-evaluates
+ * when `setSuggestionMode` dispatches `SET_SUGGESTION_MODE`.
+ *
+ * @param state      Data state.
+ * @param objectType Object type (e.g. `postType/post`).
+ * @param objectId   Object ID.
+ *
+ * @return The suggestion mode ('editing' or 'suggesting').
+ */
+export function getSuggestionMode(
+	state: State,
+	objectType: string,
+	objectId: string
+): 'editing' | 'suggesting' {
+	// Read from Redux state to establish a reactive dependency for useSelect.
+	const key = `${ objectType }/${ objectId }`;
+	const stateMode = state.suggestionModes?.[ key ];
+
+	// Prefer the sync manager as the canonical source, fall back to state.
+	return (
+		getSyncManager()?.getSuggestionMode( objectType, objectId ) ??
+		stateMode ??
+		'editing'
+	);
+}
+
+/**
  * Returns the view configuration for the given entity type.
  *
  * @param state Data state.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -722,6 +722,27 @@ export function collaborationSupported( state = true, action ) {
 }
 
 /**
+ * Reducer tracking suggestion modes per entity, keyed by `objectType/objectId`.
+ * The actual mode is stored on the sync manager — this reducer exists only to
+ * trigger selector re-evaluation when the mode changes.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function suggestionModes( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_SUGGESTION_MODE':
+			return {
+				...state,
+				[ `${ action.objectType }/${ action.objectId }` ]: action.mode,
+			};
+	}
+	return state;
+}
+
+/**
  * Reducer managing view configs, keyed by `kind/name`.
  *
  * @param {Object} state  Current state.
@@ -764,5 +785,6 @@ export default combineReducers( {
 	editorAssets,
 	syncConnectionStatuses,
 	collaborationSupported,
+	suggestionModes,
 	viewConfigs,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -16,6 +16,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { STORE_NAME } from './name';
 import { additionalEntityConfigLoaders, DEFAULT_ENTITY_KEY } from './entities';
 import { getSyncManager } from './sync';
+import { SUGGESTION_DECORATION_STORE } from './suggestion-decoration-store';
 import {
 	forwardResolver,
 	getNormalizedCommaSeparable,
@@ -283,6 +284,17 @@ export const getEntityRecord =
 									restoreSelection( selectionHistory, ydoc );
 								}, 0 );
 							}
+						},
+						// Publish suggestion decoration ranges (both
+						// insertions and deletions) to the view-layer
+						// decoration store.
+						publishDecorations: ( decorations ) => {
+							registry
+								.dispatch( SUGGESTION_DECORATION_STORE )
+								.setDecorationRanges(
+									decorations.insertions ?? {},
+									decorations.deletions ?? {}
+								);
 						},
 					}
 				);

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -5,7 +5,7 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import type { UndoManager } from '@wordpress/undo-manager';
 import deprecated from '@wordpress/deprecated';
-import type { ConnectionStatus } from '@wordpress/sync';
+import type { ConnectionStatus, SuggestionMode } from '@wordpress/sync';
 
 /**
  * Internal dependencies
@@ -54,6 +54,7 @@ export interface State {
 	editorAssets: Record< string, any > | null;
 	syncConnectionStatuses?: Record< string, ConnectionStatus >;
 	collaborationSupported: boolean;
+	suggestionModes: Record< string, SuggestionMode >;
 	viewConfigs: Record< string, Record< string, any > >;
 }
 

--- a/packages/core-data/src/suggestion-decoration-store.js
+++ b/packages/core-data/src/suggestion-decoration-store.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Store name for suggestion decorations. Used by the format-library package
+ * to apply suggestion-insert and suggestion-delete highlighting at the view
+ * layer.
+ */
+export const SUGGESTION_DECORATION_STORE = 'core/suggestion-decorations';
+
+const EMPTY_RANGES = [];
+
+const store = createReduxStore( SUGGESTION_DECORATION_STORE, {
+	reducer( state = { version: 0, insertions: {}, deletions: {} }, action ) {
+		switch ( action.type ) {
+			case 'SET_DECORATION_RANGES':
+				return {
+					version: state.version + 1,
+					insertions: action.insertions,
+					deletions: action.deletions,
+				};
+			default:
+				return state;
+		}
+	},
+	selectors: {
+		getDecorationVersion: ( state ) => state.version,
+		getInsertionRanges: ( state, key ) =>
+			state.insertions[ key ] || EMPTY_RANGES,
+		getDeletionRanges: ( state, key ) =>
+			state.deletions[ key ] || EMPTY_RANGES,
+	},
+	actions: {
+		setDecorationRanges: ( insertions, deletions ) => ( {
+			type: 'SET_DECORATION_RANGES',
+			insertions,
+			deletions,
+		} ),
+	},
+} );
+
+register( store );
+
+export { store };

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -30,6 +30,7 @@ import {
 	type YText,
 } from './crdt-utils';
 import { getCachedRichTextData } from './crdt-text';
+import { stripSuggestionMarkup } from './strip-suggestion-markup';
 import { diffStringsToLib0Delta } from '../sync';
 
 interface BlockAttributes {
@@ -863,6 +864,12 @@ export function mergeRichTextUpdate(
 	updatedValue: string,
 	cursorPosition: number | null = null
 ): void {
+	// Strip suggestion markup (<ins>/<del>) from the incoming value.
+	// When the editor reads back suggestion-annotated content, those
+	// annotations must not be written into the CRDT Y.Text — they are
+	// ephemeral display state managed by the DiffAttributionManager.
+	const cleanValue = stripSuggestionMarkup( updatedValue );
+
 	// Gutenberg does not use Yjs shared types natively, so we can only subscribe
 	// to changes from store and apply them to Yjs types that we create and
 	// manage. Crucially, for rich-text attributes, we do not receive granular
@@ -873,7 +880,7 @@ export function mergeRichTextUpdate(
 	// and new value.  Y.Type.applyDelta natively accepts lib0 deltas.
 	const diffDelta = diffStringsToLib0Delta(
 		yTextToString( blockYText ),
-		updatedValue,
+		cleanValue,
 		cursorPosition
 	);
 	blockYText.applyDelta( diffDelta );

--- a/packages/core-data/src/utils/crdt-suggestions.ts
+++ b/packages/core-data/src/utils/crdt-suggestions.ts
@@ -1,0 +1,385 @@
+/**
+ * WordPress dependencies
+ */
+import { type Y } from '@wordpress/sync';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isYArray,
+	isYMap,
+	isYText,
+	type YMapRecord,
+	type YMap,
+	type YText,
+} from './crdt-utils';
+
+/**
+ * Walk a Y.Text's delta (produced with a DiffAttributionManager) and convert
+ * it to an HTML string with suggestion markup:
+ *
+ * - Suggested insertions: `<ins class="wp-suggestion-insert">`
+ * - Suggested deletions: `<del class="wp-suggestion-delete">`
+ * - Unchanged content: output as-is
+ *
+ * @param ytext The Y.Text to render.
+ * @param am    The DiffAttributionManager providing attribution data.
+ * @return HTML string with suggestion markup.
+ */
+export function yTextToSuggestionHTML(
+	ytext: YText,
+	am: Y.DiffAttributionManager
+): string {
+	const delta = ( ytext as Y.Type ).toDelta( am );
+	const json = delta.toJSON();
+	const children = json.children;
+
+	if ( ! children || children.length === 0 ) {
+		return '';
+	}
+
+	const parts: string[] = [];
+
+	for ( const op of children ) {
+		if ( 'insert' in op && typeof op.insert === 'string' ) {
+			const text = op.insert;
+			const attribution = ( op as any ).attribution;
+
+			if ( attribution && 'delete' in attribution ) {
+				parts.push(
+					`<del class="wp-suggestion-delete">${ text }</del>`
+				);
+			} else if ( attribution && 'insert' in attribution ) {
+				parts.push(
+					`<ins class="wp-suggestion-insert">${ text }</ins>`
+				);
+			} else {
+				parts.push( text );
+			}
+		}
+	}
+
+	return parts.join( '' );
+}
+
+/**
+ * Recursively serialize a Y.Type value to its plain JavaScript equivalent,
+ * using the DiffAttributionManager to render suggestion markup for Y.Text
+ * types. This is a variant of the standard `serialize` / `yMapToJSON` that
+ * produces suggestion-aware HTML.
+ *
+ * @param value The value to serialize.
+ * @param am    The DiffAttributionManager.
+ * @return The plain JavaScript equivalent with suggestion markup.
+ */
+export function serializeWithSuggestions(
+	value: unknown,
+	am: Y.DiffAttributionManager
+): unknown {
+	if ( isYMap( value ) ) {
+		return serializeWithSuggestions(
+			( value as YMap< YMapRecord > ).getAttrs(),
+			am
+		);
+	}
+
+	if ( isYArray( value ) ) {
+		return serializeWithSuggestions( ( value as Y.Type ).toArray(), am );
+	}
+
+	if ( isYText( value ) ) {
+		return yTextToSuggestionHTML( value as YText, am );
+	}
+
+	// Serializable primitives.
+	const primitives = [ 'boolean', 'bigint', 'number', 'string', 'undefined' ];
+	if ( primitives.includes( typeof value ) ) {
+		return value;
+	}
+
+	if ( Array.isArray( value ) ) {
+		return value.map( ( item ) => serializeWithSuggestions( item, am ) );
+	}
+
+	if ( value && typeof value === 'object' ) {
+		return Object.fromEntries(
+			Object.entries( value ).map( ( [ k, v ] ) => [
+				k,
+				serializeWithSuggestions( v, am ),
+			] )
+		);
+	}
+
+	return null;
+}
+
+/**
+ * Convert a YMap to a plain JavaScript object using suggestion-aware
+ * serialization. Y.Text values are rendered with `<ins>`/`<del>` markup
+ * based on the DiffAttributionManager's attribution data.
+ *
+ * @param ymap The YMap to convert.
+ * @param am   The DiffAttributionManager.
+ * @return The plain JavaScript equivalent with suggestion markup.
+ */
+export function yMapToJSONWithSuggestions< T extends YMapRecord >(
+	ymap: YMap< T >,
+	am: Y.DiffAttributionManager
+): T {
+	return serializeWithSuggestions( ymap.getAttrs(), am ) as T;
+}
+
+/**
+ * A range of characters in a RichText plain-text value.
+ */
+export interface SuggestionDecorationRange {
+	start: number;
+	end: number;
+}
+
+const INS_OPEN = '<ins class="wp-suggestion-insert">';
+const INS_CLOSE = '</ins>';
+const DEL_OPEN = '<del class="wp-suggestion-delete">';
+const DEL_CLOSE = '</del>';
+
+/**
+ * Given an HTML string that contains suggestion markup (`<ins>` and/or
+ * `<del>` tags with suggestion classes), strip both tag types (keeping
+ * their content) and compute the character ranges for each in plain-text
+ * space.
+ *
+ * Plain-text space = the text as seen by RichText after HTML parsing
+ * (HTML tags stripped, text content preserved).
+ *
+ * @param html HTML string with suggestion markup.
+ * @return Object with cleanHTML (suggestion tags stripped) and ranges for
+ *         both insertions and deletions.
+ */
+export function extractSuggestionRangesFromHTML( html: string ): {
+	cleanHTML: string;
+	insertionRanges: SuggestionDecorationRange[];
+	deletionRanges: SuggestionDecorationRange[];
+} {
+	const hasIns = html.includes( 'wp-suggestion-insert' );
+	const hasDel = html.includes( 'wp-suggestion-delete' );
+
+	if ( ! hasIns && ! hasDel ) {
+		return { cleanHTML: html, insertionRanges: [], deletionRanges: [] };
+	}
+
+	const insRanges: SuggestionDecorationRange[] = [];
+	const delRanges: SuggestionDecorationRange[] = [];
+	let plainPos = 0;
+	let result = '';
+	let i = 0;
+	let inInsTag = false;
+	let insStart = 0;
+	let inDelTag = false;
+	let delStart = 0;
+
+	while ( i < html.length ) {
+		// Check for <ins> open tag.
+		if ( ! inInsTag && html.startsWith( INS_OPEN, i ) ) {
+			inInsTag = true;
+			insStart = plainPos;
+			i += INS_OPEN.length;
+			continue;
+		}
+
+		// Check for </ins> close tag.
+		if ( inInsTag && html.startsWith( INS_CLOSE, i ) ) {
+			if ( plainPos > insStart ) {
+				insRanges.push( { start: insStart, end: plainPos } );
+			}
+			inInsTag = false;
+			i += INS_CLOSE.length;
+			continue;
+		}
+
+		// Check for <del> open tag.
+		if ( ! inDelTag && html.startsWith( DEL_OPEN, i ) ) {
+			inDelTag = true;
+			delStart = plainPos;
+			i += DEL_OPEN.length;
+			continue;
+		}
+
+		// Check for </del> close tag.
+		if ( inDelTag && html.startsWith( DEL_CLOSE, i ) ) {
+			if ( plainPos > delStart ) {
+				delRanges.push( { start: delStart, end: plainPos } );
+			}
+			inDelTag = false;
+			i += DEL_CLOSE.length;
+			continue;
+		}
+
+		// Skip any other HTML tag (does not count as plain text).
+		if ( html[ i ] === '<' ) {
+			const tagEnd = html.indexOf( '>', i );
+			if ( tagEnd >= 0 ) {
+				result += html.substring( i, tagEnd + 1 );
+				i = tagEnd + 1;
+				continue;
+			}
+		}
+
+		// Regular text character.
+		result += html[ i ];
+		plainPos++;
+		i++;
+	}
+
+	return {
+		cleanHTML: result,
+		insertionRanges: insRanges,
+		deletionRanges: delRanges,
+	};
+}
+
+/**
+ * Given an HTML string that may contain `<del class="wp-suggestion-delete">`
+ * tags, compute the character ranges of the deletion content in plain-text
+ * space WITHOUT stripping the tags. The `<del>` tags are kept in the HTML
+ * so that `stripSuggestionMarkup` can remove the deletion text during
+ * write-back.
+ *
+ * @param html HTML string that may contain `<del>` suggestion markup.
+ * @return Deletion ranges in plain-text space.
+ */
+export function extractDeletionRangesFromHTML(
+	html: string
+): SuggestionDecorationRange[] {
+	if ( ! html.includes( 'wp-suggestion-delete' ) ) {
+		return [];
+	}
+
+	const ranges: SuggestionDecorationRange[] = [];
+	let plainPos = 0;
+	let i = 0;
+	let inDelTag = false;
+	let delStart = 0;
+
+	while ( i < html.length ) {
+		// Check for <del> open tag.
+		if ( ! inDelTag && html.startsWith( DEL_OPEN, i ) ) {
+			inDelTag = true;
+			delStart = plainPos;
+			i += DEL_OPEN.length;
+			continue;
+		}
+
+		// Check for </del> close tag.
+		if ( inDelTag && html.startsWith( DEL_CLOSE, i ) ) {
+			if ( plainPos > delStart ) {
+				ranges.push( { start: delStart, end: plainPos } );
+			}
+			inDelTag = false;
+			i += DEL_CLOSE.length;
+			continue;
+		}
+
+		// Skip any HTML tag (does not count as plain text).
+		if ( html[ i ] === '<' ) {
+			const tagEnd = html.indexOf( '>', i );
+			if ( tagEnd >= 0 ) {
+				i = tagEnd + 1;
+				continue;
+			}
+		}
+
+		// Regular text character.
+		plainPos++;
+		i++;
+	}
+
+	return ranges;
+}
+
+/**
+ * Post-process a serialized block tree (from `serializeWithSuggestions`) to:
+ * 1. Strip `<ins>` tags from all rich-text attribute values (keeping content).
+ * 2. Extract insertion ranges for each rich-text attribute.
+ * 3. Extract deletion ranges for each rich-text attribute (keeping `<del>`
+ *    tags in the HTML for write-back stripping by `stripSuggestionMarkup`).
+ *
+ * Decoration maps are keyed by `blockIndexPath:attributeName`.
+ *
+ * @param blocks Serialized block tree with full suggestion markup.
+ * @return Cleaned blocks and decoration ranges for both insertions and deletions.
+ */
+export function extractSuggestionDecorations( blocks: any[] ): {
+	blocks: any[];
+	insertions: Record< string, SuggestionDecorationRange[] >;
+	deletions: Record< string, SuggestionDecorationRange[] >;
+} {
+	const insertions: Record< string, SuggestionDecorationRange[] > = {};
+	const deletions: Record< string, SuggestionDecorationRange[] > = {};
+
+	function processBlocks( blockArray: any[], parentPath: string ): any[] {
+		return blockArray.map( ( block, index ) => {
+			const blockPath = parentPath
+				? `${ parentPath }.${ index }`
+				: `${ index }`;
+			const cleanBlock = { ...block };
+
+			if ( block.attributes && typeof block.attributes === 'object' ) {
+				cleanBlock.attributes = { ...block.attributes };
+				for ( const [ key, value ] of Object.entries(
+					cleanBlock.attributes
+				) ) {
+					if ( typeof value !== 'string' ) {
+						continue;
+					}
+
+					const decorKey = `${ blockPath }:${ key }`;
+					const strValue = value as string;
+					const hasIns = strValue.includes( 'wp-suggestion-insert' );
+					const hasDel = strValue.includes( 'wp-suggestion-delete' );
+
+					if ( ! hasIns && ! hasDel ) {
+						continue;
+					}
+
+					// Compute both insertion and deletion ranges in a
+					// single pass over the markup.
+					const { insertionRanges, deletionRanges } =
+						extractSuggestionRangesFromHTML( strValue );
+
+					if ( insertionRanges.length > 0 ) {
+						insertions[ decorKey ] = insertionRanges;
+					}
+					if ( deletionRanges.length > 0 ) {
+						deletions[ decorKey ] = deletionRanges;
+					}
+
+					// Strip only <ins> tags (keeping content). <del>
+					// tags must remain so that stripSuggestionMarkup
+					// can remove the deletion text during write-back.
+					if ( hasIns ) {
+						cleanBlock.attributes[ key ] = strValue
+							.split( INS_OPEN )
+							.join( '' )
+							.split( INS_CLOSE )
+							.join( '' );
+					}
+				}
+			}
+
+			if (
+				Array.isArray( block.innerBlocks ) &&
+				block.innerBlocks.length > 0
+			) {
+				cleanBlock.innerBlocks = processBlocks(
+					block.innerBlocks,
+					blockPath
+				);
+			}
+
+			return cleanBlock;
+		} );
+	}
+
+	return { blocks: processBlocks( blocks, '' ), insertions, deletions };
+}

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -47,6 +47,10 @@ import {
 	type YMapRecord,
 	type YMap,
 } from './crdt-utils';
+import {
+	extractSuggestionDecorations,
+	serializeWithSuggestions,
+} from './crdt-suggestions';
 
 // Changes that can be applied to a post entity record.
 export type PostChanges = Partial< Post > & {
@@ -272,22 +276,61 @@ function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
  * against the local record and determine if there are changes (edits) we want
  * to dispatch.
  *
- * @param {CRDTDoc}     ydoc
- * @param {Post}        editedRecord
- * @param {Set<string>} syncedProperties
+ * @param {CRDTDoc}                  ydoc
+ * @param {Post}                     editedRecord
+ * @param {Set<string>}              syncedProperties
+ * @param {Y.DiffAttributionManager} am
  * @return {Partial<PostChanges>} The changes that should be applied to the local record.
  */
 export function getPostChangesFromCRDTDoc(
 	ydoc: CRDTDoc,
 	editedRecord: Post,
-	syncedProperties: Set< string >
+	syncedProperties: Set< string >,
+	am?: Y.DiffAttributionManager
 ): PostChanges {
 	const ymap = getRootMap< YPostRecord >( ydoc, CRDT_RECORD_MAP_KEY );
+
+	// Always serialize the top-level map without suggestion markup so that
+	// non-block Y.Text fields (content, title, excerpt) remain clean.
+	const serialized = yMapToJSON( ymap );
+
+	// When an AM is provided, re-serialize the blocks field with suggestion
+	// markup. Both insertions and deletions are extracted as decoration
+	// ranges (applied at the view layer by the format types). `<ins>` tags
+	// are stripped (content kept). `<del>` tags are preserved so that
+	// `stripSuggestionMarkup` can remove the deletion text during
+	// write-back. The deletion *text* is present in the block attributes
+	// so the editor has characters to render with the suggestion-delete
+	// format.
+	let __suggestionInsertions:
+		| Record< string, { start: number; end: number }[] >
+		| undefined;
+	let __suggestionDeletions:
+		| Record< string, { start: number; end: number }[] >
+		| undefined;
+
+	if ( am ) {
+		const blocksValue = ymap.getAttr( 'blocks' );
+		if ( blocksValue && isYArray( blocksValue ) ) {
+			const suggestedBlocks = serializeWithSuggestions(
+				blocksValue,
+				am
+			) as any[];
+			const {
+				blocks: cleanBlocks,
+				insertions,
+				deletions,
+			} = extractSuggestionDecorations( suggestedBlocks );
+			( serialized as Record< string, unknown > ).blocks = cleanBlocks;
+			__suggestionInsertions = insertions;
+			__suggestionDeletions = deletions;
+		}
+	}
 
 	let allowedMetaChanges: Post[ 'meta' ] = {};
 
 	const changes = Object.fromEntries(
-		Object.entries( yMapToJSON( ymap ) ).filter( ( [ key, newValue ] ) => {
+		Object.entries( serialized ).filter( ( [ key, newValue ] ) => {
 			if ( ! syncedProperties.has( key ) ) {
 				return false;
 			}
@@ -414,6 +457,16 @@ export function getPostChangesFromCRDTDoc(
 		changes.selection = {
 			...shiftedSelection,
 			initialPosition: 0,
+		};
+	}
+
+	// Attach suggestion decoration data so the sync manager can publish
+	// them to the decoration store for view-layer rendering by the
+	// suggestion-insert and suggestion-delete format types.
+	if ( __suggestionInsertions || __suggestionDeletions ) {
+		( changes as any ).__suggestionDecorations = {
+			insertions: __suggestionInsertions ?? {},
+			deletions: __suggestionDeletions ?? {},
 		};
 	}
 

--- a/packages/core-data/src/utils/strip-suggestion-markup.ts
+++ b/packages/core-data/src/utils/strip-suggestion-markup.ts
@@ -1,0 +1,34 @@
+/**
+ * Strip suggestion markup (`<ins>` and `<del>` tags with suggestion classes)
+ * from an HTML string. This is used before saving to the REST API to ensure
+ * that suggestion annotations do not persist to the database.
+ *
+ * - `<ins class="wp-suggestion-insert">text</ins>` → `text` (keep the content)
+ * - `<del class="wp-suggestion-delete">text</del>` → `` (remove the content)
+ *
+ * @param html The HTML string that may contain suggestion markup.
+ * @return Clean HTML without suggestion markup.
+ */
+export function stripSuggestionMarkup( html: string ): string {
+	if (
+		! html ||
+		( ! html.includes( 'wp-suggestion-insert' ) &&
+			! html.includes( 'wp-suggestion-delete' ) )
+	) {
+		return html;
+	}
+
+	// Remove <del class="wp-suggestion-delete">...</del> entirely (reject deletions).
+	let result = html.replace(
+		/<del\s+class="wp-suggestion-delete"[^>]*>[\s\S]*?<\/del>/g,
+		''
+	);
+
+	// Unwrap <ins class="wp-suggestion-insert">...</ins> (accept insertions).
+	result = result.replace(
+		/<ins\s+class="wp-suggestion-insert"[^>]*>([\s\S]*?)<\/ins>/g,
+		'$1'
+	);
+
+	return result;
+}

--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -22,6 +22,7 @@ import { store as interfaceStore, ActionItem } from '@wordpress/interface';
  */
 import CopyContentMenuItem from './copy-content-menu-item';
 import ModeSwitcher from '../mode-switcher';
+import SuggestionModeToggle from '../suggestion-mode-toggle';
 import ToolsMoreMenuGroup from './tools-more-menu-group';
 import ViewMoreMenuGroup from './view-more-menu-group';
 import { store as editorStore } from '../../store';
@@ -111,6 +112,7 @@ export default function MoreMenu( { disabled = false } ) {
 							<ViewMoreMenuGroup.Slot fillProps={ { onClose } } />
 						</MenuGroup>
 						<ModeSwitcher />
+						<SuggestionModeToggle />
 						<ActionItem.Slot
 							name="core/plugin-more-menu"
 							label={ __( 'Panels' ) }

--- a/packages/editor/src/components/suggestion-mode-toggle/index.js
+++ b/packages/editor/src/components/suggestion-mode-toggle/index.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const MODES = [
+	{
+		value: 'editing',
+		label: __( 'Editing' ),
+	},
+	{
+		value: 'suggesting',
+		label: __( 'Suggesting' ),
+	},
+];
+
+export default function SuggestionModeToggle() {
+	const { objectType, objectId, mode, isCollaboration } = useSelect(
+		( select ) => {
+			const { getCurrentPostType, getCurrentPostId } =
+				select( editorStore );
+			const postType = getCurrentPostType();
+			const postId = getCurrentPostId();
+			const ot = `postType/${ postType }`;
+			const { getSuggestionMode, isCollaborationSupported } = unlock(
+				select( coreStore )
+			);
+
+			return {
+				objectType: ot,
+				objectId: String( postId ),
+				mode: getSuggestionMode( ot, String( postId ) ),
+				isCollaboration: isCollaborationSupported(),
+			};
+		},
+		[]
+	);
+
+	const { setSuggestionMode } = unlock( useDispatch( coreStore ) );
+
+	if ( ! isCollaboration ) {
+		return null;
+	}
+
+	return (
+		<MenuGroup label={ __( 'Editing mode' ) }>
+			<MenuItemsChoice
+				choices={ MODES }
+				value={ mode }
+				onSelect={ ( newMode ) =>
+					setSuggestionMode( objectType, objectId, newMode )
+				}
+			/>
+		</MenuGroup>
+	);
+}

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -7,6 +7,8 @@ import { image } from './image';
 import { italic } from './italic';
 import { link } from './link';
 import { strikethrough } from './strikethrough';
+import { suggestionDelete } from './suggestion-delete';
+import { suggestionInsert } from './suggestion-insert';
 import { underline } from './underline';
 import { textColor } from './text-color';
 import { subscript } from './subscript';
@@ -24,6 +26,8 @@ export default [
 	italic,
 	link,
 	strikethrough,
+	suggestionDelete,
+	suggestionInsert,
 	underline,
 	textColor,
 	subscript,

--- a/packages/format-library/src/style.scss
+++ b/packages/format-library/src/style.scss
@@ -1,5 +1,7 @@
 @use "./image/style.scss" as *;
 @use "./link/style.scss" as *;
+@use "./suggestion-delete/style.scss" as *;
+@use "./suggestion-insert/style.scss" as *;
 @use "./text-color/style.scss" as *;
 @use "./language/style.scss" as *;
 @use "./math/style.scss" as *;

--- a/packages/format-library/src/suggestion-delete/index.js
+++ b/packages/format-library/src/suggestion-delete/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const name = 'core/suggestion-delete';
+const title = __( 'Suggested deletion' );
+
+/**
+ * Format type for suggested deletions.
+ *
+ * Unlike suggestion-insert (which is purely decoration-based and stripped
+ * before serialization), suggestion-delete works via standard HTML tags.
+ * The read-back injects `<del class="wp-suggestion-delete">` into block
+ * attributes so that the deletion text is present for the editor to display.
+ * These tags MUST survive RichText serialization so that the write-back's
+ * `stripSuggestionMarkup` can strip the deletion text before writing to the
+ * CRDT.
+ *
+ * This format type intentionally does NOT use
+ * `__experimentalCreatePrepareEditableTree`. Formats added via that API are
+ * stripped by `removeEditorOnlyFormats` before serialization, which would
+ * remove the `<del>` tags and cause the deletion text to leak back into
+ * the CRDT as new content.
+ */
+export const suggestionDelete = {
+	name,
+	title,
+	tagName: 'del',
+	className: 'wp-suggestion-delete',
+	edit() {
+		return null;
+	},
+};

--- a/packages/format-library/src/suggestion-delete/style.scss
+++ b/packages/format-library/src/suggestion-delete/style.scss
@@ -1,0 +1,5 @@
+.wp-suggestion-delete {
+	background-color: rgba(244, 67, 54, 0.15);
+	text-decoration: line-through;
+	text-decoration-color: rgba(244, 67, 54, 0.6);
+}

--- a/packages/format-library/src/suggestion-insert/index.js
+++ b/packages/format-library/src/suggestion-insert/index.js
@@ -1,0 +1,95 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { applyFormat } from '@wordpress/rich-text';
+
+const name = 'core/suggestion-insert';
+const title = __( 'Suggested insertion' );
+
+/**
+ * The store name for suggestion decoration ranges. This store is registered
+ * by `@wordpress/core-data` and populated by the sync manager.
+ */
+const DECORATION_STORE = 'core/suggestion-decorations';
+
+/**
+ * Format type for suggested insertions. Highlighting is applied at the view
+ * layer via `__experimentalCreatePrepareEditableTree` — the suggestion
+ * markup (`<ins>`) is never written to block attributes or the CRDT.
+ *
+ * When no decoration data is available (e.g. sync not active), the format
+ * is inert and the edit component returns null.
+ */
+export const suggestionInsert = {
+	name,
+	title,
+	tagName: 'ins',
+	className: 'wp-suggestion-insert',
+	edit() {
+		return null;
+	},
+
+	/**
+	 * Called inside useSelect — return values trigger re-renders.
+	 * We read the decoration version (for reactivity) and compute
+	 * the insertion ranges for this specific RichText instance.
+	 *
+	 * @param {Function} select                   Data selector.
+	 * @param {Object}   props                    The RichText props.
+	 * @param {string}   props.richTextIdentifier The identifier for this RichText instance.
+	 * @param {string}   props.blockClientId      The client ID of the block containing this RichText.
+	 * @return {Object} An object containing the insertion ranges and decoration version.
+	 */
+	__experimentalGetPropsForEditableTreePreparation(
+		select,
+		{ richTextIdentifier, blockClientId }
+	) {
+		// Guard: store may not be registered if sync is inactive.
+		let version;
+		try {
+			version = select( DECORATION_STORE ).getDecorationVersion();
+		} catch {
+			return { ranges: [] };
+		}
+
+		// Compute the block's index path to match the key format used
+		// by the decoration store (blockIndexPath:attributeName).
+		const blockEditor = select( 'core/block-editor' );
+		const parents = blockEditor.getBlockParents( blockClientId );
+		const allIds = [ ...parents, blockClientId ];
+		const indexPath = allIds
+			.map( ( id ) => blockEditor.getBlockIndex( id ) )
+			.join( '.' );
+		const key = `${ indexPath }:${ richTextIdentifier }`;
+
+		const ranges = select( DECORATION_STORE ).getInsertionRanges( key );
+		return { ranges, version };
+	},
+
+	/**
+	 * Inject suggestion-insert formats at the computed ranges. These
+	 * formats exist only in the editable tree — they are automatically
+	 * stripped before serialization by the RichText hook.
+	 *
+	 * @param {Object} props        The RichText props.
+	 * @param {Array}  props.ranges The ranges at which to apply the suggestion-insert format.
+	 */
+	__experimentalCreatePrepareEditableTree( { ranges } ) {
+		return ( formats, text ) => {
+			if ( ! ranges || ranges.length === 0 ) {
+				return formats;
+			}
+
+			let record = { formats, text };
+			for ( const range of ranges ) {
+				const start = Math.min( range.start, text.length );
+				const end = Math.min( range.end, text.length );
+				if ( start < end ) {
+					record = applyFormat( record, { type: name }, start, end );
+				}
+			}
+			return record.formats;
+		};
+	},
+};

--- a/packages/format-library/src/suggestion-insert/style.scss
+++ b/packages/format-library/src/suggestion-insert/style.scss
@@ -1,0 +1,5 @@
+.wp-suggestion-insert {
+	background-color: rgba(76, 175, 80, 0.15);
+	text-decoration: underline;
+	text-decoration-color: rgba(76, 175, 80, 0.6);
+}

--- a/packages/sync/src/config.ts
+++ b/packages/sync/src/config.ts
@@ -58,3 +58,22 @@ export const LOCAL_SYNC_MANAGER_ORIGIN = 'syncManager';
  * the CRDT document (and synced to peers) without creating undo levels.
  */
 export const LOCAL_UNDO_IGNORED_ORIGIN = 'gutenberg-undo-ignored';
+
+/**
+ * Origin string for CRDT document changes that should always pass through
+ * the DiffAttributionManager, even when in suggesting mode. Used for
+ * non-block property changes (title, status, meta, etc.) that should not
+ * become suggestions.
+ */
+export const LOCAL_EDITOR_PASSTHROUGH_ORIGIN = 'gutenberg-passthrough';
+
+/**
+ * Room name suffix for the suggestions document sync room.
+ */
+export const SUGGESTION_ROOM_SUFFIX = ':suggestions';
+
+/**
+ * Root-level key for the map that holds clientID-to-WordPress-user mappings
+ * in the nextDoc.
+ */
+export const CRDT_USER_MAP_KEY = 'users';

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -11,14 +11,15 @@ import {
 	CRDT_RECORD_MAP_KEY,
 	CRDT_STATE_MAP_KEY,
 	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
+	LOCAL_EDITOR_PASSTHROUGH_ORIGIN,
 	LOCAL_SYNC_MANAGER_ORIGIN,
 } from './config';
-import {
-	logPerformanceTiming,
-	passThru,
-	yieldToEventLoop,
-} from './performance';
+import { logPerformanceTiming, passThru } from './performance';
 import { getProviderCreators } from './providers';
+import {
+	createSuggestionManager,
+	type SuggestionManager as SuggestionManagerType,
+} from './suggestion-manager';
 import type {
 	CollectionHandlers,
 	CRDTDoc,
@@ -29,6 +30,7 @@ import type {
 	MapEvent,
 	ProviderCreator,
 	RecordHandlers,
+	SuggestionMode,
 	SyncConfig,
 	SyncManager,
 	SyncManagerUpdateOptions,
@@ -85,6 +87,38 @@ export function createSyncManager( debug = false ): SyncManager {
 	const debugWrap = debug ? logPerformanceTiming : passThru;
 	const collectionStates: Map< ObjectType, CollectionState > = new Map();
 	const entityStates: Map< EntityID, EntityState > = new Map();
+	const suggestionMgr: SuggestionManagerType = createSuggestionManager();
+
+	// A flushable deferred queue for CRDT document updates. Each call to
+	// the public `update` method enqueues the write and schedules a flush
+	// via setTimeout(0). `flushPendingUpdates` can be called synchronously
+	// (e.g. before a suggestion-mode switch) to execute all pending writes
+	// immediately, ensuring they run under the correct suggestion mode.
+	let pendingUpdates: Array< () => void > = [];
+	let updateTimer: ReturnType< typeof setTimeout > | null = null;
+
+	function flushPendingUpdates(): void {
+		if ( updateTimer !== null ) {
+			clearTimeout( updateTimer );
+			updateTimer = null;
+		}
+		const updates = pendingUpdates;
+		pendingUpdates = [];
+		for ( const update of updates ) {
+			update();
+		}
+	}
+
+	function deferredUpdateCRDTDoc(
+		...args: Parameters< typeof updateCRDTDoc >
+	): void {
+		pendingUpdates.push( () => {
+			updateCRDTDoc( ...args );
+		} );
+		if ( updateTimer === null ) {
+			updateTimer = setTimeout( flushPendingUpdates, 0 );
+		}
+	}
 
 	/**
 	 * A "sync-aware" undo manager for all synced entities. It is lazily created
@@ -179,6 +213,7 @@ export function createSyncManager( debug = false ): SyncManager {
 			getEditedRecord: debugWrap( handlers.getEditedRecord ),
 			onStatusChange: debugWrap( handlers.onStatusChange ),
 			persistCRDTDoc: debugWrap( handlers.persistCRDTDoc ),
+			publishDecorations: handlers.publishDecorations,
 			refetchRecord: debugWrap( handlers.refetchRecord ),
 			restoreUndoMeta: debugWrap( handlers.restoreUndoMeta ),
 		};
@@ -191,6 +226,9 @@ export function createSyncManager( debug = false ): SyncManager {
 		// Clean up providers and in-memory state when the entity is unloaded.
 		const unload = (): void => {
 			log( 'loadEntity', 'unloading', entityId );
+			if ( readBackTimer !== null ) {
+				clearTimeout( readBackTimer );
+			}
 			providerResults.forEach( ( result ) => result.destroy() );
 			handlers.onStatusChange( null );
 			recordMap.unobserveDeep( onRecordUpdate );
@@ -202,8 +240,25 @@ export function createSyncManager( debug = false ): SyncManager {
 		// If the sync config supports awareness, create it.
 		const awareness = syncConfig.createAwareness?.( ydoc, objectId );
 
-		// When the CRDT document is updated by an UndoManager or a connection (not
-		// a local origin), update the local store.
+		// When the CRDT document is updated by an UndoManager or a connection
+		// (not a local origin), update the local store. When suggestion
+		// tracking is active (in either editing or suggesting mode), local
+		// changes also need a read-back so the editor can display
+		// suggestion markup and keep decoration positions correct. A
+		// re-entrancy guard prevents infinite cycles: the read-back sends
+		// blocks with deletion text to the editor, whose write-back strips
+		// it (via mergeRichTextUpdate / stripSuggestionMarkup), producing
+		// a CRDT no-op.
+		//
+		// In suggesting mode the read-back is debounced to avoid cursor
+		// jumps during rapid typing. Without debouncing, each keystroke
+		// triggers a full blocks update with suggestion markup, which can
+		// cause the editor to re-render and lose cursor position.
+		// In editing mode the read-back is immediate but only refreshes
+		// decorations (no editRecord dispatch).
+		let isLocalSuggestionReadBack = false;
+		let readBackTimer: ReturnType< typeof setTimeout > | null = null;
+
 		const onRecordUpdate = (
 			_event: MapEvent,
 			transaction: Y.Transaction
@@ -212,6 +267,43 @@ export function createSyncManager( debug = false ): SyncManager {
 				transaction.local &&
 				! ( transaction.origin instanceof Y.UndoManager )
 			) {
+				if (
+					suggestionMgr.hasEntity( entityId ) &&
+					! isLocalSuggestionReadBack
+				) {
+					const mode = suggestionMgr.getMode( entityId );
+
+					if ( mode === 'suggesting' ) {
+						// Debounce: wait for typing to pause before
+						// sending suggestion-marked blocks back to
+						// the editor.
+						if ( readBackTimer !== null ) {
+							clearTimeout( readBackTimer );
+						}
+						readBackTimer = setTimeout( () => {
+							readBackTimer = null;
+							isLocalSuggestionReadBack = true;
+							void internal
+								.updateEntityRecord( objectType, objectId )
+								.finally( () => {
+									isLocalSuggestionReadBack = false;
+								} );
+						}, 150 );
+					} else {
+						// In editing mode, refresh decorations
+						// immediately without dispatching editRecord
+						// (blocks from nextDoc are always treated as
+						// "changed", which would cause duplication).
+						isLocalSuggestionReadBack = true;
+						void internal
+							.updateEntityRecord( objectType, objectId, {
+								decorationsOnly: true,
+							} )
+							.finally( () => {
+								isLocalSuggestionReadBack = false;
+							} );
+					}
+				}
 				return;
 			}
 
@@ -242,8 +334,14 @@ export function createSyncManager( debug = false ): SyncManager {
 		};
 
 		// Lazily create the undo manager when the first entity is loaded.
+		// Pass the suggestion manager's suspend function so undo/redo bypasses
+		// suggestion mode (changes flow directly to currentDoc). The per-doc
+		// UndoManager map is forwarded so suspend can add the UndoManager
+		// origins to AM's suggestionOrigins.
 		if ( ! undoManager ) {
-			undoManager = createUndoManager();
+			undoManager = createUndoManager( ( undoManagerDocs ) =>
+				suggestionMgr.suspendSuggestionMode( undoManagerDocs )
+			);
 		}
 
 		const { addUndoMeta, restoreUndoMeta } = handlers;
@@ -291,6 +389,31 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		// Get and apply the persisted CRDT document, if it exists.
 		internal.applyPersistedCrdtDoc( objectType, objectId, record );
+
+		// Initialize suggestion tracking (creates nextDoc + DiffAttributionManager).
+		// The nextDoc is synced via a separate :suggestions room.
+		log( 'loadEntity', 'initializing suggestions', entityId );
+		const nextDoc = await suggestionMgr.initEntity(
+			entityId,
+			objectType,
+			objectId,
+			ydoc
+		);
+
+		// Add nextDoc's record map to the undo scope. The editor writes to
+		// nextDoc (not currentDoc), so undo must track changes there.
+		// The AM propagation to currentDoc uses its own origin (not in
+		// trackedOrigins) so the currentDoc's UndoManager won't double-capture.
+		const nextRecordMap = nextDoc.get( CRDT_RECORD_MAP_KEY );
+		undoManager.addToScope( nextRecordMap, {
+			addUndoMeta,
+			restoreUndoMeta,
+		} );
+
+		// Observe the nextDoc's record map for remote suggestion changes.
+		// When a peer sends a suggestion, the nextDoc updates and we need
+		// to refresh the local editor state.
+		nextRecordMap.observeDeep( onRecordUpdate );
 	}
 
 	/**
@@ -404,6 +527,7 @@ export function createSyncManager( debug = false ): SyncManager {
 	function unloadEntity( objectType: ObjectType, objectId: ObjectID ): void {
 		const entityId = getEntityId( objectType, objectId );
 		log( 'unloadEntity', 'unloading', entityId );
+		suggestionMgr.destroyEntity( entityId );
 		entityStates.get( entityId )?.unload();
 		updateCRDTDoc( objectType, null, {}, origin, { isSave: true } );
 	}
@@ -560,6 +684,13 @@ export function createSyncManager( debug = false ): SyncManager {
 		if ( entityState ) {
 			const { syncConfig, ydoc } = entityState;
 
+			// Determine if we should write to the nextDoc (suggestion doc)
+			// instead of the currentDoc. When suggestion tracking is active,
+			// the editor always writes to nextDoc. The DiffAttributionManager
+			// controls whether changes propagate to currentDoc.
+			const nextDoc = suggestionMgr.getNextDoc( entityId );
+			const targetDoc = nextDoc ?? ydoc;
+
 			// If this is change should create a new undo level, tell the undo
 			// manager to stop capturing and create a new undo group.
 			// We can't do this in the undo manager itself, because addRecord() is
@@ -569,16 +700,86 @@ export function createSyncManager( debug = false ): SyncManager {
 				undoManager.stopCapturing?.();
 			}
 
-			ydoc.transact( () => {
-				log( 'updateCRDTDoc', 'applying changes', entityId, {
-					changedKeys: Object.keys( changes ),
-				} );
-				syncConfig.applyChangesToCRDTDoc( ydoc, changes );
+			const mode = suggestionMgr.getMode( entityId );
 
-				if ( isSave ) {
-					markEntityAsSaved( ydoc );
+			if ( nextDoc && mode === 'suggesting' ) {
+				// In suggesting mode, split changes: blocks use the editor
+				// origin (blocked by AM) while non-blocks use the passthrough
+				// origin (allowed through AM).
+				const blocksKeys = new Set( [ 'blocks', 'content' ] );
+				const blocksChanges: Partial< ObjectData > = {};
+				const otherChanges: Partial< ObjectData > = {};
+
+				for ( const [ key, value ] of Object.entries( changes ) ) {
+					if ( blocksKeys.has( key ) ) {
+						blocksChanges[ key ] = value;
+					} else {
+						otherChanges[ key ] = value;
+					}
 				}
-			}, origin );
+
+				// Apply non-blocks changes with passthrough origin (always flows through).
+				if ( Object.keys( otherChanges ).length > 0 ) {
+					targetDoc.transact( () => {
+						log(
+							'updateCRDTDoc',
+							'applying passthrough changes',
+							entityId,
+							{
+								changedKeys: Object.keys( otherChanges ),
+							}
+						);
+						syncConfig.applyChangesToCRDTDoc(
+							targetDoc,
+							otherChanges
+						);
+					}, LOCAL_EDITOR_PASSTHROUGH_ORIGIN );
+				}
+
+				// Apply blocks changes with editor origin (blocked by AM in suggesting mode).
+				if ( Object.keys( blocksChanges ).length > 0 ) {
+					targetDoc.transact( () => {
+						log(
+							'updateCRDTDoc',
+							'applying suggestion changes',
+							entityId,
+							{
+								changedKeys: Object.keys( blocksChanges ),
+							}
+						);
+						syncConfig.applyChangesToCRDTDoc(
+							targetDoc,
+							blocksChanges
+						);
+					}, origin );
+				}
+
+				// Save is applied to the currentDoc (the canonical version).
+				if ( isSave ) {
+					ydoc.transact( () => {
+						markEntityAsSaved( ydoc );
+					}, origin );
+				}
+			} else {
+				// In editing mode or without suggestion tracking: apply all at once.
+				targetDoc.transact( () => {
+					log( 'updateCRDTDoc', 'applying changes', entityId, {
+						changedKeys: Object.keys( changes ),
+					} );
+					syncConfig.applyChangesToCRDTDoc( targetDoc, changes );
+
+					if ( isSave ) {
+						markEntityAsSaved( targetDoc );
+					}
+				}, origin );
+
+				// If writing to nextDoc in editing mode, also mark currentDoc as saved.
+				if ( isSave && nextDoc && targetDoc !== ydoc ) {
+					ydoc.transact( () => {
+						markEntityAsSaved( ydoc );
+					}, origin );
+				}
+			}
 		}
 
 		if ( collectionState && isSave ) {
@@ -592,12 +793,15 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * Update the entity record in the local store with changes from the CRDT
 	 * document.
 	 *
-	 * @param {ObjectType} objectType Object type of record to update.
-	 * @param {ObjectID}   objectId   Object ID of record to update.
+	 * @param {ObjectType} objectType              Object type of record to update.
+	 * @param {ObjectID}   objectId                Object ID of record to update.
+	 * @param {Object}     options                 Optional flags for the update.
+	 * @param {boolean}    options.decorationsOnly If true, only update suggestion decorations without editing the record. Defaults to false.
 	 */
 	async function _updateEntityRecord(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		{ decorationsOnly = false }: { decorationsOnly?: boolean } = {}
 	): Promise< void > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -609,12 +813,49 @@ export function createSyncManager( debug = false ): SyncManager {
 
 		const { handlers, syncConfig, ydoc } = entityState;
 
+		// When suggestion tracking is active, read from nextDoc (which
+		// includes pending suggestions) instead of currentDoc.
+		const nextDoc = suggestionMgr.getNextDoc( entityId );
+		const readDoc = nextDoc ?? ydoc;
+
+		// Pass the DiffAttributionManager so the sync config can generate
+		// suggestion markup for rich-text attributes.
+		const am = suggestionMgr.getAttributionManager( entityId );
+
 		// Determine which synced properties have actually changed by comparing
 		// them against the current edited entity record.
+		const editedRecord = await handlers.getEditedRecord();
+
+		// Flush any pending CRDT writes that may have been enqueued
+		// during the async getEditedRecord() call. Without this, the
+		// CRDT doc may be missing recently typed characters, causing
+		// the read-back to overwrite them with stale content.
+		flushPendingUpdates();
+
 		const changes = syncConfig.getChangesFromCRDTDoc(
-			ydoc,
-			await handlers.getEditedRecord()
+			readDoc,
+			editedRecord,
+			am
 		);
+
+		// Extract suggestion decoration ranges (attached by
+		// getPostChangesFromCRDTDoc) and publish them to the view-layer
+		// decoration store. These ranges are NOT entity data — they drive
+		// the suggestion-insert and suggestion-delete format types'
+		// view-layer highlighting.
+		const decorations = ( changes as any ).__suggestionDecorations;
+		if ( decorations !== undefined ) {
+			delete ( changes as any ).__suggestionDecorations;
+			handlers.publishDecorations?.( decorations );
+		}
+
+		// In decorations-only mode (editing-mode local read-back), skip
+		// editRecord. The editor's blocks are authoritative and dispatching
+		// CRDT blocks would cause a re-render loop because the blocks
+		// comparison always returns true for non-persisted docs.
+		if ( decorationsOnly ) {
+			return;
+		}
 
 		const changedKeys = Object.keys( changes );
 
@@ -659,17 +900,47 @@ export function createSyncManager( debug = false ): SyncManager {
 		updateEntityRecord: debugWrap( _updateEntityRecord ),
 	};
 
+	// Suggestion mode API methods.
+	function setSuggestionMode(
+		objectType: ObjectType,
+		objectId: ObjectID,
+		mode: SuggestionMode
+	): void {
+		// Flush any pending CRDT writes so they execute under their
+		// original suggestion mode. Without this, a write initiated in
+		// editing mode could be deferred past the mode switch and
+		// incorrectly treated as a suggestion.
+		flushPendingUpdates();
+
+		const entityId = getEntityId( objectType, objectId );
+		suggestionMgr.setMode( entityId, mode );
+
+		// Refresh decorations so existing suggestions remain visible
+		// regardless of which mode we switched to.
+		void internal.updateEntityRecord( objectType, objectId );
+	}
+
+	function getSuggestionMode(
+		objectType: ObjectType,
+		objectId: ObjectID
+	): SuggestionMode {
+		const entityId = getEntityId( objectType, objectId );
+		return suggestionMgr.getMode( entityId );
+	}
+
 	// Wrap and return the public API.
 	return {
 		createPersistedCRDTDoc: debugWrap( createPersistedCRDTDoc ),
 		getAwareness,
+		getSuggestionMode,
 		load: debugWrap( loadEntity ),
 		loadCollection: debugWrap( loadCollection ),
+		setSuggestionMode,
 		// Use getter to ensure we always return the current value of `undoManager`.
 		get undoManager(): SyncUndoManager | undefined {
 			return undoManager;
 		},
 		unload: debugWrap( unloadEntity ),
-		update: debugWrap( yieldToEventLoop( updateCRDTDoc ) ),
+		update: debugWrap( deferredUpdateCRDTDoc ),
 	};
 }

--- a/packages/sync/src/private-apis.ts
+++ b/packages/sync/src/private-apis.ts
@@ -5,6 +5,7 @@ import {
 	CRDT_DOC_META_PERSISTENCE_KEY,
 	CRDT_RECORD_MAP_KEY,
 	LOCAL_EDITOR_ORIGIN,
+	LOCAL_EDITOR_PASSTHROUGH_ORIGIN,
 	LOCAL_UNDO_IGNORED_ORIGIN,
 } from './config';
 import { ConnectionErrorCode } from './errors';
@@ -12,6 +13,7 @@ import { lock } from './lock-unlock';
 import { createSyncManager } from './manager';
 import { pollingManager } from './providers/http-polling/polling-manager';
 import { diffStringsToLib0Delta } from './cursor-diff';
+import { yTextToSuggestionHTML, hasSuggestions } from './suggestion-html';
 
 export const privateApis = {};
 
@@ -19,9 +21,12 @@ lock( privateApis, {
 	ConnectionErrorCode,
 	createSyncManager,
 	diffStringsToLib0Delta,
+	hasSuggestions,
+	yTextToSuggestionHTML,
 	CRDT_DOC_META_PERSISTENCE_KEY,
 	CRDT_RECORD_MAP_KEY,
 	LOCAL_EDITOR_ORIGIN,
+	LOCAL_EDITOR_PASSTHROUGH_ORIGIN,
 	LOCAL_UNDO_IGNORED_ORIGIN,
 	retrySyncConnection: () => pollingManager.retryNow(),
 } );

--- a/packages/sync/src/suggestion-html.ts
+++ b/packages/sync/src/suggestion-html.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import type * as Y from '@y/y';
+
+/**
+ * Walk a Y.Text's delta (produced with a DiffAttributionManager) and convert
+ * it to an HTML string with suggestion markup:
+ *
+ * - Suggested insertions are wrapped in `<ins class="wp-suggestion-insert">`.
+ * - Suggested deletions are wrapped in `<del class="wp-suggestion-delete">`.
+ * - Unchanged content is output as-is.
+ *
+ * @param ytext The Y.Text to render.
+ * @param am    The DiffAttributionManager providing attribution data.
+ * @return HTML string with suggestion markup.
+ */
+export function yTextToSuggestionHTML(
+	ytext: Y.Type,
+	am: Y.DiffAttributionManager
+): string {
+	const delta = ytext.toDelta( am );
+	const json = delta.toJSON();
+	const children = json.children;
+
+	if ( ! children || children.length === 0 ) {
+		return '';
+	}
+
+	const parts: string[] = [];
+
+	for ( const op of children ) {
+		if ( 'insert' in op && typeof op.insert === 'string' ) {
+			const text = op.insert;
+			const attribution = op.attribution;
+
+			if ( attribution && 'delete' in attribution ) {
+				// Suggested deletion: text from currentDoc deleted in nextDoc.
+				parts.push(
+					`<del class="wp-suggestion-delete">${ text }</del>`
+				);
+			} else if ( attribution && 'insert' in attribution ) {
+				// Suggested insertion: new text in nextDoc not in currentDoc.
+				parts.push(
+					`<ins class="wp-suggestion-insert">${ text }</ins>`
+				);
+			} else {
+				// Unchanged content.
+				parts.push( text );
+			}
+		}
+		// Skip retain/delete/modify ops — they don't contribute to full-content rendering.
+	}
+
+	return parts.join( '' );
+}
+
+/**
+ * Check whether a DiffAttributionManager has any pending suggestions
+ * (insertions or deletions).
+ *
+ * @param am The DiffAttributionManager to check.
+ * @return True if there are pending suggestions.
+ */
+export function hasSuggestions( am: Y.DiffAttributionManager ): boolean {
+	// The inserts and deletes IdMaps are non-empty when there are suggestions.
+	return (
+		( am.inserts as any ).clients?.size > 0 ||
+		( am.deletes as any ).clients?.size > 0
+	);
+}

--- a/packages/sync/src/suggestion-manager.ts
+++ b/packages/sync/src/suggestion-manager.ts
@@ -1,0 +1,333 @@
+/**
+ * External dependencies
+ */
+import * as Y from '@y/y';
+/**
+ * Internal dependencies
+ */
+import { LOCAL_EDITOR_ORIGIN, LOCAL_EDITOR_PASSTHROUGH_ORIGIN } from './config';
+import { getProviderCreators } from './providers';
+import type {
+	CRDTDoc,
+	EntityID,
+	ObjectID,
+	ObjectType,
+	ProviderCreatorResult,
+} from './types';
+import { createYjsDoc, initializeYjsDoc } from './utils';
+
+/**
+ * The suggestion mode for a given entity.
+ * - 'editing': Changes flow through to currentDoc (no suggestions created).
+ * - 'suggesting': Changes stay in nextDoc only (suggestions are created).
+ */
+export type SuggestionMode = 'editing' | 'suggesting';
+
+/**
+ * Per-entity state managed by the SuggestionManager.
+ */
+interface EntitySuggestionState {
+	/** The DiffAttributionManager linking currentDoc and nextDoc. */
+	am: Y.DiffAttributionManager;
+	/** The current suggestion mode for this entity. */
+	mode: SuggestionMode;
+	/** The nextDoc containing pending suggestions. */
+	nextDoc: CRDTDoc;
+	/** Providers for syncing nextDoc. */
+	providers: ProviderCreatorResult[];
+	/** Map of Yjs clientID → WordPress user ID. */
+	userMap: Map< number, number >;
+}
+
+/**
+ * The SuggestionManager orchestrates the two-document model for suggested
+ * edits. For each entity, it maintains:
+ *
+ * - currentDoc: The accepted content (synced via the existing room).
+ * - nextDoc: Content including pending suggestions (synced via :suggestions room).
+ * - DiffAttributionManager: Tracks the diff between the two documents.
+ */
+export interface SuggestionManager {
+	/**
+	 * Initialize suggestion tracking for an entity. Creates the nextDoc,
+	 * DiffAttributionManager, and syncs nextDoc via a :suggestions room.
+	 */
+	initEntity: (
+		entityId: EntityID,
+		objectType: ObjectType,
+		objectId: ObjectID,
+		currentDoc: CRDTDoc
+	) => Promise< CRDTDoc >;
+
+	/**
+	 * Destroy suggestion state for an entity.
+	 */
+	destroyEntity: ( entityId: EntityID ) => void;
+
+	/**
+	 * Set the suggestion mode for an entity.
+	 */
+	setMode: ( entityId: EntityID, mode: SuggestionMode ) => void;
+
+	/**
+	 * Get the current suggestion mode for an entity.
+	 */
+	getMode: ( entityId: EntityID ) => SuggestionMode;
+
+	/**
+	 * Get the nextDoc for an entity (what the editor reads/writes to).
+	 */
+	getNextDoc: ( entityId: EntityID ) => CRDTDoc | undefined;
+
+	/**
+	 * Get the DiffAttributionManager for an entity.
+	 */
+	getAttributionManager: (
+		entityId: EntityID
+	) => Y.DiffAttributionManager | undefined;
+
+	/**
+	 * Accept all pending suggestions for an entity.
+	 */
+	acceptAll: ( entityId: EntityID ) => void;
+
+	/**
+	 * Reject all pending suggestions for an entity.
+	 */
+	rejectAll: ( entityId: EntityID ) => void;
+
+	/**
+	 * Register a mapping from Yjs clientID to WordPress user ID.
+	 */
+	registerUser: (
+		entityId: EntityID,
+		clientId: number,
+		wpUserId: number
+	) => void;
+
+	/**
+	 * Get the WordPress user ID for a given Yjs clientID.
+	 */
+	getUserId: ( entityId: EntityID, clientId: number ) => number | undefined;
+
+	/**
+	 * Check if any entity has suggestion tracking initialized.
+	 */
+	hasEntity: ( entityId: EntityID ) => boolean;
+
+	/**
+	 * Temporarily suspend suggestion mode for all entities (used during
+	 * undo/redo). Returns a restore function.
+	 *
+	 * @param undoManagerDocs Per-doc UndoManager map from YMultiDocUndoManager.
+	 *                        The per-doc UndoManagers are added to AM
+	 *                        suggestionOrigins so undo transactions propagate.
+	 */
+	suspendSuggestionMode: ( undoManagerDocs?: Map< any, any > ) => () => void;
+}
+
+/**
+ * Create a SuggestionManager instance.
+ */
+export function createSuggestionManager(): SuggestionManager {
+	const states: Map< EntityID, EntitySuggestionState > = new Map();
+
+	async function initEntity(
+		entityId: EntityID,
+		objectType: ObjectType,
+		objectId: ObjectID,
+		currentDoc: CRDTDoc
+	): Promise< CRDTDoc > {
+		if ( states.has( entityId ) ) {
+			return states.get( entityId )!.nextDoc;
+		}
+
+		const nextDoc = createYjsDoc( { objectType, suggestions: true } );
+
+		// Bootstrap nextDoc with currentDoc's state so they start in sync.
+		const currentState = Y.encodeStateAsUpdateV2( currentDoc );
+		Y.applyUpdateV2( nextDoc, currentState );
+
+		// Create the DiffAttributionManager linking prevDoc (currentDoc) and
+		// nextDoc. By default, suggestionMode is true, meaning all changes to
+		// nextDoc are treated as suggestions.
+		const am = new Y.DiffAttributionManager( currentDoc, nextDoc );
+
+		// We use suggestionMode=false and control flow via suggestionOrigins.
+		// In editing mode, LOCAL_EDITOR_ORIGIN is in suggestionOrigins so
+		// changes flow through. In suggesting mode, it's removed.
+		am.suggestionMode = false;
+		am.suggestionOrigins = [
+			LOCAL_EDITOR_ORIGIN,
+			LOCAL_EDITOR_PASSTHROUGH_ORIGIN,
+		];
+
+		// Sync nextDoc via a :suggestions room. Do NOT pass awareness here —
+		// the suggestion room only syncs document state. Sharing the same
+		// awareness instance with both rooms causes duplicate listeners that
+		// emit spurious leave/rejoin events for the current user on load.
+		const providerCreators = getProviderCreators();
+		const providers = await Promise.all(
+			providerCreators.map( async ( create ) => {
+				return create( {
+					objectType,
+					objectId: `${ objectId }:suggestions`,
+					ydoc: nextDoc,
+				} );
+			} )
+		);
+
+		initializeYjsDoc( nextDoc );
+
+		const state: EntitySuggestionState = {
+			am,
+			mode: 'editing',
+			nextDoc,
+			providers,
+			userMap: new Map(),
+		};
+
+		states.set( entityId, state );
+		return nextDoc;
+	}
+
+	function destroyEntity( entityId: EntityID ): void {
+		const state = states.get( entityId );
+		if ( ! state ) {
+			return;
+		}
+
+		state.providers.forEach( ( p ) => p.destroy() );
+		state.am.destroy();
+		state.nextDoc.destroy();
+		states.delete( entityId );
+	}
+
+	function setMode( entityId: EntityID, mode: SuggestionMode ): void {
+		const state = states.get( entityId );
+		if ( ! state ) {
+			return;
+		}
+
+		state.mode = mode;
+
+		if ( mode === 'editing' ) {
+			// In editing mode, editor changes flow through to currentDoc.
+			state.am.suggestionOrigins = [
+				LOCAL_EDITOR_ORIGIN,
+				LOCAL_EDITOR_PASSTHROUGH_ORIGIN,
+			];
+		} else {
+			// In suggesting mode, only passthrough changes flow through.
+			// Block content changes (LOCAL_EDITOR_ORIGIN) are blocked.
+			state.am.suggestionOrigins = [ LOCAL_EDITOR_PASSTHROUGH_ORIGIN ];
+		}
+	}
+
+	function getMode( entityId: EntityID ): SuggestionMode {
+		return states.get( entityId )?.mode ?? 'editing';
+	}
+
+	function getNextDoc( entityId: EntityID ): CRDTDoc | undefined {
+		return states.get( entityId )?.nextDoc;
+	}
+
+	function getAttributionManager(
+		entityId: EntityID
+	): Y.DiffAttributionManager | undefined {
+		return states.get( entityId )?.am;
+	}
+
+	function acceptAll( entityId: EntityID ): void {
+		const state = states.get( entityId );
+		if ( ! state ) {
+			return;
+		}
+		state.am.acceptAllChanges();
+	}
+
+	function rejectAll( entityId: EntityID ): void {
+		const state = states.get( entityId );
+		if ( ! state ) {
+			return;
+		}
+		state.am.rejectAllChanges();
+	}
+
+	function registerUser(
+		entityId: EntityID,
+		clientId: number,
+		wpUserId: number
+	): void {
+		const state = states.get( entityId );
+		if ( ! state ) {
+			return;
+		}
+		state.userMap.set( clientId, wpUserId );
+	}
+
+	function getUserId(
+		entityId: EntityID,
+		clientId: number
+	): number | undefined {
+		return states.get( entityId )?.userMap.get( clientId );
+	}
+
+	function hasEntity( entityId: EntityID ): boolean {
+		return states.has( entityId );
+	}
+
+	function suspendSuggestionMode(
+		undoManagerDocs?: Map< any, any >
+	): () => void {
+		// Save current mode for each entity and switch to editing.
+		const savedModes: Map< EntityID, SuggestionMode > = new Map();
+
+		states.forEach( ( state, entityId ) => {
+			savedModes.set( entityId, state.mode );
+
+			if ( state.mode === 'suggesting' ) {
+				setMode( entityId, 'editing' );
+			}
+
+			// Add per-doc UndoManagers for the nextDoc to AM's
+			// suggestionOrigins. During undo/redo, Y.UndoManager uses
+			// itself as the transaction origin. Without this, the AM
+			// would treat undo reversals as suggestions instead of
+			// propagating them to currentDoc.
+			if ( undoManagerDocs ) {
+				const um = undoManagerDocs.get( state.nextDoc );
+				if ( um ) {
+					state.am.suggestionOrigins = [
+						...( state.am.suggestionOrigins ?? [] ),
+						um,
+					];
+				}
+			}
+		} );
+
+		// Return restore function. Calling setMode resets
+		// suggestionOrigins to the correct values for the mode,
+		// removing the UndoManager origins we added above.
+		return () => {
+			savedModes.forEach( ( mode, entityId ) => {
+				setMode( entityId, mode );
+			} );
+		};
+	}
+
+	return {
+		acceptAll,
+		destroyEntity,
+		getAttributionManager,
+		getMode,
+		getNextDoc,
+		getUserId,
+		hasEntity,
+		initEntity,
+		registerUser,
+		rejectAll,
+		setMode,
+		suspendSuggestionMode,
+	};
+}

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -127,6 +127,11 @@ export interface RecordHandlers {
 	getEditedRecord: () => Promise< ObjectData >;
 	onStatusChange: OnStatusChangeCallback;
 	persistCRDTDoc: () => void;
+	/** Publish suggestion decoration ranges (insertions + deletions) to the view layer. */
+	publishDecorations?: ( decorations: {
+		insertions: Record< string, { start: number; end: number }[] >;
+		deletions: Record< string, { start: number; end: number }[] >;
+	} ) => void;
 	refetchRecord: () => Promise< void >;
 	restoreUndoMeta: ( ydoc: Y.Doc, meta: Map< string, any > ) => void;
 }
@@ -142,10 +147,18 @@ export interface SyncConfig {
 	) => Awareness | undefined;
 	getChangesFromCRDTDoc: (
 		ydoc: Y.Doc,
-		editedRecord: ObjectData
+		editedRecord: ObjectData,
+		am?: Y.DiffAttributionManager
 	) => ObjectData;
 	getPersistedCRDTDoc?: ( record: ObjectData ) => string | null;
 }
+
+/**
+ * The suggestion mode for a given entity.
+ * - 'editing': Changes flow through to currentDoc (no suggestions created).
+ * - 'suggesting': Changes stay in nextDoc only (suggestions are created).
+ */
+export type SuggestionMode = 'editing' | 'suggesting';
 
 export interface SyncManager {
 	createPersistedCRDTDoc: (
@@ -178,6 +191,17 @@ export interface SyncManager {
 		origin: string,
 		options?: SyncManagerUpdateOptions
 	) => void;
+
+	// Suggestion mode API.
+	setSuggestionMode: (
+		objectType: ObjectType,
+		objectId: ObjectID,
+		mode: SuggestionMode
+	) => void;
+	getSuggestionMode: (
+		objectType: ObjectType,
+		objectId: ObjectID
+	) => SuggestionMode;
 }
 
 export interface SyncUndoManager extends WPUndoManager< ObjectData > {

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -11,7 +11,7 @@ import type { HistoryRecord } from '@wordpress/undo-manager';
 /**
  * Internal dependencies
  */
-import { LOCAL_EDITOR_ORIGIN } from './config';
+import { LOCAL_EDITOR_ORIGIN, LOCAL_EDITOR_PASSTHROUGH_ORIGIN } from './config';
 import { YMultiDocUndoManager } from './y-utilities/y-multidoc-undomanager';
 import type { ObjectData, RecordHandlers, SyncUndoManager } from './types';
 
@@ -27,16 +27,25 @@ interface StackItemEvent {
  * internally. This allows undo/redo operations to be transacted against multiple
  * CRDT documents (one per entity) and giving each peer their own undo/redo stack
  * without conflicts.
+ *
+ * @param {Function} onBeforeUndoRedo Optional callback that runs before undo/redo operations.
+ *                                    Receives the internal per-doc UndoManager map so the
+ *                                    caller can add their origins to pass-through lists.
  */
-export function createUndoManager(): SyncUndoManager {
+export function createUndoManager(
+	onBeforeUndoRedo?: ( undoManagerDocs: Map< any, any > ) => () => void
+): SyncUndoManager {
 	const yUndoManager = new YMultiDocUndoManager( [], {
 		// Throttle undo/redo captures after 500ms of inactivity.
 		// 500 was selected from subjective local UX testing, shorter timeouts
 		// may cause mid-word undo stack items.
 		captureTimeout: 500,
 		// Ensure that we only scope the undo/redo to the current editor.
-		// The yjs document's clientID is added once it's available.
-		trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
+		// Track both origins so undo works for both blocks and passthrough changes.
+		trackedOrigins: new Set( [
+			LOCAL_EDITOR_ORIGIN,
+			LOCAL_EDITOR_PASSTHROUGH_ORIGIN,
+		] ),
 	} );
 
 	return {
@@ -79,11 +88,17 @@ export function createUndoManager(): SyncUndoManager {
 			const { addUndoMeta, restoreUndoMeta } = handlers;
 
 			yUndoManager.on( 'stack-item-added', ( event: StackItemEvent ) => {
-				addUndoMeta( ydoc, event.stackItem.meta );
+				// Only process events for the doc this scope belongs to.
+				// Multiple docs may share the same YMultiDocUndoManager.
+				if ( event.ydoc === ydoc ) {
+					addUndoMeta( ydoc, event.stackItem.meta );
+				}
 			} );
 
 			yUndoManager.on( 'stack-item-popped', ( event: StackItemEvent ) => {
-				restoreUndoMeta( ydoc, event.stackItem.meta );
+				if ( event.ydoc === ydoc ) {
+					restoreUndoMeta( ydoc, event.stackItem.meta );
+				}
 			} );
 		},
 
@@ -96,8 +111,19 @@ export function createUndoManager(): SyncUndoManager {
 				return;
 			}
 
+			// Temporarily suspend suggestion mode so that undo operations flow
+			// directly to currentDoc. Without this, undoing in suggesting mode
+			// would create a new suggestion that reverses the previous one.
+			// Pass the per-doc UndoManager map so the caller can add them to
+			// the AM's suggestionOrigins (the Y.UndoManager instance is used
+			// as the transaction origin during undo).
+			const restore = onBeforeUndoRedo?.( yUndoManager.docs );
+
 			// Perform the undo operation
 			yUndoManager.undo();
+
+			// Restore suggestion mode.
+			restore?.();
 
 			// Intentionally return an empty array, because the SyncProvider will update
 			// the entity record based on the Yjs document changes.
@@ -112,8 +138,15 @@ export function createUndoManager(): SyncUndoManager {
 				return;
 			}
 
+			// Temporarily suspend suggestion mode so that redo operations flow
+			// directly to currentDoc.
+			const restore = onBeforeUndoRedo?.( yUndoManager.docs );
+
 			// Perform the redo operation
 			yUndoManager.redo();
+
+			// Restore suggestion mode.
+			restore?.();
 
 			// Intentionally return an empty array, because the SyncProvider will update
 			// the entity record based on the Yjs document changes.


### PR DESCRIPTION

## What?

> [!CAUTION]
> This is exploratory code and not ready to merge.

Implement a suggested edits feature for the collaborative editor using Yjs v14's `DiffAttributionManager`. When a user switches to "Suggesting" mode, their edits are tracked as proposals and are visible inline via a decoration-based view layer without modifying the accepted document. Other collaborators that are still in "Editing" mode continue to make direct edits as before.

This is just a prototype and there are some serious bugs! However, I think the overall architecture can light a path for someone else to push forward.

https://github.com/user-attachments/assets/695fcf17-5b5a-41ac-a89b-3c3aebfc119f


## Architecture

**Two-document model.** For each entity (post), we maintain two Yjs documents:

- **`currentDoc`**: The accepted content. This is the existing CRDT document, synced via the existing collaboration room. It represents the canonical state of the post.
- **`nextDoc`**: A copy of `currentDoc` plus any pending suggestions. Synced via a separate `suggestions` room (e.g., `post:123:suggestions`). The editor reads from and writes to `nextDoc` when suggestion tracking is active.

These two documents are linked by a `DiffAttributionManager` (AM), a Yjs v14 primitive that tracks the structural diff between them. The AM knows which content in `nextDoc` is an insertion (exists in `nextDoc` but not `currentDoc`) and which is a deletion (exists in `currentDoc` but not `nextDoc`).

**Mode switching.** The AM has a `suggestionOrigins` list. Transaction origins in this list *pass through* from `nextDoc` to `currentDoc` (i.e., are treated as direct edits). Origins not in this list are *blocked*, meaning changes stay only in `nextDoc` and become suggestions.

| Mode | `suggestionOrigins` | Effect |
|------|-------------------|--------|
| Editing | `['gutenberg', 'gutenberg-passthrough']` | All local changes flow through to `currentDoc` |
| Suggesting | `['gutenberg-passthrough']` | Block content changes (`gutenberg` origin) are blocked; passthrough changes (non-block metadata) still flow through |

In addition to powering the mode, this allows us to make decision at the content level about which changes can be suggested and which cannot.

## Data Flow

### Writing (Editor → CRDT)

1. User types in the block editor.
2. `applyPostChangesToCRDTDoc` writes the change to the CRDT document. In suggesting mode, changes are written to **`nextDoc`** using split transaction origins: block content uses `LOCAL_EDITOR_ORIGIN` (blocked by AM), while non-block properties use `LOCAL_EDITOR_PASSTHROUGH_ORIGIN` (passes through).
3. Incoming editor values are run through `stripSuggestionMarkup` before being written to the CRDT, ensuring no decoration artifacts are persisted into the document model.

### Reading (CRDT → Editor)

1. `updateEntityRecord` reads from `nextDoc` when suggestion tracking is active.
2. `serializeWithSuggestions` walks the Yjs data tree, calling `ytext.toDelta(am)` on each `Y.Text` node. The AM-aware delta includes `attribution` metadata on each operation (`{insert: true}` or `{delete: true}`).
3. `extractSuggestionDecorations` processes the serialized HTML: it strips the `<ins>` and `<del>` tags from the content (keeping inserted text, removing deleted text) and extracts character ranges for each suggestion. These ranges are attached to the changes as `__suggestionDecorations`.
4. The sync manager publishes these ranges to the **suggestion decoration store** (`core/suggestion-decorations`), a Redux store keyed by block path and attribute name (e.g., `0:content`).
5. The block editor's format types (`core/suggestion-insert`, `core/suggestion-delete`) read from the decoration store via `__experimentalCreatePrepareEditableTree`. They apply `<ins>` / `<del>` formatting with green/red highlight styling **only in the editable tree** — the RichText component automatically strips these formats before serialization, so the markup never enters the block's saved attributes.

This means the entity record content seen by the editor and the REST API always contains clean HTML. The suggestion highlights exist solely in the view layer.

### Saving (Editor → REST API)

Because the view layer approach keeps suggestion markup out of the entity record, saving requires no special handling under normal operation. As a safety net, `prePersistPostType` checks for any residual `wp-suggestion-` markup and strips it before submission:
- `<ins>` tags are unwrapped (content kept)
- `<del>` tags and their content are removed entirely

This ensures suggestion annotations never persist to the database, even in edge cases.

## Undo/Redo Integration

The `YMultiDocUndoManager` wraps per-doc `Y.UndoManager` instances. When suggestion tracking is active, `nextDoc`'s record map is added to the undo scope so that edits in suggesting mode are undoable.

During undo/redo, suggestion mode is temporarily suspended (`suspendSuggestionMode`) so that undo reversals propagate directly to `currentDoc` rather than creating new counter-suggestions. The per-doc `Y.UndoManager` instance (which Yjs uses as the transaction origin during undo) is added to `am.suggestionOrigins` for the duration of the operation.

## Sync

`nextDoc` is synced via a separate room (`{objectType}:{objectId}:suggestions`) using the same provider infrastructure as `currentDoc`. Awareness is **not** passed to the suggestion room — sharing a single `Awareness` instance across two rooms caused duplicate listeners that emitted spurious leave/rejoin events for the current user on load.

## UI

A "Suggestion mode" toggle is added to the editor's Options (three-dot) menu, gated behind `isCollaborationSupported()`. It presents "Editing" and "Suggesting" radio choices. The selected mode is stored in the `core/core-data` store and forwarded to the sync layer.

## Current Limitations

1. **Cursor position during read-back.** When the editor reads back suggestion markup, it re-renders blocks, which can cause cursor position shifts. This is mitigated with a 150ms debounce on the read-back, but rapid typing at suggestion boundaries may still occasionally produce a brief jump.

2. **Separate sync room.** Each entity with suggestion tracking opens a second sync room. This doubles the number of connections per entity. A future improvement could use Yjs subdocuments to embed `nextDoc` within `currentDoc`, eliminating the extra room.

3. Targets WordPress 6.9 to ensure that Gutenberg's version of the sync server is used. This is needed to ensure that the new `:suggestions` rooms are allowed to sync.

## What Still Needs to Be Done

- **Persist `nextDoc`**: Currently, suggestions are ephemeral and don't survive the session. We should persist `nextDoc` just as we do with `currentDoc` to span sessions and avoid the initialization problem.
	- However, suggestions should probably be considered content. We should consider if suggestions should also live in `post_content` somehow (while still being hidden from the published view).
- **Accept/reject UI.** Methods exist to accept and reject all changes in the `SuggestionManager` but there are no buttons or UI controls to trigger them yet. We additionally need controls to accept and reject individual suggestions.
- **Author attribution UI**: Display the suggesting user's name/avatar next to each suggestion, using a `clientID` → WordPress user ID mapping.
- **Structural suggestion tracking**: Currently, suggested edits are restricted to block rich-text attributes. We should explore suggested edits to block additions, removals, and reordering, as well as other non-block fields like `title`.
- **Subdoc migration** (optional): Replace the separate `:suggestions` room with a Yjs subdocument embedded in `currentDoc` to reduce connection count and simplify persistence.
