### PR TITLE
Separator Block: Apply default block variation when inserting via `---` shortcut

### DIFF
--- a/packages/block-library/src/separator/transforms.js
+++ b/packages/block-library/src/separator/transforms.js
@@ -3,7 +3,7 @@
  */
 import {
 	createBlock,
-	getBlockType,
+	getBlockVariations,
 	getDefaultBlockName,
 } from '@wordpress/blocks';
 
@@ -14,10 +14,9 @@ const transforms = {
 			regExp: /^-{3,}$/,
 			transform: () => {
 				// Check for default variation to preserve attributes.
-				const blockType = getBlockType( 'core/separator' );
-				const defaultVariation = blockType?.variations?.find(
-					( variation ) => variation.isDefault
-				);
+				const defaultVariation = getBlockVariations(
+					'core/separator'
+				)?.find( ( variation ) => variation.isDefault );
 
 				// Fall back to empty attributes if no default variation is found.
 				const attributes = defaultVariation

--- a/packages/block-library/src/separator/transforms.js
+++ b/packages/block-library/src/separator/transforms.js
@@ -1,17 +1,34 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import {
+	createBlock,
+	getBlockType,
+	getDefaultBlockName,
+} from '@wordpress/blocks';
 
 const transforms = {
 	from: [
 		{
 			type: 'input',
 			regExp: /^-{3,}$/,
-			transform: () => [
-				createBlock( 'core/separator' ),
-				createBlock( getDefaultBlockName() ),
-			],
+			transform: () => {
+				// Check for default variation to preserve attributes.
+				const blockType = getBlockType( 'core/separator' );
+				const defaultVariation = blockType?.variations?.find(
+					( variation ) => variation.isDefault
+				);
+
+				// Fall back to empty attributes if no default variation is found.
+				const attributes = defaultVariation
+					? defaultVariation.attributes
+					: {};
+
+				return [
+					createBlock( 'core/separator', attributes ),
+					createBlock( getDefaultBlockName() ),
+				];
+			},
 		},
 		{
 			type: 'raw',

--- a/packages/block-library/src/separator/transforms.js
+++ b/packages/block-library/src/separator/transforms.js
@@ -13,18 +13,16 @@ const transforms = {
 			type: 'input',
 			regExp: /^-{3,}$/,
 			transform: () => {
-				// Check for default variation to preserve attributes.
+				// Check for default variation to apply default variation attributes.
 				const defaultVariation = getBlockVariations(
 					'core/separator'
 				)?.find( ( variation ) => variation.isDefault );
 
-				// Fall back to empty attributes if no default variation is found.
-				const attributes = defaultVariation
-					? defaultVariation.attributes
-					: {};
-
 				return [
-					createBlock( 'core/separator', attributes ),
+					createBlock(
+						'core/separator',
+						defaultVariation?.attributes ?? {}
+					),
 					createBlock( getDefaultBlockName() ),
 				];
 			},


### PR DESCRIPTION
## What?
Closes #75259 

Apply default block variation attributes when creating a Separator block via the `---` markdown shortcut.

## Why?
When a default block variation is registered for the Separator block, it is correctly applied when inserting via the block inserter UI. But when inserting via the `---` shortcut, it creates the Separator block with no attributes, so the default variation is never used and the block falls back to its hardcoded defaults.

## How?
Updated the `input` transform to check the registered default variation for the Separator block before calling `createBlock`, and merge its attributes in.

If no default variation is registered, `attributes` falls back to an empty object and `createBlock` behaves exactly as before with no registered default variation.

## Testing Instructions
1. Register a default block variation for the Separator with `tagName: 'div'`  (could use the snippet from the [issue](https://github.com/WordPress/gutenberg/issues/75259))
2. Insert a Separator via the block inserter and observe it uses `div` 
3. Type `---` to insert a Separator. Before the fix it uses `hr`, after the fix it correctly uses `div`.
4. Remove the default variation registration and repeat step 3. Separator should still insert correctly with default `hr` behaviour.

## Screenshots or screencast
|Before|After|
|-|-|
|<img width="1019" height="289" alt="Screenshot 2026-04-07 at 6 59 34 PM" src="https://github.com/user-attachments/assets/1e17ef1a-97de-435b-9121-7897a96742b3" />|<img width="1023" height="294" alt="Screenshot 2026-04-08 at 1 57 32 PM" src="https://github.com/user-attachments/assets/b044002b-b156-4b4f-8505-30fe4dc408fd" />|