### PR TITLE
Calendar: fix disabled styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `CheckboxControl`: Fix disabled styles [#77132](https://github.com/WordPress/gutenberg/pull/77132).
 -   `FormTokenField`: Fix disabled styles. [#77137](https://github.com/WordPress/gutenberg/pull/77137)
 -   `Textarea`: Fix disabled styles [#77129](https://github.com/WordPress/gutenberg/pull/77129).
+-   `DateCalendar`: Fix disabled selected day having darker background than other disabled controls [#77138](https://github.com/WordPress/gutenberg/pull/77138).
 -   `Autocomplete`: Fix value comparison to avoid resetting block inserter in RTC ([#76980](https://github.com/WordPress/gutenberg/pull/76980)).
 -   `ValidatedRangeControl`: Fix `aria-label` rendered as `[object Object]` when `required` or `markWhenOptional` is set ([#77042](https://github.com/WordPress/gutenberg/pull/77042)).
 -   `Autocomplete`: Fix matching logic to prefer longest overlapping trigger ([#77018](https://github.com/WordPress/gutenberg/pull/77018)).

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -234,6 +234,13 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 		color: $components-color-foreground-inverted;
 	}
 
+	&:has(
+	.components-calendar__day-button:disabled,
+	.components-calendar__day-button:hover:disabled
+) {
+		color: $components-color-gray-600;
+	}
+
 	.components-calendar__day-button {
 		&::before {
 			background-color: $components-color-foreground;

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -234,13 +234,6 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 		color: $components-color-foreground-inverted;
 	}
 
-	&:has(
-	.components-calendar__day-button:disabled,
-	.components-calendar__day-button:hover:disabled
-) {
-		color: $components-color-gray-600;
-	}
-
 	.components-calendar__day-button {
 		&::before {
 			background-color: $components-color-foreground;
@@ -251,7 +244,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 		}
 
 		&:disabled::before {
-			background-color: $components-color-gray-100;
+			background-color: $components-color-gray-400;
 		}
 
 		&:hover:not(:disabled)::before {

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -244,7 +244,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 		}
 
 		&:disabled::before {
-			background-color: $components-color-disabled;
+			background-color: $components-color-gray-100;
 		}
 
 		&:hover:not(:disabled)::before {

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- DataForm: Fix disabled state for date(time) control. [#77138](https://github.com/WordPress/gutenberg/pull/77138)
 - DataViews: Fix `compact` density clipping and remove top/bottom padding. [#77054](https://github.com/WordPress/gutenberg/pull/77054)
 - DataForm: Remove `text-transform` from `panel` field labels. [#77196](https://github.com/WordPress/gutenberg/pull/77196)
 

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -454,6 +454,7 @@ function CalendarDateControl< Item >( {
 						timeZone={ timezoneString || undefined }
 						weekStartsOn={ weekStartsOn }
 						disabled={ disabled }
+						disableNavigation={ disabled }
 					/>
 				</Stack>
 			</BaseControl>

--- a/packages/dataviews/src/dataform/stories/layout-regular.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-regular.tsx
@@ -55,11 +55,16 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'date',
 		label: 'Date',
+		type: 'date',
+	},
+	{
+		id: 'datetime',
+		label: 'DateTime',
 		type: 'datetime',
 	},
 	{
 		id: 'birthdate',
-		label: 'Date as options',
+		label: 'DateTime as options',
 		type: 'datetime',
 		elements: [
 			{ value: '', label: 'Select a date' },
@@ -324,7 +329,8 @@ const LayoutRegularComponent = ( {
 		status: 'draft',
 		reviewer: 'fulano',
 		email: 'hello@wordpress.org',
-		date: '2021-01-01T12:00:00',
+		date: '2021-01-01',
+		datetime: '2021-01-01T12:00:00',
 		birthdate: '1950-02-23T12:00:00',
 		sticky: false,
 		can_comment: false,
@@ -363,6 +369,7 @@ const LayoutRegularComponent = ( {
 				'email',
 				'password',
 				'date',
+				'datetime',
 				'birthdate',
 				'filesize',
 				'dimensions',


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/77090

## What?

Fix disabled styles for the `DateCalendar` component and the DataForm date/datetime control.

## Why?

When a `DateCalendar` is disabled, the selected day has a darker background than other disabled controls, making it visually inconsistent. Additionally, the calendar navigation arrows remain active even when the control is disabled, allowing users to navigate months/years when they shouldn't be able to.

Before | After
--- | ---
<img width="472" height="555" alt="Screenshot 2026-04-10 at 10 36 56" src="https://github.com/user-attachments/assets/21e34ae4-e631-4710-8ada-4544c576ab6e" /> | <img width="472" height="989" alt="Screenshot 2026-04-10 at 10 37 22" src="https://github.com/user-attachments/assets/5b3f2bf7-589f-45e5-a723-55f1334a7aea" />

## How?

- Changed the disabled selected day `::before` background color from `$components-color-disabled` to `$components-color-gray-400` in `packages/components/src/calendar/style.scss`, aligning it with the `FormToggle` disabled color specs.
- Passed `disableNavigation={disabled}` to the `DateCalendar` in the DataForm date control, so navigation is disabled when the field is disabled.
- Updated the LayoutRegular story to include a separate `date` type field alongside the existing `datetime` field for better coverage.

## Testing Instructions

1. Open the Storybook for `DataForm / LayoutRegular`.
2. Observe both the "Date" and "DateTime" fields render correctly.
3. Disable a date/datetime field and verify:
   - The selected day background color is lighter and consistent with other disabled controls.
   - The calendar month/year navigation arrows are disabled and not clickable.


## Use of AI Tools

Claude Code was used to assist with implementation and to generate this PR summary.
