### PR TITLE
Core Data: Fix 'useEntityProp' for raw attributes

### DIFF
--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -64,7 +64,7 @@ export default function useEntityProp( kind, name, prop, _id ) {
 				);
 				return revision
 					? {
-							value: revision[ prop ],
+							value: revision[ prop ]?.raw ?? revision[ prop ],
 							fullValue: revision[ prop ],
 					  }
 					: {};

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -227,6 +227,40 @@ test.describe( 'Post revisions', () => {
 			editor.canvas.locator( '[data-type="test/selectors-in-revisions"]' )
 		).toHaveText( 'has-group-parent' );
 	} );
+
+	test( 'should not show warning for post title block in revisions', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/post-title' } );
+		await editor.saveDraft();
+
+		// Add a paragraph to create a second revision.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Some content' },
+		} );
+		await editor.saveDraft();
+
+		// Enter revisions mode.
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', { name: '2', exact: true } )
+			.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		const titleBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Title',
+		} );
+		await expect( titleBlock ).toBeVisible();
+		await expect( titleBlock ).not.toHaveClass( /has-warning/ );
+	} );
 } );
 
 test.describe( 'Template and template part revisions', () => {


### PR DESCRIPTION
## What?
Closes #77106.
This is a follow-up to #76106.

PR fixes value return type for raw attributes. These entity properties are returned as objects from the REST API, but `useEntityProp` should return `value.raw` or edited value. Since revisions can't be edited, we'll try to return raw when possible.

## Testing Instructions
1. Create a new page
2. Add a paragraph and save the page
3. Add a title (post title) block and save the page
4. View visual revisions to see the error

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
