### PR TITLE
Components: Standardize input field labels to sentence case

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -42,7 +42,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
 
 .emotion-6 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -41,12 +41,12 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
 }
 
 .emotion-6 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `BaseControl`, `InputControl`: Standardize label styles from uppercase to sentence case, using design system type tokens ([#77202](https://github.com/WordPress/gutenberg/pull/77202)).
+
 ### Bug Fixes
 
 -   `RadioControl`: Add `role="radiogroup"` to the wrapping `fieldset` element ([#76745](https://github.com/WordPress/gutenberg/pull/76745)).

--- a/packages/components/src/base-control/styles/base-control-styles.ts
+++ b/packages/components/src/base-control/styles/base-control-styles.ts
@@ -28,6 +28,7 @@ const labelStyles = css`
 
 	display: block;
 	margin-bottom: ${ space( 2 ) };
+	color: ${ COLORS.theme.foreground };
 	/**
 	 * Removes Chrome/Safari/Firefox user agent stylesheet padding from
 	 * StyledLabel when it is rendered as a legend.

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -314,6 +314,7 @@ const BaseLabel = styled( Text )< { labelPosition?: LabelPosition } >`
 		padding-bottom: 0;
 		max-width: 100%;
 		z-index: 1;
+		color: ${ COLORS.theme.foreground };
 	}
 `;
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -25,12 +25,12 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 }
 
 .emotion-6 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 
@@ -366,12 +366,12 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 }
 
 .emotion-6 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 
@@ -615,12 +615,12 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 }
 
 .emotion-6 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 
@@ -950,12 +950,12 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 }
 
 .emotion-6 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -26,7 +26,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 
 .emotion-6 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);
@@ -367,7 +367,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 
 .emotion-6 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);
@@ -616,7 +616,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 
 .emotion-6 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);
@@ -951,7 +951,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 
 .emotion-6 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);

--- a/packages/components/src/utils/base-label.ts
+++ b/packages/components/src/utils/base-label.ts
@@ -12,6 +12,6 @@ import CONFIG from './config-values.js';
 // Try to use BaseControl's StyledLabel or BaseControl.VisualLabel if you can.
 export const baseLabelTypography = css`
 	font-size: ${ CONFIG.fontSize };
-	font-weight: ${ CONFIG.fontWeightMedium };
+	font-weight: ${ CONFIG.fontWeight };
 	line-height: 1.4;
 `;

--- a/packages/components/src/utils/base-label.ts
+++ b/packages/components/src/utils/base-label.ts
@@ -7,7 +7,6 @@ import { css } from '@emotion/react';
  * Internal dependencies
  */
 import CONFIG from './config-values.js';
-import { COLORS } from './colors-values';
 
 // This is a very low-level mixin which you shouldn't have to use directly.
 // Try to use BaseControl's StyledLabel or BaseControl.VisualLabel if you can.
@@ -15,5 +14,4 @@ export const baseLabelTypography = css`
 	font-size: ${ CONFIG.fontSize };
 	font-weight: ${ CONFIG.fontWeightMedium };
 	line-height: 1.4;
-	color: ${ COLORS.theme.foreground };
 `;

--- a/packages/components/src/utils/base-label.ts
+++ b/packages/components/src/utils/base-label.ts
@@ -7,12 +7,13 @@ import { css } from '@emotion/react';
  * Internal dependencies
  */
 import CONFIG from './config-values.js';
+import { COLORS } from './colors-values';
 
 // This is a very low-level mixin which you shouldn't have to use directly.
 // Try to use BaseControl's StyledLabel or BaseControl.VisualLabel if you can.
 export const baseLabelTypography = css`
-	font-size: 11px;
+	font-size: ${ CONFIG.fontSize };
 	font-weight: ${ CONFIG.fontWeightMedium };
 	line-height: 1.4;
-	text-transform: uppercase;
+	color: ${ COLORS.theme.foreground };
 `;

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DataForm: Standardize panel label styles from capitalize to sentence case, matching updated BaseControl labels ([#77202](https://github.com/WordPress/gutenberg/pull/77202)).
+
 ### Breaking Changes
 
 - DataViews: Use intersectionObserver to improve performance by unloading invisible items. Change how infinite scroll is enabled to require only 2 view properties: `infiniteScrollEnabled` and `startPosition`. [#74378](https://github.com/WordPress/gutenberg/pull/74378)

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -91,8 +91,7 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
-	color: $gray-700;
-	text-transform: capitalize;
+	color: $gray-900;
 
 	.components-base-control__label {
 		display: inline;

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 
 .emotion-4 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);
@@ -246,7 +246,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 
 .emotion-4 {
   font-size: 13px;
-  font-weight: 499;
+  font-weight: normal;
   line-height: 1.4;
   display: block;
   margin-bottom: calc(4px * 2);

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -18,12 +18,12 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 }
 
 .emotion-4 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 
@@ -245,12 +245,12 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 }
 
 .emotion-4 {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 499;
   line-height: 1.4;
-  text-transform: uppercase;
   display: block;
   margin-bottom: calc(4px * 2);
+  color: var(--wp-components-color-foreground, #1e1e1e);
   padding: 0;
 }
 


### PR DESCRIPTION
## What?

Remove `text-transform: uppercase` from `BaseControl` labels and `text-transform: capitalize` from `DataForm` panel labels, replacing ALL CAPS styling with sentence case.

Update label typography to use design system type tokens: `fontSize` (13px), `fontWeightMedium` (499), and `foreground` color — matching the individual tokens used by the `heading-md` variant.

## Why?

Input field labels use ALL CAPS while other form elements (checkboxes, toggles, radio buttons) already use sentence case. This inconsistency hurts readability, accessibility (screen readers, dyslexia), and internationalization (languages without uppercase).

Closes #76673

## How?

- **`packages/components/src/utils/base-label.ts`**: Removed `text-transform: uppercase`, updated `font-size` from `11px` to `CONFIG.fontSize` (13px), added `color: COLORS.theme.foreground`.
- **`packages/dataviews/src/components/dataform-layouts/panel/style.scss`**: Removed `text-transform: capitalize`, updated `color` from `$gray-700` to `$gray-900`.

**Note:** DataViews table headers intentionally keep ALL CAPS per design system guidance — they are not affected by this change.

## Testing Instructions

1. Open the block editor and inspect input field labels (e.g., Typography panel, Dimensions panel).
2. Verify labels display in sentence case (not ALL CAPS).
3. Check DataForm panel labels match the updated style.
4. Confirm DataViews table column headers remain in ALL CAPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>