### PR TITLE
UI: Normalize render prop and ref forwarding patterns

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Bug Fixes
 
+-   `Card.Title`, `EmptyState.Title`, `EmptyState.Description`: Fix ref and props being lost when a custom `render` element is provided ([#77160](https://github.com/WordPress/gutenberg/pull/77160)).
+-   `Tabs.List`: Fix `render` prop being silently discarded ([#77160](https://github.com/WordPress/gutenberg/pull/77160)).
 -   `Card`: Set default foreground color on `Card.Root` so content and `currentColor` icons (for example the `CollapsibleCard` chevron) are themeable by default ([#77013](https://github.com/WordPress/gutenberg/pull/77013)).
 
 ### Enhancements
@@ -30,6 +32,7 @@
 ### Internal
 
 -   `Card`: Remove redundant `margin: 0` from `Card.Title` now that `Text` applies it by default ([#77187](https://github.com/WordPress/gutenberg/pull/77187)).
+-   Normalize `render` prop handling across components and document conventions in `CONTRIBUTING.md` ([#77160](https://github.com/WordPress/gutenberg/pull/77160)).
 -   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
 -   `Field.Label`, `Fieldset.Legend`, `Field.Details`: Refactor `VisuallyHidden` composition to preserve semantic HTML elements when visually hiding content.
 

--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -57,6 +57,117 @@ Why?
 -   `.Root` has required subparts, signalling an expectation that it must be composed
     -   A non-root component can still have _optional_ sub-parts, like a `Button.Icon`
 
+## `render` Prop and Ref Forwarding
+
+All `@wordpress/ui` components support a `render` prop (via the `ComponentProps` utility type) that lets consumers swap the underlying HTML element. This section codifies the two canonical implementation patterns, the rules for handling `render`, and common anti-patterns to avoid.
+
+### Canonical Patterns
+
+The correct approach depends on whether the component wraps a Base UI primitive or renders its own element.
+
+#### Pattern A: Custom components — `useRender` + `mergeProps`
+
+For components that do **not** wrap a Base UI primitive, use `useRender` and `mergeProps` from `@base-ui/react`. Destructure `render` from props (required by the `useRender` API), and pass it together with `ref` and merged props:
+
+```tsx
+import { useRender, mergeProps } from '@base-ui/react';
+import { forwardRef } from '@wordpress/element';
+
+export const Root = forwardRef( function MyComponent( { render, className, ...restProps }, ref ) {
+    const element = useRender( {
+        render,
+        defaultTagName: 'div',
+        ref,
+        props: mergeProps( { className: styles.root }, restProps ),
+    } );
+
+    return element;
+} );
+```
+
+`useRender` handles element creation, ref composition, and prop merging.
+
+#### Pattern B: Wrapper components — pass `ref` explicitly, spread `...props`
+
+For components that wrap a Base UI primitive or another `@wordpress/ui` component, pass the forwarded `ref` explicitly and spread `...props` (which carries `render` through implicitly):
+
+```tsx
+import { Collapsible as _Collapsible } from '@base-ui/react/collapsible';
+import { forwardRef } from '@wordpress/element';
+
+export const Trigger = forwardRef( function MyTrigger( props, ref ) {
+    return <_Collapsible.Trigger ref={ ref } { ...props } />;
+} );
+```
+
+The inner component (Base UI or `@wordpress/ui`) handles `render` and ref composition internally.
+
+### Explicit vs Implicit `render` Handling
+
+**Prefer implicit handling (via `...props` rest spread) unless the component needs to interact with `render`.**
+
+"Interact" means one of:
+
+1. **Assign a default** — the component overrides the default element (e.g., `render = DEFAULT_TAG`).
+2. **Transform** — the component wraps or modifies the value before passing it.
+3. **Discard** — the component intentionally prevents element customization. In this case, destructure `render` to remove it from rest props, **and** `Omit` it from the type so consumers get a TypeScript error instead of silent no-op behavior.
+4. **Pass to `useRender`** — Pattern A components where the hook API requires it as a named argument.
+
+In all other cases, let `render` flow through `...props`. Destructuring `render` only to write `render={ render }` is ceremony with no behavioral effect.
+
+### Overriding the Default Element
+
+When a component needs to render a different element than its inner component's default (e.g., a `<div>` instead of `<span>`), hoist the default to a **module-level constant** and assign it as a destructuring default:
+
+```tsx
+const DEFAULT_TAG = <div />;
+
+export const Title = forwardRef( function MyTitle(
+    { render = DEFAULT_TAG, className, children, ...props },
+    ref
+) {
+    return (
+        <Text ref={ ref } render={ render } className={ className } { ...props }>
+            { children }
+        </Text>
+    );
+} );
+```
+
+React elements are immutable descriptors — `useRender` calls `cloneElement` on them (creating a new element), never mutating the original. A hoisted constant avoids allocating a fresh object every render and gives React/Base UI a stable reference for equality checks.
+
+### Anti-patterns
+
+#### Bundling `ref` and `props` into a render fallback
+
+```tsx
+// BAD: ref and props are lost when consumer provides render
+render={ render ?? <div ref={ ref } { ...props } /> }
+```
+
+When `render` is provided by the consumer, `ref` and `...props` remain on the unused fallback element and never reach the actual rendered element. Always pass `ref` and `...props` separately to the inner component.
+
+#### Unnecessary explicit destructure
+
+```tsx
+// BAD: destructure-and-pass-through with no interaction
+function MyComponent( { render, ...props }, ref ) {
+    return <Inner ref={ ref } render={ render } { ...props } />;
+}
+
+// GOOD: let render flow through ...props
+function MyComponent( props, ref ) {
+    return <Inner ref={ ref } { ...props } />;
+}
+```
+
+### Decision Tree
+
+1. **Am I wrapping Base UI or another `@wordpress/ui` component?** → Use Pattern B (pass `ref`, spread `...props`). Let `render` flow implicitly.
+2. **Am I building a custom component with no inner primitive?** → Use Pattern A (`useRender` + `mergeProps`). Destructure `render` (required by the hook).
+3. **Do I need a different default element?** → Hoist a constant (`const DEFAULT_TAG = <div />;`), assign it as a destructuring default.
+4. **Do I need to prevent `render` customization?** → Destructure `render` to discard it, and `Omit` it from the component's type.
+
 ## CSS Architecture
 
 ### CSS Layers

--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -117,9 +117,12 @@ In all other cases, let `render` flow through `...props`. Destructuring `render`
 
 ### Overriding the Default Element
 
-When a component needs to render a different element than its inner component's default (e.g., a `<div>` instead of `<span>`), hoist the default to a **module-level constant** and assign it as a destructuring default:
+When a component needs to render a different element than its inner component's default (e.g., a `<div>` instead of `<span>`), hoist the default to a **module-level constant** and assign it as a destructuring default.
+
+The default can be a **JSX element** or a **render function**, depending on what the component needs:
 
 ```tsx
+// JSX element — suitable when you only need to swap the tag.
 const DEFAULT_TAG = <div />;
 
 export const Title = forwardRef( function MyTitle(
@@ -134,7 +137,24 @@ export const Title = forwardRef( function MyTitle(
 } );
 ```
 
-React elements are immutable descriptors — `useRender` calls `cloneElement` on them (creating a new element), never mutating the original. A hoisted constant avoids allocating a fresh object every render and gives React/Base UI a stable reference for equality checks.
+```tsx
+// Render function — useful when the default needs to compose
+// other components or add additional props.
+const defaultRender = ( props: React.ComponentProps< typeof Stack > ) => (
+    <Stack { ...props } direction="column" gap="sm" />
+);
+
+export const Root = forwardRef( function MyRoot(
+    { className, render = defaultRender, ...restProps },
+    ref
+) {
+    return (
+        <_Field.Root ref={ ref } className={ className } render={ render } { ...restProps } />
+    );
+} );
+```
+
+When using a JSX element, React elements are immutable descriptors — `useRender` calls `cloneElement` on them (creating a new element), never mutating the original. In both cases, a hoisted constant avoids allocating a fresh object every render and gives React/Base UI a stable reference for equality checks.
 
 ### Anti-patterns
 
@@ -160,13 +180,6 @@ function MyComponent( props, ref ) {
     return <Inner ref={ ref } { ...props } />;
 }
 ```
-
-### Decision Tree
-
-1. **Am I wrapping Base UI or another `@wordpress/ui` component?** → Use Pattern B (pass `ref`, spread `...props`). Let `render` flow implicitly.
-2. **Am I building a custom component with no inner primitive?** → Use Pattern A (`useRender` + `mergeProps`). Destructure `render` (required by the hook).
-3. **Do I need a different default element?** → Hoist a constant (`const DEFAULT_TAG = <div />;`), assign it as a destructuring default.
-4. **Do I need to prevent `render` customization?** → Destructure `render` to discard it, and `Omit` it from the component's type.
 
 ## CSS Architecture
 

--- a/packages/ui/src/card/test/index.test.tsx
+++ b/packages/ui/src/card/test/index.test.tsx
@@ -91,5 +91,22 @@ describe( 'Card', () => {
 				screen.getByRole( 'heading', { level: 2, name: 'Heading' } )
 			).toBeVisible();
 		} );
+
+		it( 'forwards ref to custom Title render element', () => {
+			const titleRef = createRef< HTMLHeadingElement >();
+
+			render(
+				<Card.Root>
+					<Card.Header>
+						<Card.Title ref={ titleRef } render={ <h3 /> }>
+							Heading
+						</Card.Title>
+					</Card.Header>
+				</Card.Root>
+			);
+
+			expect( titleRef.current ).toBeInstanceOf( HTMLHeadingElement );
+			expect( titleRef.current?.tagName ).toBe( 'H3' );
+		} );
 	} );
 } );

--- a/packages/ui/src/card/title.tsx
+++ b/packages/ui/src/card/title.tsx
@@ -2,16 +2,20 @@ import { forwardRef } from '@wordpress/element';
 import { Text } from '../text';
 import type { TitleProps } from './types';
 
+const DEFAULT_TAG = <div />;
+
 /**
  * The title for a card. Renders as a `<div>` by default — use the `render`
  * prop to swap in a semantic heading element when appropriate.
  */
 export const Title = forwardRef< HTMLDivElement, TitleProps >(
-	function CardTitle( { render, children, ...props }, ref ) {
+	function CardTitle( { render = DEFAULT_TAG, children, ...props }, ref ) {
 		return (
 			<Text
+				ref={ ref }
 				variant="heading-lg"
-				render={ render ?? <div ref={ ref } { ...props } /> }
+				render={ render }
+				{ ...props }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/empty-state/description.tsx
+++ b/packages/ui/src/empty-state/description.tsx
@@ -4,6 +4,8 @@ import { Text } from '../text';
 import type { EmptyStateDescriptionProps } from './types';
 import styles from './style.module.css';
 
+const DEFAULT_TAG = <p />;
+
 /**
  * The description text for an empty state, providing additional context and
  * guidance on what the user should do next.
@@ -12,14 +14,16 @@ export const Description = forwardRef<
 	HTMLParagraphElement,
 	EmptyStateDescriptionProps
 >( function EmptyStateDescription(
-	{ render, className, children, ...props },
+	{ render = DEFAULT_TAG, className, children, ...props },
 	ref
 ) {
 	return (
 		<Text
+			ref={ ref }
 			variant="body-md"
-			render={ render ?? <p ref={ ref } { ...props } /> }
+			render={ render }
 			className={ clsx( styles.description, className ) }
+			{ ...props }
 		>
 			{ children }
 		</Text>

--- a/packages/ui/src/empty-state/test/description.test.tsx
+++ b/packages/ui/src/empty-state/test/description.test.tsx
@@ -10,4 +10,17 @@ describe( 'EmptyState.Description', () => {
 
 		expect( ref.current ).toBeInstanceOf( HTMLParagraphElement );
 	} );
+
+	it( 'forwards ref to custom render element', () => {
+		const ref = createRef< HTMLDivElement >();
+
+		render(
+			<Description ref={ ref } render={ <div /> }>
+				Description text
+			</Description>
+		);
+
+		expect( ref.current ).toBeInstanceOf( HTMLDivElement );
+		expect( ref.current?.tagName ).toBe( 'DIV' );
+	} );
 } );

--- a/packages/ui/src/empty-state/test/title.test.tsx
+++ b/packages/ui/src/empty-state/test/title.test.tsx
@@ -10,4 +10,17 @@ describe( 'EmptyState.Title', () => {
 
 		expect( ref.current ).toBeInstanceOf( HTMLHeadingElement );
 	} );
+
+	it( 'forwards ref to custom render element', () => {
+		const ref = createRef< HTMLHeadingElement >();
+
+		render(
+			<Title ref={ ref } render={ <h3 /> }>
+				No results found
+			</Title>
+		);
+
+		expect( ref.current ).toBeInstanceOf( HTMLHeadingElement );
+		expect( ref.current?.tagName ).toBe( 'H3' );
+	} );
 } );

--- a/packages/ui/src/empty-state/title.tsx
+++ b/packages/ui/src/empty-state/title.tsx
@@ -4,16 +4,23 @@ import { Text } from '../text';
 import type { EmptyStateTitleProps } from './types';
 import styles from './style.module.css';
 
+const DEFAULT_TAG = <h2 />;
+
 /**
  * The title is a short heading that communicates the empty state.
  */
 export const Title = forwardRef< HTMLHeadingElement, EmptyStateTitleProps >(
-	function EmptyStateTitle( { render, className, children, ...props }, ref ) {
+	function EmptyStateTitle(
+		{ render = DEFAULT_TAG, className, children, ...props },
+		ref
+	) {
 		return (
 			<Text
+				ref={ ref }
 				variant="heading-lg"
-				render={ render ?? <h2 ref={ ref } { ...props } /> }
+				render={ render }
 				className={ clsx( styles.title, className ) }
+				{ ...props }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/popover/description.tsx
+++ b/packages/ui/src/popover/description.tsx
@@ -12,17 +12,12 @@ import type { DescriptionProps } from './types';
  * Uses the `body-md` text variant by default.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
-	function PopoverDescription(
-		{ className, children, render, ...props },
-		ref
-	) {
+	function PopoverDescription( { className, children, ...props }, ref ) {
 		return (
 			<Text
 				ref={ ref }
 				variant="body-md"
-				render={
-					<_Popover.Description render={ render } { ...props } />
-				}
+				render={ <_Popover.Description { ...props } /> }
 				className={ clsx( styles.description, className ) }
 			>
 				{ children }

--- a/packages/ui/src/popover/title.tsx
+++ b/packages/ui/src/popover/title.tsx
@@ -22,10 +22,7 @@ import type { TitleProps } from './types';
  * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function PopoverTitle(
-		{ className, children, render, ...props },
-		forwardedRef
-	) {
+	function PopoverTitle( { className, children, ...props }, forwardedRef ) {
 		const validationContext = usePopoverValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -38,7 +35,7 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 			<Text
 				ref={ mergedRef }
 				variant="heading-xl"
-				render={ <_Popover.Title render={ render } { ...props } /> }
+				render={ <_Popover.Title { ...props } /> }
 				className={ className }
 			>
 				{ children }

--- a/packages/ui/src/tabs/list.tsx
+++ b/packages/ui/src/tabs/list.tsx
@@ -21,7 +21,6 @@ export const List = forwardRef< HTMLDivElement, TabListProps >(
 			variant = 'default',
 			className,
 			activateOnFocus,
-			render,
 			...otherProps
 		},
 		forwardedRef


### PR DESCRIPTION
## What?

Follow-up to #76438.

Fix a ref-loss bug in three components, normalize `render` prop handling across `@wordpress/ui`, and document the conventions in `CONTRIBUTING.md`.

## Why?

The "explicit with fallback" pattern (`render ?? <el ref={ref} {...props} />`) loses the forwarded `ref` and rest props when consumers provide a custom `render`. Additional minor inconsistencies were found during the audit.

## How?

- **Bug fix**: `card/title`, `empty-state/title`, `empty-state/description` — hoisted defaults to module-level constants, pass `ref` and `...props` separately.
- **Cleanup**: `tabs/list` — stopped silently discarding `render`. `popover/title` and `popover/description` — let `render` flow implicitly via `...props`.
- **Docs**: Added "`render` Prop and Ref Forwarding" section to `packages/ui/CONTRIBUTING.md`.
- **Tests**: Added ref-forwarding-with-custom-render tests for the three fixed components.

<details>
<summary>Full audit details and pattern catalogue</summary>

### Pattern A: Direct `useRender` (17 components) — correct

Custom components using `useRender` + `mergeProps` from `@base-ui/react`. The forwarded `ref` is passed directly to `useRender`, which handles composition.

Used by: `badge`, `text`, `stack`, `link`, `visually-hidden`, `card/root`, `card/header`, `card/content`, `card/full-bleed`, `dialog/footer`, `dialog/header`, `empty-state/root`, `empty-state/actions`, `empty-state/visual`, `notice/root`, `notice/actions`, `fieldset/description`.

### Pattern B: Thin Base UI wrapper (16+ components) — correct

Pass `ref` explicitly, spread `...props` (which carries `render` through). Base UI handles ref + render composition.

Used by: `collapsible/*`, `button`, `dialog/*`, `alert-dialog/trigger`, `tooltip/trigger`, `tabs/*`, `field/control`, `field/root`, `field/label`, `input`, `select/*`, `popover/*`.

### Pattern C: Explicit `render` with fallback (3 components) — bug, fixed in this PR

```tsx
// Before: ref lost when consumer provides render
render={ render ?? <div ref={ ref } { ...props } /> }

// After: hoisted constant + separate ref/props
const DEFAULT_TAG = <div />;
function MyTitle( { render = DEFAULT_TAG, ...props }, ref ) {
    return <Text ref={ ref } render={ render } { ...props } />;
}
```

### Pattern D: Delegation via inner component (6 components) — correct

Pass `ref` and spread `...props` (including `render`) to inner `@wordpress/ui` components.

Used by: `notice/title`, `notice/description`, `notice/action-button`, `notice/action-link`, `notice/close-icon`, `empty-state/icon`.

### Explicit vs implicit convention

Prefer implicit (via `...props` rest spread) unless the component needs to interact with `render`:

1. **Assign a default** — `render = DEFAULT_TAG`
2. **Transform** — wrap or modify the value
3. **Discard** — intentionally prevent customization (must also `Omit` from types)
4. **Pass to `useRender`** — required by the hook API

</details>

## Testing Instructions

1. `npm run test:unit -- -- packages/ui/src/card/test/ packages/ui/src/empty-state/test/ packages/ui/src/dialog/test/ packages/ui/src/tabs/test/ packages/ui/src/popover/test/ --no-coverage`
2. Check Card, EmptyState, Dialog, Tabs, and Popover stories in Storybook.

### Testing Instructions for Keyboard

No user-facing interaction changes.

## Use of AI Tools

Cursor + Claude Opus 4.6