### PR TITLE
Writing Flow: Fix format toolbar not appearing when selecting text from block edge

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -214,7 +214,45 @@ export default function useSelectionObserver() {
 				const isSingularSelection = startClientId === endClientId;
 				if ( isSingularSelection ) {
 					if ( ! isMultiSelecting() ) {
-						selectBlock( startClientId );
+						// If the selection is not collapsed and falls
+						// within a RichText that doesn't have focus
+						// (e.g. the user started dragging from the block
+						// wrapper padding), dispatch a full
+						// selectionChange so the format toolbar appears.
+						const richTextElement =
+							! selection.isCollapsed &&
+							( getRichTextElement( startNode ) ||
+								getRichTextElement( endNode ) );
+
+						if (
+							richTextElement &&
+							ownerDocument.activeElement !== richTextElement
+						) {
+							const range = selection.getRangeAt( 0 );
+							const richTextData = create( {
+								element: richTextElement,
+								range,
+								__unstableIsEditableTree: true,
+							} );
+							selectionChange( {
+								start: {
+									clientId: startClientId,
+									attributeKey:
+										richTextElement.dataset
+											.wpBlockAttributeKey,
+									offset: richTextData.start ?? 0,
+								},
+								end: {
+									clientId: startClientId,
+									attributeKey:
+										richTextElement.dataset
+											.wpBlockAttributeKey,
+									offset: richTextData.end,
+								},
+							} );
+						} else {
+							selectBlock( startClientId );
+						}
 					} else {
 						multiSelect( startClientId, startClientId );
 					}

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1199,8 +1199,6 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setIsFixedToolbar( true );
-
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'Hello world' },
@@ -1228,12 +1226,12 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.mouse.move( endX, endY, { steps: 10 } );
 		await page.mouse.up();
 
-		// The Bold button should be visible in the top toolbar.
+		// The Bold button should be visible in the inline block toolbar.
 		await expect(
-			page.getByRole( 'button', { name: 'Bold' } )
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Bold' } )
 		).toBeVisible();
-
-		await editor.setIsFixedToolbar( false );
 	} );
 } );
 

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1194,6 +1194,47 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
 		).not.toBeFocused();
 	} );
+
+	test( 'should show format toolbar when selecting text from the left edge of a block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setIsFixedToolbar( true );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello world' },
+		} );
+
+		// Deselect the block.
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
+
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const box = await paragraphBlock.boundingBox();
+
+		// Start the drag from just before the left edge of the paragraph
+		// (on the block wrapper padding) and drag into the text.
+		const startX = box.x - 5;
+		const startY = box.y + box.height / 2;
+		const endX = box.x + box.width / 2;
+		const endY = startY;
+
+		await page.mouse.move( startX, startY );
+		await page.mouse.down();
+		await page.mouse.move( endX, endY, { steps: 10 } );
+		await page.mouse.up();
+
+		// The Bold button should be visible in the top toolbar.
+		await expect(
+			page.getByRole( 'button', { name: 'Bold' } )
+		).toBeVisible();
+
+		await editor.setIsFixedToolbar( false );
+	} );
 } );
 
 class WritingFlowUtils {


### PR DESCRIPTION
## What?
This PR fixes format toolbar not appearing when selecting text from either of the block edges.

## Why?
Highlighting text starting from the left edge of a paragraph (on the block wrapper padding) did not show the formatting options in the top toolbar. This happened because the `RichText` element never received focus when the drag started outside its `contentEditable` boundary, so its selection handlers never fired.

Fixes #77133.

## How?
This PR updates `useSelectionObserver` to detect non-collapsed selections within an unfocused `RichText` and dispatch a full `selectionChange`.

## Testing Instructions
- Enable Top Toolbar in editor preferences
- Add a paragraph block with text
- Highlight text by starting the selection from just outside the left edge of the paragraph
- Verify that Bold, Italic, and other formatting options appear in the top toolbar
- Verify normal text selection (clicking inside the text and dragging) still works
- Verify e2e tests pass

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/d51fff61-7c31-4479-9ad0-804a4b6fdf0c

After:

https://github.com/user-attachments/assets/b07cb96a-26c6-4195-b224-3d61e7751d81

## Use of AI Tools

I used Claude Code with Opus 4.6 and verified the changes manually.
