### PR TITLE
ui/`Dialog`: update Header layout, refactor Title to use Text

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Enhancements
 
+-   `Dialog`: Update `Header` layout to support multiple trailing elements alongside the title ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
 
 ### Internal

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Enhancements
 
 -   `Dialog`: Update `Header` layout to support multiple trailing elements alongside the title ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
+-   `Dialog`: Use `Text` internally for `Dialog.Title`, adopting the `heading-xl` variant for consistent typography ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
 
 ### Internal

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -64,7 +64,6 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 							<Text
 								variant="heading-xl"
 								render={ <_AlertDialog.Title /> }
-								className={ dialogStyles.title }
 							>
 								{ title }
 							</Text>

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -92,13 +92,14 @@
 
 	.header {
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
+		gap: var(--wpds-dimension-gap-sm);
 		margin-bottom: var(--wpds-dimension-gap-lg);
 	}
 
 	.title {
 		margin: 0;
+		margin-inline-end: auto;
 		font-size: var(--wpds-font-size-xl);
 		font-weight: var(--wpds-font-weight-medium);
 		line-height: var(--wpds-font-line-height-xl);

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -98,12 +98,7 @@
 	}
 
 	.title {
-		margin: 0;
 		margin-inline-end: auto;
-		font-size: var(--wpds-font-size-xl);
-		font-weight: var(--wpds-font-weight-medium);
-		line-height: var(--wpds-font-line-height-xl);
-		color: var(--wpds-color-fg-content-neutral);
 	}
 
 	.footer {

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -98,7 +98,12 @@
 	}
 
 	.title {
-		margin-inline-end: auto;
+		/* Workaround the higher specificity of the global CSS defense styles */
+		--_gcd-heading-margin: 0 auto 0 0;
+
+		&:dir(rtl) {
+			--_gcd-heading-margin: 0 0 0 auto;
+		}
 	}
 
 	.footer {

--- a/packages/ui/src/dialog/title.tsx
+++ b/packages/ui/src/dialog/title.tsx
@@ -1,7 +1,7 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
-import clsx from 'clsx';
 import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useLayoutEffect, useRef } from '@wordpress/element';
+import { Text } from '../text';
 import { useDialogValidationContext } from './context';
 import styles from './style.module.css';
 import type { TitleProps } from './types';
@@ -11,11 +11,12 @@ import type { TitleProps } from './types';
  * and serves as both the visible heading and the accessible label for
  * the dialog.
  *
- * Base UI's Dialog.Title renders an `<h2>` by default. Use the `render` prop
+ * Uses the `heading-xl` text variant, matching Popover. Base UI's
+ * Dialog.Title renders an `<h2>` by default. Use the `render` prop
  * to customize the element if needed.
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function DialogTitle( { className, render, ...props }, forwardedRef ) {
+	function DialogTitle( { children, ...props }, forwardedRef ) {
 		const validationContext = useDialogValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -26,12 +27,14 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 		}, [ validationContext ] );
 
 		return (
-			<_Dialog.Title
+			<Text
 				ref={ mergedRef }
-				className={ clsx( styles.title, className ) }
-				render={ render }
-				{ ...props }
-			/>
+				variant="heading-xl"
+				render={ <_Dialog.Title { ...props } /> }
+				className={ styles.title }
+			>
+				{ children }
+			</Text>
 		);
 	}
 );


### PR DESCRIPTION
## What?

Follow up to #75390

Two small `Dialog` improvements:
1. Fix `Header` layout to support multiple trailing elements alongside the title.
2. Refactor `Title` to use `Text` internally with the `heading-xl` variant, matching `Popover.Title`.

## Why?

1. `.header` used `justify-content: space-between`, which breaks when more than two children are present (e.g. an action button next to the close icon).
2. `Dialog.Title` duplicated typography rules in CSS instead of delegating to the `Text` component like `Popover.Title` already does.

## How?

**Header layout (CSS-only):**
- Replace `justify-content: space-between` with `gap` on `.header`
- Add `margin-inline-end: auto` on `.title` to push trailing elements to the end

**Title refactor:**
- `Dialog.Title` renders through `<Text variant="heading-xl">`, same pattern as `Popover.Title`
- `.title` CSS reduced to `margin-inline-end: auto` only; typography handled by `Text`
- `AlertDialog` drops the `dialogStyles.title` override, relying on `Text variant="heading-xl"`

<details>
<summary>Scope notes</summary>

Only `Dialog.Header` is affected by the layout change:
- `AlertDialog` uses a vertical `Stack`
- `Notice` uses CSS grid
- `Popover` / `Drawer` don't have a Header subcomponent
</details>

## Testing Instructions

1. Open Dialog Storybook stories
2. Verify title + close icon render correctly
3. Add an extra element after `<Dialog.Title>` inside `<Dialog.Header>` — confirm proper spacing
4. Verify title typography matches the `heading-xl` design token

### Testing Instructions for Keyboard

No keyboard interaction changes.

## Use of AI Tools

Made with [Cursor](https://cursor.com).