### PR TITLE
Real-time Collaboration: Use minimal save payload in persistCRDTDoc

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -260,13 +260,18 @@ export const getEntityRecord =
 										return;
 									}
 
-									// Trigger a save to persist the CRDT document. The entity's
-									// pre-persist hooks will create the persisted CRDT document
-									// and apply it to the record's meta.
+									// Trigger a minimal save to persist the CRDT document. The
+									// entity's pre-persist hooks will create the persisted CRDT
+									// document and apply it to the record's meta.
+									const entityIdKey =
+										entityConfig.key || DEFAULT_ENTITY_KEY;
 									dispatch.saveEntityRecord(
 										kind,
 										name,
-										editedRecord,
+										{
+											[ entityIdKey ]:
+												editedRecord[ entityIdKey ],
+										},
 										{ __unstableSkipSyncUpdate: true }
 									);
 								} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -234,9 +234,14 @@ describe( 'getEntityRecord', () => {
 		expect( dispatch.saveEntityRecord ).not.toHaveBeenCalled();
 	} );
 
-	it( 'persistCRDTDoc fetches edited record and saves full entity record', async () => {
+	it( 'persistCRDTDoc saves only the entity ID and omits REST-invalid fields', async () => {
 		const POST_RECORD = { id: 1, title: 'Test Post', meta: {} };
-		const EDITED_RECORD = { id: 1, title: 'Edited Post', meta: {} };
+		const EDITED_RECORD = {
+			id: 1,
+			title: 'Edited Post',
+			ping_status: '',
+			meta: { _crdt_document: 'doc2' },
+		};
 		const POST_RESPONSE = {
 			json: () => Promise.resolve( POST_RECORD ),
 		};
@@ -283,11 +288,12 @@ describe( 'getEntityRecord', () => {
 			resolveSelectWithSync.getEditedEntityRecord
 		).toHaveBeenCalledWith( 'postType', 'post', 1 );
 
-		// Should have called saveEntityRecord (not saveEditedEntityRecord).
+		// Should only send the entity ID. The pre-persist hook creates the
+		// persisted CRDT meta without round-tripping the full edited record.
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'post',
-			EDITED_RECORD,
+			{ id: 1 },
 			{ __unstableSkipSyncUpdate: true }
 		);
 	} );
@@ -335,11 +341,11 @@ describe( 'getEntityRecord', () => {
 		handlers.persistCRDTDoc();
 		await resolveSelectWithSync.getEditedEntityRecord();
 
-		// Should save the record even with no edits (the whole point of the fix).
+		// Should save only the entity ID even with no edits.
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'post',
-			POST_RECORD,
+			{ id: 1 },
 			{ __unstableSkipSyncUpdate: true }
 		);
 	} );
@@ -437,7 +443,7 @@ describe( 'getEntityRecord', () => {
 		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'post',
-			EDITED_RECORD,
+			{ id: 1 },
 			{ __unstableSkipSyncUpdate: true }
 		);
 		expect( syncManager.update ).toHaveBeenCalledWith(


### PR DESCRIPTION
## What?

Changes `persistCRDTDoc` to call `saveEntityRecord` with only the entity ID, instead of the entire `editedRecord`.

The existing post-type `__unstablePrePersist` hook still creates and attaches `meta._crdt_document` during the save. This keeps the CRDT persistence behavior while avoiding a full entity-record round trip through REST validation.

## Why?

`persistCRDTDoc` currently sends the full entity record back through the REST API on page load. This causes **400 Bad Request** errors when any field in the record doesn't pass strict REST schema validation — even though the post is otherwise valid.

Two real-world examples:

1. **`ping_status: ""`** — WordPress core stores this when the Discussion settings pingback checkbox is unchecked. The REST schema only accepts `"open"` or `"closed"`, so the round-trip fails.
2. **Co-Authors Plus** — Registers a REST field `coauthors` that returns objects, while a taxonomy `rest_base` with the same name expects integers. When the full record is sent back, REST validation rejects the objects.

Both are pre-existing data/schema issues that become visible because `persistCRDTDoc` unnecessarily round-trips the entire edited entity record. It only needs to trigger a save so the pre-persist hook can persist the CRDT document.

## How?

In `packages/core-data/src/resolvers.js`, `persistCRDTDoc` now constructs a minimal save payload containing only the entity ID key. It keeps the current `{ __unstableSkipSyncUpdate: true }` option so the save response is not replayed into the sync document.

The resolver test now covers the regression shape by including `ping_status: ""` on the edited record and asserting that the save payload omits it.

## Testing Instructions

1. Go to **Settings → Discussion**, uncheck "Allow link notifications from other blogs (pingbacks and trackbacks) on new posts", and save.
2. Create and publish a new post.
3. Enable Real-Time Collaboration (**Settings → Writing → Enable real-time collaboration**, or set `wp_collaboration_enabled` to `1`).
4. Open the published post in the block editor.
5. Open DevTools → Network tab.
6. **Before this fix**: A `POST /wp-json/wp/v2/posts/{id}` request can return 400 with `"ping_status is not one of open and closed"`.
7. **After this fix**: The CRDT persistence save is triggered with only the entity ID, and the pre-persist hook adds the CRDT meta without sending unrelated REST-invalid fields.

Focused test run:

```bash
npm run test:unit -- packages/core-data/src/test/resolvers.js --runInBand
```

Result: `PASS` — 36 tests passed.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (claude-opus-4-6), OpenCode (GPT-5.5)
- **Used for:** Bug investigation, drafting the original fix, resolving the branch against current trunk, tightening the regression test, and validating the focused resolver test. The fix logic and test evidence were reviewed by a human contributor.

Closes #77049