### PR TITLE
Remove remaining esModuleInterop usage

### DIFF
--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -4,7 +4,6 @@
 	"compilerOptions": {
 		"module": "node16",
 		"moduleResolution": "node16",
-		"esModuleInterop": true,
 		"target": "ES6",
 		"lib": [ "ES6", "ES2020.string" ],
 		"rootDir": ".",

--- a/packages/core-data/src/hooks/memoize.js
+++ b/packages/core-data/src/hooks/memoize.js
@@ -3,5 +3,4 @@
  */
 import memoize from 'memize';
 
-// re-export due to restrictive esModuleInterop setting
 export default memoize;

--- a/packages/core-data/src/hooks/memoize.js
+++ b/packages/core-data/src/hooks/memoize.js
@@ -1,6 +1,0 @@
-/**
- * External dependencies
- */
-import memoize from 'memize';
-
-export default memoize;

--- a/packages/core-data/src/hooks/use-query-select.ts
+++ b/packages/core-data/src/hooks/use-query-select.ts
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import memoize from './memoize';
+import memoize from 'memize';
 import { Status } from './constants';
 
 export const META_SELECTORS = [

--- a/packages/wp-build/tsconfig.json
+++ b/packages/wp-build/tsconfig.json
@@ -4,7 +4,6 @@
 	"compilerOptions": {
 		"module": "node16",
 		"moduleResolution": "node16",
-		"esModuleInterop": true,
 		"target": "es2021",
 		"lib": [ "es2021", "ES2020.string" ],
 		"rootDir": ".",


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/77010#discussion_r3044131089

Removes the remaining `esModuleInterop` compiler option from the codebase.

## Why?

As pointed out in the linked review comment, `esModuleInterop` was still enabled in `bin/tsconfig.json` and `packages/wp-build/tsconfig.json`. This option is unnecessary and its removal was missed in #77010.

## How?

- Removed `esModuleInterop: true` from `bin/tsconfig.json`
- Removed `esModuleInterop: true` from `packages/wp-build/tsconfig.json`
- Removed the now-unnecessary "re-export due to restrictive esModuleInterop setting" comment in `packages/core-data/src/hooks/memoize.js`

## Testing Instructions

1. Verify the TypeScript compilation still works: `npx tsc --project bin/tsconfig.json --noEmit` and `npx tsc --project packages/wp-build/tsconfig.json --noEmit`
2. Run `npm run build` and verify no errors.

## Use of AI Tools

Claude Code was used to create the commit and PR.