### PR TITLE
Search block: Derive 'isSearchFieldHidden' value

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -912,7 +912,7 @@ Help visitors find your content. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/search
 -	**Category:** widgets
 -	**Supports:** align (center, left, right), anchor, color (background, gradients, text), interactivity, spacing (margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** buttonPosition, buttonText, buttonUseIcon, isSearchFieldHidden, label, placeholder, query, showLabel, width, widthUnit
+-	**Attributes:** buttonPosition, buttonText, buttonUseIcon, label, placeholder, query, showLabel, width, widthUnit
 
 ## Separator
 

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -42,10 +42,6 @@
 		"query": {
 			"type": "object",
 			"default": {}
-		},
-		"isSearchFieldHidden": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -70,7 +70,6 @@ export default function SearchEdit( {
 		buttonText,
 		buttonPosition,
 		buttonUseIcon,
-		isSearchFieldHidden,
 		style,
 	} = attributes;
 
@@ -139,6 +138,7 @@ export default function SearchEdit( {
 	const isButtonPositionOutside = 'button-outside' === buttonPosition;
 	const hasNoButton = 'no-button' === buttonPosition;
 	const hasOnlyButton = 'button-only' === buttonPosition;
+	const isSearchFieldHidden = hasOnlyButton && ! isSelected;
 	const searchFieldRef = useRef();
 	const buttonRef = useRef();
 
@@ -146,25 +146,6 @@ export default function SearchEdit( {
 		availableUnits: [ '%', 'px' ],
 		defaultValues: { '%': PC_WIDTH_DEFAULT, px: PX_WIDTH_DEFAULT },
 	} );
-
-	useEffect( () => {
-		if ( hasOnlyButton && ! isSelected ) {
-			setAttributes( {
-				isSearchFieldHidden: true,
-			} );
-		}
-	}, [ hasOnlyButton, isSelected, setAttributes ] );
-
-	// Show the search field when width changes.
-	useEffect( () => {
-		if ( ! hasOnlyButton || ! isSelected ) {
-			return;
-		}
-
-		setAttributes( {
-			isSearchFieldHidden: false,
-		} );
-	}, [ hasOnlyButton, isSelected, setAttributes, width ] );
 
 	const getBlockClassNames = () => {
 		return clsx(
@@ -292,14 +273,6 @@ export default function SearchEdit( {
 				  }
 				: borderProps.style ),
 		};
-		const handleButtonClick = () => {
-			if ( hasOnlyButton ) {
-				setAttributes( {
-					isSearchFieldHidden: ! isSearchFieldHidden,
-				} );
-			}
-		};
-
 		return (
 			<>
 				{ buttonUseIcon && (
@@ -312,7 +285,6 @@ export default function SearchEdit( {
 								? stripHTML( buttonText )
 								: __( 'Search' )
 						}
-						onClick={ handleButtonClick }
 						ref={ buttonRef }
 					>
 						<Icon icon={ search } />
@@ -331,7 +303,6 @@ export default function SearchEdit( {
 						onChange={ ( html ) =>
 							setAttributes( { buttonText: html } )
 						}
-						onClick={ handleButtonClick }
 					/>
 				) }
 			</>
@@ -351,7 +322,6 @@ export default function SearchEdit( {
 							showLabel: true,
 							buttonUseIcon: false,
 							buttonPosition: 'button-outside',
-							isSearchFieldHidden: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -382,7 +352,6 @@ export default function SearchEdit( {
 						onDeselect={ () => {
 							setAttributes( {
 								buttonPosition: 'button-outside',
-								isSearchFieldHidden: false,
 							} );
 						} }
 						isShownByDefault
@@ -394,8 +363,6 @@ export default function SearchEdit( {
 							onChange={ ( value ) => {
 								setAttributes( {
 									buttonPosition: value,
-									isSearchFieldHidden:
-										value === 'button-only',
 								} );
 							} }
 							options={ buttonPositionControls }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -164,7 +164,7 @@ export default function SearchEdit( {
 			buttonUseIcon && ! hasNoButton
 				? 'wp-block-search__icon-button'
 				: undefined,
-			hasOnlyButton && isSearchFieldHidden
+			isSearchFieldHidden
 				? 'wp-block-search__searchfield-hidden'
 				: undefined
 		);

--- a/test/integration/fixtures/blocks/core__search.json
+++ b/test/integration/fixtures/blocks/core__search.json
@@ -7,8 +7,7 @@
 			"placeholder": "",
 			"buttonPosition": "button-outside",
 			"buttonUseIcon": false,
-			"query": {},
-			"isSearchFieldHidden": false
+			"query": {}
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__search__custom-text.json
+++ b/test/integration/fixtures/blocks/core__search__custom-text.json
@@ -9,8 +9,7 @@
 			"buttonText": "Custom button text",
 			"buttonPosition": "button-outside",
 			"buttonUseIcon": false,
-			"query": {},
-			"isSearchFieldHidden": false
+			"query": {}
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Closes #53174.
Introduced via #50487.

PR removes unnecessary attribute sync via effects, which was creating unwanted undo history entries. Use a simple derived state to apply editor-only classes.

I know this isn't 100% match to previous behavior, but expanding the block on selection is what we need most of the time.

### What's different from trunk?

Clicking on the search button in the block editor canvas will no longer collapse/example the input field.

## How?
I came to the same conclusion as @t-hamano in https://github.com/WordPress/gutenberg/pull/52519#issuecomment-1658567520.

## Testing Instructions
1. Open a post or page.
2. Insert the Search block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3db53bed-c50e-4043-b53f-221d14ffdb3f

## Use of AI Tools

None.