### PR TITLE
Editor: Extend "Apply globally" to inner blocks within parent

### DIFF
--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -444,7 +444,7 @@ function PushChangesToGlobalStylesControl( {
 				help={ sprintf(
 					// translators: 1: Block title e.g. 'Heading'. 2: Scope title e.g. 'Accordion'.
 					__(
-						"Apply this block's typography, spacing, dimensions, and color styles to either all %1$s blocks in this %2$s, or to all %1$s blocks globally across the site."
+						"Apply this block's typography, spacing, dimensions, and color styles to either all %1$s blocks in this %2$s, or to all %1$s blocks globally."
 					),
 					blockTitle,
 					scopeBlockTitle
@@ -530,7 +530,7 @@ function PushChangesToGlobalStylesControl( {
 			help={ sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
 				__(
-					"Apply this block's typography, spacing, dimensions, and color styles to all %s blocks globally across the site."
+					"Apply this block's typography, spacing, dimensions, and color styles to all %s blocks globally."
 				),
 				blockTitle
 			) }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -17,7 +17,7 @@ import {
 	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { useMemo, useCallback, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -325,7 +325,7 @@ function PushChangesToGlobalStylesControl( {
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
-	const pushChanges = useCallback( () => {
+	const pushChanges = () => {
 		if ( changes.length === 0 ) {
 			return;
 		}
@@ -385,18 +385,9 @@ function PushChangesToGlobalStylesControl( {
 				}
 			);
 		}
-	}, [
-		__unstableMarkNextChangeAsNotPersistent,
-		attributes,
-		changes,
-		createSuccessNotice,
-		name,
-		setAttributes,
-		setUserConfig,
-		userConfig,
-	] );
+	};
 
-	const applyToSiblings = useCallback( () => {
+	const applyToSiblings = () => {
 		if ( siblingClientIds.length === 0 ) {
 			return;
 		}
@@ -419,14 +410,7 @@ function PushChangesToGlobalStylesControl( {
 			),
 			{ type: 'snackbar' }
 		);
-	}, [
-		siblingClientIds,
-		attributes,
-		updateBlockAttributes,
-		createSuccessNotice,
-		name,
-		scopeBlockTitle,
-	] );
+	};
 
 	const hasSiblingOption = siblingClientIds.length > 0;
 	const hasGlobalOption = isBlockBasedTheme;
@@ -438,13 +422,13 @@ function PushChangesToGlobalStylesControl( {
 		hasSiblingOption ? SCOPE_SIBLINGS : SCOPE_GLOBAL
 	);
 
-	const handleApply = useCallback( () => {
+	const handleApply = () => {
 		if ( scope === SCOPE_SIBLINGS ) {
 			applyToSiblings();
 		} else {
 			pushChanges();
 		}
-	}, [ scope, applyToSiblings, pushChanges ] );
+	};
 
 	const blockTitle = getBlockType( name ).title;
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -9,7 +9,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { BaseControl, Button } from '@wordpress/components';
+import { BaseControl, Button, RadioControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY,
@@ -17,8 +17,8 @@ import {
 	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { useMemo, useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useMemo, useCallback, useState } from '@wordpress/element';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -103,6 +103,56 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 };
 
 const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
+
+// Style attributes copied when applying styles to sibling blocks.
+const SIBLING_STYLE_ATTRIBUTES = [
+	'borderColor',
+	'backgroundColor',
+	'textColor',
+	'gradient',
+	'fontSize',
+	'fontFamily',
+	'style',
+];
+
+/**
+ * Finds the nearest ancestor block that contains at least one other block of
+ * the same type as the current block. Returns the ancestor's block title and
+ * the clientIds of those same-type siblings (excluding the current block).
+ *
+ * @param {string} blockName The current block's name.
+ * @param {string} clientId  The current block's clientId.
+ * @return {{ scopeBlockTitle: string|null, siblingClientIds: string[] }} The nearest ancestor's title and the sibling clientIds.
+ */
+function useSiblingScope( blockName, clientId ) {
+	return useSelect(
+		( select ) => {
+			const { getBlockParents, getBlockName, getClientIdsOfDescendants } =
+				select( blockEditorStore );
+
+			for ( const parentId of getBlockParents( clientId, true ) ) {
+				const sameTypeSiblings = getClientIdsOfDescendants(
+					parentId
+				).filter(
+					( id ) =>
+						id !== clientId && getBlockName( id ) === blockName
+				);
+
+				if ( sameTypeSiblings.length > 0 ) {
+					return {
+						scopeBlockTitle: getBlockType(
+							getBlockName( parentId )
+						)?.title,
+						siblingClientIds: sameTypeSiblings,
+					};
+				}
+			}
+
+			return { scopeBlockTitle: null, siblingClientIds: [] };
+		},
+		[ blockName, clientId ]
+	);
+}
 
 const getValueFromObjectPath = ( object, path ) => {
 	let value = object;
@@ -244,14 +294,22 @@ function PushChangesToGlobalStylesControl( {
 	name,
 	attributes,
 	setAttributes,
+	clientId,
+	isBlockBasedTheme,
 } ) {
 	const { user: userConfig, setUser: setUserConfig } = useGlobalStyles();
 
 	const changes = useChangesToPush( name, attributes, userConfig );
 
-	const { __unstableMarkNextChangeAsNotPersistent } =
+	const { scopeBlockTitle, siblingClientIds } = useSiblingScope(
+		name,
+		clientId
+	);
+
+	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
+	const registry = useRegistry();
 
 	const pushChanges = useCallback( () => {
 		if ( changes.length === 0 ) {
@@ -324,15 +382,157 @@ function PushChangesToGlobalStylesControl( {
 		userConfig,
 	] );
 
+	const applyToSiblings = useCallback( () => {
+		if ( siblingClientIds.length === 0 ) {
+			return;
+		}
+
+		const styleAttrs = Object.fromEntries(
+			SIBLING_STYLE_ATTRIBUTES.map( ( key ) => [
+				key,
+				attributes[ key ],
+			] )
+		);
+
+		registry.batch( () => {
+			updateBlockAttributes( siblingClientIds, styleAttrs );
+		} );
+
+		createSuccessNotice(
+			sprintf(
+				// translators: 1: Block title e.g. 'Heading'. 2: Scope title e.g. 'Accordion'.
+				__( '%1$s styles applied to all blocks in this %2$s.' ),
+				getBlockType( name ).title,
+				scopeBlockTitle
+			),
+			{ type: 'snackbar' }
+		);
+	}, [
+		siblingClientIds,
+		attributes,
+		registry,
+		updateBlockAttributes,
+		createSuccessNotice,
+		name,
+		scopeBlockTitle,
+	] );
+
+	const hasSiblingOption = siblingClientIds.length > 0;
+	const hasGlobalOption = isBlockBasedTheme;
+	const showRadio = hasSiblingOption && hasGlobalOption;
+
+	const SCOPE_SIBLINGS = 'siblings';
+	const SCOPE_GLOBAL = 'global';
+	const [ scope, setScope ] = useState(
+		hasSiblingOption ? SCOPE_SIBLINGS : SCOPE_GLOBAL
+	);
+
+	const handleApply = useCallback( () => {
+		if ( scope === SCOPE_SIBLINGS ) {
+			applyToSiblings();
+		} else {
+			pushChanges();
+		}
+	}, [ scope, applyToSiblings, pushChanges ] );
+
+	const blockTitle = getBlockType( name ).title;
+
+	if ( showRadio ) {
+		return (
+			<BaseControl
+				className="editor-push-changes-to-global-styles-control"
+				help={ sprintf(
+					// translators: 1: Block title e.g. 'Heading'. 2: Scope title e.g. 'Accordion'.
+					__(
+						"Apply this block's typography, spacing, dimensions, and color styles to either all %1$s blocks in this %2$s, or to all %1$s blocks globally across the site."
+					),
+					blockTitle,
+					scopeBlockTitle
+				) }
+			>
+				<BaseControl.VisualLabel>
+					{ __( 'Styles' ) }
+				</BaseControl.VisualLabel>
+				<RadioControl
+					label={ __( 'Apply style changes to' ) }
+					hideLabelFromVision
+					selected={ scope }
+					options={ [
+						{
+							label: sprintf(
+								// translators: 1: Block title e.g. 'Heading'. 2: Scope title e.g. 'Accordion'.
+								__( 'Apply to all %1$s blocks in this %2$s' ),
+								blockTitle,
+								scopeBlockTitle
+							),
+							value: SCOPE_SIBLINGS,
+						},
+						{
+							label: sprintf(
+								// translators: %s: Title of the block e.g. 'Heading'.
+								__( 'Apply to all %s blocks globally' ),
+								blockTitle
+							),
+							value: SCOPE_GLOBAL,
+						},
+					] }
+					onChange={ setScope }
+				/>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					accessibleWhenDisabled
+					disabled={ scope === SCOPE_GLOBAL && changes.length === 0 }
+					onClick={ handleApply }
+					style={ { width: '100%' } }
+				>
+					{ __( 'Apply style changes' ) }
+				</Button>
+			</BaseControl>
+		);
+	}
+
+	if ( hasSiblingOption ) {
+		return (
+			<BaseControl
+				className="editor-push-changes-to-global-styles-control"
+				help={ sprintf(
+					// translators: 1: Block title e.g. 'Heading'. 2: Scope title e.g. 'Accordion'.
+					__(
+						"Apply this block's typography, spacing, dimensions, and color styles to all %1$s blocks in this %2$s."
+					),
+					blockTitle,
+					scopeBlockTitle
+				) }
+			>
+				<BaseControl.VisualLabel>
+					{ __( 'Styles' ) }
+				</BaseControl.VisualLabel>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ applyToSiblings }
+				>
+					{ sprintf(
+						// translators: 1: Block title e.g. 'Heading'. 2: Scope title e.g. 'Accordion'.
+						__( 'Apply to all %1$s blocks in this %2$s' ),
+						blockTitle,
+						scopeBlockTitle
+					) }
+				</Button>
+			</BaseControl>
+		);
+	}
+
 	return (
 		<BaseControl
 			className="editor-push-changes-to-global-styles-control"
 			help={ sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
 				__(
-					'Apply this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
+					"Apply this block's typography, spacing, dimensions, and color styles to all %s blocks globally across the site."
 				),
-				getBlockType( name ).title
+				blockTitle
 			) }
 		>
 			<BaseControl.VisualLabel>
@@ -360,16 +560,17 @@ function PushChangesToGlobalStyles( props ) {
 	const supportsStyles = SUPPORTED_STYLES.some( ( feature ) =>
 		hasBlockSupport( props.name, feature )
 	);
-	const isDisplayed =
-		blockEditingMode === 'default' && supportsStyles && isBlockBasedTheme;
 
-	if ( ! isDisplayed ) {
+	if ( blockEditingMode !== 'default' || ! supportsStyles ) {
 		return null;
 	}
 
 	return (
 		<InspectorAdvancedControls>
-			<PushChangesToGlobalStylesControl { ...props } />
+			<PushChangesToGlobalStylesControl
+				{ ...props }
+				isBlockBasedTheme={ isBlockBasedTheme }
+			/>
 		</InspectorAdvancedControls>
 	);
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -18,7 +18,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMemo, useCallback, useState } from '@wordpress/element';
-import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -324,7 +324,6 @@ function PushChangesToGlobalStylesControl( {
 	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
-	const registry = useRegistry();
 
 	const pushChanges = useCallback( () => {
 		if ( changes.length === 0 ) {
@@ -409,9 +408,7 @@ function PushChangesToGlobalStylesControl( {
 			] )
 		);
 
-		registry.batch( () => {
-			updateBlockAttributes( siblingClientIds, styleAttrs );
-		} );
+		updateBlockAttributes( siblingClientIds, styleAttrs );
 
 		createSuccessNotice(
 			sprintf(
@@ -425,7 +422,6 @@ function PushChangesToGlobalStylesControl( {
 	}, [
 		siblingClientIds,
 		attributes,
-		registry,
 		updateBlockAttributes,
 		createSuccessNotice,
 		name,

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -125,33 +125,48 @@ const SIBLING_STYLE_ATTRIBUTES = [
  * @return {{ scopeBlockTitle: string|null, siblingClientIds: string[] }} The nearest ancestor's title and the sibling clientIds.
  */
 function useSiblingScope( blockName, clientId ) {
-	return useSelect(
+	const { parentId, scopeBlockTitle } = useSelect(
 		( select ) => {
 			const { getBlockParents, getBlockName, getClientIdsOfDescendants } =
 				select( blockEditorStore );
 
-			for ( const parentId of getBlockParents( clientId, true ) ) {
-				const sameTypeSiblings = getClientIdsOfDescendants(
-					parentId
-				).filter(
+			for ( const pId of getBlockParents( clientId, true ) ) {
+				const hasSibling = getClientIdsOfDescendants( pId ).some(
 					( id ) =>
 						id !== clientId && getBlockName( id ) === blockName
 				);
 
-				if ( sameTypeSiblings.length > 0 ) {
+				if ( hasSibling ) {
 					return {
-						scopeBlockTitle: getBlockType(
-							getBlockName( parentId )
-						)?.title,
-						siblingClientIds: sameTypeSiblings,
+						parentId: pId,
+						scopeBlockTitle:
+							getBlockType( getBlockName( pId ) )?.title ?? null,
 					};
 				}
 			}
 
-			return { scopeBlockTitle: null, siblingClientIds: [] };
+			return { parentId: null, scopeBlockTitle: null };
 		},
 		[ blockName, clientId ]
 	);
+
+	const siblingClientIds = useSelect(
+		( select ) => {
+			if ( ! parentId ) {
+				return [];
+			}
+
+			const { getBlockName, getClientIdsOfDescendants } =
+				select( blockEditorStore );
+
+			return getClientIdsOfDescendants( parentId ).filter(
+				( id ) => id !== clientId && getBlockName( id ) === blockName
+			);
+		},
+		[ parentId, blockName, clientId ]
+	);
+
+	return { scopeBlockTitle, siblingClientIds };
 }
 
 const getValueFromObjectPath = ( object, path ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/76330
Alternative to https://github.com/WordPress/gutenberg/pull/76489

<!-- In a few words, what is the PR actually doing? -->

This PR extends the existing "Apply globally" feature in the Advanced inspector panel to also support applying styles to same-type blocks within the same parent container (e.g. all Accordion Heading blocks within a single Accordion).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When working with blocks that repeat within a parent, like Accordion Headings, Buttons, or Navigation Links, there's no built-in way to keep their styles consistent without manually re-styling each one. The existing "Apply globally" button only targets Global Styles (site-wide), which is too broad when you may just want consistency within a single scope of a parent container.

This PR builds on the "Apply globally" UX to add a scoped alternative, so users can apply styles either to all matching blocks in the nearest parent container or globally across the site.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A `useSiblingScope` hook walks up the block tree from the selected block using `getBlockParents` and `getClientIdsOfDescendants`, looking for the nearest ancestor that contains at least one other block of the same type. It returns the ancestor's display title and the sibling `clientIds`.

When siblings are found:
  - If only siblings are available (post editor, or classic theme): the existing single button is replaced with an "Apply to all [Block] blocks in this [Parent]" button.
  - If both siblings and Global Styles are available (site editor, block-based theme): a `RadioControl` lets the user choose between the two scopes, with a single "Apply style changes" button. The scoped option is pre-selected as the more conservative default.

Applying to siblings copies the block's style attributes to all sibling blocks in a single `registry.batch()` call, giving a single undo step. Unlike "Apply globally", this does not clear the current block's local styles, since there is no site-level canonical store to fall back to.

The `isBlockBasedTheme` gate is moved from the outer component into a prop, so the scoped button is available in both the post editor and site editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert an Accordion block (or any block that contains multiple same-type inner blocks, such as Buttons).
2. Add at least two accordion items so there are multiple Accordion Heading blocks.
3. Select one Accordion Heading and open the Advanced panel in the inspector.
4. Under Styles, you should see a radio control with two options: "Apply to all Accordion Heading blocks in this Accordion" and "Apply to all Accordion Heading blocks globally", plus an Apply style changes button.
5. Apply some typography or colour styles to the selected heading.
6. With the first radio option selected, click Apply style changes. Confirm the other Accordion Heading blocks update to match.
7. Undo (Ctrl+Z / Cmd+Z) and confirm all headings revert in a single step.
8. With the second radio option selected, click Apply style changes. Confirm it behaves identically to the original "Apply globally" button (styles pushed to Global Styles, local attributes cleared, snackbar with Undo shown).
9. Repeat in the post editor. Only the scoped option should appear (no radio, single button).
10. On a classic theme in the site editor: same as step 9.
11. Select a block with no same-type siblings. Only the original "Apply globally" button should appear (no radio).

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="301" height="282" alt="image" src="https://github.com/user-attachments/assets/6e4877f2-a011-49eb-87b4-fe7adb571f69" /> | <img width="301" height="282" alt="image" src="https://github.com/user-attachments/assets/015576f1-f072-4954-93af-01538bb52fda" /> |

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
This PR was developed with the help of Claude Code. The implementation was reviewed and tested by the author.