### PR TITLE
Added missing documentation in `collaboration.php`

### DIFF
--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -200,6 +200,8 @@ if ( ! function_exists( 'wp_is_collaboration_allowed' ) ) {
 
 /**
  * Injects the real-time collaboration setting into a global variable.
+ *
+ * @global string $pagenow The filename of the current screen.
  */
 function gutenberg_inject_real_time_collaboration_setting() {
 	global $pagenow;
@@ -244,6 +246,8 @@ add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_opt
  * user-specific lock text with "Currently being edited", changes the "Edit"
  * row action to "Join", and re-enables controls that core normally hides
  * for locked posts (since collaborative editing is possible).
+ *
+ * @global string $pagenow The filename of the current screen. 
  */
 function gutenberg_post_list_collaboration_ui() {
 	global $pagenow;

--- a/lib/compat/wordpress-7.0/collaboration.php
+++ b/lib/compat/wordpress-7.0/collaboration.php
@@ -247,7 +247,7 @@ add_action( 'activate_gutenberg/gutenberg.php', 'gutenberg_set_collaboration_opt
  * row action to "Join", and re-enables controls that core normally hides
  * for locked posts (since collaborative editing is possible).
  *
- * @global string $pagenow The filename of the current screen. 
+ * @global string $pagenow The filename of the current screen.
  */
 function gutenberg_post_list_collaboration_ui() {
 	global $pagenow;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  [#77172](https://github.com/WordPress/gutenberg/issues/77172)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Added missing documentation in `collaboration.php`

## Testing Instructions
- Open collaboration.php
- See Global documentation is missing for `global $pagenow;`
