### PR TITLE
design-system-mcp: Add new package for design system MCP tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,7 @@
 # UI Components
 /packages/components                            @ajitbohra @WordPress/gutenberg-components
 /packages/compose                               @ajitbohra
+/packages/design-system-mcp                     @WordPress/gutenberg-components
 /packages/element                               @ajitbohra
 /packages/notices                               @ajitbohra
 /packages/nux                                   @ajitbohra @peterwilsoncc

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1668,6 +1668,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/design-system-mcp",
+		"slug": "packages-design-system-mcp",
+		"markdown_source": "../packages/design-system-mcp/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/docgen",
 		"slug": "packages-docgen",
 		"markdown_source": "../packages/docgen/README.md",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -737,9 +737,10 @@ export default dedupePlugins( [
 		},
 	},
 
-	// Override: UI package — disable dependency-group.
+	// Override: Packages which have eliminated dependency grouping comments
+	// and explicitly prevent new additions.
 	{
-		files: [ 'packages/ui/src/**' ],
+		files: [ 'packages/ui/**', 'packages/design-system-mcp/**' ],
 		rules: {
 			'@wordpress/dependency-group': [ 'error', 'never' ],
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -59487,7 +59487,7 @@
 				"zod": "4.3.6"
 			},
 			"bin": {
-				"design-system-mcp": "build-module/index.mjs"
+				"design-system-mcp": "bin/design-system-mcp.mjs"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4213,6 +4213,12 @@
 				"react": "*"
 			}
 		},
