### PR TITLE
Button: Remove obsolete Safari + VoiceOver workaround

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,16 +4,14 @@
 
 ### Bug Fixes
 
-<<<<<<< fix/rtc-inline-inserter
+-   `Button`: Remove obsolete Safari + VoiceOver workaround for visually hidden text ([#77107](https://github.com/WordPress/gutenberg/pull/77107)).
 -   `Autocomplete`: Fix value comparison to avoid resetting block inserter in RTC ([#76980](https://github.com/WordPress/gutenberg/pull/76980)).
-=======
 -   `ValidatedRangeControl`: Fix `aria-label` rendered as `[object Object]` when `required` or `markWhenOptional` is set ([#77042](https://github.com/WordPress/gutenberg/pull/77042)).
 -   `Autocomplete`: Fix matching logic to prefer longest overlapping trigger ([#77018](https://github.com/WordPress/gutenberg/pull/77018)).
 
 ### Internal
 
 -   Autocomplete: Refactor `useAutocomplete` to use `useReducer` ([#77020](https://github.com/WordPress/gutenberg/pull/77020)).
->>>>>>> trunk
 
 ## 32.5.0 (2026-04-01)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Bug Fixes
 
--   `Button`: Remove obsolete Safari + VoiceOver workaround for visually hidden text ([#77107](https://github.com/WordPress/gutenberg/pull/77107)).
 -   `Autocomplete`: Fix value comparison to avoid resetting block inserter in RTC ([#76980](https://github.com/WordPress/gutenberg/pull/76980)).
 -   `ValidatedRangeControl`: Fix `aria-label` rendered as `[object Object]` when `required` or `markWhenOptional` is set ([#77042](https://github.com/WordPress/gutenberg/pull/77042)).
 -   `Autocomplete`: Fix matching logic to prefer longest overlapping trigger ([#77018](https://github.com/WordPress/gutenberg/pull/77018)).
 
 ### Internal
 
--   Autocomplete: Refactor `useAutocomplete` to use `useReducer` ([#77020](https://github.com/WordPress/gutenberg/pull/77020)).
+-   `Autocomplete`: Refactor `useAutocomplete` to use `useReducer` ([#77020](https://github.com/WordPress/gutenberg/pull/77020)).
+-   `Button`: Remove obsolete Safari + VoiceOver workaround for visually hidden text ([#77107](https://github.com/WordPress/gutenberg/pull/77107)).
 
 ## 32.5.0 (2026-04-01)
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -410,12 +410,6 @@
 			fill: CanvasText;
 		}
 	}
-
-	// Fixes a Safari+VoiceOver bug, where the screen reader text is announced not respecting the source order.
-	// See https://core.trac.wordpress.org/ticket/42006 and https://github.com/h5bp/html5-boilerplate/issues/1985
-	.components-visually-hidden {
-		height: auto;
-	}
 }
 
 @keyframes components-button__busy-animation {


### PR DESCRIPTION
## What?

Removes an old Button-specific Safari + VoiceOver workaround for visually hidden text.

## Why?

Originally introduced in #13221, this workaround appears to be obsolete now.

`Button` no longer renders its `VisuallyHidden` description content inside `.components-button`, so the old `.components-button .components-visually-hidden { height: auto; }` rule no longer applies. This has been this way for at least five years, possibly more. (Note: The class name isn't set in the component file, but comes from the context system. You should indeed see it in the rendered HTML.)

There is also a [report](https://github.com/h5bp/main.css/issues/12#issuecomment-1444046261) from 2023 that the issue no longer reproduces, and I'm unable to reproduce today either, in all three major browsers.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open the `Button` stories.
3. Add a `description` from the controls, and check the VoiceOver behavior.

## Use of AI Tools

GPT 5.4 High was used to help investigate the history of the workaround and draft this PR description.