### PR TITLE
Dataviews: remove unneeded ref callbacks

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - DataViews: Fix `compact` density clipping and remove top/bottom padding. [#77054](https://github.com/WordPress/gutenberg/pull/77054)
 
+### Code Quality
+
+- DataViewsPicker: Remove unnecessary ref callbacks in grid and table layouts. [#77179](https://github.com/WordPress/gutenberg/pull/77179)
+
 ## 14.0.0 (2026-04-01)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -78,13 +78,9 @@ function GridItem< Item >( {
 }: GridItemProps< Item > ) {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const id = getItemId( item );
-	const elementRef = useRef< HTMLElement | null >( null );
+	const elementRef = useRef< HTMLButtonElement >( null );
 
 	const isSelected = selection.includes( id );
-
-	const setElementRef = ( element: HTMLElement | null ) => {
-		elementRef.current = element;
-	};
 
 	useIntersectionObserver( elementRef, posinset );
 
@@ -102,7 +98,7 @@ function GridItem< Item >( {
 
 	return (
 		<Composite.Item
-			ref={ setElementRef }
+			ref={ elementRef }
 			aria-label={
 				titleField
 					? titleField.getValue( { item } ) || __( '(no title)' )

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -100,11 +100,7 @@ function TableRow< Item >( {
 	const isSelected = selection.includes( id );
 
 	const [ isHovered, setIsHovered ] = useState( false );
-	const elementRef = useRef< HTMLElement | null >( null );
-
-	const setElementRef = ( element: HTMLElement | null ) => {
-		elementRef.current = element;
-	};
+	const elementRef = useRef< HTMLButtonElement >( null );
 
 	useIntersectionObserver( elementRef, posinset );
 	const {
@@ -129,7 +125,7 @@ function TableRow< Item >( {
 	return (
 		<Composite.Item
 			key={ id }
-			ref={ setElementRef }
+			ref={ elementRef }
 			render={ ( { children, ...props } ) => (
 				<tr
 					className={ clsx( 'dataviews-view-table__row', {


### PR DESCRIPTION
Spinoff from ESLint upgrade in #76654 where there is a new error detected (from the `react-compiler` plugin, false positive) when assigning refs in the `setElementRef` function.

It turns out that these functions can be removed completely and we can pass the `ref` object directly to the `Composite.Item` component. All we need is to fixup the type of the `useRef` call. That was probably the original reason for adding the callback -- a type error.