### PR TITLE
Admin UI: Increase page header vertical padding

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Increase page header vertical padding. [#77152](https://github.com/WordPress/gutenberg/pull/77152)
+
 ## 1.11.0 (2026-04-01)
 
 ### Bug Fixes

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -14,7 +14,7 @@
 }
 
 .admin-ui-page__header {
-	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-2xl);
+	padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
 	border-bottom: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 	background: var(--wpds-color-bg-surface-neutral-strong);
 	position: sticky;


### PR DESCRIPTION
## What
Increase vertical padding of page header in the Admin UI package

## Why
To match the spec: https://github.com/WordPress/gutenberg/issues/76709

## How
Replace `--wpds-dimension-padding-md` with `--wpds-dimension-padding-lg`

## Testing instructions
* `npm run storybook`
* View http://localhost:50240/?path=/story/admin-ui-page--default
* Observe updated padding