### PR TITLE
FormTokenField: fix disabled styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `FormTokenField`: Fix disabled styles. [#77137](https://github.com/WordPress/gutenberg/pull/77137)
 -   `Autocomplete`: Fix value comparison to avoid resetting block inserter in RTC ([#76980](https://github.com/WordPress/gutenberg/pull/76980)).
 -   `ValidatedRangeControl`: Fix `aria-label` rendered as `[object Object]` when `required` or `markWhenOptional` is set ([#77042](https://github.com/WordPress/gutenberg/pull/77042)).
 -   `Autocomplete`: Fix matching logic to prefer longest overlapping trigger ([#77018](https://github.com/WordPress/gutenberg/pull/77018)).

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -87,8 +87,8 @@
 	&.is-disabled {
 		.components-form-token-field__token-text,
 		.components-form-token-field__remove-token.components-button {
-			background: $gray-100;
-			color: $gray-600;
+			background: $components-color-gray-100;
+			color: $components-color-gray-600;
 		}
 	}
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -11,8 +11,8 @@
 	cursor: text;
 
 	&.is-disabled {
-		background: $gray-100;
-		border-color: $gray-400;
+		background: $components-color-gray-100;
+		border-color: $components-color-gray-400;
 		cursor: default;
 		opacity: 1;
 	}

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -11,8 +11,10 @@
 	cursor: text;
 
 	&.is-disabled {
-		background: $gray-300;
-		border-color: $gray-300;
+		background: $gray-100;
+		border-color: $gray-400;
+		cursor: default;
+		opacity: 1;
 	}
 
 	&.is-active {
@@ -79,6 +81,14 @@
 		.components-form-token-field__token-text,
 		.components-form-token-field__remove-token {
 			color: $gray-700;
+		}
+	}
+
+	&.is-disabled {
+		.components-form-token-field__token-text,
+		.components-form-token-field__remove-token.components-button {
+			background: $gray-100;
+			color: $gray-600;
 		}
 	}
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/77090

## What?

Fix disabled styles for the `FormTokenField` component to be consistent with other form controls (InputControl, SelectControl, TextareaControl, etc.).

## Why?

When a `FormTokenField` is disabled, its background and border colors don't match the disabled appearance of other form controls.

Before | After
--- | ---
<img width="610" height="334" alt="Screenshot 2026-04-09 at 14 18 18" src="https://github.com/user-attachments/assets/a3dcebd0-da3d-4dbd-a4a6-b4123f18a7f5" /> | <img width="575" height="334" alt="Screenshot 2026-04-09 at 14 17 27" src="https://github.com/user-attachments/assets/76651bb0-b090-47e0-a27b-078f68149295" />


## How?

Updated the disabled styles in `style.scss` for the `FormTokenField`:

- **Container** (`.is-disabled`): Changed background from `$gray-300` to `$gray-100` and border from `$gray-300` to `$gray-400` to match the standard disabled color tokens (`COLORS.ui.backgroundDisabled` / `COLORS.ui.borderDisabled`). Added `cursor: default` and `opacity: 1`.
- **Token pills** (`.is-disabled .components-form-token-field__token-text` and `.components-form-token-field__remove-token`): Set background to `$gray-100` (matching the container) and text color to `$gray-600` (`COLORS.ui.textDisabled`) so the pills blend with the disabled container.

## Testing Instructions

1. Open Storybook and navigate to **DataViews > DataForm > Layout Regular**.
2. Observe the **Tags** field — it should appear disabled with a light gray background consistent with other disabled fields (e.g., Email, Password, Date).
3. The token pill ("Photography") should blend into the container background with no visible background difference.
4. Compare the disabled appearance with other disabled form controls on the same page to confirm visual consistency.

## Use of AI Tools

This PR was authored with assistance from Claude Code (Claude Opus 4.6). All changes were reviewed and validated by the author.
