### PR TITLE
LinkPicker: Decode HTML entities in link preview title

### DIFF
--- a/packages/block-editor/src/components/link-picker/link-preview.js
+++ b/packages/block-editor/src/components/link-picker/link-preview.js
@@ -9,6 +9,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -50,7 +51,7 @@ export function LinkPreview( { title, url, image, badges } ) {
 							numberOfLines={ 1 }
 							className="link-preview-button__title"
 						>
-							{ title }
+							{ stripHTML( title ) }
 						</Truncate>
 						{ url && (
 							<Truncate


### PR DESCRIPTION
Noticed this issue while reviewing #77155


## What?

Fix HTML entities not being decoded in the `LinkPicker` component.

## Why?

This happened because the title was rendered directly as `{ title }` in JSX without any processing. React renders JSX text content as plain text nodes, so HTML entities are not decoded automatically.

## How?

Apply `stripHTML()` to the `title` prop before rendering it. This approach is consistent with the behavior in link-control/link-preview.js.

## Testing Instructions

1. Create a page that includes HTML entities in title. (Example: `Sample & Page <>🙂`)
2. Insert a Navigation block and add the page
3. Confirm the "Link to" section
  - Before: `Sample &#038; Page <>🙂`
  - After: `Sample & Page <>🙂`

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="828" height="440" alt="image" src="https://github.com/user-attachments/assets/cdb6fa8f-008f-4dbc-881f-0694ef8a0ffc" />

### After

<img width="839" height="441" alt="image" src="https://github.com/user-attachments/assets/c35b3867-bb6c-4e6b-b08a-16c4197ce6d3" />

## Use of AI Tools

Claude Sonnet 4.6 (Claude Code) was used to assist with identifying the root cause and implementing the fix. The change was reviewed and committed by the author.