### PR TITLE
Editor: Add diff chart visualization behind revisions slider

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revision-diff-chart.js
+++ b/packages/editor/src/components/post-revisions-preview/revision-diff-chart.js
@@ -1,0 +1,178 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { diffWords } from 'diff/lib/diff/word';
+
+/**
+ * Build a smooth closed area path from data points using Catmull-Rom splines.
+ *
+ * @param {Array}  points   Array of { x, y }.
+ * @param {number} baseline The Y coordinate of the center line.
+ * @return {string} SVG path d attribute.
+ */
+function buildSmoothAreaPath( points, baseline ) {
+	if ( points.length < 2 ) {
+		return '';
+	}
+
+	const tension = 0.3;
+	let d = `M 0,${ baseline } L ${ points[ 0 ].x },${ points[ 0 ].y }`;
+
+	for ( let i = 0; i < points.length - 1; i++ ) {
+		const p0 = points[ Math.max( 0, i - 1 ) ];
+		const p1 = points[ i ];
+		const p2 = points[ i + 1 ];
+		const p3 = points[ Math.min( points.length - 1, i + 2 ) ];
+
+		const cp1x = p1.x + ( p2.x - p0.x ) * tension;
+		const cp1y = p1.y + ( p2.y - p0.y ) * tension;
+		const cp2x = p2.x - ( p3.x - p1.x ) * tension;
+		const cp2y = p2.y - ( p3.y - p1.y ) * tension;
+
+		d += ` C ${ cp1x },${ cp1y } ${ cp2x },${ cp2y } ${ p2.x },${ p2.y }`;
+	}
+
+	d += ` L ${ points[ points.length - 1 ].x },${ baseline } Z`;
+	return d;
+}
+
+function diffRevisionPair( prev, curr ) {
+	const previousContent = prev?.content?.raw ?? '';
+	const currentContent = curr?.content?.raw ?? '';
+	const changes = diffWords( previousContent, currentContent );
+
+	let added = 0;
+	let removed = 0;
+
+	for ( const change of changes ) {
+		const wordCount = change.value
+			.trim()
+			.split( /\s+/ )
+			.filter( Boolean ).length;
+		if ( change.added ) {
+			added += wordCount;
+		} else if ( change.removed ) {
+			removed += wordCount;
+		}
+	}
+
+	return { added, removed };
+}
+
+/**
+ * Compute per-revision change stats by diffing consecutive revisions.
+ * Diffs are computed asynchronously to avoid blocking the main thread.
+ *
+ * @param {Array} sortedRevisions Revisions sorted by date ascending.
+ * @return {Array<{added: number, removed: number}>} Change stats per revision.
+ */
+export function useRevisionDiffStats( sortedRevisions ) {
+	const [ stats, setStats ] = useState( [] );
+	const revisionsRef = useRef();
+
+	useEffect( () => {
+		if ( ! sortedRevisions || sortedRevisions.length < 2 ) {
+			setStats( [] );
+			return;
+		}
+
+		// Reset if revisions changed.
+		revisionsRef.current = sortedRevisions;
+		const initial = sortedRevisions.map( () => ( {
+			added: 0,
+			removed: 0,
+		} ) );
+		setStats( initial );
+
+		let index = 1;
+
+		function processNext() {
+			if ( revisionsRef.current !== sortedRevisions ) {
+				return;
+			}
+			if ( index >= sortedRevisions.length ) {
+				return;
+			}
+
+			const i = index++;
+			const result = diffRevisionPair(
+				sortedRevisions[ i - 1 ],
+				sortedRevisions[ i ]
+			);
+
+			setStats( ( prev ) => {
+				const next = [ ...prev ];
+				next[ i ] = result;
+				return next;
+			} );
+
+			window.requestIdleCallback( processNext );
+		}
+
+		const id = window.requestIdleCallback( processNext );
+		return () => window.cancelIdleCallback( id );
+	}, [ sortedRevisions ] );
+
+	return stats;
+}
+
+/**
+ * Render a flamegraph-style area chart of revision diffs.
+ *
+ * @param {Object} props
+ * @param {Array}  props.stats  Array of { added, removed } per revision.
+ * @param {number} props.width  Width of the SVG in pixels.
+ * @param {number} props.height Height of the SVG in pixels.
+ * @return {React.JSX.Element|null} The SVG chart or null if insufficient data.
+ */
+export default function RevisionDiffChart( { stats, width, height } ) {
+	if ( ! stats || stats.length < 2 || ! width || ! height ) {
+		return null;
+	}
+
+	const gap = 2;
+	const midY = height / 2;
+	const halfHeight = midY - gap - 2;
+
+	// Use square root scale so small changes remain visible
+	// relative to large ones.
+	const maxValue = Math.max(
+		1,
+		...stats.map( ( s ) =>
+			Math.max( Math.sqrt( s.added ), Math.sqrt( s.removed ) )
+		)
+	);
+	const verticalScale = halfHeight / maxValue;
+
+	const addedPoints = stats.map( ( stat, index ) => ( {
+		x: ( index / ( stats.length - 1 ) ) * width,
+		y: midY - gap - Math.sqrt( stat.added ) * verticalScale,
+	} ) );
+
+	const removedPoints = stats.map( ( stat, index ) => ( {
+		x: ( index / ( stats.length - 1 ) ) * width,
+		y: midY + gap + Math.sqrt( stat.removed ) * verticalScale,
+	} ) );
+
+	/* eslint-disable react/forbid-elements */
+	return (
+		<svg
+			className="editor-revisions-slider__chart"
+			viewBox={ `0 0 ${ width } ${ height }` }
+			preserveAspectRatio="none"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path
+				d={ buildSmoothAreaPath( addedPoints, midY - gap ) }
+				fill="rgba(0, 163, 42, 0.3)"
+			/>
+			<path
+				d={ buildSmoothAreaPath( removedPoints, midY + gap ) }
+				fill="rgba(214, 54, 56, 0.3)"
+			/>
+		</svg>
+	);
+	/* eslint-enable react/forbid-elements */
+}

