### PR TITLE
Connectors: don't clobber third-party custom render in registerDefaultConnectors

### DIFF
--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -11,10 +11,9 @@
  *    providing the render function, the other metadata).
  * 2. test_server_only_service — server-only, with no client-side render function,
  *    so it should not display a card in the UI.
- * 3. test_api_key_with_custom_render — an api_key connector whose JS render is
- *    registered *before* the page's `registerDefaultConnectors()` call runs.
- *    Regression test for the bug where the default ApiKeyConnector overwrote
- *    third-party custom renders for any api_key-authenticated connector.
+ * 3. test_api_key_with_custom_render — an api_key connector whose JS render
+ *    is registered before the default registrations run, used to verify that
+ *    a subsequent default registration does not replace an existing render.
  *
  * @package gutenberg-test-connectors-js-extensibility
  */

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -4,13 +4,17 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Author: Gutenberg Team
  *
- * Registers two custom-type connectors on the server:
+ * Registers three connectors on the server:
  *
  * 1. test_custom_service — also registered client-side via a script module using
  *    the merging strategy (two registerConnector calls with the same slug: one
  *    providing the render function, the other metadata).
  * 2. test_server_only_service — server-only, with no client-side render function,
  *    so it should not display a card in the UI.
+ * 3. test_api_key_with_custom_render — an api_key connector whose JS render is
+ *    registered *before* the page's `registerDefaultConnectors()` call runs.
+ *    Regression test for the bug where the default ApiKeyConnector overwrote
+ *    third-party custom renders for any api_key-authenticated connector.
  *
  * @package gutenberg-test-connectors-js-extensibility
  */
@@ -39,6 +43,19 @@ add_action(
 				'type'           => 'custom_service',
 				'authentication' => array(
 					'method' => 'none',
+				),
+			)
+		);
+
+		$registry->register(
+			'test_api_key_with_custom_render',
+			array(
+				'name'           => 'Test API Key With Custom Render',
+				'description'    => 'An api_key connector with a JS-registered custom render.',
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method'      => 'api_key',
+					'settingName' => 'test_api_key_with_custom_render_key',
 				),
 			)
 		);

--- a/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
@@ -34,12 +34,8 @@ registerConnector( 'test_custom_service', {
 		),
 } );
 
