### PR TITLE
Button Block: Fix block binding text not rendering when button has no placeholder content

### DIFF
--- a/packages/block-library/src/button/index.php
+++ b/packages/block-library/src/button/index.php
@@ -51,12 +51,17 @@ function render_block_core_button( $attributes, $content ) {
 		}
 	}
 
+	$has_text_binding = isset( $attributes['metadata']['bindings']['text'] );
+
 	/*
 	 * When there's no text, render nothing for the block.
 	 * See https://github.com/WordPress/gutenberg/issues/17221 for the
 	 * reasoning behind this.
+	 *
+	 * Skip when text binding exists. The content is hydrated after
+	 * this callback.
 	 */
-	if ( $is_empty ) {
+	if ( $is_empty && ! $has_text_binding ) {
 		return '';
 	}
 


### PR DESCRIPTION
## What?
Closes #75443

Skip the empty content check in the button block's render callback when the `text` attribute has a block binding configured.

## Why?
The button block’s render callback exits early when its content is empty to avoid rendering an empty `<a>` tag. However, when a block binding is applied to the `text` attribute, the bound value is added to `$attributes` but not `$content` before the render callback runs. Because of this, the block appears empty and is not rendered on the frontend.

## How?
In `packages/block-library/src/button/index.php`, check whether the `text` attribute has a block binding configured before applying the empty check.

If a binding exists, skip the early return and let the render pipeline complete.

## Testing Instructions
1. Apply this [snippet](https://gist.github.com/claycarpenter/b8a7815c68d0d066ba2aa5d916daed64) to register the CPT and post content with block bindings for testing.
2. Open the editor of 'Button block bindings test' post of 'Tests' CPT -> Both Button blocks should be visible.
3. View the post on the frontend -> Before the fix, only the button with placeholder text appears and the button without placeholder text does not render at all.
4. Apply the patch and reload the frontend -> Both buttons should now render with the bound meta value as their text.

## Alternate Testing Instructions (Pattern Overrides)
1. Create a synced pattern with two Button blocks, one empty and one with text, both with pattern overrides enabled.
2. Insert the pattern into a post and view the frontend -> Before the fix, the empty button does not appear at all.
3. Apply the patch and reload the frontend -> The empty button now renders as an empty button, and the button with text renders correctly.
4. In the pattern instance, add text to the previously empty button and remove text from the other.
5. Preview the frontend -> The first button now shows the added text, and the second renders as an empty button.

## Screenshots or screencast
||Layout|
|-|-|
|Code Editor|<img width="1022" height="510" alt="Screenshot 2026-04-06 at 9 40 00 PM" src="https://github.com/user-attachments/assets/192e0361-e1d9-4755-b320-8bd464d0d8c6" />|
|Block Editor|<img width="1029" height="396" alt="Screenshot 2026-04-06 at 9 37 12 PM" src="https://github.com/user-attachments/assets/2802987f-5496-42a8-8c2d-54d2f870eb43" />|


|Before (Frontend)|After (Frontend)|
|-|-|
|<img width="762" height="414" alt="Screenshot 2026-04-06 at 9 38 06 PM" src="https://github.com/user-attachments/assets/4502d1c6-4e98-4595-a9bc-4c8a3da2a27b" />|<img width="843" height="398" alt="Screenshot 2026-04-06 at 9 36 13 PM" src="https://github.com/user-attachments/assets/16409047-e5e0-4743-9808-9f78eb2e74c0" />|


