### PR TITLE
Private APIs: avoid `wp-polyfill` dependency from allowlist `includes` check

### DIFF
--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -78,7 +78,7 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 	consent: string,
 	moduleName: string
 ) => {
-	if ( ! CORE_MODULES_USING_PRIVATE_APIS.includes( moduleName ) ) {
+	if ( CORE_MODULES_USING_PRIVATE_APIS.indexOf( moduleName ) === -1 ) {
 		throw new Error(
 			`You tried to opt-in to unstable APIs as module "${ moduleName }". ` +
 				'This feature is only for JavaScript modules shipped with WordPress core. ' +


### PR DESCRIPTION
## What?

In `@wordpress/private-apis`, change the allowlist check from using `.includes()` to `.indexOf()`. 

## Why?

This package is currently picking up `wp-polyfill` in WordPress builds with coreJS 3.49, because `.include()` is treated as needing a polyfill when Safari is a target for support.

For small packages like `@wordpress/private-apis`, this creates an avoidable dependency for consumers. In [Jetpack's case](https://github.com/Automattic/jetpack-production/commit/2b912fd35a6bd40b8be92c9656ee39c76d25232d#diff-af35a91b0f595863e8726c8c80862e1fdae80f2419cba4b2b29ba593e0679ea7L1), it shows up in generated asset files as:

```php
<?php return array('dependencies' => array('wp-polyfill'), ... );
```

The specific `includes` usage in `@wordpress/private-apis` is a simple check against an array of strings:

```ts
if ( ! CORE_MODULES_USING_PRIVATE_APIS.includes( moduleName ) ) {
```

For that case, replacing it with `indexOf( moduleName ) === -1` is the same and avoids the extra polyfill dependency.

## How?

This behavior appears to be caused by a recent Safari sparse-array bug tracked in WebKit bug 309342 and reflected in `core-js` compat data. Since Safari is marked as no longer supporting `.includes`, a polyfill is brought back in when using the newest core-js.

- WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=309342
- `core-js` commit marking `.includes` as not supported in Safari: https://github.com/zloirock/core-js/commit/0ad3e0035b87ac941ccadc643397bb7825d4e694
- `core-js` 3.49.0 release notes - https://github.com/zloirock/core-js/releases/tag/v3.49.0

## Testing Instructions

* Check out trunk
* Make a new temporary branch
* Run `npm add core-js-compat@3.49.0` and ` npm add core-js@3.49.0` to force upgrades to versions that Gutenberg isn't using yet (but consumers may be using)
* Make a new test.js file

```js
 const path = require('path');
 const { createRequire } = require('module');

 const presetPkg = path.resolve('packages/babel-preset-default/package.json');
 const req = createRequire(presetPkg);
 const babel = req('@babel/core');
 const preset = require(path.resolve('packages/babel-preset-default'));

 for ( const src of [
       'const ok = [1,2,3].includes(2);',
       'const ok = [1,2,3].indexOf(2) !== -1;',
 ] ) {
       const out = babel.transformSync(src, {
               filename: 'test.js',
               configFile: false,
               babelrc: false,
               presets: [ [ preset, {} ] ],
               caller: { name: 'WP_BUILD_MAIN', addPolyfillComments: true, modules: false },
       });

       console.log('\nSRC:', src);
       console.log(out.code);
 }
```

Run `node test.js` and observe:
```
SRC: const ok = [1,2,3].includes(2);
/* wp:polyfill */
const ok = [1, 2, 3].includes(2);

SRC: const ok = [1,2,3].indexOf(2) !== -1;
const ok = [1, 2, 3].indexOf(2) !== -1;
```

After upgrading core.js, the polyfill marker was added to `.includes()` but not `.indexOf()`.

### Jetpack Evidence

In another, Jetpack, which has already been upgraded to core js 3.49.0, I was able to make similar changes which reduced the build's dependency needs.

**Pair 1:**
* This change https://github.com/Automattic/jetpack/pull/48010/changes
  * Caused this dependency drop https://github.com/Automattic/jetpack-production/commit/6c4ebe5cf5c86ddf3210849b247ab060c3132256#diff-8ac4621b68bf7415b4ea48702aa77725e08f51049473595e8acaf3f4984a687bL1

**Pair 2:**
* This change https://github.com/Automattic/jetpack/pull/48015/changed
  * Caused this dependency drop https://github.com/Automattic/jetpack-production/commit/2d9ade827d10925eada9aee3f3d04207a925c9b2#diff-4d250a7e2e639bbf08397537491dd444b62132dbfd2f16af08da75e58ba43420L1

This PR comes from me examining other increases of `wp-polyfill` after Jetpack upgraded core-data. Of course, the benefit here would not be for Jetpack, it would be for any consumer of `@wordpress/private-apis` who has upgraded to this core data version.

### Testing Instructions for Keyboard

## Screenshots or screencast 

|Before|After|
|-|-|
|||

## Use of AI Tools

* ChatGPT 5.4 Pro created the initial hypothesis of `.includes()` + Core Data Upgrade causing new `wp-polyfill` usages observed in Jetpack, but this was verified by humans, and also by seeing a drop in recorded polyfill requests after making similar fixes in production.
* Codex 5.4 created the test.js script above which shows the `/* wp:polyfill */` marker being applied to `.includes()`.