### PR TITLE
Tests: Fix wp-env scripts not found in test workspaces

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ const config = defineConfig( {
 	...baseConfig,
 	webServer: {
 		...baseConfig.webServer,
-		command: 'npm run wp-env-test -- start',
+		command: 'npm run --prefix ../.. wp-env-test -- start',
 	},
 	reporter: process.env.CI
 		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ], [ 'blob' ] ]

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -14,6 +14,10 @@ process.env.ASSETS_PATH = path.join( __dirname, 'assets' );
 
 const config = defineConfig( {
 	...baseConfig,
+	webServer: {
+		...baseConfig.webServer,
+		command: 'npm run --prefix ../.. wp-env -- start',
+	},
 	reporter: [ [ 'list' ], [ './config/performance-reporter.ts' ] ],
 	forbidOnly: !! process.env.CI,
 	fullyParallel: false,


### PR DESCRIPTION
## What?

Follow-up fix to #74684.

After converting test directories to workspaces, running `npm run test:e2e` locally fails with `Missing script: "wp-env-test"`.

## Why?

Playwright's `webServer.command` runs `npm run wp-env-test -- start`, but `wp-env-test` is only defined in the root `package.json`. When npm executes the test command from the workspace directory (`test/e2e/`), it can't find the script.

The same issue affects `test/performance/`, where the base Playwright config's `npm run wp-env start` would also fail from the workspace context.

## How?

Use `npm run --prefix ../..` to explicitly run the root-level wp-env scripts from the workspace directories:

- `test/e2e/playwright.config.ts`: `npm run --prefix ../.. wp-env-test -- start`
- `test/performance/playwright.config.ts`: `npm run --prefix ../.. wp-env -- start`

## Testing Instructions

1. `npm run test:e2e` — should no longer fail with "Missing script: wp-env-test"
   - Requires `wp-env` running (`npm run wp-env-test -- start`)