### PR TITLE
Fix lint-staged API docs path

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
 			"npm run docs:api-ref",
 			"npm run docs:blocks",
 			"npm run docs:theme-ref",
-			"node ./bin/api-docs/are-api-docs-unstaged.js"
+			"node ./tools/api-docs/are-api-docs-unstaged.js"
 		],
 		"packages/icons/src/library/*": [
 			"npm run -w packages/icons build"


### PR DESCRIPTION
## What?
Follow-up to #77019.

Updates the `lint-staged` API docs check in the root `package.json` to use the current script location in `tools/api-docs`.

## Why?
The pre-commit hook still points to `./bin/api-docs/are-api-docs-unstaged.js`, which no longer exists after the script move. That causes commits to fail with `MODULE_NOT_FOUND` when the matching `lint-staged` task runs.

## How?
Replaces the stale `lint-staged` path with `./tools/api-docs/are-api-docs-unstaged.js`.

## Testing Instructions
1. Stage a file that matches the `packages/**/*.{js,ts,tsx,json}` `lint-staged` glob.
2. Run the corresponding `lint-staged` task, or attempt a commit.
3. Confirm the API docs check no longer fails with `Cannot find module '/.../bin/api-docs/are-api-docs-unstaged.js'`.

## Use of AI Tools
Drafted with AI assistance and reviewed before submission.