### PR TITLE
Reduce RTC Polling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"java.compile.nullAnalysis.mode": "automatic"
+}

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -64,7 +64,7 @@ A provider is a transport layer that syncs Yjs document updates between peers. T
 
 The default provider (`src/providers/http-polling/`) uses HTTP polling to exchange updates with a central sync server. A shared polling manager batches updates for all rooms (entities) into a single request per poll cycle. See [the HTTP polling README](./src/providers/http-polling/README.md) for full details including the REST API format, sync protocol, and compaction.
 
--   Poll interval: 1 second when editing alone, 250ms when collaborators are detected.
+-   Poll interval: 4 seconds when editing alone, 1 second when collaborators are detected, with slower polling on 3g/2g connections when the Network Information API is available.
 -   On errors, the interval backs off exponentially (up to 30 seconds).
 -   Awareness state is sent and received alongside document updates in the same poll request.
 

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -64,7 +64,7 @@ A provider is a transport layer that syncs Yjs document updates between peers. T
 
 The default provider (`src/providers/http-polling/`) uses HTTP polling to exchange updates with a central sync server. A shared polling manager batches updates for all rooms (entities) into a single request per poll cycle. See [the HTTP polling README](./src/providers/http-polling/README.md) for full details including the REST API format, sync protocol, and compaction.
 
--   Poll interval: 4 seconds when editing alone, 1 second when collaborators are detected, with slower polling on 3g/2g connections when the Network Information API is available.
+-   Poll interval: 4 seconds when editing alone, 1 second when collaborators are detected, with slower polling on 3g/2g connections when the Network Information API is available and an RTT-based fallback for browsers that do not expose that API.
 -   On errors, the interval backs off exponentially (up to 30 seconds).
 -   Awareness state is sent and received alongside document updates in the same poll request.
 

--- a/packages/sync/src/providers/http-polling/README.md
+++ b/packages/sync/src/providers/http-polling/README.md
@@ -83,7 +83,8 @@ The polling manager runs continuously:
 
 - **Solo editing**: 4000ms interval, queue paused (no updates sent)
 - **With collaborators**: 1000ms interval, queue active
-- **Slower cellular links**: active-tab polling is widened on `3g`, `2g`, and `slow-2g`, capped at 25000ms to stay below the server-side awareness timeout
+- **Chromium hint**: active-tab polling is widened on `3g`, `2g`, and `slow-2g` when `navigator.connection.effectiveType` is available
+- **Cross-browser fallback**: when the Network Information API is unavailable, the last 3 successful poll RTTs are averaged and polling widens at `500ms` (`4x`) and `1500ms` (`10x`), capped at 25000ms to stay below the server-side awareness timeout
 
 Each poll cycle:
 
@@ -121,7 +122,7 @@ Awareness state (presence, cursors) is synchronized alongside document updates:
 - **Integrated endpoint**: Awareness travels with each sync request
 - **Automatic expiration**: Clients that haven't polled in 30 seconds are removed
 - **Collaborator detection**: When awareness shows multiple clients, polling speeds up
-- **Network-aware backoff**: Chromium browsers can widen polling when the reported connection type degrades
+- **Network-aware backoff**: Chromium browsers can widen polling from `effectiveType`, and other browsers can widen polling after several slow successful requests
 
 ## REST API
 
@@ -249,7 +250,7 @@ All CRDT operations happen in the browser via Yjs.
 
 ### Polling Latency
 
-Updates are not instant; there's inherent latency from the polling interval (typically 1000ms with collaborators, slower on constrained connections). This is acceptable for document editing but may not suit real-time cursor tracking at high fidelity.
+Updates are not instant; there's inherent latency from the polling interval (typically 1000ms with collaborators, slower on constrained connections or after sustained high RTT). This is acceptable for document editing but may not suit real-time cursor tracking at high fidelity.
 
 ### Single Compactor
 

