### PR TITLE
Fix: ProgressBar animation respects prefers-reduced-motion

### DIFF
--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -80,11 +80,20 @@ export const Indicator = styled.div< {
 						animationIterationCount: 'infinite',
 						animationName: animateProgressBar( isRTL() ),
 					},
+					'@media ( prefers-reduced-motion: reduce )': {
+						animationDuration: '3s',
+						animationTimingFunction: 'steps( 6, end )',
+						animationIterationCount: 'infinite',
+						animationName: animateProgressBar( isRTL() ),
+					},
 			  } )
 			: css( {
 					width: 'var(--indicator-width)',
 					'@media not ( prefers-reduced-motion )': {
 						transition: 'width 0.4s ease-in-out',
+					},
+					'@media ( prefers-reduced-motion: reduce )': {
+						transition: 'width 0.8s steps(6, end)',
 					},
 			  } ) };
 `;

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -73,15 +73,19 @@ export const Indicator = styled.div< {
 	${ ( { isIndeterminate } ) =>
 		isIndeterminate
 			? css( {
-					animationDuration: '1.5s',
-					animationTimingFunction: 'ease-in-out',
-					animationIterationCount: 'infinite',
-					animationName: animateProgressBar( isRTL() ),
 					width: `${ INDETERMINATE_TRACK_WIDTH }%`,
+					'@media not ( prefers-reduced-motion )': {
+						animationDuration: '1.5s',
+						animationTimingFunction: 'ease-in-out',
+						animationIterationCount: 'infinite',
+						animationName: animateProgressBar( isRTL() ),
+					},
 			  } )
 			: css( {
 					width: 'var(--indicator-width)',
-					transition: 'width 0.4s ease-in-out',
+					'@media not ( prefers-reduced-motion )': {
+						transition: 'width 0.4s ease-in-out',
+					},
 			  } ) };
 `;
 


### PR DESCRIPTION
The animation in ProgressBar continued to play even when prefers-reduced-motion was set. This change wraps the animation and transition properties in an '@media not (prefers-reduced-motion)' block to correctly disable them.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76926

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
