### PR TITLE
ui/VisuallyHidden: Standardize composition pattern

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -18,16 +18,19 @@
 ### Bug Fixes
 
 -   `Card`: Set default foreground color on `Card.Root` so content and `currentColor` icons (for example the `CollapsibleCard` chevron) are themeable by default ([#77013](https://github.com/WordPress/gutenberg/pull/77013)).
+-   `Field.Label`: Preserve the native `<label>` element when `hideFromVision` is enabled, improving assistive technology support.
 
 ### Enhancements
 
 -   `Dialog`: Update `Header` layout to support multiple trailing elements alongside the title ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
 -   `Dialog`: Use `Text` internally for `Dialog.Title`, adopting the `heading-xl` variant for consistent typography ([#77161](https://github.com/WordPress/gutenberg/pull/77161)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
+-   `VisuallyHidden`: Improve Storybook stories and documentation for the `render` prop composition pattern.
 
 ### Internal
 
 -   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
+-   `Field.Label`, `Fieldset.Legend`, `Field.Details`: Refactor `VisuallyHidden` composition to preserve semantic HTML elements when visually hiding content.
 
 ## 0.10.0 (2026-04-01)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -18,7 +18,6 @@
 ### Bug Fixes
 
 -   `Card`: Set default foreground color on `Card.Root` so content and `currentColor` icons (for example the `CollapsibleCard` chevron) are themeable by default ([#77013](https://github.com/WordPress/gutenberg/pull/77013)).
--   `Field.Label`: Preserve the native `<label>` element when `hideFromVision` is enabled, improving assistive technology support.
 
 ### Enhancements
 

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useId, useState } from '@wordpress/element';
 import type { ComponentProps } from 'react';
+import { VisuallyHidden } from '../../visually-hidden';
 import * as Dialog from '../index';
 
 const meta: Meta< typeof Dialog.Root > = {
@@ -160,4 +161,36 @@ export const AllSizes: Story = {
 export const WithCustomZIndex: Story = {
 	..._Default,
 	name: 'With Custom z-index',
+};
+
+/**
+ * A dialog with a visually hidden title. The title is still present in the
+ * DOM for `aria-labelledby`, but is not visible to sighted users.
+ *
+ * Use `<VisuallyHidden render={ <Dialog.Title /> }>` so that `Dialog.Title`
+ * keeps its `<h2>` element while being visually hidden.
+ */
+export const WithVisuallyHiddenTitle: Story = {
+	args: {
+		children: (
+			<>
+				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+				<Dialog.Popup>
+					<Dialog.Header>
+						<VisuallyHidden render={ <Dialog.Title /> }>
+							Accessible dialog heading
+						</VisuallyHidden>
+						<Dialog.CloseIcon />
+					</Dialog.Header>
+					<p>
+						This dialog has a visually hidden title. Inspect the DOM
+						or use a screen reader to verify the heading is present.
+					</p>
+					<Dialog.Footer>
+						<Dialog.Action>Got it</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</>
+		),
+	},
 };

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -203,10 +203,8 @@ describe( 'Dialog', () => {
 						<Dialog.Trigger>Open Dialog</Dialog.Trigger>
 						<Dialog.Popup>
 							<Dialog.Header>
-								{ /* @ts-expect-error this is just for test purposes */ }
-								<Dialog.Title>
-									{ /* Empty title */ }
-								</Dialog.Title>
+								{ /* Empty title */ }
+								<Dialog.Title />
 							</Dialog.Header>
 							<p>Content with empty title</p>
 							<Dialog.Footer>

--- a/packages/ui/src/dialog/title.tsx
+++ b/packages/ui/src/dialog/title.tsx
@@ -11,9 +11,18 @@ import type { TitleProps } from './types';
  * and serves as both the visible heading and the accessible label for
  * the dialog.
  *
- * Uses the `heading-xl` text variant, matching Popover. Base UI's
- * Dialog.Title renders an `<h2>` by default. Use the `render` prop
- * to customize the element if needed.
+ * **Required** — every dialog must include a `Dialog.Title`, even if
+ * visually hidden. The rendered element is linked to the popup via
+ * `aria-labelledby`. Renders an `<h2>` by default.
+ *
+ * To visually hide the title while keeping it accessible, wrap it with
+ * `VisuallyHidden` using the `render` prop:
+ *
+ * ```jsx
+ * <VisuallyHidden render={ <Dialog.Title /> }>
+ *   Accessible title text
+ * </VisuallyHidden>
+ * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 	function DialogTitle( { children, ...props }, forwardedRef ) {

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -74,8 +74,11 @@ export interface TitleProps extends ComponentProps< 'h2' > {
 	/**
 	 * The title content to be rendered. This serves as both the visible
 	 * heading and the accessible label for the dialog.
+	 *
+	 * When `Dialog.Title` is passed as a render element (e.g. to
+	 * `VisuallyHidden`), children can be provided by the wrapper instead.
 	 */
-	children: ReactNode;
+	children?: ReactNode;
 }
 
 export interface CloseIconProps

--- a/packages/ui/src/form/primitives/field/details.tsx
+++ b/packages/ui/src/form/primitives/field/details.tsx
@@ -22,9 +22,11 @@ export const Details = forwardRef< HTMLDivElement, FieldDetailsProps >(
 	function Details( { className, ...restProps }, ref ) {
 		return (
 			<>
-				<_Field.Description render={ <VisuallyHidden /> }>
+				{ /* VisuallyHidden is the host so that _Field.Description's
+				   semantic element is preserved. See VisuallyHidden docs. */ }
+				<VisuallyHidden render={ <_Field.Description /> }>
 					{ __( 'More details follow the field.' ) }
-				</_Field.Description>
+				</VisuallyHidden>
 				<div
 					ref={ ref }
 					className={ clsx( fieldStyles.description, className ) }

--- a/packages/ui/src/form/primitives/field/label.tsx
+++ b/packages/ui/src/form/primitives/field/label.tsx
@@ -10,7 +10,7 @@ export const Label = forwardRef< HTMLLabelElement, FieldLabelProps >(
 		{ className, hideFromVision, variant, ...restProps },
 		ref
 	) {
-		return (
+		const label = (
 			<_Field.Label
 				ref={ ref }
 				className={ clsx(
@@ -18,12 +18,16 @@ export const Label = forwardRef< HTMLLabelElement, FieldLabelProps >(
 					variant && fieldStyles[ `is-${ variant }` ],
 					className
 				) }
-				{ ...( hideFromVision && {
-					render: <VisuallyHidden />,
-					nativeLabel: false,
-				} ) }
 				{ ...restProps }
 			/>
 		);
+
+		// VisuallyHidden is the host so that _Field.Label's semantic
+		// element is preserved. See VisuallyHidden docs for details.
+		if ( hideFromVision ) {
+			return <VisuallyHidden render={ label } />;
+		}
+
+		return label;
 	}
 );

--- a/packages/ui/src/form/primitives/field/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/field/test/index.test.tsx
@@ -47,6 +47,17 @@ describe( 'Field', () => {
 		).toBeVisible();
 	} );
 
+	it( 'preserves the native label element when hideFromVision is enabled', () => {
+		render(
+			<Field.Root>
+				<Field.Label hideFromVision>Field Label</Field.Label>
+				<Field.Control render={ <input /> } />
+			</Field.Root>
+		);
+
+		expect( screen.getByText( 'Field Label' ).tagName ).toBe( 'LABEL' );
+	} );
+
 	it( 'renders details with a semantically associated description for the control', () => {
 		render(
 			<Field.Root>

--- a/packages/ui/src/form/primitives/fieldset/legend.tsx
+++ b/packages/ui/src/form/primitives/fieldset/legend.tsx
@@ -10,15 +10,20 @@ export const FieldsetLegend = forwardRef< HTMLDivElement, FieldsetLegendProps >(
 		{ className, hideFromVision, ...restProps },
 		ref
 	) {
-		return (
+		const legend = (
 			<_Fieldset.Legend
 				ref={ ref }
 				className={ clsx( fieldStyles.label, className ) }
-				{ ...( hideFromVision && {
-					render: <VisuallyHidden />,
-				} ) }
 				{ ...restProps }
 			/>
 		);
+
+		// VisuallyHidden is the host so that _Fieldset.Legend's semantic
+		// element is preserved. See VisuallyHidden docs for details.
+		if ( hideFromVision ) {
+			return <VisuallyHidden render={ legend } />;
+		}
+
+		return legend;
 	}
 );

--- a/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
@@ -43,6 +43,28 @@ describe( 'Fieldset', () => {
 		).toBeVisible();
 	} );
 
+	it( 'preserves the legend element type when hideFromVision is enabled', () => {
+		const { rerender } = render(
+			<Fieldset.Root>
+				<Fieldset.Legend>Choose your options</Fieldset.Legend>
+			</Fieldset.Root>
+		);
+
+		const tagWithout = screen.getByText( 'Choose your options' ).tagName;
+
+		rerender(
+			<Fieldset.Root>
+				<Fieldset.Legend hideFromVision>
+					Choose your options
+				</Fieldset.Legend>
+			</Fieldset.Root>
+		);
+
+		expect( screen.getByText( 'Choose your options' ).tagName ).toBe(
+			tagWithout
+		);
+	} );
+
 	it( 'accessibly associates description when Fieldset.Description is present', () => {
 		render(
 			<Fieldset.Root>

--- a/packages/ui/src/visually-hidden/stories/index.story.tsx
+++ b/packages/ui/src/visually-hidden/stories/index.story.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useId } from '@wordpress/element';
-import { Popover } from '../..';
 import { VisuallyHidden } from '../';
 
 const meta: Meta< typeof VisuallyHidden > = {
@@ -45,40 +44,4 @@ export const WithCustomElement: Story = {
 			</>
 		);
 	},
-};
-
-/**
- * When composing `VisuallyHidden` with another component that has its own
- * semantic element, always make `VisuallyHidden` the **host** (outer
- * component) and pass the other component via `render`. This preserves
- * the other component's HTML element and semantics.
- *
- * ```jsx
- * // Correct — Popover.Title keeps its <h2> element.
- * <VisuallyHidden render={ <Popover.Title /> }>
- *   Title text
- * </VisuallyHidden>
- *
- * // Avoid — replaces Popover.Title's <h2> with a <div>.
- * <Popover.Title render={ <VisuallyHidden /> }>
- *   Title text
- * </Popover.Title>
- * ```
- */
-export const ComposedWithAnotherComponent: Story = {
-	render: () => (
-		<Popover.Root defaultOpen>
-			<Popover.Trigger>Open popover</Popover.Trigger>
-			<Popover.Popup>
-				<VisuallyHidden render={ <Popover.Title /> }>
-					Accessible popover heading
-				</VisuallyHidden>
-				<p>
-					This popover has a visually hidden title that is still
-					accessible to screen readers via{ ' ' }
-					<code>aria-labelledby</code>.
-				</p>
-			</Popover.Popup>
-		</Popover.Root>
-	),
 };

--- a/packages/ui/src/visually-hidden/stories/index.story.tsx
+++ b/packages/ui/src/visually-hidden/stories/index.story.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useId } from '@wordpress/element';
+import { Popover } from '../..';
 import { VisuallyHidden } from '../';
 
 const meta: Meta< typeof VisuallyHidden > = {
@@ -18,5 +20,65 @@ export const Default: Story = {
 				always show.
 			</div>
 		</>
+	),
+};
+
+/**
+ * Use the `render` prop to change the underlying HTML element.
+ * By default, `VisuallyHidden` renders a `<div>`. Here it renders
+ * a `<label>` instead, keeping the native label–input association
+ * while hiding the label text visually.
+ */
+export const WithCustomElement: Story = {
+	render: function WithCustomElementStory() {
+		const inputId = useId();
+		return (
+			<>
+				{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+				<VisuallyHidden render={ <label htmlFor={ inputId } /> }>
+					Accessible label
+				</VisuallyHidden>
+				<input
+					id={ inputId }
+					placeholder="This input has a visually hidden label"
+				/>
+			</>
+		);
+	},
+};
+
+/**
+ * When composing `VisuallyHidden` with another component that has its own
+ * semantic element, always make `VisuallyHidden` the **host** (outer
+ * component) and pass the other component via `render`. This preserves
+ * the other component's HTML element and semantics.
+ *
+ * ```jsx
+ * // Correct — Popover.Title keeps its <h2> element.
+ * <VisuallyHidden render={ <Popover.Title /> }>
+ *   Title text
+ * </VisuallyHidden>
+ *
+ * // Avoid — replaces Popover.Title's <h2> with a <div>.
+ * <Popover.Title render={ <VisuallyHidden /> }>
+ *   Title text
+ * </Popover.Title>
+ * ```
+ */
+export const ComposedWithAnotherComponent: Story = {
+	render: () => (
+		<Popover.Root defaultOpen>
+			<Popover.Trigger>Open popover</Popover.Trigger>
+			<Popover.Popup>
+				<VisuallyHidden render={ <Popover.Title /> }>
+					Accessible popover heading
+				</VisuallyHidden>
+				<p>
+					This popover has a visually hidden title that is still
+					accessible to screen readers via{ ' ' }
+					<code>aria-labelledby</code>.
+				</p>
+			</Popover.Popup>
+		</Popover.Root>
 	),
 };

--- a/packages/ui/src/visually-hidden/visually-hidden.tsx
+++ b/packages/ui/src/visually-hidden/visually-hidden.tsx
@@ -6,6 +6,34 @@ import styles from './style.module.css';
 /**
  * Visually hides content while keeping it accessible to screen readers.
  * Useful when providing context that's only meaningful to assistive technology.
+ *
+ * Renders a `<div>` by default. Use the `render` prop to swap the
+ * underlying element while preserving the visually-hidden behavior.
+ *
+ * ## Composing with other components
+ *
+ * When composing with a component that has its own semantic element,
+ * always make `VisuallyHidden` the **host** (outer component) and pass
+ * the other component via `render`. This way the other component keeps
+ * its HTML element and semantics, and `VisuallyHidden` only contributes
+ * its hiding styles:
+ *
+ * ```jsx
+ * // Correct — OtherComponent keeps its semantic element (e.g. <h2>).
+ * <VisuallyHidden render={ <OtherComponent /> }>
+ *   Accessible text
+ * </VisuallyHidden>
+ * ```
+ *
+ * Avoid the opposite direction — it replaces the other component's
+ * element with VisuallyHidden's default `<div>`, losing semantics:
+ *
+ * ```jsx
+ * // Avoid — OtherComponent's element becomes a <div>.
+ * <OtherComponent render={ <VisuallyHidden /> }>
+ *   Accessible text
+ * </OtherComponent>
+ * ```
  */
 export const VisuallyHidden = forwardRef< HTMLDivElement, VisuallyHiddenProps >(
 	function VisuallyHidden( { render, ...restProps }, ref ) {

--- a/packages/ui/src/visually-hidden/visually-hidden.tsx
+++ b/packages/ui/src/visually-hidden/visually-hidden.tsx
@@ -12,28 +12,34 @@ import styles from './style.module.css';
  *
  * ## Composing with other components
  *
- * When composing with a component that has its own semantic element,
- * always make `VisuallyHidden` the **host** (outer component) and pass
- * the other component via `render`. This way the other component keeps
- * its HTML element and semantics, and `VisuallyHidden` only contributes
- * its hiding styles:
+ * When composing with another component that uses the `render` prop
+ * pattern, there are two directions — and they produce different results.
+ *
+ * Most of the time you'll want `VisuallyHidden` as the **host** (outer
+ * component) and pass the other component via `render`. This keeps the
+ * other component's HTML element and semantics intact, while
+ * `VisuallyHidden` only adds its hiding styles:
  *
  * ```jsx
- * // Correct — OtherComponent keeps its semantic element (e.g. <h2>).
+ * // OtherComponent keeps its semantic element (e.g. <h2>).
  * <VisuallyHidden render={ <OtherComponent /> }>
  *   Accessible text
  * </VisuallyHidden>
  * ```
  *
- * Avoid the opposite direction — it replaces the other component's
- * element with VisuallyHidden's default `<div>`, losing semantics:
+ * The opposite direction is also possible, but be aware that it replaces
+ * the other component's element with VisuallyHidden's default `<div>`:
  *
  * ```jsx
- * // Avoid — OtherComponent's element becomes a <div>.
+ * // OtherComponent's element becomes a <div>.
  * <OtherComponent render={ <VisuallyHidden /> }>
  *   Accessible text
  * </OtherComponent>
  * ```
+ *
+ * Choose based on what you need: if the other component's semantic
+ * element matters (e.g. `<label>`, `<legend>`, `<h2>`), keep
+ * `VisuallyHidden` as the host so the element is preserved.
  */
 export const VisuallyHidden = forwardRef< HTMLDivElement, VisuallyHiddenProps >(
 	function VisuallyHidden( { render, ...restProps }, ref ) {


### PR DESCRIPTION
## What?

Standardize how `VisuallyHidden` composes with other components in `@wordpress/ui`, and improve documentation.

## Why?

Two composition patterns existed in the codebase. Only one preserves semantic HTML elements — the other silently replaces them with a `<div>`. This PR adopts the first pattern consistently and documents both for consumers and maintainers.

<details>
<summary>Detailed assessment of the two patterns</summary>

**Pattern A** (preferred in most cases) — `<VisuallyHidden render={<OtherComponent />}>`
- VisuallyHidden is the host; OtherComponent dictates the rendered HTML element
- VisuallyHidden merges its hiding CSS onto that element
- Preserves semantic HTML (e.g. `<label>`, `<legend>`, `<h2>`)

**Pattern B** — `<OtherComponent render={<VisuallyHidden />}>`
- OtherComponent is the host; VisuallyHidden replaces its element with a `<div>`
- Loses the semantic HTML element
- Required workarounds like `nativeLabel: false` on `Field.Label`

Base UI's `useRender` + `cloneElement` machinery ensures that with Pattern A, the composed component still runs its own hooks, connects to context, and computes accessibility attributes — the `visually-hidden` class is simply merged through.

</details>

## How?

1. **Refactor form primitives** (`Field.Label`, `Fieldset.Legend`, `Field.Details`) from Pattern B to Pattern A
2. **Add a VisuallyHidden Storybook story** demonstrating the `render` prop with a custom element
3. **Expand VisuallyHidden JSDoc** with composition guidance explaining both patterns and their trade-offs
4. **Add `VisuallyHidden` + `render` prop docs to `Dialog.Title`** (matching existing `Popover.Title` docs), plus a `WithVisuallyHiddenTitle` story
5. **Make `Dialog.Title` children optional** to support the render-prop composition pattern (matching `Popover.Title`)
6. **Add structural tests** verifying semantic elements are preserved when `hideFromVision` is enabled

<details>
<summary>Files changed</summary>

| File | Change |
|---|---|
| `form/primitives/field/label.tsx` | Pattern B → A; remove `nativeLabel: false` |
| `form/primitives/fieldset/legend.tsx` | Pattern B → A |
| `form/primitives/field/details.tsx` | Pattern B → A |
| `visually-hidden/visually-hidden.tsx` | Expanded JSDoc |
| `visually-hidden/stories/index.story.tsx` | New `WithCustomElement` story |
| `dialog/title.tsx` | Added JSDoc with `VisuallyHidden` example |
| `dialog/types.ts` | Make `TitleProps.children` optional |
| `dialog/stories/index.story.tsx` | New `WithVisuallyHiddenTitle` story |
| `form/primitives/field/test/index.test.tsx` | New structural test |
| `form/primitives/fieldset/test/index.test.tsx` | New structural test |
| `CHANGELOG.md` | Entries under Enhancements and Internal |

</details>

## Testing Instructions

1. Run `npm run test:unit -- --testPathPattern="packages/ui/src/(form|visually-hidden)"` — all 37 tests should pass
2. Open Storybook (`npm run storybook:ui`) and navigate to:
   - **VisuallyHidden** — verify the new `WithCustomElement` story renders correctly
   - **Dialog** — verify the new `WithVisuallyHiddenTitle` story works (title hidden visually, accessible via screen reader / DOM inspection)

### Testing Instructions for Keyboard

No user-facing keyboard interaction changes.

## Use of AI Tools

Cursor with Claude was used for codebase analysis, plan drafting, and implementation under human review.