### PR TITLE
Do not merge: run e2e tests for 7.0 without Gutenberg active

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
 	"$schema": "./schemas/json/wp-env.json",
 	"testsEnvironment": false,
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"phpmyadminPort": 9000
 }

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -3,14 +3,13 @@
 	"testsEnvironment": false,
 	"port": 8889,
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"config": {
 		"WP_DEBUG": false,
 		"SCRIPT_DEBUG": false
 	},
 	"mappings": {
-		"wp-content/plugins/gutenberg": ".",
 		"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 		"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 		"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",

--- a/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/gutenberg-experiments.ts
@@ -9,14 +9,18 @@ import type { RequestUtils } from './index';
  * @param this
  * @param experiments Array of experimental flags to enable. Pass in an empty array to disable all experiments.
  *                    Use 'active_templates' for the template activation feature.
+ * @return Returns true if experiments were set successfully, false if Gutenberg plugin is not active.
  */
 async function setGutenbergExperiments(
 	this: RequestUtils,
 	experiments: string[]
-) {
+): Promise< boolean > {
 	const response = await this.request.get(
 		'/wp-admin/admin.php?page=gutenberg-experiments'
 	);
+	if ( response.status() !== 200 ) {
+		return false;
+	}
 	const html = await response.text();
 	const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
 
@@ -56,6 +60,8 @@ async function setGutenbergExperiments(
 		form: formData,
 		failOnStatusCode: true,
 	} );
+
+	return true;
 }
 
 export { setGutenbergExperiments };

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -133,6 +133,7 @@ const test = base.extend<
 	{
 		requestUtils: RequestUtils;
 		lighthousePort: number;
+		isGutenbergPluginActive: boolean;
 	}
 >( {
 	admin: async ( { page, pageUtils, editor }, use ) => {
@@ -197,6 +198,19 @@ const test = base.extend<
 	metrics: async ( { page }, use ) => {
 		await use( new Metrics( { page } ) );
 	},
+	isGutenbergPluginActive: [
+		async ( { requestUtils }, use ) => {
+			const plugins = await requestUtils.rest( {
+				path: '/wp/v2/plugins',
+			} );
+			const gutenberg = plugins.find(
+				( p: { plugin: string; status: string } ) =>
+					p.plugin === 'gutenberg/gutenberg'
+			);
+			await use( gutenberg?.status === 'active' );
+		},
+		{ scope: 'worker' },
+	],
 } );
 
 export { test, expect };

--- a/packages/e2e-tests/plugins/connectors-empty-state.php
+++ b/packages/e2e-tests/plugins/connectors-empty-state.php
@@ -9,11 +9,12 @@
  * @package gutenberg-test-connectors-empty-state
  */
 
-// Remove the Gutenberg filter that provides default connector data.
+// Remove the filter that provides default connector data.
 add_action(
 	'init',
 	static function () {
 		remove_filter( 'script_module_data_options-connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );
+		remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
 	},
 	PHP_INT_MAX
 );

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -48,8 +48,12 @@ add_action(
 // Enqueue the script module on the connectors page.
 add_action(
 	'admin_enqueue_scripts',
-	static function () {
-		if ( ! isset( $_GET['page'] ) || 'options-connectors-wp-admin' !== $_GET['page'] ) {
+	static function ( $hook_suffix ) {
+		$connectors_pages = array(
+			'settings_page_options-connectors-wp-admin', // Gutenberg.
+			'settings_page_options-connectors.php',      // Core.
+		);
+		if ( ! in_array( $hook_suffix, $connectors_pages, true ) ) {
 			return;
 		}
 

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -51,7 +51,7 @@ add_action(
 	static function ( $hook_suffix ) {
 		$connectors_pages = array(
 			'settings_page_options-connectors-wp-admin', // Gutenberg.
-			'settings_page_options-connectors.php',      // Core.
+			'options-connectors.php',                    // Core.
 		);
 		if ( ! in_array( $hook_suffix, $connectors_pages, true ) ) {
 			return;

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -56,7 +56,7 @@ function gutenberg_delete_installed_fonts() {
 	}
 
 	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -3,8 +3,8 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const SETTINGS_PAGE_PATH = 'options-general.php';
-const CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
+let SETTINGS_PAGE_PATH;
+let CONNECTORS_PAGE_QUERY;
 
 const CONNECTORS = [
 	{
@@ -36,6 +36,16 @@ const getConnectorCardByName = ( page, name ) =>
 		.first();
 
 test.describe( 'Connectors', () => {
+	test.beforeAll( async ( { isGutenbergPluginActive } ) => {
+		if ( isGutenbergPluginActive ) {
+			SETTINGS_PAGE_PATH = 'options-general.php';
+			CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
+		} else {
+			SETTINGS_PAGE_PATH = 'options-connectors.php';
+			CONNECTORS_PAGE_QUERY = '';
+		}
+	} );
+
 	test( 'should show a Connectors link in the Settings menu', async ( {
 		page,
 		admin,
@@ -49,7 +59,9 @@ test.describe( 'Connectors', () => {
 		await expect( connectorsLink ).toBeVisible();
 		await expect( connectorsLink ).toHaveAttribute(
 			'href',
-			`${ SETTINGS_PAGE_PATH }?${ CONNECTORS_PAGE_QUERY }`
+			CONNECTORS_PAGE_QUERY
+				? `${ SETTINGS_PAGE_PATH }?${ CONNECTORS_PAGE_QUERY }`
+				: SETTINGS_PAGE_PATH
 		);
 	} );
 

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,7 +8,20 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
+		requestUtils,
 	} ) => {
+		const plugins = await requestUtils.rest( { path: '/wp/v2/plugins' } );
+		const gutenberg = plugins.find(
+			( p ) => p.plugin === 'gutenberg/gutenberg'
+		);
+		const isGutenbergPluginActive = gutenberg?.status === 'active';
+
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test requires Gutenberg plugin to be active'
+		);
+
 		await admin.visitAdminPage( 'post-new.php', 'gutenberg-demo' );
 		await editor.setPreferences( 'core/edit-site', {
 			welcomeGuide: false,

--- a/test/e2e/specs/editor/local/demo.spec.js
+++ b/test/e2e/specs/editor/local/demo.spec.js
@@ -8,14 +8,8 @@ test.describe( 'New editor state', () => {
 		page,
 		admin,
 		editor,
-		requestUtils,
+		isGutenbergPluginActive,
 	} ) => {
-		const plugins = await requestUtils.rest( { path: '/wp/v2/plugins' } );
-		const gutenberg = plugins.find(
-			( p ) => p.plugin === 'gutenberg/gutenberg'
-		);
-		const isGutenbergPluginActive = gutenberg?.status === 'active';
-
 		// eslint-disable-next-line playwright/no-skipped-test
 		test.skip(
 			! isGutenbergPluginActive,

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -106,7 +106,13 @@ test.describe( 'Server-side rendered block', () => {
 } );
 
 test.describe( 'PHP-only auto-register blocks', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'This test suite requires Gutenberg plugin to be active'
+		);
+
 		await requestUtils.activatePlugin(
 			'gutenberg-test-server-side-rendered-block'
 		);

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -368,9 +368,15 @@ test.describe( 'Post Meta source', () => {
 
 	test.describe( 'Movie CPT post', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
-			await requestUtils.setGutenbergExperiments( [
-				'gutenberg-content-only-inspector-fields',
-			] );
+			const experimentsAvailable =
+				await requestUtils.setGutenbergExperiments( [
+					'gutenberg-content-only-inspector-fields',
+				] );
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! experimentsAvailable,
+				'Block Fields experiment requires Gutenberg plugin'
+			);
 		} );
 
 		test.beforeEach( async ( { admin } ) => {

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -40,7 +40,12 @@ test.use( {
 } );
 
 test.describe( 'Document-Isolation-Policy', () => {
-	test.beforeEach( async ( { admin, page } ) => {
+	test.beforeEach( async ( { admin, page, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Document-Isolation-Policy header requires Gutenberg plugin'
+		);
 		// These tests only apply to Chromium 137+.
 		test.skip(
 			( await getChromiumMajorVersion( page ) ) < 137,

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -11,6 +11,7 @@ test.describe( 'Should iframe', () => {
 	test( 'should remain iframed when a v1 block is added', async ( {
 		page,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
 		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
 
@@ -33,7 +34,12 @@ test.describe( 'Should iframe', () => {
 		// Insert the v1 block.
 		await editor.insertBlock( { name: 'test/v1' } );
 
-		// The editor should remain iframed because Gutenberg is active.
-		await expect( iframe ).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			// Gutenberg keeps the editor iframed even with v1 blocks.
+			await expect( iframe ).toBeVisible();
+		} else {
+			// Core exits iframe mode when a v1 block is added.
+			await expect( iframe ).toBeHidden();
+		}
 	} );
 } );

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -97,15 +97,15 @@ export default class InteractivityUtils {
 
 	async activatePlugins() {
 		await this.requestUtils.activateTheme( 'emptytheme' );
-		await this.requestUtils.activatePlugin(
-			'gutenberg-test-interactive-blocks'
-		);
+		// await this.requestUtils.activatePlugin(
+		// 	'gutenberg-test-interactive-blocks'
+		// );
 	}
 
 	async deactivatePlugins() {
 		await this.requestUtils.activateTheme( 'twentytwentyone' );
-		await this.requestUtils.deactivatePlugin(
-			'gutenberg-test-interactive-blocks'
-		);
+		// await this.requestUtils.deactivatePlugin(
+		// 	'gutenberg-test-interactive-blocks'
+		// );
 	}
 }

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -97,15 +97,15 @@ export default class InteractivityUtils {
 
 	async activatePlugins() {
 		await this.requestUtils.activateTheme( 'emptytheme' );
-		// await this.requestUtils.activatePlugin(
-		// 	'gutenberg-test-interactive-blocks'
-		// );
+		await this.requestUtils.activatePlugin(
+			'gutenberg-test-interactive-blocks'
+		);
 	}
 
 	async deactivatePlugins() {
 		await this.requestUtils.activateTheme( 'twentytwentyone' );
-		// await this.requestUtils.deactivatePlugin(
-		// 	'gutenberg-test-interactive-blocks'
-		// );
+		await this.requestUtils.deactivatePlugin(
+			'gutenberg-test-interactive-blocks'
+		);
 	}
 }

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -20,7 +20,10 @@ test.describe( 'Global styles sidebar', () => {
 		} );
 	} );
 
-	test( 'should filter blocks list results', async ( { page } ) => {
+	test( 'should filter blocks list results', async ( {
+		page,
+		isGutenbergPluginActive,
+	} ) => {
 		// Navigate to Styles -> Blocks.
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
@@ -43,5 +46,12 @@ test.describe( 'Global styles sidebar', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Accordion Item' } )
 		).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Table of Contents',
+				} )
+			).toBeVisible();
+		}
 	} );
 } );

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -16,6 +16,7 @@ test.describe( 'Preload', () => {
 	test( 'Should make no requests before the iframe is loaded', async ( {
 		page,
 		admin,
+		isGutenbergPluginActive,
 	} ) => {
 		const requests = [];
 
@@ -46,9 +47,13 @@ test.describe( 'Preload', () => {
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
-			// Abilities system initialization.
-			'/wp-abilities/v1/categories?per_page=100&context=edit',
-			'/wp-abilities/v1/abilities?per_page=100&context=edit',
+			// Abilities system initialization (Gutenberg only).
+			...( isGutenbergPluginActive
+				? [
+						'/wp-abilities/v1/categories?per_page=100&context=edit',
+						'/wp-abilities/v1/abilities?per_page=100&context=edit',
+				  ]
+				: [] ),
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
 			'/wp/v2/settings',

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -7,7 +7,14 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		// Enable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'active_templates' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -9,7 +9,14 @@ test.describe( 'Template Activate', () => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		// Enable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'active_templates' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -16,7 +16,14 @@ test.describe( 'Block template registration', () => {
 			'gutenberg-test-block-template-registration'
 		);
 		// Enable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
+		const experimentsAvailable = await requestUtils.setGutenbergExperiments(
+			[ 'active_templates' ]
+		);
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! experimentsAvailable,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(


### PR DESCRIPTION
## What?

Make e2e tests runnable without the Gutenberg plugin active.

Previously: #74536

## Why?

It would be nice if all e2e tests can run on core without the plugin active. This requires a few tests to be skipped or adjusted.

## How?

- Remove Gutenberg plugin from `.wp-env.json` and `.wp-env.test.json`
- Add `isGutenbergPluginActive` fixture to e2e test utils
- Make `setGutenbergExperiments` return `boolean` indicating success
- Guard or adjust tests that depend on Gutenberg-specific behavior

## Notes

- `collaboration-notes.spec.ts` failures are legitimate — we still need to backport some collaboration code to core for those to pass.
- `preload.spec.js` — preload expectations differ without Gutenberg, still to investigate
- `post-content-focus-mode.spec.js` — timeout, possibly flaky, still to investigate