### PR TITLE
RTC: Respect WP_ALLOW_COLLABORATION in Gutenberg for activation hook

### DIFF
--- a/backport-changelog/7.0/11311.md
+++ b/backport-changelog/7.0/11311.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11311
 
 * https://github.com/WordPress/gutenberg/pull/76716
+* https://github.com/WordPress/gutenberg/pull/77084

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -226,37 +226,6 @@ function gutenberg_inject_real_time_collaboration_setting() {
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 
 /**
- * Ensures real-time collaboration is enabled by default when the Gutenberg
- * plugin is active and collaboration is allowed.
- *
- * `default_option_*` fires when the option is not yet in the database,
- * ensuring get_option() returns true even before the option is saved.
- *
- * @return bool True if collaboration is allowed, false otherwise.
- */
-function gutenberg_collaboration_default_enabled() {
-	return wp_is_collaboration_allowed();
-}
-add_filter( 'default_option_wp_collaboration_enabled', 'gutenberg_collaboration_default_enabled' );
-
-/**
- * When the collaboration option is first inserted into the database with a
- * disabled value, overrides it to enabled if collaboration is allowed. This
- * hook fires only on `add_option` — not `update_option` — so it does not
- * interfere with a user explicitly disabling collaboration via the settings
- * page.
- *
- * @param string $option The option name.
- * @param mixed  $value  The option value being stored.
- */
-function gutenberg_override_collaboration_on_add( $option, $value ) {
-	if ( ! $value && wp_is_collaboration_allowed() ) {
-		update_option( 'wp_collaboration_enabled', '1' );
-	}
-}
-add_action( 'add_option_wp_collaboration_enabled', 'gutenberg_override_collaboration_on_add', 10, 2 );
-
-/**
  * Core adds an option with the default value, so we need to set the option to
  * our intended default when the Gutenberg plugin is activated, provided
  * collaboration is allowed.

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -226,11 +226,45 @@ function gutenberg_inject_real_time_collaboration_setting() {
 add_action( 'admin_init', 'gutenberg_inject_real_time_collaboration_setting' );
 
 /**
+ * Ensures real-time collaboration is enabled by default when the Gutenberg
+ * plugin is active and collaboration is allowed.
+ *
+ * `default_option_*` fires when the option is not yet in the database,
+ * ensuring get_option() returns true even before the option is saved.
+ *
+ * @return bool True if collaboration is allowed, false otherwise.
+ */
+function gutenberg_collaboration_default_enabled() {
+	return wp_is_collaboration_allowed();
+}
+add_filter( 'default_option_wp_collaboration_enabled', 'gutenberg_collaboration_default_enabled' );
+
+/**
+ * When the collaboration option is first inserted into the database with a
+ * disabled value, overrides it to enabled if collaboration is allowed. This
+ * hook fires only on `add_option` — not `update_option` — so it does not
+ * interfere with a user explicitly disabling collaboration via the settings
+ * page.
+ *
+ * @param string $option The option name.
+ * @param mixed  $value  The option value being stored.
+ */
+function gutenberg_override_collaboration_on_add( $option, $value ) {
+	if ( ! $value && wp_is_collaboration_allowed() ) {
+		update_option( 'wp_collaboration_enabled', '1' );
+	}
+}
+add_action( 'add_option_wp_collaboration_enabled', 'gutenberg_override_collaboration_on_add', 10, 2 );
+
+/**
  * Core adds an option with the default value, so we need to set the option to
- * our intended default when the Gutenberg plugin is activated.
+ * our intended default when the Gutenberg plugin is activated, provided
+ * collaboration is allowed.
  */
 function gutenberg_set_collaboration_option_on_activation() {
-	update_option( 'wp_collaboration_enabled', '1' );
+	if ( wp_is_collaboration_allowed() ) {
+		update_option( 'wp_collaboration_enabled', '1' );
+	}
 }
 add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_option_on_activation' );
 

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -7,7 +7,7 @@
 
 if ( ! defined( '_GUTENBERG_VERSION_MIGRATION' ) ) {
 	// It's necessary to update this version every time a new migration is needed.
-	define( '_GUTENBERG_VERSION_MIGRATION', '22.9.0' );
+	define( '_GUTENBERG_VERSION_MIGRATION', '22.8.0' );
 }
 
 /**
@@ -27,10 +27,6 @@ function _gutenberg_migrate_database() {
 
 		if ( version_compare( $gutenberg_installed_version, '22.8.0', '<' ) ) {
 			_gutenberg_migrate_enable_real_time_collaboration();
-		}
-
-		if ( version_compare( $gutenberg_installed_version, '22.9.0', '<' ) ) {
-			_gutenberg_migrate_enable_collaboration_default();
 		}
 
 		update_option( 'gutenberg_version_migration', _GUTENBERG_VERSION_MIGRATION );
@@ -84,19 +80,6 @@ function _gutenberg_migrate_enable_real_time_collaboration() {
 
 	delete_option( 'enable_real_time_collaboration' );
 	delete_option( 'wp_enable_real_time_collaboration' );
-}
-
-/**
- * Ensure real-time collaboration is enabled by default for existing
- * installations where the option may have been stored as disabled,
- * provided collaboration is allowed.
- *
- * @since 22.9.0
- */
-function _gutenberg_migrate_enable_collaboration_default() {
-	if ( wp_is_collaboration_allowed() ) {
-		update_option( 'wp_collaboration_enabled', '1' );
-	}
 }
 
 // Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_fse_drafts) must happen

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -7,7 +7,7 @@
 
 if ( ! defined( '_GUTENBERG_VERSION_MIGRATION' ) ) {
 	// It's necessary to update this version every time a new migration is needed.
-	define( '_GUTENBERG_VERSION_MIGRATION', '22.8.0' );
+	define( '_GUTENBERG_VERSION_MIGRATION', '22.9.0' );
 }
 
 /**
@@ -27,6 +27,10 @@ function _gutenberg_migrate_database() {
 
 		if ( version_compare( $gutenberg_installed_version, '22.8.0', '<' ) ) {
 			_gutenberg_migrate_enable_real_time_collaboration();
+		}
+
+		if ( version_compare( $gutenberg_installed_version, '22.9.0', '<' ) ) {
+			_gutenberg_migrate_enable_collaboration_default();
 		}
 
 		update_option( 'gutenberg_version_migration', _GUTENBERG_VERSION_MIGRATION );
@@ -80,6 +84,19 @@ function _gutenberg_migrate_enable_real_time_collaboration() {
 
 	delete_option( 'enable_real_time_collaboration' );
 	delete_option( 'wp_enable_real_time_collaboration' );
+}
+
+/**
+ * Ensure real-time collaboration is enabled by default for existing
+ * installations where the option may have been stored as disabled,
+ * provided collaboration is allowed.
+ *
+ * @since 22.9.0
+ */
+function _gutenberg_migrate_enable_collaboration_default() {
+	if ( wp_is_collaboration_allowed() ) {
+		update_option( 'wp_collaboration_enabled', '1' );
+	}
 }
 
 // Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_fse_drafts) must happen


### PR DESCRIPTION
## What?

Ensures real-time collaboration (RTC) is only enabled by default when collaboration is allowed at the host level. 

## Why?

In WordPress core, we have a config `WP_ALLOW_COLLABORATION` that ensures that hosts can disallow collaboration at the core level. Gutenberg should be respecting that always.

## How?

Add in a check via the `wp_is_collaboration_allowed` into the activation hook to ensure that the config is respected when flipping the option.

## Testing Instructions
1. Fresh install: Start wp-env, go to Settings > Writing. The collaboration checkbox should be checked.
2. Explicit disable: Uncheck the checkbox, save. Reload — it should stay unchecked.
3. Re-enable: Check the checkbox, save. Reload — it should stay checked.
4. `WP_ALLOW_COLLABORATION` = false: Add `"config": { "WP_ALLOW_COLLABORATION": false }` to `.wp-env.override.json`, restart wp-env. The checkbox should not appear; a "disabled" notice is shown instead. The migration and hooks should not force-enable the option.

## Use of AI Tools
This PR was authored with assistance from Claude Code (Claude Opus 4.6).