### PR TITLE
ESLint plugin: Disable `jsx-a11y/heading-has-content`

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -181,7 +181,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 	const style = isEditingContentOnlySection ? { opacity: 0.2 } : undefined;
 
 	return (
-		/* eslint-disable jsx-a11y/heading-has-content, jsx-a11y/no-noninteractive-element-to-interactive-role */
+		/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 		<h1
 			ref={ useMergeRefs( [ richTextRef, focusRef ] ) }
 			contentEditable={ ! isEditingContentOnlySection && ! isPreview }
@@ -195,7 +195,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 			onPaste={ onPaste }
 			style={ style }
 		/>
-		/* eslint-enable jsx-a11y/heading-has-content, jsx-a11y/no-noninteractive-element-to-interactive-role */
+		/* eslint-enable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	);
 } );
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Disabled the `jsx-a11y/heading-has-content` rule in the recommended configuration, which reports many false positives when heading elements are passed via a `render` prop ([#77073](https://github.com/WordPress/gutenberg/pull/77073)).
+
 ## 24.5.0 (2026-04-01)
 
 ## 24.4.0 (2026-03-18)

--- a/packages/eslint-plugin/configs/jsx-a11y.js
+++ b/packages/eslint-plugin/configs/jsx-a11y.js
@@ -2,6 +2,9 @@ module.exports = {
 	extends: [ 'plugin:jsx-a11y/recommended' ],
 	plugins: [ 'jsx-a11y' ],
 	rules: {
+		// False positives with `render` props (e.g. `<Text render={ <h1 /> }>…</Text>`).
+		// See https://github.com/WordPress/gutenberg/issues/76501
+		'jsx-a11y/heading-has-content': 'off',
 		'jsx-a11y/label-has-associated-control': [
 			'error',
 			{

--- a/packages/ui/src/card/stories/index.story.tsx
+++ b/packages/ui/src/card/stories/index.story.tsx
@@ -116,7 +116,6 @@ export const CustomSemantics: Story = {
 		children: (
 			<>
 				<Card.Header>
-					{ /* eslint-disable-next-line jsx-a11y/heading-has-content -- content provided via render prop */ }
 					<Card.Title render={ <h2 /> }>Section heading</Card.Title>
 				</Card.Header>
 				<Card.Content>

--- a/packages/ui/src/card/test/index.test.tsx
+++ b/packages/ui/src/card/test/index.test.tsx
@@ -82,7 +82,6 @@ describe( 'Card', () => {
 			render(
 				<Card.Root>
 					<Card.Header>
-						{ /* eslint-disable-next-line jsx-a11y/heading-has-content -- content provided via render prop */ }
 						<Card.Title render={ <h2 /> }>Heading</Card.Title>
 					</Card.Header>
 				</Card.Root>

--- a/packages/ui/src/empty-state/title.tsx
+++ b/packages/ui/src/empty-state/title.tsx
@@ -12,7 +12,6 @@ export const Title = forwardRef< HTMLHeadingElement, EmptyStateTitleProps >(
 		return (
 			<Text
 				variant="heading-lg"
-				// eslint-disable-next-line jsx-a11y/heading-has-content -- content provided via render prop
 				render={ render ?? <h2 ref={ ref } { ...props } /> }
 				className={ clsx( styles.title, className ) }
 			>

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/heading-has-content */
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Text } from '../index';
 import { Stack } from '../../stack';
@@ -65,4 +64,3 @@ export const WithRenderProp: Story = {
 		</Stack>
 	),
 };
-/* eslint-enable jsx-a11y/heading-has-content */

--- a/packages/ui/src/text/test/index.test.tsx
+++ b/packages/ui/src/text/test/index.test.tsx
@@ -34,10 +34,7 @@ describe( 'Text', () => {
 	} );
 
 	it( 'supports the render prop', () => {
-		render(
-			// eslint-disable-next-line jsx-a11y/heading-has-content
-			<Text render={ <h2 /> }>Section title</Text>
-		);
+		render( <Text render={ <h2 /> }>Section title</Text> );
 
 		expect(
 			screen.getByRole( 'heading', { level: 2, name: 'Section title' } )

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -146,7 +146,6 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 									'var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-lg)',
 							} }
 						>
-							{ /* eslint-disable jsx-a11y/heading-has-content */ }
 							<Text
 								variant="heading-sm"
 								render={ <h2 /> }
@@ -157,7 +156,6 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 							>
 								My App
 							</Text>
-							{ /* eslint-enable jsx-a11y/heading-has-content */ }
 							<nav>
 								<Stack
 									direction="column"
@@ -221,7 +219,6 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 											gap: 'var(--wpds-dimension-gap-md)',
 										} }
 									>
-										{ /* eslint-disable jsx-a11y/heading-has-content */ }
 										<Text
 											variant="heading-lg"
 											render={ <h1 /> }
@@ -231,7 +228,6 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 										>
 											Settings
 										</Text>
-										{ /* eslint-enable jsx-a11y/heading-has-content */ }
 										<Badge intent="informational">
 											Beta
 										</Badge>


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/76501

Turns off `jsx-a11y/heading-has-content` in the shared `@wordpress/eslint-plugin` jsx-a11y preset.

Also removes the `eslint-disable` comments that existed only for that rule (including in `PostTitle`, where the visible title comes from `useRichText` on the DOM, not from JSX children).

## Why?

The rule only looks at static JSX. It flags patterns like `<Text render={ <h1 /> }>Title</Text>` as an empty heading, even though children are composed correctly at runtime. `eslint-plugin-jsx-a11y` does not provide a way to allowlist that pattern, so the noise was likely to grow as `@wordpress/ui` adoption grows.

This specific accessibility lint rule wasn't added explicitly, just added as part of a broad set of accessibility lint rules. I doubt that empty headings was ever a problem that necessitated a dedicated lint rule, and now that it has tangible downsides, I think we should try removing it and see if that actually is a problem worth linting.

See #76501 for more details on the alternatives considered.

## How?

- Set `'jsx-a11y/heading-has-content': 'off'` in `packages/eslint-plugin/configs/jsx-a11y.js`, with a short comment pointing to the issue.
- Remove redundant suppressions in `@wordpress/ui` (Text, Card, EmptyState), Storybook, and narrow the `PostTitle` disable so it only covers `jsx-a11y/no-noninteractive-element-to-interactive-role`.

## Testing Instructions

1. `npm run lint:js`

## Use of AI Tools

Composer 2