### PR TITLE
Block Editor: Fix blockGap fallback handling for shorthand values and var() with spaces

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -237,6 +237,90 @@ function gutenberg_register_layout_support( $block_type ) {
 	}
 }
 
+
+/**
+ * Split a CSS shorthand value by top-level whitespace only.
+ *
+ * @param string $value CSS shorthand value.
+ * @return string[] Top-level parts.
+ */
+function gutenberg_split_top_level_gap_values( $value ) {
+	if ( ! is_string( $value ) || '' === trim( $value ) ) {
+		return array();
+	}
+
+	$parts   = array();
+	$current = '';
+	$depth   = 0;
+	$length  = strlen( $value );
+
+	for ( $i = 0; $i < $length; $i++ ) {
+		$char = $value[ $i ];
+
+		if ( '(' === $char ) {
+			++$depth;
+			$current .= $char;
+			continue;
+		}
+
+		if ( ')' === $char ) {
+			$depth = max( 0, $depth - 1 );
+			$current .= $char;
+			continue;
+		}
+
+		if ( preg_match( '/\s/', $char ) && 0 === $depth ) {
+			if ( '' !== $current ) {
+				$parts[] = $current;
+				$current = '';
+			}
+			continue;
+		}
+
+		$current .= $char;
+	}
+
+	if ( '' !== $current ) {
+		$parts[] = $current;
+	}
+
+	return $parts;
+}
+
+/**
+ * Resolve a block gap value against a fallback, preserving row and column separately.
+ *
+ * @param string|array|null $gap_value          User-set gap value.
+ * @param string|array|null $fallback_gap_value Fallback gap value.
+ * @return string|array|null
+ */
+function gutenberg_get_gap_value_with_fallback( $gap_value, $fallback_gap_value = '0.5em' ) {
+	if ( null === $gap_value ) {
+		return null;
+	}
+
+	if ( is_string( $gap_value ) ) {
+		return $gap_value;
+	}
+
+	if ( is_array( $fallback_gap_value ) ) {
+		$fallback_top  = $fallback_gap_value['top'] ?? reset( $fallback_gap_value ) ?? '0.5em';
+		$fallback_left = $fallback_gap_value['left'] ?? $fallback_top;
+	} else {
+		$fallback_parts = gutenberg_split_top_level_gap_values(
+			is_string( $fallback_gap_value ) ? $fallback_gap_value : '0.5em'
+		);
+
+		$fallback_top  = $fallback_parts[0] ?? ( is_string( $fallback_gap_value ) ? $fallback_gap_value : '0.5em' );
+		$fallback_left = $fallback_parts[1] ?? $fallback_top;
+	}
+
+	return array(
+		'top'  => $gap_value['top'] ?? $fallback_top,
+		'left' => $gap_value['left'] ?? $fallback_left,
+	);
+}
+
 /**
  * Generates the CSS corresponding to the provided layout.
  *
@@ -434,19 +518,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( $has_block_gap_support && isset( $gap_value ) ) {
+			$gap_value          = gutenberg_get_gap_value_with_fallback( $gap_value, $fallback_gap_value );
 			$combined_gap_value = '';
 			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
 
 			foreach ( $gap_sides as $gap_side ) {
-				$process_value = $gap_value;
-				if ( is_array( $gap_value ) ) {
-					if ( is_array( $fallback_gap_value ) ) {
-						$fallback_value = $fallback_gap_value[ $gap_side ] ?? reset( $fallback_gap_value );
-					} else {
-						$fallback_value = $fallback_gap_value;
-					}
-					$process_value = $gap_value[ $gap_side ] ?? $fallback_value;
-				}
+				$process_value = is_array( $gap_value ) ? $gap_value[ $gap_side ] ?? null : $gap_value;
+
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
 					$index_to_splice = strrpos( $process_value, '|' ) + 1;

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -44,3 +44,78 @@ export function getGapCSSValue( blockGapValue, defaultValue = '0' ) {
 
 	return row === column ? row : `${ row } ${ column }`;
 }
+
+/**
+ * Split a CSS shorthand value by top-level whitespace only.
+ *
+ * @param {?string} value CSS shorthand value.
+ * @return {string[]}     Top-level parts.
+ */
+export function splitTopLevelGapValues( value ) {
+	if ( ! value ) {
+		return [];
+	}
+
+	const parts = [];
+	let current = '';
+	let depth = 0;
+
+	for ( const char of value ) {
+		if ( char === '(' ) {
+			depth++;
+			current += char;
+			continue;
+		}
+
+		if ( char === ')' ) {
+			depth = Math.max( 0, depth - 1 );
+			current += char;
+			continue;
+		}
+
+		if ( /\s/.test( char ) && depth === 0 ) {
+			if ( current ) {
+				parts.push( current );
+				current = '';
+			}
+			continue;
+		}
+
+		current += char;
+	}
+
+	if ( current ) {
+		parts.push( current );
+	}
+
+	return parts;
+}
+
+/**
+ * Returns a CSS value for the `gap` property with fallback support.
+ *
+ * @param {?string | ?Object} blockGapValue A block gap string or axial object value, e.g., '10px' or { top: '10px', left: '10px'}.
+ * @param {?string}           fallbackValue A fallback gap value, which may be a shorthand string.
+ * @return {string|null}                    The concatenated gap value (row and column).
+ */
+export function getGapValueWithFallback( blockGapValue, fallbackValue = '0' ) {
+	const blockGapBoxControlValue =
+		getGapBoxControlValueFromStyle( blockGapValue );
+
+	if ( ! blockGapBoxControlValue ) {
+		return null;
+	}
+
+	const fallbackParts = splitTopLevelGapValues( fallbackValue );
+
+	const fallbackTop = fallbackParts[ 0 ] || fallbackValue;
+	const fallbackLeft =
+		fallbackParts[ 1 ] || fallbackParts[ 0 ] || fallbackValue;
+
+	const row =
+		getSpacingPresetCssVar( blockGapBoxControlValue?.top ) || fallbackTop;
+	const column =
+		getSpacingPresetCssVar( blockGapBoxControlValue?.left ) || fallbackLeft;
+
+	return row === column ? row : `${ row } ${ column }`;
+}

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -106,11 +106,18 @@ export function getGapValueWithFallback( blockGapValue, fallbackValue = '0' ) {
 		return null;
 	}
 
