### PR TITLE
Global Styles Revisions: Fix footer overflow

### DIFF
--- a/packages/global-styles-ui/src/screen-revisions/style.scss
+++ b/packages/global-styles-ui/src/screen-revisions/style.scss
@@ -191,4 +191,5 @@
 	background: $white;
 	padding: $grid-unit-15;
 	border-top: $border-width solid $gray-300;
+	box-sizing: border-box;
 }


### PR DESCRIPTION
## What?

| Before | After |
|--------|--------|
| <img width="308" height="675" alt="before" src="https://github.com/user-attachments/assets/242146b9-7733-4481-a218-e9c21ec0a4db" /> | <img width="314" height="675" alt="after" src="https://github.com/user-attachments/assets/c332e107-f825-49a9-9cea-9165460050bf" /> |

## Why?

This issue occurs in the post editor, not the site editor, because the site editor has box-sizing rules like the following.

https://github.com/WordPress/gutenberg/blob/9eec2234e3ac0a582112e7826c7083f0fcf3c373/packages/edit-site/src/style.scss#L67-L68

This problem likely existed since the inception of the `@wordpress/global-styles-ui` package.

## Testing Instructions

- Make over 10 changes to the global styles.
- Open the global styles revisions.
- Confirm that a horizontal scrollbar doesn't appear.

## Use of AI Tools

None