### PR TITLE
Restore original template registration tests alongside activation variants

### DIFF
--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -15,11 +15,15 @@ test.describe( 'Block template registration', () => {
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
+		// Enable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
+		// Disable the template activation experiment.
+		await requestUtils.setGutenbergExperiments( [] );
 	} );
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
@@ -41,6 +45,7 @@ test.describe( 'Block template registration', () => {
 		// Verify template is listed in the Site Editor.
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
+			activeView: 'Gutenberg',
 		} );
 		await blockTemplateRegistrationUtils.searchForTemplate(
 			'Plugin Template'
@@ -49,10 +54,17 @@ test.describe( 'Block template registration', () => {
 		await expect(
 			page.getByText( 'A template registered by a plugin.' )
 		).toBeVisible();
-		await expect( page.getByText( 'AuthorGutenberg' ) ).toBeVisible();
 
 		// Verify the template contents are rendered in the editor.
 		await page.getByText( 'Plugin Template' ).click();
+		await page.getByRole( 'button', { name: 'Duplicate' } ).click();
+		await page.waitForURL(
+			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
+		);
+		await page
+			.getByRole( 'button', { name: 'Plugin Template (Copy)' } )
+			.first()
+			.click();
 		await expect(
 			editor.canvas.getByText( 'This is a plugin-registered template.' )
 		).toBeVisible();
@@ -65,16 +77,26 @@ test.describe( 'Block template registration', () => {
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,
 		} );
+		await page
+			.getByRole( 'region', { name: 'Editor content' } )
+			.getByRole( 'button', { name: 'Activate' } )
+			.click();
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor content' } )
+				.getByText( 'Template activated.' )
+		).toBeVisible();
 		await page.goto( '/?cat=1' );
 		await expect( page.getByText( 'User-edited template' ) ).toBeVisible();
 
 		// Verify template can be reset.
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
+			activeView: 'user',
 		} );
 		const resetNotice = page
 			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"Plugin Template" reset.` );
+			.getByText( `"Plugin Template (Copy)" moved to the trash.` );
 		const savedButton = page.getByRole( 'button', {
 			name: 'Saved',
 		} );
@@ -83,8 +105,8 @@ test.describe( 'Block template registration', () => {
 		);
 		const searchResults = page.getByLabel( 'Actions' );
 		await searchResults.first().click();
-		await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
-		await page.getByRole( 'button', { name: 'Reset' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
+		await page.getByRole( 'button', { name: 'Trash' } ).click();
 
 		await expect( resetNotice ).toBeVisible();
 		await expect( savedButton ).toBeVisible();
@@ -154,6 +176,7 @@ test.describe( 'Block template registration', () => {
 		// Verify the plugin-registered template doesn't appear in the Site Editor.
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
+			activeView: 'Emptytheme',
 		} );
 		await blockTemplateRegistrationUtils.searchForTemplate( 'Custom' );
 		await expect(
@@ -165,8 +188,6 @@ test.describe( 'Block template registration', () => {
 				'A custom template registered by a plugin and overridden by a theme.'
 			)
 		).toBeVisible();
-		// Verify the theme template shows the theme name as the author.
-		await expect( page.getByText( 'AuthorEmptytheme' ) ).toBeVisible();
 	} );
 
 	test( 'templates can be deleted if the registered plugin is deactivated', async ( {
@@ -179,11 +200,20 @@ test.describe( 'Block template registration', () => {
 		// Make an edit to the template.
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
+			activeView: 'Gutenberg',
 		} );
 		await blockTemplateRegistrationUtils.searchForTemplate(
 			'Plugin Template'
 		);
 		await page.getByText( 'Plugin Template' ).click();
+		await page.getByRole( 'button', { name: 'Duplicate' } ).click();
+		await page.waitForURL(
+			'/wp-admin/site-editor.php?p=%2Ftemplate&activeView=user'
+		);
+		await page
+			.getByRole( 'button', { name: 'Plugin Template (Copy)' } )
+			.first()
+			.click();
 		await expect(
 			editor.canvas.getByText( 'This is a plugin-registered template.' )
 		).toBeVisible();
@@ -203,10 +233,11 @@ test.describe( 'Block template registration', () => {
 		// Verify template can be deleted.
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
+			activeView: 'user',
 		} );
 		const deletedNotice = page
 			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"Plugin Template" deleted.` );