--- a/packages/editor/src/components/post-revisions-preview/revision-diff-chart.js
+++ b/packages/editor/src/components/post-revisions-preview/revision-diff-chart.js
@@ -5,7 +5,9 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { diffWords } from 'diff/lib/diff/word';
 
 /**
- * Build a smooth closed area path from data points using Catmull-Rom splines.
+ * Build a smooth closed area path using monotone cubic interpolation.
+ * Unlike Catmull-Rom, monotone interpolation never overshoots data points,
+ * producing clean curves similar to Recharts' "monotone" curve type.
  *
  * @param {Array}  points   Array of { x, y }.
  * @param {number} baseline The Y coordinate of the center line.
@@ -16,25 +18,72 @@ function buildSmoothAreaPath( points, baseline ) {
 		return '';
 	}
 
-	const tension = 0.3;
-	let d = `M 0,${ baseline } L ${ points[ 0 ].x },${ points[ 0 ].y }`;
+	// Compute tangent slopes using Fritsch-Carlson monotone method.
+	const n = points.length;
+	const slopes = new Array( n );
+	const deltas = new Array( n - 1 );
 
-	for ( let i = 0; i < points.length - 1; i++ ) {
-		const p0 = points[ Math.max( 0, i - 1 ) ];
-		const p1 = points[ i ];
-		const p2 = points[ i + 1 ];
-		const p3 = points[ Math.min( points.length - 1, i + 2 ) ];
-
-		const cp1x = p1.x + ( p2.x - p0.x ) * tension;
-		const cp1y = p1.y + ( p2.y - p0.y ) * tension;
-		const cp2x = p2.x - ( p3.x - p1.x ) * tension;
-		const cp2y = p2.y - ( p3.y - p1.y ) * tension;
-
-		d += ` C ${ cp1x },${ cp1y } ${ cp2x },${ cp2y } ${ p2.x },${ p2.y }`;
+	for ( let i = 0; i < n - 1; i++ ) {
+		const dx = points[ i + 1 ].x - points[ i ].x;
+		deltas[ i ] = dx === 0 ? 0 : ( points[ i + 1 ].y - points[ i ].y ) / dx;
 	}
 
-	d += ` L ${ points[ points.length - 1 ].x },${ baseline } Z`;
+	slopes[ 0 ] = deltas[ 0 ];
+	slopes[ n - 1 ] = deltas[ n - 2 ];
+
+	for ( let i = 1; i < n - 1; i++ ) {
+		if ( deltas[ i - 1 ] * deltas[ i ] <= 0 ) {
+			slopes[ i ] = 0;
+		} else {
+			slopes[ i ] = ( deltas[ i - 1 ] + deltas[ i ] ) / 2;
+		}
+	}
+
+	// Enforce monotonicity.
+	for ( let i = 0; i < n - 1; i++ ) {
+		if ( deltas[ i ] === 0 ) {
+			slopes[ i ] = 0;
+			slopes[ i + 1 ] = 0;
+		} else {
+			const alpha = slopes[ i ] / deltas[ i ];
+			const beta = slopes[ i + 1 ] / deltas[ i ];
+			const s = alpha * alpha + beta * beta;
+			if ( s > 9 ) {
+				const t = 3 / Math.sqrt( s );
+				slopes[ i ] = t * alpha * deltas[ i ];
+				slopes[ i + 1 ] = t * beta * deltas[ i ];
+			}
+		}
+	}
+
+	// Build path.
+	let d = `M 0,${ baseline } L ${ points[ 0 ].x },${ points[ 0 ].y }`;
+
+	for ( let i = 0; i < n - 1; i++ ) {
+		const dx = points[ i + 1 ].x - points[ i ].x;
+		const cp1x = points[ i ].x + dx / 3;
+		const cp1y = points[ i ].y + ( slopes[ i ] * dx ) / 3;
+		const cp2x = points[ i + 1 ].x - dx / 3;
+		const cp2y = points[ i + 1 ].y - ( slopes[ i + 1 ] * dx ) / 3;
+		d += ` C ${ cp1x },${ cp1y } ${ cp2x },${ cp2y } ${
+			points[ i + 1 ].x
+		},${ points[ i + 1 ].y }`;
+	}
+
+	d += ` L ${ points[ n - 1 ].x },${ baseline } Z`;
 	return d;
+}
+
+const segmenter = new Intl.Segmenter( undefined, { granularity: 'word' } );
+
+function countWords( text ) {
+	let count = 0;
+	for ( const { isWordLike } of segmenter.segment( text ) ) {
+		if ( isWordLike ) {
+			count++;
+		}
+	}
+	return count;
 }
 
 function diffRevisionPair( prev, curr ) {
@@ -46,14 +95,10 @@ function diffRevisionPair( prev, curr ) {
 	let removed = 0;
 
 	for ( const change of changes ) {
-		const wordCount = change.value
-			.trim()
-			.split( /\s+/ )
-			.filter( Boolean ).length;
 		if ( change.added ) {
-			added += wordCount;
+			added += countWords( change.value );
 		} else if ( change.removed ) {
-			removed += wordCount;
+			removed += countWords( change.value );
 		}
 	}
 
@@ -85,17 +130,19 @@ export function useRevisionDiffStats( sortedRevisions ) {
 		} ) );
 		setStats( initial );
 
-		let index = 1;
+		// Process from the last revision backwards so the max scale
+		// is established early and the chart only grows, never shrinks.
+		let index = sortedRevisions.length - 1;
 
 		function processNext() {
 			if ( revisionsRef.current !== sortedRevisions ) {
 				return;
 			}
-			if ( index >= sortedRevisions.length ) {
+			if ( index < 1 ) {
 				return;
 			}
 
-			const i = index++;
+			const i = index--;
 			const result = diffRevisionPair(
 				sortedRevisions[ i - 1 ],
 				sortedRevisions[ i ]
@@ -126,6 +173,10 @@ export function useRevisionDiffStats( sortedRevisions ) {
  * @param {number} props.height Height of the SVG in pixels.
  * @return {React.JSX.Element|null} The SVG chart or null if insufficient data.
  */
