### PR TITLE
Restrict featured image selection to single image

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -190,6 +190,7 @@ function PostFeaturedImage( {
 						unstableFeaturedImageFlow
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						modalClass="editor-post-featured-image__media-modal"
+						multiple={ false }
 						render={ ( { open } ) => (
 							<div className="editor-post-featured-image__container">
 								{ isMissingMedia ? (


### PR DESCRIPTION
## Summary
- Add `multiple={ false }` to the `MediaUpload` component in the featured image panel
- This prevents users from selecting multiple images in the media library modal when setting a featured image, since a post can only have one

## Context
The `MediaUpload` component for the "Set featured image" button did not explicitly disable multiple selection. While the `onDropFiles` handler already had `multiple: false`, the media library modal itself allowed multi-select, which is confusing since only the first selected image would be used.

Trac ticket: https://core.trac.wordpress.org/ticket/65053

## Test plan
- [ ] Open a post in the editor
- [ ] In the Post sidebar, click "Set featured image" (or "Replace" if one is already set)
- [ ] In the media library modal, verify you can only select a single image (not multiple)
- [ ] Confirm the selected image is correctly set as the featured image