+			.getByText( `"Plugin Template (Copy)" moved to the trash.` );
 		const savedButton = page.getByRole( 'button', {
 			name: 'Saved',
 		} );
@@ -215,8 +246,8 @@ test.describe( 'Block template registration', () => {
 		);
 		const searchResults = page.getByLabel( 'Actions' );
 		await searchResults.first().click();
-		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
-		await page.getByRole( 'button', { name: 'Delete' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
+		await page.getByRole( 'button', { name: 'Trash' } ).click();
 
 		await expect( deletedNotice ).toBeVisible();
 		await expect( savedButton ).toBeVisible();
@@ -290,6 +321,15 @@ test.describe( 'Block template registration', () => {
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,
 		} );
+		await page
+			.getByRole( 'region', { name: 'Editor content' } )
+			.getByRole( 'button', { name: 'Activate' } )
+			.click();
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor content' } )
+				.getByText( 'Template activated.' )
+		).toBeVisible();
 
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'
@@ -313,32 +353,26 @@ test.describe( 'Block template registration', () => {
 		);
 		await expect( page.getByText( 'Plugin Author Template' ) ).toBeHidden();
 
+		await admin.visitSiteEditor( {
+			postType: 'wp_template',
+			activeView: 'user',
+		} );
+
 		// Reset the user-modified template.
 		const resetNotice = page
 			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"Author: Admin" reset.` );
+			.getByText( `"Author: Admin" moved to the trash.` );
 		await page.getByPlaceholder( 'Search' ).fill( 'Author: admin' );
 		await page
 			.locator( '.fields-field__title', { hasText: 'Author: Admin' } )
 			.click();
 		const actions = page.getByLabel( 'Actions' );
 		await actions.first().click();
-		await page.getByRole( 'menuitem', { name: 'Reset' } ).click();
-		await page.getByRole( 'button', { name: 'Reset' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
+		await page.getByRole( 'button', { name: 'Trash' } ).click();
 
 		await expect( resetNotice ).toBeVisible();
 
-		// Verify the template registered by the plugin is applied in the editor...
-		await expect(
-			editor.canvas.getByText( 'Author template customized by the user.' )
-		).toBeHidden();
-		await expect(
-			editor.canvas.getByText(
-				'This is a plugin-registered author template.'
-			)
-		).toBeVisible();
-
-		// ... and the frontend.
 		await page.goto( '?author=1' );
 		await expect(
 			page.getByText( 'Author template customized by the user.' )
@@ -363,6 +397,9 @@ class BlockTemplateRegistrationUtils {
 		await this.page.getByPlaceholder( 'Search' ).fill( searchTerm );
 		await expect
 			.poll( async () => await searchResults.count() )
-			.toBeLessThan( initialSearchResultsCount );
+			.toBeLessThanOrEqual( initialSearchResultsCount );
+		await expect
+			.poll( async () => this.page.url() )
+			.toContain( `search=${ encodeURIComponent( searchTerm ) }` );
 	}
 }

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -363,6 +363,9 @@ class BlockTemplateRegistrationUtils {
 		await this.page.getByPlaceholder( 'Search' ).fill( searchTerm );
 		await expect
 			.poll( async () => await searchResults.count() )
-			.toBeLessThan( initialSearchResultsCount );
+			.toBeLessThanOrEqual( initialSearchResultsCount );
+		await expect
+			.poll( async () => this.page.url() )
+			.toContain( `search=${ encodeURIComponent( searchTerm ) }` );
 	}
 }


### PR DESCRIPTION
## What?

Restores the original template registration e2e tests that work without the `active_templates` experiment, while keeping the template activation variants in a separate file.

## Why?

When template activation was moved to an experiment in #73252 (originally introduced in #67125), the original template registration tests were not restored.

## How?

- `template-registration.spec.js` — restored to its state before #67125, with the `searchForTemplate` stability fix from #67125 ported over
- `template-registration-activation.spec.js` — exact copy of the current trunk `template-registration.spec.js` (unchanged)

## Test plan

- [ ] Original tests pass without the `active_templates` experiment
- [ ] Template activation tests pass with the experiment enabled