### PR TITLE
Navigation: Limit list style normalization to navigation block lists to avoid affecting custom overlay lists

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -17,7 +17,8 @@ $navigation-icon-size: 24px;
 	position: relative;
 
 	// Normalize list styles.
-	ul {
+	ul.wp-block-navigation__container,
+	ul.wp-block-navigation__container ul {
 		margin-top: 0;
 		margin-bottom: 0;
 		margin-left: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76936

This updates the Navigation block list-style normalization so it applies only to navigation block lists, instead of all descendant `ul` elements inside `.wp-block-navigation`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The previous broad selector affects list-based blocks rendered inside Custom Navigation overlay content, such as Social Icons.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This change narrows the selector so the list spacing normalization applies to:

- `ul.wp-block-navigation__container`
- nested `ul` elements inside `ul.wp-block-navigation__container`


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Add a Navigation block.
2. Use the overlay menu setup that reproduces the issue.
3. Add a list-based block such as Social Icons inside the overlay content.
4. Confirm the nested block keeps its expected spacing on the front end.
5. Confirm standard Navigation block list styling still works as expected.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

- Used  ChatGPT think through selector options and specificity.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Note: We could also try :where(...) to reduce specificity, open to other inputs.

