### PR TITLE
Add `.scss` files to CSS module linting

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -55,7 +55,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/*.module.css' ],
+			files: [ '**/*.module.{css,scss}' ],
 			rules: {
 				'function-no-unknown': [
 					true,

--- a/packages/components/src/angle-picker-control/style.module.scss
+++ b/packages/components/src/angle-picker-control/style.module.scss
@@ -31,6 +31,7 @@
 	border-radius: $radius-round;
 	box-sizing: border-box;
 	display: block;
+	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Geometric centering */
 	left: 50%;
 	top: 4px;
 	transform: translateX(-50%);


### PR DESCRIPTION
## What?

Broadens the root `.stylelintrc.js` CSS module `overrides` glob from `**/*.module.css` to `**/*.module.{css,scss}` so the same rules apply to SCSS CSS modules.

## Why?

`*.module.scss` files were already picked up by `npm run lint:css` via `**/*.scss`, but they did not match the CSS module override block. That meant rules such as `property-no-unknown` (for `composes`), `declaration-property-max-values`, and the logical-properties plugin were not applied consistently between `.module.css` and `.module.scss`.

## Testing Instructions

`npm run lint:css`