### PR TITLE
Components: Refactor NavigableContainer from class to function component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `ExternalLink`: No longer adds `noreferrer` to the `rel` attribute. `noopener` is still applied. Consumers relying on the previous behavior should pass `rel="noopener noreferrer"` explicitly ([#26968](https://github.com/WordPress/gutenberg/pull/26968)).
 
+### Internal
+
+-   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
+
 ## 32.6.0 (2026-04-15)
 
 ### Documentation
@@ -36,7 +40,6 @@
 -   `BoxControl`: Remove unused state for icon side ([#77143](https://github.com/WordPress/gutenberg/pull/77143)).
 -   `Autocomplete`: Remove `getAutoCompleterUI` factory pattern ([#77048](https://github.com/WordPress/gutenberg/pull/77048)).
 -   `CustomSelectControl`, `Sandbox`: Rename internal React function names ([#77148](https://github.com/WordPress/gutenberg/pull/77148)).
--   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
 
 ### Code Quality
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `BoxControl`: Remove unused state for icon side ([#77143](https://github.com/WordPress/gutenberg/pull/77143)).
 -   `Autocomplete`: Remove `getAutoCompleterUI` factory pattern ([#77048](https://github.com/WordPress/gutenberg/pull/77048)).
 -   `CustomSelectControl`, `Sandbox`: Rename internal React function names ([#77148](https://github.com/WordPress/gutenberg/pull/77148)).
+-   `NavigableContainer`: Refactor from class component to function component with hooks ([#77171](https://github.com/WordPress/gutenberg/pull/77171)).
 
 ### Code Quality
 

--- a/packages/components/src/navigable-container/container.tsx
+++ b/packages/components/src/navigable-container/container.tsx
@@ -7,6 +7,7 @@ import type { ForwardedRef } from 'react';
  * WordPress dependencies
  */
 import { forwardRef, useRef, useEffect, useCallback } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
 import { focus } from '@wordpress/dom';
 
 /**
@@ -153,19 +154,10 @@ function UnforwardedNavigableContainer(
 		getFocusableContext,
 	] );
 
-	return (
-		<div
-			ref={ ( node ) => {
-				containerRef.current = node;
+	const mergedRef = useMergeRefs( [ containerRef, ref ] );
 
-				if ( typeof ref === 'function' ) {
-					ref( node );
-				} else if ( ref ) {
-					ref.current = node;
-				}
-			} }
-			{ ...restProps }
-		>
+	return (
+		<div ref={ mergedRef } { ...restProps }>
 			{ children }
 		</div>
 	);

--- a/packages/components/src/navigable-container/container.tsx
+++ b/packages/components/src/navigable-container/container.tsx
@@ -94,7 +94,7 @@ function UnforwardedNavigableContainer(
 				// for highlighting text.
 				const targetRole = (
 					event.target as HTMLDivElement | null
-				)?.getAttribute( 'role' );
+				 )?.getAttribute( 'role' );
 				const targetHasMenuItemRole =
 					!! targetRole && MENU_ITEM_ROLES.includes( targetRole );
 

--- a/packages/components/src/navigable-container/container.tsx
+++ b/packages/components/src/navigable-container/container.tsx
@@ -6,7 +6,7 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { Component, forwardRef } from '@wordpress/element';
+import { forwardRef, useRef, useEffect, useCallback } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
 /**
@@ -28,163 +28,150 @@ function cycleValue( value: number, total: number, offset: number ) {
 	return nextValue;
 }
 
-class NavigableContainer extends Component< NavigableContainerProps > {
-	container?: HTMLDivElement;
+function UnforwardedNavigableContainer(
+	{
+		children,
+		stopNavigationEvents,
+		eventToOffset,
+		onNavigate = noop,
+		onKeyDown,
+		cycle = true,
+		onlyBrowserTabstops,
+		...restProps
+	}: NavigableContainerProps,
+	ref: ForwardedRef< HTMLDivElement >
+) {
+	const containerRef = useRef< HTMLDivElement | null >( null );
 
-	constructor( args: NavigableContainerProps ) {
-		super( args );
-		this.onKeyDown = this.onKeyDown.bind( this );
-		this.bindContainer = this.bindContainer.bind( this );
+	const getFocusableIndex = useCallback(
+		( focusables: Element[], target: Element ) => {
+			return focusables.indexOf( target );
+		},
+		[]
+	);
 
-		this.getFocusableContext = this.getFocusableContext.bind( this );
-		this.getFocusableIndex = this.getFocusableIndex.bind( this );
-	}
+	const getFocusableContext = useCallback(
+		( target: Element ) => {
+			if ( ! containerRef.current ) {
+				return null;
+			}
 
-	componentDidMount() {
-		if ( ! this.container ) {
+			const finder = onlyBrowserTabstops
+				? focus.tabbable
+				: focus.focusable;
+			const focusables = finder.find( containerRef.current );
+
+			const index = getFocusableIndex( focusables, target );
+			if ( index > -1 && target ) {
+				return { index, target, focusables };
+			}
+			return null;
+		},
+		[ onlyBrowserTabstops, getFocusableIndex ]
+	);
+
+	useEffect( () => {
+		const container = containerRef.current;
+		if ( ! container ) {
 			return;
+		}
+
+		function handleKeyDown( event: KeyboardEvent ) {
+			if ( onKeyDown ) {
+				onKeyDown( event );
+			}
+
+			const offset = eventToOffset( event );
+
+			// eventToOffset returns undefined if the event is not handled by the component.
+			if ( offset !== undefined && stopNavigationEvents ) {
+				// Prevents arrow key handlers bound to the document directly interfering.
+				event.stopImmediatePropagation();
+
+				// When navigating a collection of items, prevent scroll containers
+				// from scrolling. The preventDefault also prevents Voiceover from
+				// 'handling' the event, as voiceover will try to use arrow keys
+				// for highlighting text.
+				const targetRole = (
+					event.target as HTMLDivElement | null
+				)?.getAttribute( 'role' );
+				const targetHasMenuItemRole =
+					!! targetRole && MENU_ITEM_ROLES.includes( targetRole );
+
+				if ( targetHasMenuItemRole ) {
+					event.preventDefault();
+				}
+			}
+
+			if ( ! offset ) {
+				return;
+			}
+
+			const activeElement = ( event.target as HTMLElement | null )
+				?.ownerDocument?.activeElement;
+			if ( ! activeElement ) {
+				return;
+			}
+
+			const context = getFocusableContext( activeElement );
+			if ( ! context ) {
+				return;
+			}
+
+			const { index, focusables } = context;
+			const nextIndex = cycle
+				? cycleValue( index, focusables.length, offset )
+				: index + offset;
+
+			if ( nextIndex >= 0 && nextIndex < focusables.length ) {
+				focusables[ nextIndex ].focus();
+				onNavigate( nextIndex, focusables[ nextIndex ] as HTMLElement );
+
+				// `preventDefault()` on tab to avoid having the browser move the focus
+				// after this component has already moved it.
+				if ( event.code === 'Tab' ) {
+					event.preventDefault();
+				}
+			}
 		}
 
 		// We use DOM event listeners instead of React event listeners
-		// because we want to catch events from the underlying DOM tree
+		// because we want to catch events from the underlying DOM tree.
 		// The React Tree can be different from the DOM tree when using
 		// portals. Block Toolbars for instance are rendered in a separate
 		// React Trees.
-		this.container.addEventListener( 'keydown', this.onKeyDown );
-	}
+		container.addEventListener( 'keydown', handleKeyDown );
+		return () => {
+			container.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [
+		onKeyDown,
+		eventToOffset,
+		stopNavigationEvents,
+		cycle,
+		onNavigate,
+		getFocusableContext,
+	] );
 
-	componentWillUnmount() {
-		if ( ! this.container ) {
-			return;
-		}
+	return (
+		<div
+			ref={ ( node ) => {
+				containerRef.current = node;
 
-		this.container.removeEventListener( 'keydown', this.onKeyDown );
-	}
-
-	bindContainer( ref: HTMLDivElement ) {
-		const { forwardedRef } = this.props;
-		this.container = ref;
-
-		if ( typeof forwardedRef === 'function' ) {
-			forwardedRef( ref );
-		} else if ( forwardedRef && 'current' in forwardedRef ) {
-			forwardedRef.current = ref;
-		}
-	}
-
-	getFocusableContext( target: Element ) {
-		if ( ! this.container ) {
-			return null;
-		}
-
-		const { onlyBrowserTabstops } = this.props;
-		const finder = onlyBrowserTabstops ? focus.tabbable : focus.focusable;
-		const focusables = finder.find( this.container );
-
-		const index = this.getFocusableIndex( focusables, target );
-		if ( index > -1 && target ) {
-			return { index, target, focusables };
-		}
-		return null;
-	}
-
-	getFocusableIndex( focusables: Element[], target: Element ) {
-		return focusables.indexOf( target );
-	}
-
-	onKeyDown( event: KeyboardEvent ) {
-		if ( this.props.onKeyDown ) {
-			this.props.onKeyDown( event );
-		}
-
-		const { getFocusableContext } = this;
-		const {
-			cycle = true,
-			eventToOffset,
-			onNavigate = noop,
-			stopNavigationEvents,
-		} = this.props;
-
-		const offset = eventToOffset( event );
-
-		// eventToOffset returns undefined if the event is not handled by the component.
-		if ( offset !== undefined && stopNavigationEvents ) {
-			// Prevents arrow key handlers bound to the document directly interfering.
-			event.stopImmediatePropagation();
-
-			// When navigating a collection of items, prevent scroll containers
-			// from scrolling. The preventDefault also prevents Voiceover from
-			// 'handling' the event, as voiceover will try to use arrow keys
-			// for highlighting text.
-			const targetRole = (
-				event.target as HTMLDivElement | null
-			 )?.getAttribute( 'role' );
-			const targetHasMenuItemRole =
-				!! targetRole && MENU_ITEM_ROLES.includes( targetRole );
-
-			if ( targetHasMenuItemRole ) {
-				event.preventDefault();
-			}
-		}
-
-		if ( ! offset ) {
-			return;
-		}
-
-		const activeElement = ( event.target as HTMLElement | null )
-			?.ownerDocument?.activeElement;
-		if ( ! activeElement ) {
-			return;
-		}
-
-		const context = getFocusableContext( activeElement );
-		if ( ! context ) {
-			return;
-		}
-
-		const { index, focusables } = context;
-		const nextIndex = cycle
-			? cycleValue( index, focusables.length, offset )
-			: index + offset;
-
-		if ( nextIndex >= 0 && nextIndex < focusables.length ) {
-			focusables[ nextIndex ].focus();
-			onNavigate( nextIndex, focusables[ nextIndex ] );
-
-			// `preventDefault()` on tab to avoid having the browser move the focus
-			// after this component has already moved it.
-			if ( event.code === 'Tab' ) {
-				event.preventDefault();
-			}
-		}
-	}
-
-	render() {
-		const {
-			children,
-			stopNavigationEvents,
-			eventToOffset,
-			onNavigate,
-			onKeyDown,
-			cycle,
-			onlyBrowserTabstops,
-			forwardedRef,
-			...restProps
-		} = this.props;
-		return (
-			<div ref={ this.bindContainer } { ...restProps }>
-				{ children }
-			</div>
-		);
-	}
+				if ( typeof ref === 'function' ) {
+					ref( node );
+				} else if ( ref ) {
+					ref.current = node;
+				}
+			} }
+			{ ...restProps }
+		>
+			{ children }
+		</div>
+	);
 }
 
-const forwardedNavigableContainer = (
-	props: NavigableContainerProps,
-	ref: ForwardedRef< HTMLDivElement >
-) => {
-	return <NavigableContainer { ...props } forwardedRef={ ref } />;
-};
-forwardedNavigableContainer.displayName = 'NavigableContainer';
+const NavigableContainer = forwardRef( UnforwardedNavigableContainer );
+NavigableContainer.displayName = 'NavigableContainer';
 
-export default forwardRef( forwardedNavigableContainer );
+export default NavigableContainer;

--- a/packages/components/src/navigable-container/test/navigable-menu.tsx
+++ b/packages/components/src/navigable-container/test/navigable-menu.tsx
@@ -215,6 +215,30 @@ describe( 'NavigableMenu', () => {
 		expect( externalWrapperOnKeyDownSpy ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'should keep forwarded callback refs stable across rerenders', () => {
+		const refSpy = jest.fn();
+
+		const { rerender } = render(
+			<NavigableMenu ref={ refSpy }>
+				<button>Item 1</button>
+			</NavigableMenu>
+		);
+
+		expect( refSpy ).toHaveBeenCalledTimes( 1 );
+		expect( refSpy ).toHaveBeenCalledWith( expect.any( HTMLElement ) );
+
+		rerender(
+			<NavigableMenu ref={ refSpy }>
+				<button>Item 1</button>
+			</NavigableMenu>
+		);
+
+		// With a stable merged ref (useMergeRefs), the callback ref should
+		// not be called again on rerender. Previously, an inline ref callback
+		// would cause React to detach (null) and reattach on every render.
+		expect( refSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'skips its internal logic when the tab key is pressed', async () => {
 		const user = userEvent.setup();
 

--- a/packages/components/src/navigable-container/types.ts
+++ b/packages/components/src/navigable-container/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ForwardedRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -35,10 +35,6 @@ export type NavigableContainerProps = WordPressComponentProps<
 		 * Gets an offset, given an event.
 		 */
 		eventToOffset: ( event: KeyboardEvent ) => -1 | 0 | 1 | undefined;
-		/**
-		 * The forwarded ref.
-		 */
-		forwardedRef?: ForwardedRef< any >;
 		/**
 		 * Whether to only consider browser tab stops.
 		 *


### PR DESCRIPTION
## What?

Part of #22890

Refactors the `NavigableContainer` component (`packages/components/src/navigable-container/container.tsx`) from a class component to a function component with hooks.

## Why?

The [official WordPress recommendation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/#component) is that all components should be implemented as function components using hooks. `NavigableContainer` was one of the remaining class components in `@wordpress/components`.

## How?

- `componentDidMount` and `componentWillUnmount` replaced with a single `useEffect` that adds/removes the DOM keydown listener
- Instance variable `this.container` replaced with `useRef`
- Bound methods (`this.onKeyDown.bind(this)`, etc.) replaced with closures and `useCallback`
- The `forwardedRef` prop pattern replaced with standard `forwardRef` (removed the prop from the type definition)
- All original comments and logic preserved exactly

## Testing Instructions

1. Open the editor and insert a block with a toolbar (e.g., Paragraph block)
2. Use arrow keys to navigate between toolbar buttons
3. Verify focus moves correctly between items
4. Test with `NavigableMenu` (block toolbar) and `TabbableContainer` (settings panels)
5. Run existing unit tests: `npm run test:unit -- --testPathPattern navigable-container`

### Testing Instructions for Keyboard

1. Focus a block toolbar using keyboard navigation
2. Use Left/Right arrow keys to move between toolbar buttons
3. Verify the focus cycles from last to first item and vice versa
4. Press Tab to move to the next tabbable region
5. Verify no regressions in keyboard navigation behavior

## Use of AI Tools

Claude Code was used to assist with the refactoring. All changes were reviewed manually and tested against existing test suites to verify behavioral parity.