### PR TITLE
Registers wp_guideline_type taxonomy

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -151,11 +151,14 @@ class Gutenberg_Guidelines_Post_Type {
 			)
 		);
 
-		// Seed default terms.
-		foreach ( self::VALID_TYPES as $type ) {
-			if ( ! term_exists( $type, self::TAXONOMY ) ) {
-				wp_insert_term( $type, self::TAXONOMY, array( 'slug' => $type ) );
+		// Seed default terms once to avoid per-request SELECT queries from term_exists().
+		if ( ! get_option( 'wp_guideline_type_terms_seeded' ) ) {
+			foreach ( self::VALID_TYPES as $type ) {
+				if ( ! term_exists( $type, self::TAXONOMY ) ) {
+					wp_insert_term( $type, self::TAXONOMY, array( 'slug' => $type ) );
+				}
 			}
+			update_option( 'wp_guideline_type_terms_seeded', true );
 		}
 	}
 

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -22,6 +22,25 @@ class Gutenberg_Guidelines_Post_Type {
 	const POST_TYPE = 'wp_guideline';
 
 	/**
+	 * The taxonomy name for guideline types.
+	 *
+	 * @var string
+	 */
+	const TAXONOMY = 'wp_guideline_type';
+
+	/**
+	 * Valid guideline type taxonomy terms.
+	 *
+	 * @var array
+	 */
+	const VALID_TYPES = array(
+		'content',
+		'skill',
+		'memory',
+		'plan',
+	);
+
+	/**
 	 * The standard guideline category meta keys.
 	 *
 	 * @var array
@@ -104,6 +123,40 @@ class Gutenberg_Guidelines_Post_Type {
 		);
 
 		register_post_type( self::POST_TYPE, $args );
+
+		register_taxonomy(
+			self::TAXONOMY,
+			self::POST_TYPE,
+			array(
+				'public'             => false,
+				'publicly_queryable' => false,
+				'show_ui'            => false,
+				'show_in_menu'       => false,
+				'show_in_rest'       => true,
+				'rest_base'          => 'wp-guideline-type',
+				'hierarchical'       => false,
+				'rewrite'            => false,
+				'query_var'          => false,
+				'show_admin_column'  => false,
+				'capabilities'       => array(
+					'manage_terms' => 'manage_options',
+					'edit_terms'   => 'manage_options',
+					'delete_terms' => 'manage_options',
+					'assign_terms' => 'manage_options',
+				),
+				'labels'             => array(
+					'name'          => __( 'Guideline Types', 'gutenberg' ),
+					'singular_name' => __( 'Guideline Type', 'gutenberg' ),
+				),
+			)
+		);
+
+		// Seed default terms.
+		foreach ( self::VALID_TYPES as $type ) {
+			if ( ! term_exists( $type, self::TAXONOMY ) ) {
+				wp_insert_term( $type, self::TAXONOMY, array( 'slug' => $type ) );
+			}
+		}
 	}
 
 	/**

--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -29,18 +29,6 @@ class Gutenberg_Guidelines_Post_Type {
 	const TAXONOMY = 'wp_guideline_type';
 
 	/**
-	 * Valid guideline type taxonomy terms.
-	 *
-	 * @var array
-	 */
-	const VALID_TYPES = array(
-		'content',
-		'skill',
-		'memory',
-		'plan',
-	);
-
-	/**
 	 * The standard guideline category meta keys.
 	 *
 	 * @var array
@@ -130,36 +118,22 @@ class Gutenberg_Guidelines_Post_Type {
 			array(
 				'public'             => false,
 				'publicly_queryable' => false,
-				'show_ui'            => false,
-				'show_in_menu'       => false,
-				'show_in_rest'       => true,
-				'rest_base'          => 'wp-guideline-type',
 				'hierarchical'       => false,
-				'rewrite'            => false,
-				'query_var'          => false,
-				'show_admin_column'  => false,
-				'capabilities'       => array(
-					'manage_terms' => 'manage_options',
-					'edit_terms'   => 'manage_options',
-					'delete_terms' => 'manage_options',
-					'assign_terms' => 'manage_options',
-				),
 				'labels'             => array(
 					'name'          => __( 'Guideline Types', 'gutenberg' ),
 					'singular_name' => __( 'Guideline Type', 'gutenberg' ),
 				),
+				'query_var'          => false,
+				'rewrite'            => false,
+				'show_ui'            => false,
+				'show_in_nav_menus'  => false,
+				'show_in_rest'       => true,
+				'default_term'       => array(
+					'name' => 'content',
+					'slug' => 'content',
+				),
 			)
 		);
-
-		// Seed default terms once to avoid per-request SELECT queries from term_exists().
-		if ( ! get_option( 'wp_guideline_type_terms_seeded' ) ) {
-			foreach ( self::VALID_TYPES as $type ) {
-				if ( ! term_exists( $type, self::TAXONOMY ) ) {
-					wp_insert_term( $type, self::TAXONOMY, array( 'slug' => $type ) );
-				}
-			}
-			update_option( 'wp_guideline_type_terms_seeded', true );
-		}
 	}
 
 	/**


### PR DESCRIPTION
## What?

Follow-up to #77147 

Registers a `wp_guideline_type` taxonomy on the guidelines CPT, following the `wp_template` + `wp_theme` pattern from core. Uses `default_term` to seed `content` as the default type.

## Why?

As discussed in the [Guidelines announcement comments](https://make.wordpress.org/ai/2026/03/23/guidelines-lands-in-gutenberg-22-7/#comment-42), the CPT is evolving to support different document types beyond site-wide editorial guidelines. A taxonomy cleanly separates these types within the same CPT, enabling REST-based discovery and filtering — the same approach core uses with `wp_template` and `wp_theme`.

## How?

 - Adds a `TAXONOMY` constant to `Gutenberg_Content_Guidelines_Post_Type`
 - Calls `register_taxonomy()` inside the existing `register()` method, right after `register_post_type()`
 - Uses `default_term` to auto-create and assign the `content` term (handled by core, no per-request queries)
 - Taxonomy is non-public, `show_in_rest = true`, registration trimmed to match core peers (`wp_theme`, `wp_pattern_category`)

No changes to the REST controller, singleton behavior, or client-side code.

## Testing Instructions

  ### Setup

  1. `npm run wp-env start`
  2. Enable the Content Guidelines experiment in **Settings > Experiments**

  ### Taxonomy verification

  3. Visit `http://localhost:8888/wp-json/wp/v2/wp_guideline_type` — should return one term: `content`
  4. Visit `http://localhost:8888/wp-json/wp/v2/taxonomies/wp_guideline_type` — should return the taxonomy definition attached to the guidelines CPT

  ### Regression

  5. Navigate to **Settings > Content Guidelines**
  6. Add text in the Copy and Images fields, click Save
  7. Refresh the page — verify saved guidelines load correctly
  8. Export guidelines as JSON — verify the file downloads
  9. Import the JSON back — verify it applies
  10. Check revision history — verify revisions are listed

### Testing Instructions for Keyboard

No special case for keyboard required.

## Screenshots or screencast

No visual changes expected.

## Use of AI Tools

Claude Code used for planning, review feedback implementation, and PR description updates.