### PR TITLE
Guidelines CPT: Changes slug from wp_content_guidelines to wp_guidelines

### DIFF
--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
@@ -19,7 +19,7 @@ class Gutenberg_Content_Guidelines_Post_Type {
 	 *
 	 * @var string
 	 */
-	const POST_TYPE = 'wp_content_guideline';
+	const POST_TYPE = 'wp_guideline';
 
 	/**
 	 * The standard guideline category meta keys.

--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-revisions-controller.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-revisions-controller.php
@@ -36,7 +36,7 @@ class Gutenberg_Content_Guidelines_Revisions_Controller extends WP_REST_Revision
 	 *
 	 * @param string $parent_post_type Post type of the parent.
 	 */
-	public function __construct( $parent_post_type = 'wp_content_guideline' ) {
+	public function __construct( $parent_post_type = 'wp_guideline' ) {
 		parent::__construct( $parent_post_type );
 
 		// Re-set private properties from WP_REST_Revisions_Controller.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

See #76384 

Renames the Content Guidelines custom post type slug from `wp_content_guideline` to `wp_guideline`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Before the 22.7 release, the public-facing name was simplified from "Content Guidelines" to just "Guidelines" — recognizing the feature extends beyond content to design guidelines, coding standards, and more ([announcement
  post](https://make.wordpress.org/ai/2026/03/23/guidelines-lands-in-gutenberg-22-7/)).

This PR aligns the internal CPT slug with that direction. As noted in the [core review comments](https://make.wordpress.org/ai/2026/03/23/guidelines-lands-in-gutenberg-22-7/#comment-42), `wp_guideline` follows WordPress's CPT naming convention (`wp_block`,
  `wp_template`, `wp_global_styles`).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Two changes:
  - `Gutenberg_Content_Guidelines_Post_Type::POST_TYPE` constant → `'wp_guideline'`
  - `Gutenberg_Content_Guidelines_Revisions_Controller` constructor default → `'wp_guideline'`

  All other code references the `POST_TYPE` constant, so they pick up the change automatically. The `rest_base` remains `content-guidelines`. Meta keys (`_content_guideline_*`) are unchanged.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**Setup**: Boot up local WordPress using `npm run wp-env start`

1. Enable the  experiment in **Settings > Experiments** under the label: "Guidelines"
2. Navigate to **Settings > Guidelines**.
3. Add text in the Copy and Images fields, click Save.
4. Refresh — verify saved guidelines load correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

No special steps for keyboard testing required

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

No visual changes

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Claude Opus used for planning the task and creating summarised draft of PR description