+		"node_modules/@cfworker/json-schema": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+			"license": "MIT"
+		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -8026,6 +8032,35 @@
 			"peerDependencies": {
 				"@types/react": ">=16",
 				"react": ">=16"
+			}
+		},
+		"node_modules/@modelcontextprotocol/server": {
+			"version": "2.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-alpha.2.tgz",
+			"integrity": "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==",
+			"license": "MIT",
+			"dependencies": {
+				"zod": "^4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/server/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -20500,6 +20535,10 @@
 		},
 		"node_modules/@wordpress/deprecated": {
 			"resolved": "packages/deprecated",
+			"link": true
+		},
+		"node_modules/@wordpress/design-system-mcp": {
+			"resolved": "packages/design-system-mcp",
 			"link": true
 		},
 		"node_modules/@wordpress/docgen": {
@@ -59436,6 +59475,35 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"packages/design-system-mcp": {
+			"name": "@wordpress/design-system-mcp",
+			"version": "0.1.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@cfworker/json-schema": "4.1.1",
+				"@modelcontextprotocol/server": "2.0.0-alpha.2",
+				"zod": "4.3.6"
+			},
+			"bin": {
+				"design-system-mcp": "build-module/index.mjs"
+			},
+			"devDependencies": {
+				"@types/jest": "^29.5.14"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"packages/design-system-mcp/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"packages/docgen": {

--- a/packages/components/src/base-control/stories/index.story.tsx
+++ b/packages/components/src/base-control/stories/index.story.tsx
@@ -10,6 +10,7 @@ import BaseControl, { useBaseControlProps } from '..';
 import Button from '../../button';
 
 const meta: Meta< typeof BaseControl > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/BaseControl',
 	id: 'components-basecontrol',
 	component: BaseControl,

--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -21,6 +21,7 @@ import {
 import Button from '..';
 
 const meta: Meta< typeof Button > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Actions/Button',
 	id: 'components-button',
 	component: Button,

--- a/packages/components/src/checkbox-control/stories/index.story.tsx
+++ b/packages/components/src/checkbox-control/stories/index.story.tsx
@@ -16,6 +16,7 @@ import { VStack } from '../../v-stack';
 import { HStack } from '../../h-stack';
 
 const meta: Meta< typeof CheckboxControl > = {
+	tags: [ 'manifest' ],
 	component: CheckboxControl,
 	title: 'Components/Selection & Input/Common/CheckboxControl',
 	id: 'components-checkboxcontrol',

--- a/packages/components/src/color-indicator/stories/index.story.tsx
+++ b/packages/components/src/color-indicator/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import ColorIndicator from '..';
 
 const meta: Meta< typeof ColorIndicator > = {
+	tags: [ 'manifest' ],
 	component: ColorIndicator,
 	title: 'Components/Selection & Input/Color/ColorIndicator',
 	id: 'components-colorindicator',

--- a/packages/components/src/color-palette/stories/index.story.tsx
+++ b/packages/components/src/color-palette/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import ColorPalette from '..';
 
 const meta: Meta< typeof ColorPalette > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Color/ColorPalette',
 	id: 'components-colorpalette',
 	component: ColorPalette,

--- a/packages/components/src/color-picker/stories/index.story.tsx
+++ b/packages/components/src/color-picker/stories/index.story.tsx
@@ -10,6 +10,7 @@ import { fn } from 'storybook/test';
 import { ColorPicker } from '../component';
 
 const meta: Meta< typeof ColorPicker > = {
+	tags: [ 'manifest' ],
 	component: ColorPicker,
 	title: 'Components/Selection & Input/Color/ColorPicker',
 	id: 'components-colorpicker',

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -35,6 +35,7 @@ const countries = [
 ];
 
 const meta: Meta< typeof ComboboxControl > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/ComboboxControl',
 	id: 'components-comboboxcontrol',
 	component: ComboboxControl,

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -16,6 +16,7 @@ import { Composite } from '..';
 import { Tooltip } from '../../tooltip';
 
 const meta: Meta< typeof Composite > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Utilities/Composite',
 	id: 'components-composite',
 	component: Composite,

--- a/packages/components/src/confirm-dialog/stories/index.story.tsx
+++ b/packages/components/src/confirm-dialog/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof ConfirmDialog > = {
 			control: false,
 		},
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	args: {
 		onCancel: fn(),
 		onConfirm: fn(),

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -15,6 +15,7 @@ import { useState } from '@wordpress/element';
 import CustomSelectControl from '..';
 
 const meta: Meta< typeof CustomSelectControl > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/CustomSelectControl',
 	component: CustomSelectControl,
 	id: 'components-customselectcontrol',

--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -18,6 +18,7 @@ import TextareaControl from '../../textarea-control/';
 import { VStack } from '../../v-stack/';
 
 const meta: Meta< typeof Disabled > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Utilities/Disabled',
 	id: 'components-disabled',
 	component: Disabled,

--- a/packages/components/src/drop-zone/stories/index.story.tsx
+++ b/packages/components/src/drop-zone/stories/index.story.tsx
@@ -17,6 +17,7 @@ import DropZone from '..';
 const ICONS = { upload, media };
 
 const meta: Meta< typeof DropZone > = {
+	tags: [ 'manifest' ],
 	component: DropZone,
 	id: 'components-dropzone',
 	title: 'Components/Selection & Input/File Upload/DropZone',

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -14,6 +14,7 @@ import MenuItem from '../../menu-item';
 import { DropdownContentWrapper } from '../dropdown-content-wrapper';
 
 const meta: Meta< typeof Dropdown > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Overlays/Dropdown',
 	id: 'components-dropdown',
 	component: Dropdown,

--- a/packages/components/src/external-link/stories/index.story.tsx
+++ b/packages/components/src/external-link/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import ExternalLink from '..';
 
 const meta: Meta< typeof ExternalLink > = {
+	tags: [ 'manifest' ],
 	component: ExternalLink,
 	title: 'Components/Navigation/ExternalLink',
 	id: 'components-externallink',

--- a/packages/components/src/form-file-upload/stories/index.story.tsx
+++ b/packages/components/src/form-file-upload/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { upload as uploadIcon } from '@wordpress/icons';
 import FormFileUpload from '..';
 
 const meta: Meta< typeof FormFileUpload > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/File Upload/FormFileUpload',
 	id: 'components-formfileupload',
 	component: FormFileUpload,

--- a/packages/components/src/form-toggle/stories/index.story.tsx
+++ b/packages/components/src/form-toggle/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import FormToggle from '..';
 
 const meta: Meta< typeof FormToggle > = {
+	tags: [ 'manifest' ],
 	component: FormToggle,
 	title: 'Components/FormToggle',
 	argTypes: {

--- a/packages/components/src/form-token-field/stories/index.story.tsx
+++ b/packages/components/src/form-token-field/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import FormTokenField from '../';
 
 const meta: Meta< typeof FormTokenField > = {
+	tags: [ 'manifest' ],
 	component: FormTokenField,
 	title: 'Components/Selection & Input/Common/FormTokenField',
 	id: 'components-formtokenfield',

--- a/packages/components/src/gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/gradient-picker/stories/index.story.tsx
@@ -15,6 +15,7 @@ import { useState } from '@wordpress/element';
 import GradientPicker from '..';
 
 const meta: Meta< typeof GradientPicker > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Color/GradientPicker',
 	id: 'components-gradientpicker',
 	component: GradientPicker,

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -16,6 +16,7 @@ import Icon from '..';
 import { VStack } from '../../v-stack';
 
 const meta: Meta< typeof Icon > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Icon',
 	component: Icon,
 	parameters: {

--- a/packages/components/src/input-control/stories/index.story.tsx
+++ b/packages/components/src/input-control/stories/index.story.tsx
@@ -31,7 +31,7 @@ const meta: Meta< typeof InputControl > = {
 		type: { control: { type: 'text' } },
 		value: { control: { disable: true } },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	args: {
 		onChange: fn(),
 		onValidate: fn(),

--- a/packages/components/src/item-group/stories/index.story.tsx
+++ b/packages/components/src/item-group/stories/index.story.tsx
@@ -19,7 +19,7 @@ const meta: Meta< typeof ItemGroup > = {
 		as: { control: false },
 		children: { control: false },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/keyboard-shortcuts/stories/index.story.tsx
+++ b/packages/components/src/keyboard-shortcuts/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import KeyboardShortcuts from '..';
 
 const meta: Meta< typeof KeyboardShortcuts > = {
+	tags: [ 'manifest' ],
 	component: KeyboardShortcuts,
 	title: 'Components/Utilities/KeyboardShortcuts',
 	id: 'components-keyboardshortcuts',

--- a/packages/components/src/menu-group/stories/index.story.tsx
+++ b/packages/components/src/menu-group/stories/index.story.tsx
@@ -16,6 +16,7 @@ import MenuItem from '../../menu-item';
 import MenuItemsChoice from '../../menu-items-choice';
 
 const meta: Meta< typeof MenuGroup > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Actions/MenuGroup',
 	component: MenuGroup,
 	id: 'components-menugroup',

--- a/packages/components/src/menu-item/stories/index.story.tsx
+++ b/packages/components/src/menu-item/stories/index.story.tsx
@@ -16,6 +16,7 @@ import MenuItem from '..';
 import Shortcut from '../../shortcut';
 
 const meta: Meta< typeof MenuItem > = {
+	tags: [ 'manifest' ],
 	component: MenuItem,
 	title: 'Components/Actions/MenuItem',
 	id: 'components-menuitem',

--- a/packages/components/src/menu-items-choice/stories/index.story.tsx
+++ b/packages/components/src/menu-items-choice/stories/index.story.tsx
@@ -15,6 +15,7 @@ import MenuItemsChoice from '..';
 import MenuGroup from '../../menu-group';
 
 const meta: Meta< typeof MenuItemsChoice > = {
+	tags: [ 'manifest' ],
 	component: MenuItemsChoice,
 	title: 'Components/Actions/MenuItemsChoice',
 	id: 'components-menuitemschoice',

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -48,7 +48,7 @@ const meta: Meta< typeof Menu > = {
 	argTypes: {
 		children: { control: false },
 	},
-	tags: [ 'status-private' ],
+	tags: [ 'status-private', 'manifest' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: {

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -48,7 +48,7 @@ const meta: Meta< typeof Menu > = {
 	argTypes: {
 		children: { control: false },
 	},
-	tags: [ 'status-private', 'manifest' ],
+	tags: [ 'status-private' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: {

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -18,6 +18,7 @@ import Modal from '../';
 import type { ModalProps } from '../types';
 
 const meta: Meta< typeof Modal > = {
+	tags: [ 'manifest' ],
 	component: Modal,
 	title: 'Components/Overlays/Modal',
 	id: 'components-modal',

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -12,6 +12,7 @@ import { HStack } from '../../h-stack';
 import { Navigator, useNavigator } from '../';
 
 const meta: Meta< typeof Navigator > = {
+	tags: [ 'manifest' ],
 	component: Navigator,
 	subcomponents: {
 		Screen: Navigator.Screen,

--- a/packages/components/src/notice/stories/index.story.tsx
+++ b/packages/components/src/notice/stories/index.story.tsx
@@ -18,6 +18,7 @@ import NoticeList from '../list';
 import type { NoticeListProps } from '../types';
 
 const meta: Meta< typeof Notice > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Feedback/Notice',
 	id: 'components-notice',
 	component: Notice,

--- a/packages/components/src/number-control/stories/index.story.tsx
+++ b/packages/components/src/number-control/stories/index.story.tsx
@@ -25,7 +25,7 @@ const meta: Meta< typeof NumberControl > = {
 		type: { control: { type: 'text' } },
 		value: { control: false },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/panel/stories/index.story.tsx
+++ b/packages/components/src/panel/stories/index.story.tsx
@@ -17,6 +17,7 @@ import PanelBody from '../body';
 import InputControl from '../../input-control';
 
 const meta: Meta< typeof Panel > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Containers/Panel',
 	id: 'components-panel',
 	component: Panel,

--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -33,6 +33,7 @@ const AVAILABLE_PLACEMENTS: PopoverProps[ 'placement' ][] = [
 ];
 
 const meta: Meta< typeof Popover > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Overlays/Popover',
 	id: 'components-popover',
 	component: Popover,

--- a/packages/components/src/progress-bar/stories/index.story.tsx
+++ b/packages/components/src/progress-bar/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import { ProgressBar } from '..';
 
 const meta: Meta< typeof ProgressBar > = {
+	tags: [ 'manifest' ],
 	component: ProgressBar,
 	title: 'Components/Feedback/ProgressBar',
 	id: 'components-progressbar',

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import RadioControl from '..';
 
 const meta: Meta< typeof RadioControl > = {
+	tags: [ 'manifest' ],
 	component: RadioControl,
 	title: 'Components/Selection & Input/Common/RadioControl',
 	id: 'components-radiocontrol',

--- a/packages/components/src/range-control/stories/index.story.tsx
+++ b/packages/components/src/range-control/stories/index.story.tsx
@@ -18,6 +18,7 @@ import RangeControl from '..';
 const ICONS = { starEmpty, starFilled, styles, wordpress };
 
 const meta: Meta< typeof RangeControl > = {
+	tags: [ 'manifest' ],
 	component: RangeControl,
 	title: 'Components/Selection & Input/Common/RangeControl',
 	id: 'components-rangecontrol',

--- a/packages/components/src/resizable-box/stories/index.story.tsx
+++ b/packages/components/src/resizable-box/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import ResizableBox from '..';
 
 const meta: Meta< typeof ResizableBox > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Utilities/ResizableBox',
 	id: 'components-resizablebox',
 	component: ResizableBox,

--- a/packages/components/src/sandbox/stories/index.story.tsx
+++ b/packages/components/src/sandbox/stories/index.story.tsx
@@ -10,6 +10,7 @@ import { fn } from 'storybook/test';
 import SandBox from '..';
 
 const meta: Meta< typeof SandBox > = {
+	tags: [ 'manifest' ],
 	component: SandBox,
 	title: 'Components/Utilities/SandBox',
 	id: 'components-sandbox',

--- a/packages/components/src/scroll-lock/stories/index.story.tsx
+++ b/packages/components/src/scroll-lock/stories/index.story.tsx
@@ -16,6 +16,7 @@ import Button from '../../button';
 import ScrollLock from '..';
 
 const meta: Meta< typeof ScrollLock > = {
+	tags: [ 'manifest' ],
 	component: ScrollLock,
 	title: 'Components/Utilities/ScrollLock',
 	id: 'components-scrolllock',

--- a/packages/components/src/search-control/stories/index.story.tsx
+++ b/packages/components/src/search-control/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import SearchControl from '..';
 
 const meta: Meta< typeof SearchControl > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/SearchControl',
 	id: 'components-searchcontrol',
 	component: SearchControl,

--- a/packages/components/src/select-control/stories/index.story.tsx
+++ b/packages/components/src/select-control/stories/index.story.tsx
@@ -16,6 +16,7 @@ import SelectControl from '../';
 import { InputControlPrefixWrapper } from '../../input-control/input-prefix-wrapper';
 
 const meta: Meta< typeof SelectControl > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/SelectControl',
 	id: 'components-selectcontrol',
 	component: SelectControl,

--- a/packages/components/src/shortcut/stories/index.story.tsx
+++ b/packages/components/src/shortcut/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import Shortcut from '../';
 
 const meta: Meta< typeof Shortcut > = {
+	tags: [ 'manifest' ],
 	component: Shortcut,
 	title: 'Components/Utilities/Shortcut',
 	id: 'components-shortcut',

--- a/packages/components/src/slot-fill/stories/index.story.tsx
+++ b/packages/components/src/slot-fill/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { createContext, useContext } from '@wordpress/element';
 import { Slot, Fill, Provider as SlotFillProvider } from '../';
 
 const meta: Meta< typeof Slot > = {
+	tags: [ 'manifest' ],
 	component: Slot,
 	title: 'Components/Utilities/SlotFill',
 	id: 'components-slotfill',

--- a/packages/components/src/snackbar/stories/index.story.tsx
+++ b/packages/components/src/snackbar/stories/index.story.tsx
@@ -15,6 +15,7 @@ import Icon from '../../icon';
 import Snackbar from '..';
 
 const meta: Meta< typeof Snackbar > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Feedback/Snackbar',
 	id: 'components-snackbar',
 	component: Snackbar,

--- a/packages/components/src/spinner/stories/index.story.tsx
+++ b/packages/components/src/spinner/stories/index.story.tsx
@@ -10,6 +10,7 @@ import Spinner from '../';
 import { space } from '../../utils/space';
 
 const meta: Meta< typeof Spinner > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Feedback/Spinner',
 	id: 'components-spinner',
 	component: Spinner,

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof Tabs > = {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		'Tabs.Context': Tabs.Context,
 	},
-	tags: [ 'status-private', 'manifest' ],
+	tags: [ 'status-private' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -30,7 +30,7 @@ const meta: Meta< typeof Tabs > = {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		'Tabs.Context': Tabs.Context,
 	},
-	tags: [ 'status-private' ],
+	tags: [ 'status-private', 'manifest' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/text-control/stories/index.story.tsx
+++ b/packages/components/src/text-control/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import TextControl from '..';
 
 const meta: Meta< typeof TextControl > = {
+	tags: [ 'manifest' ],
 	component: TextControl,
 	title: 'Components/Selection & Input/Common/TextControl',
 	id: 'components-textcontrol',

--- a/packages/components/src/text-highlight/stories/index.story.tsx
+++ b/packages/components/src/text-highlight/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import TextHighlight from '..';
 
 const meta: Meta< typeof TextHighlight > = {
+	tags: [ 'manifest' ],
 	component: TextHighlight,
 	title: 'Components/Typography/TextHighlight',
 	id: 'components-texthighlight',

--- a/packages/components/src/textarea-control/stories/index.story.tsx
+++ b/packages/components/src/textarea-control/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import TextareaControl from '..';
 
 const meta: Meta< typeof TextareaControl > = {
+	tags: [ 'manifest' ],
 	component: TextareaControl,
 	title: 'Components/Selection & Input/Common/TextareaControl',
 	id: 'components-textareacontrol',

--- a/packages/components/src/toggle-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-control/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import ToggleControl from '..';
 
 const meta: Meta< typeof ToggleControl > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/ToggleControl',
 	id: 'components-togglecontrol',
 	component: ToggleControl,

--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -33,7 +33,7 @@ const meta: Meta< typeof ToggleGroupControl > = {
 		onChange: { action: 'onChange' },
 		value: { control: false },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/tooltip/stories/index.story.tsx
+++ b/packages/components/src/tooltip/stories/index.story.tsx
@@ -15,6 +15,7 @@ import Tooltip from '..';
 import Button from '../../button';
 
 const meta: Meta< typeof Tooltip > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Overlays/Tooltip',
 	id: 'components-tooltip',
 	component: Tooltip,

--- a/packages/components/src/tree-grid/stories/index.story.tsx
+++ b/packages/components/src/tree-grid/stories/index.story.tsx
@@ -24,7 +24,7 @@ const meta: Meta< typeof TreeGrid > = {
 	argTypes: {
 		children: { control: false },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	args: {
 		onExpandRow: fn(),
 		onCollapseRow: fn(),

--- a/packages/components/src/tree-select/stories/index.story.tsx
+++ b/packages/components/src/tree-select/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import TreeSelect from '../';
 
 const meta: Meta< typeof TreeSelect > = {
+	tags: [ 'manifest' ],
 	title: 'Components/Selection & Input/Common/TreeSelect',
 	id: 'components-treeselect',
 	component: TreeSelect,

--- a/packages/components/src/truncate/stories/index.story.tsx
+++ b/packages/components/src/truncate/stories/index.story.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Truncate > = {
 		children: { control: { type: 'text' } },
 		as: { control: { type: 'text' } },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	parameters: {
 		controls: {
 			expanded: true,

--- a/packages/components/src/unit-control/stories/index.story.tsx
+++ b/packages/components/src/unit-control/stories/index.story.tsx
@@ -27,7 +27,7 @@ const meta: Meta< typeof UnitControl > = {
 		prefix: { control: { type: 'text' } },
 		value: { control: false },
 	},
-	tags: [ 'status-experimental' ],
+	tags: [ 'status-experimental', 'manifest' ],
 	args: {
 		onChange: fn(),
 		onUnitChange: fn(),

--- a/packages/components/src/visually-hidden/stories/index.story.tsx
+++ b/packages/components/src/visually-hidden/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import { VisuallyHidden } from '..';
 
 const meta: Meta< typeof VisuallyHidden > = {
+	tags: [ 'manifest' ],
 	component: VisuallyHidden,
 	title: 'Components/Typography/VisuallyHidden',
 	id: 'components-visuallyhidden',

--- a/packages/design-system-mcp/CHANGELOG.md
+++ b/packages/design-system-mcp/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+-   Initial release.

--- a/packages/design-system-mcp/README.md
+++ b/packages/design-system-mcp/README.md
@@ -1,0 +1,38 @@
+# WordPress Design System MCP
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for the WordPress Design System. Provides AI coding agents with component documentation, prop definitions, usage examples, and design tokens.
+
+## Setup
+
+### Claude Code
+
+```bash
+claude mcp add wordpress-design-system -- npx -y @wordpress/design-system-mcp
+```
+
+### Cursor
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3AifQ%3D%3D)
+
+Install link: cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3AifQ%3D%3D
+
+### Other (Claude Desktop, VS Code)
+
+Add to your MCP client configuration (`mcp.json` or equivalent):
+
+```json
+{
+	"mcpServers": {
+		"wordpress-design-system": {
+			"command": "npx",
+			"args": [ "-y", "@wordpress/design-system-mcp" ]
+		}
+	}
+}
+```
+
+## Contributing to this package
+
+This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/org/wordpress) and used by [WordPress](https://make.wordpress.org/core/) as well as by the broader JavaScript ecosystem.
+
+To find out more about contributing to this package or Gutenberg as a whole, please read the project's main [contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).

--- a/packages/design-system-mcp/README.md
+++ b/packages/design-system-mcp/README.md
@@ -1,5 +1,9 @@
 # WordPress Design System MCP
 
+<div class="callout callout-alert">
+This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for the WordPress Design System. Provides AI coding agents with component documentation, prop definitions, usage examples, and design tokens.
 
 ## Setup

--- a/packages/design-system-mcp/README.md
+++ b/packages/design-system-mcp/README.md
@@ -7,14 +7,14 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for t
 ### Claude Code
 
 ```bash
-claude mcp add wordpress-design-system -- npx -y @wordpress/design-system-mcp
+claude mcp add wordpress-design-system -- npx -y @wordpress/design-system-mcp@latest
 ```
 
 ### Cursor
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3AifQ%3D%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3BAbGF0ZXN0In0%3D)
 
-Install link: cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3AifQ%3D%3D
+Install link: [cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3BAbGF0ZXN0In0%3D](cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3BAbGF0ZXN0In0%3D)
 
 ### Other (Claude Desktop, VS Code)
 
@@ -25,7 +25,7 @@ Add to your MCP client configuration (`mcp.json` or equivalent):
 	"mcpServers": {
 		"wordpress-design-system": {
 			"command": "npx",
-			"args": [ "-y", "@wordpress/design-system-mcp" ]
+			"args": [ "-y", "@wordpress/design-system-mcp@latest" ]
 		}
 	}
 }

--- a/packages/design-system-mcp/README.md
+++ b/packages/design-system-mcp/README.md
@@ -7,14 +7,14 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for t
 ### Claude Code
 
 ```bash
-claude mcp add wordpress-design-system -- npx -y @wordpress/design-system-mcp@latest
+claude mcp add wordpress-design-system -- npx -y --ignore-scripts --min-release-age=2 @wordpress/design-system-mcp@latest
 ```
 
 ### Cursor
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3BAbGF0ZXN0In0%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IC0taWdub3JlLXNjcmlwdHMgLS1taW4tcmVsZWFzZS1hZ2U9MiBAd29yZHByZXNzL2Rlc2lnbi1zeXN0ZW0tbWNwQGxhdGVzdCJ9)
 
-Install link: [cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3BAbGF0ZXN0In0%3D](cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IEB3b3JkcHJlc3MvZGVzaWduLXN5c3RlbS1tY3BAbGF0ZXN0In0%3D)
+Install link: [cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IC0taWdub3JlLXNjcmlwdHMgLS1taW4tcmVsZWFzZS1hZ2U9MiBAd29yZHByZXNzL2Rlc2lnbi1zeXN0ZW0tbWNwQGxhdGVzdCJ9](cursor://anysphere.cursor-deeplink/mcp/install?name=wordpress-design-system&config=eyJjb21tYW5kIjoibnB4IC15IC0taWdub3JlLXNjcmlwdHMgLS1taW4tcmVsZWFzZS1hZ2U9MiBAd29yZHByZXNzL2Rlc2lnbi1zeXN0ZW0tbWNwQGxhdGVzdCJ9)
 
 ### Other (Claude Desktop, VS Code)
 
@@ -25,7 +25,12 @@ Add to your MCP client configuration (`mcp.json` or equivalent):
 	"mcpServers": {
 		"wordpress-design-system": {
 			"command": "npx",
-			"args": [ "-y", "@wordpress/design-system-mcp@latest" ]
+			"args": [
+				"-y",
+				"--ignore-scripts",
+				"--min-release-age=2",
+				"@wordpress/design-system-mcp@latest"
+			]
 		}
 	}
 }

--- a/packages/design-system-mcp/bin/design-system-mcp.mjs
+++ b/packages/design-system-mcp/bin/design-system-mcp.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from '@modelcontextprotocol/server';
+import { createServer } from '@wordpress/design-system-mcp';
+
+const transport = new StdioServerTransport();
+const server = createServer();
+
+await server.connect( transport );

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -24,6 +24,7 @@
 		"npm": ">=10.2.3"
 	},
 	"files": [
+		"bin",
 		"build-module",
 		"build-types"
 	],
@@ -37,7 +38,7 @@
 		"./package.json": "./package.json"
 	},
 	"bin": {
-		"design-system-mcp": "./build-module/index.mjs"
+		"design-system-mcp": "./bin/design-system-mcp.mjs"
 	},
 	"dependencies": {
 		"@cfworker/json-schema": "4.1.1",

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@wordpress/design-system-mcp",
+	"version": "0.1.0",
+	"description": "MCP server for the WordPress Design System.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"design-system",
+		"mcp"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/design-system-mcp/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/design-system-mcp"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	},
+	"files": [
+		"build-module",
+		"build-types"
+	],
+	"type": "module",
+	"module": "build-module/index.mjs",
+	"exports": {
+		".": {
+			"types": "./build-types/index.d.ts",
+			"import": "./build-module/index.mjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"bin": {
+		"design-system-mcp": "./build-module/index.mjs"
+	},
+	"dependencies": {
+		"@cfworker/json-schema": "4.1.1",
+		"@modelcontextprotocol/server": "2.0.0-alpha.2",
+		"zod": "4.3.6"
+	},
+	"devDependencies": {
+		"@types/jest": "^29.5.14"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/design-system-mcp/src/data.ts
+++ b/packages/design-system-mcp/src/data.ts
@@ -1,0 +1,102 @@
+import {
+	packageNameFromPath,
+	parseComponents,
+	parseComponentDetail,
+} from './parse-components';
+import type { Component, ComponentDetail, ManifestComponent } from './types';
+
+const COMPONENTS_MANIFEST_URL =
+	'https://wordpress.github.io/gutenberg/manifests/components.json';
+
+const DESIGN_TOKENS_URL =
+	'https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/trunk/packages/theme/docs/tokens.md';
+
+let cachedComponents: Record< string, ManifestComponent > | null = null;
+let cachedTokens: string | null = null;
+
+/**
+ * Clear cached data. Intended for testing.
+ */
+export function resetCache(): void {
+	cachedComponents = null;
+	cachedTokens = null;
+}
+
+/**
+ * Fetch and cache the components from the Storybook manifest, filtered to only
+ * components from allowed packages.
+ *
+ * @return The filtered components record.
+ */
+async function fetchComponents(): Promise<
+	Record< string, ManifestComponent >
+> {
+	if ( cachedComponents ) {
+		return cachedComponents;
+	}
+
+	const response = await fetch( COMPONENTS_MANIFEST_URL );
+	if ( ! response.ok ) {
+		throw new Error(
+			`Failed to fetch components manifest: ${ response.status } ${ response.statusText }`
+		);
+	}
+
+	const manifest: {
+		v: number;
+		components: Record< string, ManifestComponent >;
+	} = await response.json();
+
+	const filtered: Record< string, ManifestComponent > = {};
+	for ( const [ key, component ] of Object.entries( manifest.components ) ) {
+		if ( packageNameFromPath( component.path ) ) {
+			filtered[ key ] = component;
+		}
+	}
+
+	cachedComponents = filtered;
+	return cachedComponents;
+}
+
+/**
+ * Get all components from allowed packages.
+ *
+ * @return Parsed component list.
+ */
+export async function getComponents(): Promise< Component[] > {
+	const components = await fetchComponents();
+	return parseComponents( components );
+}
+
+/**
+ * Get detailed documentation for a single component by name.
+ *
+ * @param name - The component name (case-insensitive).
+ * @return The component detail, or null if not found.
+ */
+export async function getComponentDetail(
+	name: string
+): Promise< ComponentDetail | null > {
+	const components = await fetchComponents();
+	return parseComponentDetail( components, name );
+}
+
+/**
+ * Get the design tokens reference document as markdown.
+ *
+ * @return The tokens markdown content.
+ */
+export async function getDesignTokens(): Promise< { content: string } > {
+	if ( ! cachedTokens ) {
+		const response = await fetch( DESIGN_TOKENS_URL );
+		if ( ! response.ok ) {
+			throw new Error(
+				`Failed to fetch design tokens: ${ response.status } ${ response.statusText }`
+			);
+		}
+
+		cachedTokens = await response.text();
+	}
+
+	return { content: cachedTokens };
+}

--- a/packages/design-system-mcp/src/data.ts
+++ b/packages/design-system-mcp/src/data.ts
@@ -6,9 +6,11 @@ import {
 import type { Component, ComponentDetail, ManifestComponent } from './types';
 
 const COMPONENTS_MANIFEST_URL =
+	process.env.COMPONENTS_MANIFEST_URL ||
 	'https://wordpress.github.io/gutenberg/manifests/components.json';
 
 const DESIGN_TOKENS_URL =
+	process.env.DESIGN_TOKENS_URL ||
 	'https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/trunk/packages/theme/docs/tokens.md';
 
 let cachedComponents: Record< string, ManifestComponent > | null = null;

--- a/packages/design-system-mcp/src/format.ts
+++ b/packages/design-system-mcp/src/format.ts
@@ -1,0 +1,91 @@
+import type { Component, ComponentDetail } from './types';
+
+/**
+ * Format a component's name, package, and description as markdown.
+ *
+ * @param component    - The component to format.
+ * @param headingLevel - The heading level for the component name.
+ * @return Markdown lines.
+ */
+function formatComponentSummary(
+	component: Component,
+	headingLevel: number
+): string[] {
+	const heading = '#'.repeat( headingLevel );
+	const lines = [ `${ heading } ${ component.name }` ];
+
+	if ( component.description ) {
+		lines.push( '', component.description );
+	}
+
+	return lines;
+}
+
+/**
+ * Format the component list as markdown.
+ *
+ * @param components - The components to format.
+ * @return Formatted markdown.
+ */
+export function formatComponents( components: Component[] ): string {
+	const lines = [ '# WordPress Design System Components' ];
+
+	for ( const component of components ) {
+		lines.push( '', ...formatComponentSummary( component, 2 ) );
+	}
+
+	return lines.join( '\n' );
+}
+
+/**
+ * Format a single component's detail as markdown documentation.
+ *
+ * @param detail - The component detail to format.
+ * @return Formatted markdown.
+ */
+export function formatComponentDetail( detail: ComponentDetail ): string {
+	const lines = formatComponentSummary( detail, 1 );
+
+	lines.push( '', `**Package:** \`${ detail.packageName }\`` );
+
+	if ( detail.importStatement ) {
+		lines.push(
+			'',
+			'## Import',
+			'',
+			'```ts',
+			detail.importStatement,
+			'```'
+		);
+	}
+
+	if ( detail.props.length > 0 ) {
+		lines.push( '', '## Props', '' );
+		for ( const prop of detail.props ) {
+			const required = prop.required ? ' **(required)**' : '';
+			const defaultNote = prop.defaultValue
+				? ` (default: \`${ prop.defaultValue }\`)`
+				: '';
+			lines.push(
+				`### \`${ prop.name }\`: \`${ prop.type }\`${ required }${ defaultNote }`,
+				''
+			);
+			if ( prop.description ) {
+				lines.push( prop.description, '' );
+			}
+		}
+	}
+
+	if ( detail.stories.length > 0 ) {
+		lines.push( '', '## Examples', '' );
+		for ( const story of detail.stories ) {
+			lines.push( `### ${ story.name }` );
+			if ( story.snippet ) {
+				lines.push( '', '```tsx', story.snippet, '```' );
+			}
+			lines.push( '' );
+		}
+	}
+
+	return lines.join( '\n' );
+}

--- a/packages/design-system-mcp/src/index.ts
+++ b/packages/design-system-mcp/src/index.ts
@@ -1,0 +1,13 @@
+import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server';
+import { registerTools } from './tools/index';
+
+const server = new McpServer( {
+	name: 'WordPress Design System',
+	version: '0.1.0',
+} );
+
+registerTools( server );
+
+const transport = new StdioServerTransport();
+
+await server.connect( transport );

--- a/packages/design-system-mcp/src/index.ts
+++ b/packages/design-system-mcp/src/index.ts
@@ -1,13 +1,13 @@
-import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/server';
 import { registerTools } from './tools/index';
 
-const server = new McpServer( {
-	name: 'WordPress Design System',
-	version: '0.1.0',
-} );
+export function createServer() {
+	const server = new McpServer( {
+		name: 'WordPress Design System',
+		version: '0.1.0',
+	} );
 
-registerTools( server );
+	registerTools( server );
 
-const transport = new StdioServerTransport();
-
-await server.connect( transport );
+	return server;
+}

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -86,8 +86,7 @@ export function parseProps(
 export function parseComponents(
 	components: Record< string, ManifestComponent >
 ): Component[] {
-	const seen = new Set< string >();
-	const result: Component[] = [];
+	const byKey = new Map< string, Component >();
 
 	for ( const component of Object.values( components ) ) {
 		const packageName = packageNameFromPath( component.path );
@@ -97,28 +96,30 @@ export function parseComponents(
 
 		const name = canonicalComponentName( component.name );
 		const key = `${ packageName }:${ name }`;
-		if ( seen.has( key ) ) {
-			continue;
-		}
-		seen.add( key );
+		const existing = byKey.get( key );
+		const description = component.description || '';
 
-		result.push( {
-			name,
-			description: component.description || '',
-			packageName,
-		} );
+		if ( ! existing ) {
+			byKey.set( key, { name, description, packageName } );
+		} else {
+			// Prefer a non-empty description from a later entry over an
+			// empty one from the first.
+			existing.description ||= description;
+		}
 	}
 
-	return result.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+	return Array.from( byKey.values() ).sort( ( a, b ) =>
+		a.name.localeCompare( b.name )
+	);
 }
 
 /**
  * Find a single component by name (case-insensitive) and return its full
  * detail including props and stories. When a component is spread across
  * multiple story files, stories from every contributing file are collected
- * in manifest order; descriptions and props are taken from the first match
- * (they are authored on the component itself and do not vary between story
- * files).
+ * in manifest order. Descriptions and props are also authored on the component
+ * itself, so in principle they should be identical across story files; in
+ * practice one file may omit them, so we prefer any non-empty value found.
  *
  * @param components - The manifest components record.
  * @param name       - The component name to look up.
@@ -141,17 +142,25 @@ export function parseComponentDetail(
 			continue;
 		}
 
+		const description = component.description || '';
+		const props = parseProps( component.reactDocgen?.props || {} );
+		const stories = component.stories || [];
+
 		if ( ! detail ) {
 			detail = {
 				name: canonicalName,
-				description: component.description || '',
+				description,
 				packageName: pkg,
 				importStatement: `import { ${ canonicalName } } from '${ pkg }';`,
-				props: parseProps( component.reactDocgen?.props || {} ),
-				stories: [ ...( component.stories || [] ) ],
+				props,
+				stories: [ ...stories ],
 			};
 		} else if ( detail.packageName === pkg ) {
-			detail.stories.push( ...( component.stories || [] ) );
+			detail.description ||= description;
+			if ( detail.props.length === 0 ) {
+				detail.props = props;
+			}
+			detail.stories.push( ...stories );
 		}
 	}
 

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -6,6 +6,43 @@ import type {
 } from './types';
 
 /**
+ * Mapping of canonical name to actual exported identifier, keyed by
+ * `package:name`. A package's actual exported identifier may be different from
+ * the canonical name in the internal implementation that's known to Storybook.
+ *
+ * Ideally we could derive this from the package's source code, but MCP
+ * consumers aren't guaranteed to have these packages installed. Since this
+ * is a legacy convention, we expect this list will only ever shrink over time
+ * and can eventually be removed.
+ */
+const EXPORT_ALIASES: Record< string, string > = {
+	'@wordpress/components:ConfirmDialog': '__experimentalConfirmDialog',
+	'@wordpress/components:InputControl': '__experimentalInputControl',
+	'@wordpress/components:ItemGroup': '__experimentalItemGroup',
+	'@wordpress/components:ToggleGroupControl':
+		'__experimentalToggleGroupControl',
+	'@wordpress/components:TreeGrid': '__experimentalTreeGrid',
+	'@wordpress/components:Truncate': '__experimentalTruncate',
+};
+
+/**
+ * Build the import statement a consumer should use to bring a component into
+ * scope under its canonical name. For aliased components, emit an `as` rename
+ * so that subsequent code samples (which reference the canonical name) resolve
+ * against the actual export.
+ *
+ * @param name        - The canonical component name.
+ * @param packageName - The npm package name.
+ * @return The import statement as a single-line string.
+ */
+function buildImportStatement( name: string, packageName: string ): string {
+	const exported = EXPORT_ALIASES[ `${ packageName }:${ name }` ];
+	return exported
+		? `import { ${ exported } as ${ name } } from '${ packageName }';`
+		: `import { ${ name } } from '${ packageName }';`;
+}
+
+/**
  * Derive the npm package name from the story file path.
  *
  * Manifest paths look like `../packages/<dir>/src/.../index.story.tsx`. We
@@ -151,7 +188,7 @@ export function parseComponentDetail(
 				name: canonicalName,
 				description,
 				packageName: pkg,
-				importStatement: `import { ${ canonicalName } } from '${ pkg }';`,
+				importStatement: buildImportStatement( canonicalName, pkg ),
 				props,
 				stories: [ ...stories ],
 			};

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -6,31 +6,19 @@ import type {
 } from './types';
 
 /**
- * Map from directory name (in the story file path) to npm package name. The
- * manifest `path` field uses relative paths from the Storybook configuration.
- * For example, `../packages/ui/src/button/stories/index.story.tsx`.
- *
- * This also serves a dual purpose of filtering components to only include those
- * from allowed packages, since alternative ways of implementing a mapping would
- * be to respect the `package.json` package name (slow), or simply prepend the
- * `@wordpress/` npm namespace (not always accurate, see `packages/wp-build`).
- */
-const PACKAGE_DIR_TO_NAME: Record< string, string > = {
-	ui: '@wordpress/ui',
-};
-
-/**
  * Derive the npm package name from the story file path.
  *
- * Manifest paths look like `../packages/<dir>/src/.../index.story.tsx`.
- * We extract `<dir>` and map it through PACKAGE_DIR_TO_NAME.
+ * Manifest paths look like `../packages/<dir>/src/.../index.story.tsx`. We
+ * extract `<dir>` and prepend the `@wordpress/` npm namespace. Curation of
+ * which components appear in the manifest is handled upstream via Storybook
+ * tags, so this only needs to recognize package-shaped paths.
  *
  * @param storyPath - The story file path from the manifest.
- * @return The npm package name, or null if not an allowed package.
+ * @return The npm package name, or null for paths outside `packages/*`.
  */
 export function packageNameFromPath( storyPath: string ): string | null {
 	const match = storyPath.match( /\.\.\/packages\/([^/]+)\// );
-	return ( match && PACKAGE_DIR_TO_NAME[ match[ 1 ] ] ) ?? null;
+	return match ? `@wordpress/${ match[ 1 ] }` : null;
 }
 
 /**
@@ -87,13 +75,13 @@ export function parseProps(
 }
 
 /**
- * Parse manifest components into a flat list from allowed packages. When a
- * component is defined across multiple story files (e.g. `index.story.tsx`
- * and a companion file documenting a specific aspect), it is collapsed to a
- * single entry keyed by its canonical name and package.
+ * Parse manifest components into a flat list. When a component is defined
+ * across multiple story files (e.g. `index.story.tsx` and a companion file
+ * documenting a specific aspect), it is collapsed to a single entry keyed by
+ * its canonical name and package.
  *
  * @param components - The manifest components record.
- * @return Components from allowed packages.
+ * @return Flat list of components derived from the manifest.
  */
 export function parseComponents(
 	components: Record< string, ManifestComponent >

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -61,7 +61,10 @@ export function parseProps(
 		} )
 		.map( ( [ propName, propInfo ] ) => ( {
 			name: propName,
-			type: propInfo.tsType?.name || 'unknown',
+			// Prefer `raw` when present, as it carries the source-authored type
+			// expression a consumer could use directly. Primitives emit only
+			// `name`, so fall back if `raw` is not present.
+			type: propInfo.tsType?.raw || propInfo.tsType?.name || 'unknown',
 			required: propInfo.required || false,
 			description: propInfo.description || '',
 			defaultValue: propInfo.defaultValue?.value ?? null,

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -115,7 +115,7 @@ export function parseComponentDetail(
 				name: component.name,
 				description: component.description || '',
 				packageName: pkg,
-				importStatement: component.import ?? null,
+				importStatement: `import { ${ component.name } } from '${ pkg }';`,
 				props: parseProps( component.reactDocgen?.props || {} ),
 				stories: component.stories || [],
 			};

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -1,0 +1,123 @@
+import type {
+	Component,
+	ComponentDetail,
+	ComponentProp,
+	ManifestComponent,
+} from './types';
+
+/**
+ * Map from directory name (in the story file path) to npm package name. The
+ * manifest `path` field uses relative paths from the Storybook configuration.
+ * For example, `../packages/ui/src/button/stories/index.story.tsx`.
+ *
+ * This also serves a dual purpose of filtering components to only include those
+ * from allowed packages, since alternative ways of implementing a mapping would
+ * be to respect the `package.json` package name (slow), or simply prepend the
+ * `@wordpress/` npm namespace (not always accurate, see `packages/wp-build`).
+ */
+const PACKAGE_DIR_TO_NAME: Record< string, string > = {
+	ui: '@wordpress/ui',
+};
+
+/**
+ * Derive the npm package name from the story file path.
+ *
+ * Manifest paths look like `../packages/<dir>/src/.../index.story.tsx`.
+ * We extract `<dir>` and map it through PACKAGE_DIR_TO_NAME.
+ *
+ * @param storyPath - The story file path from the manifest.
+ * @return The npm package name, or null if not an allowed package.
+ */
+export function packageNameFromPath( storyPath: string ): string | null {
+	const match = storyPath.match( /\.\.\/packages\/([^/]+)\// );
+	return ( match && PACKAGE_DIR_TO_NAME[ match[ 1 ] ] ) ?? null;
+}
+
+/**
+ * Parse props from a component's reactDocgen data, filtering out
+ * deprecated and ignored props.
+ *
+ * @param rawProps - The reactDocgen props record.
+ * @return Parsed props with deprecated entries removed.
+ */
+export function parseProps(
+	rawProps: Record<
+		string,
+		{
+			required?: boolean;
+			tsType?: { name: string; raw?: string };
+			description?: string;
+			defaultValue?: { value: string };
+		}
+	>
+): ComponentProp[] {
+	return Object.entries( rawProps )
+		.filter( ( [ , propInfo ] ) => {
+			const description = ( propInfo.description || '' ).toLowerCase();
+			return (
+				! description.includes( '@deprecated' ) &&
+				! description.includes( '@ignore' )
+			);
+		} )
+		.map( ( [ propName, propInfo ] ) => ( {
+			name: propName,
+			type: propInfo.tsType?.name || 'unknown',
+			required: propInfo.required || false,
+			description: propInfo.description || '',
+			defaultValue: propInfo.defaultValue?.value ?? null,
+		} ) );
+}
+
+/**
+ * Parse manifest components into a flat list from allowed packages.
+ *
+ * @param components - The manifest components record.
+ * @return Components from allowed packages.
+ */
+export function parseComponents(
+	components: Record< string, ManifestComponent >
+): Component[] {
+	return Object.values( components )
+		.map( ( component ) => ( {
+			name: component.name,
+			description: component.description || '',
+			packageName: packageNameFromPath( component.path ),
+		} ) )
+		.filter(
+			( component ): component is Component =>
+				component.packageName !== null
+		);
+}
+
+/**
+ * Find a single component by name (case-insensitive) and return its
+ * full detail including props and stories.
+ *
+ * @param components - The manifest components record.
+ * @param name       - The component name to look up.
+ * @return The component detail, or null if not found.
+ */
+export function parseComponentDetail(
+	components: Record< string, ManifestComponent >,
+	name: string
+): ComponentDetail | null {
+	for ( const component of Object.values( components ) ) {
+		if ( component.name.toLowerCase() !== name.toLowerCase() ) {
+			continue;
+		}
+
+		const pkg = packageNameFromPath( component.path );
+		if ( pkg ) {
+			return {
+				name: component.name,
+				description: component.description || '',
+				packageName: pkg,
+				importStatement: component.import ?? null,
+				props: parseProps( component.reactDocgen?.props || {} ),
+				stories: component.stories || [],
+			};
+		}
+	}
+
+	return null;
+}

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -87,7 +87,10 @@ export function parseProps(
 }
 
 /**
- * Parse manifest components into a flat list from allowed packages.
+ * Parse manifest components into a flat list from allowed packages. When a
+ * component is defined across multiple story files (e.g. `index.story.tsx`
+ * and a companion file documenting a specific aspect), it is collapsed to a
+ * single entry keyed by its canonical name and package.
  *
  * @param components - The manifest components record.
  * @return Components from allowed packages.
@@ -95,21 +98,39 @@ export function parseProps(
 export function parseComponents(
 	components: Record< string, ManifestComponent >
 ): Component[] {
-	return Object.values( components )
-		.map( ( component ) => ( {
-			name: canonicalComponentName( component.name ),
+	const seen = new Set< string >();
+	const result: Component[] = [];
+
+	for ( const component of Object.values( components ) ) {
+		const packageName = packageNameFromPath( component.path );
+		if ( ! packageName ) {
+			continue;
+		}
+
+		const name = canonicalComponentName( component.name );
+		const key = `${ packageName }:${ name }`;
+		if ( seen.has( key ) ) {
+			continue;
+		}
+		seen.add( key );
+
+		result.push( {
+			name,
 			description: component.description || '',
-			packageName: packageNameFromPath( component.path ),
-		} ) )
-		.filter(
-			( component ): component is Component =>
-				component.packageName !== null
-		);
+			packageName,
+		} );
+	}
+
+	return result;
 }
 
 /**
- * Find a single component by name (case-insensitive) and return its
- * full detail including props and stories.
+ * Find a single component by name (case-insensitive) and return its full
+ * detail including props and stories. When a component is spread across
+ * multiple story files, stories from every contributing file are collected
+ * in manifest order; descriptions and props are taken from the first match
+ * (they are authored on the component itself and do not vary between story
+ * files).
  *
  * @param components - The manifest components record.
  * @param name       - The component name to look up.
@@ -119,6 +140,8 @@ export function parseComponentDetail(
 	components: Record< string, ManifestComponent >,
 	name: string
 ): ComponentDetail | null {
+	let detail: ComponentDetail | null = null;
+
 	for ( const component of Object.values( components ) ) {
 		const canonicalName = canonicalComponentName( component.name );
 		if ( canonicalName.toLowerCase() !== name.toLowerCase() ) {
@@ -126,17 +149,23 @@ export function parseComponentDetail(
 		}
 
 		const pkg = packageNameFromPath( component.path );
-		if ( pkg ) {
-			return {
+		if ( ! pkg ) {
+			continue;
+		}
+
+		if ( ! detail ) {
+			detail = {
 				name: canonicalName,
 				description: component.description || '',
 				packageName: pkg,
 				importStatement: `import { ${ canonicalName } } from '${ pkg }';`,
 				props: parseProps( component.reactDocgen?.props || {} ),
-				stories: component.stories || [],
+				stories: [ ...( component.stories || [] ) ],
 			};
+		} else if ( detail.packageName === pkg ) {
+			detail.stories.push( ...( component.stories || [] ) );
 		}
 	}
 
-	return null;
+	return detail;
 }

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -34,6 +34,21 @@ export function packageNameFromPath( storyPath: string ): string | null {
 }
 
 /**
+ * For components exported as a namespace (e.g. `AlertDialog`, with members
+ * `AlertDialog.Root`, `AlertDialog.Trigger`, etc.), the manifest lists the
+ * primary entry under a dotted name like `AlertDialog.Root`. The canonical
+ * name we expose is the top-level identifier a consumer actually imports,
+ * which is the portion before the first dot. For simple components (e.g.
+ * `Button`), this is a no-op.
+ *
+ * @param name - The component name from the manifest.
+ * @return The top-level importable identifier.
+ */
+function canonicalComponentName( name: string ): string {
+	return name.split( '.', 1 )[ 0 ];
+}
+
+/**
  * Parse props from a component's reactDocgen data, filtering out
  * deprecated and ignored props.
  *
@@ -82,7 +97,7 @@ export function parseComponents(
 ): Component[] {
 	return Object.values( components )
 		.map( ( component ) => ( {
-			name: component.name,
+			name: canonicalComponentName( component.name ),
 			description: component.description || '',
 			packageName: packageNameFromPath( component.path ),
 		} ) )
@@ -105,17 +120,18 @@ export function parseComponentDetail(
 	name: string
 ): ComponentDetail | null {
 	for ( const component of Object.values( components ) ) {
-		if ( component.name.toLowerCase() !== name.toLowerCase() ) {
+		const canonicalName = canonicalComponentName( component.name );
+		if ( canonicalName.toLowerCase() !== name.toLowerCase() ) {
 			continue;
 		}
 
 		const pkg = packageNameFromPath( component.path );
 		if ( pkg ) {
 			return {
-				name: component.name,
+				name: canonicalName,
 				description: component.description || '',
 				packageName: pkg,
-				importStatement: `import { ${ component.name } } from '${ pkg }';`,
+				importStatement: `import { ${ canonicalName } } from '${ pkg }';`,
 				props: parseProps( component.reactDocgen?.props || {} ),
 				stories: component.stories || [],
 			};

--- a/packages/design-system-mcp/src/parse-components.ts
+++ b/packages/design-system-mcp/src/parse-components.ts
@@ -75,10 +75,10 @@ export function parseProps(
 }
 
 /**
- * Parse manifest components into a flat list. When a component is defined
- * across multiple story files (e.g. `index.story.tsx` and a companion file
- * documenting a specific aspect), it is collapsed to a single entry keyed by
- * its canonical name and package.
+ * Parse manifest components into a flat list sorted alphabetically by name.
+ * When a component is defined across multiple story files (e.g. a companion
+ * file documenting a specific aspect), it is collapsed to a single entry keyed
+ * by its canonical name and package.
  *
  * @param components - The manifest components record.
  * @return Flat list of components derived from the manifest.
@@ -109,7 +109,7 @@ export function parseComponents(
 		} );
 	}
 
-	return result;
+	return result.sort( ( a, b ) => a.name.localeCompare( b.name ) );
 }
 
 /**

--- a/packages/design-system-mcp/src/test/data.ts
+++ b/packages/design-system-mcp/src/test/data.ts
@@ -1,0 +1,169 @@
+import {
+	getComponents,
+	getComponentDetail,
+	getDesignTokens,
+	resetCache,
+} from '../data';
+import manifestFixture from './fixtures/manifest.json';
+
+const MANIFEST_URL =
+	'https://wordpress.github.io/gutenberg/manifests/components.json';
+const TOKENS_URL =
+	'https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/trunk/packages/theme/docs/tokens.md';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchResponses(
+	handlers: Record< string, { ok: boolean; body: unknown } >
+) {
+	globalThis.fetch = jest.fn( ( url: RequestInfo | URL ) => {
+		const urlStr = url.toString();
+		const handler = handlers[ urlStr ];
+		if ( ! handler ) {
+			return Promise.reject(
+				new Error( `Unexpected fetch: ${ urlStr }` )
+			);
+		}
+		return Promise.resolve( {
+			ok: handler.ok,
+			status: handler.ok ? 200 : 500,
+			statusText: handler.ok ? 'OK' : 'Internal Server Error',
+			json: () => Promise.resolve( handler.body ),
+			text: () => Promise.resolve( handler.body as string ),
+		} as Response );
+	} );
+}
+
+describe( 'data', () => {
+	beforeEach( () => {
+		resetCache();
+		globalThis.fetch = jest.fn();
+	} );
+
+	afterEach( () => {
+		globalThis.fetch = originalFetch;
+	} );
+
+	describe( 'getComponents', () => {
+		it( 'should fetch manifest and return only allowed components', async () => {
+			mockFetchResponses( {
+				[ MANIFEST_URL ]: { ok: true, body: manifestFixture },
+			} );
+
+			const result = await getComponents();
+
+			expect( result ).toEqual( [
+				{
+					name: 'Button',
+					description: 'A button.',
+					packageName: '@wordpress/ui',
+				},
+			] );
+		} );
+
+		it( 'should cache the manifest across calls', async () => {
+			mockFetchResponses( {
+				[ MANIFEST_URL ]: { ok: true, body: manifestFixture },
+			} );
+
+			await getComponents();
+			await getComponents();
+
+			expect( globalThis.fetch ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should throw on fetch failure', async () => {
+			mockFetchResponses( {
+				[ MANIFEST_URL ]: { ok: false, body: null },
+			} );
+
+			await expect( getComponents() ).rejects.toThrow(
+				'Failed to fetch components manifest'
+			);
+		} );
+	} );
+
+	describe( 'getComponentDetail', () => {
+		it( 'should return detail for a matching component', async () => {
+			mockFetchResponses( {
+				[ MANIFEST_URL ]: { ok: true, body: manifestFixture },
+			} );
+
+			const result = await getComponentDetail( 'Button' );
+
+			expect( result ).toEqual( {
+				name: 'Button',
+				description: 'A button.',
+				packageName: '@wordpress/ui',
+				importStatement: 'import { Button } from "@wordpress/ui";',
+				props: [
+					{
+						name: 'variant',
+						type: 'string',
+						required: false,
+						description: 'The variant.',
+						defaultValue: null,
+					},
+				],
+				stories: [ { name: 'Default', snippet: '<Button />' } ],
+			} );
+		} );
+
+		it( 'should return null for non-existent component', async () => {
+			mockFetchResponses( {
+				[ MANIFEST_URL ]: { ok: true, body: manifestFixture },
+			} );
+
+			expect( await getComponentDetail( 'NonExistent' ) ).toBeNull();
+		} );
+
+		it( 'should share cache with getComponents', async () => {
+			mockFetchResponses( {
+				[ MANIFEST_URL ]: { ok: true, body: manifestFixture },
+			} );
+
+			await getComponents();
+			await getComponentDetail( 'Button' );
+
+			expect( globalThis.fetch ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'getDesignTokens', () => {
+		it( 'should fetch and return token content', async () => {
+			mockFetchResponses( {
+				[ TOKENS_URL ]: {
+					ok: true,
+					body: '# Tokens\n\n| token | value |',
+				},
+			} );
+
+			const result = await getDesignTokens();
+
+			expect( result ).toEqual( {
+				content: '# Tokens\n\n| token | value |',
+			} );
+		} );
+
+		it( 'should cache tokens across calls', async () => {
+			mockFetchResponses( {
+				[ TOKENS_URL ]: { ok: true, body: '# Tokens' },
+			} );
+
+			await getDesignTokens();
+			await getDesignTokens();
+
+			expect( globalThis.fetch ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should throw on fetch failure', async () => {
+			mockFetchResponses( {
+				[ TOKENS_URL ]: { ok: false, body: null },
+			} );
+
+			await expect( getDesignTokens() ).rejects.toThrow(
+				'Failed to fetch design tokens'
+			);
+		} );
+	} );
+} );

--- a/packages/design-system-mcp/src/test/data.ts
+++ b/packages/design-system-mcp/src/test/data.ts
@@ -45,7 +45,7 @@ describe( 'data', () => {
 	} );
 
 	describe( 'getComponents', () => {
-		it( 'should fetch manifest and return only allowed components', async () => {
+		it( 'should fetch manifest and return parsed components', async () => {
 			mockFetchResponses( {
 				[ MANIFEST_URL ]: { ok: true, body: manifestFixture },
 			} );
@@ -54,9 +54,14 @@ describe( 'data', () => {
 
 			expect( result ).toEqual( [
 				{
+					name: 'Badge',
+					description: 'A badge.',
+					packageName: '@wordpress/ui',
+				},
+				{
 					name: 'Button',
 					description: 'A button.',
-					packageName: '@wordpress/ui',
+					packageName: '@wordpress/components',
 				},
 			] );
 		} );
@@ -94,8 +99,9 @@ describe( 'data', () => {
 			expect( result ).toEqual( {
 				name: 'Button',
 				description: 'A button.',
-				packageName: '@wordpress/ui',
-				importStatement: "import { Button } from '@wordpress/ui';",
+				packageName: '@wordpress/components',
+				importStatement:
+					"import { Button } from '@wordpress/components';",
 				props: [
 					{
 						name: 'variant',

--- a/packages/design-system-mcp/src/test/data.ts
+++ b/packages/design-system-mcp/src/test/data.ts
@@ -95,7 +95,7 @@ describe( 'data', () => {
 				name: 'Button',
 				description: 'A button.',
 				packageName: '@wordpress/ui',
-				importStatement: 'import { Button } from "@wordpress/ui";',
+				importStatement: "import { Button } from '@wordpress/ui';",
 				props: [
 					{
 						name: 'variant',

--- a/packages/design-system-mcp/src/test/fixtures/manifest.json
+++ b/packages/design-system-mcp/src/test/fixtures/manifest.json
@@ -1,0 +1,34 @@
+{
+	"v": 0,
+	"components": {
+		"ui-button": {
+			"id": "ui-button",
+			"name": "Button",
+			"path": "../packages/ui/src/button/stories/index.story.tsx",
+			"import": "import { Button } from \"@wordpress/ui\";",
+			"description": "A button.",
+			"reactDocgen": {
+				"props": {
+					"variant": {
+						"required": false,
+						"tsType": { "name": "string" },
+						"description": "The variant."
+					}
+				}
+			},
+			"stories": [ { "name": "Default", "snippet": "<Button />" } ]
+		},
+		"components-button": {
+			"id": "components-button",
+			"name": "Button",
+			"path": "../packages/components/src/button/stories/index.story.tsx",
+			"import": "import { Button } from \"@wordpress/components\";"
+		},
+		"theme-provider": {
+			"id": "theme-provider",
+			"name": "ThemeProvider",
+			"path": "../packages/theme/src/stories/index.story.tsx",
+			"import": "import { ThemeProvider } from \"@wordpress/theme\";"
+		}
+	}
+}

--- a/packages/design-system-mcp/src/test/fixtures/manifest.json
+++ b/packages/design-system-mcp/src/test/fixtures/manifest.json
@@ -1,11 +1,16 @@
 {
 	"v": 0,
 	"components": {
-		"ui-button": {
-			"id": "ui-button",
+		"ui-badge": {
+			"id": "ui-badge",
+			"name": "Badge",
+			"path": "../packages/ui/src/badge/stories/index.story.tsx",
+			"description": "A badge."
+		},
+		"components-button": {
+			"id": "components-button",
 			"name": "Button",
-			"path": "../packages/ui/src/button/stories/index.story.tsx",
-			"import": "import { Button } from \"@wordpress/ui\";",
+			"path": "../packages/components/src/button/stories/index.story.tsx",
 			"description": "A button.",
 			"reactDocgen": {
 				"props": {
@@ -17,18 +22,6 @@
 				}
 			},
 			"stories": [ { "name": "Default", "snippet": "<Button />" } ]
-		},
-		"components-button": {
-			"id": "components-button",
-			"name": "Button",
-			"path": "../packages/components/src/button/stories/index.story.tsx",
-			"import": "import { Button } from \"@wordpress/components\";"
-		},
-		"theme-provider": {
-			"id": "theme-provider",
-			"name": "ThemeProvider",
-			"path": "../packages/theme/src/stories/index.story.tsx",
-			"import": "import { ThemeProvider } from \"@wordpress/theme\";"
 		}
 	}
 }

--- a/packages/design-system-mcp/src/test/format.ts
+++ b/packages/design-system-mcp/src/test/format.ts
@@ -1,0 +1,187 @@
+import { formatComponents, formatComponentDetail } from '../format';
+
+describe( 'formatComponents', () => {
+	it( 'should format components as markdown sections', () => {
+		const result = formatComponents( [
+			{
+				name: 'Button',
+				description: 'A button.',
+				packageName: '@wordpress/ui',
+			},
+			{
+				name: 'Badge',
+				description: 'A badge.',
+				packageName: '@wordpress/ui',
+			},
+		] );
+
+		expect( result ).toBe(
+			`# WordPress Design System Components
+
+## Button
+
+A button.
+
+## Badge
+
+A badge.`
+		);
+	} );
+
+	it( 'should handle empty list', () => {
+		expect( formatComponents( [] ) ).toBe(
+			'# WordPress Design System Components'
+		);
+	} );
+
+	it( 'should omit description when empty', () => {
+		const result = formatComponents( [
+			{
+				name: 'Button',
+				description: '',
+				packageName: '@wordpress/ui',
+			},
+		] );
+
+		expect( result ).toBe(
+			`# WordPress Design System Components
+
+## Button`
+		);
+	} );
+} );
+
+describe( 'formatComponentDetail', () => {
+	it( 'should format name, package, and description', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: 'A button component.',
+			packageName: '@wordpress/ui',
+			importStatement: null,
+			props: [],
+			stories: [],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+A button component.
+
+**Package:** \`@wordpress/ui\``
+		);
+	} );
+
+	it( 'should format import statement', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: '',
+			packageName: '@wordpress/ui',
+			importStatement: 'import { Button } from "@wordpress/ui";',
+			props: [],
+			stories: [],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+**Package:** \`@wordpress/ui\`
+
+## Import
+
+\`\`\`ts
+import { Button } from "@wordpress/ui";
+\`\`\``
+		);
+	} );
+
+	it( 'should format props with types and defaults', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: '',
+			packageName: '@wordpress/ui',
+			importStatement: null,
+			props: [
+				{
+					name: 'variant',
+					type: 'string',
+					required: false,
+					description: 'The button variant.',
+					defaultValue: "'solid'",
+				},
+				{
+					name: 'children',
+					type: 'ReactNode',
+					required: true,
+					description: 'Button content.',
+					defaultValue: null,
+				},
+			],
+			stories: [],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+**Package:** \`@wordpress/ui\`
+
+## Props
+
+### \`variant\`: \`string\` (default: \`'solid'\`)
+
+The button variant.
+
+### \`children\`: \`ReactNode\` **(required)**
+
+Button content.
+`
+		);
+	} );
+
+	it( 'should format stories as code examples', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: '',
+			packageName: '@wordpress/ui',
+			importStatement: null,
+			props: [],
+			stories: [
+				{ name: 'Default', snippet: '<Button>Click</Button>' },
+				{ name: 'No Snippet' },
+			],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+**Package:** \`@wordpress/ui\`
+
+## Examples
+
+### Default
+
+\`\`\`tsx
+<Button>Click</Button>
+\`\`\`
+
+### No Snippet
+`
+		);
+	} );
+
+	it( 'should omit sections when data is empty', () => {
+		const result = formatComponentDetail( {
+			name: 'Button',
+			description: '',
+			packageName: '@wordpress/ui',
+			importStatement: null,
+			props: [],
+			stories: [],
+		} );
+
+		expect( result ).toBe(
+			`# Button
+
+**Package:** \`@wordpress/ui\``
+		);
+	} );
+} );

--- a/packages/design-system-mcp/src/test/format.ts
+++ b/packages/design-system-mcp/src/test/format.ts
@@ -76,7 +76,7 @@ A button component.
 			name: 'Button',
 			description: '',
 			packageName: '@wordpress/ui',
-			importStatement: 'import { Button } from "@wordpress/ui";',
+			importStatement: "import { Button } from '@wordpress/ui';",
 			props: [],
 			stories: [],
 		} );
@@ -89,7 +89,7 @@ A button component.
 ## Import
 
 \`\`\`ts
-import { Button } from "@wordpress/ui";
+import { Button } from '@wordpress/ui';
 \`\`\``
 		);
 	} );

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -7,20 +7,17 @@ import {
 import type { ManifestComponent } from '../types';
 
 describe( 'packageNameFromPath', () => {
-	it( 'should return @wordpress/ui for packages/ui paths', () => {
+	it( 'should derive @wordpress/<package> from any packages path', () => {
 		expect(
 			packageNameFromPath(
 				'../packages/ui/src/button/stories/index.story.tsx'
 			)
 		).toBe( '@wordpress/ui' );
-	} );
-
-	it( 'should return null for non-allowed packages', () => {
 		expect(
 			packageNameFromPath(
 				'../packages/components/src/button/stories/index.story.tsx'
 			)
-		).toBeNull();
+		).toBe( '@wordpress/components' );
 	} );
 
 	it( 'should return null for non-package paths', () => {
@@ -163,11 +160,11 @@ function createComponents(
 }
 
 describe( 'parseComponents', () => {
-	it( 'should return only components from allowed packages', () => {
+	it( 'should return components from any recognized @wordpress/* package', () => {
 		const components = createComponents( {
-			'ui-button': {
-				name: 'Button',
-				path: '../packages/ui/src/button/stories/index.story.tsx',
+			'ui-badge': {
+				name: 'Badge',
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
 			},
 			'components-button': {
 				name: 'Button',
@@ -175,9 +172,18 @@ describe( 'parseComponents', () => {
 			},
 		} );
 
-		const result = parseComponents( components );
-		expect( result ).toHaveLength( 1 );
-		expect( result[ 0 ].packageName ).toBe( '@wordpress/ui' );
+		expect( parseComponents( components ) ).toEqual( [
+			{
+				name: 'Badge',
+				description: '',
+				packageName: '@wordpress/ui',
+			},
+			{
+				name: 'Button',
+				description: '',
+				packageName: '@wordpress/components',
+			},
+		] );
 	} );
 
 	it( 'should exclude components with non-package paths', () => {
@@ -301,34 +307,24 @@ describe( 'parseComponentDetail', () => {
 		expect( parseComponentDetail( {}, 'NonExistent' ) ).toBeNull();
 	} );
 
-	it( 'should prefer @wordpress/ui over other packages', () => {
+	it( 'should return detail for a component from @wordpress/components', () => {
 		const components = createComponents( {
-			'components-button': {
+			button: {
 				name: 'Button',
+				description: 'A button component.',
 				path: '../packages/components/src/button/stories/index.story.tsx',
-				description: 'Old button.',
-			},
-			'ui-button': {
-				name: 'Button',
-				path: '../packages/ui/src/button/stories/index.story.tsx',
-				description: 'New button.',
 			},
 		} );
 
 		const result = parseComponentDetail( components, 'Button' );
-		expect( result?.packageName ).toBe( '@wordpress/ui' );
-		expect( result?.description ).toBe( 'New button.' );
-	} );
-
-	it( 'should return null for components only in non-allowed packages', () => {
-		const components = createComponents( {
-			oldButton: {
+		expect( result ).toEqual(
+			expect.objectContaining( {
 				name: 'Button',
-				path: '../packages/components/src/button/stories/index.story.tsx',
-			},
-		} );
-
-		expect( parseComponentDetail( components, 'Button' ) ).toBeNull();
+				packageName: '@wordpress/components',
+				importStatement:
+					"import { Button } from '@wordpress/components';",
+			} )
+		);
 	} );
 
 	it( 'should filter deprecated props from detail', () => {

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -374,6 +374,20 @@ describe( 'parseComponentDetail', () => {
 		);
 	} );
 
+	it( 'should emit an aliased import for a component exported with an __experimental prefix', () => {
+		const components = createComponents( {
+			truncate: {
+				name: 'Truncate',
+				path: '../packages/components/src/truncate/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Truncate' );
+		expect( result?.importStatement ).toBe(
+			"import { __experimentalTruncate as Truncate } from '@wordpress/components';"
+		);
+	} );
+
 	it( 'should filter deprecated props from detail', () => {
 		const components = createComponents( {
 			button: {

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -1,0 +1,317 @@
+import {
+	packageNameFromPath,
+	parseProps,
+	parseComponents,
+	parseComponentDetail,
+} from '../parse-components';
+import type { ManifestComponent } from '../types';
+
+describe( 'packageNameFromPath', () => {
+	it( 'should return @wordpress/ui for packages/ui paths', () => {
+		expect(
+			packageNameFromPath(
+				'../packages/ui/src/button/stories/index.story.tsx'
+			)
+		).toBe( '@wordpress/ui' );
+	} );
+
+	it( 'should return null for non-allowed packages', () => {
+		expect(
+			packageNameFromPath(
+				'../packages/components/src/button/stories/index.story.tsx'
+			)
+		).toBeNull();
+	} );
+
+	it( 'should return null for non-package paths', () => {
+		expect(
+			packageNameFromPath(
+				'./stories/design-system/theme-example-application.story.tsx'
+			)
+		).toBeNull();
+	} );
+} );
+
+describe( 'parseProps', () => {
+	it( 'should parse basic props', () => {
+		const result = parseProps( {
+			disabled: {
+				required: false,
+				tsType: { name: 'boolean' },
+				description: 'Whether the button is disabled.',
+				defaultValue: { value: 'false' },
+			},
+		} );
+
+		expect( result ).toEqual( [
+			{
+				name: 'disabled',
+				type: 'boolean',
+				required: false,
+				description: 'Whether the button is disabled.',
+				defaultValue: 'false',
+			},
+		] );
+	} );
+
+	it( 'should filter out deprecated props', () => {
+		const result = parseProps( {
+			variant: {
+				required: false,
+				tsType: { name: 'string' },
+				description: 'The button variant.',
+			},
+			oldProp: {
+				required: false,
+				tsType: { name: 'string' },
+				description: '@deprecated Use variant instead.',
+			},
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].name ).toBe( 'variant' );
+	} );
+
+	it( 'should filter out ignored props', () => {
+		const result = parseProps( {
+			visible: {
+				required: true,
+				tsType: { name: 'boolean' },
+				description: 'Whether visible.',
+			},
+			internal: {
+				required: false,
+				tsType: { name: 'string' },
+				description: '@ignore Internal use only.',
+			},
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].name ).toBe( 'visible' );
+	} );
+
+	it( 'should default missing type to unknown', () => {
+		const result = parseProps( {
+			something: {
+				description: 'A prop without type info.',
+			},
+		} );
+
+		expect( result[ 0 ].type ).toBe( 'unknown' );
+	} );
+
+	it( 'should default missing values', () => {
+		const result = parseProps( {
+			minimal: {},
+		} );
+
+		expect( result[ 0 ] ).toEqual( {
+			name: 'minimal',
+			type: 'unknown',
+			required: false,
+			description: '',
+			defaultValue: null,
+		} );
+	} );
+} );
+
+function createComponents(
+	entries: Record< string, Partial< ManifestComponent > >
+): Record< string, ManifestComponent > {
+	const result: Record< string, ManifestComponent > = {};
+	for ( const [ key, value ] of Object.entries( entries ) ) {
+		result[ key ] = {
+			id: key,
+			name: value.name ?? key,
+			path:
+				value.path ??
+				`../packages/ui/src/${ key }/stories/index.story.tsx`,
+			...value,
+		};
+	}
+	return result;
+}
+
+describe( 'parseComponents', () => {
+	it( 'should return only components from allowed packages', () => {
+		const components = createComponents( {
+			'ui-button': {
+				name: 'Button',
+				path: '../packages/ui/src/button/stories/index.story.tsx',
+			},
+			'components-button': {
+				name: 'Button',
+				path: '../packages/components/src/button/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponents( components );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].packageName ).toBe( '@wordpress/ui' );
+	} );
+
+	it( 'should exclude components with non-package paths', () => {
+		const components = createComponents( {
+			example: {
+				name: 'ThemeProvider',
+				path: './stories/design-system/theme-example-application.story.tsx',
+			},
+		} );
+
+		expect( parseComponents( components ) ).toHaveLength( 0 );
+	} );
+
+	it( 'should not be confused by stories that import from allowed packages', () => {
+		const components = createComponents( {
+			example: {
+				name: 'ThemeProvider',
+				// Story lives in the theme package, not ui
+				path: '../packages/theme/src/stories/index.story.tsx',
+				// But the import mentions @wordpress/ui
+				import: 'import { Badge, Button } from "@wordpress/ui";',
+			},
+		} );
+
+		// Path-based detection correctly excludes this
+		expect( parseComponents( components ) ).toHaveLength( 0 );
+	} );
+
+	it( 'should include description from manifest', () => {
+		const components = createComponents( {
+			badge: {
+				name: 'Badge',
+				description: 'A badge component.',
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponents( components );
+		expect( result[ 0 ].description ).toBe( 'A badge component.' );
+	} );
+} );
+
+describe( 'parseComponentDetail', () => {
+	it( 'should find a component by exact name', () => {
+		const components = createComponents( {
+			button: {
+				name: 'Button',
+				description: 'A button component.',
+				path: '../packages/ui/src/button/stories/index.story.tsx',
+				import: 'import { Button } from "@wordpress/ui";',
+				reactDocgen: {
+					props: {
+						variant: {
+							required: false,
+							tsType: { name: 'string' },
+							description: 'The button variant.',
+						},
+					},
+				},
+				stories: [ { name: 'Default', snippet: '<Button />' } ],
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Button' );
+		expect( result ).toEqual( {
+			name: 'Button',
+			description: 'A button component.',
+			packageName: '@wordpress/ui',
+			importStatement: 'import { Button } from "@wordpress/ui";',
+			props: [
+				{
+					name: 'variant',
+					type: 'string',
+					required: false,
+					description: 'The button variant.',
+					defaultValue: null,
+				},
+			],
+			stories: [ { name: 'Default', snippet: '<Button />' } ],
+		} );
+	} );
+
+	it( 'should match case-insensitively', () => {
+		const components = createComponents( {
+			button: {
+				name: 'Button',
+				path: '../packages/ui/src/button/stories/index.story.tsx',
+			},
+		} );
+
+		expect( parseComponentDetail( components, 'button' ) ).not.toBeNull();
+		expect( parseComponentDetail( components, 'BUTTON' ) ).not.toBeNull();
+	} );
+
+	it( 'should return null for unknown components', () => {
+		expect( parseComponentDetail( {}, 'NonExistent' ) ).toBeNull();
+	} );
+
+	it( 'should prefer @wordpress/ui over other packages', () => {
+		const components = createComponents( {
+			'components-button': {
+				name: 'Button',
+				path: '../packages/components/src/button/stories/index.story.tsx',
+				description: 'Old button.',
+			},
+			'ui-button': {
+				name: 'Button',
+				path: '../packages/ui/src/button/stories/index.story.tsx',
+				description: 'New button.',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Button' );
+		expect( result?.packageName ).toBe( '@wordpress/ui' );
+		expect( result?.description ).toBe( 'New button.' );
+	} );
+
+	it( 'should return null for components only in non-allowed packages', () => {
+		const components = createComponents( {
+			oldButton: {
+				name: 'Button',
+				path: '../packages/components/src/button/stories/index.story.tsx',
+			},
+		} );
+
+		expect( parseComponentDetail( components, 'Button' ) ).toBeNull();
+	} );
+
+	it( 'should filter deprecated props from detail', () => {
+		const components = createComponents( {
+			button: {
+				name: 'Button',
+				path: '../packages/ui/src/button/stories/index.story.tsx',
+				reactDocgen: {
+					props: {
+						variant: {
+							tsType: { name: 'string' },
+							description: 'Current prop.',
+						},
+						legacy: {
+							tsType: { name: 'string' },
+							description: '@deprecated Use variant.',
+						},
+					},
+				},
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Button' );
+		expect( result?.props ).toHaveLength( 1 );
+		expect( result?.props[ 0 ].name ).toBe( 'variant' );
+	} );
+
+	it( 'should not match non-package story paths', () => {
+		const components = createComponents( {
+			example: {
+				name: 'ThemeProvider',
+				path: './stories/design-system/theme-example-application.story.tsx',
+				import: 'import { Badge } from "@wordpress/ui";',
+			},
+		} );
+
+		expect(
+			parseComponentDetail( components, 'ThemeProvider' )
+		).toBeNull();
+	} );
+} );

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -274,6 +274,29 @@ describe( 'parseComponents', () => {
 			},
 		] );
 	} );
+
+	it( 'should prefer a non-empty description when merging entries', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				// First entry has no description
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			'badge-intent': {
+				name: 'Badge',
+				description: 'A badge component.',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+			},
+		} );
+
+		expect( parseComponents( components ) ).toEqual( [
+			{
+				name: 'Badge',
+				description: 'A badge component.',
+				packageName: '@wordpress/ui',
+			},
+		] );
+	} );
 } );
 
 describe( 'parseComponentDetail', () => {
@@ -422,6 +445,50 @@ describe( 'parseComponentDetail', () => {
 			},
 			{ name: 'All Intents', snippet: '<Badge />' },
 		] );
+	} );
+
+	it( 'should prefer a non-empty description when merging story files', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				// First entry has no description
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			'badge-intent': {
+				name: 'Badge',
+				description: 'A badge component.',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Badge' );
+		expect( result?.description ).toBe( 'A badge component.' );
+	} );
+
+	it( 'should prefer non-empty props when merging story files', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				// First entry has no reactDocgen props
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			'badge-intent': {
+				name: 'Badge',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+				reactDocgen: {
+					props: {
+						intent: {
+							tsType: { name: 'string' },
+							description: 'The badge intent.',
+						},
+					},
+				},
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Badge' );
+		expect( result?.props ).toHaveLength( 1 );
+		expect( result?.props[ 0 ].name ).toBe( 'intent' );
 	} );
 
 	it( 'should return detail for a compound component by its root identifier', () => {

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -221,6 +221,29 @@ describe( 'parseComponents', () => {
 			},
 		] );
 	} );
+
+	it( 'should list a component only once when multiple story files contribute entries', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				description: 'A badge component.',
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			'badge-intent': {
+				name: 'Badge',
+				description: 'A badge component.',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+			},
+		} );
+
+		expect( parseComponents( components ) ).toEqual( [
+			{
+				name: 'Badge',
+				description: 'A badge component.',
+				packageName: '@wordpress/ui',
+			},
+		] );
+	} );
 } );
 
 describe( 'parseComponentDetail', () => {
@@ -344,6 +367,41 @@ describe( 'parseComponentDetail', () => {
 		expect(
 			parseComponentDetail( components, 'ThemeProvider' )
 		).toBeNull();
+	} );
+
+	it( 'should include stories from every story file contributing to a component', () => {
+		const components = createComponents( {
+			'badge-index': {
+				name: 'Badge',
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+				stories: [
+					{ name: 'Default', snippet: '<Badge />' },
+					{ name: 'High', snippet: '<Badge intent="high" />' },
+				],
+			},
+			'badge-intent': {
+				name: 'Badge',
+				path: '../packages/ui/src/badge/stories/choosing-intent.story.tsx',
+				stories: [
+					{
+						name: 'High',
+						snippet: '<Badge intent="high">Contextual</Badge>',
+					},
+					{ name: 'All Intents', snippet: '<Badge />' },
+				],
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'Badge' );
+		expect( result?.stories ).toEqual( [
+			{ name: 'Default', snippet: '<Badge />' },
+			{ name: 'High', snippet: '<Badge intent="high" />' },
+			{
+				name: 'High',
+				snippet: '<Badge intent="high">Contextual</Badge>',
+			},
+			{ name: 'All Intents', snippet: '<Badge />' },
+		] );
 	} );
 
 	it( 'should return detail for a compound component by its root identifier', () => {

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -228,6 +228,30 @@ describe( 'parseComponents', () => {
 		] );
 	} );
 
+	it( 'should return components sorted alphabetically by name', () => {
+		const components = createComponents( {
+			a: {
+				name: 'Tabs',
+				path: '../packages/components/src/tabs/stories/index.story.tsx',
+			},
+			b: {
+				name: 'Badge',
+				path: '../packages/ui/src/badge/stories/index.story.tsx',
+			},
+			c: {
+				name: 'Notice',
+				path: '../packages/components/src/notice/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponents( components );
+		expect( result.map( ( c ) => c.name ) ).toEqual( [
+			'Badge',
+			'Notice',
+			'Tabs',
+		] );
+	} );
+
 	it( 'should list a component only once when multiple story files contribute entries', () => {
 		const components = createComponents( {
 			'badge-index': {

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -191,21 +191,6 @@ describe( 'parseComponents', () => {
 		expect( parseComponents( components ) ).toHaveLength( 0 );
 	} );
 
-	it( 'should not be confused by stories that import from allowed packages', () => {
-		const components = createComponents( {
-			example: {
-				name: 'ThemeProvider',
-				// Story lives in the theme package, not ui
-				path: '../packages/theme/src/stories/index.story.tsx',
-				// But the import mentions @wordpress/ui
-				import: 'import { Badge, Button } from "@wordpress/ui";',
-			},
-		} );
-
-		// Path-based detection correctly excludes this
-		expect( parseComponents( components ) ).toHaveLength( 0 );
-	} );
-
 	it( 'should include description from manifest', () => {
 		const components = createComponents( {
 			badge: {
@@ -227,7 +212,6 @@ describe( 'parseComponentDetail', () => {
 				name: 'Button',
 				description: 'A button component.',
 				path: '../packages/ui/src/button/stories/index.story.tsx',
-				import: 'import { Button } from "@wordpress/ui";',
 				reactDocgen: {
 					props: {
 						variant: {
@@ -246,7 +230,7 @@ describe( 'parseComponentDetail', () => {
 			name: 'Button',
 			description: 'A button component.',
 			packageName: '@wordpress/ui',
-			importStatement: 'import { Button } from "@wordpress/ui";',
+			importStatement: "import { Button } from '@wordpress/ui';",
 			props: [
 				{
 					name: 'variant',
@@ -336,7 +320,6 @@ describe( 'parseComponentDetail', () => {
 			example: {
 				name: 'ThemeProvider',
 				path: './stories/design-system/theme-example-application.story.tsx',
-				import: 'import { Badge } from "@wordpress/ui";',
 			},
 		} );
 

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -33,13 +33,29 @@ describe( 'packageNameFromPath', () => {
 } );
 
 describe( 'parseProps', () => {
-	it( 'should parse basic props', () => {
+	it( 'should parse props with readable type expressions', () => {
 		const result = parseProps( {
 			disabled: {
 				required: false,
 				tsType: { name: 'boolean' },
 				description: 'Whether the button is disabled.',
 				defaultValue: { value: 'false' },
+			},
+			variant: {
+				required: false,
+				tsType: {
+					name: 'union',
+					raw: "'solid' | 'outline' | 'minimal' | 'unstyled'",
+				},
+				description: 'The button variant.',
+			},
+			style: {
+				required: false,
+				tsType: {
+					name: 'ReactCSSProperties',
+					raw: 'React.CSSProperties',
+				},
+				description: 'Inline styles.',
 			},
 		} );
 
@@ -50,6 +66,20 @@ describe( 'parseProps', () => {
 				required: false,
 				description: 'Whether the button is disabled.',
 				defaultValue: 'false',
+			},
+			{
+				name: 'variant',
+				type: "'solid' | 'outline' | 'minimal' | 'unstyled'",
+				required: false,
+				description: 'The button variant.',
+				defaultValue: null,
+			},
+			{
+				name: 'style',
+				type: 'React.CSSProperties',
+				required: false,
+				description: 'Inline styles.',
+				defaultValue: null,
 			},
 		] );
 	} );

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -203,6 +203,24 @@ describe( 'parseComponents', () => {
 		const result = parseComponents( components );
 		expect( result[ 0 ].description ).toBe( 'A badge component.' );
 	} );
+
+	it( 'should use the root identifier as the canonical name for compound components', () => {
+		const components = createComponents( {
+			'alert-dialog': {
+				name: 'AlertDialog.Root',
+				description: 'An alert dialog.',
+				path: '../packages/ui/src/alert-dialog/stories/index.story.tsx',
+			},
+		} );
+
+		expect( parseComponents( components ) ).toEqual( [
+			{
+				name: 'AlertDialog',
+				description: 'An alert dialog.',
+				packageName: '@wordpress/ui',
+			},
+		] );
+	} );
 } );
 
 describe( 'parseComponentDetail', () => {
@@ -326,5 +344,23 @@ describe( 'parseComponentDetail', () => {
 		expect(
 			parseComponentDetail( components, 'ThemeProvider' )
 		).toBeNull();
+	} );
+
+	it( 'should return detail for a compound component by its root identifier', () => {
+		const components = createComponents( {
+			'alert-dialog': {
+				name: 'AlertDialog.Root',
+				description: 'An alert dialog.',
+				path: '../packages/ui/src/alert-dialog/stories/index.story.tsx',
+			},
+		} );
+
+		const result = parseComponentDetail( components, 'AlertDialog' );
+		expect( result ).toEqual(
+			expect.objectContaining( {
+				name: 'AlertDialog',
+				importStatement: "import { AlertDialog } from '@wordpress/ui';",
+			} )
+		);
 	} );
 } );

--- a/packages/design-system-mcp/src/tools/get-component-details.ts
+++ b/packages/design-system-mcp/src/tools/get-component-details.ts
@@ -1,0 +1,51 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import { getComponentDetail } from '../data';
+import { formatComponentDetail } from '../format';
+
+/**
+ * Register the get_component_details tool.
+ *
+ * @param server - The MCP server instance.
+ */
+export function register( server: McpServer ): void {
+	server.registerTool(
+		'get_component_details',
+		{
+			title: 'Get Component Details',
+			description:
+				'Get detailed documentation for a WordPress Design System component including props, usage examples, and import statements.',
+			inputSchema: z.object( {
+				name: z
+					.string()
+					.min( 1 )
+					.describe( 'The component name (e.g. "Button", "Tabs")' ),
+			} ),
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async ( { name } ) => {
+			const detail = await getComponentDetail( name );
+			if ( ! detail ) {
+				return {
+					content: [
+						{
+							type: 'text',
+							text: `No component named "${ name }" was found.`,
+						},
+					],
+					isError: true,
+				};
+			}
+			return {
+				content: [
+					{
+						type: 'text',
+						text: formatComponentDetail( detail ),
+					},
+				],
+			};
+		}
+	);
+}

--- a/packages/design-system-mcp/src/tools/get-components.ts
+++ b/packages/design-system-mcp/src/tools/get-components.ts
@@ -1,0 +1,33 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import { getComponents } from '../data';
+import { formatComponents } from '../format';
+
+/**
+ * Register the get_components tool.
+ *
+ * @param server - The MCP server instance.
+ */
+export function register( server: McpServer ): void {
+	server.registerTool(
+		'get_components',
+		{
+			title: 'Get Components',
+			description:
+				'Get a list of all available WordPress Design System components with their package names and descriptions.',
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async () => {
+			const components = await getComponents();
+			return {
+				content: [
+					{
+						type: 'text',
+						text: formatComponents( components ),
+					},
+				],
+			};
+		}
+	);
+}

--- a/packages/design-system-mcp/src/tools/get-design-tokens.ts
+++ b/packages/design-system-mcp/src/tools/get-design-tokens.ts
@@ -1,0 +1,32 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import { getDesignTokens } from '../data';
+
+/**
+ * Register the get_design_tokens tool.
+ *
+ * @param server - The MCP server instance.
+ */
+export function register( server: McpServer ): void {
+	server.registerTool(
+		'get_design_tokens',
+		{
+			title: 'Get Design Tokens',
+			description:
+				'Get the WordPress Design System design tokens reference (colors, spacing, typography, elevation, etc.).',
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async () => {
+			const tokens = await getDesignTokens();
+			return {
+				content: [
+					{
+						type: 'text',
+						text: tokens.content,
+					},
+				],
+			};
+		}
+	);
+}

--- a/packages/design-system-mcp/src/tools/index.ts
+++ b/packages/design-system-mcp/src/tools/index.ts
@@ -1,0 +1,15 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import { register as getComponents } from './get-components';
+import { register as getComponentDetails } from './get-component-details';
+import { register as getDesignTokens } from './get-design-tokens';
+
+/**
+ * Register all MCP tools on the server.
+ *
+ * @param server - The MCP server instance.
+ */
+export function registerTools( server: McpServer ): void {
+	getComponents( server );
+	getComponentDetails( server );
+	getDesignTokens( server );
+}

--- a/packages/design-system-mcp/src/types.ts
+++ b/packages/design-system-mcp/src/types.ts
@@ -2,7 +2,6 @@ export interface ManifestComponent {
 	id: string;
 	name: string;
 	path: string;
-	import?: string;
 	description?: string;
 	stories?: Array< {
 		name: string;

--- a/packages/design-system-mcp/src/types.ts
+++ b/packages/design-system-mcp/src/types.ts
@@ -1,0 +1,52 @@
+export interface ManifestComponent {
+	id: string;
+	name: string;
+	path: string;
+	import?: string;
+	description?: string;
+	stories?: Array< {
+		name: string;
+		snippet?: string;
+		description?: string;
+	} >;
+	reactDocgen?: {
+		description?: string;
+		displayName?: string;
+		props?: Record<
+			string,
+			{
+				required?: boolean;
+				tsType?: { name: string; raw?: string };
+				description?: string;
+				defaultValue?: { value: string };
+			}
+		>;
+	};
+}
+
+export interface Component {
+	name: string;
+	description: string;
+	packageName: string;
+}
+
+export interface ComponentProp {
+	name: string;
+	type: string;
+	required: boolean;
+	description: string;
+	defaultValue: string | null;
+}
+
+export interface ComponentDetail {
+	name: string;
+	description: string;
+	packageName: string;
+	importStatement: string | null;
+	props: ComponentProp[];
+	stories: Array< {
+		name: string;
+		snippet?: string;
+		description?: string;
+	} >;
+}

--- a/packages/design-system-mcp/tsconfig.json
+++ b/packages/design-system-mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"types": [ "jest" ]
+	},
+	"include": [ "src" ],
+	"exclude": []
+}

--- a/packages/ui/src/badge/stories/choosing-intent.story.tsx
+++ b/packages/ui/src/badge/stories/choosing-intent.story.tsx
@@ -15,7 +15,7 @@ const meta: Meta< typeof Badge > = {
 	parameters: {
 		controls: { disable: true },
 	},
-	tags: [ '!dev' /* Hide individual story pages from sidebar */ ],
+	tags: [ '!dev' /* Hide individual story pages from sidebar */, 'manifest' ],
 };
 export default meta;
 

--- a/packages/ui/src/badge/stories/index.story.tsx
+++ b/packages/ui/src/badge/stories/index.story.tsx
@@ -3,6 +3,7 @@ import { Fragment } from '@wordpress/element';
 import { Badge } from '../index';
 
 const meta: Meta< typeof Badge > = {
+	tags: [ 'manifest' ],
 	title: 'Design System/Components/Badge',
 	component: Badge,
 };

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Stack } from '../index';
 
 const meta: Meta< typeof Stack > = {
+	tags: [ 'manifest' ],
 	title: 'Design System/Components/Stack',
 	component: Stack,
 };

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -3,6 +3,7 @@ import { Text } from '../index';
 import { Stack } from '../../stack';
 
 const meta: Meta< typeof Text > = {
+	tags: [ 'manifest' ],
 	title: 'Design System/Components/Text',
 	component: Text,
 };

--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -251,4 +251,4 @@ export const parameters = {
 	},
 };
 
-export const tags = [ 'autodocs' ];
+export const tags = [ 'autodocs', '!manifest' ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
 		{ "path": "packages/dataviews" },
 		{ "path": "packages/date" },
 		{ "path": "packages/deprecated" },
+		{ "path": "packages/design-system-mcp" },
 		{ "path": "packages/docgen" },
 		{ "path": "packages/dom" },
 		{ "path": "packages/dom-ready" },


### PR DESCRIPTION
## What?

Closes #77206

Implements a new package `@wordpress/design-system-mcp` which serves as a local [MCP server](https://modelcontextprotocol.io/docs/learn/server-concepts), providing a bridge between AI agents and the WordPress design system implementation.

Related: #74626

Note that the current manifests have some existing issues that need to be resolved for this to work well (e.g. #77112)

## Why?

Agents are a common part of many developer's workflow, but often struggle to achieve the consistency we hope to see with a design system in recommending guidance and offerings (components, tokens). The goal of this new package is to provide a simple setup experience for someone already using AI agents in development to make those guidance and offerings more readily available, while neither increasing our own maintenance burden nor favoring one documentation vehicle over another (see "How" below).

## How?

This leverages _existing resources_ that can be reliably assured as up-to-date:

- The [design token reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md), which is generated automatically as an artifact from [the source design tokens](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme/tokens) via a [custom plugin](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts) for our [Terrazzo](https://terrazzo.app/) setup
- Existing Storybook data, which is already available in raw JSON format ([components.json](https://wordpress.github.io/gutenberg/manifests/components.json)) as of #74626

It's implemented as a npm Node binary, which works well with `mcp.json` configuration. This also avoids the need for external MCP server hosting. This is a common setup experience for other projects offering MCP (e.g. [Chakra UI](https://chakra-ui.com/docs/get-started/ai/mcp-server#setup)).

I had explored an alternative approach leveraging [WordPress Abilities API](https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/) + [mcp-adapter](https://github.com/WordPress/mcp-adapter) which, while an interesting example of "dog-fooding", may not be a great fit:

- It requires that we figure out a hosting arrangement for where this lives, presumably somewhere on wordpress.org
- The bigger issue is that MCP servers using HTTP as a transport layer are _stateful_, and require session management. The existing WordPress tooling around MCP (i.e. [mcp-adapter](https://github.com/WordPress/mcp-adapter)) is optimized for authenticated users, and isn't a good fit for a public MCP server where we'd want to support anonymous access.
- It's also overkill, since the proposed approach here doesn't do anything particularly special beyond fetching and transforming static assets

## Testing Instructions

The ideal workflow (i.e. referencing the published npm package) is only possible to test once this is merged and published.

In the meantime, you can test a couple ways:

- Using the [MCP inspector tool](https://modelcontextprotocol.io/docs/tools/inspector): 
   1. Run `npm run build` to build files
   2. Run `npx @modelcontextprotocol/inspector node packages/design-system-mcp/bin/design-system-mcp.mjs`
   3. A browser window should be opened at http://localhost:6274/ (or visit manually)
   4. Click "Connect" (options should be configured already)
   5. Click "List Tools"
   6. Observe three tools: `get_components`, `get_component_details`, `get_design_tokens`
   7. Click each of the tools and then play with parameters and "Run Tool" to observe expected output
- Using `mcp.json`, pointing to the local built file:
   1. This varies by client, but in my case using Claude Code it looks like: `claude mcp add wordpress-design-system -- node /path/to/gutenberg/packages/design-system-mcp/bin/design-system-mcp.mjs`
   2. Open an agent conversation in the context of wherever you configured the MCP server
   3. Ask the agent something about the design system (e.g. 

## Screenshots or screencast <!-- if applicable -->

MCP Inspector example:

<img width="1677" height="1137" alt="image" src="https://github.com/user-attachments/assets/0e97640f-91bc-4e44-a21d-3638b5ee8c6a" />

Claude Code example:

<img width="1127" height="313" alt="image" src="https://github.com/user-attachments/assets/a16e5b2f-02e4-4aa8-b1a9-e8b768e1ceb2" />

## Use of AI Tools

Claude Code + Claude Opus 4.6, plus a fair bit of back-and-forth and post-processing manual edits. Used for both research of approach and package implementation.