### PR TITLE
contentOnly template lock: Fix block insertion and removal rules

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1768,8 +1768,8 @@ export const insertBeforeBlock =
 			return;
 		}
 		const rootClientId = select.getBlockRootClientId( clientId );
-		const isLocked = select.getTemplateLock( rootClientId );
-		if ( isLocked ) {
+		const templateLock = select.getTemplateLock( rootClientId );
+		if ( templateLock && templateLock !== 'contentOnly' ) {
 			return;
 		}
 
@@ -1811,8 +1811,8 @@ export const insertAfterBlock =
 			return;
 		}
 		const rootClientId = select.getBlockRootClientId( clientId );
-		const isLocked = select.getTemplateLock( rootClientId );
-		if ( isLocked ) {
+		const templateLock = select.getTemplateLock( rootClientId );
+		if ( templateLock && templateLock !== 'contentOnly' ) {
 			return;
 		}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1768,10 +1768,6 @@ export const insertBeforeBlock =
 			return;
 		}
 		const rootClientId = select.getBlockRootClientId( clientId );
-		const templateLock = select.getTemplateLock( rootClientId );
-		if ( templateLock && templateLock !== 'contentOnly' ) {
-			return;
-		}
 
 		const blockIndex = select.getBlockIndex( clientId );
 		const directInsertBlock = rootClientId
@@ -1811,10 +1807,6 @@ export const insertAfterBlock =
 			return;
 		}
 		const rootClientId = select.getBlockRootClientId( clientId );
-		const templateLock = select.getTemplateLock( rootClientId );
-		if ( templateLock && templateLock !== 'contentOnly' ) {
-			return;
-		}
 
 		const blockIndex = select.getBlockIndex( clientId );
 		const directInsertBlock = rootClientId

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1992,9 +1992,9 @@ export function canRemoveBlock( state, clientId ) {
 			if ( defaultBlocks.length > 1 ) {
 				return true;
 			}
-		} else {
 			return false;
 		}
+		return false;
 	}
 
 	return rootBlockEditingMode !== 'disabled';

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -625,4 +625,240 @@ test.describe( 'Content-only lock', () => {
 		const afterColumn = afterBlocks[ 0 ].innerBlocks[ 0 ].innerBlocks[ 1 ];
 		expect( afterColumn.innerBlocks.length ).toBe( initialColumnChildren );
 	} );
+
+	test( 'should insert blocks via Add before and Add after for paragraphs in contentOnly mode', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Original</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+			includeHidden: true,
+		} );
+
+		// Select the paragraph and click "Add after".
+		await editor.selectBlocks( paragraph );
+		await editor.clickBlockOptionsMenuItem( 'Add after' );
+
+		// Verify a new default block was inserted after the original.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Original' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: '' },
+					},
+				],
+			},
+		] );
+
+		// Re-select the first paragraph and click "Add before".
+		const firstParagraph = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} )
+			.first();
+		await editor.selectBlocks( firstParagraph );
+		await editor.clickBlockOptionsMenuItem( 'Add before' );
+
+		// Verify a new default block was inserted before the original.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: '' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Original' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: '' },
+					},
+				],
+			},
+		] );
+	} );
+
+	test( 'should duplicate paragraphs in contentOnly mode', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Hello</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+			includeHidden: true,
+		} );
+
+		// Select the paragraph and duplicate it.
+		await editor.selectBlocks( paragraph );
+		await editor.clickBlockOptionsMenuItem( 'Duplicate' );
+
+		// Verify the block tree now has two paragraphs with the same content.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Hello' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Hello' },
+					},
+				],
+			},
+		] );
+	} );
+
+	test( 'should allow removing a default block when siblings exist but not the last one', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>First</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		// Select the first paragraph and delete it.
+		const firstParagraph = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} )
+			.first();
+		await editor.selectBlocks( firstParagraph );
+		await editor.clickBlockOptionsMenuItem( 'Delete' );
+
+		// Verify only the second paragraph remains.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Second' },
+					},
+				],
+			},
+		] );
+
+		// Select the remaining paragraph and open the Options menu —
+		// "Delete" should not be available since it is the last default block.
+		const remainingParagraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+			includeHidden: true,
+		} );
+		await editor.selectBlocks( remainingParagraph );
+		await editor.showBlockToolbar();
+
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
+
+		await expect(
+			page
+				.getByRole( 'menu', { name: 'Options' } )
+				.getByRole( 'menuitem', { name: 'Delete' } )
+		).toBeHidden();
+	} );
+
+	test( 'should not allow removing non-content-role blocks via keyboard shortcut in contentOnly mode', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading">My Heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>A paragraph</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const heading = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Heading',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'My Heading' } );
+
+		// Select the content-locked group block first.
+		await editor.selectBlocks( groupBlock );
+
+		// Select the heading and attempt to delete via keyboard shortcut.
+		await editor.selectBlocks( heading );
+		await pageUtils.pressKeys( 'access+z' );
+
+		// Verify both blocks still exist — the heading was not removed.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/heading',
+						attributes: { content: 'My Heading' },
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'A paragraph' },
+					},
+				],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/76881

Fixes two bugs with `templateLock: "contentOnly"` and adds e2e tests covering block operations in content-only mode.

## Why?

When using `templateLock: "contentOnly"` on a Group block, "Add before" and "Add after" options were visible in the block options menu but did nothing when clicked.

Additionally, the block removal logic had an inconsistency where the last default block (paragraph) in a content-only section could sometimes be removed when it shouldn't be.

## How?

### Fix 1: Remove redundant template lock checks from `insertBeforeBlock`/`insertAfterBlock`

The `insertBeforeBlock` and `insertAfterBlock` actions had their own template lock guard that bailed out for any truthy `templateLock`, including `contentOnly`. This check prevented Add before / after from working as expected. The fix is to remove it entirely since there are already separate checks against `canInsertBlockType` in the codebase prior to inserting blocks.

### Fix 2: Fix inconsistent block removal in `canRemoveBlock`

The `canRemoveBlock` selector had a bug in the content-only section. When checking whether a default block (paragraph) could be removed, the code had an `else` branch that was unreachable (the enclosing `if` already ensured `blockName === defaultBlockName`). This caused the `return false` for single-default-block cases to be skipped, falling through to a less restrictive check. The fix restructures the conditionals so that when only one default block remains, removal is correctly disallowed.

### E2e tests

Adds new e2e tests.

## Testing Instructions

1. Create a new post.
2. Switch to the Code Editor (Ctrl+Shift+Alt+M).
3. Paste the following:

```
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>First paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Second paragraph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

4. Switch back to the Visual Editor.
5. Select the first paragraph, open the Options menu (three dots).
6. Click "Add before" — a new empty paragraph should appear above.
7. Click "Add after" — a new empty paragraph should appear below.
8. Click "Duplicate" — the paragraph should be duplicated with the same content.
9. Delete paragraphs until only one remains — verify "Delete" is no longer in the Options menu.

## Use of AI Tools

OpenCode (Claude) was used to assist with writing the e2e tests and the PR description. All changes were reviewed and validated by the author.
