### PR TITLE
UI/Tooltip: Add usage guidelines documentation

### DIFF
--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -1267,7 +1267,7 @@ export const HoverTrigger: Story = {
  * popup itself, it's a popover. If the trigger's purpose is unrelated to
  * opening the popup, it's a tooltip.
  */
-export const InfoTip: Story = {
+export const Infotip: Story = {
 	parameters: { controls: { disable: true } },
 	render: function Render( args ) {
 		return (

--- a/packages/ui/src/tooltip/root.tsx
+++ b/packages/ui/src/tooltip/root.tsx
@@ -2,16 +2,17 @@ import { Tooltip } from '@base-ui/react/tooltip';
 import type { RootProps } from './types';
 
 /**
- * `Tooltip` is used to visually show the label of an icon button, or other such interactive controls
- * that don't have a visual text label.
+ * `Tooltip` is used to visually show the label of an icon button, or other such
+ * interactive controls that don't have a visual text label.
  *
- * Tooltips are not available on touch devices, and thus should not be used for infotips,
- * descriptions, or dynamic status messages.
+ * Tooltip popups are visual-only and not exposed to assistive technologies.
+ * The trigger's accessible name (e.g. `aria-label`) is the source of truth
+ * for screen reader users. Tooltips are not available on touch devices,
+ * and thus should not be used for infotips, descriptions, or dynamic status
+ * messages.
  *
- * The tooltip itself does not provide any accessible labeling, so when using the
- * `Tooltip` primitive you must ensure that the trigger is accessibly labeled (e.g. with an `aria-label`).
- *
- * See also: [IconButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs)
+ * @see {@link https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-tooltip-usage-guidelines--docs Usage Guidelines}
+ * @see {@link https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs IconButton}
  */
 function Root( props: RootProps ) {
 	return <Tooltip.Root { ...props } />;

--- a/packages/ui/src/tooltip/stories/usage-guidelines.mdx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.mdx
@@ -7,7 +7,7 @@ import * as UsageGuidelinesStories from './usage-guidelines.story';
 
 ## Usage guidelines
 
--   **Prefer using tooltips as visual labels only.** Tooltips should act as
+-   **Use tooltips as visual labels only.** Tooltips should act as
     supplementary visual labels for sighted mouse and keyboard users.
     Tooltip popups are not exposed to assistive technologies — the
     trigger's accessible name (e.g. `aria-label`) is what provides the
@@ -56,9 +56,9 @@ To know when to reach for a popover instead of a tooltip, consider the
 popup itself, it's a popover. If the trigger's purpose is unrelated to
 opening the popup, it's a tooltip.
 
-<Canvas of={ UsageGuidelinesStories.InfoTipWithPopover } />
+<Canvas of={ UsageGuidelinesStories.InfotipWithPopover } />
 
-See also the [Popover InfoTip story](?path=/story/design-system-components-popover--info-tip).
+See also the [Popover Infotip story](?path=/story/design-system-components-popover--infotip).
 
 Infotips opened on hover can be dismissed by pressing `Escape`.
 
@@ -87,5 +87,5 @@ content, such as a
 
 ## References
 
-- [WCAG 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) — tooltips must be dismissible (Escape), hoverable, and persistent.
-- [WAI-ARIA APG: Tooltip pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) — note that this component intentionally diverges from the traditional `role="tooltip"` + `aria-describedby` pattern. The trigger's `aria-label` is the source of truth for assistive technologies, and the tooltip popup is a visual-only supplement.
+-   [WCAG 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) — tooltips must be dismissible (Escape), hoverable, and persistent.
+-   [WAI-ARIA APG: Tooltip pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) — note that this component intentionally diverges from the traditional `role="tooltip"` + `aria-describedby` pattern. The trigger's `aria-label` is the source of truth for assistive technologies, and the tooltip popup is a visual-only supplement.

--- a/packages/ui/src/tooltip/stories/usage-guidelines.mdx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.mdx
@@ -1,0 +1,91 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as UsageGuidelinesStories from './usage-guidelines.story';
+
+<Meta of={ UsageGuidelinesStories } />
+
+# Tooltip usage guidelines
+
+## Usage guidelines
+
+-   **Prefer using tooltips as visual labels only.** Tooltips should act as
+    supplementary visual labels for sighted mouse and keyboard users.
+    Tooltip popups are not exposed to assistive technologies — the
+    trigger's accessible name (e.g. `aria-label`) is what provides the
+    label for screen reader users.
+    See [_Alternatives to tooltips_](#alternatives-to-tooltips) below for
+    more details.
+-   **Provide an accessible name for the trigger.** Tooltips are visual-only
+    elements and are not a replacement for labeling the trigger. The
+    tooltip's trigger must have an `aria-label` that matches or is a concise
+    equivalent of the tooltip's content to ensure consistency for screen
+    reader users. If the tooltip also displays a keyboard shortcut, use
+    `aria-keyshortcuts` on the trigger.
+
+<Canvas of={ UsageGuidelinesStories.RecommendedUsage } />
+
+`IconButton` has built-in tooltip support via the `label` prop, making it
+the easiest way to provide a tooltip for icon-only actions.
+
+<Canvas of={ UsageGuidelinesStories.IconButtonWithTooltip } />
+
+## Alternatives to tooltips
+
+Tooltips should be supplementary popups that provide non-essential clarity in
+high-density UIs. A user should not miss critical information if they never
+see a tooltip.
+
+Tooltips don't work well with touch input. Unlike mouse pointers with hover
+capability, there's no easily discoverable way to reveal a tooltip before
+tapping its trigger on a touch device.
+
+iOS doesn't provide a system-standard, touch-friendly tooltip affordance,
+while Android may show a tooltip on long press. However, on the web,
+long press is often used to trigger contextual menus in the browser, which
+can lead to potential conflicts. For this reason, tooltips are disabled on
+touch devices.
+
+### Infotips
+
+Popups that open when hovering an info icon should use
+[Popover](?path=/docs/design-system-components-popover--docs) with the
+`openOnHover` prop on the trigger instead of a tooltip. This way, touch
+users and screen reader users can access the content.
+
+To know when to reach for a popover instead of a tooltip, consider the
+**purpose** of the trigger element: if the trigger's purpose is to open the
+popup itself, it's a popover. If the trigger's purpose is unrelated to
+opening the popup, it's a tooltip.
+
+<Canvas of={ UsageGuidelinesStories.InfoTipWithPopover } />
+
+See also the [Popover InfoTip story](?path=/story/design-system-components-popover--info-tip).
+
+Infotips opened on hover can be dismissed by pressing `Escape`.
+
+### Description text
+
+Tooltips are designed for sighted mouse and keyboard users and are not a reliable way to deliver
+important information to touch users or assistive technologies. If the
+description is important to understanding the element, don't hide it behind a
+tooltip — use inline text or
+[Popover](?path=/docs/design-system-components-popover--docs) if space is
+limited, so the information is accessible to everyone.
+
+Since tooltips serve sighted mouse and keyboard users, iconography should
+clearly communicate the purpose of icon-only triggers, especially on mobile
+where the text label may not be visible.
+
+If the description is not critical, a tooltip can still be used to provide
+extra clarity for sighted mouse or keyboard users.
+
+### Contextual feedback messages
+
+For contextual feedback after an action (e.g. "Copied!"), prefer a pattern
+that ensures the message is announced to screen readers and supports complex
+content, such as a
+[Notice](?path=/docs/design-system-components-notice--docs).
+
+## References
+
+- [WCAG 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) — tooltips must be dismissible (Escape), hoverable, and persistent.
+- [WAI-ARIA APG: Tooltip pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) — note that this component intentionally diverges from the traditional `role="tooltip"` + `aria-describedby` pattern. The trigger's `aria-label` is the source of truth for assistive technologies, and the tooltip popup is a visual-only supplement.

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+	formatBold,
+	formatItalic,
+	formatUnderline,
+	info,
+} from '@wordpress/icons';
+import { Icon, IconButton, Popover, Tooltip, VisuallyHidden } from '../..';
+
+const meta: Meta = {
+	title: 'Design System/Components/Tooltip/Usage Guidelines',
+	parameters: {
+		controls: { disable: true },
+	},
+	tags: [ '!dev' ],
+};
+export default meta;
+
+type Story = StoryObj;
+
+/**
+ * Tooltips work best as visual labels for icon-only controls. Each trigger
+ * must have its own accessible name via `aria-label`.
+ */
+export const RecommendedUsage: Story = {
+	render: () => (
+		<Tooltip.Provider delay={ 0 }>
+			<div style={ { display: 'flex', gap: '0.25rem' } }>
+				<Tooltip.Root>
+					<Tooltip.Trigger aria-label="Bold">
+						<Icon icon={ formatBold } />
+					</Tooltip.Trigger>
+					<Tooltip.Popup>Bold</Tooltip.Popup>
+				</Tooltip.Root>
+
+				<Tooltip.Root>
+					<Tooltip.Trigger aria-label="Italic">
+						<Icon icon={ formatItalic } />
+					</Tooltip.Trigger>
+					<Tooltip.Popup>Italic</Tooltip.Popup>
+				</Tooltip.Root>
+
+				<Tooltip.Root>
+					<Tooltip.Trigger aria-label="Underline">
+						<Icon icon={ formatUnderline } />
+					</Tooltip.Trigger>
+					<Tooltip.Popup>Underline</Tooltip.Popup>
+				</Tooltip.Root>
+			</div>
+		</Tooltip.Provider>
+	),
+};
+
+/**
+ * Popups that open when hovering an info icon should use `Popover` with
+ * `openOnHover` instead of a Tooltip. This ensures the content is accessible
+ * to touch and screen reader users.
+ */
+export const InfoTipWithPopover: Story = {
+	render: () => (
+		<div
+			style={ {
+				display: 'flex',
+				alignItems: 'center',
+				gap: 'var(--wpds-dimension-gap-xs)',
+			} }
+		>
+			<span>Label</span>
+			<Popover.Root>
+				<Popover.Trigger
+					openOnHover
+					delay={ 200 }
+					closeDelay={ 200 }
+					aria-label="More information"
+					style={ {
+						background: 'none',
+						border: 'none',
+						padding: 0,
+						cursor: 'var(--wpds-cursor-control)',
+						display: 'inline-flex',
+						alignItems: 'center',
+						borderRadius: 'var(--wpds-border-radius-sm)',
+					} }
+				>
+					<Icon icon={ info } size={ 20 } />
+				</Popover.Trigger>
+				<Popover.Popup>
+					<Popover.Arrow />
+					<VisuallyHidden render={ <Popover.Title /> }>
+						More information
+					</VisuallyHidden>
+					<Popover.Description>
+						This is additional context about the label. Unlike
+						tooltips, this content is accessible to touch and screen
+						reader users.
+					</Popover.Description>
+				</Popover.Popup>
+			</Popover.Root>
+		</div>
+	),
+};
+
+/**
+ * `IconButton` has built-in tooltip support via the `label` prop,
+ * making it the easiest way to provide a tooltip for icon-only actions.
+ */
+export const IconButtonWithTooltip: Story = {
+	render: () => (
+		<div style={ { display: 'flex', gap: '0.25rem' } }>
+			<IconButton icon={ formatBold } label="Bold" size="compact" />
+			<IconButton icon={ formatItalic } label="Italic" size="compact" />
+			<IconButton
+				icon={ formatUnderline }
+				label="Underline"
+				size="compact"
+			/>
+		</div>
+	),
+};

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -56,7 +56,7 @@ export const RecommendedUsage: Story = {
  * `openOnHover` instead of a Tooltip. This ensures the content is accessible
  * to touch and screen reader users.
  */
-export const InfoTipWithPopover: Story = {
+export const InfotipWithPopover: Story = {
 	render: () => (
 		<div
 			style={ {


### PR DESCRIPTION
## What?

Follow-up to #76705.

Add a Storybook docs page for the `@wordpress/ui` Tooltip with usage guidelines and alternatives, adapted from [Base UI's tooltip docs](https://base-ui.com/react/components/tooltip).

## Why?

Tooltip docs lack guidance on when (not) to use tooltips, leading to misuse for infotips, descriptions, or feedback messages — all inaccessible to touch and screen reader users.

## How?

- New MDX docs page and companion stories under `packages/ui/src/tooltip/stories/`.
- Added `@see` JSDoc links on `Tooltip.Root`.

## Testing Instructions

1. `npm run storybook:dev`
2. Navigate to **Design System / Components / Tooltip / Usage Guidelines**
3. Verify the page renders with interactive examples.

### Open question

Should similar guidance be added to the `@wordpress/components` Tooltip README? Could be a follow-up.

## Use of AI Tools

Cursor (Claude).