### PR TITLE
Media Inserter: Try hacking in DataViews to see how it looks and feels

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,6 +18,8 @@ import { getBlockAndPreviewFromMedia } from './utils';
 import MobileTabNavigation from '../mobile-tab-navigation';
 import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
+import { store as blockEditorStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
 
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video', 'audio' ];
 
@@ -30,17 +33,19 @@ function MediaTab( {
 	const mediaCategories = useMediaCategories( rootClientId );
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const baseCssClass = 'block-editor-inserter__media-tabs';
+
+	const InserterMediaPanel = useSelect( ( select ) => {
+		return unlock( select( blockEditorStore ) ).getInserterMediaPanel();
+	}, [] );
+
 	const onSelectMedia = useCallback(
 		( media ) => {
 			if ( ! media?.url ) {
 				return;
 			}
-			// When the experimental DataViews media modal is enabled,
-			// we need to extract the media type from mime_type (e.g., 'image/jpeg' -> 'image')
-			const mediaType =
-				window.__experimentalDataViewsMediaModal && media.mime_type
-					? media.mime_type.split( '/' )[ 0 ]
-					: media.type;
+			const mediaType = media.mime_type
+				? media.mime_type.split( '/' )[ 0 ]
+				: media.type;
 			const [ block ] = getBlockAndPreviewFromMedia( media, mediaType );
 			onInsert( block );
 		},
@@ -54,6 +59,48 @@ function MediaTab( {
 			} ) ),
 		[ mediaCategories ]
 	);
+
+	// If the DataViews-based media panel is available, render it
+	// instead of the category tabs.
+	if ( InserterMediaPanel ) {
+		return (
+			<div className={ `${ baseCssClass }-container` }>
+				<InserterMediaPanel
+					rootClientId={ rootClientId }
+					onInsert={ onInsert }
+				/>
+				<div className="block-editor-inserter__media-library-button-container">
+					<MediaUploadCheck>
+						<MediaUpload
+							multiple={ false }
+							onSelect={ onSelectMedia }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							render={ ( { open } ) => (
+								<Button
+									__next40pxDefaultSize
+									onClick={ ( event ) => {
+										// Safari doesn't emit a focus event on button elements when
+										// clicked and we need to manually focus the button here.
+										// The reason is that core's Media Library modal explicitly triggers a
+										// focus event and therefore a `blur` event is triggered on a different
+										// element, which doesn't contain the `data-unstable-ignore-focus-outside-for-relatedtarget`
+										// attribute making the Inserter dialog to close.
+										event.target.focus();
+										open();
+									} }
+									className="block-editor-inserter__media-library-button"
+									variant="secondary"
+									data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
+								>
+									{ __( 'Open Media Library' ) }
+								</Button>
+							) }
+						/>
+					</MediaUploadCheck>
+				</div>
+			</div>
+		);
+	}
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -246,6 +246,19 @@ export function getRegisteredInserterMediaCategories( state ) {
 }
 
 /**
+ * Returns the inserter media panel component injected via settings,
+ * if available. This allows the editor package to provide a DataViews-based
+ * media panel that replaces the default category-based media tab.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Function|undefined} The inserter media panel component, or undefined.
+ */
+export function getInserterMediaPanel( state ) {
+	return state.settings.inserterMediaPanel;
+}
+
+/**
  * Returns an array containing the allowed inserter media categories.
  * It merges the registered media categories from extenders with the
  * core ones. It also takes into account the allowed `mime_types`, which

--- a/packages/editor/src/components/inserter-media-panel/index.js
+++ b/packages/editor/src/components/inserter-media-panel/index.js
@@ -1,0 +1,404 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { DataViews } from '@wordpress/dataviews';
+import { store as noticesStore } from '@wordpress/notices';
+import { createBlock, cloneBlock } from '@wordpress/blocks';
+import { mediaThumbnailField } from '@wordpress/media-fields';
+import { isBlobURL } from '@wordpress/blob';
+import { getFilename } from '@wordpress/url';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import useOpenverseResults from './use-openverse-results';
+import { unlock } from '../../lock-unlock';
+
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
+
+const LAYOUT_GRID = 'grid';
+
+const SOURCE_LIBRARY = 'library';
+const SOURCE_OPENVERSE = 'openverse';
+
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+/**
+ * Normalizes a WP attachment record into the common item shape.
+ *
+ * @param {Object} attachment WP attachment record.
+ * @return {Object} Normalized media item.
+ */
+function normalizeAttachment( attachment ) {
+	const mediaType = attachment.media_type || 'image';
+	return {
+		id: String( attachment.id ),
+		title:
+			attachment.title?.raw ||
+			attachment.title?.rendered ||
+			__( '(no title)' ),
+		thumbnailUrl:
+			attachment.media_details?.sizes?.medium?.source_url ||
+			attachment.source_url,
+		url: attachment.source_url,
+		mediaType,
+		mimeType: attachment.mime_type,
+		alt: attachment.alt_text,
+		caption: attachment.caption?.raw,
+		source: SOURCE_LIBRARY,
+		wpId: attachment.id,
+		_raw: attachment,
+	};
+}
+
+/**
+ * Creates a block from a normalized media item.
+ *
+ * @param {Object} item      Normalized media item.
+ * @param {string} mediaType The media type (image, video, audio).
+ * @return {Object} A WordPress block.
+ */
+function createMediaBlock( item, mediaType ) {
+	const attributes = {
+		id: item.wpId || undefined,
+		caption: item.caption || undefined,
+	};
+
+	if ( mediaType === 'image' ) {
+		attributes.url = item.url;
+		attributes.alt = item.alt;
+	} else if ( [ 'video', 'audio' ].includes( mediaType ) ) {
+		attributes.src = item.url;
+	}
+
+	return createBlock( `core/${ mediaType }`, attributes );
+}
+
+const DEFAULT_VIEW = {
+	type: LAYOUT_GRID,
+	fields: [],
+	showTitle: false,
+	titleField: 'title',
+	mediaField: 'media_thumbnail',
+	search: '',
+	page: 1,
+	perPage: 20,
+	filters: [],
+	layout: {
+		previewSize: 120,
+		density: 'compact',
+	},
+};
+
+const DEFAULT_LAYOUTS = {
+	[ LAYOUT_GRID ]: {
+		fields: [],
+		showTitle: false,
+		layout: {
+			previewSize: 120,
+			density: 'compact',
+		},
+	},
+};
+
+/**
+ * DataViews-based media inserter panel.
+ * Provides a unified media browsing experience with source switching
+ * (Media Library / Openverse), search, filters, and pagination.
+ *
+ * @param {Object}   props          Component props.
+ * @param {Function} props.onInsert Callback to insert a block.
+ */
+export default function InserterMediaPanel( { onInsert } ) {
+	const [ activeSource, setActiveSource ] = useState( SOURCE_LIBRARY );
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+	const { getSettings, getBlock } = useSelect( blockEditorStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const isOpenverse = activeSource === SOURCE_OPENVERSE;
+
+	// Build query args for WP library from view state.
+	const libraryQueryArgs = useMemo( () => {
+		const filters = {};
+		view.filters?.forEach( ( filter ) => {
+			if ( filter.field === 'media_type' ) {
+				filters.media_type = filter.value;
+			}
+		} );
+
+		return {
+			per_page: view.perPage || 20,
+			page: view.page || 1,
+			status: 'inherit',
+			order: view.sort?.direction || 'desc',
+			orderby: view.sort?.field || 'date',
+			search: view.search,
+			media_type: filters.media_type || undefined,
+			_embed: 'author',
+		};
+	}, [ view ] );
+
+	// WP library data.
+	const {
+		records: libraryRecords,
+		isResolving: isLibraryLoading,
+		totalItems: libraryTotalItems,
+		totalPages: libraryTotalPages,
+	} = useEntityRecordsWithPermissions(
+		'postType',
+		'attachment',
+		libraryQueryArgs,
+		{
+			enabled: ! isOpenverse,
+		}
+	);
+
+	// Openverse data.
+	const {
+		data: openverseData,
+		totalItems: openverseTotalItems,
+		totalPages: openverseTotalPages,
+		isLoading: isOpenverseLoading,
+	} = useOpenverseResults( {
+		search: view.search || '',
+		page: view.page || 1,
+		perPage: view.perPage || 20,
+		isEnabled: isOpenverse,
+	} );
+
+	// Normalize WP library records.
+	const libraryData = useMemo( () => {
+		if ( ! libraryRecords ) {
+			return [];
+		}
+		return libraryRecords.map( normalizeAttachment );
+	}, [ libraryRecords ] );
+
+	// Select active data/pagination based on source.
+	const data = isOpenverse ? openverseData : libraryData;
+	const isLoading = isOpenverse ? isOpenverseLoading : isLibraryLoading;
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: isOpenverse
+				? openverseTotalItems
+				: libraryTotalItems || 0,
+			totalPages: isOpenverse
+				? openverseTotalPages
+				: libraryTotalPages || 0,
+		} ),
+		[
+			isOpenverse,
+			openverseTotalItems,
+			openverseTotalPages,
+			libraryTotalItems,
+			libraryTotalPages,
+		]
+	);
+
+	// Field definitions for DataViews.
+	const fields = useMemo(
+		() => [
+			{
+				...mediaThumbnailField,
+				id: 'media_thumbnail',
+				enableHiding: false,
+				getValue: ( { item } ) => item.thumbnailUrl,
+				render: ( { item } ) =>
+					item.thumbnailUrl ? (
+						<img
+							src={ item.thumbnailUrl }
+							alt={ item.alt || item.title }
+							style={ {
+								width: '100%',
+								height: '100%',
+								objectFit: 'cover',
+							} }
+						/>
+					) : null,
+			},
+			{
+				id: 'title',
+				type: 'text',
+				label: __( 'Title' ),
+				getValue: ( { item } ) => item.title,
+				enableSorting: false,
+				enableHiding: false,
+			},
+			{
+				id: 'media_type',
+				type: 'text',
+				label: __( 'Type' ),
+				getValue: ( { item } ) => item.mediaType,
+				elements: [
+					{ value: 'image', label: __( 'Image' ) },
+					{ value: 'video', label: __( 'Video' ) },
+					{ value: 'audio', label: __( 'Audio' ) },
+				],
+				filterBy: {
+					operators: [ 'is' ],
+					isPrimary: ! isOpenverse,
+				},
+				enableSorting: false,
+				enableHiding: false,
+			},
+		],
+		[ isOpenverse ]
+	);
+
+	// Handle click-to-insert for a media item.
+	const handleClickItem = useCallback(
+		( item ) => {
+			if ( ! item ) {
+				return;
+			}
+
+			const mediaType = item.mediaType || 'image';
+
+			// WP library item — direct insert.
+			if ( item.source === SOURCE_LIBRARY && item.wpId ) {
+				const block = createMediaBlock( item, mediaType );
+				onInsert( block );
+				return;
+			}
+
+			// External item (Openverse) — fetch and upload.
+			const settings = getSettings();
+			const block = createMediaBlock( item, mediaType );
+
+			// If user can't upload, insert with external URL.
+			if ( ! settings.mediaUpload ) {
+				onInsert( block );
+				return;
+			}
+
+			// Clone the block once so the same clientId is used
+			// across multiple onFileChange callbacks.
+			const clonedBlock = cloneBlock( block );
+
+			window
+				.fetch( item.url )
+				.then( ( response ) => response.blob() )
+				.then( ( blob ) => {
+					const fileName = getFilename( item.url ) || 'image.jpg';
+					const file = new File( [ blob ], fileName, {
+						type: blob.type,
+					} );
+
+					settings.mediaUpload( {
+						filesList: [ file ],
+						additionalData: { caption: item.caption },
+						onFileChange( [ img ] ) {
+							if ( isBlobURL( img.url ) ) {
+								return;
+							}
+
+							if ( ! getBlock( clonedBlock.clientId ) ) {
+								onInsert( {
+									...clonedBlock,
+									attributes: {
+										...clonedBlock.attributes,
+										id: img.id,
+										url: img.url,
+									},
+								} );
+								createSuccessNotice(
+									__( 'Image uploaded and inserted.' ),
+									{
+										type: 'snackbar',
+										id: 'inserter-notice',
+									}
+								);
+							} else {
+								updateBlockAttributes( clonedBlock.clientId, {
+									...clonedBlock.attributes,
+									id: img.id,
+									url: img.url,
+								} );
+							}
+						},
+						allowedTypes: ALLOWED_MEDIA_TYPES,
+						onError( message ) {
+							createErrorNotice( message, {
+								type: 'snackbar',
+								id: 'inserter-notice',
+							} );
+						},
+					} );
+				} )
+				.catch( () => {
+					// If fetch fails (CORS), insert with external URL.
+					onInsert( block );
+					createSuccessNotice( __( 'Image inserted.' ), {
+						type: 'snackbar',
+						id: 'inserter-notice',
+					} );
+				} );
+		},
+		[
+			onInsert,
+			getSettings,
+			getBlock,
+			updateBlockAttributes,
+			createErrorNotice,
+			createSuccessNotice,
+		]
+	);
+
+	// Reset page when switching sources.
+	const handleSourceChange = useCallback( ( newSource ) => {
+		setActiveSource( newSource );
+		setView( ( prev ) => ( {
+			...prev,
+			page: 1,
+			search: '',
+			filters: [],
+		} ) );
+	}, [] );
+
+	return (
+		<div className="inserter-media-panel">
+			<div className="inserter-media-panel__source-switcher">
+				<button
+					className={ `inserter-media-panel__source-button ${
+						! isOpenverse
+							? 'inserter-media-panel__source-button--active'
+							: ''
+					}` }
+					onClick={ () => handleSourceChange( SOURCE_LIBRARY ) }
+				>
+					{ __( 'Media Library' ) }
+				</button>
+				<button
+					className={ `inserter-media-panel__source-button ${
+						isOpenverse
+							? 'inserter-media-panel__source-button--active'
+							: ''
+					}` }
+					onClick={ () => handleSourceChange( SOURCE_OPENVERSE ) }
+				>
+					{ __( 'Openverse' ) }
+				</button>
+			</div>
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				onClickItem={ handleClickItem }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ ( item ) => item.id }
+				searchLabel={ __( 'Search media' ) }
+			/>
+		</div>
+	);
+}

