### PR TITLE
[WIP] Add icon support for Breadcrumbs separator in block editor

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail showing the path to the current page. ([Source](https
 -	**Name:** core/breadcrumbs
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, separatorIconUrl, showCurrentItem, showHomeItem, showOnHomePage
+-	**Attributes:** prefersTaxonomy, seprator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail showing the path to the current page. ([Source](https
 -	**Name:** core/breadcrumbs
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
+-	**Attributes:** prefersTaxonomy, separator, separatorIconUrl, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -11,7 +11,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"separatorIconUrl": {
+		"separatorIcon": {
 			"type": "string"
 		},
 		"showHomeItem": {

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -11,6 +11,14 @@
 			"type": "boolean",
 			"default": false
 		},
+		"separator": {
+			"type": "string",
+			"default": "/"
+		},
+		"separatorType": {
+			"type": "string",
+			"default": "text"
+		},
 		"separatorIcon": {
 			"type": "string"
 		},
@@ -73,5 +81,6 @@
 			"clientNavigation": true
 		}
 	},
-	"style": "wp-block-breadcrumbs"
+	"style": "wp-block-breadcrumbs",
+	"editorStyle": "wp-block-breadcrumbs-editor"
 }

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -11,9 +11,8 @@
 			"type": "boolean",
 			"default": false
 		},
-		"separator": {
-			"type": "string",
-			"default": "/"
+		"separatorIconUrl": {
+			"type": "string"
 		},
 		"showHomeItem": {
 			"type": "boolean",

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
+	TextControl,
 	Button,
 	CheckboxControl,
 	__experimentalToolsPanel as ToolsPanel,
@@ -24,6 +25,8 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import HtmlRenderer from '../utils/html-renderer';
 import { CustomInserterModal } from '../icon/components';
 
+const separatorDefaultValue = '/';
+
 export default function BreadcrumbEdit( {
 	attributes,
 	setAttributes,
@@ -31,6 +34,8 @@ export default function BreadcrumbEdit( {
 	context: { postId, postType, templateSlug },
 } ) {
 	const {
+		separator,
+		separatorType,
 		separatorIcon,
 		showHomeItem,
 		showCurrentItem,
@@ -181,7 +186,7 @@ export default function BreadcrumbEdit( {
 		( templateSlug && ! postType ) ||
 		( ! _showTerms && ! isPostTypeHierarchical ) ||
 		( _showTerms && ! hasTermsAssigned );
-	const separatorElement = selectedIconContent?.content ? (
+	const iconSeparatorElement = selectedIconContent?.content ? (
 		<span className="wp-block-breadcrumbs__separator" aria-hidden="true">
 			<HtmlRenderer html={ selectedIconContent.content } />
 		</span>
@@ -190,6 +195,18 @@ export default function BreadcrumbEdit( {
 			/
 		</span>
 	);
+	const separatorElement =
+		separatorType === 'icon' ? iconSeparatorElement : null;
+
+	const navStyle =
+		separatorType === 'icon'
+			? { '--separator': 'none', ...blockProps.style }
+			: {
+					'--separator': `"${ separator
+						.replace( /\\/g, '\\\\' )
+						.replace( /"/g, '\\"' ) }"`,
+					...blockProps.style,
+			  };
 
 	if ( showPlaceholder ) {
 		const placeholderItems = [];
@@ -204,7 +221,7 @@ export default function BreadcrumbEdit( {
 			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
 		}
 		placeholder = (
-			<nav { ...blockProps }>
+			<nav { ...blockProps } style={ navStyle }>
 				<ol>
 					{ placeholderItems.map( ( text, index ) => (
 						<li key={ index }>
@@ -230,6 +247,8 @@ export default function BreadcrumbEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
+							separator: separatorDefaultValue,
+							separatorType: 'text',
 							separatorIcon: undefined,
 							showHomeItem: true,
 							showCurrentItem: true,
@@ -274,43 +293,91 @@ export default function BreadcrumbEdit( {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						label={ __( 'Separator icon' ) }
+						label={ __( 'Separator' ) }
 						isShownByDefault
-						hasValue={ () => !! separatorIcon }
+						hasValue={ () =>
+							separator !== separatorDefaultValue ||
+							separatorType !== 'text' ||
+							!! separatorIcon
+						}
 						onDeselect={ () =>
-							setAttributes( { separatorIcon: undefined } )
+							setAttributes( {
+								separator: separatorDefaultValue,
+								separatorType: 'text',
+								separatorIcon: undefined,
+							} )
 						}
 					>
-						<div className="wp-block-breadcrumbs__separator-icon-control">
-							{ separatorIcon && selectedIconContent?.content && (
-								<HtmlRenderer
-									html={ selectedIconContent.content }
-									wrapperProps={ {
-										className:
-											'wp-block-breadcrumbs__separator-icon-preview',
-										style: { width: '24px' },
+						<ToggleControl
+							label={ __( 'Use icon as separator' ) }
+							checked={ separatorType === 'icon' }
+							onChange={ ( value ) =>
+								setAttributes( {
+									separatorType: value ? 'icon' : 'text',
+								} )
+							}
+						/>
+						{ separatorType !== 'icon' ? (
+							<div className="wp-block-breadcrumbs__separator-control">
+								<TextControl
+									__next40pxDefaultSize
+									autoComplete="off"
+									label={ __( 'Separator character' ) }
+									value={ separator }
+									onChange={ ( value ) =>
+										setAttributes( { separator: value } )
+									}
+									onBlur={ () => {
+										if ( ! separator ) {
+											setAttributes( {
+												separator:
+													separatorDefaultValue,
+											} );
+										}
 									} }
 								/>
-							) }
-							<Button
-								__next40pxDefaultSize
-								variant="secondary"
-								onClick={ () => setIconInserterOpen( true ) }
-							>
-								{ separatorIcon
-									? __( 'Replace icon' )
-									: __( 'Choose icon' ) }
-							</Button>
-						</div>
-						{ isIconInserterOpen && (
-							<CustomInserterModal
-								icons={ allIcons ?? [] }
-								setInserterOpen={ setIconInserterOpen }
-								attributes={ { icon: separatorIcon } }
-								setAttributes={ ( { icon } ) =>
-									setAttributes( { separatorIcon: icon } )
-								}
-							/>
+							</div>
+						) : (
+							<>
+								<div className="wp-block-breadcrumbs__separator-icon-control">
+									{ separatorIcon &&
+										selectedIconContent?.content && (
+											<HtmlRenderer
+												html={
+													selectedIconContent.content
+												}
+												wrapperProps={ {
+													className:
+														'wp-block-breadcrumbs__separator-icon-preview',
+													style: { width: '24px' },
+												} }
+											/>
+										) }
+									<Button
+										__next40pxDefaultSize
+										variant="secondary"
+										onClick={ () =>
+											setIconInserterOpen( true )
+										}
+									>
+										{ separatorIcon
+											? __( 'Replace icon' )
+											: __( 'Choose icon' ) }
+									</Button>
+								</div>
+								{ isIconInserterOpen && (
+									<CustomInserterModal
+										icons={ allIcons ?? [] }
+										setInserterOpen={ setIconInserterOpen }
+										attributes={ { icon: separatorIcon } }
+										setAttributes={ ( { icon } ) =>
+											setAttributes( {
+												separatorIcon: icon,
+											} )
+										}
+									/>
+								) }
+							</>
 						) }
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
-	TextControl,
+	Button,
 	CheckboxControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -22,8 +22,7 @@ import { useDisabled } from '@wordpress/compose';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import HtmlRenderer from '../utils/html-renderer';
-
-const separatorDefaultValue = '/';
+import { CustomInserterModal } from '../icon/components';
 
 export default function BreadcrumbEdit( {
 	attributes,
@@ -32,22 +31,34 @@ export default function BreadcrumbEdit( {
 	context: { postId, postType, templateSlug },
 } ) {
 	const {
-		separator,
+		separatorIcon,
 		showHomeItem,
 		showCurrentItem,
 		prefersTaxonomy,
 		showOnHomePage,
 	} = attributes;
+
+	const [ isIconInserterOpen, setIconInserterOpen ] = useState( false );
 	const {
 		post,
 		isPostTypeHierarchical,
 		postTypeHasTaxonomies,
 		hasTermsAssigned,
 		isLoading,
+		selectedIconContent,
+		allIcons,
 	} = useSelect(
 		( select ) => {
+			const { getEntityRecord, getEntityRecords } = select( coreStore );
 			if ( ! postType ) {
-				return {};
+				return {
+					selectedIconContent: separatorIcon
+						? getEntityRecord( 'root', 'icon', separatorIcon )
+						: null,
+					allIcons: isIconInserterOpen
+						? getEntityRecords( 'root', 'icon' )
+						: undefined,
+				};
 			}
 			const _post = select( coreStore ).getEntityRecord(
 				'postType',
@@ -81,9 +92,15 @@ export default function BreadcrumbEdit( {
 					( postId && ! _post ) ||
 					! postTypeObject ||
 					( _postTypeHasTaxonomies && ! taxonomies ),
+				selectedIconContent: separatorIcon
+					? getEntityRecord( 'root', 'icon', separatorIcon )
+					: null,
+				allIcons: isIconInserterOpen
+					? getEntityRecords( 'root', 'icon' )
+					: undefined,
 			};
 		},
-		[ postType, postId ]
+		[ postType, postId, separatorIcon, isIconInserterOpen ]
 	);
 
 	/**
@@ -164,6 +181,16 @@ export default function BreadcrumbEdit( {
 		( templateSlug && ! postType ) ||
 		( ! _showTerms && ! isPostTypeHierarchical ) ||
 		( _showTerms && ! hasTermsAssigned );
+	const separatorElement = selectedIconContent?.content ? (
+		<span className="wp-block-breadcrumbs__separator" aria-hidden="true">
+			<HtmlRenderer html={ selectedIconContent.content } />
+		</span>
+	) : (
+		<span className="wp-block-breadcrumbs__separator" aria-hidden="true">
+			/
+		</span>
+	);
+
 	if ( showPlaceholder ) {
 		const placeholderItems = [];
 		if ( showHomeItem ) {
@@ -177,21 +204,14 @@ export default function BreadcrumbEdit( {
 			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
 		}
 		placeholder = (
-			<nav
-				{ ...blockProps }
-				style={ {
-					'--separator': `"${ separator
-						.replace( /\\/g, '\\\\' )
-						.replace( /"/g, '\\"' ) }"`,
-					...blockProps.style,
-				} }
-			>
+			<nav { ...blockProps }>
 				<ol>
 					{ placeholderItems.map( ( text, index ) => (
 						<li key={ index }>
 							<a href={ `#breadcrumbs-pseudo-link-${ index }` }>
 								{ text }
 							</a>
+							{ separatorElement }
 						</li>
 					) ) }
 					{ showCurrentItem && (
@@ -210,7 +230,7 @@ export default function BreadcrumbEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
-							separator: separatorDefaultValue,
+							separatorIcon: undefined,
 							showHomeItem: true,
 							showCurrentItem: true,
 						} );
@@ -254,31 +274,44 @@ export default function BreadcrumbEdit( {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						label={ __( 'Separator' ) }
+						label={ __( 'Separator icon' ) }
 						isShownByDefault
-						hasValue={ () => separator !== separatorDefaultValue }
+						hasValue={ () => !! separatorIcon }
 						onDeselect={ () =>
-							setAttributes( {
-								separator: separatorDefaultValue,
-							} )
+							setAttributes( { separatorIcon: undefined } )
 						}
 					>
-						<TextControl
-							__next40pxDefaultSize
-							autoComplete="off"
-							label={ __( 'Separator' ) }
-							value={ separator }
-							onChange={ ( value ) =>
-								setAttributes( { separator: value } )
-							}
-							onBlur={ () => {
-								if ( ! separator ) {
-									setAttributes( {
-										separator: separatorDefaultValue,
-									} );
+						<div className="wp-block-breadcrumbs__separator-icon-control">
+							{ separatorIcon && selectedIconContent?.content && (
+								<HtmlRenderer
+									html={ selectedIconContent.content }
+									wrapperProps={ {
+										className:
+											'wp-block-breadcrumbs__separator-icon-preview',
+										style: { width: '24px' },
+									} }
+								/>
+							) }
+							<Button
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ () => setIconInserterOpen( true ) }
+							>
+								{ separatorIcon
+									? __( 'Replace icon' )
+									: __( 'Choose icon' ) }
+							</Button>
+						</div>
+						{ isIconInserterOpen && (
+							<CustomInserterModal
+								icons={ allIcons ?? [] }
+								setInserterOpen={ setIconInserterOpen }
+								attributes={ { icon: separatorIcon } }
+								setAttributes={ ( { icon } ) =>
+									setAttributes( { separatorIcon: icon } )
 								}
-							} }
-						/>
+							/>
+						) }
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>

--- a/packages/block-library/src/breadcrumbs/editor.scss
+++ b/packages/block-library/src/breadcrumbs/editor.scss
@@ -1,0 +1,10 @@
+.wp-block-breadcrumbs__separator-control,
+.wp-block-breadcrumbs__separator-icon-control {
+	margin-top: 12px;
+}
+
+.wp-block-breadcrumbs__separator-icon-control {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}

--- a/packages/block-library/src/breadcrumbs/index.js
+++ b/packages/block-library/src/breadcrumbs/index.js
@@ -10,6 +10,11 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 
+/**
+ * Internal styles
+ */
+import './editor.scss';
+
 const { name } = metadata;
 
 export { metadata, name };

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -183,25 +183,38 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// Build separator HTML from registered icon.
+	$separator_html = '/';
+	$separator_icon = ! empty( $attributes['separatorIcon'] ) ? $attributes['separatorIcon'] : '';
+	if ( $separator_icon ) {
+		$registry = WP_Icons_Registry::get_instance();
+		$icon     = $registry->get_registered_icon( $separator_icon );
+		if ( $icon ) {
+			$separator_html = '<span class="wp-block-breadcrumbs__separator" aria-hidden="true">' . $icon['content'] . '</span>';
+		}
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'style'      => '--separator: "' . addcslashes( $attributes['separator'], '\\"' ) . '";',
 			'aria-label' => __( 'Breadcrumbs' ),
 		)
 	);
 
+	$total_items   = count( $breadcrumb_items );
+	$item_index    = 0;
 	$breadcrumb_html = sprintf(
 		'<nav %s><ol>%s</ol></nav>',
 		$wrapper_attributes,
 		implode(
 			'',
 			array_map(
-				static function ( $item ) {
+				static function ( $item ) use ( $separator_html, $total_items, &$item_index ) {
 					$label = ! empty( $item['allow_html'] ) ? wp_kses_post( $item['label'] ) : esc_html( $item['label'] );
+					$sep   = ( ++$item_index < $total_items ) ? $separator_html : '/';
 					if ( ! empty( $item['url'] ) ) {
-						return '<li><a href="' . esc_url( $item['url'] ) . '">' . $label . '</a></li>';
+						return '<li><a href="' . esc_url( $item['url'] ) . '">' . $label . '</a>' . $sep . '</li>';
 					}
-					return '<li><span aria-current="page">' . $label . '</span></li>';
+					return '<li><span aria-current="page">' . $label . '</span>' . $sep . '</li>';
 				},
 				$breadcrumb_items
 			)

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -183,43 +183,76 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// Build separator HTML from registered icon.
-	$separator_html = '/';
-	$separator_icon = ! empty( $attributes['separatorIcon'] ) ? $attributes['separatorIcon'] : '';
-	if ( $separator_icon ) {
-		$registry = WP_Icons_Registry::get_instance();
-		$icon     = $registry->get_registered_icon( $separator_icon );
-		if ( $icon ) {
-			$separator_html = '<span class="wp-block-breadcrumbs__separator" aria-hidden="true">' . $icon['content'] . '</span>';
+	$separator_type = $attributes['separatorType'] ?? 'text';
+
+	if ( 'icon' === $separator_type ) {
+		// Build separator HTML from registered icon.
+		$separator_html = '<span class="wp-block-breadcrumbs__separator" aria-hidden="true">/</span>';
+		$separator_icon = ! empty( $attributes['separatorIcon'] ) ? $attributes['separatorIcon'] : '';
+		if ( $separator_icon ) {
+			$registry = WP_Icons_Registry::get_instance();
+			$icon     = $registry->get_registered_icon( $separator_icon );
+			if ( $icon ) {
+				$separator_html = '<span class="wp-block-breadcrumbs__separator" aria-hidden="true">' . $icon['content'] . '</span>';
+			}
 		}
-	}
 
-	$wrapper_attributes = get_block_wrapper_attributes(
-		array(
-			'aria-label' => __( 'Breadcrumbs' ),
-		)
-	);
-
-	$total_items   = count( $breadcrumb_items );
-	$item_index    = 0;
-	$breadcrumb_html = sprintf(
-		'<nav %s><ol>%s</ol></nav>',
-		$wrapper_attributes,
-		implode(
-			'',
-			array_map(
-				static function ( $item ) use ( $separator_html, $total_items, &$item_index ) {
-					$label = ! empty( $item['allow_html'] ) ? wp_kses_post( $item['label'] ) : esc_html( $item['label'] );
-					$sep   = ( ++$item_index < $total_items ) ? $separator_html : '/';
-					if ( ! empty( $item['url'] ) ) {
-						return '<li><a href="' . esc_url( $item['url'] ) . '">' . $label . '</a>' . $sep . '</li>';
-					}
-					return '<li><span aria-current="page">' . $label . '</span>' . $sep . '</li>';
-				},
-				$breadcrumb_items
+		// Set --separator: none so the CSS ::after pseudo-element is suppressed.
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'style'      => '--separator: none;',
+				'aria-label' => __( 'Breadcrumbs' ),
 			)
-		)
-	);
+		);
+
+		$total_items     = count( $breadcrumb_items );
+		$item_index      = 0;
+		$breadcrumb_html = sprintf(
+			'<nav %s><ol>%s</ol></nav>',
+			$wrapper_attributes,
+			implode(
+				'',
+				array_map(
+					static function ( $item ) use ( $separator_html, $total_items, &$item_index ) {
+						$label = ! empty( $item['allow_html'] ) ? wp_kses_post( $item['label'] ) : esc_html( $item['label'] );
+						$sep   = ( ++$item_index < $total_items ) ? $separator_html : '';
+						if ( ! empty( $item['url'] ) ) {
+							return '<li><a href="' . esc_url( $item['url'] ) . '">' . $label . '</a>' . $sep . '</li>';
+						}
+						return '<li><span aria-current="page">' . $label . '</span>' . $sep . '</li>';
+					},
+					$breadcrumb_items
+				)
+			)
+		);
+	} else {
+		// Text mode: use CSS custom property so the ::after pseudo-element renders the separator.
+		$separator          = ! empty( $attributes['separator'] ) ? $attributes['separator'] : '/';
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'style'      => '--separator: "' . addcslashes( $separator, '\\"' ) . '";',
+				'aria-label' => __( 'Breadcrumbs' ),
+			)
+		);
+
+		$breadcrumb_html = sprintf(
+			'<nav %s><ol>%s</ol></nav>',
+			$wrapper_attributes,
+			implode(
+				'',
+				array_map(
+					static function ( $item ) {
+						$label = ! empty( $item['allow_html'] ) ? wp_kses_post( $item['label'] ) : esc_html( $item['label'] );
+						if ( ! empty( $item['url'] ) ) {
+							return '<li><a href="' . esc_url( $item['url'] ) . '">' . $label . '</a></li>';
+						}
+						return '<li><span aria-current="page">' . $label . '</span></li>';
+					},
+					$breadcrumb_items
+				)
+			)
+		);
+	}
 
 	return $breadcrumb_html;
 }

--- a/packages/block-library/src/breadcrumbs/style.scss
+++ b/packages/block-library/src/breadcrumbs/style.scss
@@ -16,8 +16,17 @@
 		padding: 0;
 		display: flex;
 		align-items: center;
+
+		// Text-mode separator rendered via CSS custom property.
+		&:not(:last-child)::after {
+			content: var(--separator, "/");
+			margin: 0 0.5em;
+			opacity: 0.7;
+		}
 	}
 
+	// Icon-mode separator: an inline SVG span injected into each <li>.
+	// Setting --separator: none on the wrapper suppresses the ::after above.
 	.wp-block-breadcrumbs__separator {
 		display: flex;
 		align-items: center;

--- a/packages/block-library/src/breadcrumbs/style.scss
+++ b/packages/block-library/src/breadcrumbs/style.scss
@@ -16,11 +16,17 @@
 		padding: 0;
 		display: flex;
 		align-items: center;
+	}
 
-		&:not(:last-child)::after {
-			content: var(--separator, "/");
-			margin: 0 0.5em;
-			opacity: 0.7;
+	.wp-block-breadcrumbs__separator {
+		display: flex;
+		align-items: center;
+		margin: 0 0.5em;
+		opacity: 0.7;
+
+		svg {
+			width: 1em;
+			height: 1em;
 		}
 	}
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/75715 (Icon block enhancements)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
