### PR TITLE
Remove 'Home' and 'End' key usage from Navigation Tests

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -449,7 +449,7 @@ test.describe( 'Navigation block', () => {
 
 			await test.step( 'focus returns to the submenu appender when exiting the submenu link creation without creating a link', async () => {
 				// Move focus to the submenu navigation appender
-				await page.keyboard.press( 'End' );
+				await page.keyboard.press( Navigation.END_KEY );
 				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 
 				await pageUtils.pressKeys( 'ArrowDown' );
@@ -516,7 +516,6 @@ test.describe( 'Navigation block', () => {
 			// Move to the submenu item (only one ArrowUp needed - skips the
 			// submenu wrapper directly to Cat's content)
 			await page.keyboard.press( 'ArrowUp' );
-			await page.keyboard.press( 'Home' );
 
 			// Check we're on our submenu link
 			await navigation.checkLabelFocus( 'Cat' );
@@ -571,7 +570,7 @@ test.describe( 'Navigation block', () => {
 			 * Test: Deleting first item returns focus to the parent submenu item
 			 */
 			// Add a link back so we can delete the first submenu link.
-			await page.keyboard.press( 'End' );
+			await page.keyboard.press( Navigation.END_KEY );
 			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 			await navigation.useBlockInserter();
 			await navigation.addCustomURL( 'https://wordpress.org' );
@@ -2135,6 +2134,10 @@ test.describe( 'Navigation block', () => {
 } );
 
 class Navigation {
+	/** Platform-aware Home/End keys for caret movement in contenteditable. */
+	static END_KEY = process.platform === 'darwin' ? 'Meta+ArrowRight' : 'End';
+	static HOME_KEY = process.platform === 'darwin' ? 'Meta+ArrowLeft' : 'Home';
+
 	constructor( { page, pageUtils, editor } ) {
 		this.page = page;
 		this.pageUtils = pageUtils;
@@ -2315,9 +2318,7 @@ class Navigation {
 	 * @param {string} label Nav label text
 	 */
 	async checkLabelFocus( label ) {
-		await this.page.keyboard.press( 'Home' );
-		// Select all the text
-		await this.pageUtils.pressKeys( 'Shift+End' );
+		await this.pageUtils.pressKeys( 'primary+a' );
 		await this.expectToHaveTextSelected( label );
 		// Move caret back to starting position
 		await this.pageUtils.pressKeys( 'ArrowLeft' );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -449,7 +449,7 @@ test.describe( 'Navigation block', () => {
 
 			await test.step( 'focus returns to the submenu appender when exiting the submenu link creation without creating a link', async () => {
 				// Move focus to the submenu navigation appender
-				await page.keyboard.press( Navigation.END_KEY );
+				await pageUtils.pressKeys( 'ArrowDown' );
 				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 
 				await pageUtils.pressKeys( 'ArrowDown' );
@@ -570,7 +570,7 @@ test.describe( 'Navigation block', () => {
 			 * Test: Deleting first item returns focus to the parent submenu item
 			 */
 			// Add a link back so we can delete the first submenu link.
-			await page.keyboard.press( Navigation.END_KEY );
+			await pageUtils.pressKeys( 'ArrowDown' );
 			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 			await navigation.useBlockInserter();
 			await navigation.addCustomURL( 'https://wordpress.org' );
@@ -2134,10 +2134,6 @@ test.describe( 'Navigation block', () => {
 } );
 
 class Navigation {
-	/** Platform-aware Home/End keys for caret movement in contenteditable. */
-	static END_KEY = process.platform === 'darwin' ? 'Meta+ArrowRight' : 'End';
-	static HOME_KEY = process.platform === 'darwin' ? 'Meta+ArrowLeft' : 'Home';
-
 	constructor( { page, pageUtils, editor } ) {
 		this.page = page;
 		this.pageUtils = pageUtils;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes focus management navigation e2e tests failing in mac environments.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Easier debugging for understanding issues in the e2e test failures. 
- Get e2e tests passing in Mac environments

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check platform for Home and End and use the correct one:

1. To select block text, replace `Home` + `Shift+End` with `primary+a`
2. To move cursor to end of block text area, replace `End` with `ArrowDown`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
npm run test:e2e test/e2e/specs/editor/blocks/navigation.spec.js

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Claude helped debug and find the solution.