### PR TITLE
Feat: Add “Show related posts” toggle & "same term" filter/flag to display related posts.

### DIFF
--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -42,7 +42,7 @@
 			"default": false
 		}
 	},
-	"usesContext": [ "templateSlug" ],
+	"usesContext": [ "templateSlug", "postId" ],
 	"providesContext": {
 		"queryId": "queryId",
 		"query": "query",

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -40,7 +40,7 @@ import {
 import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, isSingular } = props;
+	const { attributes, setQuery, isSingular, context } = props;
 	const { query } = attributes;
 	const {
 		order,
@@ -407,6 +407,7 @@ export default function QueryInspectorControls( props ) {
 							<TaxonomyControls
 								onChange={ setQuery }
 								query={ query }
+								context={ context }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -55,12 +55,16 @@ export function TaxonomyControls( { onChange, query, context } ) {
 	const taxonomies = useTaxonomies( postType );
 
 	const currentPost = useSelect(
-		( select ) =>
+		( select ) => {
+			if ( ! postId ) {
+				return null;
+			}
 			select( coreStore ).getEditedEntityRecord(
 				'postType',
 				postType,
 				postId
-			),
+			);
+		},
 		[ postType, postId ]
 	);
 
@@ -81,7 +85,11 @@ export function TaxonomyControls( { onChange, query, context } ) {
 	);
 
 	useEffect( () => {
-		if ( ! taxQuery?.__experimentalSameTerm || ! taxonomies?.length ) {
+		if (
+			! postId ||
+			! taxQuery?.__experimentalSameTerm ||
+			! taxonomies?.length
+		) {
 			return;
 		}
 
@@ -139,7 +147,7 @@ export function TaxonomyControls( { onChange, query, context } ) {
 				__experimentalSameTerm: true,
 			},
 		} );
-	}, [ CurrentPostTerms, onChange, postId, query, taxQuery, taxonomies ] );
+	}, [ CurrentPostTerms, onChange, postId, taxQuery, taxonomies ] );
 
 	if ( ! taxonomies?.length ) {
 		return null;

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -64,12 +64,20 @@ export function TaxonomyControls( { onChange, query, context } ) {
 		[ postType, postId ]
 	);
 
+	const postTypeObject = useSelect(
+		( select ) => select( coreStore ).getPostType( postType ),
+		[ postType ]
+	);
+
 	const CurrentPostTerms = useMemo(
-		() => ( {
-			category: currentPost?.categories || [],
-			post_tag: currentPost?.tags || [],
-		} ),
-		[ currentPost?.categories, currentPost?.tags ]
+		() =>
+			( taxonomies || [] ).reduce( ( termsByTaxonomy, taxonomy ) => {
+				const restBase = taxonomy.rest_base || taxonomy.slug;
+				termsByTaxonomy[ taxonomy.slug ] =
+					currentPost?.[ restBase ] || [];
+				return termsByTaxonomy;
+			}, {} ),
+		[ currentPost, taxonomies ]
 	);
 
 	useEffect( () => {
@@ -86,7 +94,7 @@ export function TaxonomyControls( { onChange, query, context } ) {
 		const nextQueryUpdates = {};
 
 		for ( const taxonomy of taxonomies ) {
-			const termIds = CurrentPostTerms?.[ taxonomy.slug ];
+			const termIds = CurrentPostTerms?.[ taxonomy.slug ] || [];
 
 			const existingIds = taxQuery?.include?.[ taxonomy.slug ] || [];
 
@@ -98,15 +106,19 @@ export function TaxonomyControls( { onChange, query, context } ) {
 				continue;
 			}
 
-			nextInclude[ taxonomy.slug ] = termIds;
+			if ( termIds?.length ) {
+				nextInclude[ taxonomy.slug ] = termIds;
+			} else {
+				delete nextInclude[ taxonomy.slug ];
+			}
 			hasChanged = true;
 
-			if ( taxonomy.slug === 'category' ) {
-				nextQueryUpdates.categories = termIds;
-			}
+			const restBase = taxonomy.rest_base || taxonomy.slug;
 
-			if ( taxonomy.slug === 'post_tag' ) {
-				nextQueryUpdates.tags = termIds;
+			if ( termIds.length ) {
+				nextQueryUpdates[ restBase ] = termIds;
+			} else {
+				nextQueryUpdates[ restBase ] = [];
 			}
 		}
 
@@ -114,24 +126,33 @@ export function TaxonomyControls( { onChange, query, context } ) {
 			return;
 		}
 
+		const nextExclude = query.exclude?.includes( postId )
+			? query.exclude
+			: [ ...( query.exclude || [] ), postId ];
+
 		onChange( {
 			...nextQueryUpdates,
+			exclude: nextExclude,
 			taxQuery: {
 				...taxQuery,
 				include: nextInclude,
 				__experimentalSameTerm: true,
 			},
 		} );
-	}, [ CurrentPostTerms, onChange, taxQuery, taxonomies ] );
+	}, [ CurrentPostTerms, onChange, postId, query, taxQuery, taxonomies ] );
 
 	if ( ! taxonomies?.length ) {
 		return null;
 	}
-
+	const label = sprintf(
+		/* translators: %s: Post type plural name */
+		__( 'Show related %s' ),
+		postTypeObject.labels.name.toLowerCase()
+	);
 	return (
 		<VStack spacing={ 4 }>
 			<ToggleControl
-				label="Show related posts"
+				label={ label }
 				checked={ !! taxQuery?.__experimentalSameTerm }
 				onChange={ ( value ) => {
 					onChange(
@@ -144,8 +165,18 @@ export function TaxonomyControls( { onChange, query, context } ) {
 							  }
 							: {
 									taxQuery: undefined,
-									categories: [],
-									tags: [],
+									exclude: ( query.exclude || [] ).filter(
+										( id ) => id !== postId
+									),
+									...Object.fromEntries(
+										( taxonomies || [] ).map(
+											( taxonomy ) => [
+												taxonomy.rest_base ||
+													taxonomy.slug,
+												[],
+											]
+										)
+									),
 							  }
 					);
 				} }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -4,10 +4,11 @@
 import {
 	FormTokenField,
 	__experimentalVStack as VStack,
+	ToggleControl,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useState, useEffect, Fragment } from '@wordpress/element';
+import { useState, useEffect, Fragment, useMemo } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -48,16 +49,107 @@ const getTermIdByTermValue = ( terms, termValue ) => {
 	)?.id;
 };
 
-export function TaxonomyControls( { onChange, query } ) {
+export function TaxonomyControls( { onChange, query, context } ) {
 	const { postType, taxQuery } = query;
-
+	const { postId } = context;
 	const taxonomies = useTaxonomies( postType );
+
+	const currentPost = useSelect(
+		( select ) =>
+			select( coreStore ).getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			),
+		[ postType, postId ]
+	);
+
+	const CurrentPostTerms = useMemo(
+		() => ( {
+			category: currentPost?.categories || [],
+			post_tag: currentPost?.tags || [],
+		} ),
+		[ currentPost?.categories, currentPost?.tags ]
+	);
+
+	useEffect( () => {
+		if ( ! taxQuery?.__experimentalSameTerm || ! taxonomies?.length ) {
+			return;
+		}
+
+		const nextInclude = {
+			...taxQuery?.include,
+		};
+
+		let hasChanged = false;
+
+		const nextQueryUpdates = {};
+
+		for ( const taxonomy of taxonomies ) {
+			const termIds = CurrentPostTerms?.[ taxonomy.slug ];
+
+			const existingIds = taxQuery?.include?.[ taxonomy.slug ] || [];
+
+			const isSame =
+				existingIds.length === termIds.length &&
+				existingIds.every( ( id ) => termIds.includes( id ) );
+
+			if ( isSame ) {
+				continue;
+			}
+
+			nextInclude[ taxonomy.slug ] = termIds;
+			hasChanged = true;
+
+			if ( taxonomy.slug === 'category' ) {
+				nextQueryUpdates.categories = termIds;
+			}
+
+			if ( taxonomy.slug === 'post_tag' ) {
+				nextQueryUpdates.tags = termIds;
+			}
+		}
+
+		if ( ! hasChanged ) {
+			return;
+		}
+
+		onChange( {
+			...nextQueryUpdates,
+			taxQuery: {
+				...taxQuery,
+				include: nextInclude,
+				__experimentalSameTerm: true,
+			},
+		} );
+	}, [ CurrentPostTerms, onChange, taxQuery, taxonomies ] );
+
 	if ( ! taxonomies?.length ) {
 		return null;
 	}
 
 	return (
 		<VStack spacing={ 4 }>
+			<ToggleControl
+				label="Show related posts"
+				checked={ !! taxQuery?.__experimentalSameTerm }
+				onChange={ ( value ) => {
+					onChange(
+						value
+							? {
+									taxQuery: {
+										...taxQuery,
+										__experimentalSameTerm: true,
+									},
+							  }
+							: {
+									taxQuery: undefined,
+									categories: [],
+									tags: [],
+							  }
+					);
+				} }
+			/>
 			{ taxonomies.map( ( taxonomy ) => {
 				const includeTermIds =
 					taxQuery?.include?.[ taxonomy.slug ] || [];
@@ -100,6 +192,7 @@ export function TaxonomyControls( { onChange, query } ) {
 								onChangeTaxQuery( value, 'include' )
 							}
 							label={ taxonomy.name }
+							isSameTerm={ !! taxQuery?.__experimentalSameTerm }
 						/>
 						<TaxonomyItem
 							taxonomy={ taxonomy }
@@ -112,6 +205,7 @@ export function TaxonomyControls( { onChange, query } ) {
 								/* translators: %s: taxonomy name */
 								sprintf( __( 'Exclude: %s' ), taxonomy.name )
 							}
+							isSameTerm={ !! taxQuery?.__experimentalSameTerm }
 						/>
 					</Fragment>
 				);
@@ -129,6 +223,7 @@ export function TaxonomyControls( { onChange, query } ) {
  * @param {number[]} props.oppositeTermIds An array with the opposite control's term ids (to exclude from suggestions).
  * @param {Function} props.onChange        Callback `onChange` function.
  * @param {string}   props.label           Label of the control.
+ * @param {boolean}  props.isSameTerm      Whether to show related posts.
  * @return {React.JSX.Element} The rendered component.
  */
 function TaxonomyItem( {
@@ -137,6 +232,7 @@ function TaxonomyItem( {
 	oppositeTermIds,
 	onChange,
 	label,
+	isSameTerm,
 } ) {
 	const [ search, setSearch ] = useState( '' );
 	const [ value, setValue ] = useState( EMPTY_ARRAY );
@@ -244,6 +340,7 @@ function TaxonomyItem( {
 				onChange={ onTermsChange }
 				__experimentalShowHowTo={ false }
 				__next40pxDefaultSize
+				disabled={ isSameTerm }
 			/>
 		</div>
 	);

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -150,6 +150,7 @@ export default function QueryContent( {
 					setAttributes={ setAttributes }
 					clientId={ clientId }
 					isSingular={ isSingular }
+					context={ context }
 				/>
 			</InspectorControls>
 			<InspectorControls group="advanced">

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -150,3 +150,47 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 }
 
 add_filter( 'render_block_data', 'block_core_query_disable_enhanced_pagination', 10, 1 );
+
+function block_core_query_use_same_term( $query, $block ) {
+
+	if (
+		empty( $block->context['query']['taxQuery']['__experimentalSameTerm'] )
+	) {
+		return $query;
+	}
+
+	if ( ! is_singular() ) {
+		return $query;
+	}
+
+	$post_id = get_the_ID();
+
+	$tax_query = [];
+
+	$taxonomies = get_object_taxonomies( get_post_type( $post_id ) );
+
+	foreach ( $taxonomies as $taxonomy ) {
+		$terms = wp_get_post_terms( $post_id, $taxonomy, [
+			'fields' => 'ids',
+		] );
+
+		if ( empty( $terms ) ) {
+			continue;
+		}
+
+		$tax_query[] = [
+			'taxonomy' => $taxonomy,
+			'field'    => 'term_id',
+			'terms'    => $terms,
+		];
+	}
+
+	if ( ! empty( $tax_query ) ) {
+		$query['tax_query'] = $tax_query;
+	}
+
+	return $query;
+
+}
+
+add_filter( 'query_loop_block_query_vars', 'block_core_query_use_same_term', 10, 2 );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -151,6 +151,22 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 
 add_filter( 'render_block_data', 'block_core_query_disable_enhanced_pagination', 10, 1 );
 
+/**
+ * Modify a Query block's query to include posts sharing the same terms
+ * (categories, or tags) as the current post.
+ *
+ * When `__experimentalSameTerm` is enabled in the block's `taxQuery` context,
+ * this function adds a `tax_query` so the Query block fetches only posts
+ * that share terms with the current post. This allows editors and theme authors
+ * to implement “Related Posts” functionality directly in the editor without
+ * manually specifying terms.
+ *
+ * @since 23.0.0
+ *
+ * @param array $query The original query arguments for the Query block.
+ * @param object $block The parsed block object, containing context and attributes.
+ * @return array Returns the modified query with `tax_query` applied if needed.
+ */
 function block_core_query_use_same_term( $query, $block ) {
 
 	if (
@@ -165,24 +181,28 @@ function block_core_query_use_same_term( $query, $block ) {
 
 	$post_id = get_the_ID();
 
-	$tax_query = [];
+	$tax_query = array();
 
 	$taxonomies = get_object_taxonomies( get_post_type( $post_id ) );
 
 	foreach ( $taxonomies as $taxonomy ) {
-		$terms = wp_get_post_terms( $post_id, $taxonomy, [
-			'fields' => 'ids',
-		] );
+		$terms = wp_get_post_terms(
+			$post_id,
+			$taxonomy,
+			array(
+				'fields' => 'ids',
+			)
+		);
 
 		if ( empty( $terms ) ) {
 			continue;
 		}
 
-		$tax_query[] = [
+		$tax_query[] = array(
 			'taxonomy' => $taxonomy,
 			'field'    => 'term_id',
 			'terms'    => $terms,
-		];
+		);
 	}
 
 	if ( ! empty( $tax_query ) ) {
@@ -190,7 +210,6 @@ function block_core_query_use_same_term( $query, $block ) {
 	}
 
 	return $query;
-
 }
 
 add_filter( 'query_loop_block_query_vars', 'block_core_query_use_same_term', 10, 2 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77099

Adds a “Show related posts” toggle to display posts sharing the same categories/tags as the current post.

<!-- In a few words, what is the PR actually doing? -->

## Why?
This is a longstanding gap for theme authors. The most common use case is a “Related Posts” section at the bottom of a single post. Today, the Query Loop block requires selecting explicit terms and has no awareness of the current post’s terms.

## How?
Added a toggle labeled “Show related posts” for same-term filtering.
Uses core-data to fetch the current post’s categories/tags dynamically.
Automatically update the block query when terms change.

## Testing Instructions

1. Edit a post with multiple categories and tags.
2. Insert the Query loop block.
3. Toggle “Show related posts” on, the block should list posts with the same categories/tags.
4. Toggle “Show related posts” off, manual include/exclude lists should apply instead.
5. Save the post, confirm the block list remains correct in the editor and on the frontend.

The Theme authors can use `__experimentalSameTerm` flag to enable this feature.

## Screenshots or screencast <!-- if applicable -->

<img width="2940" height="1296" alt="image" src="https://github.com/user-attachments/assets/293970d5-3b04-4447-a075-1c26deae105b" />