--- a/packages/sync/src/providers/http-polling/README.md
+++ b/packages/sync/src/providers/http-polling/README.md
@@ -81,8 +81,9 @@ const provider = new HttpPollingProvider( {
 
 The polling manager runs continuously:
 
-- **Solo editing**: 1000ms interval, queue paused (no updates sent)
-- **With collaborators**: 250ms interval, queue active
+- **Solo editing**: 4000ms interval, queue paused (no updates sent)
+- **With collaborators**: 1000ms interval, queue active
+- **Slower cellular links**: active-tab polling is widened on `3g`, `2g`, and `slow-2g`, capped at 25000ms to stay below the server-side awareness timeout
 
 Each poll cycle:
 
@@ -120,6 +121,7 @@ Awareness state (presence, cursors) is synchronized alongside document updates:
 - **Integrated endpoint**: Awareness travels with each sync request
 - **Automatic expiration**: Clients that haven't polled in 30 seconds are removed
 - **Collaborator detection**: When awareness shows multiple clients, polling speeds up
+- **Network-aware backoff**: Chromium browsers can widen polling when the reported connection type degrades
 
 ## REST API
 
@@ -247,7 +249,7 @@ All CRDT operations happen in the browser via Yjs.
 
 ### Polling Latency
 
-Updates are not instant; there's inherent latency from the polling interval (250ms with collaborators). This is acceptable for document editing but may not suit real-time cursor tracking at high fidelity.
+Updates are not instant; there's inherent latency from the polling interval (typically 1000ms with collaborators, slower on constrained connections). This is acceptable for document editing but may not suit real-time cursor tracking at high fidelity.
 
 ### Single Compactor
 

--- a/packages/sync/src/providers/http-polling/latency-info.ts
+++ b/packages/sync/src/providers/http-polling/latency-info.ts
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import { POLLING_INTERVAL_BACKGROUND_TAB_IN_MS } from './config';
+
+const MEDIUM_RTT_THRESHOLD_IN_MS = 500;
+const SLOW_RTT_THRESHOLD_IN_MS = 1500;
+const SUCCESSFUL_POLL_SAMPLE_SIZE = 3;
+
+const successfulPollDurationsInMs: number[] = [];
+
+function getIntervalMultiplierFromAverageRtt( averageRttInMs: number ): number {
+	if ( averageRttInMs >= SLOW_RTT_THRESHOLD_IN_MS ) {
+		return 10;
+	}
+
+	if ( averageRttInMs >= MEDIUM_RTT_THRESHOLD_IN_MS ) {
+		return 4;
+	}
+
+	return 1;
+}
+
+export function clearSuccessfulPollDurations(): void {
+	successfulPollDurationsInMs.splice( 0, successfulPollDurationsInMs.length );
+}
+
+export function getLatencyAwarePollingInterval( baseInterval: number ): number {
+	if ( successfulPollDurationsInMs.length < SUCCESSFUL_POLL_SAMPLE_SIZE ) {
+		return baseInterval;
+	}
+
+	const averageRttInMs =
+		successfulPollDurationsInMs.reduce(
+			( sum, durationInMs ) => sum + durationInMs,
+			0
+		) / successfulPollDurationsInMs.length;
+
+	return Math.min(
+		baseInterval * getIntervalMultiplierFromAverageRtt( averageRttInMs ),
+		POLLING_INTERVAL_BACKGROUND_TAB_IN_MS
+	);
+}
+
+export function recordSuccessfulPollDuration( durationInMs: number ): void {
+	successfulPollDurationsInMs.push( durationInMs );
+
+	if ( successfulPollDurationsInMs.length > SUCCESSFUL_POLL_SAMPLE_SIZE ) {
+		successfulPollDurationsInMs.shift();
+	}
+}

--- a/packages/sync/src/providers/http-polling/network-info.ts
+++ b/packages/sync/src/providers/http-polling/network-info.ts
@@ -1,0 +1,80 @@
+/**
+ * Internal dependencies
+ */
+import { POLLING_INTERVAL_BACKGROUND_TAB_IN_MS } from './config';
+
+type EffectiveConnectionType = 'slow-2g' | '2g' | '3g' | '4g';
+
+interface NetworkInformationLike {
+	effectiveType?: EffectiveConnectionType;
+	addEventListener?: ( type: 'change', listener: () => void ) => void;
+	removeEventListener?: ( type: 'change', listener: () => void ) => void;
+}
+
+interface NavigatorWithConnection extends Navigator {
+	connection?: NetworkInformationLike;
+}
+
+function getNetworkInformation(): NetworkInformationLike | undefined {
+	if ( typeof navigator === 'undefined' ) {
+		return;
+	}
+
+	return ( navigator as NavigatorWithConnection ).connection;
+}
+
+function getIntervalMultiplier(
+	effectiveType?: EffectiveConnectionType
+): number {
+	switch ( effectiveType ) {
+		case '3g':
+			return 4;
+		case '2g':
+		case 'slow-2g':
+			return 10;
+		default:
+			return 1;
+	}
+}
+
+/**
+ * Slow active-tab polling on slower cellular links without exceeding the
+ * background-tab interval. This keeps awareness updates below the server's
+ * 30 second timeout while still reducing polling frequency substantially.
+ *
+ * @param baseInterval Base polling interval in milliseconds.
+ * @return Network-aware polling interval in milliseconds.
+ */
+export function getNetworkAwarePollingInterval( baseInterval: number ): number {
+	const connection = getNetworkInformation();
+
+	if ( ! connection ) {
+		return baseInterval;
+	}
+
+	return Math.min(
+		baseInterval * getIntervalMultiplier( connection.effectiveType ),
+		POLLING_INTERVAL_BACKGROUND_TAB_IN_MS
+	);
+}
+
+/**
+ * Subscribe to connection changes when the Network Information API is
+ * available. Returns an unsubscribe callback when a listener is registered.
+ *
+ * @param listener Callback invoked when the connection type changes.
+ * @return Unsubscribe callback, if supported.
+ */
+export function subscribeToNetworkChanges(
+	listener: () => void
+): ( () => void ) | undefined {
+	const connection = getNetworkInformation();
+
+	if ( ! connection?.addEventListener || ! connection.removeEventListener ) {
+		return;
+	}
+
+	connection.addEventListener( 'change', listener );
+
+	return () => connection.removeEventListener!( 'change', listener );
+}

--- a/packages/sync/src/providers/http-polling/network-info.ts
+++ b/packages/sync/src/providers/http-polling/network-info.ts
@@ -23,6 +23,10 @@ function getNetworkInformation(): NetworkInformationLike | undefined {
 	return ( navigator as NavigatorWithConnection ).connection;
 }
 
+export function hasEffectiveConnectionTypeSupport(): boolean {
+	return 'string' === typeof getNetworkInformation()?.effectiveType;
+}
+
 function getIntervalMultiplier(
 	effectiveType?: EffectiveConnectionType
 ): number {
@@ -48,7 +52,7 @@ function getIntervalMultiplier(
 export function getNetworkAwarePollingInterval( baseInterval: number ): number {
 	const connection = getNetworkInformation();
 
-	if ( ! connection ) {
+	if ( 'string' !== typeof connection?.effectiveType ) {
 		return baseInterval;
 	}
 
@@ -70,7 +74,11 @@ export function subscribeToNetworkChanges(
 ): ( () => void ) | undefined {
 	const connection = getNetworkInformation();
 
-	if ( ! connection?.addEventListener || ! connection.removeEventListener ) {
+	if (
+		'string' !== typeof connection?.effectiveType ||
+		! connection.addEventListener ||
+		! connection.removeEventListener
+	) {
 		return;
 	}
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -44,8 +44,14 @@ import {
 } from './utils';
 import {
 	getNetworkAwarePollingInterval,
+	hasEffectiveConnectionTypeSupport,
 	subscribeToNetworkChanges,
 } from './network-info';
+import {
+	clearSuccessfulPollDurations,
+	getLatencyAwarePollingInterval,
+	recordSuccessfulPollDuration,
+} from './latency-info';
 
 const POLLING_MANAGER_ORIGIN = 'polling-manager';
 
@@ -314,6 +320,14 @@ let pollInterval = POLLING_INTERVAL_IN_MS;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
 let unsubscribeFromNetworkChanges: ( () => void ) | null = null;
 
+function getCurrentTimeInMs(): number {
+	if ( typeof performance !== 'undefined' ) {
+		return performance.now();
+	}
+
+	return Date.now();
+}
+
 /**
  * Mark that a page unload has been requested. This fires on
  * `beforeunload` which happens before the browser aborts in-flight
@@ -396,7 +410,11 @@ function getPollIntervalForCurrentState(): number {
 		? POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS
 		: POLLING_INTERVAL_IN_MS;
 
-	return getNetworkAwarePollingInterval( baseInterval );
+	if ( hasEffectiveConnectionTypeSupport() ) {
+		return getNetworkAwarePollingInterval( baseInterval );
+	}
+
+	return getLatencyAwarePollingInterval( baseInterval );
 }
 
 /**
@@ -450,9 +468,18 @@ function poll(): void {
 				} )
 			),
 		};
+		const hasNetworkInformationSupport =
+			hasEffectiveConnectionTypeSupport();
+		const pollStartedAtInMs = getCurrentTimeInMs();
 
 		try {
 			const { rooms } = await postSyncUpdate( payload );
+
+			if ( ! hasNetworkInformationSupport ) {
+				recordSuccessfulPollDuration(
+					getCurrentTimeInMs() - pollStartedAtInMs
+				);
+			}
 
 			// Emit 'connected' status.
 			roomStates.forEach( ( state ) => {
@@ -755,6 +782,7 @@ function unregisterRoom( room: string ): void {
 		unsubscribeFromNetworkChanges = null;
 		areListenersRegistered = false;
 		hasCheckedConnectionLimit = false;
+		clearSuccessfulPollDurations();
 	}
 }
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -42,6 +42,10 @@ import {
 	postSyncUpdate,
 	postSyncUpdateNonBlocking,
 } from './utils';
+import {
+	getNetworkAwarePollingInterval,
+	subscribeToNetworkChanges,
+} from './network-info';
 
 const POLLING_MANAGER_ORIGIN = 'polling-manager';
 
@@ -305,8 +309,10 @@ let hasCollaborators = false;
 let isActiveBrowser = 'visible' === document.visibilityState;
 let isPolling = false;
 let isUnloadPending = false;
+let isPollBackoffPending = false;
 let pollInterval = POLLING_INTERVAL_IN_MS;
 let pollingTimeoutId: ReturnType< typeof setTimeout > | null = null;
+let unsubscribeFromNetworkChanges: ( () => void ) | null = null;
 
 /**
  * Mark that a page unload has been requested. This fires on
@@ -373,6 +379,40 @@ function handleVisibilityChange() {
 			poll();
 		}
 	}
+}
+
+/**
+ * Calculate the appropriate polling interval based on tab visibility,
+ * collaborator presence, and network conditions.
+ *
+ * @return The polling interval in milliseconds.
+ */
+function getPollIntervalForCurrentState(): number {
+	if ( ! isActiveBrowser ) {
+		return POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
+	}
+
+	const baseInterval = hasCollaborators
+		? POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS
+		: POLLING_INTERVAL_IN_MS;
+
+	return getNetworkAwarePollingInterval( baseInterval );
+}
+
+/**
+ * Handle changes in network connection type (e.g., switching from WiFi to 3G).
+ * Recalculates and reschedules the next poll with the updated interval.
+ */
+function handleNetworkChange(): void {
+	// Don't interrupt error backoff or in-flight requests
+	if ( isPollBackoffPending || ! pollingTimeoutId ) {
+		return;
+	}
+
+	// Reschedule the next poll with the new network-aware interval
+	clearTimeout( pollingTimeoutId );
+	pollInterval = getPollIntervalForCurrentState();
+	pollingTimeoutId = setTimeout( poll, pollInterval );
 }
 
 function poll(): void {
@@ -491,19 +531,15 @@ function poll(): void {
 			} );
 
 			// Recalculate polling interval.
-			if ( isActiveBrowser && hasCollaborators ) {
-				pollInterval = POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS;
-			} else if ( isActiveBrowser ) {
-				pollInterval = POLLING_INTERVAL_IN_MS;
-			} else {
-				pollInterval = POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
-			}
+			pollInterval = getPollIntervalForCurrentState();
+			isPollBackoffPending = false;
 		} catch ( error ) {
 			// Exponential backoff on error: double the backoff time, up to max
 			pollInterval = Math.min(
 				pollInterval * 2,
 				MAX_ERROR_BACKOFF_IN_MS
 			);
+			isPollBackoffPending = true;
 
 			// Recover from the failed request. We don't know whether the server stored
 			// our updates before the error occurred (e.g. a network timeout after a
@@ -678,6 +714,8 @@ function registerRoom( {
 		window.addEventListener( 'beforeunload', handleBeforeUnload );
 		window.addEventListener( 'pagehide', handlePageHide );
 		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		unsubscribeFromNetworkChanges =
+			subscribeToNetworkChanges( handleNetworkChange ) ?? null;
 		areListenersRegistered = true;
 	}
 
@@ -713,6 +751,8 @@ function unregisterRoom( room: string ): void {
 			'visibilitychange',
 			handleVisibilityChange
 		);
+		unsubscribeFromNetworkChanges?.();
+		unsubscribeFromNetworkChanges = null;
 		areListenersRegistered = false;
 		hasCheckedConnectionLimit = false;
 	}

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -107,6 +107,40 @@ function simulateVisibilityChange( state: string ) {
 	document.dispatchEvent( new Event( 'visibilitychange' ) );
 }
 
+function mockNetworkConnection(
+	effectiveType: 'slow-2g' | '2g' | '3g' | '4g'
+) {
+	const listeners = new Set< () => void >();
+	const connection = {
+		effectiveType,
+		addEventListener: jest.fn(
+			( _type: 'change', listener: () => void ) => {
+				listeners.add( listener );
+			}
+		),
+		removeEventListener: jest.fn(
+			( _type: 'change', listener: () => void ) => {
+				listeners.delete( listener );
+			}
+		),
+	};
+
+	Object.defineProperty( navigator, 'connection', {
+		configurable: true,
+		value: connection,
+	} );
+
+	return {
+		connection,
+		setEffectiveType( nextEffectiveType: typeof effectiveType ) {
+			connection.effectiveType = nextEffectiveType;
+		},
+		dispatchChange() {
+			listeners.forEach( ( listener ) => listener() );
+		},
+	};
+}
+
 const syncResponse = {
 	rooms: [
 		{
@@ -149,6 +183,7 @@ describe( 'polling-manager', () => {
 			configurable: true,
 			get: () => 'visible',
 		} );
+		delete ( navigator as Navigator & { connection?: unknown } ).connection;
 	} );
 
 	describe( 'document size limit', () => {
@@ -969,6 +1004,80 @@ describe( 'polling-manager', () => {
 
 			// Should trigger an immediate repoll (not wait for timeout).
 			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+
+	describe( 'network-aware polling', () => {
+		it( 'slows active polling on 3g connections', async () => {
+			mockNetworkConnection( '3g' );
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 15999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'caps slow-network polling below the awareness timeout', async () => {
+			mockNetworkConnection( 'slow-2g' );
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 24999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'reschedules pending polling when the connection changes', async () => {
+			const network = mockNetworkConnection( '4g' );
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			network.setEffectiveType( '3g' );
+			network.dispatchChange();
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 12001 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -141,12 +141,40 @@ function mockNetworkConnection(
 	};
 }
 
+function mockPerformanceNowForPolls(
+	polls: Array< { duration: number; success?: boolean } >
+) {
+	let now = 0;
+	const values = polls.flatMap( ( { duration, success = true } ) => {
+		const start = now;
+		now += duration;
+
+		return success ? [ start, now ] : [ start ];
+	} );
+
+	return jest.spyOn( performance, 'now' ).mockImplementation( () => {
+		const next = values.shift();
+		return undefined === next ? now : next;
+	} );
+}
+
 const syncResponse = {
 	rooms: [
 		{
 			room: 'test-room',
 			end_cursor: 1,
 			awareness: {},
+			updates: [],
+		},
+	],
+};
+
+const syncResponseWithCollaborators = {
+	rooms: [
+		{
+			room: 'test-room',
+			end_cursor: 1,
+			awareness: { 1: {}, 2: {} },
 			updates: [],
 		},
 	],
@@ -177,6 +205,7 @@ describe( 'polling-manager', () => {
 	} );
 
 	afterEach( () => {
+		jest.restoreAllMocks();
 		jest.clearAllTimers();
 		jest.useRealTimers();
 		Object.defineProperty( document, 'visibilityState', {
@@ -1009,6 +1038,333 @@ describe( 'polling-manager', () => {
 	} );
 
 	describe( 'network-aware polling', () => {
+		it( 'keeps the base interval until three successful polls exist when network info is unavailable', async () => {
+			mockPerformanceNowForPolls( [
+				{ duration: 600 },
+				{ duration: 600 },
+				{ duration: 600 },
+				{ duration: 600 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 15999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+		} );
+
+		it( 'widens collaborator polling to 10x after three very slow successful polls without network info', async () => {
+			mockPerformanceNowForPolls( [
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue(
+				syncResponseWithCollaborators
+			);
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 9999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+		} );
+
+		it( 'returns to the base collaborator interval after three newer fast successful polls', async () => {
+			mockPerformanceNowForPolls( [
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 400 },
+				{ duration: 400 },
+				{ duration: 400 },
+				{ duration: 400 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue(
+				syncResponseWithCollaborators
+			);
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 9999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 5 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 5 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 6 );
+
+			await jest.advanceTimersByTimeAsync( 999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 6 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 7 );
+		} );
+
+		it( 'uses the Network Information API when available even if successful polls are slow', async () => {
+			mockNetworkConnection( '4g' );
+			mockPerformanceNowForPolls( [
+				{ duration: 2000 },
+				{ duration: 2000 },
+				{ duration: 2000 },
+				{ duration: 2000 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+		} );
+
+		it( 'does not count failed polls toward RTT fallback and keeps error backoff unchanged', async () => {
+			mockPerformanceNowForPolls( [
+				{ duration: 600 },
+				{ duration: 600 },
+				{ duration: 600, success: false },
+				{ duration: 600 },
+				{ duration: 600 },
+			] );
+			mockPostSyncUpdate
+				.mockResolvedValueOnce( syncResponse )
+				.mockResolvedValueOnce( syncResponse )
+				.mockRejectedValueOnce( new Error( 'timeout' ) )
+				.mockResolvedValueOnce( syncResponse )
+				.mockResolvedValueOnce( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 7999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 15999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 5 );
+		} );
+
+		it( 'uses the background-tab interval while hidden even when RTT fallback is active', async () => {
+			mockPerformanceNowForPolls( [
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+			] );
+			const deferred = createDeferred< SyncResponse >();
+			mockPostSyncUpdate
+				.mockResolvedValueOnce( syncResponseWithCollaborators )
+				.mockResolvedValueOnce( syncResponseWithCollaborators )
+				.mockResolvedValueOnce( syncResponseWithCollaborators )
+				.mockReturnValueOnce( deferred.promise )
+				.mockResolvedValue( syncResponseWithCollaborators );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 10000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			simulateVisibilityChange( 'hidden' );
+			deferred.resolve( syncResponseWithCollaborators );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			await jest.advanceTimersByTimeAsync( 24999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 5 );
+		} );
+
+		it( 'clears RTT history when the final room unregisters', async () => {
+			mockPerformanceNowForPolls( [
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 1600 },
+				{ duration: 100 },
+				{ duration: 100 },
+			] );
+			mockPostSyncUpdate.mockResolvedValue( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'first-room',
+				doc: createMockDoc(),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			pollingManager.unregisterRoom( 'first-room' );
+
+			pollingManager.registerRoom( {
+				room: 'second-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 24999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 3999 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 4 );
+
+			await jest.advanceTimersByTimeAsync( 1 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 5 );
+		} );
+
 		it( 'slows active polling on 3g connections', async () => {
 			mockNetworkConnection( '3g' );
 			mockPostSyncUpdate.mockResolvedValue( syncResponse );


### PR DESCRIPTION

Closes #76631 
<!-- In a few words, what is the PR actually doing? -->

## Why?
## High-level implementation overview

This update adds **adaptive RTC polling** for the HTTP polling transport using two signals:

1. **Network Information API** when available (`navigator.connection.effectiveType`)
2. **Observed poll RTT fallback** when that API is not available (Firefox, Safari, iOS browsers)

The goal is to reduce unnecessary polling on slower networks without changing the existing polling model or interfering with error backoff / background-tab behavior.

### 1. Network Information API path

For browsers that expose `navigator.connection.effectiveType`, we use it as an immediate hint for active-tab polling.

Implemented in:

-   `packages/sync/src/providers/http-polling/network-info.ts`
-   `packages/sync/src/providers/http-polling/polling-manager.ts`

What changed:

-   Added feature detection for `navigator.connection?.effectiveType`
-   Kept the existing multiplier logic:
    -   `4g` -> `1x`
    -   `3g` -> `4x`
    -   `2g` / `slow-2g` -> `10x`
-   Continued capping active-tab polling at `25000ms` so awareness stays below the server timeout
-   Kept support for the `change` event so pending polling can be rescheduled if the browser reports a new connection type mid-session

### 2. Cross-browser RTT fallback

For browsers that do **not** expose `effectiveType`, polling now adapts based on recent successful poll latency.

Implemented in:

-   `packages/sync/src/providers/http-polling/latency-info.ts`
-   `packages/sync/src/providers/http-polling/polling-manager.ts`

What changed:

-   Added a small internal helper to track the last **3 successful poll durations**
-   Measured RTT around `postSyncUpdate()` in the polling loop
-   Only recorded **successful** polls
-   Used the average of the last 3 successful polls to choose a multiplier:
    -   average `< 500ms` -> `1x`
    -   average `>= 500ms` and `< 1500ms` -> `4x`
    -   average `>= 1500ms` -> `10x`
-   Applied that multiplier to the existing base interval:
    -   collaborators -> `1000ms`
    -   solo editing -> `4000ms`
-   Cleared RTT history when the last room unregisters so a new session starts cleanly

### Polling behavior preserved

This change intentionally does **not** alter the rest of the transport model:

-   Background tabs still poll at `25000ms`
-   Existing exponential error backoff is unchanged
-   Failed polls do not contribute to RTT sampling
-   `retryNow()` continues to affect retry timing only, not latency history
-   No browser sniffing or UA detection was added; this uses feature detection only

### Result

With this change:

-   Chromium browsers get an immediate network-quality hint from `effectiveType`
-   Firefox / Safari / iOS browsers can still reduce polling on slower conditions via measured RTT
-   RTC polling remains conservative, capped, and compatible with the existing sync and awareness behavior

## Use of AI Tools

Codex was used to strategize and plan and also for testing. Functionality is properly tested by human.