### PR TITLE
TextArea: add disabled styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Textarea`: Fix disabled styles [#77129](https://github.com/WordPress/gutenberg/pull/77129).
 -   `Autocomplete`: Fix value comparison to avoid resetting block inserter in RTC ([#76980](https://github.com/WordPress/gutenberg/pull/76980)).
 -   `ValidatedRangeControl`: Fix `aria-label` rendered as `[object Object]` when `required` or `markWhenOptional` is set ([#77042](https://github.com/WordPress/gutenberg/pull/77042)).
 -   `Autocomplete`: Fix matching logic to prefer longest overlapping trigger ([#77018](https://github.com/WordPress/gutenberg/pull/77018)).

--- a/packages/components/src/textarea-control/stories/index.story.tsx
+++ b/packages/components/src/textarea-control/stories/index.story.tsx
@@ -21,6 +21,9 @@ const meta: Meta< typeof TextareaControl > = {
 		onChange: { action: 'onChange' },
 		label: { control: { type: 'text' } },
 		help: { control: { type: 'text' } },
+		disabled: {
+			control: { type: 'boolean' },
+		},
 		value: { control: false },
 	},
 	parameters: {

--- a/packages/components/src/textarea-control/styles/textarea-control-styles.ts
+++ b/packages/components/src/textarea-control/styles/textarea-control-styles.ts
@@ -62,6 +62,13 @@ export const StyledTextarea = styled.textarea`
 		${ inputStyleFocus }
 	}
 
+	&:disabled {
+		background: ${ COLORS.ui.backgroundDisabled };
+		border-color: ${ COLORS.ui.borderDisabled };
+		color: ${ COLORS.ui.textDisabled };
+		opacity: 1;
+	}
+
 	// Use opacity to work in various editor styles.
 	&::-webkit-input-placeholder {
 		color: ${ COLORS.ui.darkGrayPlaceholder };

--- a/packages/components/src/textarea-control/types.ts
+++ b/packages/components/src/textarea-control/types.ts
@@ -13,6 +13,12 @@ export type TextareaControlProps = Pick<
 	'__nextHasNoMarginBottom' | 'hideLabelFromVision' | 'help' | 'label'
 > & {
 	/**
+	 * Whether the textarea should be disabled.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
+	/**
 	 * A function that receives the new value of the textarea each time it
 	 * changes.
 	 */

--- a/packages/components/src/textarea-control/types.ts
+++ b/packages/components/src/textarea-control/types.ts
@@ -13,12 +13,6 @@ export type TextareaControlProps = Pick<
 	'__nextHasNoMarginBottom' | 'hideLabelFromVision' | 'help' | 'label'
 > & {
 	/**
-	 * Whether the textarea should be disabled.
-	 *
-	 * @default false
-	 */
-	disabled?: boolean;
-	/**
 	 * A function that receives the new value of the textarea each time it
 	 * changes.
 	 */


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/77090

## What?

Add disabled styles to the `TextareaControl` component.

## Why?

The `TextareaControl` component can be disabled via the `disabled` HTML attribute, but it had no visual disabled styles — the textarea looks identical whether enabled or disabled. This is inconsistent with other form controls like `InputControl` and `RadioControl` (fixed in #77127), which already have distinct disabled appearances.

Control with disabled state in story:

Before | After
--- | ---
<img width="940" height="168" alt="Screenshot 2026-04-08 at 10 38 46" src="https://github.com/user-attachments/assets/a9603bce-33ee-4aea-90b6-62511fef7c19" /> | <img width="940" height="168" alt="Screenshot 2026-04-08 at 10 38 29" src="https://github.com/user-attachments/assets/e32b4529-6786-435c-8a5d-057d1db2432c" />

Control with disabled state in DataForm story:

Before | After
--- | ---
<img width="471" height="431" alt="Screenshot 2026-04-09 at 14 33 31" src="https://github.com/user-attachments/assets/00db83c2-e169-41b0-85f6-694329552f27" /> | <img width="609" height="431" alt="Screenshot 2026-04-09 at 14 33 01" src="https://github.com/user-attachments/assets/fce4652f-a52d-43d3-b58d-097a3995c455" />


## How?

- Added `&:disabled` CSS styles to `StyledTextarea` using the same semantic design tokens as `InputControl`: `backgroundDisabled`, `borderDisabled`, `textDisabled`, and `opacity: 1` to prevent browser default dimming.
- Added an explicit `disabled` prop to `TextareaControlProps` with JSDoc documentation.
- Added a `disabled` boolean control to the Storybook story for testing.
- Updated the CHANGELOG (and resolved pre-existing merge conflict markers).

## Testing Instructions

The control's story:

1. Open Storybook and navigate to **Components / Selection & Input / Common / TextareaControl**.
2. Toggle the **disabled** control on.
3. Verify the textarea has a light gray background, muted border, and grayed-out text — matching the disabled appearance of `InputControl`.
4. Toggle **disabled** off and verify the textarea returns to its normal appearance.

DataForm's story:

1. Open Storybook and navigate to **DataViews / DataForm / Layout Regular **.
2. Toggle the **disabled** control on.
3. Verify the textarea has a light gray background, muted border, and grayed-out text — matching the disabled appearance of `InputControl`.
4. Toggle **disabled** off and verify the textarea returns to its normal appearance.

## Use of AI Tools

Claude Code was used to assist with implementation and to generate this PR summary.
