### PR TITLE
Components: Add context validation to Composite subcomponents

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
--   `Composite`: Add context validation to subcomponents to throw a helpful error when rendered outside of `Composite`.
+-   `Composite`: Add context validation to subcomponents to throw a helpful error when rendered outside of `Composite` ([#77183](https://github.com/WordPress/gutenberg/pull/77183)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,10 @@
 -   `ValidatedRangeControl`: Fix `aria-label` rendered as `[object Object]` when `required` or `markWhenOptional` is set ([#77042](https://github.com/WordPress/gutenberg/pull/77042)).
 -   `Autocomplete`: Fix matching logic to prefer longest overlapping trigger ([#77018](https://github.com/WordPress/gutenberg/pull/77018)).
 
+### Enhancements
+
+-   `Composite`: Add context validation to subcomponents to throw a helpful error when rendered outside of `Composite`.
+
 ### Internal
 
 -   `Autocomplete`: Refactor `useAutocomplete` to use `useReducer` ([#77020](https://github.com/WordPress/gutenberg/pull/77020)).

--- a/packages/components/src/composite/context.tsx
+++ b/packages/components/src/composite/context.tsx
@@ -8,7 +8,9 @@ import { createContext, useContext } from '@wordpress/element';
  */
 import type { CompositeContextProps } from './types';
 
-export const CompositeContext = createContext< CompositeContextProps >( {} );
+export const CompositeContext = createContext<
+	CompositeContextProps | undefined
+>( undefined );
 CompositeContext.displayName = 'CompositeContext';
 
 export const useCompositeContext = () => useContext( CompositeContext );

--- a/packages/components/src/composite/group-label.tsx
+++ b/packages/components/src/composite/group-label.tsx
@@ -24,7 +24,13 @@ export const CompositeGroupLabel = forwardRef<
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
-	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	const store = ( props.store ?? context?.store ) as Ariakit.CompositeStore;
+
+	if ( ! store ) {
+		throw new Error(
+			'Composite.GroupLabel can only be rendered inside a Composite component'
+		);
+	}
 
 	return (
 		<Ariakit.CompositeGroupLabel store={ store } { ...props } ref={ ref } />

--- a/packages/components/src/composite/group.tsx
+++ b/packages/components/src/composite/group.tsx
@@ -24,7 +24,13 @@ export const CompositeGroup = forwardRef<
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
-	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	const store = ( props.store ?? context?.store ) as Ariakit.CompositeStore;
+
+	if ( ! store ) {
+		throw new Error(
+			'Composite.Group can only be rendered inside a Composite component'
+		);
+	}
 
 	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/hover.tsx
+++ b/packages/components/src/composite/hover.tsx
@@ -24,7 +24,13 @@ export const CompositeHover = forwardRef<
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
-	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	const store = ( props.store ?? context?.store ) as Ariakit.CompositeStore;
+
+	if ( ! store ) {
+		throw new Error(
+			'Composite.Hover can only be rendered inside a Composite component'
+		);
+	}
 
 	return <Ariakit.CompositeHover store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -24,7 +24,13 @@ export const CompositeItem = forwardRef<
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
-	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	const store = ( props.store ?? context?.store ) as Ariakit.CompositeStore;
+
+	if ( ! store ) {
+		throw new Error(
+			'Composite.Item can only be rendered inside a Composite component'
+		);
+	}
 
 	return <Ariakit.CompositeItem store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/row.tsx
+++ b/packages/components/src/composite/row.tsx
@@ -24,7 +24,13 @@ export const CompositeRow = forwardRef<
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
-	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	const store = ( props.store ?? context?.store ) as Ariakit.CompositeStore;
+
+	if ( ! store ) {
+		throw new Error(
+			'Composite.Row can only be rendered inside a Composite component'
+		);
+	}
 
 	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/test/index.tsx
+++ b/packages/components/src/composite/test/index.tsx
@@ -711,4 +711,60 @@ describe( 'Composite', () => {
 			} );
 		} );
 	} );
+
+	describe( 'context validation', () => {
+		it( 'should throw when Composite.Item is rendered outside of Composite', () => {
+			expect( () =>
+				render( <Composite.Item>Item</Composite.Item> )
+			).toThrow(
+				'Composite.Item can only be rendered inside a Composite component'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'should throw when Composite.Row is rendered outside of Composite', () => {
+			expect( () =>
+				render( <Composite.Row>Row</Composite.Row> )
+			).toThrow(
+				'Composite.Row can only be rendered inside a Composite component'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'should throw when Composite.Group is rendered outside of Composite', () => {
+			expect( () =>
+				render( <Composite.Group>Group</Composite.Group> )
+			).toThrow(
+				'Composite.Group can only be rendered inside a Composite component'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'should throw when Composite.GroupLabel is rendered outside of Composite', () => {
+			expect( () =>
+				render( <Composite.GroupLabel>Label</Composite.GroupLabel> )
+			).toThrow(
+				'Composite.GroupLabel can only be rendered inside a Composite component'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'should throw when Composite.Hover is rendered outside of Composite', () => {
+			expect( () =>
+				render( <Composite.Hover>Hover</Composite.Hover> )
+			).toThrow(
+				'Composite.Hover can only be rendered inside a Composite component'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'should throw when Composite.Typeahead is rendered outside of Composite', () => {
+			expect( () =>
+				render( <Composite.Typeahead>Typeahead</Composite.Typeahead> )
+			).toThrow(
+				'Composite.Typeahead can only be rendered inside a Composite component'
+			);
+			expect( console ).toHaveErrored();
+		} );
+	} );
 } );

--- a/packages/components/src/composite/typeahead.tsx
+++ b/packages/components/src/composite/typeahead.tsx
@@ -24,7 +24,13 @@ export const CompositeTypeahead = forwardRef<
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
-	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	const store = ( props.store ?? context?.store ) as Ariakit.CompositeStore;
+
+	if ( ! store ) {
+		throw new Error(
+			'Composite.Typeahead can only be rendered inside a Composite component'
+		);
+	}
 
 	return (
 		<Ariakit.CompositeTypeahead store={ store } { ...props } ref={ ref } />


### PR DESCRIPTION
## What?

Closes #66530

## Why?

When `Composite` subcomponents (`Composite.Item`, `Composite.Group`, etc.) are rendered outside of a `Composite` parent, they silently fail or produce cryptic Ariakit errors because the context store is missing. The `Menu` component already validates this and throws a helpful error — `Composite` should do the same.

## How?

- Changed `CompositeContext` default from `{}` to `undefined` (matching `Menu`'s pattern)
- Added throw guards to all 6 subcomponents: `Item`, `Group`, `Row`, `Hover`, `Typeahead`, `GroupLabel`
- Each guard checks `props.store ?? context?.store` — only throws when **both** are undefined (preserving the legacy compat layer that passes store via props)
- Error messages follow the same format as Menu: `"Composite.Item can only be rendered inside a Composite component"`

## Testing Instructions

1. Try rendering `<Composite.Item>Test</Composite.Item>` without a `Composite` wrapper
2. Should see a clear error: "Composite.Item can only be rendered inside a Composite component"
3. Verify normal usage (`<Composite><Composite.Item>...</Composite.Item></Composite>`) still works

## Use of AI Tools

Claude Code was used to assist with this enhancement. All changes were reviewed, tested, and verified manually.