### PR TITLE
Make “Time to read” opt-in for custom post types

### DIFF
--- a/packages/editor/src/components/post-content-information/index.js
+++ b/packages/editor/src/components/post-content-information/index.js
@@ -42,15 +42,13 @@ export default function PostContentInformation() {
 				postType
 			);
 
+		if ( postType === 'post' || postType === 'page' ) {
+			return showPostContentInfo && getEditedPostAttribute( 'content' );
+		}
 		const type = postType ? getPostType( postType ) : null;
 		const supportsTimeToRead = type?.supports?.[ 'time-to-read' ];
 
-		const isSupported =
-			postType === 'post' ||
-			postType === 'page' ||
-			supportsTimeToRead === true;
-
-		return showPostContentInfo && isSupported
+		return showPostContentInfo && supportsTimeToRead
 			? getEditedPostAttribute( 'content' )
 			: null;
 	}, [] );

--- a/packages/editor/src/components/post-content-information/index.js
+++ b/packages/editor/src/components/post-content-information/index.js
@@ -26,7 +26,7 @@ export default function PostContentInformation() {
 		const { getEditedPostAttribute, getCurrentPostType, getCurrentPostId } =
 			select( editorStore );
 		const { canUser } = select( coreStore );
-		const { getEntityRecord } = select( coreStore );
+		const { getEntityRecord, getPostType } = select( coreStore );
 		const siteSettings = canUser( 'read', {
 			kind: 'root',
 			name: 'site',
@@ -41,8 +41,24 @@ export default function PostContentInformation() {
 			! [ TEMPLATE_POST_TYPE, TEMPLATE_PART_POST_TYPE ].includes(
 				postType
 			);
-		return showPostContentInfo && getEditedPostAttribute( 'content' );
+
+		const type = postType ? getPostType( postType ) : null;
+		const supportsTimeToRead = type?.supports?.[ 'time-to-read' ];
+
+		const isSupported =
+			postType === 'post' ||
+			postType === 'page' ||
+			supportsTimeToRead === true;
+
+		return showPostContentInfo && isSupported
+			? getEditedPostAttribute( 'content' )
+			: null;
 	}, [] );
+
+	if ( ! postContent ) {
+		return null;
+	}
+
 	return <PostContentInformationUI postContent={ postContent } />;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77220

This PR updates the “Time to read” functionality to be opt-in for custom post types (CPTs).
Introduces support for a new post type flag: 'time-to-read'
Displays “Time to read” only when the current post type explicitly supports it
Ensures backward compatibility by enabling support for the default post types

<!-- In a few words, what is the PR actually doing? -->

## Why?
The “Time to read” information does not always make sense for many custom post types, such as:

- Listings
- Products
- Events
- Metadata-driven content

## How?

1. Updated editor logic in `PostContentInformation` to conditionally render based on post type support.
2. Enabled default support for the `post` & `page` post type to preserve existing behavior.

CPTs must explicitly opt-in via:
`add_post_type_support( 'your_cpt', 'time-to-read' );`

## Testing Instructions
### Default behavior (Post)

1. Open the editor and create a new Post.
2. Add some content (a few paragraphs).
3. Observe the “Time to read” information in the Post Content Information panel.
4. Confirm that it is visible and displays correct values.

### Custom Post Type without support

1. Register a custom post type without `'time-to-read'` support.
2. Open the editor and create a new “CPT” post.
3. Add some content.
4. Observe the Post Content Information panel.
5. Confirm that the “Time to read” information is NOT displayed.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Post|CPT|
|-|-|
| <img width="552" height="334" alt="image" src="https://github.com/user-attachments/assets/6f0f6f12-6faa-4de1-8d64-a0f0600ab022" /> | <img width="550" height="274" alt="image" src="https://github.com/user-attachments/assets/e07691be-6c8a-40fa-b1e4-48233b13ed7b" /> |