-// Regression test: register a custom render for an api_key-authenticated
-// connector. The page's `registerDefaultConnectors()` would otherwise
-// overwrite this render with the generic ApiKeyConnector form because the
-// store reducer spreads new config over existing entries. The fix in
-// `routes/connectors-home/default-connectors.tsx` skips setting
-// `args.render = ApiKeyConnector` when an existing render is present.
+// Registers a custom render for an api_key connector to verify that a
+// subsequent default registration for the same slug does not replace it.
 registerConnector( 'test_api_key_with_custom_render', {
 	render: ( props ) =>
 		h(

--- a/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs
@@ -33,3 +33,27 @@ registerConnector( 'test_custom_service', {
 			)
 		),
 } );
+
+// Regression test: register a custom render for an api_key-authenticated
+// connector. The page's `registerDefaultConnectors()` would otherwise
+// overwrite this render with the generic ApiKeyConnector form because the
+// store reducer spreads new config over existing entries. The fix in
+// `routes/connectors-home/default-connectors.tsx` skips setting
+// `args.render = ApiKeyConnector` when an existing render is present.
+registerConnector( 'test_api_key_with_custom_render', {
+	render: ( props ) =>
+		h(
+			ConnectorItem,
+			{
+				className: 'connector-item--test_api_key_with_custom_render',
+				name: props.name,
+				description: props.description,
+				logo: props.logo,
+			},
+			h(
+				'p',
+				{ className: 'test-api-key-with-custom-render-content' },
+				'Custom render survived registerDefaultConnectors().'
+			)
+		),
+} );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -262,15 +262,12 @@ export function registerDefaultConnectors() {
 			plugin: data.plugin,
 		};
 
-		// If a third-party plugin's script module already registered a
-		// custom render for this slug (which can happen when the plugin's
-		// connector bundle executes before this module's dynamic import
-		// chain settles), don't overwrite it. The reducer spreads the
-		// existing entry first, so leaving `render` out of `args` here
-		// preserves the plugin's render while still merging the
-		// server-side metadata (logo, plugin install state, etc.).
-		const existing =
-			unlock( select( connectorsStore ) ).getConnector( connectorName );
+		// Preserve a render that was already registered for this slug by
+		// another caller. Omitting `render` from `args` leaves the existing
+		// render in place while the server-side metadata still merges on top.
+		const existing = unlock( select( connectorsStore ) ).getConnector(
+			connectorName
+		);
 		if ( authentication.method === 'api_key' && ! existing?.render ) {
 			args.render = ApiKeyConnector;
 		}

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -7,15 +7,18 @@ import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
 	__experimentalDefaultConnectorSettings as DefaultConnectorSettings,
+	privateApis as connectorsPrivateApis,
 	type ConnectorConfig,
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
+import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Badge } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../lock-unlock';
 import { useConnectorPlugin } from './use-connector-plugin';
 import {
 	OpenAILogo,
@@ -24,6 +27,8 @@ import {
 	AkismetLogo,
 	DefaultConnectorLogo,
 } from './logos';
+
+const { store: connectorsStore } = unlock( connectorsPrivateApis );
 
 interface ConnectorData {
 	name: string;
@@ -256,7 +261,17 @@ export function registerDefaultConnectors() {
 			authentication,
 			plugin: data.plugin,
 		};
-		if ( authentication.method === 'api_key' ) {
+
+		// If a third-party plugin's script module already registered a
+		// custom render for this slug (which can happen when the plugin's
+		// connector bundle executes before this module's dynamic import
+		// chain settles), don't overwrite it. The reducer spreads the
+		// existing entry first, so leaving `render` out of `args` here
+		// preserves the plugin's render while still merging the
+		// server-side metadata (logo, plugin install state, etc.).
+		const existing =
+			unlock( select( connectorsStore ) ).getConnector( connectorName );
+		if ( authentication.method === 'api_key' && ! existing?.render ) {
 			args.render = ApiKeyConnector;
 		}
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -581,5 +581,31 @@ test.describe( 'Connectors', () => {
 				card.getByText( 'A custom service for E2E testing.' )
 			).toBeVisible();
 		} );
+
+		test( 'should preserve a custom render for an api_key connector registered before registerDefaultConnectors', async ( {
+			page,
+			admin,
+		} ) => {
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONNECTORS_PAGE_QUERY
+			);
+
+			const card = page.locator(
+				'.connector-item--test_api_key_with_custom_render'
+			);
+			await expect( card ).toBeVisible();
+
+			// The custom render content must be visible — proving the
+			// JS-supplied render survived registerDefaultConnectors().
+			await expect(
+				card.getByText(
+					'Custom render survived registerDefaultConnectors().'
+				)
+			).toBeVisible();
+
+			// And the default API key form must NOT be present in this card.
+			await expect( card.getByLabel( 'API Key' ) ).toHaveCount( 0 );
+		} );
 	} );
 } );

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -596,16 +596,17 @@ test.describe( 'Connectors', () => {
 			);
 			await expect( card ).toBeVisible();
 
-			// The custom render content must be visible — proving the
-			// JS-supplied render survived registerDefaultConnectors().
+			// The JS-registered custom render must be visible inside the card.
 			await expect(
 				card.getByText(
 					'Custom render survived registerDefaultConnectors().'
 				)
 			).toBeVisible();
 
-			// And the default API key form must NOT be present in this card.
-			await expect( card.getByLabel( 'API Key' ) ).toHaveCount( 0 );
+			// The default API key input must not appear inside the card.
+			await expect(
+				card.getByRole( 'textbox', { name: 'API Key' } )
+			).toHaveCount( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What

`registerDefaultConnectors()` in `routes/connectors-home/default-connectors.tsx` was unconditionally setting `args.render = ApiKeyConnector` for any `api_key`-authenticated connector, overwriting custom renders that third-party plugin script modules had already supplied via `__experimentalRegisterConnector()`.

This PR makes the assignment conditional on no existing render being registered, so plugin-supplied renders survive while the rest of the server-side metadata (logo, plugin install state, authentication config) still merges on top.

## Why

`registerDefaultConnectors()` runs inside the dynamically-imported `routes/connectors-home/content` module. By the time it runs, every top-level plugin script module — including any that enqueued on the standard `options-connectors-wp-admin_init` action — has already executed and registered its connectors. The store reducer spreads new config over existing entries:

```ts
[ action.slug ]: {
    ...state.connectors[ action.slug ],   // existing
    slug: action.slug,
    ...action.config,                      // new (wins per key)
}
```

So whichever caller fires *last* wins per key, and `registerDefaultConnectors()` is always last for plugins that enqueue at the standard hook. The result is that any plugin shipping a custom Connectors-page card sees it silently replaced by the generic `ApiKeyConnector` API-key form.

This is particularly painful for local/self-hosted AI providers (Ollama, LM Studio, WebLLM, etc.) that don't have an API-key concept at all — the rendered form is meaningless and confusing for users.

PR #76722 added JS-extensibility e2e coverage but only for the *server-then-client* direction (where the test plugin's connector uses `auth: 'none'`, so the clobber path is never hit). The *client-then-server* direction for `auth: 'api_key'` connectors was unverified and broken — see issue #77115 for the full root-cause walkthrough and a live reproducer plugin.

## How

In `default-connectors.tsx`, before deciding whether to assign the default `ApiKeyConnector` render, read the current entry from the connectors store via the same `unlock( connectorsPrivateApis )` pattern `stage.tsx` already uses:

```ts
const existing =
    unlock( select( connectorsStore ) ).getConnector( connectorName );
if ( authentication.method === 'api_key' && ! existing?.render ) {
    args.render = ApiKeyConnector;
}
```

When `args.render` is omitted, the reducer's spread of the existing entry preserves whatever render the plugin already registered. Server-side metadata (`name`, `description`, `logo`, `authentication`, `plugin`) still merges on top of the existing entry as before.

## Test plan

Adds a third connector `test_api_key_with_custom_render` to the `connectors-js-extensibility` test plugin:

- **PHP** (`packages/e2e-tests/plugins/connectors-js-extensibility.php`): registers `test_api_key_with_custom_render` with `type: 'ai_provider'` and `authentication.method: 'api_key'` — exactly the path that hits the clobber.
- **JS** (`packages/e2e-tests/plugins/connectors-js-extensibility/index.mjs`): calls `registerConnector( 'test_api_key_with_custom_render', { render: ... } )` for it. This is what `registerDefaultConnectors()` would have overwritten without the fix.
- **Spec** (`test/e2e/specs/admin/connectors.spec.js`): a new test inside the `JS extensibility` describe block:
    - Asserts the custom render's text content (`'Custom render survived registerDefaultConnectors().'`) is visible inside the expected card.
    - Asserts the card has zero `API Key` labels — i.e. the default `ApiKeyConnector` form is absent.

This explicitly exercises the previously-uncovered direction. Without the source fix, the new spec fails (the card shows the API Key form instead of the custom content).

- [ ] Existing `JS extensibility` tests still pass.
- [ ] New `should preserve a custom render for an api_key connector...` test passes.
- [ ] Manual smoke: install any third-party AI provider plugin that registers a custom connector card (e.g. https://github.com/Ultimate-Multisite/ultimate-ai-connector-webllm) and verify the custom card renders without needing the multi-tick `registerConnector` workaround.

Closes #77115.
