### PR TITLE
UI Dialog: Add Description, modal context, and misc improvements

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Enhancements
 
--   `Dialog`: Add `Dialog.Description` sub-component, expose `onOpenChangeComplete`, and skip the backdrop when `modal` is not `true` ([#77194](https://github.com/WordPress/gutenberg/pull/77194)).
+-   `Dialog`: Add `Dialog.Description` sub-component, expose `onOpenChangeComplete`, skip the backdrop when `modal` is not `true`, use `100dvh` for viewport-based heights so the popup fits the dynamic viewport on mobile, and forward `className` on `Dialog.Title` ([#77194](https://github.com/WordPress/gutenberg/pull/77194)).
 -   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Enhancements
 
+-   `Dialog`: Add `Dialog.Description` sub-component, expose `onOpenChangeComplete`, and skip the backdrop when `modal` is not `true` ([#77194](https://github.com/WordPress/gutenberg/pull/77194)).
 -   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Enhancements
 
+-   `Dialog`: Add `Dialog.Description` sub-component, expose `onOpenChangeComplete`, and skip the backdrop when `modal` is not `true` ([#77194](https://github.com/WordPress/gutenberg/pull/77194)).
 -   `Dialog`, `Popover`: Upgrade dev-only title validation from mount-only to cleanup-based re-validation, catching conditionally rendered titles ([#77165](https://github.com/WordPress/gutenberg/pull/77165)).
 -   `Link`: Honor `openInNewTab` consistently instead of treating hash links as a special case ([#77422](https://github.com/WordPress/gutenberg/pull/77422)).
 

--- a/packages/ui/src/dialog/context.tsx
+++ b/packages/ui/src/dialog/context.tsx
@@ -1,3 +1,4 @@
+import type { Dialog as _Dialog } from '@base-ui/react/dialog';
 import {
 	createContext,
 	useCallback,
@@ -7,6 +8,31 @@ import {
 	useRef,
 } from '@wordpress/element';
 import { useScheduleValidation } from '../utils/use-schedule-validation';
+
+// -- Modal context ----------------------------------------------------------
+
+const DialogModalContext =
+	createContext< _Dialog.Root.Props[ 'modal' ] >( true );
+
+export function DialogModalProvider( {
+	modal = true,
+	children,
+}: {
+	modal?: _Dialog.Root.Props[ 'modal' ];
+	children: React.ReactNode;
+} ) {
+	return (
+		<DialogModalContext.Provider value={ modal }>
+			{ children }
+		</DialogModalContext.Provider>
+	);
+}
+
+export function useDialogModal() {
+	return useContext( DialogModalContext );
+}
+
+// -- Validation context (dev-only) ------------------------------------------
 
 /**
  * Whether validation is enabled. This is a build-time constant that allows

--- a/packages/ui/src/dialog/context.tsx
+++ b/packages/ui/src/dialog/context.tsx
@@ -15,10 +15,10 @@ const DialogModalContext =
 	createContext< _Dialog.Root.Props[ 'modal' ] >( true );
 
 export function DialogModalProvider( {
-	modal = true,
+	modal,
 	children,
 }: {
-	modal?: _Dialog.Root.Props[ 'modal' ];
+	modal: _Dialog.Root.Props[ 'modal' ];
 	children: React.ReactNode;
 } ) {
 	return (

--- a/packages/ui/src/dialog/context.tsx
+++ b/packages/ui/src/dialog/context.tsx
@@ -114,16 +114,16 @@ function DialogValidationProviderDev( {
 		[ scheduleValidation ]
 	);
 
+	const contextValue = useMemo(
+		() => ( { registerTitle } ),
+		[ registerTitle ]
+	);
+
 	// Schedule an initial validation on mount to catch missing titles
 	// (when no Title component is rendered, registerTitle is never called).
 	useEffect( () => {
 		scheduleValidation();
 	}, [ scheduleValidation ] );
-
-	const contextValue = useMemo(
-		() => ( { registerTitle } ),
-		[ registerTitle ]
-	);
 
 	return (
 		<DialogValidationContext.Provider value={ contextValue }>

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -1,0 +1,24 @@
+import { Dialog as _Dialog } from '@base-ui/react/dialog';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { Text } from '../text';
+import styles from './style.module.css';
+import type { DescriptionProps } from './types';
+
+/**
+ * A paragraph with additional information about the dialog.
+ */
+const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
+	function DialogDescription( { className, render, ...props }, ref ) {
+		return (
+			<_Dialog.Description
+				ref={ ref }
+				render={ <Text variant="body-md" render={ render ?? <p /> } /> }
+				className={ clsx( styles.description, className ) }
+				{ ...props }
+			/>
+		);
+	}
+);
+
+export { Description };

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -9,7 +9,6 @@ import type { DescriptionProps } from './types';
  * Renders a paragraph with additional information about the dialog.
  *
  * The rendered element is linked to the popup via `aria-describedby`.
- * Uses the `body-md` text variant by default.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 	function DialogDescription( { className, render, ...props }, ref ) {

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -6,7 +6,7 @@ import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
- * A paragraph with additional information about the dialog.
+ * Renders a paragraph with additional information about the dialog.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 	function DialogDescription( { className, render, ...props }, ref ) {

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -7,6 +7,9 @@ import type { DescriptionProps } from './types';
 
 /**
  * Renders a paragraph with additional information about the dialog.
+ *
+ * The rendered element is linked to the popup via `aria-describedby`.
+ * Uses the `body-md` text variant by default.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 	function DialogDescription( { className, render, ...props }, ref ) {

--- a/packages/ui/src/dialog/description.tsx
+++ b/packages/ui/src/dialog/description.tsx
@@ -6,19 +6,21 @@ import styles from './style.module.css';
 import type { DescriptionProps } from './types';
 
 /**
- * Renders a paragraph with additional information about the dialog.
+ * Renders an optional paragraph that describes the dialog content.
  *
  * The rendered element is linked to the popup via `aria-describedby`.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
-	function DialogDescription( { className, render, ...props }, ref ) {
+	function DialogDescription( { className, children, ...props }, ref ) {
 		return (
-			<_Dialog.Description
+			<Text
 				ref={ ref }
-				render={ <Text variant="body-md" render={ render ?? <p /> } /> }
+				variant="body-md"
+				render={ <_Dialog.Description { ...props } /> }
 				className={ clsx( styles.description, className ) }
-				{ ...props }
-			/>
+			>
+				{ children }
+			</Text>
 		);
 	}
 );

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -1,5 +1,6 @@
 import { Action } from './action';
 import { CloseIcon } from './close-icon';
+import { Description } from './description';
 import { Footer } from './footer';
 import { Header } from './header';
 import { Popup } from './popup';
@@ -11,6 +12,7 @@ import { Trigger } from './trigger';
 export {
 	Action,
 	CloseIcon,
+	Description,
 	Footer,
 	Header,
 	Popup,

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -1,5 +1,6 @@
 import { Action } from './action';
 import { CloseIcon } from './close-icon';
+import { Description } from './description';
 import { Footer } from './footer';
 import { Header } from './header';
 import { Popup } from './popup';
@@ -7,4 +8,14 @@ import { Root } from './root';
 import { Title } from './title';
 import { Trigger } from './trigger';
 
-export { Action, CloseIcon, Footer, Header, Popup, Root, Title, Trigger };
+export {
+	Action,
+	CloseIcon,
+	Description,
+	Footer,
+	Header,
+	Popup,
+	Root,
+	Title,
+	Trigger,
+};

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -53,7 +53,10 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 			 * interactions enabled, so a backdrop would misrepresent that mode.
 			 */ }
 			{ modal === true && (
-				<_Dialog.Backdrop className={ styles.backdrop } />
+				<_Dialog.Backdrop
+					className={ styles.backdrop }
+					data-wp-ui-dialog-backdrop=""
+				/>
 			) }
 			<ThemeProvider>
 				<_Dialog.Popup

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -30,10 +30,10 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	{
 		className,
 		portal,
+		children,
 		size = 'medium',
 		initialFocus,
 		finalFocus,
-		children,
 		...props
 	},
 	ref
@@ -47,6 +47,11 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 
 	const portalChildren = (
 		<>
+			{ /*
+			 * Only render a backdrop for fully modal dialogs. Non-modal dialogs
+			 * should not dim the page, and `trap-focus` keeps outside pointer
+			 * interactions enabled, so a backdrop would misrepresent that mode.
+			 */ }
 			{ modal === true && (
 				<_Dialog.Backdrop className={ styles.backdrop } />
 			) }

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -9,7 +9,7 @@ import {
 import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
 import { renderPortalWithChildren } from '../utils/render-portal-with-children';
-import { DialogValidationProvider } from './context';
+import { DialogValidationProvider, useDialogModal } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
@@ -43,10 +43,13 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 		deprioritizedAttribute: CLOSE_ICON_ATTR,
 	} );
 	const mergedRef = useMergeRefs( [ ref, popupRef ] );
+	const modal = useDialogModal();
 
 	const portalChildren = (
 		<>
-			<_Dialog.Backdrop className={ styles.backdrop } />
+			{ modal === true && (
+				<_Dialog.Backdrop className={ styles.backdrop } />
+			) }
 			<ThemeProvider>
 				<_Dialog.Popup
 					ref={ mergedRef }

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/theme';
 import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
-import { DialogValidationProvider } from './context';
+import { DialogValidationProvider, useDialogModal } from './context';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
 
@@ -38,10 +38,13 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 		deprioritizedAttribute: CLOSE_ICON_ATTR,
 	} );
 	const mergedRef = useMergeRefs( [ ref, popupRef ] );
+	const modal = useDialogModal();
 
 	return (
 		<_Dialog.Portal container={ container }>
-			<_Dialog.Backdrop className={ styles.backdrop } />
+			{ modal === true && (
+				<_Dialog.Backdrop className={ styles.backdrop } />
+			) }
 			<ThemeProvider>
 				<_Dialog.Popup
 					ref={ mergedRef }

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -24,11 +24,11 @@ const CLOSE_ICON_ATTR = 'data-wp-ui-dialog-close-icon';
 const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 	{
 		className,
+		children,
 		container,
 		size = 'medium',
 		initialFocus,
 		finalFocus,
-		children,
 		...props
 	},
 	ref
@@ -42,6 +42,11 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >( function DialogPopup(
 
 	return (
 		<_Dialog.Portal container={ container }>
+			{ /*
+			 * Only render a backdrop for fully modal dialogs. Non-modal dialogs
+			 * should not dim the page, and `trap-focus` keeps outside pointer
+			 * interactions enabled, so a backdrop would misrepresent that mode.
+			 */ }
 			{ modal === true && (
 				<_Dialog.Backdrop className={ styles.backdrop } />
 			) }

--- a/packages/ui/src/dialog/root.tsx
+++ b/packages/ui/src/dialog/root.tsx
@@ -18,7 +18,7 @@ import type { RootProps } from './types';
  * actions), omit the close icon and rely on footer action buttons like "Cancel"
  * and "Confirm" instead.
  */
-function Root( { modal, children, ...props }: RootProps ) {
+function Root( { modal = true, children, ...props }: RootProps ) {
 	return (
 		<_Dialog.Root modal={ modal } { ...props }>
 			<DialogModalProvider modal={ modal }>

--- a/packages/ui/src/dialog/root.tsx
+++ b/packages/ui/src/dialog/root.tsx
@@ -1,14 +1,31 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
+import { DialogModalProvider } from './context';
 import type { RootProps } from './types';
 
 /**
- * Groups the dialog trigger and popup.
+ * An ARIA-compliant dialog that opens on top of the entire page.
  *
- * `Dialog` is a collection of React components that combine to render
- * an ARIA-compliant dialog pattern.
+ * Every dialog must include a `Dialog.Title` component for accessibility — it
+ * serves as both the visible heading and the accessible label for the dialog.
+ *
+ * Always include a visible close button, either `Dialog.CloseIcon` or a clear
+ * dismissing action button. If your dialog has a "Cancel" button in the footer,
+ * the close icon may be redundant and create confusion about what clicking "X"
+ * means.
+ *
+ * Use `Dialog.CloseIcon` for informational dialogs where dismissing is safe and
+ * expected. For dialogs requiring explicit user choice (especially destructive
+ * actions), omit the close icon and rely on footer action buttons like "Cancel"
+ * and "Confirm" instead.
  */
-function Root( props: RootProps ) {
-	return <_Dialog.Root { ...props } />;
+function Root( { modal, children, ...props }: RootProps ) {
+	return (
+		<_Dialog.Root modal={ modal } { ...props }>
+			<DialogModalProvider modal={ modal }>
+				{ children }
+			</DialogModalProvider>
+		</_Dialog.Root>
+	);
 }
 
 export { Root };

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -21,12 +21,6 @@ const meta: Meta< typeof Dialog.Root > = {
 		modal: {
 			control: 'inline-radio',
 			options: [ true, false, 'trap-focus' ],
-			table: {
-				defaultValue: { summary: 'true' },
-				type: {
-					summary: 'boolean | "trap-focus"',
-				},
-			},
 		},
 	},
 };

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -48,11 +48,11 @@ export const _Default: Story = {
 						<Dialog.Title>Welcome</Dialog.Title>
 						<Dialog.CloseIcon />
 					</Dialog.Header>
-					<p>
+					<Dialog.Description>
 						This dialog demonstrates best practices for
 						informational dialogs. It includes a close icon because
 						dismissing it is safe and expected.
-					</p>
+					</Dialog.Description>
 					<Dialog.Footer>
 						<Dialog.Action>Got it</Dialog.Action>
 					</Dialog.Footer>

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -12,6 +12,7 @@ const meta: Meta< typeof Dialog.Root > = {
 		'Dialog.Popup': Dialog.Popup,
 		'Dialog.Header': Dialog.Header,
 		'Dialog.Title': Dialog.Title,
+		'Dialog.Description': Dialog.Description,
 		'Dialog.CloseIcon': Dialog.CloseIcon,
 		'Dialog.Action': Dialog.Action,
 		'Dialog.Footer': Dialog.Footer,
@@ -25,19 +26,6 @@ const meta: Meta< typeof Dialog.Root > = {
 				type: {
 					summary: 'boolean | "trap-focus"',
 				},
-			},
-		},
-	},
-	parameters: {
-		docs: {
-			description: {
-				component: `
-Dialog is a popup that opens on top of the entire page. Every dialog must include a \`Dialog.Title\` component for accessibility — it serves as both the visible heading and the accessible label for the dialog.
-
-When using the Dialog component, make sure to always include a visible close button, either \`Dialog.CloseIcon\` or a clear dismissing action button. If your dialog has a "Cancel" button in the footer, the close icon may be redundant and create confusion about what clicking "X" means.
-
-Use \`Dialog.CloseIcon\` for informational dialogs where dismissing is safe and expected. For dialogs requiring explicit user choice (especially destructive actions), omit the close icon and rely on footer action buttons like "Cancel" and "Confirm" instead.
-				`,
 			},
 		},
 	},

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -34,7 +34,7 @@
 	}
 
 	.popup {
-		--viewport-inset: var(--wpds-dimension-padding-2xl);
+		--_viewport-inset: var(--wpds-dimension-padding-2xl);
 
 		position: fixed;
 		top: 50%;
@@ -44,8 +44,8 @@
 		transform: translate(-50%, -50%);
 		box-sizing: border-box;
 		min-width: var(--wpds-dimension-surface-width-sm);
-		width: calc(100vw - 2 * var(--viewport-inset));
-		max-height: calc(100dvh - 2 * var(--viewport-inset));
+		width: calc(100vw - 2 * var(--_viewport-inset));
+		max-height: calc(100dvh - 2 * var(--_viewport-inset));
 		padding: var(--wpds-dimension-padding-2xl);
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-lg);

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -45,7 +45,7 @@
 		box-sizing: border-box;
 		min-width: var(--wpds-dimension-surface-width-sm);
 		width: calc(100vw - 2 * var(--viewport-inset));
-		max-height: calc(100vh - 2 * var(--viewport-inset));
+		max-height: calc(100dvh - 2 * var(--viewport-inset));
 		padding: var(--wpds-dimension-padding-2xl);
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-lg);
@@ -100,7 +100,7 @@
 			 * Force full height (full width is already in default styles).
 			 * The max-{width,height} properties will make sure some padding is shown.
 			 */
-			height: 100vh;
+			height: 100dvh;
 		}
 	}
 

--- a/packages/ui/src/dialog/style.module.css
+++ b/packages/ui/src/dialog/style.module.css
@@ -34,6 +34,8 @@
 	}
 
 	.popup {
+		--viewport-inset: var(--wpds-dimension-padding-2xl);
+
 		position: fixed;
 		top: 50%;
 		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Physical centering technique used with transform: translate(-50%, -50%) */
@@ -42,8 +44,8 @@
 		transform: translate(-50%, -50%);
 		box-sizing: border-box;
 		min-width: var(--wpds-dimension-surface-width-sm);
-		width: calc(100vw - 2 * var(--wpds-dimension-padding-2xl));
-		max-height: calc(100vh - 2 * var(--wpds-dimension-padding-2xl));
+		width: calc(100vw - 2 * var(--viewport-inset));
+		max-height: calc(100vh - 2 * var(--viewport-inset));
 		padding: var(--wpds-dimension-padding-2xl);
 		background-color: var(--wpds-color-bg-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-lg);
@@ -119,6 +121,11 @@
 		&:dir(rtl) {
 			--_gcd-heading-margin: 0 0 0 auto;
 		}
+	}
+
+	.description {
+		margin-bottom: var(--wpds-dimension-gap-lg);
+		color: var(--wpds-color-fg-content-neutral-weak);
 	}
 
 	.footer {

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -220,7 +220,7 @@ describe( 'Dialog', () => {
 		const action = await screen.findByRole( 'button', {
 			name: 'Explicit not-disabled',
 		} );
-		expect( action ).toHaveAttribute( 'aria-disabled', 'false' );
+		expect( action ).not.toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	describe( 'Development mode validation', () => {

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -68,6 +68,161 @@ describe( 'Dialog', () => {
 		expect( footerRef.current ).toBeInstanceOf( HTMLDivElement );
 	} );
 
+	it( 'renders Dialog.Footer and supports render/className props', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Dialog.Root>
+				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+				<Dialog.Popup>
+					<Dialog.Title>Test Dialog</Dialog.Title>
+					<Dialog.Footer
+						render={ <section data-testid="dialog-footer" /> }
+						className="custom-footer"
+					>
+						<Dialog.Action>Close</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Dialog' } )
+		);
+
+		const footer = await screen.findByTestId( 'dialog-footer' );
+		expect( footer.tagName ).toBe( 'SECTION' );
+		expect( footer ).toHaveClass( 'custom-footer' );
+		expect(
+			screen.getByRole( 'button', { name: 'Close' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders backdrop only when modal is true', async () => {
+		const getOpenPresentationElements = () =>
+			screen
+				.queryAllByRole( 'presentation', { hidden: true } )
+				.filter( ( element ) => element.hasAttribute( 'data-open' ) );
+
+		const view = render(
+			<Dialog.Root open modal>
+				<Dialog.Popup>
+					<Dialog.Title>Modal dialog</Dialog.Title>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( getOpenPresentationElements() ).toHaveLength( 1 );
+
+		view.rerender(
+			<Dialog.Root open modal={ false }>
+				<Dialog.Popup>
+					<Dialog.Title>Non modal dialog</Dialog.Title>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( getOpenPresentationElements() ).toHaveLength( 0 );
+
+		view.rerender(
+			<Dialog.Root open modal="trap-focus">
+				<Dialog.Popup>
+					<Dialog.Title>Trap focus dialog</Dialog.Title>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( getOpenPresentationElements() ).toHaveLength( 0 );
+	} );
+
+	it( 'renders the popup across default and explicit size values', async () => {
+		const view = render(
+			<Dialog.Root open>
+				<Dialog.Popup>
+					<Dialog.Title>Default size dialog</Dialog.Title>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+
+		for ( const size of [
+			'small',
+			'medium',
+			'large',
+			'stretch',
+			'full',
+		] as const ) {
+			view.rerender(
+				<Dialog.Root open>
+					<Dialog.Popup size={ size }>
+						<Dialog.Title>{ size } dialog</Dialog.Title>
+					</Dialog.Popup>
+				</Dialog.Root>
+			);
+			expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
+		}
+	} );
+
+	it( 'marks Dialog.Action as disabled when loading is true', async () => {
+		render(
+			<Dialog.Root open>
+				<Dialog.Popup>
+					<Dialog.Title>Action states</Dialog.Title>
+					<Dialog.Footer>
+						<Dialog.Action loading>Loading action</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		const action = await screen.findByRole( 'button', {
+			name: 'Loading action',
+		} );
+		expect( action ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'marks Dialog.Action as disabled when disabled is true', async () => {
+		render(
+			<Dialog.Root open>
+				<Dialog.Popup>
+					<Dialog.Title>Action states</Dialog.Title>
+					<Dialog.Footer>
+						<Dialog.Action disabled>Disabled action</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		const action = await screen.findByRole( 'button', {
+			name: 'Disabled action',
+		} );
+		expect( action ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'lets explicit disabled={ false } override loading on Dialog.Action', async () => {
+		// `Dialog.Action` uses `disabled ?? loading`, so an explicit
+		// `disabled={ false }` wins over an active loading state.
+		render(
+			<Dialog.Root open>
+				<Dialog.Popup>
+					<Dialog.Title>Action states</Dialog.Title>
+					<Dialog.Footer>
+						<Dialog.Action disabled={ false } loading>
+							Explicit not-disabled
+						</Dialog.Action>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		const action = await screen.findByRole( 'button', {
+			name: 'Explicit not-disabled',
+		} );
+		expect( action ).toHaveAttribute( 'aria-disabled', 'false' );
+	} );
+
 	describe( 'Development mode validation', () => {
 		// Suppress console.error from React act() warnings and jsdom
 		// unhandled-error logging. Validation errors are caught via

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -122,10 +122,9 @@ describe( 'Dialog', () => {
 	} );
 
 	it( 'renders backdrop only when modal is true', async () => {
-		const getOpenPresentationElements = () =>
-			screen
-				.queryAllByRole( 'presentation', { hidden: true } )
-				.filter( ( element ) => element.hasAttribute( 'data-open' ) );
+		const getBackdrops = () =>
+			// eslint-disable-next-line testing-library/no-node-access -- The backdrop has no semantic role; querying by the stable `data-wp-ui-dialog-backdrop` attribute (mirroring the Dialog close-icon pattern) is more robust than the Base UI role/state it inherits.
+			document.querySelectorAll( '[data-wp-ui-dialog-backdrop]' );
 
 		const view = render(
 			<Dialog.Root open modal>
@@ -136,7 +135,7 @@ describe( 'Dialog', () => {
 		);
 
 		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
-		expect( getOpenPresentationElements() ).toHaveLength( 1 );
+		expect( getBackdrops() ).toHaveLength( 1 );
 
 		view.rerender(
 			<Dialog.Root open modal={ false }>
@@ -146,7 +145,7 @@ describe( 'Dialog', () => {
 			</Dialog.Root>
 		);
 		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
-		expect( getOpenPresentationElements() ).toHaveLength( 0 );
+		expect( getBackdrops() ).toHaveLength( 0 );
 
 		view.rerender(
 			<Dialog.Root open modal="trap-focus">
@@ -156,7 +155,7 @@ describe( 'Dialog', () => {
 			</Dialog.Root>
 		);
 		expect( await screen.findByRole( 'dialog' ) ).toBeInTheDocument();
-		expect( getOpenPresentationElements() ).toHaveLength( 0 );
+		expect( getBackdrops() ).toHaveLength( 0 );
 	} );
 
 	it( 'renders the popup across default and explicit size values', async () => {

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -24,6 +24,7 @@ describe( 'Dialog', () => {
 		const actionRef = createRef< HTMLButtonElement >();
 		const headerRef = createRef< HTMLDivElement >();
 		const titleRef = createRef< HTMLHeadingElement >();
+		const descriptionRef = createRef< HTMLParagraphElement >();
 		const closeIconRef = createRef< HTMLButtonElement >();
 		const footerRef = createRef< HTMLDivElement >();
 
@@ -37,6 +38,9 @@ describe( 'Dialog', () => {
 						</Dialog.Title>
 						<Dialog.CloseIcon ref={ closeIconRef } />
 					</Dialog.Header>
+					<Dialog.Description ref={ descriptionRef }>
+						A test description
+					</Dialog.Description>
 					<Dialog.Footer ref={ footerRef }>
 						<Dialog.Action ref={ actionRef }>Close</Dialog.Action>
 					</Dialog.Footer>
@@ -58,6 +62,7 @@ describe( 'Dialog', () => {
 		// Now that the dialog is open, verify all inner refs
 		expect( headerRef.current ).toBeInstanceOf( HTMLDivElement );
 		expect( titleRef.current ).toBeInstanceOf( HTMLHeadingElement );
+		expect( descriptionRef.current ).toBeInstanceOf( HTMLParagraphElement );
 		expect( closeIconRef.current ).toBeInstanceOf( HTMLButtonElement );
 		expect( actionRef.current ).toBeInstanceOf( HTMLButtonElement );
 		expect( footerRef.current ).toBeInstanceOf( HTMLDivElement );

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -68,6 +68,29 @@ describe( 'Dialog', () => {
 		expect( footerRef.current ).toBeInstanceOf( HTMLDivElement );
 	} );
 
+	it( 'associates Dialog.Description with the popup via aria-describedby', async () => {
+		const user = userEvent.setup();
+		const popupRef = createRef< HTMLDivElement >();
+
+		render(
+			<Dialog.Root>
+				<Dialog.Trigger>Open</Dialog.Trigger>
+				<Dialog.Popup ref={ popupRef }>
+					<Dialog.Title>Title</Dialog.Title>
+					<Dialog.Description>My description</Dialog.Description>
+				</Dialog.Popup>
+			</Dialog.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+		await waitFor( () => {
+			expect( popupRef.current ).toHaveAccessibleDescription(
+				'My description'
+			);
+		} );
+	} );
+
 	it( 'renders Dialog.Footer and supports render/className props', async () => {
 		const user = userEvent.setup();
 

--- a/packages/ui/src/dialog/title.tsx
+++ b/packages/ui/src/dialog/title.tsx
@@ -1,4 +1,5 @@
 import { Dialog as _Dialog } from '@base-ui/react/dialog';
+import clsx from 'clsx';
 import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { Text } from '../text';
@@ -25,7 +26,7 @@ import type { TitleProps } from './types';
  * ```
  */
 const Title = forwardRef< HTMLHeadingElement, TitleProps >(
-	function DialogTitle( { children, ...props }, forwardedRef ) {
+	function DialogTitle( { children, className, ...props }, forwardedRef ) {
 		const validationContext = useDialogValidationContext();
 		const internalRef = useRef< HTMLHeadingElement >( null );
 		const mergedRef = useMergeRefs( [ internalRef, forwardedRef ] );
@@ -42,7 +43,7 @@ const Title = forwardRef< HTMLHeadingElement, TitleProps >(
 				ref={ mergedRef }
 				variant="heading-xl"
 				render={ <_Dialog.Title { ...props } /> }
-				className={ styles.title }
+				className={ clsx( styles.title, className ) }
 			>
 				{ children }
 			</Text>

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -52,10 +52,15 @@ export interface PopupProps
 	 * Renders the dialog at a preset width (excluding additional padding from
 	 * the viewport edges).
 	 *
+	 * Height is not directly controlled by `size`: for every value except
+	 * `'full'`, the dialog fits its content up to the viewport height
+	 * (minus the viewport inset) and scrolls internally when it overflows.
+	 * `'full'` stretches the dialog to the available viewport height.
+	 *
 	 * - `'small'` — narrow max-width.
 	 * - `'medium'` — moderate max-width.
 	 * - `'large'` — wide max-width.
-	 * - `'stretch'` — no max-width, stretches to fill available space.
+	 * - `'stretch'` — no max-width, stretches to fill available width.
 	 * - `'full'` — stretches to fill available width and height.
 	 *
 	 * @default 'medium'

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -44,7 +44,8 @@ export interface PopupProps
 	 * rendered as this portal's children (do not pass `children` on the portal
 	 * element; they would be ignored).
 	 *
-	 * When omitted, `Dialog.Popup` uses `Dialog.Portal` with default props.
+	 * When omitted, `Dialog.Popup` uses `Dialog.Portal` with default props,
+	 * rendering the portal in the current document's `<body>`.
 	 */
 	portal?: ReactElement< Omit< PortalProps, 'children' > >;
 

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -12,6 +12,7 @@ export interface RootProps
 		_Dialog.Root.Props,
 		| 'open'
 		| 'onOpenChange'
+		| 'onOpenChangeComplete'
 		| 'defaultOpen'
 		| 'modal'
 		| 'disablePointerDismissal'
@@ -90,6 +91,13 @@ export interface TitleProps extends ComponentProps< 'h2' > {
 	 *
 	 * When `Dialog.Title` is passed as a render element (e.g. to
 	 * `VisuallyHidden`), children can be provided by the wrapper instead.
+	 */
+	children?: ReactNode;
+}
+
+export interface DescriptionProps extends ComponentProps< 'p' > {
+	/**
+	 * The description content to be rendered inside the component.
 	 */
 	children?: ReactNode;
 }

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -9,6 +9,7 @@ export interface RootProps
 		_Dialog.Root.Props,
 		| 'open'
 		| 'onOpenChange'
+		| 'onOpenChangeComplete'
 		| 'defaultOpen'
 		| 'modal'
 		| 'disablePointerDismissal'
@@ -82,6 +83,13 @@ export interface TitleProps extends ComponentProps< 'h2' > {
 	 *
 	 * When `Dialog.Title` is passed as a render element (e.g. to
 	 * `VisuallyHidden`), children can be provided by the wrapper instead.
+	 */
+	children?: ReactNode;
+}
+
+export interface DescriptionProps extends ComponentProps< 'p' > {
+	/**
+	 * The description content to be rendered inside the component.
 	 */
 	children?: ReactNode;
 }

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -37,6 +37,9 @@ export interface PopupProps
 
 	/**
 	 * A parent element to render the portal into.
+	 *
+	 * Useful for cross-document rendering, such as rendering a dialog
+	 * in a parent document when the trigger is inside an iframe.
 	 */
 	container?: _Dialog.Portal.Props[ 'container' ];
 
@@ -44,10 +47,15 @@ export interface PopupProps
 	 * Renders the dialog at a preset width (excluding additional padding from
 	 * the viewport edges).
 	 *
+	 * Height is not directly controlled by `size`: for every value except
+	 * `'full'`, the dialog fits its content up to the viewport height
+	 * (minus the viewport inset) and scrolls internally when it overflows.
+	 * `'full'` stretches the dialog to the available viewport height.
+	 *
 	 * - `'small'` — narrow max-width.
 	 * - `'medium'` — moderate max-width.
 	 * - `'large'` — wide max-width.
-	 * - `'stretch'` — no max-width, stretches to fill available space.
+	 * - `'stretch'` — no max-width, stretches to fill available width.
 	 * - `'full'` — stretches to fill available width and height.
 	 *
 	 * @default 'medium'

--- a/packages/ui/src/dialog/types.ts
+++ b/packages/ui/src/dialog/types.ts
@@ -36,10 +36,14 @@ export interface PopupProps
 	children?: ReactNode;
 
 	/**
-	 * A parent element to render the portal into.
+	 * The parent element the portal is attached to.
 	 *
-	 * Useful for cross-document rendering, such as rendering a dialog
-	 * in a parent document when the trigger is inside an iframe.
+	 * Useful for cross-document rendering — for example, rendering the
+	 * dialog in a parent document when the trigger lives inside an iframe.
+	 *
+	 * Accepts an `HTMLElement`, a ref to one, or a function returning one.
+	 *
+	 * @default the current document's `<body>`
 	 */
 	container?: _Dialog.Portal.Props[ 'container' ];
 

--- a/packages/ui/src/popover/description.tsx
+++ b/packages/ui/src/popover/description.tsx
@@ -9,7 +9,6 @@ import type { DescriptionProps } from './types';
  * Renders an optional paragraph that describes the popover content.
  *
  * The rendered element is linked to the popup via `aria-describedby`.
- * Uses the `body-md` text variant by default.
  */
 const Description = forwardRef< HTMLParagraphElement, DescriptionProps >(
 	function PopoverDescription( { className, children, ...props }, ref ) {


### PR DESCRIPTION
## What?

Split from #76690 (Drawer primitive PR).

Adds several improvements to the `Dialog` component that were originally bundled with the Drawer PR, plus broader alignment with the Drawer's conventions and additional test coverage.

## Why?

These changes are independent of the Drawer implementation and are better reviewed and merged separately to keep the Drawer PR focused.

## How?

### New sub-component: `Dialog.Description`

- Wraps Base UI's `Dialog.Description` with the `Text` component (`variant="body-md"`), matching the `Popover.Description` wrapping shape
- Adds `DescriptionProps` type, barrel export, CSS (`.description` rule), story subcomponent entry, and ref-forwarding test
- Default story now uses `Dialog.Description` so the new sub-component is visible from the main story
- JSDoc explicitly documents the `aria-describedby` association, and a test verifies the association at runtime via `toHaveAccessibleDescription`

### Modal context + conditional backdrop

- Adds `DialogModalContext` / `DialogModalProvider` / `useDialogModal` to `context.tsx`
- `Dialog.Root` applies the `modal = true` default once and forwards the resolved value to both `_Dialog.Root` and `DialogModalProvider`, so `Popup` can read it via context
- Makes `<Dialog.Backdrop>` conditional on `modal === true` (previously always rendered). Non-modal dialogs shouldn't dim the page, and `trap-focus` keeps outside pointer interactions enabled, so a backdrop would misrepresent either mode
- Tags the backdrop with a stable `data-wp-ui-dialog-backdrop` attribute (mirroring the existing `data-wp-ui-dialog-close-icon`), so tests can query it without relying on Base UI internals
- Test verifies backdrop presence across `modal={ true }`, `modal={ false }`, and `modal="trap-focus"`

### CSS refactor

- Extracts hardcoded `--wpds-dimension-padding-2xl` used in `width` and `max-height` calculations into a `--_viewport-inset` internal CSS custom property (using the existing underscore-prefixed internal naming convention), matching the Drawer's approach
- Swaps `100vh` for `100dvh` in the popup's `max-height` and the `is-full` full-height variant so the popup is bounded by the dynamic viewport (avoids overflow under mobile browser chrome)

### Type + docs

- Adds `onOpenChangeComplete` to `Dialog.RootProps`
- Elaborates the JSDoc for `PopupProps.container` (mentions the cross-document / iframe use case, matching `Drawer`)
- Moves the component description from Storybook `parameters.docs.description.component` to a JSDoc block on the `Root` function
- Aligns `Dialog.Description`'s JSDoc phrasing with the sibling components (including the explicit `aria-describedby` note), and drops the matching `body-md` note from `Popover.Description`'s JSDoc for consistency

### Alignment with Drawer + additional coverage

- `Dialog.Title`: accepts and merges a `className` prop (matches `Drawer.Title`)
- `Dialog.Popup`: prop destructuring order matches `Drawer.Popup` (`children` near the top)
- `Dialog.context`: `contextValue` memo now lives next to the rest of the memoized data, matching `Drawer.context`
- New tests cover `Dialog.Description`'s `aria-describedby` wiring, conditional backdrop rendering across `modal` values, `Dialog.Action`'s `disabled` / `loading` precedence, `Dialog.Footer`'s `render` / `className` support, and `Dialog.Popup` across all size values (default + `small`, `medium`, `large`, `stretch`, `full`) — none of these were previously exercised
- CHANGELOG entry added

## Testing Instructions

1. `npm run storybook:dev`
2. Navigate to **Design System / Components / Dialog** — verify all stories render correctly, including `Dialog.Description` in the default story
3. Verify that `modal={ false }` (and `modal="trap-focus"`) no longer render a backdrop overlay
4. Run `npm run test:unit packages/ui/src/dialog` — all 22 tests should pass

## Follow-ups

- Port the `data-wp-ui-*-backdrop` test hook to `Popover` and `AlertDialog` so their backdrops can be queried without relying on Base UI internals (separate PR).
- Add a dev-mode guard that warns when `Dialog.Popup` is rendered without a `Dialog.Root` ancestor, to prevent floating backdrops in misuse scenarios.

## Use of AI Tools

Cursor + Claude Opus 4.6 and Claude Opus 4.7

Made with [Cursor](https://cursor.com)
