### PR TITLE
Fix duotone filter not applying on style variation switch

### DIFF
--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1943,7 +1943,7 @@ export function generateGlobalStyles(
 		},
 		{
 			assets: svgs,
-			__unstableType: 'svg',
+			__unstableType: 'svgs',
 			isGlobalStyles: true,
 		},
 	];

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -808,6 +808,53 @@ describe( 'global styles renderer', () => {
 				':root :where(p){color:red;}'
 			);
 		} );
+
+		it( 'should output duotone SVG filters with __unstableType of svgs', () => {
+			const mockSelect = require( '@wordpress/data' ).select as jest.Mock;
+			mockSelect.mockReturnValue( {
+				getBlockStyles: () => [],
+			} );
+
+			const config = {
+				version: 3,
+				settings: {
+					color: {
+						duotone: {
+							theme: [
+								{
+									slug: 'midnight',
+									name: 'Midnight',
+									colors: [ '#263135', '#69a8a7' ],
+								},
+							],
+						},
+					},
+				},
+				styles: {},
+			};
+
+			const blockTypes = [
+				{
+					name: 'core/image',
+					selectors: {
+						root: '.wp-block-image',
+						filter: { duotone: '.wp-block-image img' },
+					},
+				},
+			];
+
+			const [ styles ] = generateGlobalStyles( config, blockTypes );
+
+			const svgStyle = styles.find(
+				( s: any ) => s.__unstableType === 'svgs'
+			);
+
+			expect( svgStyle ).toBeDefined();
+			expect( svgStyle.__unstableType ).toBe( 'svgs' );
+			expect( svgStyle.assets.join( '' ) ).toContain(
+				'wp-duotone-midnight'
+			);
+		} );
 	} );
 
 	describe( 'getBlockSelectors', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #69847
Fix duotone filter not applying when switching style variations in the Site Editor for template parts.

## Why?
When switching to a style variation that includes a duotone filter (e.g. the "Midnight" variation in Twenty Twenty-Five theme), the duotone effect was not applied to blocks inside template parts (such as the Site Logo in the header) until the page was manually refreshed.

The root cause was a type string mismatch in the global styles pipeline. In packages/global-styles-engine/src/core/render.ts, the SVG filter assets were tagged with __unstableType: 'svg', but EditorStyles in packages/block-editor/src/components/editor-styles/index.js filters for __unstableType === 'svgs' (with an s). Because of this mismatch, the globally generated duotone preset SVG filter definitions were silently dropped and never injected into the DOM, so the CSS filter: url(#wp-duotone-midnight-filter) rule had nothing to reference.

## How?
Changed __unstableType: 'svg' to __unstableType: 'svgs' in generateGlobalStyles inside packages/global-styles-engine/src/core/render.ts to match the value that EditorStyles expects.
This is a one-character fix. The SVG filters were already being correctly generated for all style variations via generateSvgFilters (including non-active variations via getThemeVariationSettingsNodes), but were never consumed by EditorStyles due to this typo.
No other code in the codebase reads __unstableType === 'svg' — confirmed by grep. All other writers of __unstableType for SVGs already use 'svgs', so this change brings render.ts in line with the rest of the codebase.

## Testing Instructions

1. Activate the Twenty Twenty-Five theme.
2. Open the Site Editor (Appearance → Editor).
3. Navigate to Header and edit it.
4. Add a Site Logo block to the header.
5. Save.
6. Open the Styles panel in Editor.
7. Click Browse styles and switch from Default to Midnight.
8. Observe that the duotone filter is now applied to the site logo immediately without requiring a page refresh.

### Testing Instructions for Keyboard
This PR does not change any UI interactions. The fix is purely in the styles pipeline. No keyboard-specific testing is required.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| Duotone filter not visible after switching to Midnight variation until page refresh | Duotone filter applied immediately upon switching to Midnight variation |
| <img width="1467" height="830" alt="image" src="https://github.com/user-attachments/assets/764e0384-e7ab-4dba-a09b-fc93031ae276" /> | <img width="1470" height="819" alt="image" src="https://github.com/user-attachments/assets/bd2c50ba-791d-44eb-8e0f-cebb0266221a" /> |

## Use of AI Tools
None
