### PR TITLE
Revision: Fix 'Show changes' button reset state

### DIFF
--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -462,7 +462,8 @@ export function showRevisionDiff( state = true, action ) {
 		case 'SET_SHOW_REVISION_DIFF':
 			return action.showDiff;
 		case 'SET_CURRENT_REVISION_ID':
-			return true; // reset on enter/exit revisions
+			// Reset during the exit.
+			return ! action.revisionId ? true : state;
 	}
 	return state;
 }


### PR DESCRIPTION
## What?
Closes #77078.

PR updates the `showRevisionDiff` reducer's logic to reset the state only when there's no current revision. This allows retaining the "show changes" state while switching between revisions.

## Testing Instructions
1. Open a post with revisions.
2. Enter the revisions mode.
3. Toggle "Show changes" in the top left corner.
4. Switch between revisions.
5. Confirm that the "Show changes" button remains in the same state.
6. Exit revisions and open them again.
7. Confirm that "Show changes" is enabled. Default state.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
