### PR TITLE
Eslint: Suggest alternative in `no-setting-ds-tokens` rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-setting-ds-tokens.md
+++ b/packages/eslint-plugin/docs/rules/no-setting-ds-tokens.md
@@ -1,6 +1,6 @@
 # Disallow setting Design System token CSS custom properties (no-setting-ds-tokens)
 
-Design System tokens (CSS custom properties beginning with `--wpds-`) are meant to be consumed, not set. Setting these properties can lead to unexpected behavior and breaks the Design System's theming capabilities.
+Design System tokens (CSS custom properties beginning with `--wpds-`) are meant to be consumed, not set. Setting these properties can lead to unexpected behavior and breaks the Design System's theming capabilities. To customize parts of the Design System, use the `ThemeProvider` component from the [`@wordpress/theme`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-theme-introduction--docs) package.
 
 This rule lints all object property keys in JavaScript/TypeScript files. For CSS files, use the [corresponding Stylelint rule](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-theme/#stylelint-plugins) from the `@wordpress/theme` package.
 

--- a/packages/eslint-plugin/rules/no-setting-ds-tokens.js
+++ b/packages/eslint-plugin/rules/no-setting-ds-tokens.js
@@ -8,7 +8,7 @@ module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 		schema: [],
 		messages: {
 			disallowedSet:
-				'Do not set CSS custom properties using the Design System tokens namespace (i.e. beginning with --wpds-*).',
+				'Do not set CSS custom properties using the Design System tokens namespace (i.e. beginning with --wpds-*). Use `ThemeProvider` from `@wordpress/theme` instead.',
 		},
 	},
 	create( context ) {


### PR DESCRIPTION
Noticed while looking into #76686

## What?

Mention the `ThemeProvider` solution in the error messages for the `no-setting-ds-tokens` lint rule.

## Why?

I noticed we didn't mention this as the recommended approach. Without it, the consumer is left wondering what to do instead.

## Testing Instructions

Check that the copy makes sense.

## Use of AI Tools

None