### PR TITLE
Breadcrumbs: Add character limit control with ellipsis truncation

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -92,7 +92,7 @@ Display a breadcrumb trail showing the path to the current page. ([Source](https
 -	**Name:** core/breadcrumbs
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
+-	**Attributes:** characterLimit, prefersTaxonomy, separator, showCurrentItem, showHomeItem, showOnHomePage
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -26,6 +26,10 @@
 		"showOnHomePage": {
 			"type": "boolean",
 			"default": false
+		},
+		"characterLimit": {
+			"type": "number",
+			"default": 10
 		}
 	},
 	"usesContext": [ "postId", "postType", "templateSlug" ],

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -7,6 +7,7 @@ import {
 	ToggleControl,
 	TextControl,
 	CheckboxControl,
+	RangeControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	Spinner,
@@ -37,6 +38,7 @@ export default function BreadcrumbEdit( {
 		showCurrentItem,
 		prefersTaxonomy,
 		showOnHomePage,
+		characterLimit,
 	} = attributes;
 	const {
 		post,
@@ -213,6 +215,7 @@ export default function BreadcrumbEdit( {
 							separator: separatorDefaultValue,
 							showHomeItem: true,
 							showCurrentItem: true,
+							characterLimit: 10,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -278,6 +281,25 @@ export default function BreadcrumbEdit( {
 									} );
 								}
 							} }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => characterLimit !== 10 }
+						label={ __( 'Max characters' ) }
+						onDeselect={ () =>
+							setAttributes( { characterLimit: 10 } )
+						}
+						isShownByDefault
+					>
+						<RangeControl
+							__next40pxDefaultSize
+							label={ __( 'Max characters' ) }
+							value={ characterLimit }
+							onChange={ ( value ) => {
+								setAttributes( { characterLimit: value } );
+							} }
+							min="0"
+							max="200"
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -623,7 +623,7 @@ function block_core_breadcrumbs_truncate_items( $breadcrumb_items, $character_li
 	// Calculate total characters in all labels.
 	$total_chars = 0;
 	foreach ( $breadcrumb_items as $item ) {
-		$label = isset( $item['allow_html'] ) && $item['allow_html'] ? wp_strip_all_tags( $item['label'] ) : $item['label'];
+		$label       = isset( $item['allow_html'] ) && $item['allow_html'] ? wp_strip_all_tags( $item['label'] ) : $item['label'];
 		$total_chars += strlen( $label );
 	}
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -637,14 +637,14 @@ function block_core_breadcrumbs_truncate_items( $breadcrumb_items, $character_li
 	$truncated_items = array();
 
 	foreach ( $breadcrumb_items as $index => $item ) {
-		$label = isset( $item['allow_html'] ) && $item['allow_html'] ? wp_strip_all_tags( $item['label'] ) : $item['label'];
+		$label        = isset( $item['allow_html'] ) && $item['allow_html'] ? wp_strip_all_tags( $item['label'] ) : $item['label'];
 		$label_length = strlen( $label );
 
-		if ( $index === count( $breadcrumb_items ) - 1 ) {
+		if ( count( $breadcrumb_items ) - 1 === $index ) {
 			// Last item: truncate if necessary.
 			if ( $remaining_chars < $label_length ) {
 				$truncated_label = substr( $label, 0, max( 0, $remaining_chars - 3 ) ) . '…';
-				$item['label'] = $truncated_label;
+				$item['label']   = $truncated_label;
 			}
 		} else {
 			// Not the last item: use full label if it fits, otherwise skip remaining items.
@@ -652,14 +652,14 @@ function block_core_breadcrumbs_truncate_items( $breadcrumb_items, $character_li
 				// If this item doesn't fit, we've reached the truncation point.
 				// Replace this item with ellipsis.
 				$item['label'] = '…';
-				$item['url'] = ''; // Remove URL for ellipsis item.
+				$item['url']   = ''; // Remove URL for ellipsis item.
 				unset( $item['allow_html'] );
 				$truncated_items[] = $item;
 				break;
 			}
 		}
 
-		$remaining_chars -= $label_length;
+		$remaining_chars  -= $label_length;
 		$truncated_items[] = $item;
 	}
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -23,6 +23,8 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$character_limit = isset( $attributes['characterLimit'] ) ? (int) $attributes['characterLimit'] : 10;
+
 	$is_home          = is_home();
 	$page_for_posts   = get_option( 'page_for_posts' );
 	$breadcrumb_items = array();
@@ -181,6 +183,11 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 
 	if ( empty( $breadcrumb_items ) ) {
 		return '';
+	}
+
+	// Apply character limit truncation if set.
+	if ( $character_limit > 0 ) {
+		$breadcrumb_items = block_core_breadcrumbs_truncate_items( $breadcrumb_items, $character_limit );
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
@@ -593,6 +600,70 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 		);
 	}
 	return $breadcrumb_items;
+}
+
+/**
+ * Truncates breadcrumb items to fit within a character limit.
+ *
+ * If the total character count of breadcrumb labels exceeds the limit,
+ * truncates the last item's label and adds an ellipsis.
+ *
+ * @since 7.0.0
+ *
+ * @param array $breadcrumb_items Array of breadcrumb item data.
+ * @param int   $character_limit  The maximum number of characters allowed.
+ *
+ * @return array Modified array of breadcrumb item data.
+ */
+function block_core_breadcrumbs_truncate_items( $breadcrumb_items, $character_limit ) {
+	if ( empty( $breadcrumb_items ) || $character_limit <= 0 ) {
+		return $breadcrumb_items;
+	}
+
+	// Calculate total characters in all labels.
+	$total_chars = 0;
+	foreach ( $breadcrumb_items as $item ) {
+		$label = isset( $item['allow_html'] ) && $item['allow_html'] ? wp_strip_all_tags( $item['label'] ) : $item['label'];
+		$total_chars += strlen( $label );
+	}
+
+	// If within limit, return as is.
+	if ( $total_chars <= $character_limit ) {
+		return $breadcrumb_items;
+	}
+
+	// Truncate the last item's label to fit within the limit.
+	$remaining_chars = $character_limit;
+	$truncated_items = array();
+
+	foreach ( $breadcrumb_items as $index => $item ) {
+		$label = isset( $item['allow_html'] ) && $item['allow_html'] ? wp_strip_all_tags( $item['label'] ) : $item['label'];
+		$label_length = strlen( $label );
+
+		if ( $index === count( $breadcrumb_items ) - 1 ) {
+			// Last item: truncate if necessary.
+			if ( $remaining_chars < $label_length ) {
+				$truncated_label = substr( $label, 0, max( 0, $remaining_chars - 3 ) ) . '…';
+				$item['label'] = $truncated_label;
+			}
+		} else {
+			// Not the last item: use full label if it fits, otherwise skip remaining items.
+			if ( $remaining_chars < $label_length ) {
+				// If this item doesn't fit, we've reached the truncation point.
+				// Replace this item with ellipsis.
+				$item['label'] = '…';
+				$item['url'] = ''; // Remove URL for ellipsis item.
+				unset( $item['allow_html'] );
+				$truncated_items[] = $item;
+				break;
+			}
+		}
+
+		$remaining_chars -= $label_length;
+		$truncated_items[] = $item;
+	}
+
+	return $truncated_items;
 }
 
 /**


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/76533

Adds a character limit control to the Breadcrumbs block that truncates the rendered breadcrumb trail with an ellipsis (...) when the defined limit is exceeded.

## Why?
The Breadcrumbs block currently has no way to limit the trail's length. On mobile viewports and narrow layouts, a deep breadcrumb path easily wraps to multiple lines, breaking layouts and consuming disproportionate vertical space. This feature provides a native way to gracefully truncate the output for better responsive design.

The behavior mirrors the existing Excerpt block controls for consistency with established patterns in Gutenberg.

## Testing Instructions

1. Navigate to a single post/page with a deep hierarchy (e.g., Parent > Child > Grandchild > Current Page)
2. Insert a Breadcrumbs block
3. In the block inspector, locate the "Max characters" slider in the Settings panel
4. Test the following scenarios:
   - Set the limit to `20` and verify breadcrumbs are truncated with ellipsis
   - Set the limit to `50` and verify more complete trail is shown
   - Set the limit to `0` (disabled) and verify full breadcrumb trail is displayed
   - Verify the ellipsis is properly appended to truncated content
   - Test with different viewport widths on mobile to confirm improved layout