### PR TITLE
Global Styles: move pseudo-state slicing logic into `useStyle` hook

### DIFF
--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -36,17 +36,21 @@ extend( [ a11yPlugin ] );
  * @param blockName          The name of the block, if applicable.
  * @param readFrom           Which source to read from: "base" (theme), "user" (customizations), or "merged" (final result).
  * @param shouldDecodeEncode Whether to decode and encode the style value.
+ * @param state              Optional pseudo-selector state (e.g. `:hover`, `:focus`). When provided,
+ *                           reads from and writes to the state sub-object automatically.
  * @return An array containing the style value and a function to set the style
  * value.
  *
  * @example
  * const [ color, setColor ] = useStyle<string>( 'color.text', 'core/button', 'merged' );
+ * const [ hoverColor, setHoverColor ] = useStyle<string>( 'color.text', 'core/button', 'user', true, ':hover' );
  */
 export function useStyle< T = any >(
 	path: string,
 	blockName?: string,
 	readFrom: 'base' | 'user' | 'merged' = 'merged',
-	shouldDecodeEncode: boolean = true
+	shouldDecodeEncode: boolean = true,
+	state?: string
 ) {
 	const { user, base, merged, onChange } = useContext( GlobalStylesContext );
 
@@ -57,22 +61,43 @@ export function useStyle< T = any >(
 		sourceValue = user;
 	}
 
-	const styleValue = useMemo(
-		() => getStyle< T >( sourceValue, path, blockName, shouldDecodeEncode ),
-		[ sourceValue, path, blockName, shouldDecodeEncode ]
-	);
+	const styleValue = useMemo( () => {
+		const rawValue = getStyle< T >(
+			sourceValue,
+			path,
+			blockName,
+			shouldDecodeEncode
+		);
+		if ( state ) {
+			return ( rawValue as any )?.[ state ] ?? {};
+		}
+		return rawValue;
+	}, [ sourceValue, path, blockName, shouldDecodeEncode, state ] );
 
 	const setStyleValue = useCallback(
 		( newValue: T | undefined ) => {
-			const newGlobalStyles = setStyle< T >(
+			let valueToSet: any = newValue;
+			if ( state ) {
+				const fullCurrentValue = getStyle(
+					user,
+					path,
+					blockName,
+					false
+				);
+				valueToSet = {
+					...( fullCurrentValue as object ),
+					[ state ]: newValue,
+				};
+			}
+			const newGlobalStyles = setStyle< any >(
 				user,
 				path,
-				newValue,
+				valueToSet,
 				blockName
 			);
 			onChange( newGlobalStyles );
 		},
-		[ user, onChange, path, blockName ]
+		[ user, onChange, path, blockName, state ]
 	);
 
 	return [ styleValue, setStyleValue ] as const;

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -114,42 +114,21 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 	const [ selectedState, setSelectedState ] = useState< string >( 'default' );
 	const validStates = useMemo( () => getValidStates( name ), [ name ] );
 
-	const [ rawStyle ] = useStyle( prefix, name, 'user', false );
-	const [ rawInheritedStyle, rawSetStyle ] = useStyle(
+	const stateParam = selectedState !== 'default' ? selectedState : undefined;
+	const [ style, setStyle ] = useStyle(
+		prefix,
+		name,
+		'user',
+		false,
+		stateParam
+	);
+	const [ inheritedStyle ] = useStyle(
 		prefix,
 		name,
 		'merged',
-		false
+		false,
+		stateParam
 	);
-
-	// Extract style for the selected state
-	const style = useMemo( () => {
-		if ( selectedState === 'default' ) {
-			return rawStyle || {};
-		}
-		return rawStyle?.[ selectedState ] || {};
-	}, [ rawStyle, selectedState ] );
-
-	const inheritedStyle = useMemo( () => {
-		if ( selectedState === 'default' ) {
-			return rawInheritedStyle || {};
-		}
-		return rawInheritedStyle?.[ selectedState ] || {};
-	}, [ rawInheritedStyle, selectedState ] );
-
-	// Wrapper for setStyle that handles states
-	const setStyle = ( newStyle: any ) => {
-		if ( selectedState === 'default' ) {
-			rawSetStyle( newStyle );
-		} else {
-			// Merge the new style into the state
-			const updatedStyle = {
-				...rawStyle,
-				[ selectedState ]: newStyle,
-			};
-			rawSetStyle( updatedStyle );
-		}
-	};
 
 	const [ userSettings ] = useSetting( '', name, 'user' );
 	const [ rawSettings, setSettings ] = useSetting( '', name );
@@ -355,11 +334,7 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 				name={ name }
 				variation={ variation }
 				selectedState={ selectedState }
-				stateStyles={
-					selectedState !== 'default'
-						? rawStyle?.[ selectedState ]
-						: undefined
-				}
+				stateStyles={ selectedState !== 'default' ? style : undefined }
 			/>
 			{ hasVariationsPanel && (
 				<div className="global-styles-ui-screen-variations">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This PR partially addresses some of the [feedback](https://github.com/WordPress/gutenberg/pull/76491#pullrequestreview-4066385524) on https://github.com/WordPress/gutenberg/pull/76491

When #75627 landed, `ScreenBlock` needed to display style controls scoped to a pseudo-state (:hover, :focus, etc.). The way it did that was: fetch the entire style object for the block, then manually slice out the relevant state sub-object before passing it to the panels, and on save, manually re-nest the updated value back under the state key before writing. That logic lived directly in `ScreenBlock`, it wasn't part of the hook.

The problem is that `useStyle` is supposed to be the single abstraction for "read/write a style value in Global Styles." But state awareness was leaking out of it into the component. Any other screen that wanted state support in the future would have to copy the same slicing pattern.

Moving that logic into useStyle itself means the hook now fully owns the concern of "where in the config does this value live". The component just says what it wants (color.text for :hover) and the hook handles the rest.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
This PR was authored with Claude Code (Claude Opus 4.6).