### PR TITLE
Autocomplete: Clarify 'isDebounced' setting limitation

### DIFF
--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -145,7 +145,7 @@ A class name to apply to the autocompletion popup menu.
 
 #### isDebounced
 
-Whether to apply debouncing for the autocompleter. Set to true to enable debouncing.
+Whether to debounce the autocompleter. This setting only affects the `options` argument; it is ignored by the `useItems`.
 
 -   Type: `Boolean`
 -   Required: No


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/76995#discussion_r3038383432.

PR adds clarification for `isDebounced` settings for autocompleters.

## Testing Instructions
None. It's just a documentation update. We can also ignore changelog entry for this change.

## Use of AI Tools

None.
