### PR TITLE
Search block : Match behaviour of global styling for border and color with local styling (inspector controls) to remove inconsistency

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -92,5 +92,9 @@
 		"html": false
 	},
 	"editorStyle": "wp-block-search-editor",
-	"style": "wp-block-search"
+	"style": "wp-block-search",
+	"selectors": {
+		"color": ".wp-block-search .wp-block-search__button",
+		"border": ".wp-block-search.wp-block-search__button-outside .wp-block-search__input, .wp-block-search.wp-block-search__button-outside .wp-block-search__button, .wp-block-search.wp-block-search__no-button .wp-block-search__input, .wp-block-search.wp-block-search__button-only .wp-block-search__input, .wp-block-search.wp-block-search__button-only .wp-block-search__button, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper"
+	}
 }


### PR DESCRIPTION
## What?

Closes #42339

This PR ensures that Global Styles for border and color properties are correctly mapped to the Search block's internal sub-elements (input and button) instead of the outer container.

## Why?
The Search block uses `__experimentalSkipSerialization` to handle its complex layout. However, this caused Global Styles (applied via the Styles panel) to target the root block container by default. This created a discrepancy with local Inspector Controls, which target the input and button. Users expected global styling to match the visual outcome of local styling.

Furthermore, we identified a specificity conflict where hardcoded CSS in a theme's `theme.json` (like Twenty Twenty-Five) could override these Global Styles because both are wrapped in `:root :where()` and the theme's custom CSS was winning via cascade order.

<img width="537" height="176" alt="Screenshot 2026-04-06 at 6 20 55 PM" src="https://github.com/user-attachments/assets/1b2f33b2-ad52-41d5-ac82-4f530a25a35f" />

## How?
1. Updated `packages/block-library/src/search/block.json` to add explicit `selectors` mapping for `border` and `color`.
2. The `border` selector now targets specific internal elements (`.wp-block-search__content`, `.wp-block-search__input`, and `.wp-block-search__button`) depending on the block configuration.
3. The `color` selector was updated to target the `.wp-block-search__button` ensuring that global background and text color settings apply to the button as they do in local settings.
4. Specificity was increased by explicitly including the `.wp-block-search` class in these selectors.

## Screenshots or screencast

#### Before ( Border issue )

<img width="1330" height="338" alt="image" src="https://github.com/user-attachments/assets/f425482d-f784-4bc8-930b-4f534b280e32" />

#### After ( Border issue )

<img width="658" height="172" alt="Screenshot 2026-04-06 at 6 25 38 PM" src="https://github.com/user-attachments/assets/7f53f9ed-7773-4da8-9f60-38b5ab7807ed" />

#### Before ( Color issue )

<img width="666" height="167" alt="Screenshot 2026-04-06 at 6 34 38 PM" src="https://github.com/user-attachments/assets/2d2fb877-acc9-448d-a652-6dc1d3daef08" />

#### After ( Color issue )

<img width="669" height="177" alt="Screenshot 2026-04-06 at 6 31 56 PM" src="https://github.com/user-attachments/assets/bb6c6d16-b7c7-4d8f-9b2e-371ccf9f99f5" />

#### Below testing is done

- Tested all four button position modes (button outside, inside, no button, icon-only) with both global and local styles to confirm they match.

- Checked that resetting global styles properly clears the border/color from those inner elements.

- Verified there are no specificity conflicts where global selectors now override local ones unexpectedly (since these selectors are quite specific).

## Testing Instructions
1. Open the Site Editor and navigate to **Styles > Blocks > Search**.
2. Set a global border (e.g., 5px solid red).
3. Add a Search block to a post and verify the border applies to the input/button area, matching the behavior of local block settings.
4. Set a global Background and Text color for the Search block.
5. Verify that the button colors update to match these global settings.
6. Verify that these changes do not break existing Search block layouts (e.g., button inside/outside/no button).

## Use of AI Tools
Used AI assistance (Gemini 3.1 Pro) for code analysis, specificity debugging, and drafting PR text. All logic changes were manually reviewed and validated in a local environment.
