### PR TITLE
Components: update React function names for better ESLint detection

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `Button`: Remove obsolete Safari + VoiceOver workaround for visually hidden text ([#77107](https://github.com/WordPress/gutenberg/pull/77107)).
 -   `BoxControl`: Remove unused state for icon side ([#77143](https://github.com/WordPress/gutenberg/pull/77143)).
 -   `Autocomplete`: Remove `getAutoCompleterUI` factory pattern ([#77048](https://github.com/WordPress/gutenberg/pull/77048)).
+-   `CustomSelectControl`, `Sandbox`: Rename internal React function names ([#77148](https://github.com/WordPress/gutenberg/pull/77148)).
 
 ## 32.5.0 (2026-04-01)
 

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -19,7 +19,7 @@ import type {
 	CustomSelectStore,
 	CustomSelectButtonProps,
 	CustomSelectButtonSize,
-	_CustomSelectInternalProps,
+	CustomSelectInternalProps,
 	_CustomSelectProps,
 } from './types';
 import InputBase from '../input-control/input-base';
@@ -85,8 +85,8 @@ const CustomSelectButton = ( {
 	);
 };
 
-function _CustomSelect(
-	props: _CustomSelectInternalProps &
+function CustomSelect(
+	props: CustomSelectInternalProps &
 		_CustomSelectProps &
 		CustomSelectStore &
 		CustomSelectButtonSize
@@ -161,4 +161,4 @@ function _CustomSelect(
 	);
 }
 
-export default _CustomSelect;
+export default CustomSelect;

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -5,7 +5,7 @@ import * as Ariakit from '@ariakit/react';
 /**
  * Internal dependencies
  */
-import _CustomSelect from './custom-select';
+import CustomSelect from './custom-select';
 import type { CustomSelectProps } from './types';
 import type { WordPressComponentProps } from '../context';
 import Item from './item';
@@ -21,7 +21,7 @@ function CustomSelectControlV2(
 		value,
 	} );
 
-	return <_CustomSelect { ...restProps } store={ store } />;
+	return <CustomSelect { ...restProps } store={ store } />;
 }
 
 CustomSelectControlV2.Item = Item;

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -50,7 +50,7 @@ export type CustomSelectButtonProps = {
 };
 
 // Props only exposed on the internal implementation
-export type _CustomSelectInternalProps = {
+export type CustomSelectInternalProps = {
 	/**
 	 * True if the consumer is emulating the legacy component behavior and look
 	 */

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -13,7 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import _CustomSelect from '../custom-select-control-v2/custom-select';
+import CustomSelect from '../custom-select-control-v2/custom-select';
 import CustomSelectItem from '../custom-select-control-v2/item';
 import * as Styled from '../custom-select-control-v2/styles';
 import type { CustomSelectProps, CustomSelectOption } from './types';
@@ -189,7 +189,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 
 	return (
 		<>
-			<_CustomSelect
+			<CustomSelect
 				aria-describedby={ descriptionId }
 				renderSelectedValue={ renderSelectedValue }
 				size={ translatedSize }
@@ -203,7 +203,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 				{ ...restProps }
 			>
 				{ children }
-			</_CustomSelect>
+			</CustomSelect>
 			<VisuallyHidden>
 				<span id={ descriptionId }>
 					{ getDescribedBy( selectedOption?.name, describedBy ) }

--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -172,7 +172,7 @@ const style = `
 
 const EMPTY_ARRAY = [];
 
-const Sandbox = forwardRef( function Sandbox(
+const Sandbox = forwardRef( function UnforwardedSandbox(
 	{
 		containerStyle,
 		customJS,


### PR DESCRIPTION
Spinoff from ESLint upgrade in #76654. Updates React component names so that ESLint recognizes them as React components and allows hooks usage inside. The `_` prefix prevented that detection.

I'm removing prefixes from `CustomSelect` that seem unnecessary. @ciampo can you confirm that this is OK? The only identifier that keeps the prefix is `_CustomSelectProps` because there is also `CustomSelectProps`. The difference is some magic with the type of the `size` component, I don't understand this.

There's also a `Sandbox` name update, using the `UnforwardedSandbox` convention to prevent a "no shadow" lint error.

After this, #76654 can remove a few disable comments.