### PR TITLE
Fixed customized message for draft notice

### DIFF
--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -30,6 +30,7 @@ const postTypeEntity = {
 	slug: 'post',
 	rest_base: 'posts',
 	labels: {
+		item_drafted: 'Draft saved as post type label.',
 		item_updated: 'Updated Post',
 		item_published: 'Post published',
 		item_reverted_to_draft: 'Post reverted to draft.',
@@ -138,7 +139,7 @@ describe( 'Post actions', () => {
 			expect( notices ).toMatchObject( [
 				{
 					status: 'success',
-					content: 'Draft saved.',
+					content: 'Draft saved as post type label.',
 				},
 			] );
 		} );

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -43,7 +43,9 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 		shouldShowLink = false;
 	} else if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
-		noticeMessage = __( 'Draft saved.' );
+		noticeMessage =
+			postType.labels.item_drafted ||
+			_x( 'Draft saved.', 'post saved in draft status' );
 		isDraft = true;
 	} else if ( isPublished && ! willPublish ) {
 		// If undoing publish status, show specific notice.

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -10,6 +10,7 @@ import {
 describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 	const postType = {
 		labels: {
+			item_drafted: 'drafted',
 			item_reverted_to_draft: 'draft',
 			item_published: 'publish',
 			item_published_privately: 'private',
@@ -34,7 +35,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 		[
 			'when previous post is not published and post will not be published',
 			[ 'draft', 'draft', false ],
-			[ 'Draft saved.', defaultExpectedAction ],
+			[ 'drafted', defaultExpectedAction ],
 		],
 		[
 			'when previous post is published and post will be unpublished',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Issue https://github.com/WordPress/gutenberg/issues/77014

Updates the Draft saved notice so it can use a post type label, similar to the existing trash notice behavior.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Draft saved message was hardcoded, which made it unavailable to post types that need a custom save notice.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a new post type label for draft saves and updates the editor success notice logic to use that label instead of the hardcoded string.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
1. Register a custom post type with a custom draft-save label.
2. Open a new draft for that post type in the editor.
3. Save the draft.
4. Confirm the snackbar shows the custom draft-save message.
5. Save a regular post draft and confirm the default Draft saved message still appears.