### PR TITLE
Upload external media: Ensure notice only fires once

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -535,6 +535,7 @@ export default function Image( {
 		if ( ! mediaUpload ) {
 			return;
 		}
+		let notified = false;
 		mediaUpload( {
 			filesList: [ externalBlob ],
 			onFileChange( [ img ] ) {
@@ -544,10 +545,15 @@ export default function Image( {
 					return;
 				}
 
-				setExternalBlob();
-				createSuccessNotice( __( 'Image uploaded.' ), {
-					type: 'snackbar',
-				} );
+				// With client-side media processing, onFileChange fires
+				// for each generated sub-size. Only show the notice once.
+				if ( ! notified ) {
+					notified = true;
+					setExternalBlob();
+					createSuccessNotice( __( 'Image uploaded.' ), {
+						type: 'snackbar',
+					} );
+				}
 			},
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			onError( message ) {


### PR DESCRIPTION
## What?

Ensure "Image uploaded" notice, fired by the "Upload to Media Library" toolbar button, only fires once.

## Why?

Found while testing #77178. With client-side media processing active (i.e. running GB locally with Chrome browser), the notice fires too many times (i.e. once when each sub-size image is generated), whereas we want it to only fire once.

## How?

Add a variable within the `uploadExternal` function to track whether we've fired the notice yet.

This is a fairly simple and naive fix. Another way to do it would be to add an `onSuccess` handler for the client-side media uploading path, and in `onFileChange` add a check to see if client-side media handling is active, and if not fire in there instead. IMO that would be a little more complex than this change, which is a little tidier.

## Testing Instructions

In a local environment (i.e. not Playground) where client-side media processing is active, add the following in the code view of a post. It's an externally linked image that will give you access to the "Upload to Media Library" button:

```html
<!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://picsum.photos/id/237/800/600" alt=""/></figure>
<!-- /wp:image -->
```

Switch back to the visual view and click the "Upload to Media Library" button:

<img width="691" height="141" alt="image" src="https://github.com/user-attachments/assets/f52047b1-0a51-46eb-aba0-6bf92a65c3ca" />

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1778" height="1450" alt="image" src="https://github.com/user-attachments/assets/5e7847b3-2648-43ab-bef8-03c51050bfc2" />

### After

https://github.com/user-attachments/assets/109f17e1-9ec4-49a0-b4ba-a2c816c5b666

## Use of AI Tools

Claude Code (Opus 4.6)