### PR TITLE
Tabs: Simplify anchor handling

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1060,7 +1060,6 @@ A single tab button in the tabs menu. ([Source](https://github.com/WordPress/gut
 -	**Category:** design
 -	**Parent:** core/tabs-menu
 -	**Supports:** color (background, text), layout (~~allowEditing~~), spacing (padding), typography (fontSize, textAlign), ~~html~~, ~~lock~~, ~~reusable~~
--	**Attributes:** anchor
 
 ## Tag Cloud
 

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -65,7 +65,7 @@ export default function QuickInserter( {
 
 	useEffect( () => {
 		if ( setInserterIsOpened ) {
-			// setInserterIsOpened( false );
+			setInserterIsOpened( false );
 		}
 	}, [ setInserterIsOpened ] );
 

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -65,7 +65,7 @@ export default function QuickInserter( {
 
 	useEffect( () => {
 		if ( setInserterIsOpened ) {
-			setInserterIsOpened( false );
+			// setInserterIsOpened( false );
 		}
 	}, [ setInserterIsOpened ] );
 

--- a/packages/block-library/src/tab/add-tab-toolbar-control.js
+++ b/packages/block-library/src/tab/add-tab-toolbar-control.js
@@ -22,61 +22,46 @@ import { useDispatch, useSelect } from '@wordpress/data';
 export default function AddTabToolbarControl( { tabsClientId } ) {
 	const { insertBlock } = useDispatch( blockEditorStore );
 
-	const { tabPanelClientId, tabsMenuClientId, tabCount, existingAnchors } =
-		useSelect(
-			( select ) => {
-				if ( ! tabsClientId ) {
-					return {
-						tabPanelClientId: null,
-						tabsMenuClientId: null,
-						existingAnchors: [],
-					};
-				}
-				const { getBlocks } = select( blockEditorStore );
-				const innerBlocks = getBlocks( tabsClientId );
-				const tabPanel = innerBlocks.find(
-					( block ) => block.name === 'core/tab-panel'
-				);
-				const tabsMenu = innerBlocks.find(
-					( block ) => block.name === 'core/tabs-menu'
-				);
+	const { tabPanelClientId, tabsMenuClientId, tabCount } = useSelect(
+		( select ) => {
+			if ( ! tabsClientId ) {
 				return {
-					tabPanelClientId: tabPanel?.clientId || null,
-					tabsMenuClientId: tabsMenu?.clientId || null,
-					tabCount: tabPanel?.innerBlocks?.length || 0,
-					existingAnchors: ( tabPanel?.innerBlocks || [] )
-						.map( ( block ) => block.attributes.anchor )
-						.filter( Boolean ),
+					tabPanelClientId: null,
+					tabsMenuClientId: null,
+					tabCount: 0,
 				};
-			},
-			[ tabsClientId ]
-		);
+			}
+			const { getBlocks } = select( blockEditorStore );
+			const innerBlocks = getBlocks( tabsClientId );
+			const tabPanel = innerBlocks.find(
+				( block ) => block.name === 'core/tab-panel'
+			);
+			const tabsMenu = innerBlocks.find(
+				( block ) => block.name === 'core/tabs-menu'
+			);
+			return {
+				tabPanelClientId: tabPanel?.clientId || null,
+				tabsMenuClientId: tabsMenu?.clientId || null,
+				tabCount: tabPanel?.innerBlocks?.length || 0,
+			};
+		},
+		[ tabsClientId ]
+	);
 
 	const addTab = () => {
 		if ( ! tabPanelClientId ) {
 			return;
 		}
 
-		// Start from count + 1 so the label stays sequential, then increment
-		// until the anchor slot is free.
-		const existingAnchorSet = new Set( existingAnchors );
-		let tabNumber = tabCount + 1;
-		while ( existingAnchorSet.has( `tab-${ tabNumber }` ) ) {
-			tabNumber++;
-		}
-
 		const newTabBlock = createBlock( 'core/tab', {
-			anchor: `tab-${ tabNumber }`,
 			/* translators: %d: tab number */
-			label: sprintf( __( 'Tab %d' ), tabNumber ),
+			label: sprintf( __( 'Tab %d' ), tabCount + 1 ),
 		} );
 		insertBlock( newTabBlock, undefined, tabPanelClientId );
 
 		// Insert a corresponding menu item into the tabs-menu.
 		if ( tabsMenuClientId ) {
-			const newMenuItemBlock = createBlock( 'core/tabs-menu-item', {
-				anchor: `tab-${ tabNumber }-button`,
-			} );
+			const newMenuItemBlock = createBlock( 'core/tabs-menu-item', {} );
 			insertBlock( newMenuItemBlock, undefined, tabsMenuClientId );
 		}
 	};

--- a/packages/block-library/src/tab/block.json
+++ b/packages/block-library/src/tab/block.json
@@ -17,7 +17,8 @@
 	"parent": [ "core/tab-panel" ],
 	"usesContext": [
 		"core/tabs-activeTabIndex",
-		"core/tabs-editorActiveTabIndex"
+		"core/tabs-editorActiveTabIndex",
+		"core/tabs-id"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/tab/index.php
+++ b/packages/block-library/src/tab/index.php
@@ -15,13 +15,28 @@
  *
  * @return string Updated HTML.
  */
-function block_core_tab_render( array $attributes, string $content ): string {
+function block_core_tab_render( array $attributes, string $content, \WP_Block $block ): string {
+	$tabs_id = $block->context['core/tabs-id'] ?? '';
+
+	static $tab_counters = array();
+
+	if ( ! isset( $tab_counters[ $tabs_id ] ) ) {
+		$tab_counters[ $tabs_id ] = 0;
+	}
+
+	$tab_index = $tab_counters[ $tabs_id ];
+	++$tab_counters[ $tabs_id ];
+
 	$tag_processor = new WP_HTML_Tag_Processor( $content );
 	$tag_processor->next_tag( array( 'class_name' => 'wp-block-tab' ) );
+
+	// Use the user's custom anchor if present, otherwise fall back to
+	// the generated position-based ID.
 	$tab_id = (string) $tag_processor->get_attribute( 'id' );
-	// If no id, generate a unique one
 	if ( empty( $tab_id ) ) {
-		$tab_id = sanitize_title( $attributes['label'] );
+		$tab_id = ! empty( $tabs_id )
+			? $tabs_id . '-tab-' . $tab_index
+			: 'tab-' . $tab_index;
 		$tag_processor->set_attribute( 'id', $tab_id );
 	}
 

--- a/packages/block-library/src/tab/index.php
+++ b/packages/block-library/src/tab/index.php
@@ -11,7 +11,9 @@
  * @since 7.0.0
  *
  * @param array     $attributes Block attributes.
- * @param string    $content    Block content.
+* @param array     $attributes Block attributes.
+* @param string    $content    Block content.
+* @param \WP_Block $block      Block instance.
  *
  * @return string Updated HTML.
  */

--- a/packages/block-library/src/tab/remove-tab-toolbar-control.js
+++ b/packages/block-library/src/tab/remove-tab-toolbar-control.js
@@ -58,15 +58,7 @@ export default function RemoveTabToolbarControl( { tabsClientId } ) {
 			const tabs = tabPanel?.innerBlocks || [];
 			const menuItems = tabsMenu?.innerBlocks || [];
 			const activeTab = tabs[ activeIndex ];
-			// Match menu item by anchor (e.g. "tab-1" → "tab-1-button").
-			const expectedMenuAnchor = activeTab?.attributes?.anchor
-				? `${ activeTab.attributes.anchor }-button`
-				: null;
-			const activeMenuItem = expectedMenuAnchor
-				? menuItems.find(
-						( m ) => m.attributes?.anchor === expectedMenuAnchor
-				  )
-				: menuItems[ activeIndex ];
+			const activeMenuItem = menuItems[ activeIndex ];
 			return {
 				activeTabClientId: activeTab?.clientId || null,
 				activeMenuItemClientId: activeMenuItem?.clientId || null,

--- a/packages/block-library/src/tabs-menu-item/block.json
+++ b/packages/block-library/src/tabs-menu-item/block.json
@@ -17,12 +17,6 @@
 		"core/tabs-menu-item-id",
 		"core/tabs-menu-item-label"
 	],
-	"attributes": {
-		"anchor": {
-			"type": "string",
-			"default": ""
-		}
-	},
 	"supports": {
 		"html": false,
 		"reusable": false,

--- a/packages/block-library/src/tabs-menu-item/edit.js
+++ b/packages/block-library/src/tabs-menu-item/edit.js
@@ -23,7 +23,6 @@ import Controls from './controls';
 const EMPTY_ARRAY = [];
 
 function Edit( {
-	attributes,
 	context,
 	clientId,
 	__unstableLayoutClassNames: layoutClassNames,
@@ -75,14 +74,7 @@ function Edit( {
 		[ clientId, tabsList ]
 	);
 
-	// Find the corresponding tab's anchor from this menu item's anchor
-	// attribute (e.g., "tab-1-button" → "tab-1"), then look it up in tabsList.
-	// Falls back to positional lookup when no anchor is set.
-	const tabAnchor = attributes.anchor?.replace( /-button$/, '' ) ?? '';
-	const tab =
-		( tabAnchor && tabsList.find( ( t ) => t.id === tabAnchor ) ) ||
-		tabsList[ menuItemIndex ] ||
-		{};
+	const tab = tabsList[ menuItemIndex ] || {};
 
 	// tabListIndex is the tab's position in tabsList, used for active-state
 	// checks and click handling.

--- a/packages/block-library/src/tabs-menu/index.php
+++ b/packages/block-library/src/tabs-menu/index.php
@@ -29,7 +29,7 @@ function block_core_tabs_menu_render_callback( array $attributes, string $conten
 
 	// Re-render each tabs-menu-item with per-item context (index, id, label).
 	// Match by position so items align with their corresponding tabs.
-	$buttons_html      = '';
+	$buttons_html       = '';
 	$menu_item_position = 0;
 
 	foreach ( $block->parsed_block['innerBlocks'] ?? array() as $parsed_menu_item ) {

--- a/packages/block-library/src/tabs-menu/index.php
+++ b/packages/block-library/src/tabs-menu/index.php
@@ -28,29 +28,18 @@ function block_core_tabs_menu_render_callback( array $attributes, string $conten
 	}
 
 	// Re-render each tabs-menu-item with per-item context (index, id, label).
-	// Match by anchor so the correct tab is found even when the two lists
-	// are in different orders.
-	$buttons_html = '';
+	// Match by position so items align with their corresponding tabs.
+	$buttons_html      = '';
+	$menu_item_position = 0;
 
 	foreach ( $block->parsed_block['innerBlocks'] ?? array() as $parsed_menu_item ) {
 		if ( 'core/tabs-menu-item' !== ( $parsed_menu_item['blockName'] ?? '' ) ) {
 			continue;
 		}
 
-		// Find the tab anchor from the menu item anchor (e.g. "tab-1-button" → "tab-1").
-		$menu_item_anchor = $parsed_menu_item['attrs']['anchor'] ?? '';
-		$tab_anchor       = preg_replace( '/-button$/', '', $menu_item_anchor );
-
-		// Find the matching tab in $tabs_list by id.
-		$tab       = null;
-		$tab_index = 0;
-		foreach ( $tabs_list as $index => $candidate ) {
-			if ( ( $candidate['id'] ?? '' ) === $tab_anchor ) {
-				$tab       = $candidate;
-				$tab_index = $index;
-				break;
-			}
-		}
+		$tab       = $tabs_list[ $menu_item_position ] ?? null;
+		$tab_index = $menu_item_position;
+		++$menu_item_position;
 
 		// Skip menu items with no matching tab.
 		if ( null === $tab ) {

--- a/packages/block-library/src/tabs/edit.js
+++ b/packages/block-library/src/tabs/edit.js
@@ -15,6 +15,8 @@ import { useMemo, useEffect, useRef } from '@wordpress/element';
  */
 import Controls from './controls';
 
+const EMPTY_ARRAY = [];
+
 const TABS_TEMPLATE = [
 	[
 		'core/tabs-menu',
@@ -24,8 +26,8 @@ const TABS_TEMPLATE = [
 			},
 		},
 		[
-			[ 'core/tabs-menu-item', { anchor: 'tab-1-button' } ],
-			[ 'core/tabs-menu-item', { anchor: 'tab-2-button' } ],
+			[ 'core/tabs-menu-item', {} ],
+			[ 'core/tabs-menu-item', {} ],
 		],
 	],
 	[
@@ -39,7 +41,6 @@ const TABS_TEMPLATE = [
 			[
 				'core/tab',
 				{
-					anchor: 'tab-1',
 					label: 'Tab 1',
 				},
 				[ [ 'core/paragraph' ] ],
@@ -47,7 +48,6 @@ const TABS_TEMPLATE = [
 			[
 				'core/tab',
 				{
-					anchor: 'tab-2',
 					label: 'Tab 2',
 				},
 				[ [ 'core/paragraph' ] ],
@@ -74,41 +74,24 @@ function Edit( {
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	const { removeBlock } = useDispatch( blockEditorStore );
+	const { removeBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
 
-	/**
-	 * Construct a list of core/tab blocks, used to create tabs-list context.
-	 * Also select menu items with their anchors for anchor-based deletion sync.
-	 */
-	const { tabs, menuItems } = useSelect(
+	const { tabs, tabPanelClientId, menuItems } = useSelect(
 		( select ) => {
 			const { getBlocks } = select( blockEditorStore );
 			const innerBlocks = getBlocks( clientId );
 
-			// Find tab-panel block and extract tab data.
 			const tabPanel = innerBlocks.find(
 				( block ) => block.name === 'core/tab-panel'
 			);
-
-			// Find tabs-menu block and get its children with their anchors.
 			const tabsMenu = innerBlocks.find(
 				( block ) => block.name === 'core/tabs-menu'
 			);
 
 			return {
-				tabs: tabPanel
-					? tabPanel.innerBlocks.filter(
-							( block ) => block.name === 'core/tab'
-					  )
-					: [],
-				menuItems: tabsMenu
-					? getBlocks( tabsMenu.clientId )
-							.filter( ( b ) => b.name === 'core/tabs-menu-item' )
-							.map( ( b ) => ( {
-								clientId: b.clientId,
-								anchor: b.attributes.anchor ?? '',
-							} ) )
-					: [],
+				tabs: tabPanel?.innerBlocks ?? EMPTY_ARRAY,
+				tabPanelClientId: tabPanel?.clientId ?? null,
+				menuItems: tabsMenu?.innerBlocks ?? EMPTY_ARRAY,
 			};
 		},
 		[ clientId ]
@@ -130,7 +113,6 @@ function Edit( {
 	useEffect( () => {
 		const currentTabs = tabs.map( ( tab ) => ( {
 			clientId: tab.clientId,
-			anchor: tab.attributes.anchor ?? '',
 		} ) );
 
 		if ( prevSyncStateRef.current === null ) {
@@ -146,6 +128,13 @@ function Edit( {
 
 		const tabsRemoved = currentTabs.length < prevTabs.length;
 		const menuItemsRemoved = menuItems.length < prevMenuItems.length;
+		const menuItemsReordered =
+			! tabsRemoved &&
+			! menuItemsRemoved &&
+			menuItems.length === prevMenuItems.length &&
+			menuItems.some(
+				( m, i ) => m.clientId !== prevMenuItems[ i ]?.clientId
+			);
 
 		// Update snapshot to the current state.
 		// Snapshot is updated eagerly; post-removal mutations keep it consistent
@@ -154,6 +143,23 @@ function Edit( {
 			tabs: currentTabs,
 			menuItems: [ ...menuItems ],
 		};
+
+		// When menu items are reordered, move the corresponding tab content
+		// blocks to match the new order.
+		if ( menuItemsReordered && tabPanelClientId ) {
+			const reorderedTabs = menuItems
+				.map( ( menuItem ) => {
+					const oldIndex = prevMenuItems.findIndex(
+						( pm ) => pm.clientId === menuItem.clientId
+					);
+					return oldIndex !== -1 ? tabs[ oldIndex ] : null;
+				} )
+				.filter( Boolean );
+			if ( reorderedTabs.length === tabs.length ) {
+				replaceInnerBlocks( tabPanelClientId, reorderedTabs, false );
+			}
+			return;
+		}
 
 		// Lists are in sync, nothing changed, or toolbar already removed both.
 		if (
@@ -169,45 +175,31 @@ function Edit( {
 		);
 
 		if ( tabsRemoved ) {
-			prevTabs.forEach( ( prevTab ) => {
-				if ( currentTabIds.has( prevTab.clientId ) ) {
-					return;
-				}
-				const expectedMenuAnchor = prevTab.anchor
-					? `${ prevTab.anchor }-button`
-					: null;
-				const menuItemToRemove = expectedMenuAnchor
-					? menuItems.find( ( m ) => m.anchor === expectedMenuAnchor )
-					: null;
-				if ( menuItemToRemove ) {
-					removeBlock( menuItemToRemove.clientId, false );
-					prevSyncStateRef.current.menuItems =
-						prevSyncStateRef.current.menuItems.filter(
-							( m ) => m.clientId !== menuItemToRemove.clientId
-						);
-				}
-			} );
+			// Remove the menu item at the same position.
+			const removedIndex = prevTabs.findIndex(
+				( t ) => ! currentTabIds.has( t.clientId )
+			);
+			if ( removedIndex >= 0 && menuItems[ removedIndex ] ) {
+				removeBlock( menuItems[ removedIndex ].clientId, false );
+				prevSyncStateRef.current.menuItems =
+					prevSyncStateRef.current.menuItems.filter(
+						( _, i ) => i !== removedIndex
+					);
+			}
 		} else {
-			prevMenuItems.forEach( ( prevItem ) => {
-				if ( currentMenuItemIds.has( prevItem.clientId ) ) {
-					return;
-				}
-				const expectedTabAnchor =
-					prevItem.anchor?.replace( /-button$/, '' ) ?? '';
-				const tabToRemove = tabs.find(
-					( tab ) =>
-						( tab.attributes.anchor ?? '' ) === expectedTabAnchor
-				);
-				if ( tabToRemove ) {
-					removeBlock( tabToRemove.clientId, false );
-					prevSyncStateRef.current.tabs =
-						prevSyncStateRef.current.tabs.filter(
-							( t ) => t.clientId !== tabToRemove.clientId
-						);
-				}
-			} );
+			// Remove the tab at the same position.
+			const removedIndex = prevMenuItems.findIndex(
+				( m ) => ! currentMenuItemIds.has( m.clientId )
+			);
+			if ( removedIndex >= 0 && tabs[ removedIndex ] ) {
+				removeBlock( tabs[ removedIndex ].clientId, false );
+				prevSyncStateRef.current.tabs =
+					prevSyncStateRef.current.tabs.filter(
+						( _, i ) => i !== removedIndex
+					);
+			}
 		}
-	}, [ tabs, menuItems, removeBlock ] );
+	}, [ tabs, tabPanelClientId, menuItems, removeBlock, replaceInnerBlocks ] );
 
 	/**
 	 * Memoize context value to prevent unnecessary re-renders.

--- a/packages/block-library/src/tabs/index.php
+++ b/packages/block-library/src/tabs/index.php
@@ -10,11 +10,12 @@
  *
  * @since 7.0.0
  *
- * @param array $innerblocks Parsed inner blocks of tabs block.
+ * @param array  $innerblocks Parsed inner blocks of tabs block.
+ * @param string $tabs_id     Unique ID for the tabs instance, used to generate tab IDs.
  *
  * @return array List of tabs with id, label, index.
  */
-function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): array {
+function block_core_tabs_generate_tabs_list( array $innerblocks = array(), string $tabs_id = '' ): array {
 	$tabs_list = array();
 
 	// Find tab-panel block
@@ -26,17 +27,11 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
 					$attrs     = $tab_block['attrs'] ?? array();
 					$tab_label = $attrs['label'] ?? '';
 
-					// Try to get the ID from the rendered content
-					$tab_id = $attrs['anchor'] ?? '';
-					if ( empty( $tab_id ) && ! empty( $tab_block['innerHTML'] ) ) {
-						$tag_processor = new WP_HTML_Tag_Processor( $tab_block['innerHTML'] );
-						if ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-tab' ) ) ) {
-							$tab_id = $tag_processor->get_attribute( 'id' ) ?? '';
-						}
-					}
-					if ( empty( $tab_id ) ) {
-						$tab_id = 'tab-' . $tab_index;
-					}
+					$tab_id = ! empty( $attrs['anchor'] )
+						? $attrs['anchor']
+						: ( ! empty( $tabs_id )
+							? $tabs_id . '-tab-' . $tab_index
+							: 'tab-' . $tab_index );
 
 					$tabs_list[] = array(
 						'id'    => esc_attr( $tab_id ),
@@ -67,9 +62,13 @@ function block_core_tabs_generate_tabs_list( array $innerblocks = array() ): arr
  */
 function block_core_tabs_provide_context( array $context, array $parsed_block ): array {
 	if ( 'core/tabs' === $parsed_block['blockName'] ) {
-		$tabs_list                 = block_core_tabs_generate_tabs_list( $parsed_block['innerBlocks'] ?? array() );
+		// Generate a unique ID for the tabs instance first, so it can be used
+		// to derive stable tab IDs. Used for 3rd party extensibility to identify
+		// the tabs instance.
+		$tabs_id                   = $parsed_block['attrs']['anchor'] ?? wp_unique_id( 'tabs_' );
+		$tabs_list                 = block_core_tabs_generate_tabs_list( $parsed_block['innerBlocks'] ?? array(), $tabs_id );
 		$context['core/tabs-list'] = $tabs_list;
-		$context['core/tabs-id']   = $parsed_block['attrs']['anchor'] ?? wp_unique_id( 'tabs_' ); // Generate a unique ID for each tabs instance. Used for 3rd party extensibility to identify the tabs instance.
+		$context['core/tabs-id']   = $tabs_id;
 	}
 
 	return $context;


### PR DESCRIPTION
## What?

Simplifies how `core/tab` and `core/tabs-menu-item` blocks are linked by replacing explicit anchor-based matching with positional (index-based) matching.

| Before | After |
|--------|--------|
| <img width="363" height="294" alt="image" src="https://github.com/user-attachments/assets/8cfd25cd-198a-4ebe-a0e9-2955e225cbdc" /> | <img width="366" height="302" alt="image" src="https://github.com/user-attachments/assets/8752c897-10b5-4e1d-99c1-644a449b418b" /> |

## Why?

In the current implementation, when a Tabs block is inserted, explicit IDs are assigned to the Tab Menu Item and Tab. This is because the synchronization between the tab block and the tab-menu-item block is based on HTML anchors, but it feels redundant;



Another problem with this approach is that when a Tabs block is duplicated, the HTML anchor is also duplicated, resulting in multiple instances of the same ID existing on the same page.

The addition, reordering, and deletion of tabs should all be manageable using an index-based approach.

## How?

The basic policy is as follows:

- When inserting a Tabs block, do not automatically inject HTML anchors into the markup. HTML anchors are guaranteed to be calculated on the server side, generating a unique ID. The HTML anchor format is `tabs_{tabsBlockIndex}-tab-{tabIndex}`.
- Only use an explicit HTML anchor if the user has set one for a tab.

This PR also resolves a large number of browser warnings that were being logged when the Tabs block was inserted.

<img width="610" height="339" alt="image" src="https://github.com/user-attachments/assets/29f3c548-191a-48ba-9bda-7297e4d49b27" />

## Testing Instructions

- Confirm that adding, deleting, and reordering tabs in the editor function as expected.
- Confirm that tabs and panels are correctly linked on the front end
- Confirm that custom HTML anchors work properly.

## Use of AI Tools

This pull request was developed with the assistance of Claude Code (AI coding assistant). All generated code has been reviewed and tested by the author.