### PR TITLE
fix: Numeric value clearing in preset input controls

### DIFF
--- a/packages/block-editor/src/components/preset-input-control/index.js
+++ b/packages/block-editor/src/components/preset-input-control/index.js
@@ -168,8 +168,18 @@ export default function PresetInputControl( {
 		unitConfig?.max ?? customValueSettings[ computedUnit ]?.max ?? 10;
 
 	const handleCustomValueChange = ( newValue ) => {
-		const isNumeric = ! isNaN( parseFloat( newValue ) );
-		const newCustomValue = isNumeric ? newValue : undefined;
+		const isExplicitlyEmpty = newValue === '';
+		const isNumeric =
+			newValue !== undefined && ! isNaN( parseFloat( newValue ) );
+
+		let newCustomValue;
+		if ( isExplicitlyEmpty ) {
+			newCustomValue = '';
+		} else if ( isNumeric ) {
+			newCustomValue = newValue;
+		} else {
+			newCustomValue = undefined;
+		}
 
 		if ( newCustomValue !== undefined ) {
 			onChange( newCustomValue );

--- a/packages/block-editor/src/components/preset-input-control/index.js
+++ b/packages/block-editor/src/components/preset-input-control/index.js
@@ -168,22 +168,18 @@ export default function PresetInputControl( {
 		unitConfig?.max ?? customValueSettings[ computedUnit ]?.max ?? 10;
 
 	const handleCustomValueChange = ( newValue ) => {
-		const isExplicitlyEmpty = newValue === '';
-		const isNumeric =
-			newValue !== undefined && ! isNaN( parseFloat( newValue ) );
-
-		let newCustomValue;
-		if ( isExplicitlyEmpty ) {
-			newCustomValue = '';
-		} else if ( isNumeric ) {
-			newCustomValue = newValue;
-		} else {
-			newCustomValue = undefined;
+		// Treat empty or undefined as an explicit clear and propagate undefined.
+		if ( newValue === undefined || newValue === '' ) {
+			onChange( undefined );
+			return;
 		}
 
-		if ( newCustomValue !== undefined ) {
-			onChange( newCustomValue );
+		// Ignore non-numeric intermediate input (e.g. just a unit).
+		if ( isNaN( parseFloat( newValue ) ) ) {
+			return;
 		}
+
+		onChange( newValue );
 	};
 	const handleCustomValueSliderChange = ( next ) => {
 		onChange( [ next, computedUnit ].join( '' ) );

--- a/packages/block-editor/src/components/preset-input-control/test/index.js
+++ b/packages/block-editor/src/components/preset-input-control/test/index.js
@@ -92,6 +92,76 @@ describe( 'PresetInputControl', () => {
 		expect( mockOnChange ).toHaveBeenCalledWith( '25px' );
 	} );
 
+	it( 'clears value with undefined when input is fully erased via backspace', () => {
+		render(
+			<PresetInputControl
+				{ ...defaultProps }
+				presets={ presets }
+				value="60px"
+				disableCustomValues={ false }
+			/>
+		);
+
+		const input = screen.getByRole( 'spinbutton' );
+
+		// Simulate the bug scenario: backspace through "60" one character
+		// at a time. fireEvent.change is used here (rather than userEvent
+		// keyboard interactions) because the controlled UnitControl input
+		// does not respond to synthesised key events in jsdom. The
+		// intermediate "6" forwarding is expected and correct; the bug
+		// was that the final clear silently failed to propagate, leaving
+		// the parent stuck on the partial value.
+		fireEvent.change( input, { target: { value: '6' } } );
+		fireEvent.change( input, { target: { value: '' } } );
+
+		// The final clear must propagate as undefined, not be swallowed,
+		// and never be persisted as an empty string.
+		expect( mockOnChange ).toHaveBeenLastCalledWith( undefined );
+		expect( mockOnChange ).not.toHaveBeenCalledWith( '' );
+	} );
+
+	it( 'clears value with undefined when input is cleared in one shot', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<PresetInputControl
+				{ ...defaultProps }
+				presets={ presets }
+				value="25px"
+				disableCustomValues={ false }
+			/>
+		);
+
+		const input = screen.getByRole( 'spinbutton' );
+		await user.clear( input );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( undefined );
+		expect( mockOnChange ).not.toHaveBeenCalledWith( '' );
+	} );
+
+	it( 'does not call onChange for non-numeric intermediate input', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<PresetInputControl
+				{ ...defaultProps }
+				presets={ presets }
+				value="15px"
+				disableCustomValues={ false }
+			/>
+		);
+
+		const input = screen.getByRole( 'spinbutton' );
+		await user.clear( input );
+		mockOnChange.mockClear();
+
+		// Typing a stray non-numeric character should not propagate a change.
+		await user.type( input, 'a' );
+
+		expect( mockOnChange ).not.toHaveBeenCalledWith( 'a' );
+		expect( mockOnChange ).not.toHaveBeenCalledWith( 'apx' );
+	} );
+
 	it( 'uses select dropdown for many presets', async () => {
 		const manyPresets = Array.from( { length: 12 }, ( _, i ) => ( {
 			name: `Preset ${ i + 1 }`,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77124

<!-- In a few words, what is the PR actually doing? -->
Fixes a bug where clearing numeric values in shared preset-based controls (used by inputs like margin and border radius) could retain a partial value (for example, `6` after deleting `60`). 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When users clear numeric values with backspace in affected block controls, the intermediate partial value may be applied and persisted instead of the field becoming fully empty. This creates incorrect style values and inconsistent UX.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates `PresetInputControl` custom value change handling so empty input is treated as a valid cleared state instead of being discarded as `undefined`. This allows the control to propagate a true empty value and avoids persisting transient partial numeric states during deletion.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open the editor and insert a block (for example, Paragraph).
2. In block settings, set a numeric value like `60` in controls backed by preset input (e.g. Margin, Padding).
3. Place the cursor in the numeric field and press backspace until cleared.
4. Confirm the value is fully cleared (empty), and no partial value like `6` is retained.
5. Repeat for at least one additional affected control to confirm shared behavior.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/a9d3bb6f-9d64-4bf8-9486-5304e85dcbce

### After
https://github.com/user-attachments/assets/6a725496-f3f0-42b3-8d09-628daa554f41

## Use of AI Tools
I used GitHub Copilot as an assistive drafting and code-review aid for the PR. 
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
