### PR TITLE
RTC: Improve array attribute stability when structural changes occur

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -693,13 +693,15 @@ function mergeYArray(
 		newValue.length - yArray.length
 	);
 
-	for ( let i = 0; i < numOfInsertionsNeeded; i++ ) {
-		yArray.insert( left + numOfUpdatesNeeded + i, [
-			createYMapFromQuery(
-				query,
-				newValue[ left + numOfUpdatesNeeded + i ]
-			),
-		] );
+	if ( numOfInsertionsNeeded > 0 ) {
+		const insertAt = left + numOfUpdatesNeeded;
+
+		yArray.insert(
+			insertAt,
+			newValue
+				.slice( insertAt, insertAt + numOfInsertionsNeeded )
+				.map( ( item ) => createYMapFromQuery( query, item ) )
+		);
 	}
 }
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -695,13 +695,18 @@ function mergeYArray(
 
 	if ( numOfInsertionsNeeded > 0 ) {
 		const insertAt = left + numOfUpdatesNeeded;
-
-		yArray.insert(
-			insertAt,
-			newValue
-				.slice( insertAt, insertAt + numOfInsertionsNeeded )
-				.map( ( item ) => createYMapFromQuery( query, item ) )
+		const itemsToInsert: Y.Map< unknown >[] = new Array(
+			numOfInsertionsNeeded
 		);
+
+		for ( let i = 0; i < numOfInsertionsNeeded; i++ ) {
+			itemsToInsert[ i ] = createYMapFromQuery(
+				query,
+				newValue[ insertAt + i ]
+			);
+		}
+
+		yArray.insert( insertAt, itemsToInsert );
 	}
 }
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -458,6 +458,7 @@ export function mergeCrdtBlocks(
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
 		const block = blocksToSync[ left ];
 		const yblock = yblocks.get( left );
+
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'attributes': {
@@ -582,12 +583,32 @@ export function mergeCrdtBlocks(
 }
 
 /**
+ * Compare a plain array element against a Y.Map element for equality.
+ * Used by the left-right sweep diff in mergeYArray.
+ *
+ * @param newElement The plain object from the incoming array.
+ * @param yElement   The Y.Map element from the existing Y.Array.
+ * @return True if the elements are deeply equal.
+ */
+function areArrayElementsEqual(
+	newElement: unknown,
+	yElement: unknown
+): boolean {
+	if ( yElement instanceof Y.Map && isRecord( newElement ) ) {
+		return fastDeepEqual( newElement, yElement.toJSON() );
+	}
+
+	return fastDeepEqual( newElement, yElement );
+}
+
+/**
  * Merge an incoming plain array into an existing Y.Array in-place.
  *
- * When the array length is unchanged (stable structure), each element is
- * merged individually via `mergeYMapValues`, preserving concurrent edits to
- * different elements. When the length changes (structural edit such as row
- * insertion/deletion), the Y.Array is rebuilt from scratch.
+ * Uses the same left-right sweep diff approach as mergeCrdtBlocks:
+ * equal elements are skipped from both ends, then the middle section
+ * is updated, deleted, or inserted as needed. This preserves existing
+ * Y.Map/Y.Text objects for unchanged elements, so concurrent edits
+ * to those elements are not lost.
  *
  * @param yArray         The existing Y.Array to update.
  * @param newValue       The new plain array to merge into the Y.Array.
@@ -605,40 +626,80 @@ function mergeYArray(
 	}
 
 	const query = schema.query;
+	const numOfCommonEntries = Math.min( newValue.length, yArray.length );
 
-	if ( yArray.length === newValue.length ) {
-		// Same length: update each element in-place.
-		for ( let i = 0; i < newValue.length; i++ ) {
-			const currentElement = yArray.get( i );
-			const newElement = newValue[ i ];
+	let left = 0;
+	let right = 0;
 
-			if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
-				mergeYMapValues(
-					currentElement,
-					newElement,
-					query,
-					cursorPosition
-				);
-			} else {
-				// Element is the wrong type (e.g. partial migration) or the
-				// incoming value is not an object. Rebuild the entire array.
-				yArray.delete( 0, yArray.length );
-				yArray.insert(
-					0,
-					newValue.map( ( item ) =>
-						createYMapFromQuery( query, item )
-					)
-				);
-				return;
-			}
-		}
-	} else {
-		// Structure changed: rebuild the Y.Array.
-		yArray.delete( 0, yArray.length );
-		yArray.insert(
-			0,
-			newValue.map( ( item ) => createYMapFromQuery( query, item ) )
+	// Skip equal elements from left.
+	for (
+		;
+		left < numOfCommonEntries &&
+		areArrayElementsEqual( newValue[ left ], yArray.get( left ) );
+		left++
+	) {
+		/* nop */
+	}
+
+	// Skip equal elements from right.
+	for (
+		;
+		right < numOfCommonEntries - left &&
+		areArrayElementsEqual(
+			newValue[ newValue.length - right - 1 ],
+			yArray.get( yArray.length - right - 1 )
 		);
+		right++
+	) {
+		/* nop */
+	}
+
+	// Updates: merge changed elements in-place.
+	const numOfUpdatesNeeded = numOfCommonEntries - left - right;
+
+	for ( let i = 0; i < numOfUpdatesNeeded; i++ ) {
+		const currentElement = yArray.get( left + i );
+		const newElement = newValue[ left + i ];
+
+		if ( currentElement instanceof Y.Map && isRecord( newElement ) ) {
+			mergeYMapValues(
+				currentElement,
+				newElement,
+				query,
+				cursorPosition
+			);
+		} else {
+			// Element is the wrong type (e.g. partial migration) or the
+			// incoming value is not an object. Rebuild the entire array.
+			yArray.delete( 0, yArray.length );
+			yArray.insert(
+				0,
+				newValue.map( ( item ) => createYMapFromQuery( query, item ) )
+			);
+			return;
+		}
+	}
+
+	// Deletes.
+	const numOfDeletionsNeeded = Math.max( 0, yArray.length - newValue.length );
+
+	if ( numOfDeletionsNeeded > 0 ) {
+		yArray.delete( left + numOfUpdatesNeeded, numOfDeletionsNeeded );
+	}
+
+	// Inserts.
+	const numOfInsertionsNeeded = Math.max(
+		0,
+		newValue.length - yArray.length
+	);
+
+	for ( let i = 0; i < numOfInsertionsNeeded; i++ ) {
+		yArray.insert( left + numOfUpdatesNeeded + i, [
+			createYMapFromQuery(
+				query,
+				newValue[ left + numOfUpdatesNeeded + i ]
+			),
+		] );
 	}
 }
 

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -1428,7 +1428,7 @@ describe( 'crdt-blocks', () => {
 			expect( a1Content.toString() ).toBe( 'A1-edited' );
 		} );
 
-		it( 'rebuilds Y.Array when row count changes (structural edit)', () => {
+		it( 'preserves existing elements and appends new rows when row count increases', () => {
 			const tableBlocks: Block[] = [
 				{
 					name: 'core/table',
@@ -1565,6 +1565,298 @@ describe( 'crdt-blocks', () => {
 			}
 
 			doc2.destroy();
+		} );
+
+		it( 'concurrent cell edit is preserved when another user appends a row', () => {
+			// Two users: A edits a cell, B appends a row. After sync,
+			// A's edit should be preserved alongside the new row.
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			// Set up doc1 (User A).
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Set up doc2 (User B) by syncing initial state.
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			// User A edits cell A1.
+			const userABlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1-userA', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			mergeCrdtBlocks( yblocks, userABlocks, null );
+
+			// User B appends a third row (concurrently, before syncing).
+			const userBBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A3', tag: 'td' },
+									{ content: 'B3', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			mergeCrdtBlocks( yblocks2, userBBlocks, null );
+
+			// Sync: apply each other's changes.
+			const updateA = Y.encodeStateAsUpdate( doc );
+			const updateB = Y.encodeStateAsUpdate( doc2 );
+			Y.applyUpdate( doc2, updateA );
+			Y.applyUpdate( doc, updateB );
+
+			// Both docs should have A's cell edit and B's new row.
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				const attrs = checkBlocks
+					.get( 0 )
+					.get( 'attributes' ) as YBlockAttributes;
+				const body = (
+					attrs.get( 'body' ) as Y.Array< unknown >
+				 ).toJSON() as { cells: { content: string }[] }[];
+
+				expect( body.length ).toBe( 3 );
+				expect( body[ 0 ].cells[ 0 ].content ).toBe( 'A1-userA' );
+				expect( body[ 0 ].cells[ 1 ].content ).toBe( 'B1' );
+				expect( body[ 1 ].cells[ 0 ].content ).toBe( 'A2' );
+				expect( body[ 2 ].cells[ 0 ].content ).toBe( 'A3' );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'concurrent cell edit is preserved when another user deletes a different row', () => {
+			// Two users: A edits a cell in row 1, B deletes row 2.
+			// After sync, A's edit should survive and row 2 should be gone.
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A3', tag: 'td' },
+									{ content: 'B3', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			// Set up doc1 (User A).
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Set up doc2 (User B) by syncing initial state.
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			// User A edits cell A1 in row 1.
+			const userABlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1-userA', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A2', tag: 'td' },
+									{ content: 'B2', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A3', tag: 'td' },
+									{ content: 'B3', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			mergeCrdtBlocks( yblocks, userABlocks, null );
+
+			// User B deletes row 2 (the middle row).
+			const userBBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [
+									{ content: 'A1', tag: 'td' },
+									{ content: 'B1', tag: 'td' },
+								],
+							},
+							{
+								cells: [
+									{ content: 'A3', tag: 'td' },
+									{ content: 'B3', tag: 'td' },
+								],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+			mergeCrdtBlocks( yblocks2, userBBlocks, null );
+
+			// Sync: apply each other's changes.
+			const updateA = Y.encodeStateAsUpdate( doc );
+			const updateB = Y.encodeStateAsUpdate( doc2 );
+			Y.applyUpdate( doc2, updateA );
+			Y.applyUpdate( doc, updateB );
+
+			// Both docs should have A's cell edit and B's row deletion.
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				const attrs = checkBlocks
+					.get( 0 )
+					.get( 'attributes' ) as YBlockAttributes;
+				const body = (
+					attrs.get( 'body' ) as Y.Array< unknown >
+				 ).toJSON() as { cells: { content: string }[] }[];
+
+				expect( body.length ).toBe( 2 );
+				expect( body[ 0 ].cells[ 0 ].content ).toBe( 'A1-userA' );
+				expect( body[ 1 ].cells[ 0 ].content ).toBe( 'A3' );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'preserves Y.Map identity for untouched rows when a row is appended', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Capture a reference to the Y.Map for the first row.
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row0Before = body.get( 0 ) as Y.Map< unknown >;
+
+			// Append a second row.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			// The first row's Y.Map should be the exact same object.
+			const row0After = body.get( 0 ) as Y.Map< unknown >;
+			expect( row0After ).toBe( row0Before );
+
+			// And the new row should exist.
+			expect( body.length ).toBe( 2 );
+			const row1 = body.get( 1 ) as Y.Map< unknown >;
+			const cells = ( row1.get( 'cells' ) as Y.Array< unknown > ).get(
+				0
+			) as Y.Map< unknown >;
+			const content = cells.get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'A2' );
 		} );
 
 		it( 'migrates plain array to Y.Array on first update', () => {

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -1859,6 +1859,257 @@ describe( 'crdt-blocks', () => {
 			expect( content.toString() ).toBe( 'A2' );
 		} );
 
+		it( 'preserves Y.Map identity when a row is prepended', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row0Before = body.get( 0 ) as Y.Map< unknown >;
+			const row1Before = body.get( 1 ) as Y.Map< unknown >;
+
+			// Prepend a new row.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'NEW', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( body.length ).toBe( 3 );
+
+			const bodyJson = body.toJSON() as {
+				cells: { content: string }[];
+			}[];
+			expect( bodyJson[ 0 ].cells[ 0 ].content ).toBe( 'NEW' );
+			expect( bodyJson[ 1 ].cells[ 0 ].content ).toBe( 'A1' );
+			expect( bodyJson[ 2 ].cells[ 0 ].content ).toBe( 'A2' );
+
+			// Original rows should be the same Y.Map objects (shifted).
+			expect( body.get( 1 ) ).toBe( row0Before );
+			expect( body.get( 2 ) ).toBe( row1Before );
+		} );
+
+		it( 'preserves Y.Map identity when a row is inserted in the middle', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A3', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row0Before = body.get( 0 ) as Y.Map< unknown >;
+			const row1Before = body.get( 1 ) as Y.Map< unknown >;
+
+			// Insert a new row in the middle.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A3', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( body.length ).toBe( 3 );
+
+			const bodyJson = body.toJSON() as {
+				cells: { content: string }[];
+			}[];
+			expect( bodyJson[ 0 ].cells[ 0 ].content ).toBe( 'A1' );
+			expect( bodyJson[ 1 ].cells[ 0 ].content ).toBe( 'A2' );
+			expect( bodyJson[ 2 ].cells[ 0 ].content ).toBe( 'A3' );
+
+			// Original rows should be preserved.
+			expect( body.get( 0 ) ).toBe( row0Before );
+			expect( body.get( 2 ) ).toBe( row1Before );
+		} );
+
+		it( 'preserves Y.Map identity when a row is deleted from the end', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A3', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row0Before = body.get( 0 ) as Y.Map< unknown >;
+			const row1Before = body.get( 1 ) as Y.Map< unknown >;
+
+			// Delete the last row.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( body.length ).toBe( 2 );
+
+			const bodyJson = body.toJSON() as {
+				cells: { content: string }[];
+			}[];
+			expect( bodyJson[ 0 ].cells[ 0 ].content ).toBe( 'A1' );
+			expect( bodyJson[ 1 ].cells[ 0 ].content ).toBe( 'A2' );
+
+			// Remaining rows should be the same Y.Map objects.
+			expect( body.get( 0 ) ).toBe( row0Before );
+			expect( body.get( 1 ) ).toBe( row1Before );
+		} );
+
+		it( 'updates all elements in-place when every row changes', () => {
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'A1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'A2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			const attrs = yblocks
+				.get( 0 )
+				.get( 'attributes' ) as YBlockAttributes;
+			const body = attrs.get( 'body' ) as Y.Array< unknown >;
+			const row0Before = body.get( 0 ) as Y.Map< unknown >;
+			const row1Before = body.get( 1 ) as Y.Map< unknown >;
+
+			// Replace all row contents.
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/table',
+					attributes: {
+						body: [
+							{
+								cells: [ { content: 'X1', tag: 'td' } ],
+							},
+							{
+								cells: [ { content: 'X2', tag: 'td' } ],
+							},
+						],
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( body.length ).toBe( 2 );
+
+			const bodyJson = body.toJSON() as {
+				cells: { content: string }[];
+			}[];
+			expect( bodyJson[ 0 ].cells[ 0 ].content ).toBe( 'X1' );
+			expect( bodyJson[ 1 ].cells[ 0 ].content ).toBe( 'X2' );
+
+			// Y.Map objects should be updated in-place, not recreated.
+			expect( body.get( 0 ) ).toBe( row0Before );
+			expect( body.get( 1 ) ).toBe( row1Before );
+		} );
+
 		it( 'migrates plain array to Y.Array on first update', () => {
 			// Manually set up a block with a plain array body (old format).
 			const block = new Y.Map() as unknown as YBlock;


### PR DESCRIPTION
## What?

In current `trunk`, changing the array-type block attributes (like in a `core/table` block) can cause data loss to other folks editing within the same block:

https://github.com/user-attachments/assets/a83c0624-2444-4c97-ae13-0eb35f049ebd

Instead of [rebuilding the entire `Y.Array`](https://github.com/WordPress/gutenberg/blob/f42fde507b2f0f0407faa7ef9b5b9989f989d416/packages/core-data/src/utils/crdt-blocks.ts#L636-L641) when its length changes, the merge function in this PR now diffs the old and new arrays and applies only the necessary inserts, deletes, and updates, like `mergeCrdtBlocks()`.

## Why?

When a block attribute is an array with a `query` schema (e.g. `core/table` rows), the CRDT layer uses `mergeYArray` to sync changes. Previously, any change to the array's length caused the entire Y.Array to be deleted and rebuilt from scratch. This destroys the existing Y.Map and Y.Text objects inside, so concurrent edits to other elements in the array are lost and the higher client ID wins. This also applies to structured `array` data used in custom blocks.

## How?

Replaced the same-length-or-rebuild logic in `mergeYArray()` with the same left-right sweep diff algorithm already used by `mergeCrdtBlocks()` for the top-level blocks array. The approach skips equal elements from both ends, then updates changed elements in-place, deletes removed elements from the middle, and inserts new elements into the middle.

This means appending a row to a table no longer destroys the `Y.Text` objects in existing cells. Only the newly inserted element creates a new `Y.Map`, and concurrent edits to untouched elements are preserved:

https://github.com/user-attachments/assets/aec4aa87-2e8b-4019-b560-eaa637ecea5a

Note that inserting rows / columns *before* the active cell still causes issues. That's because the selected cell is a state attribute [stored in the table block](https://github.com/WordPress/gutenberg/blob/f42fde507b2f0f0407faa7ef9b5b9989f989d416/packages/block-library/src/table/edit.js#L112). It will likely take block-specific changes in order to correctly handle updates from remote peers that change the local selected cell.

## Testing Instructions

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Open a post collaboratively in two tabs.
3. In one session, insert a table. Begin continuously typing in a cell. Here's a JS one-liner that can do that:

    ```js
    // First, click into cell, then paste this into the developer console:
    ((d=document.querySelector('iframe[name="editor-canvas"]').contentDocument,t=d.activeElement,i=0,buf='')=>window._typer=setInterval(()=>{if(!buf){i++;buf=(i===1?'':', ')+i}let k=buf[0];buf=buf.slice(1);t.dispatchEvent(new KeyboardEvent('keydown',{key:k,bubbles:true}));d.execCommand('insertText',false,k);t.dispatchEvent(new KeyboardEvent('keyup',{key:k,bubbles:true}))},150))()

    // To stop typing:
    // clearInterval(window._typer)
    ```
4. In the other session, while the first user is still typing, insert a new row at the end of the table. Confirm that the cell edit from the first window is not lost after the row is added.
5. Try deleting a row in one window while editing a different row's cell in the other. Confirm the cell edit is preserved and the correct row is removed.

If you try the same steps on `trunk`, you'll see some updates get lost during the table transformation as shown in the video at the start of this PR.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Writing the left-right sweep diff algorithm for `mergeYArray()`