### PR TITLE
BlockStyleVariationOverridesWithConfig: change name and fix lint errors

### DIFF
--- a/docs/private-apis.md
+++ b/docs/private-apis.md
@@ -122,7 +122,7 @@ Private exports:
 - `PrivatePublishDateTimePicker`: version of public `PublishDateTimePicker` that has two extra props: `isCompact` and `showPopoverHeaderActions`.
 - `useSpacingSizes`
 - `useBlockDisplayTitle`
-- `__unstableBlockStyleVariationOverridesWithConfig`
+- `BlockStyleVariationOverridesWithConfig`
 - `setBackgroundStyleDefaults`
 - `sectionRootClientIdKey`
 - `__unstableCommentIconFill`

--- a/packages/block-editor/src/hooks/block-style-variation.js
+++ b/packages/block-editor/src/hooks/block-style-variation.js
@@ -73,10 +73,9 @@ function OverrideStyles( { override } ) {
  * @param {Object} props.config A global styles object, containing settings and styles.
  * @return {React.JSX.Element}  An array of new block variation overrides.
  */
-export function __unstableBlockStyleVariationOverridesWithConfig( { config } ) {
-	const { getBlockStyles, overrides } = useSelect(
+export function BlockStyleVariationOverridesWithConfig( { config } ) {
+	const { overrides } = useSelect(
 		( select ) => ( {
-			getBlockStyles: select( blocksStore ).getBlockStyles,
 			overrides: unlock( select( blockEditorStore ) ).getStyleOverrides(),
 		} ),
 		[]
@@ -161,7 +160,7 @@ export function __unstableBlockStyleVariationOverridesWithConfig( { config } ) {
 			}
 		}
 		return newOverrides;
-	}, [ config, overrides, getBlockStyles, getBlockName ] );
+	}, [ config, overrides, getBlockName ] );
 
 	if ( ! overridesWithConfig || ! overridesWithConfig.length ) {
 		return null;

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -105,5 +105,5 @@ export { getGapCSSValue } from './gap';
 export { useCachedTruthy } from './use-cached-truthy';
 export { setBackgroundStyleDefaults } from './background';
 export { useZoomOut } from './use-zoom-out';
-export { __unstableBlockStyleVariationOverridesWithConfig } from './block-style-variation';
+export { BlockStyleVariationOverridesWithConfig } from './block-style-variation';
 export { useStyleOverride } from './utils';

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,7 +24,7 @@ import {
 	setBackgroundStyleDefaults,
 	useLayoutClasses,
 	useLayoutStyles,
-	__unstableBlockStyleVariationOverridesWithConfig,
+	BlockStyleVariationOverridesWithConfig as __unstableBlockStyleVariationOverridesWithConfig,
 	useZoomOut,
 } from './hooks';
 import DimensionsTool from './components/dimensions-tool';

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,7 +24,7 @@ import {
 	setBackgroundStyleDefaults,
 	useLayoutClasses,
 	useLayoutStyles,
-	BlockStyleVariationOverridesWithConfig as __unstableBlockStyleVariationOverridesWithConfig,
+	BlockStyleVariationOverridesWithConfig,
 	useZoomOut,
 } from './hooks';
 import DimensionsTool from './components/dimensions-tool';
@@ -121,7 +121,7 @@ lock( privateApis, {
 	PrivatePublishDateTimePicker,
 	useSpacingSizes,
 	useBlockDisplayTitle,
-	__unstableBlockStyleVariationOverridesWithConfig,
+	BlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
 	sectionRootClientIdKey,
 	CommentIconSlotFill,

--- a/packages/editor/src/components/styles-canvas/revisions.js
+++ b/packages/editor/src/components/styles-canvas/revisions.js
@@ -23,8 +23,7 @@ import { unlock } from '../../lock-unlock';
 
 const {
 	ExperimentalBlockEditorProvider,
-	__unstableBlockStyleVariationOverridesWithConfig:
-		BlockStyleVariationOverridesWithConfig,
+	BlockStyleVariationOverridesWithConfig,
 } = unlock( blockEditorPrivateApis );
 
 function isObjectEmpty( object ) {

--- a/packages/editor/src/components/styles-canvas/revisions.js
+++ b/packages/editor/src/components/styles-canvas/revisions.js
@@ -23,7 +23,8 @@ import { unlock } from '../../lock-unlock';
 
 const {
 	ExperimentalBlockEditorProvider,
-	__unstableBlockStyleVariationOverridesWithConfig,
+	__unstableBlockStyleVariationOverridesWithConfig:
+		BlockStyleVariationOverridesWithConfig,
 } = unlock( blockEditorPrivateApis );
 
 function isObjectEmpty( object ) {
@@ -133,7 +134,7 @@ function StylesCanvasRevisions( { path }, ref ) {
 					 * so they can access any registered style overrides.
 					 */ }
 					<EditorStyles styles={ editorStyles } />
-					<__unstableBlockStyleVariationOverridesWithConfig
+					<BlockStyleVariationOverridesWithConfig
 						config={ mergedConfig }
 					/>
 				</ExperimentalBlockEditorProvider>


### PR DESCRIPTION
Spinoff from ESLint upgrade in #76654 that fixes one of the linting issues detected there. The problems are:
- when a function name has the `__unstable` prefix, ESLint doesn't detect it as a React component and complains about any hook usage inside. This PR removes the `__unstable` prefix from the name and adds it back only when actually exporting the name as part of `block-editor` private APIs. I wouldn't mind removing the prefix completely, as the function is a private API, it doesn't need an extra prefix. It's used by the `editor` package.
- there is an unneeded `getBlockStyles` dependency in a `useMemo` hook. If you look at the #72464 diff, it removed the actual call of `getBlockStyles` (as a `getBlockSelectors` parameter) but forgot the remove the dependency, too. Removing this fixes a warning.
