### PR TITLE
Editor: Paginate revisions slider by 100 per page

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -2,10 +2,17 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { RangeControl, Spinner } from '@wordpress/components';
+import {
+	RangeControl,
+	Spinner,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useEffect, useMemo } from '@wordpress/element';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -13,65 +20,112 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const REVISIONS_PER_PAGE = 100;
+
 /**
- * Slider component for navigating revisions.
+ * Slider component for navigating revisions with pagination.
+ *
+ * Page 1 contains the newest revisions. The API returns them in
+ * descending date order, and we reverse for display so the slider
+ * reads oldest-left → newest-right.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
-	const { revisions, isLoading, currentRevisionId, revisionKey } = useSelect(
-		( select ) => {
-			const { getCurrentPostId, getCurrentPostType } =
-				select( editorStore );
-			const { getRevisions, isResolving, getEntityConfig } =
-				select( coreStore );
+	const {
+		revisions: rawRevisions,
+		isLoading,
+		currentRevisionId,
+		revisionKey,
+		revisionPage,
+		totalRevisions,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentPostId,
+			getCurrentPostType,
+			getCurrentPostRevisionsCount,
+		} = select( editorStore );
+		const { getRevisions, isResolving, getEntityConfig } =
+			select( coreStore );
+		const { getCurrentRevisionId, getRevisionPage } = unlock(
+			select( editorStore )
+		);
 
-			const postId = getCurrentPostId();
-			const postType = getCurrentPostType();
+		const postId = getCurrentPostId();
+		const postType = getCurrentPostType();
 
-			if ( ! postId || ! postType ) {
-				return {};
-			}
+		if ( ! postId || ! postType ) {
+			return {};
+		}
 
-			const entityConfig = getEntityConfig( 'postType', postType );
-			const _revisionKey = entityConfig?.revisionKey || 'id';
-			const query = {
-				per_page: -1,
-				context: 'edit',
-				orderby: 'date',
-				order: 'asc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						_revisionKey,
-					] ),
-				].join(),
-			};
+		const entityConfig = getEntityConfig( 'postType', postType );
+		const _revisionKey = entityConfig?.revisionKey || 'id';
+		const _totalRevisions = getCurrentPostRevisionsCount();
+		const _revisionPage = getRevisionPage();
+
+		// Don't fetch until we have a page number.
+		if ( ! _revisionPage ) {
 			return {
-				revisions: getRevisions( 'postType', postType, postId, query ),
-				isLoading: isResolving( 'getRevisions', [
-					'postType',
-					postType,
-					postId,
-					query,
-				] ),
-				currentRevisionId: unlock(
-					select( editorStore )
-				).getCurrentRevisionId(),
+				isLoading: true,
+				totalRevisions: _totalRevisions,
+				revisionPage: _revisionPage,
 				revisionKey: _revisionKey,
 			};
-		},
-		[]
+		}
+
+		const query = {
+			per_page: REVISIONS_PER_PAGE,
+			page: _revisionPage,
+			context: 'edit',
+			orderby: 'date',
+			order: 'desc',
+			_fields: [
+				...new Set( [
+					'id',
+					'date',
+					'modified',
+					'author',
+					'meta',
+					'title.raw',
+					'excerpt.raw',
+					'content.raw',
+					_revisionKey,
+				] ),
+			].join(),
+		};
+		return {
+			revisions: getRevisions( 'postType', postType, postId, query ),
+			isLoading: isResolving( 'getRevisions', [
+				'postType',
+				postType,
+				postId,
+				query,
+			] ),
+			currentRevisionId: getCurrentRevisionId(),
+			revisionKey: _revisionKey,
+			revisionPage: _revisionPage,
+			totalRevisions: _totalRevisions,
+		};
+	}, [] );
+
+	const { setCurrentRevisionId, setRevisionPage } = unlock(
+		useDispatch( editorStore )
 	);
 
-	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
+	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+
+	// Reverse so the slider reads oldest (left) → newest (right).
+	const revisions = useMemo(
+		() => rawRevisions && [ ...rawRevisions ].reverse(),
+		[ rawRevisions ]
+	);
+
+	// Set initial page to 1 (newest revisions) when entering revisions mode.
+	useEffect( () => {
+		if ( revisionPage === null && totalRevisions > 0 ) {
+			setRevisionPage( 1 );
+		}
+	}, [ revisionPage, totalRevisions, setRevisionPage ] );
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -83,6 +137,19 @@ function RevisionsSlider() {
 			setCurrentRevisionId( revision[ revisionKey ] );
 		}
 	};
+
+	const handlePageChange = ( newPage ) => {
+		setRevisionPage( newPage );
+	};
+
+	// When revisions load and no revision is selected (after page change),
+	// select the last revision on the page (newest = last in reversed array).
+	useEffect( () => {
+		if ( revisions?.length && selectedIndex === -1 ) {
+			const lastRevision = revisions[ revisions.length - 1 ];
+			setCurrentRevisionId( lastRevision[ revisionKey ] );
+		}
+	}, [ revisions, selectedIndex, revisionKey, setCurrentRevisionId ] );
 
 	// Format date for tooltip.
 	const dateSettings = getDateSettings();
@@ -106,7 +173,7 @@ function RevisionsSlider() {
 		);
 	}
 
-	if ( revisions?.length === 1 ) {
+	if ( totalRevisions <= 1 ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'Only one revision found.' ) }
@@ -114,7 +181,22 @@ function RevisionsSlider() {
 		);
 	}
 
-	return (
+	const showPagination = totalPages > 1;
+
+	// Compute the 1-based revision range for a given page.
+	// Page 1 = newest, so page 1 of 1000 → "901–1000".
+	const getPageRangeLabel = ( page ) => {
+		const end = totalRevisions - ( page - 1 ) * REVISIONS_PER_PAGE;
+		const start = Math.max( 1, end - REVISIONS_PER_PAGE + 1 );
+		return sprintf(
+			/* translators: 1: first revision number, 2: last revision number */
+			__( 'Revisions %1$s\u2013%2$s' ),
+			start,
+			end
+		);
+	};
+
+	const slider = (
 		<RangeControl
 			__next40pxDefaultSize
 			className="editor-revisions-header__slider"
@@ -125,10 +207,45 @@ function RevisionsSlider() {
 			marks
 			onChange={ handleSliderChange }
 			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex }
+			value={ selectedIndex >= 0 ? selectedIndex : 0 }
 			withInputField={ false }
 		/>
 	);
+
+	if ( ! showPagination ) {
+		return slider;
+	}
+
+	return (
+		<HStack spacing={ 2 } expanded wrap={ false }>
+			<Button
+				icon={ chevronLeft }
+				label={
+					revisionPage < totalPages
+						? getPageRangeLabel( revisionPage + 1 )
+						: __( 'Older revisions' )
+				}
+				onClick={ () => handlePageChange( revisionPage + 1 ) }
+				disabled={ revisionPage >= totalPages }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+			<div style={ { flex: 1, minWidth: 0 } }>{ slider }</div>
+			<Button
+				icon={ chevronRight }
+				label={
+					revisionPage > 1
+						? getPageRangeLabel( revisionPage - 1 )
+						: __( 'Newer revisions' )
+				}
+				onClick={ () => handlePageChange( revisionPage - 1 ) }
+				disabled={ revisionPage <= 1 }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+		</HStack>
+	);
 }
 
+export { REVISIONS_PER_PAGE };
 export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -11,7 +11,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
@@ -65,19 +65,13 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const isLoading = !! revisionPage && ! rawRevisions;
+	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
 
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
 	);
-
-	useEffect( () => {
-		if ( revisionPage === null && totalRevisions > 0 ) {
-			setRevisionPage( 1 );
-		}
-	}, [ revisionPage, totalRevisions, setRevisionPage ] );
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -93,13 +87,6 @@ function RevisionsSlider() {
 	const handlePageChange = ( newPage ) => {
 		setRevisionPage( newPage );
 	};
-
-	useEffect( () => {
-		if ( revisions?.length && selectedIndex === -1 ) {
-			const lastRevision = revisions[ revisions.length - 1 ];
-			setCurrentRevisionId( lastRevision[ revisionKey ] );
-		}
-	}, [ revisions, selectedIndex, revisionKey, setCurrentRevisionId ] );
 
 	// Format date for tooltip.
 	const dateSettings = getDateSettings();
@@ -144,23 +131,24 @@ function RevisionsSlider() {
 		);
 	};
 