-	const fallbackParts = splitTopLevelGapValues( fallbackValue );
+	let fallbackTop;
+	let fallbackLeft;
 
-	const fallbackTop = fallbackParts[ 0 ] || fallbackValue;
-	const fallbackLeft =
-		fallbackParts[ 1 ] || fallbackParts[ 0 ] || fallbackValue;
+	if ( typeof fallbackValue === 'object' && fallbackValue !== null ) {
+		fallbackTop = fallbackValue?.top || fallbackValue?.left || '0';
+		fallbackLeft = fallbackValue?.left || fallbackValue?.top || '0';
+	} else {
+		const fallbackParts = splitTopLevelGapValues( fallbackValue );
+		fallbackTop = fallbackParts[ 0 ] || fallbackValue;
+		fallbackLeft =
+			fallbackParts[ 1 ] || fallbackParts[ 0 ] || fallbackValue;
+	}
 
 	const row =
 		getSpacingPresetCssVar( blockGapBoxControlValue?.top ) || fallbackTop;

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -23,7 +23,7 @@ import {
  * Internal dependencies
  */
 import { appendSelectors, getBlockGapCSS } from './utils';
-import { getGapCSSValue } from '../hooks/gap';
+import { getGapValueWithFallback } from '../hooks/gap';
 import {
 	BlockControls,
 	JustifyContentControl,
@@ -145,25 +145,17 @@ export default {
 
 		// Determine the fallback gap value using global styles (theme.json),
 		// falling back to '0.5em' for backwards compatibility.
-		let fallbackGapValue = '0.5em';
-		if ( globalBlockGapValue ) {
-			// Process the global gap value to handle preset values
-			const processedGlobalGap = getGapCSSValue(
-				globalBlockGapValue,
-				'0.5em'
-			);
-			// Use the column gap value (second value if two values exist)
-			const gapParts = processedGlobalGap.split( ' ' );
-			fallbackGapValue =
-				gapParts.length > 1 ? gapParts[ 1 ] : gapParts[ 0 ];
-		}
+		const fallbackGapValue = globalBlockGapValue || '0.5em';
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
 		const blockGapValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
+				? getGapValueWithFallback(
+						style?.spacing?.blockGap,
+						fallbackGapValue
+				  )
 				: undefined;
 		const justifyContent = justifyContentMap[ layout.justifyContent ];
 		const flexWrap = flexWrapOptions.includes( layout.flexWrap )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related Issues
#76896 

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
