### PR TITLE
Use entity link title for link control preview

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -744,7 +744,6 @@ function LinkControl( {
 					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
-					isEntityLink={ isEntity }
 					onRemove={ () => {
 						onRemove();
 						setIsEditingLink( true );

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -744,6 +744,7 @@ function LinkControl( {
 					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
+					isEntityLink={ isEntity }
 					onRemove={ () => {
 						onRemove();
 						setIsEditingLink( true );

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -40,28 +40,11 @@ const { Badge } = unlock( componentsPrivateApis );
 
 import useRichUrlData from './use-rich-url-data';
 
-const getDisplayTitle = ( { value, richData, displayURL, isEntity } ) => {
-	let displayTitle = '';
-
-	// Prioritize the bound entity title
-	if ( isEntity ) {
-		displayTitle = value?.title;
-	}
-
-	// If we don't have a title from a bound entity (or the bound entity title is empty), prioritize the rich data title
-	if ( ! displayTitle ) {
-		displayTitle = richData?.title || value?.title || displayURL;
-	}
-
-	return stripHTML( displayTitle );
-};
-
 export default function LinkPreview( {
 	value,
 	onEditClick,
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
-	isEntity = false,
 	onRemove,
 } ) {
 	const showIconLabels = useSelect(
@@ -85,12 +68,11 @@ export default function LinkPreview( {
 	// url can be undefined if the href attribute is unset
 	const isEmptyURL = ! value?.url?.length;
 
-	const displayTitle = getDisplayTitle( {
-		value,
-		richData,
-		displayURL,
-		isEntity,
-	} );
+	const displayTitle =
+		! isEmptyURL &&
+		stripHTML(
+			value?.entityTitle || richData?.title || value?.title || displayURL
+		);
 
 	let icon;
 

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -40,11 +40,28 @@ const { Badge } = unlock( componentsPrivateApis );
 
 import useRichUrlData from './use-rich-url-data';
 
+const getDisplayTitle = ( { value, richData, displayURL, isEntity } ) => {
+	let displayTitle = '';
+
+	// Prioritize the bound entity title
+	if ( isEntity ) {
+		displayTitle = value?.title;
+	}
+
+	// If we don't have a title from a bound entity (or the bound entity title is empty), prioritize the rich data title
+	if ( ! displayTitle ) {
+		displayTitle = richData?.title || value?.title || displayURL;
+	}
+
+	return stripHTML( displayTitle );
+};
+
 export default function LinkPreview( {
 	value,
 	onEditClick,
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
+	isEntity = false,
 	onRemove,
 } ) {
 	const showIconLabels = useSelect(
@@ -68,9 +85,12 @@ export default function LinkPreview( {
 	// url can be undefined if the href attribute is unset
 	const isEmptyURL = ! value?.url?.length;
 
-	const displayTitle =
-		! isEmptyURL &&
-		stripHTML( richData?.title || value?.title || displayURL );
+	const displayTitle = getDisplayTitle( {
+		value,
+		richData,
+		displayURL,
+		isEntity,
+	} );
 
 	let icon;
 

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -124,13 +124,24 @@ function UnforwardedLinkUI( props, ref ) {
 			url,
 			opensInNewTab,
 			title: label && stripHTML( label ),
+			entityTitle: entityRecord?.title?.rendered || entityRecord?.name,
 			kind,
 			type,
 			id,
 			image,
 			badges,
 		} ),
-		[ label, opensInNewTab, url, kind, type, id, image, badges ]
+		[
+			label,
+			opensInNewTab,
+			url,
+			kind,
+			type,
+			id,
+			image,
+			badges,
+			entityRecord,
+		]
 	);
 
 	const handlePageCreated = ( pageLink ) => {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
https://github.com/WordPress/gutenberg/pull/77057 exposed an inconsistency between the sidebar inspector link preview and link control link preview. The link title shows the RichData title which often includes the site. This wasn't our design intention for the link previews.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consistency between link previews.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When we have a bound entity link, we should use the bound entity link title in the link control preview. If there is none, fallback to `richText.title || navigation block title || navigation block url`


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a Navigation block with a bound entity, unbound internal link, and external link
- Check that the link preview for the bound entity shows the title of the bound entity.
- Change the title of the navigation link for the bound entity. 
- Open the link preview
- The link preview should still show the bound entity link title, NOT the text from the navigation link block
- The unbound internal link should show the navigation link block title
- The external link should show a richData title, like `Page title - site title`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/901f7d7b-48c3-4ac0-8a6b-06c78d1e2925


|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Assistance from Claude Sonnet 4.6
