### PR TITLE
Image block: Hide drag handles while an upload is in progress

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1105,11 +1105,17 @@ export default function Image( {
 		img = <ImageWrapper href={ href }>{ img }</ImageWrapper>;
 	}
 
+	// Don't show resize handles while an image is uploading — the
+	// temporary preview dimensions may not reflect the final image,
+	// and resizing mid-upload is not useful.
+	const isUploading = !! temporaryURL || isSideloading;
+
 	let resizableBox;
 	if (
 		isResizable &&
 		isSingleSelected &&
 		! isEditingImage &&
+		! isUploading &&
 		! SIZED_LAYOUTS.includes( parentLayoutType )
 	) {
 		const numericRatio = aspectRatio && evalAspectRatio( aspectRatio );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1079,7 +1079,7 @@ export default function Image( {
 						...shadowProps.style,
 					} }
 				/>
-				{ ( temporaryURL || isSideloading ) && <Spinner /> }
+				{ isUploading && <Spinner /> }
 			</>
 		);
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -396,6 +396,9 @@ export default function Image( {
 		hasNonContentControls &&
 		! isWideAligned &&
 		isLargeViewport;
+	// An image is uploading if it has a temporary blob URL, or if it is
+	// being processed client-side (e.g. transcoded or generating sub-sizes).
+	const isUploading = !! temporaryURL || isSideloading;
 	const imageSizeOptions = imageSizes
 		.filter(
 			( { slug } ) => image?.media_details?.sizes?.[ slug ]?.source_url
@@ -885,9 +888,7 @@ export default function Image( {
 									onSelectURL={ onSelectURL }
 									onError={ onUploadError }
 									onReset={ () => onSelectImage( undefined ) }
-									isUploading={
-										!! temporaryURL || isSideloading
-									}
+									isUploading={ isUploading }
 									emptyLabel={ __( 'Add image' ) }
 								/>
 							</ToolsPanelItem>
@@ -1104,11 +1105,6 @@ export default function Image( {
 	} else {
 		img = <ImageWrapper href={ href }>{ img }</ImageWrapper>;
 	}
-
-	// Don't show resize handles while an image is uploading — the
-	// temporary preview dimensions may not reflect the final image,
-	// and resizing mid-upload is not useful.
-	const isUploading = !! temporaryURL || isSideloading;
 
 	let resizableBox;
 	if (


### PR DESCRIPTION
## What?

Hide the drag handles on an image block while an upload is in progress.

## Why?

While you can _technically_ interact with the block while the upload is in progress, the drag handles in this state aren't particularly useful.

Additionally, if a user is uploading an HEIC file, then (currently) using the server-side upload approach, the image isn't previewable in the editor during upload and the resize handles can display in the wrong place.

It's tidier all around if we hide the drag handles while an upload is in progress.

## How?

Add some simple conditions to ensure the drag handles are not visible if the image is a temporary URL (i.e. an upload is in progress), or the sub-size images are being sideloaded.

## Testing Instructions

On trunk:

* Add an image block
* With the image block selected, try uploading an HEIC image to it
* Notice the drag handles are present

With this PR:

* Do the same, and the drag handles should not be present until the upload is complete
* Also do the same with a JPEG image and note that the drag handles will be hidden until the upload is complete

## Screenshots or screencast <!-- if applicable -->

### Before (JPEG)

https://github.com/user-attachments/assets/2a174fe2-4c79-4662-bb2f-224725a10a26

### After (JPEG)

https://github.com/user-attachments/assets/31e1efee-1777-43b3-b971-cd53ec84b5ad

### Before (HEIC)

https://github.com/user-attachments/assets/4520afa5-0453-4e56-a305-87a6d77c603a

### After (HEIC)

https://github.com/user-attachments/assets/c3dcb62d-50b0-4b12-b7f5-dcdee24ca37a

## Use of AI Tools

Claude Code to generate the code change. Tested manually and wrote the PR description myself 😄