### PR TITLE
Media Modal Experiment: Set matching picker grid layout properties for when a user switches layouts

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -23,7 +23,12 @@ import { resolveSelect, useDispatch } from '@wordpress/data';
 import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
-import type { View, Field, ActionButton } from '@wordpress/dataviews';
+import type {
+	View,
+	Field,
+	ActionButton,
+	SupportedLayouts,
+} from '@wordpress/dataviews';
 import { Stack } from '@wordpress/ui';
 import {
 	altTextField,
@@ -451,11 +456,15 @@ export function MediaUploadModal( {
 		[ totalItems, totalPages ]
 	);
 
-	const defaultLayouts = useMemo(
+	const defaultLayouts: SupportedLayouts = useMemo(
 		() => ( {
 			[ LAYOUT_PICKER_GRID ]: {
 				fields: [],
 				showTitle: false,
+				layout: {
+					previewSize: 170,
+					density: 'compact',
+				},
 			},
 			[ LAYOUT_PICKER_TABLE ]: {
 				fields: [


### PR DESCRIPTION
## What?

Follows:

* https://github.com/WordPress/gutenberg/pull/75887

This is a simple PR to ensure that the default layout properties for the picker grid layout in the experimental media modal match the initial state of the modal.

## Why?

If a user switches from the grid layout to the table layout and back to grid, currently we lose the original default preview size and density (i.e. small grid items with narrow gaps between items).

This PR ensures that when a user switches between the layouts, when they select the grid layout again, the grid items remain small and with narrow gaps.

Note: this PR does not address the idea of preserving user selection if a user customises these values themselves. This is tracked in https://github.com/WordPress/gutenberg/issues/76380 and can be looked into separately.

## How?

For the picker grid layout in the default layouts for the experimental media modal, add values for `previewSize` and density.

## Testing Instructions

Active the media modal experiment in Gutenberg settings:

<img width="956" height="71" alt="image" src="https://github.com/user-attachments/assets/3506a46b-8a02-47a6-86d3-9dfb11b4dabd" />

Go to add a featured image to a post or page. With the media modal open, toggle between the grid and table layouts and back again. After switching back, the grid items should be small with compact density.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/af169618-cdd9-46aa-9ec5-94be286e5852

### After

https://github.com/user-attachments/assets/cb915645-f5a8-4868-a948-4c65305dd32e

## Use of AI Tools

None, I felt like using my hands 😄 