### PR TITLE
ui/Card: Remove redundant margin reset from Card.Title

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Internal
 
+-   `Card`: Remove redundant `margin: 0` from `Card.Title` now that `Text` applies it by default ([#77187](https://github.com/WordPress/gutenberg/pull/77187)).
 -   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
 
 ## 0.10.0 (2026-04-01)

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -38,8 +38,4 @@
 		margin-inline: calc(-1 * var(--wp-ui-card-padding));
 		width: calc(100% + 2 * var(--wp-ui-card-padding));
 	}
-
-	.title {
-		margin: 0;
-	}
 }

--- a/packages/ui/src/card/title.tsx
+++ b/packages/ui/src/card/title.tsx
@@ -1,7 +1,5 @@
 import { forwardRef } from '@wordpress/element';
-import clsx from 'clsx';
 import { Text } from '../text';
-import styles from './style.module.css';
 import type { TitleProps } from './types';
 
 /**
@@ -9,12 +7,11 @@ import type { TitleProps } from './types';
  * prop to swap in a semantic heading element when appropriate.
  */
 export const Title = forwardRef< HTMLDivElement, TitleProps >(
-	function CardTitle( { className, render, children, ...props }, ref ) {
+	function CardTitle( { render, children, ...props }, ref ) {
 		return (
 			<Text
 				variant="heading-lg"
 				render={ render ?? <div ref={ ref } { ...props } /> }
-				className={ clsx( styles.title, className ) }
 			>
 				{ children }
 			</Text>


### PR DESCRIPTION
## What?

Split from #76690.

Remove the now-redundant `margin: 0` override from `Card.Title`, since the `Text` component applies it by default after #76970.

## Why?

`Text` now resets margins on all elements (#76970). `Card.Title` had its own `.title { margin: 0 }` CSS class and `clsx` wiring solely for this purpose — it's dead code now.

## How?

<details>
<summary>Details</summary>

- Delete the `.title { margin: 0 }` rule from `card/style.module.css`.
- Remove the `clsx` / `styles` imports and `className` prop plumbing from `Card.Title` (`title.tsx`).
- `className` is still forwarded to the underlying element via `...props` on the render element.

</details>

## Testing Instructions

1. `npm run storybook:dev`
2. Navigate to **Design System / Components / Card** — verify the title renders without extra margin.
3. Check the `CollapsibleCard` stories as well (they use `Card.Title` internally).

## Use of AI Tools

Cursor + Claude Opus 4.6