### PR TITLE
UI: Upgrade title validation to cleanup-based re-validation

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 -   `Dialog`, `AlertDialog`, `Popover`, `Tooltip`, `Select`: Fix broken focus-trap caused by ThemeProvider's `display: contents` and Base UI's `checkVisibility()` ([#77381](https://github.com/WordPress/gutenberg/pull/77381)).
 
+### Enhancements
+
+-   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
+
+### Internal
+
+-   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
+
 ## 0.11.0 (2026-04-15)
 
 ### Breaking Changes
@@ -34,7 +42,6 @@
 -   `Dialog`, `AlertDialog`, `Tooltip`, `Select`: Add `container` prop to `Popup` for custom portal targets ([#77163](https://github.com/WordPress/gutenberg/pull/77163)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
 -   `VisuallyHidden`: Improve Storybook stories and documentation for the `render` prop composition pattern.
--   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 
 ### Internal
 
@@ -45,7 +52,6 @@
 -   `Badge`: Use `Text` component for typography ([#77295](https://github.com/WordPress/gutenberg/pull/77295)).
 -   `Notice.ActionLink`: Use `Text` component for typography ([#77332](https://github.com/WordPress/gutenberg/pull/77332)).
 -   Update `@base-ui/react` from `1.3.0` to `1.4.0` ([#77308](https://github.com/WordPress/gutenberg/pull/77308)).
--   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 
 ## 0.10.0 (2026-04-01)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -34,6 +34,7 @@
 -   `Dialog`, `AlertDialog`, `Tooltip`, `Select`: Add `container` prop to `Popup` for custom portal targets ([#77163](https://github.com/WordPress/gutenberg/pull/77163)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
 -   `VisuallyHidden`: Improve Storybook stories and documentation for the `render` prop composition pattern.
+-   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 
 ### Internal
 
@@ -44,6 +45,7 @@
 -   `Badge`: Use `Text` component for typography ([#77295](https://github.com/WordPress/gutenberg/pull/77295)).
 -   `Notice.ActionLink`: Use `Text` component for typography ([#77332](https://github.com/WordPress/gutenberg/pull/77332)).
 -   Update `@base-ui/react` from `1.3.0` to `1.4.0` ([#77308](https://github.com/WordPress/gutenberg/pull/77308)).
+-   Extract shared `useScheduleValidation` hook; refactor `Dialog`, `Popover`, and `Tabs` validation contexts to use it ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 
 ## 0.10.0 (2026-04-01)
 

--- a/packages/ui/src/dialog/context.tsx
+++ b/packages/ui/src/dialog/context.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useRef,
 } from '@wordpress/element';
+import { useScheduleValidation } from '../utils/use-schedule-validation';
 
 /**
  * Whether validation is enabled. This is a build-time constant that allows
@@ -14,7 +15,7 @@ import {
 const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
 
 type DialogValidationContextType = {
-	registerTitle: ( element: HTMLElement | null ) => void;
+	registerTitle: ( element: HTMLElement | null ) => () => void;
 };
 
 // Context is only created in development mode.
@@ -54,19 +55,7 @@ function DialogValidationProviderDev( {
 } ) {
 	const titleElementRef = useRef< HTMLElement | null >( null );
 
-	const registerTitle = useCallback( ( element: HTMLElement | null ) => {
-		titleElementRef.current = element;
-	}, [] );
-
-	const contextValue = useMemo(
-		() => ( { registerTitle } ),
-		[ registerTitle ]
-	);
-
-	// Validate that Dialog.Title is rendered with non-empty text content
-	useEffect( () => {
-		// useLayoutEffect in Title runs before this useEffect,
-		// so titleElementRef should already be set if Title is present
+	const scheduleValidation = useScheduleValidation( () => {
 		const titleElement = titleElementRef.current;
 
 		if ( ! titleElement ) {
@@ -84,7 +73,31 @@ function DialogValidationProviderDev( {
 					'Provide meaningful text content for the dialog title.'
 			);
 		}
-	}, [] );
+	} );
+
+	const registerTitle = useCallback(
+		( element: HTMLElement | null ) => {
+			titleElementRef.current = element;
+			scheduleValidation();
+
+			return () => {
+				titleElementRef.current = null;
+				scheduleValidation();
+			};
+		},
+		[ scheduleValidation ]
+	);
+
+	// Schedule an initial validation on mount to catch missing titles
+	// (when no Title component is rendered, registerTitle is never called).
+	useEffect( () => {
+		scheduleValidation();
+	}, [ scheduleValidation ] );
+
+	const contextValue = useMemo(
+		() => ( { registerTitle } ),
+		[ registerTitle ]
+	);
 
 	return (
 		<DialogValidationContext.Provider value={ contextValue }>

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -1,36 +1,19 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Component, createRef } from '@wordpress/element';
-import type { ReactNode } from 'react';
+import { createRef, useState } from '@wordpress/element';
 import * as Dialog from '../index';
 
-class TestErrorBoundary extends Component<
-	{ children: ReactNode; onError: ( error: Error ) => void },
-	{ hasError: boolean }
-> {
-	constructor( props: {
-		children: ReactNode;
-		onError: ( error: Error ) => void;
-	} ) {
-		super( props );
-		this.state = { hasError: false };
-	}
-
-	static getDerivedStateFromError() {
-		return { hasError: true };
-	}
-
-	componentDidCatch( error: Error ) {
-		this.props.onError( error );
-	}
-
-	render() {
-		if ( this.state.hasError ) {
-			return null;
-		}
-
-		return this.props.children;
-	}
+function collectUncaughtErrors() {
+	const errors: Error[] = [];
+	const handler = ( event: ErrorEvent ) => {
+		event.preventDefault();
+		errors.push( event.error );
+	};
+	window.addEventListener( 'error', handler );
+	return {
+		errors,
+		cleanup: () => window.removeEventListener( 'error', handler ),
+	};
 }
 
 describe( 'Dialog', () => {
@@ -81,7 +64,9 @@ describe( 'Dialog', () => {
 	} );
 
 	describe( 'Development mode validation', () => {
-		// Suppress React's error boundary logging for these tests.
+		// Suppress console.error from React act() warnings and jsdom
+		// unhandled-error logging. Validation errors are caught via
+		// collectUncaughtErrors (window 'error' event) instead.
 		let originalConsoleError: typeof console.error;
 
 		beforeEach( () => {
@@ -98,210 +83,305 @@ describe( 'Dialog', () => {
 
 		it( 'should throw when Dialog.Title is missing', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<TestErrorBoundary onError={ onError }>
-					<Dialog.Root>
-						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-						<Dialog.Popup>
-							<Dialog.Header>
-								{ /* Missing Dialog.Title */ }
-							</Dialog.Header>
-							<p>Content without a title</p>
-							<Dialog.Footer>
-								<Dialog.Action>Close</Dialog.Action>
-							</Dialog.Footer>
-						</Dialog.Popup>
-					</Dialog.Root>
-				</TestErrorBoundary>
+				<Dialog.Root>
+					<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+					<Dialog.Popup>
+						<Dialog.Header>
+							{ /* Missing Dialog.Title */ }
+						</Dialog.Header>
+						<p>Content without a title</p>
+						<Dialog.Footer>
+							<Dialog.Action>Close</Dialog.Action>
+						</Dialog.Footer>
+					</Dialog.Popup>
+				</Dialog.Root>
 			);
 
-			// Open the dialog - this will trigger the error in useEffect
 			await user.click(
 				screen.getByRole( 'button', { name: 'Open Dialog' } )
 			);
 
 			await waitFor( () => {
-				expect( onError ).toHaveBeenCalled();
+				expect( errors.length ).toBeGreaterThan( 0 );
 			} );
 
-			expect( onError.mock.calls[ 0 ][ 0 ] ).toBeInstanceOf( Error );
-			expect( ( onError.mock.calls[ 0 ][ 0 ] as Error ).message ).toBe(
+			expect( errors[ 0 ].message ).toBe(
 				'Dialog: Missing <Dialog.Title>. ' +
 					'For accessibility, every dialog requires a title. ' +
 					'If needed, the title can be visually hidden but must not be omitted.'
 			);
+
+			cleanup();
 		} );
 
 		it( 'should not throw before opening the dialog', async () => {
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<TestErrorBoundary onError={ onError }>
-					<Dialog.Root>
-						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-						<Dialog.Popup>
-							<Dialog.Header>
-								<Dialog.Title>My Title</Dialog.Title>
-							</Dialog.Header>
-							<p>Content with a title</p>
-							<Dialog.Footer>
-								<Dialog.Action>Close</Dialog.Action>
-							</Dialog.Footer>
-						</Dialog.Popup>
-					</Dialog.Root>
-				</TestErrorBoundary>
+				<Dialog.Root>
+					<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+					<Dialog.Popup>
+						<Dialog.Header>
+							<Dialog.Title>My Title</Dialog.Title>
+						</Dialog.Header>
+						<p>Content with a title</p>
+						<Dialog.Footer>
+							<Dialog.Action>Close</Dialog.Action>
+						</Dialog.Footer>
+					</Dialog.Popup>
+				</Dialog.Root>
 			);
 
-			// Check that the dialog itself hasn't been rendered in the DOM.
 			await expect( screen.findByRole( 'dialog' ) ).rejects.toThrow();
+			expect( errors ).toHaveLength( 0 );
 
-			expect( onError ).not.toHaveBeenCalled();
+			cleanup();
 		} );
 
 		it( 'should not throw when Dialog.Title is present', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<TestErrorBoundary onError={ onError }>
-					<Dialog.Root>
-						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-						<Dialog.Popup>
-							<Dialog.Header>
-								<Dialog.Title>My Title</Dialog.Title>
-							</Dialog.Header>
-							<p>Content with a title</p>
-							<Dialog.Footer>
-								<Dialog.Action>Close</Dialog.Action>
-							</Dialog.Footer>
-						</Dialog.Popup>
-					</Dialog.Root>
-				</TestErrorBoundary>
+				<Dialog.Root>
+					<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+					<Dialog.Popup>
+						<Dialog.Header>
+							<Dialog.Title>My Title</Dialog.Title>
+						</Dialog.Header>
+						<p>Content with a title</p>
+						<Dialog.Footer>
+							<Dialog.Action>Close</Dialog.Action>
+						</Dialog.Footer>
+					</Dialog.Popup>
+				</Dialog.Root>
 			);
 
-			// Open the dialog - should not throw
 			await user.click(
 				screen.getByRole( 'button', { name: 'Open Dialog' } )
 			);
 
-			// Wait for the dialog to appear and ensure validation does not trigger errors
 			await waitFor( () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
-			expect( onError ).not.toHaveBeenCalled();
+
+			// Allow deferred validation to settle.
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			cleanup();
 		} );
 
 		it( 'should throw when Dialog.Title is empty', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<TestErrorBoundary onError={ onError }>
-					<Dialog.Root>
-						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-						<Dialog.Popup>
-							<Dialog.Header>
-								{ /* Empty title */ }
-								<Dialog.Title />
-							</Dialog.Header>
-							<p>Content with empty title</p>
-							<Dialog.Footer>
-								<Dialog.Action>Close</Dialog.Action>
-							</Dialog.Footer>
-						</Dialog.Popup>
-					</Dialog.Root>
-				</TestErrorBoundary>
+				<Dialog.Root>
+					<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+					<Dialog.Popup>
+						<Dialog.Header>
+							<Dialog.Title />
+						</Dialog.Header>
+						<p>Content with empty title</p>
+						<Dialog.Footer>
+							<Dialog.Action>Close</Dialog.Action>
+						</Dialog.Footer>
+					</Dialog.Popup>
+				</Dialog.Root>
 			);
 
-			// Open the dialog - this will trigger the error
 			await user.click(
 				screen.getByRole( 'button', { name: 'Open Dialog' } )
 			);
 
 			await waitFor( () => {
-				expect( onError ).toHaveBeenCalled();
+				expect( errors.length ).toBeGreaterThan( 0 );
 			} );
 
-			expect( onError.mock.calls[ 0 ][ 0 ] ).toBeInstanceOf( Error );
-			expect( ( onError.mock.calls[ 0 ][ 0 ] as Error ).message ).toBe(
+			expect( errors[ 0 ].message ).toBe(
 				'Dialog: <Dialog.Title> cannot be empty. ' +
 					'Provide meaningful text content for the dialog title.'
 			);
+
+			cleanup();
 		} );
 
 		it( 'should throw when Dialog.Title contains only whitespace', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<TestErrorBoundary onError={ onError }>
-					<Dialog.Root>
-						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-						<Dialog.Popup>
-							<Dialog.Header>
-								<Dialog.Title> </Dialog.Title>
-							</Dialog.Header>
-							<p>Content with whitespace-only title</p>
-							<Dialog.Footer>
-								<Dialog.Action>Close</Dialog.Action>
-							</Dialog.Footer>
-						</Dialog.Popup>
-					</Dialog.Root>
-				</TestErrorBoundary>
+				<Dialog.Root>
+					<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+					<Dialog.Popup>
+						<Dialog.Header>
+							<Dialog.Title> </Dialog.Title>
+						</Dialog.Header>
+						<p>Content with whitespace-only title</p>
+						<Dialog.Footer>
+							<Dialog.Action>Close</Dialog.Action>
+						</Dialog.Footer>
+					</Dialog.Popup>
+				</Dialog.Root>
 			);
 
-			// Open the dialog - this will trigger the error
 			await user.click(
 				screen.getByRole( 'button', { name: 'Open Dialog' } )
 			);
 
 			await waitFor( () => {
-				expect( onError ).toHaveBeenCalled();
+				expect( errors.length ).toBeGreaterThan( 0 );
 			} );
 
-			expect( onError.mock.calls[ 0 ][ 0 ] ).toBeInstanceOf( Error );
-			expect( ( onError.mock.calls[ 0 ][ 0 ] as Error ).message ).toBe(
+			expect( errors[ 0 ].message ).toBe(
 				'Dialog: <Dialog.Title> cannot be empty. ' +
 					'Provide meaningful text content for the dialog title.'
 			);
+
+			cleanup();
 		} );
 
 		it( 'should not throw when Dialog.Title contains mixed content with text', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<TestErrorBoundary onError={ onError }>
-					<Dialog.Root>
-						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-						<Dialog.Popup>
-							<Dialog.Header>
-								<Dialog.Title>
-									<span aria-hidden="true">🎉</span>
-									Settings
-								</Dialog.Title>
-							</Dialog.Header>
-							<p>Content with icon and text title</p>
-							<Dialog.Footer>
-								<Dialog.Action>Close</Dialog.Action>
-							</Dialog.Footer>
-						</Dialog.Popup>
-					</Dialog.Root>
-				</TestErrorBoundary>
+				<Dialog.Root>
+					<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+					<Dialog.Popup>
+						<Dialog.Header>
+							<Dialog.Title>
+								<span aria-hidden="true">🎉</span>
+								Settings
+							</Dialog.Title>
+						</Dialog.Header>
+						<p>Content with icon and text title</p>
+						<Dialog.Footer>
+							<Dialog.Action>Close</Dialog.Action>
+						</Dialog.Footer>
+					</Dialog.Popup>
+				</Dialog.Root>
 			);
 
-			// Open the dialog - should not throw
 			await user.click(
 				screen.getByRole( 'button', { name: 'Open Dialog' } )
 			);
 
-			// Wait for the dialog to appear and ensure validation does not trigger errors
 			await waitFor( () => {
 				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			} );
-			expect( onError ).not.toHaveBeenCalled();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			cleanup();
+		} );
+
+		it( 'should throw when title is removed after mount', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			function Test() {
+				const [ showTitle, setShowTitle ] = useState( true );
+				return (
+					<Dialog.Root>
+						<Dialog.Trigger>Open</Dialog.Trigger>
+						<Dialog.Popup>
+							{ showTitle && (
+								<Dialog.Title>My Title</Dialog.Title>
+							) }
+							<button onClick={ () => setShowTitle( false ) }>
+								Remove Title
+							</button>
+						</Dialog.Popup>
+					</Dialog.Root>
+				);
+			}
+
+			render( <Test /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+
+			// Let initial validation settle — no errors expected.
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			// Remove the title.
+			await user.click(
+				screen.getByRole( 'button', { name: 'Remove Title' } )
+			);
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			expect( errors[ 0 ].message ).toBe(
+				'Dialog: Missing <Dialog.Title>. ' +
+					'For accessibility, every dialog requires a title. ' +
+					'If needed, the title can be visually hidden but must not be omitted.'
+			);
+
+			cleanup();
+		} );
+
+		it( 'should recover when title is added back', async () => {
+			const user = userEvent.setup();
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			function Test() {
+				const [ showTitle, setShowTitle ] = useState( false );
+				return (
+					<Dialog.Root>
+						<Dialog.Trigger>Open</Dialog.Trigger>
+						<Dialog.Popup>
+							{ showTitle && (
+								<Dialog.Title>My Title</Dialog.Title>
+							) }
+							<button
+								onClick={ () => setShowTitle( ( s ) => ! s ) }
+							>
+								Toggle Title
+							</button>
+						</Dialog.Popup>
+					</Dialog.Root>
+				);
+			}
+
+			render( <Test /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+
+			// Initially no title — should error.
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			const errorCountAfterInitial = errors.length;
+
+			// Add the title back.
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle Title' } )
+			);
+
+			// Wait for deferred validation to settle.
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+
+			// No new errors should have been thrown.
+			expect( errors ).toHaveLength( errorCountAfterInitial );
+
+			cleanup();
 		} );
 	} );
 

--- a/packages/ui/src/dialog/title.tsx
+++ b/packages/ui/src/dialog/title.tsx
@@ -1,6 +1,6 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import { useMergeRefs } from '@wordpress/compose';
-import { forwardRef, useLayoutEffect, useRef } from '@wordpress/element';
+import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
 import { useDialogValidationContext } from './context';
 import styles from './style.module.css';
@@ -30,9 +30,11 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
 
-		// Register this title with the parent Popup for validation (dev only)
-		useLayoutEffect( () => {
-			validationContext?.registerTitle( internalRef.current );
+		useEffect( () => {
+			if ( validationContext ) {
+				return validationContext.registerTitle( internalRef.current );
+			}
+			return undefined;
 		}, [ validationContext ] );
 
 		return (

--- a/packages/ui/src/popover/context.tsx
+++ b/packages/ui/src/popover/context.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useRef,
 } from '@wordpress/element';
+import { useScheduleValidation } from '../utils/use-schedule-validation';
 
 /**
  * Whether validation is enabled. This is a build-time constant that allows
@@ -14,7 +15,7 @@ import {
 const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
 
 type PopoverValidationContextType = {
-	registerTitle: ( element: HTMLElement | null ) => void;
+	registerTitle: ( element: HTMLElement | null ) => () => void;
 };
 
 const PopoverValidationContext = VALIDATION_ENABLED
@@ -47,16 +48,7 @@ function PopoverValidationProviderDev( {
 } ) {
 	const titleElementRef = useRef< HTMLElement | null >( null );
 
-	const registerTitle = useCallback( ( element: HTMLElement | null ) => {
-		titleElementRef.current = element;
-	}, [] );
-
-	const contextValue = useMemo(
-		() => ( { registerTitle } ),
-		[ registerTitle ]
-	);
-
-	useEffect( () => {
+	const scheduleValidation = useScheduleValidation( () => {
 		const titleElement = titleElementRef.current;
 
 		if ( ! titleElement ) {
@@ -74,7 +66,31 @@ function PopoverValidationProviderDev( {
 					'Provide meaningful text content for the popover title.'
 			);
 		}
-	}, [] );
+	} );
+
+	const registerTitle = useCallback(
+		( element: HTMLElement | null ) => {
+			titleElementRef.current = element;
+			scheduleValidation();
+
+			return () => {
+				titleElementRef.current = null;
+				scheduleValidation();
+			};
+		},
+		[ scheduleValidation ]
+	);
+
+	// Schedule an initial validation on mount to catch missing titles
+	// (when no Title component is rendered, registerTitle is never called).
+	useEffect( () => {
+		scheduleValidation();
+	}, [ scheduleValidation ] );
+
+	const contextValue = useMemo(
+		() => ( { registerTitle } ),
+		[ registerTitle ]
+	);
 
 	return (
 		<PopoverValidationContext.Provider value={ contextValue }>

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Component, createRef, useState } from '@wordpress/element';
+import { createRef, useState } from '@wordpress/element';
 import * as Popover from '../index';
+
+function collectUncaughtErrors() {
+	const errors: Error[] = [];
+	const handler = ( event: ErrorEvent ) => {
+		event.preventDefault();
+		errors.push( event.error );
+	};
+	window.addEventListener( 'error', handler );
+	return {
+		errors,
+		cleanup: () => window.removeEventListener( 'error', handler ),
+	};
+}
 
 describe( 'Popover', () => {
 	describe( 'forwards ref', () => {
@@ -613,84 +626,87 @@ describe( 'Popover', () => {
 	} );
 
 	describe( 'title validation', () => {
+		// Suppress console.error from React act() warnings and jsdom
+		// unhandled-error logging. Validation errors are caught via
+		// collectUncaughtErrors (window 'error' event) instead.
+		let originalConsoleError: typeof console.error;
+
+		beforeEach( () => {
+			// eslint-disable-next-line no-console
+			originalConsoleError = console.error;
+			// eslint-disable-next-line no-console
+			console.error = jest.fn();
+		} );
+
+		afterEach( () => {
+			// eslint-disable-next-line no-console
+			console.error = originalConsoleError;
+		} );
+
 		it( 'should throw when Popover.Title is missing', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
-
-			// Suppress console.error from React error boundary
-			const spy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation( () => {} );
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<ErrorBoundary onError={ onError }>
-					<Popover.Root>
-						<Popover.Trigger>Open</Popover.Trigger>
-						<Popover.Popup>No title here</Popover.Popup>
-					</Popover.Root>
-				</ErrorBoundary>
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>No title here</Popover.Popup>
+				</Popover.Root>
 			);
 
 			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
 
 			await waitFor( () => {
-				expect( onError ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						message: expect.stringContaining(
-							'Missing <Popover.Title>'
-						),
-					} )
-				);
+				expect( errors.length ).toBeGreaterThan( 0 );
 			} );
 
-			spy.mockRestore();
+			expect( errors[ 0 ].message ).toBe(
+				'Popover: Missing <Popover.Title>. ' +
+					'For accessibility, every popover requires a title. ' +
+					'If needed, the title can be visually hidden but must not be omitted.'
+			);
+
+			cleanup();
 		} );
 
 		it( 'should throw when Popover.Title is empty', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
-
-			const spy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation( () => {} );
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<ErrorBoundary onError={ onError }>
-					<Popover.Root>
-						<Popover.Trigger>Open</Popover.Trigger>
-						<Popover.Popup>
-							<Popover.Title />
-						</Popover.Popup>
-					</Popover.Root>
-				</ErrorBoundary>
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Title />
+					</Popover.Popup>
+				</Popover.Root>
 			);
 
 			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
 
 			await waitFor( () => {
-				expect( onError ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						message: expect.stringContaining( 'cannot be empty' ),
-					} )
-				);
+				expect( errors.length ).toBeGreaterThan( 0 );
 			} );
 
-			spy.mockRestore();
+			expect( errors[ 0 ].message ).toBe(
+				'Popover: <Popover.Title> cannot be empty. ' +
+					'Provide meaningful text content for the popover title.'
+			);
+
+			cleanup();
 		} );
 
 		it( 'should not throw when Popover.Title is present', async () => {
 			const user = userEvent.setup();
-			const onError = jest.fn();
+			const { errors, cleanup } = collectUncaughtErrors();
 
 			render(
-				<ErrorBoundary onError={ onError }>
-					<Popover.Root>
-						<Popover.Trigger>Open</Popover.Trigger>
-						<Popover.Popup>
-							<Popover.Title>Valid Title</Popover.Title>
-						</Popover.Popup>
-					</Popover.Root>
-				</ErrorBoundary>
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Title>Valid Title</Popover.Title>
+					</Popover.Popup>
+				</Popover.Root>
 			);
 
 			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
@@ -699,29 +715,89 @@ describe( 'Popover', () => {
 				expect( screen.getByText( 'Valid Title' ) ).toBeVisible();
 			} );
 
-			expect( onError ).not.toHaveBeenCalled();
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			cleanup();
+		} );
+
+		it( 'should throw when title is removed after mount', async () => {
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			const ui = ( showTitle: boolean ) => (
+				<Popover.Root defaultOpen>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						{ showTitle && <Popover.Title>My Title</Popover.Title> }
+						<p>Content</p>
+					</Popover.Popup>
+				</Popover.Root>
+			);
+
+			const { rerender } = render( ui( true ) );
+
+			// Wait for the popover to render.
+			await waitFor( () => {
+				expect( screen.getByText( 'Content' ) ).toBeInTheDocument();
+			} );
+
+			// Let initial validation settle — no errors expected.
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+			expect( errors ).toHaveLength( 0 );
+
+			// Remove the title via rerender.
+			rerender( ui( false ) );
+
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			expect( errors[ 0 ].message ).toBe(
+				'Popover: Missing <Popover.Title>. ' +
+					'For accessibility, every popover requires a title. ' +
+					'If needed, the title can be visually hidden but must not be omitted.'
+			);
+
+			cleanup();
+		} );
+
+		it( 'should recover when title is added back', async () => {
+			const { errors, cleanup } = collectUncaughtErrors();
+
+			const ui = ( showTitle: boolean ) => (
+				<Popover.Root defaultOpen>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						{ showTitle && <Popover.Title>My Title</Popover.Title> }
+						<p>Content</p>
+					</Popover.Popup>
+				</Popover.Root>
+			);
+
+			const { rerender } = render( ui( false ) );
+
+			// Wait for the popover to render.
+			await waitFor( () => {
+				expect( screen.getByText( 'Content' ) ).toBeInTheDocument();
+			} );
+
+			// Initially no title — should error.
+			await waitFor( () => {
+				expect( errors.length ).toBeGreaterThan( 0 );
+			} );
+
+			const errorCountAfterInitial = errors.length;
+
+			// Add the title back via rerender.
+			rerender( ui( true ) );
+
+			// Wait for deferred validation to settle.
+			await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+
+			// No new errors should have been thrown.
+			expect( errors ).toHaveLength( errorCountAfterInitial );
+
+			cleanup();
 		} );
 	} );
 } );
-
-class ErrorBoundary extends Component<
-	{ children: React.ReactNode; onError: ( error: Error ) => void },
-	{ hasError: boolean }
-> {
-	state = { hasError: false };
-
-	static getDerivedStateFromError() {
-		return { hasError: true };
-	}
-
-	componentDidCatch( error: Error ) {
-		this.props.onError( error );
-	}
-
-	render() {
-		if ( this.state.hasError ) {
-			return null;
-		}
-		return this.props.children;
-	}
-}

--- a/packages/ui/src/popover/title.tsx
+++ b/packages/ui/src/popover/title.tsx
@@ -1,6 +1,6 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import { useMergeRefs } from '@wordpress/compose';
-import { forwardRef, useLayoutEffect, useRef } from '@wordpress/element';
+import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
 import { usePopoverValidationContext } from './context';
 import type { TitleProps } from './types';
@@ -27,8 +27,11 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
 
-		useLayoutEffect( () => {
-			validationContext?.registerTitle( internalRef.current );
+		useEffect( () => {
+			if ( validationContext ) {
+				return validationContext.registerTitle( internalRef.current );
+			}
+			return undefined;
 		}, [ validationContext ] );
 
 		return (

--- a/packages/ui/src/tabs/context.tsx
+++ b/packages/ui/src/tabs/context.tsx
@@ -2,10 +2,11 @@ import {
 	createContext,
 	useContext,
 	useCallback,
+	useEffect,
 	useMemo,
 	useRef,
-	useEffect,
 } from '@wordpress/element';
+import { useScheduleValidation } from '../utils/use-schedule-validation';
 
 type TabsValidationContextType = {
 	registerTab: () => () => void;
@@ -77,33 +78,20 @@ function TabsValidationProviderDev( {
 } ) {
 	const tabCountRef = useRef( 0 );
 	const panelCountRef = useRef( 0 );
-	const validationScheduledRef = useRef< ReturnType<
-		typeof setTimeout
-	> | null >( null );
 
-	const scheduleValidation = useCallback( () => {
-		if ( validationScheduledRef.current ) {
-			clearTimeout( validationScheduledRef.current );
+	const scheduleValidation = useScheduleValidation( () => {
+		const tabCount = tabCountRef.current;
+		const panelCount = panelCountRef.current;
+
+		if ( tabCount !== panelCount ) {
+			throw new Error(
+				`Tabs: Tab/Panel count mismatch (${ tabCount } Tabs, ${ panelCount } Panels). ` +
+					`Each Tab must be associated with exactly one Panel. ` +
+					`Mismatched or missing associations can break screen reader navigation ` +
+					`and violate WAI-ARIA Tabs pattern requirements.`
+			);
 		}
-
-		// Schedule validation for the next tick to allow all
-		// registrations/unregistrations to complete.
-		validationScheduledRef.current = setTimeout( () => {
-			const tabCount = tabCountRef.current;
-			const panelCount = panelCountRef.current;
-
-			if ( tabCount !== panelCount ) {
-				throw new Error(
-					`Tabs: Tab/Panel count mismatch (${ tabCount } Tabs, ${ panelCount } Panels). ` +
-						`Each Tab must be associated with exactly one Panel. ` +
-						`Mismatched or missing associations can break screen reader navigation ` +
-						`and violate WAI-ARIA Tabs pattern requirements.`
-				);
-			}
-
-			validationScheduledRef.current = null;
-		}, 0 );
-	}, [] );
+	} );
 
 	const registerTab = useCallback( () => {
 		tabCountRef.current += 1;
@@ -124,14 +112,6 @@ function TabsValidationProviderDev( {
 			scheduleValidation();
 		};
 	}, [ scheduleValidation ] );
-
-	useEffect( () => {
-		return () => {
-			if ( validationScheduledRef.current ) {
-				clearTimeout( validationScheduledRef.current );
-			}
-		};
-	}, [] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/ui/src/utils/use-schedule-validation.ts
+++ b/packages/ui/src/utils/use-schedule-validation.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Dev-only hook that returns a stable `scheduleValidation` function.
+ *
+ * Each call debounces to `setTimeout(…, 0)` so that rapid
+ * register / unregister cycles (e.g. React strict-mode double-mount)
+ * settle before the check runs. The timer is cleaned up on unmount,
+ * and calls after unmount are silently ignored.
+ *
+ * @param validate Callback that performs the actual validation.
+ *                 Stored in a ref — safe to pass an unstable closure.
+ */
+export function useScheduleValidation( validate: () => void ) {
+	const validateRef = useRef( validate );
+	validateRef.current = validate;
+
+	const timerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const unmountedRef = useRef( false );
+
+	const scheduleValidation = useCallback( () => {
+		if ( unmountedRef.current ) {
+			return;
+		}
+		if ( timerRef.current ) {
+			clearTimeout( timerRef.current );
+		}
+		timerRef.current = setTimeout( () => {
+			validateRef.current();
+			timerRef.current = null;
+		}, 0 );
+	}, [] );
+
+	useEffect( () => {
+		return () => {
+			unmountedRef.current = true;
+			if ( timerRef.current ) {
+				clearTimeout( timerRef.current );
+			}
+		};
+	}, [] );
+
+	return scheduleValidation;
+}

--- a/packages/ui/src/utils/use-schedule-validation.ts
+++ b/packages/ui/src/utils/use-schedule-validation.ts
@@ -32,6 +32,7 @@ export function useScheduleValidation( validate: () => void ) {
 	}, [] );
 
 	useEffect( () => {
+		unmountedRef.current = false;
 		return () => {
 			unmountedRef.current = true;
 			if ( timerRef.current ) {


### PR DESCRIPTION
## What?

Follow-up to #76438.

Upgrade dev-only title validation in Dialog and Popover from mount-only to cleanup-based re-validation, so conditionally rendered titles are caught. Extract a shared `useScheduleValidation` hook and refactor Tabs to use it too.

## Why?

The current validation only runs on mount (`useEffect([], [])`). If a title is conditionally rendered (added/removed after mount), the check never re-fires, silently allowing an inaccessible dialog or popover.

## How?

- Extract a shared `useScheduleValidation` hook that handles deferred `setTimeout(..., 0)` scheduling and timer cleanup.
- Refactor Dialog and Popover validation contexts: `registerTitle` now returns a cleanup function. Both register and unregister trigger `scheduleValidation`.
- Refactor Tabs validation context to use the same shared hook (reduces duplication).
- Switch title components from fire-once `useLayoutEffect` to `useEffect` with cleanup.

<details>
<summary>Implementation details</summary>

### `useScheduleValidation` hook (`packages/ui/src/utils/`)

- Accepts a `validate` callback (ref-stored to avoid stale closures)
- Returns a stable `scheduleValidation` function
- Debounces via `setTimeout(..., 0)` to let all registrations/unregistrations settle
- Cleans up the timer on unmount; calls after unmount are silently ignored
- Only called inside dev-only code paths; fully tree-shaken in production

### Error mechanism change

Validation errors are now thrown inside `setTimeout` (uncaught window errors) rather than during React's commit phase (error boundary). This is consistent with Tabs' existing behavior. Tests switch from `TestErrorBoundary` to `collectUncaughtErrors`.

### Files changed

| Area | File | Change |
|---|---|---|
| Shared | `utils/use-schedule-validation.ts` | New hook |
| Tabs | `tabs/context.tsx` | Use shared hook |
| Dialog | `dialog/context.tsx` | Shared hook + register/unregister |
| Dialog | `dialog/title.tsx` | `useEffect` with cleanup |
| Dialog | `dialog/test/index.test.tsx` | `collectUncaughtErrors` + new tests |
| Popover | `popover/context.tsx` | Shared hook + register/unregister |
| Popover | `popover/title.tsx` | `useEffect` with cleanup |
| Popover | `popover/test/index.test.tsx` | `collectUncaughtErrors` + new tests |

</details>

## Testing Instructions

1. `npm run test:unit packages/ui/src/dialog/test/index.test.tsx`
2. `npm run test:unit packages/ui/src/popover/test/index.test.tsx`
3. `npm run test:unit packages/ui/src/tabs/test/index.test.tsx`

## Use of AI Tools

Cursor + Claude Opus 4.6