### PR TITLE
DataViews: Introduce --wp-dataviews-edge-padding CSS custom property

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DataViews: Introduce `--wp-dataviews-edge-padding` CSS custom property. [#77053](https://github.com/WordPress/gutenberg/pull/77053)
+
 ## 14.0.0 (2026-04-01)
 
 ### Breaking Changes

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -525,6 +525,8 @@ These are the CSS Custom Properties that can be used to tweak the appearance of 
 
 `--wp-dataviews-color-background`: sets the background color.
 
+`--wp-dataviews-edge-padding`: sets the horizontal edge padding for all layouts (header, footer, grid, table, list, activity). Defaults to `24px`.
+
 ### Composition modes
 
 The `DataViews` component supports two composition modes:

--- a/packages/dataviews/src/components/dataviews-footer/style.scss
+++ b/packages/dataviews/src/components/dataviews-footer/style.scss
@@ -8,7 +8,7 @@
 	bottom: 0;
 	left: 0;
 	background-color: inherit;
-	padding: $grid-unit-15 $grid-unit-30;
+	padding: $grid-unit-15 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 	border-top: $border-width solid $gray-100;
 	flex-shrink: 0;
 

--- a/packages/dataviews/src/components/dataviews-layouts/activity/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/style.scss
@@ -4,7 +4,7 @@
 
 .dataviews-view-activity {
 	margin: 0 0 auto;
-	padding: $grid-unit-10 $grid-unit-30;
+	padding: 0 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 
 	.dataviews-view-activity__group-header {
 		font-size: $font-size-large;
@@ -104,7 +104,7 @@
 	.dataviews-view-activity__item {
 		&.is-compact {
 			.dataviews-view-activity__item-type {
-				width: $grid-unit-10;
+				width: $grid-unit-15;
 
 				&::before {
 					height: $grid-unit-15;

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -6,7 +6,7 @@
 @use "../../../dataviews/style" as *;
 
 .dataviews-view-grid {
-	padding: 0 $grid-unit-30 $grid-unit-30;
+	padding: 0 var(--wp-dataviews-edge-padding, #{$grid-unit-30}) $grid-unit-30;
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-30;
@@ -258,6 +258,6 @@
 	font-weight: $font-weight-medium;
 	color: $gray-900;
 	margin: 0 0 $grid-unit-10 0;
-	padding: 0 $grid-unit-30;
+	padding: 0 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 	container-type: inline-size;
 }

--- a/packages/dataviews/src/components/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/list/style.scss
@@ -16,7 +16,7 @@ div.dataviews-view-list {
 
 		.dataviews-view-list__item-wrapper {
 			position: relative;
-			padding: $grid-unit-20 $grid-unit-30;
+			padding: $grid-unit-20 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 			box-sizing: border-box;
 		}
 
@@ -211,7 +211,7 @@ div.dataviews-view-list {
 	&.has-compact-density {
 		div[role="row"] {
 			.dataviews-view-list__item-wrapper {
-				padding: $grid-unit-10 $grid-unit-30;
+				padding: $grid-unit-10 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 			}
 
 			.dataviews-view-list__title-field {
@@ -239,7 +239,7 @@ div.dataviews-view-list {
 	&.has-comfortable-density {
 		div[role="row"] {
 			.dataviews-view-list__item-wrapper {
-				padding: $grid-unit-30 $grid-unit-30;
+				padding: $grid-unit-30 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 			}
 
 			.dataviews-view-list__title-field {
@@ -274,5 +274,5 @@ div.dataviews-view-list {
 	font-weight: $font-weight-medium;
 	color: $gray-900;
 	margin: 0 0 $grid-unit-10 0;
-	padding: 0 $grid-unit-30;
+	padding: 0 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 }

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -62,12 +62,12 @@
 
 		td:first-child,
 		th:first-child {
-			padding-left: $grid-unit-30;
+			padding-left: var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 		}
 
 		td:last-child,
 		th:last-child {
-			padding-right: $grid-unit-30;
+			padding-right: var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 		}
 
 		&:last-child {
@@ -168,13 +168,13 @@
 			}
 
 			&:has(.dataviews-view-table-header-button):first-child {
-				// Table cell padding minus the header button padding.
-				padding-left: $grid-unit-20;
+				// Edge padding minus the header button padding.
+				padding-left: calc(var(--wp-dataviews-edge-padding, #{$grid-unit-30}) - #{$grid-unit-10});
 			}
 
 			&:has(.dataviews-view-table-header-button):last-child {
-				// Table cell padding minus the header button padding.
-				padding-right: $grid-unit-20;
+				// Edge padding minus the header button padding.
+				padding-right: calc(var(--wp-dataviews-edge-padding, #{$grid-unit-30}) - #{$grid-unit-10});
 			}
 		}
 	}
@@ -315,7 +315,7 @@
 .dataviews-view-table__group-header-row {
 	.dataviews-view-table__group-header-cell {
 		font-weight: $font-weight-medium;
-		padding: $grid-unit-15 $grid-unit-30;
+		padding: $grid-unit-15 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 		color: $gray-900;
 	}
 }

--- a/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.scss
@@ -6,7 +6,7 @@
 	gap: $grid-unit-30;
 	grid-template-rows: max-content;
 	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-	padding: 0 $grid-unit-30 $grid-unit-30;
+	padding: 0 var(--wp-dataviews-edge-padding, #{$grid-unit-30}) $grid-unit-30;
 	container-type: inline-size;
 
 	@media not (prefers-reduced-motion) {

--- a/packages/dataviews/src/dataviews/style.scss
+++ b/packages/dataviews/src/dataviews/style.scss
@@ -29,7 +29,7 @@
 .dataviews__view-actions,
 .dataviews-filters__container {
 	box-sizing: border-box;
-	padding: $grid-unit-20 $grid-unit-30;
+	padding: $grid-unit-20 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 	flex-shrink: 0;
 	position: sticky;
 	left: 0;
@@ -42,7 +42,7 @@
 
 .dataviews-no-results,
 .dataviews-loading {
-	padding: 0 $grid-unit-30;
+	padding: 0 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 	flex-grow: 1;
 	display: flex;
 	align-items: center;
@@ -75,7 +75,7 @@
 @container (max-width: 430px) {
 	.dataviews__view-actions,
 	.dataviews-filters__container {
-		padding: $grid-unit-15 $grid-unit-30;
+		padding: $grid-unit-15 var(--wp-dataviews-edge-padding, #{$grid-unit-30});
 	}
 }
 

--- a/packages/editor/src/components/post-revisions-panel/style.scss
+++ b/packages/editor/src/components/post-revisions-panel/style.scss
@@ -1,4 +1,8 @@
+@use "@wordpress/base-styles/variables" as *;
+
 .editor-post-revisions-panel {
+	--wp-dataviews-edge-padding: 0;
+
 	.editor-post-revisions-panel__view-all {
 		justify-content: center;
 	}

--- a/packages/editor/src/components/post-revisions-panel/style.scss
+++ b/packages/editor/src/components/post-revisions-panel/style.scss
@@ -1,5 +1,3 @@
-@use "@wordpress/base-styles/variables" as *;
-
 .editor-post-revisions-panel {
 	--wp-dataviews-edge-padding: 0;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

 DataViews components currently hardcode `$grid-unit-30` (24px) as horizontal edge padding independently across ~8 SCSS files. This makes it impossible for consumers to adjust edge padding without CSS overrides.                                                                                                       
   
  - Introduces `--wp-dataviews-edge-padding` CSS custom property to allow consumers to override horizontal edge padding across all DataViews layouts (grid, table, list, activity, header, footer).                                                                                                                     
  - Follows the same pattern as `--wp-dataviews-color-background`: consumed with an inline fallback (`var(--wp-dataviews-edge-padding, 24px)`), not defined on  the wrapper — consumers set it on any ancestor.       

## Prior art
There were huge discussions around padding which had let to just [reducing the default padding
](https://github.com/WordPress/gutenberg/pull/73334). While this PR doesn't remove the default existing padding, it adds a way for consumers to control this value easily.

## Testing Instructions
1. Verify all layouts (grid, table, list, activity) at all densities look unchanged (default fallback matches previous value)                          
2. Test consumer override: set `--wp-dataviews-edge-padding: 0` on a parent element and verify all edge padding disappears uniformly

## Notes

I'll extract the vertical padding and one bug from `activity` layout in a separate PR





### Example with `Revisions panel` under `Expand Editor Inspector` experiment
|Before|After|
|-|-|
|<img width="282" height="374" alt="Screenshot 2026-04-06 at 1 39 30 PM" src="https://github.com/user-attachments/assets/adb7aa81-39d4-44fc-add1-8af8e8388600" />|<img width="282" height="358" alt="Screenshot 2026-04-06 at 1 36 39 PM" src="https://github.com/user-attachments/assets/5fd2cadc-2d55-4360-8677-c86bc2fff527" />|

## Use of AI Tools
Claude Code (Claude Opus 4.6) was used to assist with implementation, code exploration, etc.
