### PR TITLE
CI: Skip workflow jobs that should not run on forks

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -84,7 +84,7 @@ jobs:
 
     merge-artifacts:
         name: Merge Artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request') }}
         needs: [e2e-playwright]
         runs-on: 'ubuntu-24.04'
         permissions:

--- a/.github/workflows/sync-backport-changelog.yml
+++ b/.github/workflows/sync-backport-changelog.yml
@@ -19,11 +19,13 @@ jobs:
             contents: read
             issues: write
         if: >
-            github.event_name == 'push' ||
-            (
-                github.event_name == 'issues' &&
-                github.event.action == 'labeled' &&
-                github.event.label.name == '🤖 Sync Backport Changelog'
+            github.repository == 'WordPress/gutenberg' && (
+                github.event_name == 'push' ||
+                (
+                    github.event_name == 'issues' &&
+                    github.event.action == 'labeled' &&
+                    github.event.label.name == '🤖 Sync Backport Changelog'
+                )
             )
         steps:
             - name: Checkout

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -369,7 +369,7 @@ jobs:
         runs-on: 'ubuntu-24.04'
         permissions: {}
         needs: [test-php, phpcs]
-        if: ${{ always() }}
+        if: ${{ always() && (github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request') }}
         steps:
             - name: Fail the job if the PHPUnit tests fail
               if: ${{ needs.test-php.result != 'success' }}


### PR DESCRIPTION
## What

Adds fork-repository guards to three workflow jobs that currently run (and in one case, fail) on every push to `trunk` in forked repositories.

## Why

When syncing a fork of `WordPress/gutenberg`, every push to `trunk` triggers workflow runs. Most jobs are correctly gated with `github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request'`, but three are not:

1. **`unit-test.yml` → `unit-php` aggregator job** — gated only by `if: always()`. When `test-php` and `phpcs` are skipped on a fork, this job runs and evaluates `needs.test-php.result != 'success'`. Since `skipped != success`, it exits 1, marking every fork push as a failed Unit Tests run. This is the most visible problem — forks see a red ❌ on every commit synced from upstream.

2. **`end2end-test.yml` → `merge-artifacts` job** — gated only by `if: !cancelled()`. The upstream `e2e-playwright` job is correctly skipped on forks, but `merge-artifacts` still spins up a runner, checks out the repo, and runs `npm install` for nothing.

3. **`sync-backport-changelog.yml`** — has no fork guard at all. On every push to `trunk` in a fork it attempts to look up an issue with the `🤖 Sync Backport Changelog` label in the fork itself, which is meaningless outside of `WordPress/gutenberg`.

## How

Each job now also checks `github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request'`, matching the guard already used by the sibling jobs in the same workflows.

## Testing instructions

- Verify the unit-test workflow still passes on a PR (the `pull_request` branch of the condition is unchanged).
- After merging, fork pushes to `trunk` should no longer show the failing `Unit Tests` run, the `Merge Artifacts` job should be skipped, and `Sync Core Backport Issue` should not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)