### PR TITLE
Add iteration issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Iteration_issue.md
+++ b/.github/ISSUE_TEMPLATE/Iteration_issue.md
@@ -37,6 +37,14 @@ are not essential. These may slip to a future iteration.
 - [ ] #
 - [ ] #
 
+## Known Open Questions or Decisions Needed
+<!--
+List any unresolved questions or pending decisions related to this iteration.
+Link to individual issues where deeper discussions are happening.
+-->
+
+- 
+
 ## Contributors
 <!--
 List the people working on this iteration so it's clear who to coordinate with.

--- a/.github/ISSUE_TEMPLATE/Iteration_issue.md
+++ b/.github/ISSUE_TEMPLATE/Iteration_issue.md
@@ -36,3 +36,11 @@ are not essential. These may slip to a future iteration.
 
 - [ ] #
 - [ ] #
+
+## Contributors
+<!--
+List the people working on this iteration so it's clear who to coordinate with.
+Use GitHub @mentions.
+-->
+
+- @

--- a/.github/ISSUE_TEMPLATE/Iteration_issue.md
+++ b/.github/ISSUE_TEMPLATE/Iteration_issue.md
@@ -37,7 +37,7 @@ are not essential. These may slip to a future iteration.
 - [ ] #
 - [ ] #
 
-## Known Open Questions or Decisions Needed
+## Open Questions & Decisions required
 <!--
 List any unresolved questions or pending decisions related to this iteration.
 Link to individual issues where deeper discussions are happening.

--- a/.github/ISSUE_TEMPLATE/Iteration_issue.md
+++ b/.github/ISSUE_TEMPLATE/Iteration_issue.md
@@ -1,0 +1,38 @@
+---
+name: Iteration issue
+about: Track the scope and tasks for a feature or focus area during a release cycle
+labels: "[Type] Iteration"
+
+---
+
+## Overall Goal
+<!--
+Provide a high-level description of what will be worked on during this release cycle.
+Link to any previous iteration issues or overarching tracking issues for context.
+-->
+
+## Scope for This Release
+<!--
+Describe the planned scope for this release. What are the expected outcomes?
+If this carries over work from a previous release, note what shipped previously
+and what remains.
+-->
+
+## Tasks
+<!--
+List the specific issues and PRs to be completed during this release.
+Use task lists so progress is trackable.
+-->
+
+- [ ] #
+- [ ] #
+- [ ] #
+
+## Nice to Have
+<!--
+List stretch goals or tasks that would be good to land in this release but
+are not essential. These may slip to a future iteration.
+-->
+
+- [ ] #
+- [ ] #

--- a/.github/ISSUE_TEMPLATE/Iteration_issue.md
+++ b/.github/ISSUE_TEMPLATE/Iteration_issue.md
@@ -43,7 +43,7 @@ List any unresolved questions or pending decisions related to this iteration.
 Link to individual issues where deeper discussions are happening.
 -->
 
-- 
+- [ ] ?
 
 ## Contributors
 <!--


### PR DESCRIPTION
## Summary
- Adds a new GitHub issue template for iteration/release cycle tracking
- Standardizes the format already used across existing [Type] Iteration issues (e.g. #76756, #76525, #76316) into a reusable template
- Includes sections for: Overall Goal, Scope for This Release, Tasks (as checklists), and Nice to Have (stretch goals)
- Auto-applies the `[Type] Iteration` label

## Test plan
- [ ] Verify the template appears when creating a new issue at https://github.com/WordPress/gutenberg/issues/new/choose
- [ ] Confirm the rendered template includes all four sections with placeholder guidance
- [ ] Confirm the `[Type] Iteration` label is auto-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)