--- a/packages/editor/src/components/inserter-media-panel/style.scss
+++ b/packages/editor/src/components/inserter-media-panel/style.scss
@@ -1,0 +1,73 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/mixins" as *;
+
+// Override the parent container when the DataViews panel is present.
+// - Remove padding: DataViews manages its own internal spacing.
+// - Set height: 100% so the container fills the tabpanel instead of
+//   growing to fit content (which would cause the tabpanel to scroll
+//   as a whole instead of just the DataViews grid).
+.block-editor-inserter__media-tabs-container:has(.inserter-media-panel) {
+	padding: 0;
+	height: 100%;
+	overflow: hidden;
+}
+
+.inserter-media-panel {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0; // Allow flex child to shrink for proper overflow.
+}
+
+.inserter-media-panel__source-switcher {
+	display: flex;
+	gap: $grid-unit-10;
+	padding: $grid-unit-20;
+	border-bottom: $border-width solid $gray-200;
+	flex-shrink: 0;
+}
+
+.inserter-media-panel__source-button {
+	flex: 1;
+	padding: $grid-unit-10 $grid-unit-15;
+	border: $border-width solid $gray-300;
+	border-radius: $radius-small;
+	background: $white;
+	cursor: pointer;
+	font-size: $default-font-size;
+	color: $gray-700;
+	transition: background-color 0.1s ease, border-color 0.1s ease;
+
+	&:hover {
+		background: $gray-100;
+	}
+
+	&--active {
+		background: var(--wp-admin-theme-color, #3858e9);
+		color: $white;
+		border-color: var(--wp-admin-theme-color, #3858e9);
+
+		&:hover {
+			background: var(--wp-admin-theme-color-darker-10, #2145e6);
+		}
+	}
+}
+
+// Let the DataViews wrapper scroll so that the sticky footer works.
+.inserter-media-panel .dataviews-wrapper {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+// Give the "Open Media Library" button the same padding as the source switcher.
+.inserter-media-panel + .block-editor-inserter__media-library-button-container {
+	padding: 0 $grid-unit-20 $grid-unit-20;
+	flex-shrink: 0;
+
+	// Remove the button's default margin-top since the container padding handles spacing.
+	.block-editor-inserter__media-library-button.components-button {
+		margin-top: 0;
+	}
+}

--- a/packages/editor/src/components/inserter-media-panel/use-openverse-results.js
+++ b/packages/editor/src/components/inserter-media-panel/use-openverse-results.js
@@ -1,0 +1,221 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useRef, useMemo } from '@wordpress/element';
+import { __, sprintf, _x } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+
+const getExternalLink = ( url, text ) =>
+	`<a ${ getExternalLinkAttributes( url ) }>${ text }</a>`;
+
+const getExternalLinkAttributes = ( url ) =>
+	`href="${ url }" target="_blank" rel="noreferrer noopener"`;
+
+const getOpenverseLicense = ( license, licenseVersion ) => {
+	let licenseName = license.trim();
+	if ( license !== 'pdm' ) {
+		licenseName = license.toUpperCase().replace( 'SAMPLING', 'Sampling' );
+	}
+	if ( licenseVersion ) {
+		licenseName += ` ${ licenseVersion }`;
+	}
+	if ( ! [ 'pdm', 'cc0' ].includes( license ) ) {
+		licenseName = `CC ${ licenseName }`;
+	}
+	return licenseName;
+};
+
+const getOpenverseCaption = ( item ) => {
+	const {
+		title,
+		foreign_landing_url: foreignLandingUrl,
+		creator,
+		creator_url: creatorUrl,
+		license,
+		license_version: licenseVersion,
+		license_url: licenseUrl,
+	} = item;
+	const fullLicense = getOpenverseLicense( license, licenseVersion );
+	const _creator = decodeEntities( creator );
+	let _caption;
+	if ( _creator ) {
+		_caption = title
+			? sprintf(
+					// translators: %1s: Title of a media work from Openverse; %2$s: Name of the work's creator; %3s: Work's licence e.g: "CC0 1.0".
+					_x( '"%1$s" by %2$s/ %3$s', 'caption' ),
+					getExternalLink(
+						foreignLandingUrl,
+						decodeEntities( title )
+					),
+					creatorUrl
+						? getExternalLink( creatorUrl, _creator )
+						: _creator,
+					licenseUrl
+						? getExternalLink(
+								`${ licenseUrl }?ref=openverse`,
+								fullLicense
+						  )
+						: fullLicense
+			  )
+			: sprintf(
+					// translators: %1s: Link attributes for a given Openverse media work; %2s: Name of the work's creator; %3s: Works's licence e.g: "CC0 1.0".
+					_x( '<a %1$s>Work</a> by %2$s/ %3$s', 'caption' ),
+					getExternalLinkAttributes( foreignLandingUrl ),
+					creatorUrl
+						? getExternalLink( creatorUrl, _creator )
+						: _creator,
+					licenseUrl
+						? getExternalLink(
+								`${ licenseUrl }?ref=openverse`,
+								fullLicense
+						  )
+						: fullLicense
+			  );
+	} else {
+		_caption = title
+			? sprintf(
+					// translators: %1s: Title of a media work from Openverse; %2s: Work's licence e.g: "CC0 1.0".
+					_x( '"%1$s"/ %2$s', 'caption' ),
+					getExternalLink(
+						foreignLandingUrl,
+						decodeEntities( title )
+					),
+					licenseUrl
+						? getExternalLink(
+								`${ licenseUrl }?ref=openverse`,
+								fullLicense
+						  )
+						: fullLicense
+			  )
+			: sprintf(
+					// translators: %1s: Link attributes for a given Openverse media work; %2s: Works's licence e.g: "CC0 1.0".
+					_x( '<a %1$s>Work</a>/ %2$s', 'caption' ),
+					getExternalLinkAttributes( foreignLandingUrl ),
+					licenseUrl
+						? getExternalLink(
+								`${ licenseUrl }?ref=openverse`,
+								fullLicense
+						  )
+						: fullLicense
+			  );
+	}
+	return _caption.replace( /\s{2}/g, ' ' );
+};
+
+/**
+ * Normalizes an Openverse API result into the common item shape
+ * used by the DataViews-based inserter media panel.
+ *
+ * @param {Object} result Raw Openverse API result.
+ * @return {Object} Normalized media item.
+ */
+function normalizeOpenverseResult( result ) {
+	const title = result.title?.toLowerCase().startsWith( 'file:' )
+		? result.title.slice( 5 )
+		: result.title;
+
+	return {
+		id: `openverse-${ result.id }`,
+		title: title || __( '(no title)' ),
+		thumbnailUrl: result.thumbnail,
+		url: result.url,
+		mediaType: 'image',
+		alt: title,
+		caption: getOpenverseCaption( result ),
+		source: 'openverse',
+		sourceId: result.id,
+		isExternalResource: true,
+		reportUrl: `https://wordpress.org/openverse/image/${ result.id }/report/`,
+		_raw: result,
+	};
+}
+
+const OPENVERSE_DEFAULT_ARGS = {
+	mature: false,
+	excluded_source: 'flickr,inaturalist,wikimedia',
+	license: 'pdm,cc0',
+};
+
+/**
+ * Hook that fetches Openverse results and returns them in a
+ * DataViews-compatible format with pagination info.
+ *
+ * @param {Object}  options           Query options.
+ * @param {string}  options.search    Search term.
+ * @param {number}  options.page      Current page (1-indexed).
+ * @param {number}  options.perPage   Items per page.
+ * @param {boolean} options.isEnabled Whether to fetch results.
+ * @return {Object} DataViews-compatible result with data, totalItems, totalPages, isLoading.
+ */
+export default function useOpenverseResults( {
+	search = '',
+	page = 1,
+	perPage = 20,
+	isEnabled = true,
+} ) {
+	const [ data, setData ] = useState( [] );
+	const [ totalItems, setTotalItems ] = useState( 0 );
+	const [ totalPages, setTotalPages ] = useState( 0 );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const lastRequestRef = useRef( 0 );
+
+	useEffect( () => {
+		if ( ! isEnabled ) {
+			setData( [] );
+			setTotalItems( 0 );
+			setTotalPages( 0 );
+			return;
+		}
+
+		const requestId = ++lastRequestRef.current;
+		setIsLoading( true );
+
+		const url = new URL( 'https://api.openverse.org/v1/images/' );
+		const queryParams = {
+			...OPENVERSE_DEFAULT_ARGS,
+			q: search,
+			page_size: perPage,
+			page,
+		};
+
+		Object.entries( queryParams ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== '' ) {
+				url.searchParams.set( key, value );
+			}
+		} );
+
+		window
+			.fetch( url, {
+				headers: {
+					'User-Agent': 'WordPress/inserter-media-fetch',
+				},
+			} )
+			.then( ( response ) => response.json() )
+			.then( ( jsonResponse ) => {
+				if ( requestId !== lastRequestRef.current ) {
+					return;
+				}
+				const results = ( jsonResponse.results || [] ).map(
+					normalizeOpenverseResult
+				);
+				setData( results );
+				setTotalItems( jsonResponse.result_count || 0 );
+				setTotalPages( jsonResponse.page_count || 0 );
+				setIsLoading( false );
+			} )
+			.catch( () => {
+				if ( requestId !== lastRequestRef.current ) {
+					return;
+				}
+				setData( [] );
+				setTotalItems( 0 );
+				setTotalPages( 0 );
+				setIsLoading( false );
+			} );
+	}, [ search, page, perPage, isEnabled ] );
+
+	return useMemo(
+		() => ( { data, totalItems, totalPages, isLoading } ),
+		[ data, totalItems, totalPages, isLoading ]
+	);
+}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -22,6 +22,7 @@ import {
  * Internal dependencies
  */
 import inserterMediaCategories from '../media-categories';
+import InserterMediaPanel from '../inserter-media-panel';
 import { mediaUpload } from '../../utils';
 import mediaUploadOnSuccess from '../../utils/media-upload/on-success';
 import { default as mediaSideload } from '../../utils/media-sideload';
@@ -360,6 +361,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
+			inserterMediaPanel: InserterMediaPanel,
 			__experimentalFetchRichUrlData: fetchUrlData,
 			// Todo: This only checks the top level post, not the post within a template or any other entity that can be edited.
 			// This might be better as a generic "canUser" selector.

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -20,6 +20,7 @@
 @use "./components/global-styles/style.scss" as *;
 @use "./components/global-styles-sidebar/style.scss" as *;
 @use "./components/header/style.scss" as *;
+@use "./components/inserter-media-panel/style.scss" as *;
 @use "./components/inserter-sidebar/style.scss" as *;
 @use "./components/keyboard-shortcut-help-modal/style.scss" as *;
 @use "./components/list-view-sidebar/style.scss" as *;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Inspired by ideas and thoughts in:

* https://github.com/WordPress/gutenberg/issues/76955

> [!NOTE]
> This is a vibe-coded prototype, please ignore the code for now. It's just to try out a UI idea.
> If the idea has merit, then it would likely need to be revisited in a more careful way
> 🚧 🚧 🚧 

Try hacking in DataViews into the media inserter in the left-hand panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Right now, the left-hand panel shows a list of categories to choose from, which isn't very useful and takes up a lot of room. While it allows for some extensibility, it just adds an extra click before anyone can get to their media. They either have to use an awkward flyout or open the media library proper.

This PR is trying out the idea of jamming DataViews in the Grid layout in the inserter sidebar and seeing how it fares.

While it could be a bit noisy, the thing to explore here is whether offering more immediate access to the media library in this way makes it easy to add media quickly.

## How?

* Add some new components for this in the editor package, and pipe it through to the block editor
* Note: the code is _very_ messy and entirely vibe-coded, let's ignore the "how" for now, this PR is really more about trying out the what

## Testing Instructions

Open up the inserter and click the Media tab. With this PR applied, you'll get an immediate view of media in your media library. It should also (kinda) support browsing through the Openverse media, too.

If we were to pursue this properly, we'd need to make sure this works with any additional categories folks might be integrating with / ensure back-compat, etc, etc. But for now, just get a sense of: how does this feel? Is this a direction we want to pursue?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5c7852a4-0930-4269-9ff6-62e8af0f2eb5

## Use of AI Tools

Nearly entirely created with Claude Code (Opus 4.6). This is a vibe-coded prototype.