+// Fixed reference for log scale — changes of this many words
+// or more fill the full chart height. Larger values clip.
+const LOG_SCALE_REF = Math.log10( 2000 );
+
 export default function RevisionDiffChart( { stats, width, height } ) {
 	if ( ! stats || stats.length < 2 || ! width || ! height ) {
 		return null;
@@ -134,25 +185,19 @@ export default function RevisionDiffChart( { stats, width, height } ) {
 	const gap = 2;
 	const midY = height / 2;
 	const halfHeight = midY - gap - 2;
-
-	// Use square root scale so small changes remain visible
-	// relative to large ones.
-	const maxValue = Math.max(
-		1,
-		...stats.map( ( s ) =>
-			Math.max( Math.sqrt( s.added ), Math.sqrt( s.removed ) )
-		)
-	);
-	const verticalScale = halfHeight / maxValue;
+	const verticalScale = halfHeight / LOG_SCALE_REF;
 
 	const addedPoints = stats.map( ( stat, index ) => ( {
 		x: ( index / ( stats.length - 1 ) ) * width,
-		y: midY - gap - Math.sqrt( stat.added ) * verticalScale,
+		y: midY - gap - Math.max( 0, Math.log10( stat.added ) ) * verticalScale,
 	} ) );
 
 	const removedPoints = stats.map( ( stat, index ) => ( {
 		x: ( index / ( stats.length - 1 ) ) * width,
-		y: midY + gap + Math.sqrt( stat.removed ) * verticalScale,
+		y:
+			midY +
+			gap +
+			Math.max( 0, Math.log10( stat.removed ) ) * verticalScale,
 	} ) );
 
 	/* eslint-disable react/forbid-elements */

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -8,10 +8,11 @@ import {
 	Button,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
@@ -19,6 +20,7 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
  */
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import RevisionDiffChart, { useRevisionDiffStats } from './revision-diff-chart';
 
 /**
  * Slider component for navigating revisions with pagination.
@@ -98,6 +100,12 @@ function RevisionsSlider() {
 		return dateI18n( dateSettings.formats.datetime, revision.date );
 	};
 
+	const diffStats = useRevisionDiffStats( revisions );
+	const [ chartWidth, setChartWidth ] = useState( 0 );
+	const resizeRef = useResizeObserver( ( entries ) => {
+		setChartWidth( entries[ 0 ].contentRect.width );
+	} );
+
 	const showPagination = totalPages > 1;
 
 	if ( isLoading && ! showPagination ) {
@@ -135,19 +143,29 @@ function RevisionsSlider() {
 		isLoading || selectedIndex === -1 ? (
 			<Spinner />
 		) : (
-			<RangeControl
-				__next40pxDefaultSize
-				className="editor-revisions-header__slider"
-				hideLabelFromVision
-				label={ __( 'Revision' ) }
-				max={ revisions?.length - 1 }
-				min={ 0 }
-				marks
-				onChange={ handleSliderChange }
-				renderTooltipContent={ renderTooltipContent }
-				value={ selectedIndex }
-				withInputField={ false }
-			/>
+			<div
+				className="editor-revisions-slider__container"
+				ref={ resizeRef }
+			>
+				<RevisionDiffChart
+					stats={ diffStats }
+					width={ chartWidth }
+					height={ 30 }
+				/>
+				<RangeControl
+					__next40pxDefaultSize
+					className="editor-revisions-header__slider"
+					hideLabelFromVision
+					label={ __( 'Revision' ) }
+					max={ revisions?.length - 1 }
+					min={ 0 }
+					marks
+					onChange={ handleSliderChange }
+					renderTooltipContent={ renderTooltipContent }
+					value={ selectedIndex }
+					withInputField={ false }
+				/>
+			</div>
 		);
 
 	if ( ! showPagination ) {

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -2,10 +2,17 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { RangeControl, Spinner } from '@wordpress/components';
+import {
+	RangeControl,
+	Spinner,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useEffect, useMemo } from '@wordpress/element';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -13,65 +20,112 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const REVISIONS_PER_PAGE = 100;
+
 /**
- * Slider component for navigating revisions.
+ * Slider component for navigating revisions with pagination.
+ *
+ * Page 1 contains the newest revisions. The API returns them in
+ * descending date order, and we reverse for display so the slider
+ * reads oldest-left → newest-right.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
-	const { revisions, isLoading, currentRevisionId, revisionKey } = useSelect(
-		( select ) => {
-			const { getCurrentPostId, getCurrentPostType } =
-				select( editorStore );
-			const { getRevisions, isResolving, getEntityConfig } =
-				select( coreStore );
+	const {
+		revisions: rawRevisions,
+		isLoading,
+		currentRevisionId,
+		revisionKey,
+		revisionPage,
+		totalRevisions,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentPostId,
+			getCurrentPostType,
+			getCurrentPostRevisionsCount,
+		} = select( editorStore );
+		const { getRevisions, isResolving, getEntityConfig } =
+			select( coreStore );
+		const { getCurrentRevisionId, getRevisionPage } = unlock(
+			select( editorStore )
+		);
 
-			const postId = getCurrentPostId();
-			const postType = getCurrentPostType();
+		const postId = getCurrentPostId();
+		const postType = getCurrentPostType();
 
-			if ( ! postId || ! postType ) {
-				return {};
-			}
+		if ( ! postId || ! postType ) {
+			return {};
+		}
 
-			const entityConfig = getEntityConfig( 'postType', postType );
-			const _revisionKey = entityConfig?.revisionKey || 'id';
-			const query = {
-				per_page: -1,
-				context: 'edit',
-				orderby: 'date',
-				order: 'asc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						_revisionKey,
-					] ),
-				].join(),
-			};
+		const entityConfig = getEntityConfig( 'postType', postType );
+		const _revisionKey = entityConfig?.revisionKey || 'id';
+		const _totalRevisions = getCurrentPostRevisionsCount();
+		const _revisionPage = getRevisionPage();
+
+		// Don't fetch until we have a page number.
+		if ( ! _revisionPage ) {
 			return {
-				revisions: getRevisions( 'postType', postType, postId, query ),
-				isLoading: isResolving( 'getRevisions', [
-					'postType',
-					postType,
-					postId,
-					query,
-				] ),
-				currentRevisionId: unlock(
-					select( editorStore )
-				).getCurrentRevisionId(),
+				isLoading: true,
+				totalRevisions: _totalRevisions,
+				revisionPage: _revisionPage,
 				revisionKey: _revisionKey,
 			};
-		},
-		[]
+		}
+
+		const query = {
+			per_page: REVISIONS_PER_PAGE,
+			page: _revisionPage,
+			context: 'edit',
+			orderby: 'date',
+			order: 'desc',
+			_fields: [
+				...new Set( [
+					'id',
+					'date',
+					'modified',
+					'author',
+					'meta',
+					'title.raw',
+					'excerpt.raw',
+					'content.raw',
+					_revisionKey,
+				] ),
+			].join(),
+		};
+		return {
+			revisions: getRevisions( 'postType', postType, postId, query ),
+			isLoading: isResolving( 'getRevisions', [
+				'postType',
+				postType,
+				postId,
+				query,
+			] ),
+			currentRevisionId: getCurrentRevisionId(),
+			revisionKey: _revisionKey,
+			revisionPage: _revisionPage,
+			totalRevisions: _totalRevisions,
+		};
+	}, [] );
+
+	const { setCurrentRevisionId, setRevisionPage } = unlock(
+		useDispatch( editorStore )
 	);
 
-	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
+	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+
+	// Reverse so the slider reads oldest (left) → newest (right).
+	const revisions = useMemo(
+		() => rawRevisions && [ ...rawRevisions ].reverse(),
+		[ rawRevisions ]
+	);
+
+	// Set initial page to 1 (newest revisions) when entering revisions mode.
+	useEffect( () => {
+		if ( revisionPage === null && totalRevisions > 0 ) {
+			setRevisionPage( 1 );
+		}
+	}, [ revisionPage, totalRevisions, setRevisionPage ] );
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -83,6 +137,19 @@ function RevisionsSlider() {
 			setCurrentRevisionId( revision[ revisionKey ] );
 		}
 	};
+
+	const handlePageChange = ( newPage ) => {
+		setRevisionPage( newPage );
+	};
+
+	// When revisions load and no revision is selected (after page change),
+	// select the last revision on the page (newest = last in reversed array).
+	useEffect( () => {
+		if ( revisions?.length && selectedIndex === -1 ) {
+			const lastRevision = revisions[ revisions.length - 1 ];
+			setCurrentRevisionId( lastRevision[ revisionKey ] );
+		}
+	}, [ revisions, selectedIndex, revisionKey, setCurrentRevisionId ] );
 
 	// Format date for tooltip.
 	const dateSettings = getDateSettings();
@@ -106,7 +173,7 @@ function RevisionsSlider() {
 		);
 	}
 
-	if ( revisions?.length === 1 ) {
+	if ( totalRevisions <= 1 ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'Only one revision found.' ) }
@@ -114,7 +181,22 @@ function RevisionsSlider() {
 		);
 	}
 
-	return (
+	const showPagination = totalPages > 1;
+
+	// Compute the 1-based revision range for a given page.
+	// Page 1 = newest, so page 1 of 1000 → "901–1000".
+	const getPageRangeLabel = ( page ) => {
+		const end = totalRevisions - ( page - 1 ) * REVISIONS_PER_PAGE;
+		const start = Math.max( 1, end - REVISIONS_PER_PAGE + 1 );
+		return sprintf(
+			/* translators: 1: first revision number, 2: last revision number */
+			__( 'Revisions %1$s\u2013%2$s' ),
+			start,
+			end
+		);
+	};
+
+	const slider = (
 		<RangeControl
 			__next40pxDefaultSize
 			className="editor-revisions-header__slider"
@@ -125,10 +207,45 @@ function RevisionsSlider() {
 			marks
 			onChange={ handleSliderChange }
 			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex }
+			value={ selectedIndex >= 0 ? selectedIndex : 0 }
 			withInputField={ false }
 		/>
 	);
+
+	if ( ! showPagination ) {
+		return slider;
+	}
+
+	return (
+		<HStack spacing={ 2 } expanded wrap={ false }>
+			<Button
+				icon={ chevronLeft }
+				label={
+					revisionPage < totalPages
+						? getPageRangeLabel( revisionPage + 1 )
+						: __( 'Older revisions' )
+				}
+				onClick={ () => handlePageChange( revisionPage + 1 ) }
+				disabled={ revisionPage >= totalPages }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+			<div style={ { flex: 1, minWidth: 0 } }>{ slider }</div>
+			<Button
+				icon={ chevronRight }
+				label={
+					revisionPage > 1
+						? getPageRangeLabel( revisionPage - 1 )
+						: __( 'Newer revisions' )
+				}
+				onClick={ () => handlePageChange( revisionPage - 1 ) }
+				disabled={ revisionPage <= 1 }
+				size="compact"
+				accessibleWhenDisabled
+			/>
+		</HStack>
+	);
 }
 
+export { REVISIONS_PER_PAGE };
 export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -11,7 +11,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
@@ -65,19 +65,13 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const isLoading = !! revisionPage && ! rawRevisions;
+	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
 
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
 	);
