### PR TITLE
Document WP 6.7 block editor save hooks

### DIFF
--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -202,10 +202,10 @@ addFilter( 'editor.preSavePost', 'handler', async ( edits, options ) => {
 
 ### `editor.savePost`
 
-This async action is run after the post is saved and lets you perform additional work after the save. For example, the Gutenberg post editor itself uses this action to save legacy metaboxes for the post. This action receives one argument, the `options` object, the same one as the `editor.preSavePost` action also receives.
+This async action is run after the post is saved and lets you perform additional work after the save. For example, the Gutenberg post editor itself uses this action to save legacy metaboxes for the post. This action receives one additional argument, the `options` object, the same one as the `editor.preSavePost` action also receives.
 
 ```js
-addAction( 'editor.savePost', 'handler', async ( options ) => {
+addAction( 'editor.savePost', 'handler', async ( post, options ) => {
 	if ( options.isPreview ) {
 		// Do something for previews only.
 	}

--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -185,6 +185,33 @@ addFilter(
 );
 ```
 
+### `editor.preSavePost`
+
+This async filter can modify the post edits. The filter can also abort the save, e.g., when some custom validation fails, by throwing an error or returning a rejected promise. It receives two arguments:
+- `edits` is an object that contains the id of the saved post and the modified attributes. This is the modified object that will be sent to the server as the payload of the save POST request. 
+- `options` is a read-only second argument that contains an `isAutosave` (boolean) field that lets the filter distinguish between regular saves and autosaves, and also an `isPreview` field that indicated whether the saved post is a draft intended to be previewed.
+
+```js
+addFilter( 'editor.preSavePost', 'handler', async ( edits, options ) => {
+	if ( ! await customValidation( edits ) ) {
+		throw new Error( 'validation failed' );
+	}
+	return edits;
+} );
+```
+
+### `editor.savePost`
+
+This async action is run after the post is saved and lets you perform additional work after the save. For example, the Gutenberg post editor itself uses this action to save legacy metaboxes for the post. This action receives one argument, the `options` object, the same one as the `editor.preSavePost` action also receives.
+
+```js
+addAction( 'editor.savePost', 'handler', async ( options ) => {
+	if ( options.isPreview ) {
+		// Do something for previews only.
+	}
+} );
+```
+
 ### `media.crossOrigin`
 
 This filter is used to set or modify the `crossOrigin` attribute for foreign-origin media elements (i.e., `<audio>`, `<img>`, `<link>`, `<script>`, `<video>`). See this [article](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) for more information on the `crossOrigin` attribute, its values, and how it applies to each element.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds missing documentation for [post save editor hooks introduced in WordPress 6.7](https://make.wordpress.org/core/2024/10/20/miscellaneous-block-editor-changes-in-wordpress-6-7/#new-filters-to-customize-and-extend-behavior-of-post-save).

## Why?

Would be useful to have these hooks documented in a living document, instead of in a release blog post.

## How?

Adds documentation sections to `reference-guides/filters/editor-filters.md`, in the _Editor Filters_ section. Copied wording from [the previously linked blog](https://make.wordpress.org/core/2024/10/20/miscellaneous-block-editor-changes-in-wordpress-6-7/#new-filters-to-customize-and-extend-behavior-of-post-save), with some slight sentence structure changes to match the existing style of the documentation page.

## Testing Instructions

See the updated file `reference-guides/filters/editor-filters.md`

## Use of AI Tools

None.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
