### PR TITLE
Search Block: Ensure color settings apply to input field when button is disabled

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -42,10 +42,6 @@
 		"query": {
 			"type": "object",
 			"default": {}
-		},
-		"isSearchFieldHidden": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -42,6 +42,10 @@
 		"query": {
 			"type": "object",
 			"default": {}
+		},
+		"isSearchFieldHidden": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {
@@ -90,7 +94,7 @@
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search",
 	"selectors": {
-		"color": ".wp-block-search .wp-block-search__button",
+		"color": ".wp-block-search .wp-block-search__button, .wp-block-search.wp-block-search__no-button .wp-block-search__input",
 		"border": ".wp-block-search.wp-block-search__button-outside .wp-block-search__input, .wp-block-search.wp-block-search__button-outside .wp-block-search__button, .wp-block-search.wp-block-search__no-button .wp-block-search__input, .wp-block-search.wp-block-search__button-only .wp-block-search__input, .wp-block-search.wp-block-search__button-only .wp-block-search__button, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper"
 	}
 }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -204,10 +204,12 @@ export default function SearchEdit( {
 		// If the input is inside the wrapper, the wrapper gets the border color styles/classes, not the input control.
 		const textFieldClasses = clsx(
 			'wp-block-search__input',
+			hasNoButton ? colorProps.className : undefined,
 			isButtonPositionInside ? undefined : borderProps.className,
 			typographyProps.className
 		);
 		const textFieldStyles = {
+			...( hasNoButton ? colorProps.style : {} ),
 			...( isButtonPositionInside
 				? {
 						borderRadius: borderProps.style?.borderRadius,

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -75,7 +75,7 @@ function render_block_core_search( $attributes ) {
 	if ( $input->next_tag() ) {
 		$input->add_class( implode( ' ', $input_classes ) );
 		$input->set_attribute( 'id', $input_id );
-		$input->set_attribute( 'value', get_search_query() );
+		$input->set_attribute( 'value', get_search_query( false ) );
 		$input->set_attribute( 'placeholder', $attributes['placeholder'] );
 
 		// If it's interactive, enqueue the script module and add the directives.

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -69,10 +69,13 @@ function render_block_core_search( $attributes ) {
 	if ( ! empty( $typography_classes ) ) {
 		$input_classes[] = $typography_classes;
 	}
+	if ( ! $show_button && ! empty( $color_classes ) ) {
+		$input_classes[] = $color_classes;
+	}
 	if ( $input->next_tag() ) {
 		$input->add_class( implode( ' ', $input_classes ) );
 		$input->set_attribute( 'id', $input_id );
-		$input->set_attribute( 'value', get_search_query( false ) );
+		$input->set_attribute( 'value', get_search_query() );
 		$input->set_attribute( 'placeholder', $attributes['placeholder'] );
 
 		// If it's interactive, enqueue the script module and add the directives.
@@ -430,20 +433,37 @@ function styles_for_block_core_search( $attributes ) {
 		}
 	}
 
+	$use_input_for_colors = ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'];
+
 	// Add color styles.
 	$has_text_color = ! empty( $attributes['style']['color']['text'] );
 	if ( $has_text_color ) {
-		$button_styles[] = sprintf( 'color: %s;', $attributes['style']['color']['text'] );
+		$text_color_style = sprintf( 'color: %s;', $attributes['style']['color']['text'] );
+		if ( $use_input_for_colors ) {
+			$input_styles[] = $text_color_style;
+		} else {
+			$button_styles[] = $text_color_style;
+		}
 	}
 
 	$has_background_color = ! empty( $attributes['style']['color']['background'] );
 	if ( $has_background_color ) {
-		$button_styles[] = sprintf( 'background-color: %s;', $attributes['style']['color']['background'] );
+		$background_color_style = sprintf( 'background-color: %s;', $attributes['style']['color']['background'] );
+		if ( $use_input_for_colors ) {
+			$input_styles[] = $background_color_style;
+		} else {
+			$button_styles[] = $background_color_style;
+		}
 	}
 
 	$has_custom_gradient = ! empty( $attributes['style']['color']['gradient'] );
 	if ( $has_custom_gradient ) {
-		$button_styles[] = sprintf( 'background: %s;', $attributes['style']['color']['gradient'] );
+		$custom_gradient_style = sprintf( 'background: %s;', $attributes['style']['color']['gradient'] );
+		if ( $use_input_for_colors ) {
+			$input_styles[] = $custom_gradient_style;
+		} else {
+			$button_styles[] = $custom_gradient_style;
+		}
 	}
 
 	// Get typography styles to be shared across inner elements.


### PR DESCRIPTION
## What?
Closes #62715 

This PR updates the coloring logic for the Search block so that background and text colors correctly apply to the input field when the block is configured *without* a search button.

## Why?

When a user changed the background or text color in the Search block, the styles only applied to the search button. If the user configured the block to hide the button (using the "no-button" state), the color settings had no visual effect because they were not cascaded down to the input field. This enhancement satisfies user expectations by ensuring custom colors gracefully fallback to styling the input field when the primary button component is absent.

## How?

1. **Global Styles (`block.json`):** Updated `selectors.color` to target both the button (`.wp-block-search__button`) *and* the input field when the wrapper explicitly defines the no-button state (`.wp-block-search.wp-block-search__no-button .wp-block-search__input`). 
2. **Local Styles (`index.php`):** Added a conditional check (`$use_input_for_colors`) to determine if the block is configured as `no-button`. If so, inline color and background-color styles are redirected to `$input_styles` instead of `$button_styles`.
3. **HTML Generation (`index.php`):** Updated the rendering logic so that if the button is missing (`! $show_button`), the generated `$color_classes` (like `has-text-color` and `has-background`) are correctly appended to the `<input>` element's class array.
4. **Editor Rendering (`edit.js`):** Pushed down `colorProps.className` and `colorProps.style` directly into `textFieldClasses` and `textFieldStyles` dynamically when `hasNoButton` is true, ensuring 1:1 visual parity within the canvas editor when configured from Inspector Controls.

## Testing Instructions

1. Open a post or template in the Site Editor.
2. Insert a **Search** block.
3. In the block inspector toolbar, toggle the "Button position" to **No button**.
4. Still in the block settings, change the **Text**, **Background**, and **Gradient** colors.
5. Verify that the selected colors apply directly to the input field.
6. Toggle the "Button position" back to **Button outside** or **Button inside**.
7. Verify the color selections shift seamlessly over to the submit button while the input returns to its standard uncolored state.
8. Perform these same tests using the **Styles** panel (Global Styles) applied to the `core/search` block to confirm the `theme.json` engine routes the CSS accurately.

## Screenshots or screencast

### Before the fix

https://github.com/user-attachments/assets/b62987be-4a21-4a8d-b48b-7ade31f96b48

### After the fix

https://github.com/user-attachments/assets/09a1eecd-b100-4c4f-825d-8c06e116c9d8

|Before|After|
|-|-|
|<img width="674" height="185" alt="Screenshot 2026-04-10 at 11 37 19 AM" src="https://github.com/user-attachments/assets/71b84731-5d03-4edc-860c-be7ef0dc2616" />|<img width="658" height="171" alt="Screenshot 2026-04-10 at 11 38 15 AM" src="https://github.com/user-attachments/assets/80ef98eb-664a-40ad-a164-781d14d5d069" />|

## Use of AI Tools

Used AI assistance for logic evaluation for block state dependencies, and drafting PR text. All generated changes were reviewed and logically validated.