### PR TITLE
fix(format-library): prevent page jump when clicking anchor links

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -67,10 +67,18 @@ function Edit( {
 			// to be rendered in "creating" mode. We need to check isActive to see if
 			// we have an active link format.
 			const link = event.target.closest( '[contenteditable] a' );
-			if (
-				! link || // other formats (e.g. bold) may be nested within the link.
-				! isActive
-			) {
+			if ( ! link ) {
+				// other formats (e.g. bold) may be nested within the link.
+				return;
+			}
+
+			// Prevent the browser from following the link. Without this, anchor links
+			// (e.g. href="#section") cause the page to jump before the Link UI opens.
+			// This must happen before the isActive check because clicking the leftmost
+			// edge of a link can fire the click event while isActive is still false.
+			event.preventDefault();
+
+			if ( ! isActive ) {
 				return;
 			}
 


### PR DESCRIPTION
## Description

When a user clicks an anchor link (e.g. `href="#section"`) inside the editor, the browser scrolls/jumps to the target before the Link UI popover opens. This PR fixes the issue by calling `event.preventDefault()` before the `isActive` guard in `handleClick`.

## Why this is different from #75579

PR #75579 places `event.preventDefault()` *after* the combined `!link || !isActive` guard. The existing code already documents an edge case:

> There is a situation whereby there is an existing link in the rich text and the user clicks on the leftmost edge of that link and **fails to activate the link format**, but the click event still fires on the `<a>` element.

In that scenario `isActive` is `false` at the time of the click, so #75579's `preventDefault()` is never reached — the page still jumps.

This PR splits the guard so `event.preventDefault()` fires for any click on a `[contenteditable] a` element, regardless of `isActive`:

```js
// Before
if ( ! link || ! isActive ) { return; }
event.preventDefault();  // skipped when isActive is false

// After
if ( ! link ) { return; }
event.preventDefault();  // always fires for contenteditable link clicks
if ( ! isActive ) { return; }
```

## Changes

- `packages/format-library/src/link/index.js` — split the early-return guard; move `event.preventDefault()` before the `isActive` check; add explanatory comment.

## Testing Instructions

1. Create a new Post with enough content to make the page scrollable.
2. Select some text near the bottom and add a link with `href="#"` or `href="#section"`.
3. Click elsewhere to deselect, then click the link text again.
4. **Expected:** Link UI popover opens; the page does **not** jump to the top.
5. Repeat step 3 by clicking the very leftmost edge of the link text (edge case from existing comment) — page should still not jump.
6. Confirm that non-anchor links (external URLs) also open the Link UI correctly.

Fixes #72505.