### PR TITLE
Image block: Validate attachment ID exists before treating image as local

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -313,7 +313,7 @@ export default function Image( {
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
 	const { allowResize = true } = context;
 
-	const { image, canUserEdit } = useSelect(
+	const { image, canUserEdit, hasResolvedImage } = useSelect(
 		( select ) => {
 			const imageRecord =
 				id && isSingleSelected
@@ -324,6 +324,20 @@ export default function Image( {
 							{ context: 'view' }
 					  )
 					: null;
+
+			// Check if the attachment resolution has completed (not still loading).
+			const hasResolved =
+				id && isSingleSelected
+					? select( coreStore ).hasFinishedResolution(
+							'getEntityRecord',
+							[
+								'postType',
+								'attachment',
+								id,
+								{ context: 'view' },
+							]
+					  )
+					: false;
 
 			// Check edit permissions when the media editor experiment is enabled.
 			// Only check when imageRecord is available to avoid unnecessary API requests.
@@ -339,10 +353,25 @@ export default function Image( {
 			return {
 				image: imageRecord,
 				canUserEdit: canEdit,
+				hasResolvedImage: hasResolved,
 			};
 		},
 		[ id, isSingleSelected ]
 	);
+
+	// If the image has an id but the attachment doesn't exist on this site,
+	// clear the id so Gutenberg treats the image as external.
+	// This handles content copied between WordPress sites.
+	// See: https://github.com/WordPress/gutenberg/issues/74156
+	useEffect( () => {
+		if ( ! id || ! isSingleSelected || ! hasResolvedImage ) {
+			return;
+		}
+		// Resolution finished but no record found = attachment doesn't exist locally.
+		if ( ! image ) {
+			setAttributes( { id: undefined } );
+		}
+	}, [ id, isSingleSelected, hasResolvedImage, image, setAttributes ] );
 
 	const {
 		canInsertCover,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -313,7 +313,7 @@ export default function Image( {
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
 	const { allowResize = true } = context;
 
-	const { image, canUserEdit, hasResolvedImage } = useSelect(
+	const { image, canUserEdit, attachmentResolutionError } = useSelect(
 		( select ) => {
 			const imageRecord =
 				id && isSingleSelected
@@ -325,10 +325,13 @@ export default function Image( {
 					  )
 					: null;
 
-			// Check if the attachment resolution has completed (not still loading).
-			const hasResolved =
+			// Check if the attachment resolution failed with a specific error.
+			// We use getResolutionError instead of hasFinishedResolution so we
+			// can distinguish 404 (attachment doesn't exist) from transient
+			// errors (500, 403, network) that shouldn't clear the id.
+			const resolutionError =
 				id && isSingleSelected
-					? select( coreStore ).hasFinishedResolution(
+					? select( coreStore ).getResolutionError(
 							'getEntityRecord',
 							[
 								'postType',
@@ -337,7 +340,7 @@ export default function Image( {
 								{ context: 'view' },
 							]
 					  )
-					: false;
+					: null;
 
 			// Check edit permissions when the media editor experiment is enabled.
 			// Only check when imageRecord is available to avoid unnecessary API requests.
@@ -353,7 +356,7 @@ export default function Image( {
 			return {
 				image: imageRecord,
 				canUserEdit: canEdit,
-				hasResolvedImage: hasResolved,
+				attachmentResolutionError: resolutionError,
 			};
 		},
 		[ id, isSingleSelected ]
@@ -364,14 +367,17 @@ export default function Image( {
 	// This handles content copied between WordPress sites.
 	// See: https://github.com/WordPress/gutenberg/issues/74156
 	useEffect( () => {
-		if ( ! id || ! isSingleSelected || ! hasResolvedImage ) {
+		if ( ! id || ! isSingleSelected ) {
 			return;
 		}
-		// Resolution finished but no record found = attachment doesn't exist locally.
-		if ( ! image ) {
+		// Only clear for confirmed 404s. apiFetch throws the Response object
+		// for HTTP errors, so checking .status === 404 avoids incorrectly
+		// clearing the id on 403, 500, or network failures, which would
+		// cause data loss for valid local attachments.
+		if ( attachmentResolutionError?.status === 404 ) {
 			setAttributes( { id: undefined } );
 		}
-	}, [ id, isSingleSelected, hasResolvedImage, image, setAttributes ] );
+	}, [ id, isSingleSelected, attachmentResolutionError, setAttributes ] );
 
 	const {
 		canInsertCover,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -365,6 +365,10 @@ export default function Image( {
 	// If the image has an id but the attachment doesn't exist on this site,
 	// clear the id so Gutenberg treats the image as external.
 	// This handles content copied between WordPress sites.
+	//
+	// Known limitation: if a different attachment with the same id happens to
+	// exist on the destination site, the lookup will succeed and the wrong
+	// local image will be used. URL matching could address this in a follow-up.
 	// See: https://github.com/WordPress/gutenberg/issues/74156
 	useEffect( () => {
 		if ( ! id || ! isSingleSelected ) {


### PR DESCRIPTION
## Description

When block markup is copied from one WordPress site to another, image blocks carry attachment IDs from the source site. The editor assumes these IDs reference local attachments and suppresses the "Upload to Media Library" button.

This change piggybacks on the existing `getEntityRecord` call (which already fires when an image block is selected) and adds a `hasFinishedResolution` check. Once resolution confirms the attachment doesn't exist locally, the invalid `id` is cleared from block attributes, allowing the existing external image upload flow to activate correctly.

### How it works

1. Block arrives with `id: 107491` from Site A
2. Existing `useSelect` fires `getEntityRecord('postType', 'attachment', 107491)` - returns 404
3. New `hasFinishedResolution` check confirms resolution is complete (not still loading)
4. New `useEffect` detects: id exists, resolution finished, but no record found - clears the `id`
5. `isExternalImage(undefined, url)` now returns `true`
6. Existing external image upload flow activates - "Upload to Media Library" button appears

### What this doesn't change

- Zero new API calls. The REST call was already happening.
- `hasFinishedResolution` is a local state check (zero network cost)
- Only runs when `isSingleSelected` is true (user clicked on the specific image block)
- Valid local images are unaffected

## Future scope

- **ID collision detection:** If Site B has a different attachment with the same ID as Site A, the current fix won't detect the mismatch. This was discussed in #74156 and agreed to be out of scope for the MVP. URL matching could address this in a follow-up.
- **Other attachment blocks:** As noted by @ramonjd in the issue discussion, this pattern should eventually extend to video, audio, and file blocks. Those blocks don't currently have external upload logic, so extending to them would require building that flow from scratch.

## Testing Instructions

1. Start a local WordPress dev environment
2. Create a new post, switch to Code Editor, paste:
```html
<!-- wp:image {"id":999999,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://picsum.photos/id/237/800/600" alt="" class="wp-image-999999"/></figure>
<!-- /wp:image -->
```
3. Exit code editor, click the image block
4. **Expected:** "Upload to Media Library" button appears in the toolbar
5. Click the button - image uploads successfully
6. **Verify no regression:** Upload a real image via the image block, click it - no upload button appears (correct)
7. **Multiple images:** Paste multiple image blocks with different fake IDs, click each - upload button appears on each

Fixes #74156