### PR TITLE
DataViews: Fix `compact` density clipping and remove top/bottom padding

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - DataForm: support `isDisabled` field property. [#77090](https://github.com/WordPress/gutenberg/pull/77090)
 
+### Bug Fixes
+
+- DataViews: Fix `compact` density clipping and remove top/bottom padding. [#77054](https://github.com/WordPress/gutenberg/pull/77054)
+
 ## 14.0.0 (2026-04-01)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-layouts/activity/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/style.scss
@@ -4,7 +4,7 @@
 
 .dataviews-view-activity {
 	margin: 0 0 auto;
-	padding: $grid-unit-10 $grid-unit-30;
+	padding: 0 $grid-unit-30;
 
 	.dataviews-view-activity__group-header {
 		font-size: $font-size-large;
@@ -104,7 +104,7 @@
 	.dataviews-view-activity__item {
 		&.is-compact {
 			.dataviews-view-activity__item-type {
-				width: $grid-unit-10;
+				width: $grid-unit-15;
 
 				&::before {
 					height: $grid-unit-15;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from: https://github.com/WordPress/gutenberg/pull/77053

There is a bug in `activity` layout when `density:compact` that is not visible right now because of the default left-padding that is used. The `dataviews-view-activity__item-type` is set to `8px` but the `dataviews-view-activity__item-type-icon` is set to `11px` making it overflow the container. 

If we had zero padding in the activity layout container (which is updated in https://github.com/WordPress/gutenberg/pull/77053) the icons is clipped. This PR fixes that by making both widths match. 

Additionally I'm removing the top/bottom padding of the layout, as it doesn't seem to be something layouts should do. It's optional to this PR though and could be removed to scope down further.

## Testing Instructions
1. You have to set the padding of the activity layout to zero and select the `compact` density option.
2. In this PR there is no clipping.




## Screenshots or screencast <!-- if applicable -->

Since we don't have a current usage with zero padding, I'm sharing some screenshots that have the padding zeroed out and using the `compact` density.

|Before|After|
|-|-|
|<img width="282" height="374" alt="Screenshot 2026-04-08 at 9 48 17 AM" src="https://github.com/user-attachments/assets/f58151d8-04ff-4740-9555-59956bbe65cd" />|<img width="282" height="358" alt="Screenshot 2026-04-06 at 1 36 39 PM" src="https://github.com/user-attachments/assets/5fd2cadc-2d55-4360-8677-c86bc2fff527" />|
