### PR TITLE
Components: Stabilize __unstablePopoverProps as popoverProps in BorderControl

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   `BorderControl`: Stabilize `__unstablePopoverProps` as `popoverProps`. The old prop is deprecated and will be removed in a future version.
+
 ### Bug Fixes
 
 -   `Autocomplete`: Fix value comparison to avoid resetting block inserter in RTC ([#76980](https://github.com/WordPress/gutenberg/pull/76980)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
--   `BorderControl`: Stabilize `__unstablePopoverProps` as `popoverProps`. The old prop is deprecated and will be removed in a future version.
+-   `BorderControl`: Stabilize `__unstablePopoverProps` as `popoverProps`. The old prop is deprecated and will be removed in a future version ([#77184](https://github.com/WordPress/gutenberg/pull/77184)).
 
 ### Bug Fixes
 

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -45,19 +45,18 @@ const BorderBoxControlSplitControls = (
 	);
 
 	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps: BorderControlProps[ '__unstablePopoverProps' ] =
-		useMemo(
-			() =>
-				popoverPlacement
-					? {
-							placement: popoverPlacement,
-							offset: popoverOffset,
-							anchor: popoverAnchor,
-							shift: true,
-					  }
-					: undefined,
-			[ popoverPlacement, popoverOffset, popoverAnchor ]
-		);
+	const popoverProps: BorderControlProps[ 'popoverProps' ] = useMemo(
+		() =>
+			popoverPlacement
+				? {
+						placement: popoverPlacement,
+						offset: popoverOffset,
+						anchor: popoverAnchor,
+						shift: true,
+				  }
+				: undefined,
+		[ popoverPlacement, popoverOffset, popoverAnchor ]
+	);
 
 	const sharedBorderControlProps = {
 		colors,
@@ -83,7 +82,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision
 				label={ __( 'Top border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'top' ) }
-				__unstablePopoverProps={ popoverProps }
+				popoverProps={ popoverProps }
 				value={ value?.top }
 				{ ...sharedBorderControlProps }
 			/>
@@ -93,7 +92,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
-				__unstablePopoverProps={ popoverProps }
+				popoverProps={ popoverProps }
 				value={ value?.left }
 				{ ...sharedBorderControlProps }
 			/>
@@ -104,7 +103,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision
 				label={ __( 'Right border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
-				__unstablePopoverProps={ popoverProps }
+				popoverProps={ popoverProps }
 				value={ value?.right }
 				{ ...sharedBorderControlProps }
 			/>
@@ -115,7 +114,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision
 				label={ __( 'Bottom border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'bottom' ) }
-				__unstablePopoverProps={ popoverProps }
+				popoverProps={ popoverProps }
 				value={ value?.bottom }
 				{ ...sharedBorderControlProps }
 			/>

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -74,19 +74,18 @@ const UnconnectedBorderBoxControl = (
 	);
 
 	// Memoize popoverProps to avoid returning a new object every time.
-	const popoverProps: BorderControlProps[ '__unstablePopoverProps' ] =
-		useMemo(
-			() =>
-				popoverPlacement
-					? {
-							placement: popoverPlacement,
-							offset: popoverOffset,
-							anchor: popoverAnchor,
-							shift: true,
-					  }
-					: undefined,
-			[ popoverPlacement, popoverOffset, popoverAnchor ]
-		);
+	const popoverProps: BorderControlProps[ 'popoverProps' ] = useMemo(
+		() =>
+			popoverPlacement
+				? {
+						placement: popoverPlacement,
+						offset: popoverOffset,
+						anchor: popoverAnchor,
+						shift: true,
+				  }
+				: undefined,
+		[ popoverPlacement, popoverOffset, popoverAnchor ]
+	);
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
 	return (
@@ -108,7 +107,7 @@ const UnconnectedBorderBoxControl = (
 						placeholder={
 							hasMixedBorders ? __( 'Mixed' ) : undefined
 						}
-						__unstablePopoverProps={ popoverProps }
+						popoverProps={ popoverProps }
 						shouldSanitizeBorder={ false } // This component will handle that.
 						value={ linkedValue }
 						withSlider

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -159,7 +159,7 @@ const BorderControlDropdown = (
 		popoverControlsClassName,
 		resetButtonWrapperClassName,
 		size,
-		__unstablePopoverProps,
+		popoverProps,
 		...otherProps
 	} = useBorderControlDropdown( props );
 
@@ -244,7 +244,7 @@ const BorderControlDropdown = (
 			renderToggle={ renderToggle }
 			renderContent={ renderContent }
 			popoverProps={ {
-				...__unstablePopoverProps,
+				...popoverProps,
 			} }
 			{ ...otherProps }
 			ref={ forwardedRef }

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -54,7 +54,7 @@ const UnconnectedBorderControl = (
 		onSliderChange,
 		onWidthChange,
 		placeholder,
-		__unstablePopoverProps,
+		popoverProps,
 		previousStyleSelection,
 		showDropdownHeader,
 		size,
@@ -82,9 +82,7 @@ const UnconnectedBorderControl = (
 							<BorderControlDropdown
 								border={ border }
 								colors={ colors }
-								__unstablePopoverProps={
-									__unstablePopoverProps
-								}
+								popoverProps={ popoverProps }
 								disableCustomColors={ disableCustomColors }
 								enableAlpha={ enableAlpha }
 								enableStyle={ enableStyle }

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useMemo, useState } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -36,11 +37,23 @@ export function useBorderControl(
 		size = 'default',
 		value: border,
 		width,
+		popoverProps,
+		__unstablePopoverProps,
 		__experimentalIsRenderedInSidebar = false,
 		__next40pxDefaultSize,
 		__shouldNotWarnDeprecated36pxSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderControl' );
+
+	if ( __unstablePopoverProps !== undefined ) {
+		deprecated(
+			'`__unstablePopoverProps` prop in wp.components.BorderControl',
+			{
+				since: '7.0',
+				alternative: '`popoverProps`',
+			}
+		);
+	}
 
 	maybeWarnDeprecated36pxSize( {
 		componentName: 'BorderControl',
@@ -163,6 +176,7 @@ export function useBorderControl(
 		onBorderChange,
 		onSliderChange,
 		onWidthChange,
+		popoverProps: popoverProps ?? __unstablePopoverProps,
 		previousStyleSelection: styleSelection,
 		sliderClassName,
 		value: border,

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -73,7 +73,13 @@ export type BorderControlProps = ColorProps &
 		 */
 		placeholder?: HTMLInputElement[ 'placeholder' ];
 		/**
-		 * An internal prop used to control the visibility of the dropdown.
+		 * Props to pass to the popover that contains the border color and style
+		 * picker dropdown.
+		 */
+		popoverProps?: Omit< PopoverProps, 'children' >;
+		/**
+		 * @deprecated Use `popoverProps` instead.
+		 * @ignore
 		 */
 		__unstablePopoverProps?: Omit< PopoverProps, 'children' >;
 		/**
@@ -138,9 +144,10 @@ export type DropdownProps = ColorProps &
 		 */
 		isStyleSettable: boolean;
 		/**
-		 * An internal prop used to control the visibility of the dropdown.
+		 * Props to pass to the popover that contains the border color and style
+		 * picker dropdown.
 		 */
-		__unstablePopoverProps?: Omit< PopoverProps, 'children' >;
+		popoverProps?: Omit< PopoverProps, 'children' >;
 		/**
 		 * A callback invoked when the border color or style selections change.
 		 */


### PR DESCRIPTION
## What?

Closes #65581

## Why?

`BorderControl` exposes `__unstablePopoverProps` for controlling the dropdown popover. This prop has been stable in practice and is used internally by `BorderBoxControl`. Stabilizing it as `popoverProps` gives consumers a public API to position the dropdown.

## How?

- Added `popoverProps` as the stable prop name on `BorderControlProps`
- Kept `__unstablePopoverProps` with `@deprecated` / `@ignore` JSDoc annotations
- Added deprecation warning via `@wordpress/deprecated` when the old prop is used
- Hook resolves `popoverProps ?? __unstablePopoverProps` for backward compatibility
- Updated all internal callers in `BorderBoxControl` to use the stable name
- Updated `DropdownProps` (internal) to use `popoverProps`

## Testing Instructions

1. Render `<BorderControl popoverProps={{ placement: 'bottom' }} />` — dropdown should respect placement
2. Render `<BorderControl __unstablePopoverProps={{ placement: 'bottom' }} />` — should still work but emit a deprecation warning in the console
3. Verify `BorderBoxControl` still functions correctly (it passes popoverProps internally)

## Use of AI Tools

Claude Code was used to assist with this stabilization. All changes were reviewed, tested, and verified manually.