-
-	useEffect( () => {
-		if ( revisionPage === null && totalRevisions > 0 ) {
-			setRevisionPage( 1 );
-		}
-	}, [ revisionPage, totalRevisions, setRevisionPage ] );
 
 	const selectedIndex = revisions?.findIndex(
 		( r ) => r[ revisionKey ] === currentRevisionId
@@ -93,13 +87,6 @@ function RevisionsSlider() {
 	const handlePageChange = ( newPage ) => {
 		setRevisionPage( newPage );
 	};
-
-	useEffect( () => {
-		if ( revisions?.length && selectedIndex === -1 ) {
-			const lastRevision = revisions[ revisions.length - 1 ];
-			setCurrentRevisionId( lastRevision[ revisionKey ] );
-		}
-	}, [ revisions, selectedIndex, revisionKey, setCurrentRevisionId ] );
 
 	// Format date for tooltip.
 	const dateSettings = getDateSettings();
@@ -144,23 +131,24 @@ function RevisionsSlider() {
 		);
 	};
 
-	const sliderOrSpinner = isLoading ? (
-		<Spinner />
-	) : (
-		<RangeControl
-			__next40pxDefaultSize
-			className="editor-revisions-header__slider"
-			hideLabelFromVision
-			label={ __( 'Revision' ) }
-			max={ revisions?.length - 1 }
-			min={ 0 }
-			marks
-			onChange={ handleSliderChange }
-			renderTooltipContent={ renderTooltipContent }
-			value={ selectedIndex >= 0 ? selectedIndex : 0 }
-			withInputField={ false }
-		/>
-	);
+	const sliderOrSpinner =
+		isLoading || selectedIndex === -1 ? (
+			<Spinner />
+		) : (
+			<RangeControl
+				__next40pxDefaultSize
+				className="editor-revisions-header__slider"
+				hideLabelFromVision
+				label={ __( 'Revision' ) }
+				max={ revisions?.length - 1 }
+				min={ 0 }
+				marks
+				onChange={ handleSliderChange }
+				renderTooltipContent={ renderTooltipContent }
+				value={ selectedIndex }
+				withInputField={ false }
+			/>
+		);
 
 	if ( ! showPagination ) {
 		return sliderOrSpinner;

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -161,11 +161,13 @@ function RevisionsSlider() {
 		return dateI18n( dateSettings.formats.datetime, revision.date );
 	};
 
-	if ( isLoading ) {
+	const showPagination = totalPages > 1;
+
+	if ( isLoading && ! showPagination ) {
 		return <Spinner />;
 	}
 
-	if ( ! revisions?.length ) {
+	if ( ! isLoading && ! revisions?.length ) {
 		return (
 			<span className="editor-revisions-header__no-revisions">
 				{ __( 'No revisions found.' ) }
@@ -181,8 +183,6 @@ function RevisionsSlider() {
 		);
 	}
 
-	const showPagination = totalPages > 1;
-
 	// Compute the 1-based revision range for a given page.
 	// Page 1 = newest, so page 1 of 1000 → "901–1000".
 	const getPageRangeLabel = ( page ) => {
@@ -196,7 +196,9 @@ function RevisionsSlider() {
 		);
 	};
 
-	const slider = (
+	const sliderOrSpinner = isLoading ? (
+		<Spinner />
+	) : (
 		<RangeControl
 			__next40pxDefaultSize
 			className="editor-revisions-header__slider"
@@ -213,7 +215,7 @@ function RevisionsSlider() {
 	);
 
 	if ( ! showPagination ) {
-		return slider;
+		return sliderOrSpinner;
 	}
 
 	return (
@@ -226,11 +228,11 @@ function RevisionsSlider() {
 						: __( 'Older revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage + 1 ) }
-				disabled={ revisionPage >= totalPages }
+				disabled={ isLoading || revisionPage >= totalPages }
 				size="compact"
 				accessibleWhenDisabled
 			/>
-			<div style={ { flex: 1, minWidth: 0 } }>{ slider }</div>
+			<div style={ { flex: 1, minWidth: 0 } }>{ sliderOrSpinner }</div>
 			<Button
 				icon={ chevronRight }
 				label={
@@ -239,7 +241,7 @@ function RevisionsSlider() {
 						: __( 'Newer revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage - 1 ) }
-				disabled={ revisionPage <= 1 }
+				disabled={ isLoading || revisionPage <= 1 }
 				size="compact"
 				accessibleWhenDisabled
 			/>

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -150,7 +150,7 @@ function RevisionsSlider() {
 				<RevisionDiffChart
 					stats={ diffStats }
 					width={ chartWidth }
-					height={ 30 }
+					height={ 40 }
 				/>
 				<RangeControl
 					__next40pxDefaultSize

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -34,8 +34,12 @@ function RevisionsSlider() {
 		revisionPage,
 		totalRevisions,
 	} = useSelect( ( select ) => {
-		const { getCurrentRevisionId, getRevisionPage, getPageRevisions } =
-			unlock( select( editorStore ) );
+		const {
+			getCurrentRevisionId,
+			getRevisionPage,
+			getPageRevisions,
+			getRevisionsPerPage,
+		} = unlock( select( editorStore ) );
 
 		const postType = select( editorStore ).getCurrentPostType();
 		if ( ! postType ) {
@@ -48,11 +52,10 @@ function RevisionsSlider() {
 		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
 		const _revisionPage = getRevisionPage();
-		const pageData = getPageRevisions( _revisionPage );
 
 		return {
-			revisions: pageData?.revisions,
-			perPage: pageData?.perPage,
+			revisions: getPageRevisions( _revisionPage ),
+			perPage: getRevisionsPerPage(),
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
@@ -66,7 +69,7 @@ function RevisionsSlider() {
 	);
 
 	const isLoading = ! rawRevisions;
-	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
+	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
 
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
@@ -82,10 +85,6 @@ function RevisionsSlider() {
 		if ( revision ) {
 			setCurrentRevisionId( revision[ revisionKey ] );
 		}
-	};
-
-	const handlePageChange = ( newPage ) => {
-		setRevisionPage( newPage );
 	};
 
 	// Format date for tooltip.
@@ -163,7 +162,7 @@ function RevisionsSlider() {
 						? getPageRangeLabel( revisionPage + 1 )
 						: __( 'No older revisions' )
 				}
-				onClick={ () => handlePageChange( revisionPage + 1 ) }
+				onClick={ () => setRevisionPage( revisionPage + 1 ) }
 				disabled={ isLoading || revisionPage >= totalPages }
 				size="compact"
 				accessibleWhenDisabled
@@ -185,7 +184,7 @@ function RevisionsSlider() {
 						? getPageRangeLabel( revisionPage - 1 )
 						: __( 'No newer revisions' )
 				}
-				onClick={ () => handlePageChange( revisionPage - 1 ) }
+				onClick={ () => setRevisionPage( revisionPage - 1 ) }
 				disabled={ isLoading || revisionPage <= 1 }
 				size="compact"
 				accessibleWhenDisabled

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -71,6 +71,7 @@ function RevisionsSlider() {
 	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
 
+	// Reverse desc→asc so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
@@ -124,7 +125,7 @@ function RevisionsSlider() {
 		const start = Math.max( 1, end - perPage + 1 );
 		return sprintf(
 			/* translators: 1: first revision number, 2: last revision number */
-			__( 'Revisions %1$s\u2013%2$s' ),
+			__( 'Revisions %1$s–%2$s' ),
 			start,
 			end
 		);

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -34,77 +34,33 @@ const REVISIONS_PER_PAGE = 100;
 function RevisionsSlider() {
 	const {
 		revisions: rawRevisions,
-		isLoading,
 		currentRevisionId,
 		revisionKey,
 		revisionPage,
 		totalRevisions,
 	} = useSelect( ( select ) => {
-		const {
-			getCurrentPostId,
-			getCurrentPostType,
-			getCurrentPostRevisionsCount,
-		} = select( editorStore );
-		const { getRevisions, isResolving, getEntityConfig } =
-			select( coreStore );
-		const { getCurrentRevisionId, getRevisionPage } = unlock(
-			select( editorStore )
-		);
+		const { getCurrentRevisionId, getRevisionPage, getPageRevisions } =
+			unlock( select( editorStore ) );
 
-		const postId = getCurrentPostId();
-		const postType = getCurrentPostType();
-
-		if ( ! postId || ! postType ) {
+		const postType = select( editorStore ).getCurrentPostType();
+		if ( ! postType ) {
 			return {};
 		}
 
-		const entityConfig = getEntityConfig( 'postType', postType );
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
-		const _totalRevisions = getCurrentPostRevisionsCount();
 		const _revisionPage = getRevisionPage();
 
-		// Don't fetch until we have a page number.
-		if ( ! _revisionPage ) {
-			return {
-				isLoading: true,
-				totalRevisions: _totalRevisions,
-				revisionPage: _revisionPage,
-				revisionKey: _revisionKey,
-			};
-		}
-
-		const query = {
-			per_page: REVISIONS_PER_PAGE,
-			page: _revisionPage,
-			context: 'edit',
-			orderby: 'date',
-			order: 'desc',
-			_fields: [
-				...new Set( [
-					'id',
-					'date',
-					'modified',
-					'author',
-					'meta',
-					'title.raw',
-					'excerpt.raw',
-					'content.raw',
-					_revisionKey,
-				] ),
-			].join(),
-		};
 		return {
-			revisions: getRevisions( 'postType', postType, postId, query ),
-			isLoading: isResolving( 'getRevisions', [
-				'postType',
-				postType,
-				postId,
-				query,
-			] ),
+			revisions: getPageRevisions( _revisionPage ),
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
-			totalRevisions: _totalRevisions,
+			totalRevisions:
+				select( editorStore ).getCurrentPostRevisionsCount(),
 		};
 	}, [] );
 
@@ -113,6 +69,7 @@ function RevisionsSlider() {
 	);
 
 	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+	const isLoading = !! revisionPage && ! rawRevisions;
 
 	// Reverse so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -232,7 +232,16 @@ function RevisionsSlider() {
 				size="compact"
 				accessibleWhenDisabled
 			/>
-			<div style={ { flex: 1, minWidth: 0 } }>{ sliderOrSpinner }</div>
+			<div
+				style={ {
+					flex: 1,
+					minWidth: 0,
+					display: 'flex',
+					justifyContent: 'center',
+				} }
+			>
+				{ sliderOrSpinner }
+			</div>
 			<Button
 				icon={ chevronRight }
 				label={

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -20,20 +20,15 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const REVISIONS_PER_PAGE = 100;
-
 /**
  * Slider component for navigating revisions with pagination.
- *
- * Page 1 contains the newest revisions. The API returns them in
- * descending date order, and we reverse for display so the slider
- * reads oldest-left → newest-right.
  *
  * @return {React.JSX.Element} The revisions slider component.
  */
 function RevisionsSlider() {
 	const {
 		revisions: rawRevisions,
+		perPage,
 		currentRevisionId,
 		revisionKey,
 		revisionPage,
@@ -53,9 +48,11 @@ function RevisionsSlider() {
 		);
 		const _revisionKey = entityConfig?.revisionKey || 'id';
 		const _revisionPage = getRevisionPage();
+		const pageData = getPageRevisions( _revisionPage );
 
 		return {
-			revisions: getPageRevisions( _revisionPage ),
+			revisions: pageData?.revisions,
+			perPage: pageData?.perPage,
 			currentRevisionId: getCurrentRevisionId(),
 			revisionKey: _revisionKey,
 			revisionPage: _revisionPage,
@@ -68,16 +65,14 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const totalPages = Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
 	const isLoading = !! revisionPage && ! rawRevisions;
+	const totalPages = Math.ceil( totalRevisions / ( perPage || 1 ) ) || 1;
 
-	// Reverse so the slider reads oldest (left) → newest (right).
 	const revisions = useMemo(
 		() => rawRevisions && [ ...rawRevisions ].reverse(),
 		[ rawRevisions ]
 	);
 
-	// Set initial page to 1 (newest revisions) when entering revisions mode.
 	useEffect( () => {
 		if ( revisionPage === null && totalRevisions > 0 ) {
 			setRevisionPage( 1 );
@@ -99,8 +94,6 @@ function RevisionsSlider() {
 		setRevisionPage( newPage );
 	};
 
-	// When revisions load and no revision is selected (after page change),
-	// select the last revision on the page (newest = last in reversed array).
 	useEffect( () => {
 		if ( revisions?.length && selectedIndex === -1 ) {
 			const lastRevision = revisions[ revisions.length - 1 ];
@@ -140,11 +133,9 @@ function RevisionsSlider() {
 		);
 	}
 
-	// Compute the 1-based revision range for a given page.
-	// Page 1 = newest, so page 1 of 1000 → "901–1000".
 	const getPageRangeLabel = ( page ) => {
-		const end = totalRevisions - ( page - 1 ) * REVISIONS_PER_PAGE;
-		const start = Math.max( 1, end - REVISIONS_PER_PAGE + 1 );
+		const end = totalRevisions - ( page - 1 ) * perPage;
+		const start = Math.max( 1, end - perPage + 1 );
 		return sprintf(
 			/* translators: 1: first revision number, 2: last revision number */
 			__( 'Revisions %1$s\u2013%2$s' ),
@@ -182,7 +173,7 @@ function RevisionsSlider() {
 				label={
 					revisionPage < totalPages
 						? getPageRangeLabel( revisionPage + 1 )
-						: __( 'Older revisions' )
+						: __( 'No older revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage + 1 ) }
 				disabled={ isLoading || revisionPage >= totalPages }
@@ -204,7 +195,7 @@ function RevisionsSlider() {
 				label={
 					revisionPage > 1
 						? getPageRangeLabel( revisionPage - 1 )
-						: __( 'Newer revisions' )
+						: __( 'No newer revisions' )
 				}
 				onClick={ () => handlePageChange( revisionPage - 1 ) }
 				disabled={ isLoading || revisionPage <= 1 }
@@ -215,5 +206,4 @@ function RevisionsSlider() {
 	);
 }
 
-export { REVISIONS_PER_PAGE };
 export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -8,10 +8,10 @@
 
 .editor-revisions-slider__chart {
 	position: absolute;
-	top: 5px;
+	top: 0;
 	left: 0;
 	width: 100%;
-	height: 30px;
+	height: 40px;
 	pointer-events: none;
 	z-index: 1;
 }

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -1,6 +1,21 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+.editor-revisions-slider__container {
+	position: relative;
+	width: 100%;
+}
+
+.editor-revisions-slider__chart {
+	position: absolute;
+	top: 5px;
+	left: 0;
+	width: 100%;
+	height: 30px;
+	pointer-events: none;
+	z-index: 1;
+}
+
 .editor-revisions-header__slider {
 	width: 100%;
 

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -603,6 +603,19 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
+ * Set the current revisions page number.
+ *
+ * @param {number} page The page number.
+ * @return {Object} Action object.
+ */
+export function setRevisionPage( page ) {
+	return {
+		type: 'SET_REVISION_PAGE',
+		page,
+	};
+}
+
+/**
  * Set whether the revision diff highlighting is shown.
  *
  * @param {boolean} showDiff Whether to show diff highlighting.

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -16,6 +16,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import isTemplateRevertable from './utils/is-template-revertable';
+import { buildRevisionsPageQuery } from './private-selectors';
 export * from '../dataviews/store/private-actions';
 
 /**
@@ -603,17 +604,37 @@ export function setCurrentRevisionId( revisionId ) {
 }
 
 /**
- * Set the current revisions page number.
+ * Set the current revisions page number and select the newest
+ * revision on that page once it loads.
  *
  * @param {number} page The page number.
- * @return {Object} Action object.
  */
-export function setRevisionPage( page ) {
-	return {
-		type: 'SET_REVISION_PAGE',
-		page,
+export const setRevisionPage =
+	( page ) =>
+	async ( { dispatch, select, registry } ) => {
+		const postType = select.getCurrentPostType();
+		const postId = select.getCurrentPostId();
+		const entityConfig = registry
+			.select( coreStore )
+			.getEntityConfig( 'postType', postType );
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		const revisions = await registry
+			.resolveSelect( coreStore )
+			.getRevisions(
+				'postType',
+				postType,
+				postId,
+				buildRevisionsPageQuery( revisionKey, page )
+			);
+
+		registry.batch( () => {
+			dispatch( { type: 'SET_REVISION_PAGE', page } );
+			if ( revisions?.length ) {
+				dispatch.setCurrentRevisionId( revisions[ 0 ][ revisionKey ] );
+			}
+		} );
 	};
-}
 
 /**
  * Set whether the revision diff highlighting is shown.

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -21,7 +21,11 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /**
  * Internal dependencies
  */
-import { getRenderingMode, getCurrentPost } from './selectors';
+import {
+	getRenderingMode,
+	getCurrentPost,
+	getCurrentPostRevisionsCount,
+} from './selectors';
 import {
 	getEntityActions as _getEntityActions,
 	getEntityFields as _getEntityFields,
@@ -464,9 +468,8 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions. Uses the paginated revisions
- * from the current page. At page boundaries (first revision on a page),
- * returns null since the previous revision is on another page.
+ * Used for diffing between revisions. At page boundaries, fetches the
+ * adjacent page to find the previous revision.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
@@ -489,6 +492,20 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		const fields = [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join();
+
 		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
@@ -500,19 +517,7 @@ export const getPreviousRevision = createRegistrySelector(
 				context: 'edit',
 				orderby: 'date',
 				order: 'desc',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
+				_fields: fields,
 			}
 		);
 		if ( ! revisions ) {
@@ -527,6 +532,28 @@ export const getPreviousRevision = createRegistrySelector(
 		// The previous (older) revision is the next index in desc order.
 		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
 			return revisions[ currentIndex + 1 ];
+		}
+
+		// At page boundary: fetch the first revision from the next page
+		// (older revisions). The next page in desc order is page + 1.
+		const totalRevisions = getCurrentPostRevisionsCount( state );
+		const totalPages = Math.ceil( totalRevisions / 100 ) || 1;
+		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
+			const nextPageRevisions = select( coreStore ).getRevisions(
+				'postType',
+				postType,
+				postId,
+				{
+					per_page: 100,
+					page: page + 1,
+					context: 'edit',
+					orderby: 'date',
+					order: 'desc',
+					_fields: fields,
+				}
+			);
+			// Return the first (newest) revision from the next page.
+			return nextPageRevisions?.[ 0 ] ?? null;
 		}
 
 		return null;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -347,6 +347,16 @@ export function getCanvasMinHeight( state ) {
 }
 
 /**
+ * Returns the current revisions page number.
+ *
+ * @param {Object} state Global application state.
+ * @return {number|null} The page number, or null if not set.
+ */
+export function getRevisionPage( state ) {
+	return state.revisionPage;
+}
+
+/**
  * Returns whether the editor is in revisions preview mode.
  *
  * @param {Object} state Global application state.
@@ -378,14 +388,16 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
+ * Uses getRevision (singular) to look up from the cache populated by
+ * the paginated getRevisions call in the slider.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
  */
 export const getCurrentRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const revisionId = getCurrentRevisionId( state );
-		if ( ! revisionId ) {
+		const currentRevId = getCurrentRevisionId( state );
+		if ( ! currentRevId ) {
 			return undefined;
 		}
 
@@ -395,41 +407,36 @@ export const getCurrentRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		// - Use getRevisions (plural) instead of getRevision (singular) to
-		//   avoid a race condition where both API calls complete around the
-		//   same time and the single revision fetch overwrites the list in the
-		//   store.
-		// - getRevision also needs to be updated to check if there's any
-		//   received revisions from the collection API call to avoid unnecessary
-		//   API calls.
-		const revisions = select( coreStore ).getRevisions(
+		const fields = [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join();
+
+		// Use getRevision (singular) which reads from the cache populated
+		// by the paginated getRevisions call. The plural resolver marks
+		// individual getRevision resolutions as done, so this won't
+		// trigger a new API call.
+		const revision = select( coreStore ).getRevision(
 			'postType',
 			postType,
 			postId,
+			currentRevId,
 			{
-				per_page: -1,
 				context: 'edit',
-				_fields: [
-					...new Set( [
-						'id',
-						'date',
-						'modified',
-						'author',
-						'meta',
-						'title.raw',
-						'excerpt.raw',
-						'content.raw',
-						revisionKey,
-					] ),
-				].join(),
+				_fields: fields,
 			}
 		);
-		if ( ! revisions ) {
-			return null;
-		}
-		return (
-			revisions.find( ( r ) => r[ revisionKey ] === revisionId ) ?? null
-		);
+
+		return revision ?? null;
 	}
 );
 
@@ -457,16 +464,23 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions.
+ * Used for diffing between revisions. Uses the paginated revisions
+ * from the current page. At page boundaries (first revision on a page),
+ * returns null since the previous revision is on another page.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
  */
 export const getPreviousRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevisionId = getCurrentRevisionId( state );
-		if ( ! currentRevisionId ) {
+		const currentRevId = getCurrentRevisionId( state );
+		if ( ! currentRevId ) {
 			return undefined;
+		}
+
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
 		}
 
 		const { type: postType, id: postId } = getCurrentPost( state );
@@ -475,15 +489,17 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
 			{
-				per_page: -1,
+				per_page: 100,
+				page,
 				context: 'edit',
 				orderby: 'date',
-				order: 'asc',
+				order: 'desc',
 				_fields: [
 					...new Set( [
 						'id',
@@ -503,14 +519,14 @@ export const getPreviousRevision = createRegistrySelector(
 			return null;
 		}
 
-		// Find current revision index.
+		// Find current revision index. The array is newest-first (desc).
 		const currentIndex = revisions.findIndex(
-			( r ) => r[ revisionKey ] === currentRevisionId
+			( r ) => r[ revisionKey ] === currentRevId
 		);
 
-		// Return the previous revision (older one) if it exists.
-		if ( currentIndex > 0 ) {
-			return revisions[ currentIndex - 1 ];
+		// The previous (older) revision is the next index in desc order.
+		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
+			return revisions[ currentIndex + 1 ];
 		}
 
 		return null;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -367,7 +367,7 @@ export function getRevisionPage( state ) {
  * @param {number} page        The 1-based page number (page 1 = newest).
  * @return {Object} Query object for getRevisions.
  */
-function buildRevisionsPageQuery( revisionKey, page ) {
+export function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
 		per_page: 100,
 		page,

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -360,12 +360,8 @@ export function getRevisionPage( state ) {
 	return state.revisionPage;
 }
 
-const REVISIONS_PER_PAGE = 100;
-
 /**
  * Builds the query object for fetching a page of revisions.
- * Shared by getPageRevisions, getCurrentRevision, and getPreviousRevision
- * so they all hit the same cache key.
  *
  * @param {string} revisionKey The entity's revision key.
  * @param {number} page        The 1-based page number (page 1 = newest).
@@ -373,7 +369,7 @@ const REVISIONS_PER_PAGE = 100;
  */
 function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
-		per_page: REVISIONS_PER_PAGE,
+		per_page: 100,
 		page,
 		context: 'edit',
 		orderby: 'date',
@@ -395,13 +391,11 @@ function buildRevisionsPageQuery( revisionKey, page ) {
 }
 
 /**
- * Returns revisions for the given page number. Centralises the
- * paginated query so the slider, getCurrentRevision, and
- * getPreviousRevision all share the same cache key.
+ * Returns revisions and pagination info for the given page number.
  *
  * @param {Object} state Global application state.
  * @param {number} page  The 1-based page number (page 1 = newest).
- * @return {Array|null} The revisions array, or null if not yet loaded.
+ * @return {Object|null} Object with `revisions` and `perPage`, or null if not yet loaded.
  */
 export const getPageRevisions = createRegistrySelector(
 	( select ) => ( state, page ) => {
@@ -419,13 +413,19 @@ export const getPageRevisions = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-
-		return select( coreStore ).getRevisions(
+		const query = buildRevisionsPageQuery( revisionKey, page );
+		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			buildRevisionsPageQuery( revisionKey, page )
+			query
 		);
+
+		if ( ! revisions ) {
+			return null;
+		}
+
+		return { revisions, perPage: query.per_page };
 	}
 );
 
@@ -461,15 +461,14 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
- * Looks up from the cache populated by the paginated getPageRevisions call.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
  */
 export const getCurrentRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevId = getCurrentRevisionId( state );
-		if ( ! currentRevId ) {
+		const revisionId = getCurrentRevisionId( state );
+		if ( ! revisionId ) {
 			return undefined;
 		}
 
@@ -493,9 +492,8 @@ export const getCurrentRevision = createRegistrySelector(
 		if ( ! revisions ) {
 			return null;
 		}
-
 		return (
-			revisions.find( ( r ) => r[ revisionKey ] === currentRevId ) ?? null
+			revisions.find( ( r ) => r[ revisionKey ] === revisionId ) ?? null
 		);
 	}
 );
@@ -524,16 +522,15 @@ export function isNoteFocused( state ) {
 
 /**
  * Returns the previous revision (the one before the current revision).
- * Used for diffing between revisions. At page boundaries, fetches the
- * adjacent page to find the previous revision.
+ * Used for diffing between revisions.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The previous revision object, null if loading or no previous revision, or undefined if not in revisions mode.
  */
 export const getPreviousRevision = createRegistrySelector(
 	( select ) => ( state ) => {
-		const currentRevId = getCurrentRevisionId( state );
-		if ( ! currentRevId ) {
+		const currentRevisionId = getCurrentRevisionId( state );
+		if ( ! currentRevisionId ) {
 			return undefined;
 		}
 
@@ -548,30 +545,30 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
+		const query = buildRevisionsPageQuery( revisionKey, page );
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			buildRevisionsPageQuery( revisionKey, page )
+			query
 		);
 		if ( ! revisions ) {
 			return null;
 		}
 
-		// Find current revision index. The array is newest-first (desc).
+		// Find current revision index.
 		const currentIndex = revisions.findIndex(
-			( r ) => r[ revisionKey ] === currentRevId
+			( r ) => r[ revisionKey ] === currentRevisionId
 		);
 
-		// The previous (older) revision is the next index in desc order.
+		// Return the previous revision (older one) if it exists.
 		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {
 			return revisions[ currentIndex + 1 ];
 		}
 
 		// At page boundary: fetch the first revision from the next page.
 		const totalRevisions = getCurrentPostRevisionsCount( state );
-		const totalPages =
-			Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
+		const totalPages = Math.ceil( totalRevisions / query.per_page ) || 1;
 		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
 			const nextPageRevisions = select( coreStore ).getRevisions(
 				'postType',

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -354,7 +354,7 @@ export function getCanvasMinHeight( state ) {
  * Returns the current revisions page number.
  *
  * @param {Object} state Global application state.
- * @return {number|null} The page number, or null if not set.
+ * @return {number} The page number.
  */
 export function getRevisionPage( state ) {
 	return state.revisionPage;
@@ -369,7 +369,7 @@ export function getRevisionPage( state ) {
  */
 export function buildRevisionsPageQuery( revisionKey, page ) {
 	return {
-		per_page: 100,
+		per_page: REVISIONS_PER_PAGE,
 		page,
 		context: 'edit',
 		orderby: 'date',
@@ -390,12 +390,18 @@ export function buildRevisionsPageQuery( revisionKey, page ) {
 	};
 }
 
+const REVISIONS_PER_PAGE = 100;
+
+export function getRevisionsPerPage() {
+	return REVISIONS_PER_PAGE;
+}
+
 /**
- * Returns revisions and pagination info for the given page number.
+ * Returns revisions for the given page number.
  *
  * @param {Object} state Global application state.
  * @param {number} page  The 1-based page number (page 1 = newest).
- * @return {Object|null} Object with `revisions` and `perPage`, or null if not yet loaded.
+ * @return {Array|null} The revisions array, or null if not yet loaded.
  */
 export const getPageRevisions = createRegistrySelector(
 	( select ) => ( state, page ) => {
@@ -413,19 +419,13 @@ export const getPageRevisions = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const query = buildRevisionsPageQuery( revisionKey, page );
-		const revisions = select( coreStore ).getRevisions(
+
+		return select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			query
+			buildRevisionsPageQuery( revisionKey, page )
 		);
-
-		if ( ! revisions ) {
-			return null;
-		}
-
-		return { revisions, perPage: query.per_page };
 	}
 );
 

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -360,6 +360,75 @@ export function getRevisionPage( state ) {
 	return state.revisionPage;
 }
 
+const REVISIONS_PER_PAGE = 100;
+
+/**
+ * Builds the query object for fetching a page of revisions.
+ * Shared by getPageRevisions, getCurrentRevision, and getPreviousRevision
+ * so they all hit the same cache key.
+ *
+ * @param {string} revisionKey The entity's revision key.
+ * @param {number} page        The 1-based page number (page 1 = newest).
+ * @return {Object} Query object for getRevisions.
+ */
+function buildRevisionsPageQuery( revisionKey, page ) {
+	return {
+		per_page: REVISIONS_PER_PAGE,
+		page,
+		context: 'edit',
+		orderby: 'date',
+		order: 'desc',
+		_fields: [
+			...new Set( [
+				'id',
+				'date',
+				'modified',
+				'author',
+				'meta',
+				'title.raw',
+				'excerpt.raw',
+				'content.raw',
+				revisionKey,
+			] ),
+		].join(),
+	};
+}
+
+/**
+ * Returns revisions for the given page number. Centralises the
+ * paginated query so the slider, getCurrentRevision, and
+ * getPreviousRevision all share the same cache key.
+ *
+ * @param {Object} state Global application state.
+ * @param {number} page  The 1-based page number (page 1 = newest).
+ * @return {Array|null} The revisions array, or null if not yet loaded.
+ */
+export const getPageRevisions = createRegistrySelector(
+	( select ) => ( state, page ) => {
+		if ( ! page ) {
+			return null;
+		}
+
+		const { type: postType, id: postId } = getCurrentPost( state );
+		if ( ! postType || ! postId ) {
+			return null;
+		}
+
+		const entityConfig = select( coreStore ).getEntityConfig(
+			'postType',
+			postType
+		);
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		return select( coreStore ).getRevisions(
+			'postType',
+			postType,
+			postId,
+			buildRevisionsPageQuery( revisionKey, page )
+		);
+	}
+);
+
 /**
  * Returns whether the editor is in revisions preview mode.
  *
@@ -392,8 +461,7 @@ export function getCurrentRevisionId( state ) {
 
 /**
  * Returns the current revision object in revisions mode.
- * Uses getRevision (singular) to look up from the cache populated by
- * the paginated getRevisions call in the slider.
+ * Looks up from the cache populated by the paginated getPageRevisions call.
  *
  * @param {Object} state Global application state.
  * @return {Object|null|undefined} The revision object, null if loading, or undefined if not in revisions mode.
@@ -405,42 +473,30 @@ export const getCurrentRevision = createRegistrySelector(
 			return undefined;
 		}
 
+		const page = getRevisionPage( state );
+		if ( ! page ) {
+			return null;
+		}
+
 		const { type: postType, id: postId } = getCurrentPost( state );
 		const entityConfig = select( coreStore ).getEntityConfig(
 			'postType',
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const fields = [
-			...new Set( [
-				'id',
-				'date',
-				'modified',
-				'author',
-				'meta',
-				'title.raw',
-				'excerpt.raw',
-				'content.raw',
-				revisionKey,
-			] ),
-		].join();
-
-		// Use getRevision (singular) which reads from the cache populated
-		// by the paginated getRevisions call. The plural resolver marks
-		// individual getRevision resolutions as done, so this won't
-		// trigger a new API call.
-		const revision = select( coreStore ).getRevision(
+		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			currentRevId,
-			{
-				context: 'edit',
-				_fields: fields,
-			}
+			buildRevisionsPageQuery( revisionKey, page )
 		);
+		if ( ! revisions ) {
+			return null;
+		}
 
-		return revision ?? null;
+		return (
+			revisions.find( ( r ) => r[ revisionKey ] === currentRevId ) ?? null
+		);
 	}
 );
 
@@ -492,33 +548,11 @@ export const getPreviousRevision = createRegistrySelector(
 			postType
 		);
 		const revisionKey = entityConfig?.revisionKey || 'id';
-		const fields = [
-			...new Set( [
-				'id',
-				'date',
-				'modified',
-				'author',
-				'meta',
-				'title.raw',
-				'excerpt.raw',
-				'content.raw',
-				revisionKey,
-			] ),
-		].join();
-
-		// Query matches the slider: desc order, page 1 = newest.
 		const revisions = select( coreStore ).getRevisions(
 			'postType',
 			postType,
 			postId,
-			{
-				per_page: 100,
-				page,
-				context: 'edit',
-				orderby: 'date',
-				order: 'desc',
-				_fields: fields,
-			}
+			buildRevisionsPageQuery( revisionKey, page )
 		);
 		if ( ! revisions ) {
 			return null;
@@ -534,25 +568,17 @@ export const getPreviousRevision = createRegistrySelector(
 			return revisions[ currentIndex + 1 ];
 		}
 
-		// At page boundary: fetch the first revision from the next page
-		// (older revisions). The next page in desc order is page + 1.
+		// At page boundary: fetch the first revision from the next page.
 		const totalRevisions = getCurrentPostRevisionsCount( state );
-		const totalPages = Math.ceil( totalRevisions / 100 ) || 1;
+		const totalPages =
+			Math.ceil( totalRevisions / REVISIONS_PER_PAGE ) || 1;
 		if ( currentIndex === revisions.length - 1 && page < totalPages ) {
 			const nextPageRevisions = select( coreStore ).getRevisions(
 				'postType',
 				postType,
 				postId,
-				{
-					per_page: 100,
-					page: page + 1,
-					context: 'edit',
-					orderby: 'date',
-					order: 'desc',
-					_fields: fields,
-				}
+				buildRevisionsPageQuery( revisionKey, page + 1 )
 			);
-			// Return the first (newest) revision from the next page.
 			return nextPageRevisions?.[ 0 ] ?? null;
 		}
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -451,11 +451,10 @@ export function revisionId( state = null, action ) {
 
 /**
  * Reducer for the current revisions page number.
- * Resets to null when exiting revisions mode.
  *
- * @param {number|null} state  Current page number.
- * @param {Object}      action Dispatched action.
- * @return {number|null} Updated state.
+ * @param {number} state  Current page number.
+ * @param {Object} action Dispatched action.
+ * @return {number} Updated state.
  */
 export function revisionPage( state = 1, action ) {
 	switch ( action.type ) {

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -450,6 +450,28 @@ export function revisionId( state = null, action ) {
 }
 
 /**
+ * Reducer for the current revisions page number.
+ * Resets to null when exiting revisions mode.
+ *
+ * @param {number|null} state  Current page number.
+ * @param {Object}      action Dispatched action.
+ * @return {number|null} Updated state.
+ */
+export function revisionPage( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_REVISION_PAGE':
+			return action.page;
+		case 'SET_CURRENT_REVISION_ID':
+			// Reset page when exiting revisions mode.
+			if ( ! action.revisionId ) {
+				return null;
+			}
+			return state;
+	}
+	return state;
+}
+
+/**
  * Reducer for whether the revision diff is shown.
  * Resets to true when entering/exiting revisions mode.
  *
@@ -506,6 +528,7 @@ export default combineReducers( {
 	showStylebook,
 	canvasMinHeight,
 	revisionId,
+	revisionPage,
 	showRevisionDiff,
 	selectedNote,
 	dataviews: dataviewsReducer,

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -457,14 +457,13 @@ export function revisionId( state = null, action ) {
  * @param {Object}      action Dispatched action.
  * @return {number|null} Updated state.
  */
-export function revisionPage( state = null, action ) {
+export function revisionPage( state = 1, action ) {
 	switch ( action.type ) {
 		case 'SET_REVISION_PAGE':
 			return action.page;
 		case 'SET_CURRENT_REVISION_ID':
-			// Reset page when exiting revisions mode.
 			if ( ! action.revisionId ) {
-				return null;
+				return 1;
 			}
 			return state;
 	}


### PR DESCRIPTION
> [!WARNING]
> Work in progress. Based on #77200 — please review that PR first.

These screenshots are from AI generated revisions so they feel a bit artificial.

<img width="1200" height="288" alt="image" src="https://github.com/user-attachments/assets/98e7abd7-52b6-427d-aa32-ff563f462a18" />
<img width="1224" height="278" alt="image" src="https://github.com/user-attachments/assets/528b5ddc-715d-428b-b55e-b6ba3d62f32b" />
<img width="1354" height="276" alt="image" src="https://github.com/user-attachments/assets/10d284cd-adea-4a72-ba35-c4c073504ddf" />


## What?

Add a flamegraph-style area chart behind the revisions slider showing additions (green) and deletions (red) per revision.

## Why?

Gives users an at-a-glance view of how much content changed across the revision history, similar to writing apps like iA Writer.

## How?

- New `RevisionDiffChart` SVG component with smooth Catmull-Rom curves
- `useRevisionDiffStats` hook diffs consecutive revisions using `diffWords` to count added/removed words
- Diffs computed lazily via `requestIdleCallback` to avoid blocking the UI
- Square root scaling so small changes remain visible alongside large ones
- 2px gap at center line so the slider track shows through
- `pointer-events: none` so the chart doesn't interfere with slider interaction

## Testing Instructions

1. Open a post with multiple revisions
2. Enter the revisions view
3. Verify the area chart appears behind the slider
4. Verify green areas (additions) extend upward and red areas (deletions) extend downward
5. Verify the slider remains fully interactive (dragging, clicking marks)
6. Verify the chart fills in progressively (lazy computation)

### Testing Instructions for Keyboard

1. Use arrow keys on the slider — chart should not interfere with keyboard navigation

## Use of AI Tools

This PR was authored with Claude Code (Claude Opus 4.6). All code was reviewed and tested manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)