-	const sliderOrSpinner = isLoading ? (
-		<Spinner />
-	) : (
-		<RangeControl
-			__next40pxDefaultSize
-			className="editor-revisions-header__slider"
-			hideLabelFromVision
-			label={ __( 'Revision' ) }
-			max={ revisions?.length - 1 }
-			min={ 0 }
-			marks
-			onChange={ handleSliderChange }
-			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex >= 0 ? selectedIndex : 0 }
-			withInputField={ false }
-		/>
-	);
+	const sliderOrSpinner =
+		isLoading || selectedIndex === -1 ? (
+			<Spinner />
+		) : (
+			<RangeControl
+				__next40pxDefaultSize
+				className="editor-revisions-header__slider"
+				hideLabelFromVision
+				label={ __( 'Revision' ) }
+				max={ revisions?.length - 1 }
+				min={ 0 }
+				marks
+				onChange={ handleSliderChange }
+				renderTooltipContent={ renderTooltipContent }
+				value={ selectedIndex }
+				withInputField={ false }
+			/>
+		);
 
 	if ( ! showPagination ) {
 		return sliderOrSpinner;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -161,11 +161,13 @@ function RevisionsSlider() {
 		return dateI18n( dateSettings.formats.datetime, revision.date );
 	};
 
-	if ( isLoading ) {
+	const showPagination = totalPages > 1;
+
+	if ( isLoading && ! showPagination ) {
 		return <Spinner />;
 	}
 
-	if ( ! revisions?.length ) {
+	if ( ! isLoading && ! revisions?.length ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'No revisions found.' ) }
@@ -181,8 +183,6 @@ function RevisionsSlider() {
 		);
 	}
 
-	const showPagination = totalPages > 1;
-
 	// Compute the 1-based revision range for a given page.
 	// Page 1 = newest, so page 1 of 1000 → "901–1000".
 	const getPageRangeLabel = ( page ) => {
@@ -196,7 +196,9 @@ function RevisionsSlider() {
 		);
 	};
 
-	const slider = (
+	const sliderOrSpinner = isLoading ? (
+		<Spinner />
+	) : (
 		<RangeControl
 			__next40pxDefaultSize
 			className="editor-revisions-header__slider"
@@ -213,7 +215,7 @@ function RevisionsSlider() {
 	);
 
 	if ( ! showPagination ) {
-		return slider;
+		return sliderOrSpinner;
 	}
 
 	return (
@@ -226,11 +228,11 @@ function RevisionsSlider() {
 						: __( 'Older revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage + 1 ) }
-				disabled={ revisionPage >= totalPages }
+				disabled={ isLoading || revisionPage >= totalPages }
 				size="compact"
 				accessibleWhenDisabled
 			/>
-			<div style={ { flex: 1, minWidth: 0 } }>{ slider }</div>
+			<div style={ { flex: 1, minWidth: 0 } }>{ sliderOrSpinner }</div>
 			<Button
 				icon={ chevronRight }
 				label={
@@ -239,7 +241,7 @@ function RevisionsSlider() {
 						: __( 'Newer revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage - 1 ) }
-				disabled={ revisionPage <= 1 }
+				disabled={ isLoading || revisionPage <= 1 }
 				size="compact"
 				accessibleWhenDisabled
 			/>

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -34,8 +34,12 @@ function RevisionsSlider() {
 		revisionPage,
 		totalRevisions,
 	} = useSelect( ( select ) => {
-		const { getCurrentRevisionId, getRevisionPage, getPageRevisions } =
-			unlock( select( editorStore ) );
+		const {
+			getCurrentRevisionId,
+			getRevisionPage,
+			getPageRevisions,
+			getRevisionsPerPage,
+		} = unlock( select( editorStore ) );
 
 		const postType = select( editorStore ).getCurrentPostType();
 		if ( ! postType ) {
@@ -48,11 +52,10 @@ function RevisionsSlider() {
 		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
 		const _revisionPage = getRevisionPage();
-		const pageData = getPageRevisions( _revisionPage );
 
 		return {
-			revisions: pageData?.revisions,
-			perPage: pageData?.perPage,
+			revisions: getPageRevisions( _revisionPage ),
+			perPage: getRevisionsPerPage(),
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
@@ -66,7 +69,7 @@ function RevisionsSlider() {
 	);
 
 	const isLoading = ! rawRevisions;
-	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
+	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
 
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
@@ -82,10 +85,6 @@ function RevisionsSlider() {
 		if ( revision ) {
 			setCurrentRevisionId( revision[ revisionKey ] );
 		}
-	};
-
-	const handlePageChange = ( newPage ) => {
-		setRevisionPage( newPage );
 	};
 
 	// Format date for tooltip.
@@ -163,7 +162,7 @@ function RevisionsSlider() {
 						? getPageRangeLabel( revisionPage + 1 )
 						: __( 'No older revisions' )
 				}
-				onClick={ () => handlePageChange( revisionPage + 1 ) }
+				onClick={ () => setRevisionPage( revisionPage + 1 ) }
 				disabled={ isLoading || revisionPage >= totalPages }
 				size="compact"
 				accessibleWhenDisabled
@@ -185,7 +184,7 @@ function RevisionsSlider() {
 						? getPageRangeLabel( revisionPage - 1 )
 						: __( 'No newer revisions' )
 				}
-				onClick={ () => handlePageChange( revisionPage - 1 ) }
+				onClick={ () => setRevisionPage( revisionPage - 1 ) }
 				disabled={ isLoading || revisionPage <= 1 }
 				size="compact"
 				accessibleWhenDisabled

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -71,6 +71,7 @@ function RevisionsSlider() {
 	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
 
+	// Reverse desc→asc so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
@@ -124,7 +125,7 @@ function RevisionsSlider() {
 		const start = Math.max( 1, end - perPage + 1 );
 		return sprintf(
 			/* translators: 1: first revision number, 2: last revision number */
-			__( 'Revisions %1$s\u2013%2$s' ),
+			__( 'Revisions %1$s–%2$s' ),
 			start,
 			end
 		);

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -34,77 +34,33 @@ const REVISIONS_PER_PAGE = 100;
 function RevisionsSlider() {
 	const {
 		revisions: rawRevisions,
-		isLoading,
 		currentRevisionId,
 		revisionKey,
 		revisionPage,
 		totalRevisions,
 	} = useSelect( ( select ) => {
-		const {
-			getCurrentPostId,
-			getCurrentPostType,
-			getCurrentPostRevisionsCount,
-		} = select( editorStore );
-		const { getRevisions, isResolving, getEntityConfig } =
-			select( coreStore );
-		const { getCurrentRevisionId, getRevisionPage } = unlock(
-			select( editorStore )
-		);
+		const { getCurrentRevisionId, getRevisionPage, getPageRevisions } =
+			unlock( select( editorStore ) );
 
-		const postId = getCurrentPostId();
-		const postType = getCurrentPostType();
-
-		if ( ! postId || ! postType ) {
+		const postType = select( editorStore ).getCurrentPostType();
+		if ( ! postType ) {
 			return {};
 		}
 
-		const entityConfig = getEntityConfig( 'postType', postType );
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
-		const _totalRevisions = getCurrentPostRevisionsCount();
 		const _revisionPage = getRevisionPage();
 
-		// Don't fetch until we have a page number.
-		if ( ! _revisionPage ) {
-			return {
-				isLoading: true,
-				totalRevisions: _totalRevisions,
-				revisionPage: _revisionPage,
-				revisionKey: _revisionKey,
-			};
-		}
-
-		const query = {
-			per_page: REVISIONS_PER_PAGE,
-			page: _revisionPage,
-			context: 'edit',
-			orderby: 'date',
-			order: 'desc',
-			_fields: [
-				...new Set( [
-					'id',
-					'date',
-					'modified',
-					'author',
-					'meta',
-					'title.raw',
-					'excerpt.raw',
-					'content.raw',
-					_revisionKey,
-				] ),
-			].join(),
-		};
 		return {
-			revisions: getRevisions( 'postType', postType, postId, query ),
-			isLoading: isResolving( 'getRevisions', [
-				'postType',
-				postType,
-				postId,
-				query,
-			] ),
+			revisions: getPageRevisions( _revisionPage ),
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
-			totalRevisions: _totalRevisions,
+			totalRevisions:
+				select( editorStore ).getCurrentPostRevisionsCount(),
 		};
 	}, [] );
 
@@ -113,6 +69,7 @@ function RevisionsSlider() {
 	);
 
 	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+	const isLoading = !! revisionPage && ! rawRevisions;
 
 	// Reverse so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -232,7 +232,16 @@ function RevisionsSlider() {
 				size="compact"
 				accessibleWhenDisabled
 			/>
-			<div style={ { flex: 1, minWidth: 0 } }>{ sliderOrSpinner }</div>
+			<div
+				style={ {
+					flex: 1,
+					minWidth: 0,
+					display: 'flex',
+					justifyContent: 'center',
+				} }
+			>
+				{ sliderOrSpinner }
+			</div>
 			<Button
 				icon={ chevronRight }
 				label={

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -20,20 +20,15 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const REVISIONS_PER_PAGE = 100;
-
 /**
  * Slider component for navigating revisions with pagination.
- *
- * Page 1 contains the newest revisions. The API returns them in
- * descending date order, and we reverse for display so the slider
- * reads oldest-left → newest-right.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
 	const {
 		revisions: rawRevisions,
+		perPage,
 		currentRevisionId,
 		revisionKey,
 		revisionPage,
@@ -53,9 +48,11 @@ function RevisionsSlider() {
 		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
 		const _revisionPage = getRevisionPage();
+		const pageData = getPageRevisions( _revisionPage );
 
 		return {
-			revisions: getPageRevisions( _revisionPage ),
+			revisions: pageData?.revisions,
+			perPage: pageData?.perPage,
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
@@ -68,16 +65,14 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
 	const isLoading = !! revisionPage && ! rawRevisions;
+	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
 
-	// Reverse so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
 	);
 
-	// Set initial page to 1 (newest revisions) when entering revisions mode.
 	useEffect( () => {
 		if ( revisionPage === null && totalRevisions > 0 ) {
 			setRevisionPage( 1 );
@@ -99,8 +94,6 @@ function RevisionsSlider() {
 		setRevisionPage( newPage );
 	};
 
-	// When revisions load and no revision is selected (after page change),
-	// select the last revision on the page (newest = last in reversed array).
 	useEffect( () => {
 		if ( revisions?.length && selectedIndex === -1 ) {
 			const lastRevision = revisions[ revisions.length - 1 ];
@@ -140,11 +133,9 @@ function RevisionsSlider() {
 		);
 	}
 
-	// Compute the 1-based revision range for a given page.
-	// Page 1 = newest, so page 1 of 1000 → "901–1000".
 	const getPageRangeLabel = ( page ) => {
-		const end = totalRevisions - ( page - 1 ) * REVISIONS_PER_PAGE;
-		const start = Math.max( 1, end - REVISIONS_PER_PAGE + 1 );
+		const end = totalRevisions - ( page - 1 ) * perPage;
+		const start = Math.max( 1, end - perPage + 1 );
 		return sprintf(
 			/* translators: 1: first revision number, 2: last revision number */
 			__( 'Revisions %1$s\u2013%2$s' ),
@@ -182,7 +173,7 @@ function RevisionsSlider() {
 				label={
 					revisionPage < totalPages
 						? getPageRangeLabel( revisionPage + 1 )
-						: __( 'Older revisions' )
+						: __( 'No older revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage + 1 ) }
 				disabled={ isLoading || revisionPage >= totalPages }
@@ -204,7 +195,7 @@ function RevisionsSlider() {
 				label={
 					revisionPage > 1
 						? getPageRangeLabel( revisionPage - 1 )
-						: __( 'Newer revisions' )
+						: __( 'No newer revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage - 1 ) }
 				disabled={ isLoading || revisionPage <= 1 }
@@ -215,5 +206,4 @@ function RevisionsSlider() {
 	);
 }
 
-export { REVISIONS_PER_PAGE };
 export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -20,20 +20,15 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const REVISIONS_PER_PAGE = 100;
-
 /**
  * Slider component for navigating revisions with pagination.
- *
- * Page 1 contains the newest revisions. The API returns them in
- * descending date order, and we reverse for display so the slider
- * reads oldest-left → newest-right.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
 	const {
 		revisions: rawRevisions,
+		perPage,
 		currentRevisionId,
 		revisionKey,
 		revisionPage,
@@ -53,9 +48,11 @@ function RevisionsSlider() {
 		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
 		const _revisionPage = getRevisionPage();
+		const pageData = getPageRevisions( _revisionPage );
 
 		return {
-			revisions: getPageRevisions( _revisionPage ),
+			revisions: pageData?.revisions,
+			perPage: pageData?.perPage,
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
@@ -68,16 +65,14 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
 	const isLoading = !! revisionPage && ! rawRevisions;
+	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
 
-	// Reverse so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
 	);
 
-	// Set initial page to 1 (newest revisions) when entering revisions mode.
 	useEffect( () => {
 		if ( revisionPage === null && totalRevisions > 0 ) {
 			setRevisionPage( 1 );
@@ -99,8 +94,6 @@ function RevisionsSlider() {
 		setRevisionPage( newPage );
 	};
 
-	// When revisions load and no revision is selected (after page change),
-	// select the last revision on the page (newest = last in reversed array).
 	useEffect( () => {
 		if ( revisions?.length && selectedIndex === -1 ) {
 			const lastRevision = revisions[ revisions.length - 1 ];
@@ -140,11 +133,9 @@ function RevisionsSlider() {
 		);
 	}
 
-	// Compute the 1-based revision range for a given page.
-	// Page 1 = newest, so page 1 of 1000 → "901–1000".
 	const getPageRangeLabel = ( page ) => {
-		const end = totalRevisions - ( page - 1 ) * REVISIONS_PER_PAGE;
-		const start = Math.max( 1, end - REVISIONS_PER_PAGE + 1 );
+		const end = totalRevisions - ( page - 1 ) * perPage;
+		const start = Math.max( 1, end - perPage + 1 );
 		return sprintf(
 			/* translators: 1: first revision number, 2: last revision number */
 			__( 'Revisions %1$s\u2013%2$s' ),
@@ -183,7 +174,7 @@ function RevisionsSlider() {
 				label={
 					revisionPage < totalPages
 						? getPageRangeLabel( revisionPage + 1 )
-						: __( 'Older revisions' )
+						: __( 'No older revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage + 1 ) }
 				disabled={ isLoading || revisionPage >= totalPages }
@@ -205,7 +196,7 @@ function RevisionsSlider() {
 				label={
 					revisionPage > 1
 						? getPageRangeLabel( revisionPage - 1 )
-						: __( 'Newer revisions' )
+						: __( 'No newer revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage - 1 ) }
 				disabled={ isLoading || revisionPage <= 1 }
@@ -216,5 +207,4 @@ function RevisionsSlider() {
 	);
 }
 
-export { REVISIONS_PER_PAGE };
 export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -152,7 +152,7 @@ function RevisionsSlider() {
 	}
 
 	return (
-		<Stack direction="row" gap="sm" align="center">
+		<Stack direction="row" gap="sm" align="center" style={ { flex: 1 } }>
 			<Button
 				icon={ chevronLeft }
 				label={

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -11,7 +11,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
@@ -65,19 +65,13 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const isLoading = !! revisionPage && ! rawRevisions;
+	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
 
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
 	);
-
-	useEffect( () => {
-		if ( revisionPage === null && totalRevisions > 0 ) {
-			setRevisionPage( 1 );
-		}
-	}, [ revisionPage, totalRevisions, setRevisionPage ] );
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -93,13 +87,6 @@ function RevisionsSlider() {
 	const handlePageChange = ( newPage ) => {
 		setRevisionPage( newPage );
 	};
-
-	useEffect( () => {
-		if ( revisions?.length && selectedIndex === -1 ) {
-			const lastRevision = revisions[ revisions.length - 1 ];
-			setCurrentRevisionId( lastRevision[ revisionKey ] );
-		}
-	}, [ revisions, selectedIndex, revisionKey, setCurrentRevisionId ] );
 
 	// Format date for tooltip.
 	const dateSettings = getDateSettings();
@@ -144,24 +131,25 @@ function RevisionsSlider() {
 		);
 	};
 
-	const sliderOrSpinner = isLoading ? (
-		<Spinner />
-	) : (
-		<RangeControl
-			__next40pxDefaultSize
-			aria-valuetext={ renderTooltipContent( selectedIndex ) }
-			className="editor-revisions-header__slider"
-			hideLabelFromVision
-			label={ __( 'Revision' ) }
-			max={ revisions?.length - 1 }
-			min={ 0 }
-			marks
-			onChange={ handleSliderChange }
-			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex >= 0 ? selectedIndex : 0 }
-			withInputField={ false }
-		/>
-	);
+	const sliderOrSpinner =
+		isLoading || selectedIndex === -1 ? (
+			<Spinner />
+		) : (
+			<RangeControl
+				__next40pxDefaultSize
+				aria-valuetext={ renderTooltipContent( selectedIndex ) }
+				className="editor-revisions-header__slider"
+				hideLabelFromVision
+				label={ __( 'Revision' ) }
+				max={ revisions?.length - 1 }
+				min={ 0 }
+				marks
+				onChange={ handleSliderChange }
+				renderTooltipContent={ renderTooltipContent }
+				value={ selectedIndex }
+				withInputField={ false }
+			/>
+		);
 
 	if ( ! showPagination ) {
 		return sliderOrSpinner;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -161,11 +161,13 @@ function RevisionsSlider() {
 		return dateI18n( dateSettings.formats.datetime, revision.date );
 	};
 
-	if ( isLoading ) {
+	const showPagination = totalPages > 1;
+
+	if ( isLoading && ! showPagination ) {
 		return <Spinner />;
 	}
 
-	if ( ! revisions?.length ) {
+	if ( ! isLoading && ! revisions?.length ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'No revisions found.' ) }
@@ -181,8 +183,6 @@ function RevisionsSlider() {
 		);
 	}
 
-	const showPagination = totalPages > 1;
-
 	// Compute the 1-based revision range for a given page.
 	// Page 1 = newest, so page 1 of 1000 → "901–1000".
 	const getPageRangeLabel = ( page ) => {
@@ -196,7 +196,9 @@ function RevisionsSlider() {
 		);
 	};
 
-	const slider = (
+	const sliderOrSpinner = isLoading ? (
+		<Spinner />
+	) : (
 		<RangeControl
 			__next40pxDefaultSize
 			aria-valuetext={ renderTooltipContent( selectedIndex ) }
@@ -214,7 +216,7 @@ function RevisionsSlider() {
 	);
 
 	if ( ! showPagination ) {
-		return slider;
+		return sliderOrSpinner;
 	}
 
 	return (
@@ -227,11 +229,11 @@ function RevisionsSlider() {
 						: __( 'Older revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage + 1 ) }
-				disabled={ revisionPage >= totalPages }
+				disabled={ isLoading || revisionPage >= totalPages }
 				size="compact"
 				accessibleWhenDisabled
 			/>
-			<div style={ { flex: 1, minWidth: 0 } }>{ slider }</div>
+			<div style={ { flex: 1, minWidth: 0 } }>{ sliderOrSpinner }</div>
 			<Button
 				icon={ chevronRight }
 				label={
@@ -240,7 +242,7 @@ function RevisionsSlider() {
 						: __( 'Newer revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage - 1 ) }
-				disabled={ revisionPage <= 1 }
+				disabled={ isLoading || revisionPage <= 1 }
 				size="compact"
 				accessibleWhenDisabled
 			/>

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -233,7 +233,16 @@ function RevisionsSlider() {
 				size="compact"
 				accessibleWhenDisabled
 			/>
-			<div style={ { flex: 1, minWidth: 0 } }>{ sliderOrSpinner }</div>
+			<div
+				style={ {
+					flex: 1,
+					minWidth: 0,
+					display: 'flex',
+					justifyContent: 'center',
+				} }
+			>
+				{ sliderOrSpinner }
+			</div>
 			<Button
 				icon={ chevronRight }
 				label={

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -34,8 +34,12 @@ function RevisionsSlider() {
 		revisionPage,
 		totalRevisions,
 	} = useSelect( ( select ) => {
-		const { getCurrentRevisionId, getRevisionPage, getPageRevisions } =
-			unlock( select( editorStore ) );
+		const {
+			getCurrentRevisionId,
+			getRevisionPage,
+			getPageRevisions,
+			getRevisionsPerPage,
+		} = unlock( select( editorStore ) );
 
 		const postType = select( editorStore ).getCurrentPostType();
 		if ( ! postType ) {
@@ -48,11 +52,10 @@ function RevisionsSlider() {
 		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
 		const _revisionPage = getRevisionPage();
-		const pageData = getPageRevisions( _revisionPage );
 
 		return {
-			revisions: pageData?.revisions,
-			perPage: pageData?.perPage,
+			revisions: getPageRevisions( _revisionPage ),
+			perPage: getRevisionsPerPage(),
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
@@ -66,7 +69,7 @@ function RevisionsSlider() {
 	);
 
 	const isLoading = ! rawRevisions;
-	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
+	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
 
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
@@ -82,10 +85,6 @@ function RevisionsSlider() {
 		if ( revision ) {
 			setCurrentRevisionId( revision[ revisionKey ] );
 		}
-	};
-
-	const handlePageChange = ( newPage ) => {
-		setRevisionPage( newPage );
 	};
 
 	// Format date for tooltip.
@@ -164,7 +163,7 @@ function RevisionsSlider() {
 						? getPageRangeLabel( revisionPage + 1 )
 						: __( 'No older revisions' )
 				}
-				onClick={ () => handlePageChange( revisionPage + 1 ) }
+				onClick={ () => setRevisionPage( revisionPage + 1 ) }
 				disabled={ isLoading || revisionPage >= totalPages }
 				size="compact"
 				accessibleWhenDisabled
@@ -186,7 +185,7 @@ function RevisionsSlider() {
 						? getPageRangeLabel( revisionPage - 1 )
 						: __( 'No newer revisions' )
 				}
-				onClick={ () => handlePageChange( revisionPage - 1 ) }
+				onClick={ () => setRevisionPage( revisionPage - 1 ) }
 				disabled={ isLoading || revisionPage <= 1 }
 				size="compact"
 				accessibleWhenDisabled

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -2,10 +2,17 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { RangeControl, Spinner } from '@wordpress/components';
+import {
+	RangeControl,
+	Spinner,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useEffect, useMemo } from '@wordpress/element';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -13,65 +20,112 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const REVISIONS_PER_PAGE = 100;
+
 /**
- * Slider component for navigating revisions.
+ * Slider component for navigating revisions with pagination.
+ *
+ * Page 1 contains the newest revisions. The API returns them in
+ * descending date order, and we reverse for display so the slider
+ * reads oldest-left → newest-right.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
-	const { revisions, isLoading, currentRevisionId, revisionKey } = useSelect(
-		( select ) => {
-			const { getCurrentPostId, getCurrentPostType } =
-				select( editorStore );
-			const { getRevisions, isResolving, getEntityConfig } =
-				select( coreStore );
+	const {
+		revisions: rawRevisions,
+		isLoading,
+		currentRevisionId,
+		revisionKey,
+		revisionPage,
+		totalRevisions,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentPostId,
+			getCurrentPostType,
+			getCurrentPostRevisionsCount,
+		} = select( editorStore );
+		const { getRevisions, isResolving, getEntityConfig } =
+			select( coreStore );
+		const { getCurrentRevisionId, getRevisionPage } = unlock(
+			select( editorStore )
+		);
 
-			const postId = getCurrentPostId();
-			const postType = getCurrentPostType();
+		const postId = getCurrentPostId();
+		const postType = getCurrentPostType();
 
-			if ( ! postId || ! postType ) {
-				return {};
-			}
+		if ( ! postId || ! postType ) {
+			return {};
+		}
 
-			const entityConfig = getEntityConfig( 'postType', postType );
-			const _revisionKey = entityConfig?.revisionKey || 'id';
-			const query = {
-				per_page: -1,
-				context: 'edit',
-				orderby: 'date',
-				order: 'asc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						_revisionKey,
-					] ),
-				].join(),
-			};
+		const entityConfig = getEntityConfig( 'postType', postType );
+		const _revisionKey = entityConfig?.revisionKey || 'id';
+		const _totalRevisions = getCurrentPostRevisionsCount();
+		const _revisionPage = getRevisionPage();
+
+		// Don't fetch until we have a page number.
+		if ( ! _revisionPage ) {
 			return {
-				revisions: getRevisions( 'postType', postType, postId, query ),
-				isLoading: isResolving( 'getRevisions', [
-					'postType',
-					postType,
-					postId,
-					query,
-				] ),
-				currentRevisionId: unlock(
-					select( editorStore )
-				).getCurrentRevisionId(),
+				isLoading: true,
+				totalRevisions: _totalRevisions,
+				revisionPage: _revisionPage,
 				revisionKey: _revisionKey,
 			};
-		},
-		[]
+		}
+
+		const query = {
+			per_page: REVISIONS_PER_PAGE,
+			page: _revisionPage,
+			context: 'edit',
+			orderby: 'date',
+			order: 'desc',
+			_fields: [
+				...new Set( [
+					'id',
+					'date',
+					'modified',
+					'author',
+					'meta',
+					'title.raw',
+					'excerpt.raw',
+					'content.raw',
+					_revisionKey,
+				] ),
+			].join(),
+		};
+		return {
+			revisions: getRevisions( 'postType', postType, postId, query ),
+			isLoading: isResolving( 'getRevisions', [
+				'postType',
+				postType,
+				postId,
+				query,
+			] ),
+			currentRevisionId: getCurrentRevisionId(),
+			revisionKey: _revisionKey,
+			revisionPage: _revisionPage,
+			totalRevisions: _totalRevisions,
+		};
+	}, [] );
+
+	const { setCurrentRevisionId, setRevisionPage } = unlock(
+		useDispatch( editorStore )
 	);
 
-	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
+	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+
+	// Reverse so the slider reads oldest (left) → newest (right).
+	const revisions = useMemo(
+		() => rawRevisions && [ ...rawRevisions ].reverse(),
+		[ rawRevisions ]
+	);
+
+	// Set initial page to 1 (newest revisions) when entering revisions mode.
+	useEffect( () => {
+		if ( revisionPage === null && totalRevisions > 0 ) {
+			setRevisionPage( 1 );
+		}
+	}, [ revisionPage, totalRevisions, setRevisionPage ] );
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -83,6 +137,19 @@ function RevisionsSlider() {
 			setCurrentRevisionId( revision[ revisionKey ] );
 		}
 	};
+
+	const handlePageChange = ( newPage ) => {
+		setRevisionPage( newPage );
+	};
+
+	// When revisions load and no revision is selected (after page change),
+	// select the last revision on the page (newest = last in reversed array).
+	useEffect( () => {
+		if ( revisions?.length && selectedIndex === -1 ) {
+			const lastRevision = revisions[ revisions.length - 1 ];
+			setCurrentRevisionId( lastRevision[ revisionKey ] );
+		}
+	}, [ revisions, selectedIndex, revisionKey, setCurrentRevisionId ] );
 
 	// Format date for tooltip.
 	const dateSettings = getDateSettings();
@@ -106,7 +173,7 @@ function RevisionsSlider() {
 		);
 	}
 
-	if ( revisions?.length === 1 ) {
+	if ( totalRevisions <= 1 ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'Only one revision found.' ) }
@@ -114,7 +181,22 @@ function RevisionsSlider() {
 		);
 	}
 
-	return (
+	const showPagination = totalPages > 1;
+
+	// Compute the 1-based revision range for a given page.
+	// Page 1 = newest, so page 1 of 1000 → "901–1000".
+	const getPageRangeLabel = ( page ) => {
+		const end = totalRevisions - ( page - 1 ) * REVISIONS_PER_PAGE;
+		const start = Math.max( 1, end - REVISIONS_PER_PAGE + 1 );
+		return sprintf(
+			/* translators: 1: first revision number, 2: last revision number */
+			__( 'Revisions %1$s\u2013%2$s' ),
+			start,
+			end
+		);
+	};
+
+	const slider = (
 		<RangeControl
 			__next40pxDefaultSize
 			aria-valuetext={ renderTooltipContent( selectedIndex ) }
@@ -126,10 +208,45 @@ function RevisionsSlider() {
 			marks
 			onChange={ handleSliderChange }
 			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex }
+			value={ selectedIndex >= 0 ? selectedIndex : 0 }
 			withInputField={ false }
 		/>
 	);
+
+	if ( ! showPagination ) {
+		return slider;
+	}
+
+	return (
+		<HStack spacing={ 2 } expanded wrap={ false }>
+			<Button
+				icon={ chevronLeft }
+				label={
+					revisionPage < totalPages
+						? getPageRangeLabel( revisionPage + 1 )
+						: __( 'Older revisions' )
+				}
+				onClick={ () => handlePageChange( revisionPage + 1 ) }
+				disabled={ revisionPage >= totalPages }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+			<div style={ { flex: 1, minWidth: 0 } }>{ slider }</div>
+			<Button
+				icon={ chevronRight }
+				label={
+					revisionPage > 1
+						? getPageRangeLabel( revisionPage - 1 )
+						: __( 'Newer revisions' )
+				}
+				onClick={ () => handlePageChange( revisionPage - 1 ) }
+				disabled={ revisionPage <= 1 }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+		</HStack>
+	);
 }
 
+export { REVISIONS_PER_PAGE };
 export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -2,17 +2,13 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	RangeControl,
-	Spinner,
-	Button,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { RangeControl, Spinner, Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useMemo } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -156,7 +152,7 @@ function RevisionsSlider() {
 	}
 
 	return (
-		<HStack spacing={ 2 } expanded wrap={ false }>
+		<Stack direction="row" gap="sm" align="center">
 			<Button
 				icon={ chevronLeft }
 				label={
@@ -191,7 +187,7 @@ function RevisionsSlider() {
 				size="compact"
 				accessibleWhenDisabled
 			/>
-		</HStack>
+		</Stack>
 	);
 }
 

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -603,6 +603,19 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
+ * Set the current revisions page number.
+ *
+ * @param {number} page The page number.
+ * @return {Object} Action object.
+ */
+export function setRevisionPage( page ) {
+	return {
+		type: 'SET_REVISION_PAGE',
+		page,
+	};
+}
+
+/**
  * Set whether the revision diff highlighting is shown.
  *
  * @param {boolean} showDiff Whether to show diff highlighting.

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -16,6 +16,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import isTemplateRevertable from './utils/is-template-revertable';
+import { buildRevisionsPageQuery } from './private-selectors';
 export * from '../dataviews/store/private-actions';
 
 /**
@@ -603,17 +604,37 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
- * Set the current revisions page number.
+ * Set the current revisions page number and select the newest
+ * revision on that page once it loads.
  *
  * @param {number} page The page number.
- * @return {Object} Action object.
  */
-export function setRevisionPage( page ) {
-	return {
-		type: 'SET_REVISION_PAGE',
-		page,
+export const setRevisionPage =
+	( page ) =>
+	async ( { dispatch, select, registry } ) => {
+		const postType = select.getCurrentPostType();
+		const postId = select.getCurrentPostId();
+		const entityConfig = registry
+			.select( coreStore )
+			.getEntityConfig( 'postType', postType );
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		const revisions = await registry
+			.resolveSelect( coreStore )
+			.getRevisions(
+				'postType',
+				postType,
+				postId,
+				buildRevisionsPageQuery( revisionKey, page )
+			);
+
+		registry.batch( () => {
+			dispatch( { type: 'SET_REVISION_PAGE', page } );
+			if ( revisions?.length ) {
+				dispatch.setCurrentRevisionId( revisions[ 0 ][ revisionKey ] );
+			}
+		} );
 	};
-}
 
 /**
  * Set whether the revision diff highlighting is shown.

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -590,6 +590,19 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
+ * Set the current revisions page number.
+ *
+ * @param {number} page The page number.
+ * @return {Object} Action object.
+ */
+export function setRevisionPage( page ) {
+	return {
+		type: 'SET_REVISION_PAGE',
+		page,
+	};
+}
+
+/**
  * Set whether the revision diff highlighting is shown.
  *
  * @param {boolean} showDiff Whether to show diff highlighting.

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -16,6 +16,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import isTemplateRevertable from './utils/is-template-revertable';
+import { buildRevisionsPageQuery } from './private-selectors';
 export * from '../dataviews/store/private-actions';
 
 /**
@@ -590,17 +591,37 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
- * Set the current revisions page number.
+ * Set the current revisions page number and select the newest
+ * revision on that page once it loads.
  *
  * @param {number} page The page number.
- * @return {Object} Action object.
  */
-export function setRevisionPage( page ) {
-	return {
-		type: 'SET_REVISION_PAGE',
-		page,
+export const setRevisionPage =
+	( page ) =>
+	async ( { dispatch, select, registry } ) => {
+		const postType = select.getCurrentPostType();
+		const postId = select.getCurrentPostId();
+		const entityConfig = registry
+			.select( coreStore )
+			.getEntityConfig( 'postType', postType );
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		const revisions = await registry
+			.resolveSelect( coreStore )
+			.getRevisions(
+				'postType',
+				postType,
+				postId,
+				buildRevisionsPageQuery( revisionKey, page )
+			);
+
+		registry.batch( () => {
+			dispatch( { type: 'SET_REVISION_PAGE', page } );
+			if ( revisions?.length ) {
+				dispatch.setCurrentRevisionId( revisions[ 0 ][ revisionKey ] );
+			}
+		} );
 	};
-}
 
 /**
  * Set whether the revision diff highlighting is shown.

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -21,7 +21,11 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
-import { getRenderingMode, getCurrentPost } from './selectors';
+import {
+	getRenderingMode,
+	getCurrentPost,
+	getCurrentPostRevisionsCount,
+} from './selectors';
 import {
 	getEntityActions as _getEntityActions,
 	getEntityFields as _getEntityFields,
@@ -464,9 +468,8 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions. Uses the paginated revisions
- * from the current page. At page boundaries (first revision on a page),
- * returns null since the previous revision is on another page.
+ * Used for diffing between revisions. At page boundaries, fetches the
+ * adjacent page to find the previous revision.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
@@ -489,6 +492,20 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		const fields = [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join();
+
 		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
@@ -500,19 +517,7 @@ export const getPreviousRevision = createRegistrySelector(
 				context: 'edit',
 				orderby: 'date',
 				order: 'desc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
+				_fields: fields,
 			}
 		);
 		if ( ! revisions ) {
@@ -527,6 +532,28 @@ export const getPreviousRevision = createRegistrySelector(
 		// The previous (older) revision is the next index in desc order.
 		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
 			return revisions[ currentIndex + 1 ];
+		}
+
+		// At page boundary: fetch the first revision from the next page
+		// (older revisions). The next page in desc order is page + 1.
+		const totalRevisions = getCurrentPostRevisionsCount( state );
+		const totalPages = Math.ceil( totalRevisions / 100 ) || 1;
+		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
+			const nextPageRevisions = select( coreStore ).getRevisions(
+				'postType',
+				postType,
+				postId,
+				{
+					per_page: 100,
+					page: page + 1,
+					context: 'edit',
+					orderby: 'date',
+					order: 'desc',
+					_fields: fields,
+				}
+			);
+			// Return the first (newest) revision from the next page.
+			return nextPageRevisions?.[ 0 ] ?? null;
 		}
 
 		return null;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -347,6 +347,16 @@ export function getCanvasMinHeight( state ) {
 }
 
 /**
+ * Returns the current revisions page number.
+ *
+ * @param {Object} state Global application state.
+ * @return {number|null} The page number, or null if not set.
+ */
+export function getRevisionPage( state ) {
+	return state.revisionPage;
+}
+
+/**
  * Returns whether the editor is in revisions preview mode.
  *
  * @param {Object} state Global application state.
@@ -378,14 +388,16 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
+ * Uses getRevision (singular) to look up from the cache populated by
+ * the paginated getRevisions call in the slider.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
  */
 export const getCurrentRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const revisionId = getCurrentRevisionId( state );
-		if ( ! revisionId ) {
+		const currentRevId = getCurrentRevisionId( state );
+		if ( ! currentRevId ) {
 			return undefined;
 		}
 
@@ -395,41 +407,36 @@ export const getCurrentRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		// - Use getRevisions (plural) instead of getRevision (singular) to
-		//   avoid a race condition where both API calls complete around the
-		//   same time and the single revision fetch overwrites the list in the
-		//   store.
-		// - getRevision also needs to be updated to check if there's any
-		//   received revisions from the collection API call to avoid unnecessary
-		//   API calls.
-		const revisions = select( coreStore ).getRevisions(
+		const fields = [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join();
+
+		// Use getRevision (singular) which reads from the cache populated
+		// by the paginated getRevisions call. The plural resolver marks
+		// individual getRevision resolutions as done, so this won't
+		// trigger a new API call.
+		const revision = select( coreStore ).getRevision(
 			'postType',
 			postType,
 			postId,
+			currentRevId,
 			{
-				per_page: -1,
 				context: 'edit',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
+				_fields: fields,
 			}
 		);
-		if ( ! revisions ) {
-			return null;
-		}
-		return (
-			revisions.find( ( r ) => r[ revisionKey ] === revisionId ) ?? null
-		);
+
+		return revision ?? null;
 	}
 );
 
@@ -457,16 +464,23 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions.
+ * Used for diffing between revisions. Uses the paginated revisions
+ * from the current page. At page boundaries (first revision on a page),
+ * returns null since the previous revision is on another page.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
  */
 export const getPreviousRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevisionId = getCurrentRevisionId( state );
-		if ( ! currentRevisionId ) {
+		const currentRevId = getCurrentRevisionId( state );
+		if ( ! currentRevId ) {
 			return undefined;
+		}
+
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
 		}
 
 		const { type: postType, id: postId } = getCurrentPost( state );
@@ -475,15 +489,17 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
 			{
-				per_page: -1,
+				per_page: 100,
+				page,
 				context: 'edit',
 				orderby: 'date',
-				order: 'asc',
+				order: 'desc',
 				_fields: [
 					...new Set( [
 						'id',
@@ -503,14 +519,14 @@ export const getPreviousRevision = createRegistrySelector(
 			return null;
 		}
 
-		// Find current revision index.
+		// Find current revision index. The array is newest-first (desc).
 		const currentIndex = revisions.findIndex(
-			( r ) => r[ revisionKey ] === currentRevisionId
+			( r ) => r[ revisionKey ] === currentRevId
 		);
 
-		// Return the previous revision (older one) if it exists.
-		if ( currentIndex > 0 ) {
-			return revisions[ currentIndex - 1 ];
+		// The previous (older) revision is the next index in desc order.
+		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
+			return revisions[ currentIndex + 1 ];
 		}
 
 		return null;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -367,7 +367,7 @@ export function getRevisionPage( state ) {
  * @param {number} page        The 1-based page number (page 1 = newest).
  * @return {Object} Query object for getRevisions.
  */
-function buildRevisionsPageQuery( revisionKey, page ) {
+export function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
 		per_page: 100,
 		page,

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -360,12 +360,8 @@ export function getRevisionPage( state ) {
 	return state.revisionPage;
 }
 
-const REVISIONS_PER_PAGE = 100;
-
 /**
  * Builds the query object for fetching a page of revisions.
- * Shared by getPageRevisions, getCurrentRevision, and getPreviousRevision
- * so they all hit the same cache key.
  *
  * @param {string} revisionKey The entity's revision key.
  * @param {number} page        The 1-based page number (page 1 = newest).
@@ -373,7 +369,7 @@ const REVISIONS_PER_PAGE = 100;
  */
 function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
-		per_page: REVISIONS_PER_PAGE,
+		per_page: 100,
 		page,
 		context: 'edit',
 		orderby: 'date',
@@ -395,13 +391,11 @@ function buildRevisionsPageQuery( revisionKey, page ) {
 }
 
 /**
- * Returns revisions for the given page number. Centralises the
- * paginated query so the slider, getCurrentRevision, and
- * getPreviousRevision all share the same cache key.
+ * Returns revisions and pagination info for the given page number.
  *
  * @param {Object} state Global application state.
  * @param {number} page  The 1-based page number (page 1 = newest).
- * @return {Array|null} The revisions array, or null if not yet loaded.
+ * @return {Object|null} Object with `revisions` and `perPage`, or null if not yet loaded.
  */
 export const getPageRevisions = createRegistrySelector(
 	( select ) => ( state, page ) => {
@@ -419,13 +413,19 @@ export const getPageRevisions = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-
-		return select( coreStore ).getRevisions(
+		const query = buildRevisionsPageQuery( revisionKey, page );
+		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			buildRevisionsPageQuery( revisionKey, page )
+			query
 		);
+
+		if ( ! revisions ) {
+			return null;
+		}
+
+		return { revisions, perPage: query.per_page };
 	}
 );
 
@@ -461,15 +461,14 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
- * Looks up from the cache populated by the paginated getPageRevisions call.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
  */
 export const getCurrentRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevId = getCurrentRevisionId( state );
-		if ( ! currentRevId ) {
+		const revisionId = getCurrentRevisionId( state );
+		if ( ! revisionId ) {
 			return undefined;
 		}
 
@@ -493,9 +492,8 @@ export const getCurrentRevision = createRegistrySelector(
 		if ( ! revisions ) {
 			return null;
 		}
-
 		return (
-			revisions.find( ( r ) => r[ revisionKey ] === currentRevId ) ?? null
+			revisions.find( ( r ) => r[ revisionKey ] === revisionId ) ?? null
 		);
 	}
 );
@@ -524,16 +522,15 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions. At page boundaries, fetches the
- * adjacent page to find the previous revision.
+ * Used for diffing between revisions.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
  */
 export const getPreviousRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevId = getCurrentRevisionId( state );
-		if ( ! currentRevId ) {
+		const currentRevisionId = getCurrentRevisionId( state );
+		if ( ! currentRevisionId ) {
 			return undefined;
 		}
 
@@ -548,30 +545,30 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		const query = buildRevisionsPageQuery( revisionKey, page );
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			buildRevisionsPageQuery( revisionKey, page )
+			query
 		);
 		if ( ! revisions ) {
 			return null;
 		}
 
-		// Find current revision index. The array is newest-first (desc).
+		// Find current revision index.
 		const currentIndex = revisions.findIndex(
-			( r ) => r[ revisionKey ] === currentRevId
+			( r ) => r[ revisionKey ] === currentRevisionId
 		);
 
-		// The previous (older) revision is the next index in desc order.
+		// Return the previous revision (older one) if it exists.
 		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
 			return revisions[ currentIndex + 1 ];
 		}
 
 		// At page boundary: fetch the first revision from the next page.
 		const totalRevisions = getCurrentPostRevisionsCount( state );
-		const totalPages =
-			Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+		const totalPages = Math.ceil( totalRevisions / query.per_page ) || 1;
 		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
 			const nextPageRevisions = select( coreStore ).getRevisions(
 				'postType',

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -354,7 +354,7 @@ export function getCanvasMinHeight( state ) {
  * Returns the current revisions page number.
  *
  * @param {Object} state Global application state.
- * @return {number|null} The page number, or null if not set.
+ * @return {number} The page number.
  */
 export function getRevisionPage( state ) {
 	return state.revisionPage;
@@ -369,7 +369,7 @@ export function getRevisionPage( state ) {
  */
 export function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
-		per_page: 100,
+		per_page: REVISIONS_PER_PAGE,
 		page,
 		context: 'edit',
 		orderby: 'date',
@@ -390,12 +390,18 @@ export function buildRevisionsPageQuery( revisionKey, page ) {
 	};
 }
 
+const REVISIONS_PER_PAGE = 100;
+
+export function getRevisionsPerPage() {
+	return REVISIONS_PER_PAGE;
+}
+
 /**
- * Returns revisions and pagination info for the given page number.
+ * Returns revisions for the given page number.
  *
  * @param {Object} state Global application state.
  * @param {number} page  The 1-based page number (page 1 = newest).
- * @return {Object|null} Object with `revisions` and `perPage`, or null if not yet loaded.
+ * @return {Array|null} The revisions array, or null if not yet loaded.
  */
 export const getPageRevisions = createRegistrySelector(
 	( select ) => ( state, page ) => {
@@ -413,19 +419,13 @@ export const getPageRevisions = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const query = buildRevisionsPageQuery( revisionKey, page );
-		const revisions = select( coreStore ).getRevisions(
+
+		return select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			query
+			buildRevisionsPageQuery( revisionKey, page )
 		);
-
-		if ( ! revisions ) {
-			return null;
-		}
-
-		return { revisions, perPage: query.per_page };
 	}
 );
 

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -360,6 +360,75 @@ export function getRevisionPage( state ) {
 	return state.revisionPage;
 }
 
+const REVISIONS_PER_PAGE = 100;
+
+/**
+ * Builds the query object for fetching a page of revisions.
+ * Shared by getPageRevisions, getCurrentRevision, and getPreviousRevision
+ * so they all hit the same cache key.
+ *
+ * @param {string} revisionKey The entity's revision key.
+ * @param {number} page        The 1-based page number (page 1 = newest).
+ * @return {Object} Query object for getRevisions.
+ */
+function buildRevisionsPageQuery( revisionKey, page ) {
+	return {
+		per_page: REVISIONS_PER_PAGE,
+		page,
+		context: 'edit',
+		orderby: 'date',
+		order: 'desc',
+		_fields: [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join(),
+	};
+}
+
+/**
+ * Returns revisions for the given page number. Centralises the
+ * paginated query so the slider, getCurrentRevision, and
+ * getPreviousRevision all share the same cache key.
+ *
+ * @param {Object} state Global application state.
+ * @param {number} page  The 1-based page number (page 1 = newest).
+ * @return {Array|null} The revisions array, or null if not yet loaded.
+ */
+export const getPageRevisions = createRegistrySelector(
+	( select ) => ( state, page ) => {
+		if ( ! page ) {
+			return null;
+		}
+
+		const { type: postType, id: postId } = getCurrentPost( state );
+		if ( ! postType || ! postId ) {
+			return null;
+		}
+
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		return select( coreStore ).getRevisions(
+			'postType',
+			postType,
+			postId,
+			buildRevisionsPageQuery( revisionKey, page )
+		);
+	}
+);
+
 /**
  * Returns whether the editor is in revisions preview mode.
  *
@@ -392,8 +461,7 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
- * Uses getRevision (singular) to look up from the cache populated by
- * the paginated getRevisions call in the slider.
+ * Looks up from the cache populated by the paginated getPageRevisions call.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
@@ -405,42 +473,30 @@ export const getCurrentRevision = createRegistrySelector(
 			return undefined;
 		}
 
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
+		}
+
 		const { type: postType, id: postId } = getCurrentPost( state );
 		const entityConfig = select( coreStore ).getEntityConfig(
 			'postType',
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const fields = [
-			...new Set( [
-				'id',
-				'date',
-				'modified',
-				'author',
-				'meta',
-				'title.raw',
-				'excerpt.raw',
-				'content.raw',
-				revisionKey,
-			] ),
-		].join();
-
-		// Use getRevision (singular) which reads from the cache populated
-		// by the paginated getRevisions call. The plural resolver marks
-		// individual getRevision resolutions as done, so this won't
-		// trigger a new API call.
-		const revision = select( coreStore ).getRevision(
+		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			currentRevId,
-			{
-				context: 'edit',
-				_fields: fields,
-			}
+			buildRevisionsPageQuery( revisionKey, page )
 		);
+		if ( ! revisions ) {
+			return null;
+		}
 
-		return revision ?? null;
+		return (
+			revisions.find( ( r ) => r[ revisionKey ] === currentRevId ) ?? null
+		);
 	}
 );
 
@@ -492,33 +548,11 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const fields = [
-			...new Set( [
-				'id',
-				'date',
-				'modified',
-				'author',
-				'meta',
-				'title.raw',
-				'excerpt.raw',
-				'content.raw',
-				revisionKey,
-			] ),
-		].join();
-
-		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			{
-				per_page: 100,
-				page,
-				context: 'edit',
-				orderby: 'date',
-				order: 'desc',
-				_fields: fields,
-			}
+			buildRevisionsPageQuery( revisionKey, page )
 		);
 		if ( ! revisions ) {
 			return null;
@@ -534,25 +568,17 @@ export const getPreviousRevision = createRegistrySelector(
 			return revisions[ currentIndex + 1 ];
 		}
 
-		// At page boundary: fetch the first revision from the next page
-		// (older revisions). The next page in desc order is page + 1.
+		// At page boundary: fetch the first revision from the next page.
 		const totalRevisions = getCurrentPostRevisionsCount( state );
-		const totalPages = Math.ceil( totalRevisions / 100 ) || 1;
+		const totalPages =
+			Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
 		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
 			const nextPageRevisions = select( coreStore ).getRevisions(
 				'postType',
 				postType,
 				postId,
-				{
-					per_page: 100,
-					page: page + 1,
-					context: 'edit',
-					orderby: 'date',
-					order: 'desc',
-					_fields: fields,
-				}
+				buildRevisionsPageQuery( revisionKey, page + 1 )
 			);
-			// Return the first (newest) revision from the next page.
 			return nextPageRevisions?.[ 0 ] ?? null;
 		}
 

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -25,6 +25,7 @@ import {
 	getRenderingMode,
 	getCurrentPost,
 	getEditorSettings,
+	getCurrentPostRevisionsCount,
 } from './selectors';
 import {
 	getEntityActions as _getEntityActions,
@@ -467,9 +468,8 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions. Uses the paginated revisions
- * from the current page. At page boundaries (first revision on a page),
- * returns null since the previous revision is on another page.
+ * Used for diffing between revisions. At page boundaries, fetches the
+ * adjacent page to find the previous revision.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
@@ -492,6 +492,20 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		const fields = [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join();
+
 		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
@@ -503,19 +517,7 @@ export const getPreviousRevision = createRegistrySelector(
 				context: 'edit',
 				orderby: 'date',
 				order: 'desc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
+				_fields: fields,
 			}
 		);
 		if ( ! revisions ) {
@@ -530,6 +532,28 @@ export const getPreviousRevision = createRegistrySelector(
 		// The previous (older) revision is the next index in desc order.
 		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
 			return revisions[ currentIndex + 1 ];
+		}
+
+		// At page boundary: fetch the first revision from the next page
+		// (older revisions). The next page in desc order is page + 1.
+		const totalRevisions = getCurrentPostRevisionsCount( state );
+		const totalPages = Math.ceil( totalRevisions / 100 ) || 1;
+		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
+			const nextPageRevisions = select( coreStore ).getRevisions(
+				'postType',
+				postType,
+				postId,
+				{
+					per_page: 100,
+					page: page + 1,
+					context: 'edit',
+					orderby: 'date',
+					order: 'desc',
+					_fields: fields,
+				}
+			);
+			// Return the first (newest) revision from the next page.
+			return nextPageRevisions?.[ 0 ] ?? null;
 		}
 
 		return null;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -350,6 +350,16 @@ export function getShowStylebook( state ) {
 }
 
 /**
+ * Returns the current revisions page number.
+ *
+ * @param {Object} state Global application state.
+ * @return {number|null} The page number, or null if not set.
+ */
+export function getRevisionPage( state ) {
+	return state.revisionPage;
+}
+
+/**
  * Returns whether the editor is in revisions preview mode.
  *
  * @param {Object} state Global application state.
@@ -381,14 +391,16 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
+ * Uses getRevision (singular) to look up from the cache populated by
+ * the paginated getRevisions call in the slider.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
  */
 export const getCurrentRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const revisionId = getCurrentRevisionId( state );
-		if ( ! revisionId ) {
+		const currentRevId = getCurrentRevisionId( state );
+		if ( ! currentRevId ) {
 			return undefined;
 		}
 
@@ -398,41 +410,36 @@ export const getCurrentRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		// - Use getRevisions (plural) instead of getRevision (singular) to
-		//   avoid a race condition where both API calls complete around the
-		//   same time and the single revision fetch overwrites the list in the
-		//   store.
-		// - getRevision also needs to be updated to check if there's any
-		//   received revisions from the collection API call to avoid unnecessary
-		//   API calls.
-		const revisions = select( coreStore ).getRevisions(
+		const fields = [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join();
+
+		// Use getRevision (singular) which reads from the cache populated
+		// by the paginated getRevisions call. The plural resolver marks
+		// individual getRevision resolutions as done, so this won't
+		// trigger a new API call.
+		const revision = select( coreStore ).getRevision(
 			'postType',
 			postType,
 			postId,
+			currentRevId,
 			{
-				per_page: -1,
 				context: 'edit',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
+				_fields: fields,
 			}
 		);
-		if ( ! revisions ) {
-			return null;
-		}
-		return (
-			revisions.find( ( r ) => r[ revisionKey ] === revisionId ) ?? null
-		);
+
+		return revision ?? null;
 	}
 );
 
@@ -460,16 +467,23 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions.
+ * Used for diffing between revisions. Uses the paginated revisions
+ * from the current page. At page boundaries (first revision on a page),
+ * returns null since the previous revision is on another page.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
  */
 export const getPreviousRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevisionId = getCurrentRevisionId( state );
-		if ( ! currentRevisionId ) {
+		const currentRevId = getCurrentRevisionId( state );
+		if ( ! currentRevId ) {
 			return undefined;
+		}
+
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
 		}
 
 		const { type: postType, id: postId } = getCurrentPost( state );
@@ -478,15 +492,17 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
 			{
-				per_page: -1,
+				per_page: 100,
+				page,
 				context: 'edit',
 				orderby: 'date',
-				order: 'asc',
+				order: 'desc',
 				_fields: [
 					...new Set( [
 						'id',
@@ -506,14 +522,14 @@ export const getPreviousRevision = createRegistrySelector(
 			return null;
 		}
 
-		// Find current revision index.
+		// Find current revision index. The array is newest-first (desc).
 		const currentIndex = revisions.findIndex(
-			( r ) => r[ revisionKey ] === currentRevisionId
+			( r ) => r[ revisionKey ] === currentRevId
 		);
 
-		// Return the previous revision (older one) if it exists.
-		if ( currentIndex > 0 ) {
-			return revisions[ currentIndex - 1 ];
+		// The previous (older) revision is the next index in desc order.
+		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
+			return revisions[ currentIndex + 1 ];
 		}
 
 		return null;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -354,7 +354,7 @@ export function getShowStylebook( state ) {
  * Returns the current revisions page number.
  *
  * @param {Object} state Global application state.
- * @return {number|null} The page number, or null if not set.
+ * @return {number} The page number.
  */
 export function getRevisionPage( state ) {
 	return state.revisionPage;
@@ -369,7 +369,7 @@ export function getRevisionPage( state ) {
  */
 export function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
-		per_page: 100,
+		per_page: REVISIONS_PER_PAGE,
 		page,
 		context: 'edit',
 		orderby: 'date',
@@ -390,12 +390,18 @@ export function buildRevisionsPageQuery( revisionKey, page ) {
 	};
 }
 
+const REVISIONS_PER_PAGE = 100;
+
+export function getRevisionsPerPage() {
+	return REVISIONS_PER_PAGE;
+}
+
 /**
- * Returns revisions and pagination info for the given page number.
+ * Returns revisions for the given page number.
  *
  * @param {Object} state Global application state.
  * @param {number} page  The 1-based page number (page 1 = newest).
- * @return {Object|null} Object with `revisions` and `perPage`, or null if not yet loaded.
+ * @return {Array|null} The revisions array, or null if not yet loaded.
  */
 export const getPageRevisions = createRegistrySelector(
 	( select ) => ( state, page ) => {
@@ -413,19 +419,13 @@ export const getPageRevisions = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const query = buildRevisionsPageQuery( revisionKey, page );
-		const revisions = select( coreStore ).getRevisions(
+
+		return select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			query
+			buildRevisionsPageQuery( revisionKey, page )
 		);
-
-		if ( ! revisions ) {
-			return null;
-		}
-
-		return { revisions, perPage: query.per_page };
 	}
 );
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -451,11 +451,10 @@ export function revisionId( state = null, action ) {
 
 /**
  * Reducer for the current revisions page number.
- * Resets to null when exiting revisions mode.
  *
- * @param {number|null} state  Current page number.
- * @param {Object}      action Dispatched action.
- * @return {number|null} Updated state.
+ * @param {number} state  Current page number.
+ * @param {Object} action Dispatched action.
+ * @return {number} Updated state.
  */
 export function revisionPage( state = 1, action ) {
 	switch ( action.type ) {

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -450,6 +450,28 @@ export function revisionId( state = null, action ) {
 }
 
 /**
+ * Reducer for the current revisions page number.
+ * Resets to null when exiting revisions mode.
+ *
+ * @param {number|null} state  Current page number.
+ * @param {Object}      action Dispatched action.
+ * @return {number|null} Updated state.
+ */
+export function revisionPage( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_REVISION_PAGE':
+			return action.page;
+		case 'SET_CURRENT_REVISION_ID':
+			// Reset page when exiting revisions mode.
+			if ( ! action.revisionId ) {
+				return null;
+			}
+			return state;
+	}
+	return state;
+}
+
+/**
  * Reducer for whether the revision diff is shown.
  * Resets to true when entering/exiting revisions mode.
  *
@@ -506,6 +528,7 @@ export default combineReducers( {
 	showStylebook,
 	canvasMinHeight,
 	revisionId,
+	revisionPage,
 	showRevisionDiff,
 	selectedNote,
 	dataviews: dataviewsReducer,

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -457,14 +457,13 @@ export function revisionId( state = null, action ) {
  * @param {Object}      action Dispatched action.
  * @return {number|null} Updated state.
  */
-export function revisionPage( state = null, action ) {
+export function revisionPage( state = 1, action ) {
 	switch ( action.type ) {
 		case 'SET_REVISION_PAGE':
 			return action.page;
 		case 'SET_CURRENT_REVISION_ID':
-			// Reset page when exiting revisions mode.
 			if ( ! action.revisionId ) {
-				return null;
+				return 1;
 			}
 			return state;
 	}

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -442,14 +442,13 @@ export function revisionId( state = null, action ) {
  * @param {Object}      action Dispatched action.
  * @return {number|null} Updated state.
  */
-export function revisionPage( state = null, action ) {
+export function revisionPage( state = 1, action ) {
 	switch ( action.type ) {
 		case 'SET_REVISION_PAGE':
 			return action.page;
 		case 'SET_CURRENT_REVISION_ID':
-			// Reset page when exiting revisions mode.
 			if ( ! action.revisionId ) {
-				return null;
+				return 1;
 			}
 			return state;
 	}

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -436,11 +436,10 @@ export function revisionId( state = null, action ) {
 
 /**
  * Reducer for the current revisions page number.
- * Resets to null when exiting revisions mode.
  *
- * @param {number|null} state  Current page number.
- * @param {Object}      action Dispatched action.
- * @return {number|null} Updated state.
+ * @param {number} state  Current page number.
+ * @param {Object} action Dispatched action.
+ * @return {number} Updated state.
  */
 export function revisionPage( state = 1, action ) {
 	switch ( action.type ) {

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -435,6 +435,28 @@ export function revisionId( state = null, action ) {
 }
 
 /**
+ * Reducer for the current revisions page number.
+ * Resets to null when exiting revisions mode.
+ *
+ * @param {number|null} state  Current page number.
+ * @param {Object}      action Dispatched action.
+ * @return {number|null} Updated state.
+ */
+export function revisionPage( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_REVISION_PAGE':
+			return action.page;
+		case 'SET_CURRENT_REVISION_ID':
+			// Reset page when exiting revisions mode.
+			if ( ! action.revisionId ) {
+				return null;
+			}
+			return state;
+	}
+	return state;
+}
+
+/**
  * Reducer for whether the revision diff is shown.
  * Resets to true when entering/exiting revisions mode.
  *
@@ -490,6 +512,7 @@ export default combineReducers( {
 	stylesPath,
 	showStylebook,
 	revisionId,
+	revisionPage,
 	showRevisionDiff,
 	selectedNote,
 	dataviews: dataviewsReducer,

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -342,15 +342,23 @@ test.describe( 'Post revisions slider pagination', () => {
 		await slider.focus();
 		await page.keyboard.press( 'Home' );
 
-		// The diff should still pair adjacent revisions as a modification
-		// (not render the entire current revision as "added", which would
-		// happen if the cross-page lookup failed).
-		await expect(
-			page
-				.locator( 'iframe[name="editor-canvas"]' )
-				.contentFrame()
-				.locator( '.is-revision-modified' )
-		).toBeVisible();
+		// Adjacent revision contents differ by exactly 1 (we created them
+		// as sequential integers), so the boundary diff must show N as
+		// added and N-1 as removed inside a modified paragraph.
+		const canvas = page
+			.locator( 'iframe[name="editor-canvas"]' )
+			.contentFrame()
+			.locator( '.is-revision-modified' );
+		await expect( canvas ).toBeVisible();
+		const added = parseInt(
+			await canvas.locator( '.revision-diff-added' ).textContent(),
+			10
+		);
+		const removed = parseInt(
+			await canvas.locator( '.revision-diff-removed' ).textContent(),
+			10
+		);
+		expect( added - removed ).toBe( 1 );
 
 		// Navigate to page 2 via the chevron.
 		await prevPageButton.click();

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -268,7 +268,7 @@ test.describe( 'Post revisions slider pagination', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test( 'should paginate when there are more than 100 revisions', async ( {
+	test( 'should paginate, navigate pages, and diff across page boundaries', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -285,6 +285,8 @@ test.describe( 'Post revisions slider pagination', () => {
 			},
 		} );
 
+		// Sequential REST calls to enforce ordering (concurrent writes to
+		// the same post race and produce non-monotonic revision content).
 		for ( let i = 1; i <= 105; i++ ) {
 			await requestUtils.rest( {
 				method: 'POST',
@@ -335,6 +337,22 @@ test.describe( 'Post revisions slider pagination', () => {
 		const slider = page.getByRole( 'slider', { name: 'Revision' } );
 		await expect( slider ).toHaveAttribute( 'max', '99' );
 
+		// Slide to the leftmost (oldest revision on page 1). Computing the
+		// previous-revision diff requires fetching the adjacent page.
+		await slider.focus();
+		await page.keyboard.press( 'Home' );
+
+		// The diff should still pair adjacent revisions as a modification
+		// (not render the entire current revision as "added", which would
+		// happen if the cross-page lookup failed).
+		await expect(
+			page
+				.locator( 'iframe[name="editor-canvas"]' )
+				.contentFrame()
+				.locator( '.is-revision-modified' )
+		).toBeVisible();
+
+		// Navigate to page 2 via the chevron.
 		await prevPageButton.click();
 
 		// After loading page 2: prev chevron disabled, next chevron enabled.
@@ -352,61 +370,6 @@ test.describe( 'Post revisions slider pagination', () => {
 			'max',
 			String( olderPageSize - 1 )
 		);
-	} );
-
-	test( 'should not show pagination when there are 100 or fewer revisions', async ( {
-		admin,
-		page,
-		requestUtils,
-	} ) => {
-		const post = await requestUtils.rest( {
-			method: 'POST',
-			path: '/wp/v2/posts',
-			data: {
-				title: 'No Pagination Test',
-				content: '<!-- wp:paragraph --><p>0</p><!-- /wp:paragraph -->',
-				status: 'draft',
-			},
-		} );
-
-		for ( let i = 1; i <= 5; i++ ) {
-			await requestUtils.rest( {
-				method: 'POST',
-				path: `/wp/v2/posts/${ post.id }`,
-				data: {
-					content: `<!-- wp:paragraph --><p>${ i }</p><!-- /wp:paragraph -->`,
-				},
-			} );
-		}
-
-		await admin.editPost( post.id );
-
-		const settingsSidebar = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
-
-		const revisionsButton = settingsSidebar
-			.getByRole( 'button' )
-			.filter( { hasText: /^\d+$/ } );
-		await expect( revisionsButton ).toBeVisible();
-		await revisionsButton.click();
-		await expect(
-			page.getByRole( 'button', { name: 'Restore' } )
-		).toBeVisible();
-
-		await expect(
-			page.getByRole( 'slider', { name: 'Revision' } )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'button', { name: /^Revisions \d/ } )
-		).toHaveCount( 0 );
-		await expect(
-			page.getByRole( 'button', { name: 'No older revisions' } )
-		).toHaveCount( 0 );
-		await expect(
-			page.getByRole( 'button', { name: 'No newer revisions' } )
-		).toHaveCount( 0 );
 	} );
 } );
 

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -263,6 +263,153 @@ test.describe( 'Post revisions', () => {
 	} );
 } );
 
+test.describe( 'Post revisions slider pagination', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'should paginate when there are more than 100 revisions', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Create a post and update it enough times to require pagination.
+		// Page 1 holds the newest 100 revisions, so > 100 total → 2 pages.
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Pagination Test',
+				content: '<!-- wp:paragraph --><p>0</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+
+		for ( let i = 1; i <= 105; i++ ) {
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/posts/${ post.id }`,
+				data: {
+					content: `<!-- wp:paragraph --><p>${ i }</p><!-- /wp:paragraph -->`,
+				},
+			} );
+		}
+
+		await admin.editPost( post.id );
+
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+
+		// The revisions button is labeled with the count. The editor count
+		// may differ from the REST version-history count by an autosave,
+		// so read it from the rendered button.
+		const revisionsButton = settingsSidebar
+			.getByRole( 'button' )
+			.filter( { hasText: /^\d+$/ } );
+		await expect( revisionsButton ).toBeVisible();
+		const totalRevisions = parseInt(
+			await revisionsButton.textContent(),
+			10
+		);
+		const olderPageSize = totalRevisions - 100;
+
+		await revisionsButton.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		// Page 1 holds the newest 100 revisions. The prev chevron points
+		// at page 2, which holds the remaining older revisions.
+		const prevPageButton = page.getByRole( 'button', {
+			name: `Revisions 1–${ olderPageSize }`,
+		} );
+		const nextPageButton = page.getByRole( 'button', {
+			name: 'No newer revisions',
+		} );
+		await expect( prevPageButton ).toBeEnabled();
+		await expect( nextPageButton ).toBeDisabled();
+
+		// Page 1 holds 100 revisions, so the slider's max is 99.
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await expect( slider ).toHaveAttribute( 'max', '99' );
+
+		await prevPageButton.click();
+
+		// After loading page 2: prev chevron disabled, next chevron enabled.
+		await expect(
+			page.getByRole( 'button', { name: 'No older revisions' } )
+		).toBeDisabled();
+		await expect(
+			page.getByRole( 'button', {
+				name: `Revisions ${ olderPageSize + 1 }–${ totalRevisions }`,
+			} )
+		).toBeEnabled();
+
+		// Slider now reflects page 2's smaller revision count.
+		await expect( slider ).toHaveAttribute(
+			'max',
+			String( olderPageSize - 1 )
+		);
+	} );
+
+	test( 'should not show pagination when there are 100 or fewer revisions', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'No Pagination Test',
+				content: '<!-- wp:paragraph --><p>0</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+
+		for ( let i = 1; i <= 5; i++ ) {
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/posts/${ post.id }`,
+				data: {
+					content: `<!-- wp:paragraph --><p>${ i }</p><!-- /wp:paragraph -->`,
+				},
+			} );
+		}
+
+		await admin.editPost( post.id );
+
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+
+		const revisionsButton = settingsSidebar
+			.getByRole( 'button' )
+			.filter( { hasText: /^\d+$/ } );
+		await expect( revisionsButton ).toBeVisible();
+		await revisionsButton.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'slider', { name: 'Revision' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: /^Revisions \d/ } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByRole( 'button', { name: 'No older revisions' } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByRole( 'button', { name: 'No newer revisions' } )
+		).toHaveCount( 0 );
+	} );
+} );
+
 test.describe( 'Template and template part revisions', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );


### PR DESCRIPTION
## What?

Paginates the revisions slider to load 100 revisions per page instead of fetching all revisions at once.

## Why?

The revisions slider previously used `per_page: -1`, fetching every revision in a single API call. For posts with hundreds or thousands of revisions, this is a performance bottleneck — slow to load and memory-heavy on both client and server.

## How?

- Added `revisionPage` state to the editor store (reducer, action, selector) to track the current page.
- Changed the slider query from `per_page: -1` to `per_page: 100` with `order: 'desc'` so page 1 contains the newest revisions (fast initial load).
- The API response is reversed for display so the slider still reads oldest (left) → newest (right).
- When more than one page exists, prev/next chevron buttons appear flanking the slider. Their tooltips show the target revision range (e.g. "Revisions 801–900").
- Updated `getCurrentRevision` to use `getRevision` (singular) which reads from the cache populated by the paginated fetch — no extra API call.
- Updated `getPreviousRevision` to use the same paginated query so it shares the cache.

## Testing Instructions

1. Create or use a post with more than 100 revisions.
2. Open the post in the editor and enter revisions mode (click "Revisions" in the sidebar panel, or the revisions count button).
3. Verify the slider loads quickly with the newest 100 revisions on page 1.
4. Hover the prev/next chevron buttons and verify tooltips show revision ranges.
5. Click the left chevron to load older revisions, verify the slider updates.
6. Slide between revisions and verify diff highlighting works.
7. Test with a post that has fewer than 100 revisions — no pagination buttons should appear.
8. Test restoring a revision still works.

### Testing Instructions for Keyboard

1. Enter revisions mode.
2. Tab to the slider and use arrow keys to navigate between revisions.
3. Tab to the chevron buttons and press Enter to change pages.
4. Verify focus management and that the slider is operable via keyboard.

## Screenshots or screencast

Revisions slider with pagination on a post with 1000 revisions — tooltip shows target revision range:

<img width="1464" height="960" alt="image" src="https://github.com/user-attachments/assets/aeb9829f-7245-437e-8b31-0ddd577e351d" />


## Use of AI Tools

This PR was authored with assistance from Claude Code (Claude Opus 4.6).