### PR TITLE
DataViews: simplify `defaultLayouts` prop

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - DataForm: support `isDisabled` field property. [#77090](https://github.com/WordPress/gutenberg/pull/77090)
+- DataViews/DataViewsPicker: simplify `defaultLayouts` property. [#77232](https://github.com/WordPress/gutenberg/pull/77232)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -15,7 +15,7 @@ import type {
 	View,
 	Action,
 	NormalizedField,
-	SupportedLayouts,
+	NormalizedSupportedLayouts,
 	NormalizedFilter,
 } from '../../types';
 import type { SetSelection } from '../../types/private';
@@ -50,7 +50,7 @@ type DataViewsContextType< Item > = {
 	resizeObserverRef:
 		| ( ( element?: HTMLDivElement | null ) => void )
 		| React.RefObject< HTMLDivElement >;
-	defaultLayouts: SupportedLayouts;
+	defaultLayouts: NormalizedSupportedLayouts;
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -90,14 +90,10 @@ export function ViewTypeMenu() {
 										if ( 'layout' in viewWithoutLayout ) {
 											delete viewWithoutLayout.layout;
 										}
-										const layoutDefaults =
-											defaultLayouts[ e.target.value ];
 										return onChangeView( {
 											...viewWithoutLayout,
 											type: e.target.value,
-											...( layoutDefaults === true
-												? {}
-												: layoutDefaults ),
+											...defaultLayouts[ e.target.value ],
 										} as View );
 								}
 								warning( 'Invalid dataview' );

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -90,10 +90,14 @@ export function ViewTypeMenu() {
 										if ( 'layout' in viewWithoutLayout ) {
 											delete viewWithoutLayout.layout;
 										}
+										const layoutDefaults =
+											defaultLayouts[ e.target.value ];
 										return onChangeView( {
 											...viewWithoutLayout,
 											type: e.target.value,
-											...defaultLayouts[ e.target.value ],
+											...( layoutDefaults === true
+												? {}
+												: layoutDefaults ),
 										} as View );
 								}
 								warning( 'Invalid dataview' );

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -62,7 +62,7 @@ type DataViewsPickerProps< Item > = {
 		totalItems: number;
 		totalPages: number;
 	};
-	defaultLayouts: SupportedLayouts;
+	defaultLayouts?: SupportedLayouts;
 	selection: string[];
 	onChangeSelection: ( items: string[] ) => void;
 	children?: ReactNode;
@@ -77,6 +77,10 @@ type DataViewsPickerProps< Item > = {
 
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const EMPTY_ARRAY: any[] = [];
+const DEFAULT_PICKER_LAYOUTS: SupportedLayouts = {
+	pickerGrid: {},
+	pickerTable: {},
+};
 
 type DefaultUIProps = Pick<
 	DataViewsPickerProps< any >,
@@ -132,7 +136,7 @@ function DataViewsPicker< Item >( {
 	getItemId = defaultGetItemId,
 	isLoading = false,
 	paginationInfo,
-	defaultLayouts: defaultLayoutsProperty,
+	defaultLayouts: defaultLayoutsProperty = DEFAULT_PICKER_LAYOUTS,
 	selection,
 	onChangeSelection,
 	children,

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -78,8 +78,8 @@ type DataViewsPickerProps< Item > = {
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const EMPTY_ARRAY: any[] = [];
 const DEFAULT_PICKER_LAYOUTS: SupportedLayouts = {
-	pickerGrid: {},
-	pickerTable: {},
+	pickerGrid: true,
+	pickerTable: true,
 };
 
 type DefaultUIProps = Pick<
@@ -202,17 +202,20 @@ function DataViewsPicker< Item >( {
 		}
 	}, [ hasPrimaryOrLockedFilters, isShowingFilter ] );
 
-	// Filter out DataViewsPicker layouts.
+	// Filter out non-picker layouts and normalize `true` to `{}`.
 	const defaultLayouts = useMemo(
 		() =>
 			Object.fromEntries(
-				Object.entries( defaultLayoutsProperty ).filter(
-					( [ layoutType ] ) => {
+				Object.entries( defaultLayoutsProperty )
+					.filter( ( [ layoutType ] ) => {
 						return dataViewsPickerLayouts.some(
 							( viewLayout ) => viewLayout.type === layoutType
 						);
-					}
-				)
+					} )
+					.map( ( [ key, value ] ) => [
+						key,
+						value === true ? {} : value,
+					] )
 			),
 		[ defaultLayoutsProperty ]
 	);

--- a/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
@@ -14,7 +14,7 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import DataViewsPicker from '../index';
-import { LAYOUT_PICKER_GRID, LAYOUT_PICKER_TABLE } from '../../constants';
+import { LAYOUT_PICKER_GRID } from '../../constants';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
 import type { ActionButton, View } from '../../types';
 import { data, fields, type SpaceObject } from './fixtures';
@@ -187,10 +187,6 @@ const DataViewsPickerContent = ( {
 				onChangeView={ setView }
 				config={ { perPageSizes } }
 				itemListLabel="Galactic Bodies"
-				defaultLayouts={ {
-					[ LAYOUT_PICKER_GRID ]: {},
-					[ LAYOUT_PICKER_TABLE ]: {},
-				} }
 			/>
 		</>
 	);

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -107,7 +107,7 @@ function Picker( {
 		paginationInfo,
 		data: shownData,
 		view,
-		defaultLayouts: { [ LAYOUT_PICKER_GRID ]: {} },
+		defaultLayouts: { [ LAYOUT_PICKER_GRID ]: true },
 		fields: [],
 		onChangeView: setView,
 		multiselect,

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -480,4 +480,76 @@ describe( 'DataViews Picker', () => {
 			} );
 		} );
 	} );
+
+	describe( 'Default layouts', () => {
+		/**
+		 * A minimal Picker that intentionally omits the `defaultLayouts` prop so
+		 * that DataViewsPicker falls back to its internal DEFAULT_PICKER_LAYOUTS
+		 * constant ({ pickerGrid: true, pickerTable: true }).
+		 */
+		function PickerWithoutDefaultLayouts() {
+			const [ view, setView ] = useState< View >( {
+				type: LAYOUT_PICKER_GRID,
+				fields: [],
+				titleField: 'title',
+				mediaField: 'image',
+				search: '',
+				page: 1,
+				perPage: 10,
+				filters: [],
+			} satisfies ViewPickerGrid );
+
+			const [ selection, setSelection ] = useState< string[] >( [] );
+
+			const { data: shownData, paginationInfo } = useMemo( () => {
+				return filterSortAndPaginate( data, view, [] );
+			}, [ view ] );
+
+			return (
+				<DataViewsPicker
+					getItemId={ ( item: Data ) => item.id.toString() }
+					paginationInfo={ paginationInfo }
+					data={ shownData }
+					view={ view }
+					fields={ [] }
+					onChangeView={ setView }
+					selection={ selection }
+					onChangeSelection={ setSelection }
+					// No `defaultLayouts` prop falls back to DEFAULT_PICKER_LAYOUTS
+				/>
+			);
+		}
+
+		it( 'renders both picker layout options when defaultLayouts is not provided', async () => {
+			render( <PickerWithoutDefaultLayouts /> );
+
+			const user = userEvent.setup();
+
+			// Both picker layouts are available, so the Layout switcher button
+			// (rendered by ViewTypeMenu) must be present.
+			const layoutButton = screen.getByRole( 'button', {
+				name: 'Layout',
+			} );
+			expect( layoutButton ).toBeInTheDocument();
+
+			// Open the layout menu.
+			await user.click( layoutButton );
+
+			// Both "Grid" and "Table" picker layout options must appear in the menu.
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Grid' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Table' } )
+			).toBeInTheDocument();
+
+			// The grid layout is active by default.
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Grid' } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Table' } )
+			).not.toBeChecked();
+		} );
+	} );
 } );

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -14,7 +14,12 @@ import { useMemo, useState } from '@wordpress/element';
  */
 import DataViewsPicker from '../index';
 import { LAYOUT_PICKER_GRID } from '../../constants';
-import type { ActionButton, View, ViewPickerGrid } from '../../types';
+import type {
+	ActionButton,
+	SupportedLayouts,
+	View,
+	ViewPickerGrid,
+} from '../../types';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
 
 type Data = {
@@ -107,7 +112,7 @@ function Picker( {
 		paginationInfo,
 		data: shownData,
 		view,
-		defaultLayouts: { [ LAYOUT_PICKER_GRID ]: true },
+		defaultLayouts: { [ LAYOUT_PICKER_GRID ]: true } as SupportedLayouts,
 		fields: [],
 		onChangeView: setView,
 		multiselect,

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -57,7 +57,7 @@ type DataViewsProps< Item > = {
 		totalItems: number;
 		totalPages: number;
 	};
-	defaultLayouts: SupportedLayouts;
+	defaultLayouts?: SupportedLayouts;
 	selection?: string[];
 	onChangeSelection?: ( items: string[] ) => void;
 	onClickItem?: ( item: Item ) => void;
@@ -82,6 +82,7 @@ type DataViewsProps< Item > = {
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
+const DEFAULT_LAYOUTS: SupportedLayouts = { table: {}, grid: {}, list: {} };
 
 const dataViewsLayouts = VIEW_LAYOUTS.filter(
 	( viewLayout ) => ! viewLayout.isPicker
@@ -144,7 +145,7 @@ function DataViews< Item >( {
 	getItemLevel,
 	isLoading = false,
 	paginationInfo,
-	defaultLayouts: defaultLayoutsProperty,
+	defaultLayouts: defaultLayoutsProperty = DEFAULT_LAYOUTS,
 	selection: selectionProperty,
 	onChangeSelection,
 	onClickItem,

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -242,17 +242,20 @@ function DataViews< Item >( {
 		}
 	}, [ hasPrimaryOrLockedFilters, isShowingFilter ] );
 
-	// Filter out DataViewsPicker layouts.
+	// Filter out DataViewsPicker layouts and normalize `true` to `{}`.
 	const defaultLayouts = useMemo(
 		() =>
 			Object.fromEntries(
-				Object.entries( defaultLayoutsProperty ).filter(
-					( [ layoutType ] ) => {
+				Object.entries( defaultLayoutsProperty )
+					.filter( ( [ layoutType ] ) => {
 						return dataViewsLayouts.some(
 							( viewLayout ) => viewLayout.type === layoutType
 						);
-					}
-				)
+					} )
+					.map( ( [ key, value ] ) => [
+						key,
+						value === true ? {} : value,
+					] )
 			),
 		[ defaultLayoutsProperty ]
 	);

--- a/packages/dataviews/src/dataviews/stories/empty.tsx
+++ b/packages/dataviews/src/dataviews/stories/empty.tsx
@@ -79,10 +79,10 @@ const EmptyComponent = ( {
 				onChangeView={ setView }
 				actions={ actions }
 				defaultLayouts={ {
-					[ LAYOUT_TABLE ]: {},
-					[ LAYOUT_GRID ]: {},
-					[ LAYOUT_LIST ]: {},
-					[ LAYOUT_ACTIVITY ]: {},
+					[ LAYOUT_TABLE ]: true,
+					[ LAYOUT_GRID ]: true,
+					[ LAYOUT_LIST ]: true,
+					[ LAYOUT_ACTIVITY ]: true,
 				} }
 				isLoading={ isLoading }
 				empty={ customEmpty ? <CustomEmptyComponent /> : undefined }

--- a/packages/dataviews/src/dataviews/stories/free-composition.tsx
+++ b/packages/dataviews/src/dataviews/stories/free-composition.tsx
@@ -162,8 +162,8 @@ export const FreeCompositionComponent = () => {
 			actions={ actions }
 			onChangeView={ setView }
 			defaultLayouts={ {
-				table: {},
-				grid: {},
+				table: true,
+				grid: true,
 			} }
 			empty={
 				<Stack

--- a/packages/dataviews/src/dataviews/stories/infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/infinite-scroll.tsx
@@ -50,10 +50,10 @@ const InfiniteScroll = () => {
 				onChangeView={ setView }
 				actions={ actions }
 				defaultLayouts={ {
-					[ LAYOUT_TABLE ]: {},
-					[ LAYOUT_GRID ]: {},
-					[ LAYOUT_LIST ]: {},
-					[ LAYOUT_ACTIVITY ]: {},
+					[ LAYOUT_TABLE ]: true,
+					[ LAYOUT_GRID ]: true,
+					[ LAYOUT_LIST ]: true,
+					[ LAYOUT_ACTIVITY ]: true,
 				} }
 			/>
 		</>

--- a/packages/dataviews/src/dataviews/stories/layout-custom.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-custom.tsx
@@ -130,7 +130,7 @@ export const LayoutCustomComponent = ( {
 			view={ view }
 			fields={ fields }
 			onChangeView={ setView }
-			defaultLayouts={ { table: {} } }
+			defaultLayouts={ { table: true } }
 		>
 			<div style={ { padding: '2px', height: containerHeight } }>
 				<DataViews.Search />

--- a/packages/dataviews/src/dataviews/stories/layout-grid.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-grid.tsx
@@ -97,7 +97,7 @@ export const LayoutTableComponent = ( {
 				) }
 				isItemClickable={ () => hasClickableItems }
 				defaultLayouts={ {
-					[ LAYOUT_GRID ]: {},
+					[ LAYOUT_GRID ]: true,
 				} }
 				config={ { perPageSizes } }
 			/>

--- a/packages/dataviews/src/dataviews/stories/layout-list.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-list.tsx
@@ -100,7 +100,7 @@ export const LayoutTableComponent = ( {
 				) }
 				isItemClickable={ () => hasClickableItems }
 				defaultLayouts={ {
-					[ LAYOUT_LIST ]: {},
+					[ LAYOUT_LIST ]: true,
 				} }
 				config={ { perPageSizes } }
 			/>

--- a/packages/dataviews/src/dataviews/stories/layout-table.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-table.tsx
@@ -98,7 +98,7 @@ export const LayoutTableComponent = ( {
 				) }
 				isItemClickable={ () => hasClickableItems }
 				defaultLayouts={ {
-					[ LAYOUT_TABLE ]: {},
+					[ LAYOUT_TABLE ]: true,
 				} }
 				config={ { perPageSizes } }
 			/>

--- a/packages/dataviews/src/dataviews/stories/minimal-ui.tsx
+++ b/packages/dataviews/src/dataviews/stories/minimal-ui.tsx
@@ -54,7 +54,7 @@ const MinimalUIComponent = ( {
 			view={ view }
 			fields={ _fields }
 			onChangeView={ setView }
-			defaultLayouts={ { [ layout ]: {} } }
+			defaultLayouts={ { [ layout ]: true } }
 		>
 			<DataViews.Layout />
 			<DataViews.Footer />

--- a/packages/dataviews/src/dataviews/stories/with-card.tsx
+++ b/packages/dataviews/src/dataviews/stories/with-card.tsx
@@ -59,10 +59,10 @@ const WithCardComponent = ( {
 							( action ) => ! action.supportsBulk
 						) }
 						defaultLayouts={ {
-							[ LAYOUT_TABLE ]: {},
-							[ LAYOUT_GRID ]: {},
-							[ LAYOUT_LIST ]: {},
-							[ LAYOUT_ACTIVITY ]: {},
+							[ LAYOUT_TABLE ]: true,
+							[ LAYOUT_GRID ]: true,
+							[ LAYOUT_LIST ]: true,
+							[ LAYOUT_ACTIVITY ]: true,
 						} }
 					/>
 				</Card.FullBleed>

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -19,7 +19,7 @@ import {
 	LAYOUT_LIST,
 	LAYOUT_TABLE,
 } from '../../constants';
-import type { Action, View } from '../../types';
+import type { Action, SupportedLayouts, View } from '../../types';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
 
 type Data = {
@@ -38,7 +38,7 @@ const DEFAULT_VIEW = {
 	filters: [],
 };
 
-const defaultLayouts = {
+const defaultLayouts: SupportedLayouts = {
 	[ LAYOUT_TABLE ]: true,
 	[ LAYOUT_GRID ]: true,
 	[ LAYOUT_LIST ]: true,

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -737,4 +737,71 @@ describe( 'DataViews component', () => {
 			).toEqual( 3 );
 		} );
 	} );
+	describe( 'Default layouts', () => {
+		/**
+		 * A minimal wrapper that intentionally omits the `defaultLayouts` prop so
+		 * DataViews falls back to its internal DEFAULT_LAYOUTS constant
+		 * ({ table: true, grid: true, list: true }).
+		 */
+		function DataViewWrapperWithoutDefaultLayouts() {
+			const [ view, setView ] = useState< View >( {
+				...DEFAULT_VIEW,
+				fields: [ 'title', 'order', 'author' ],
+			} );
+
+			const { data: shownData, paginationInfo } = useMemo( () => {
+				return filterSortAndPaginate( data, view, fields );
+			}, [ view ] );
+
+			return (
+				<DataViews
+					getItemId={ ( item: Data ) => item.id.toString() }
+					paginationInfo={ paginationInfo }
+					data={ shownData }
+					view={ view }
+					fields={ fields }
+					onChangeView={ setView }
+					// No `defaultLayouts` prop — falls back to DEFAULT_LAYOUTS
+				/>
+			);
+		}
+
+		it( 'renders Table, Grid, and List layout options when defaultLayouts is not provided', async () => {
+			render( <DataViewWrapperWithoutDefaultLayouts /> );
+
+			const user = userEvent.setup();
+
+			// All three default layouts are available, so the Layout switcher
+			// button (rendered by ViewTypeMenu) must be present.
+			const layoutButton = screen.getByRole( 'button', {
+				name: 'Layout',
+			} );
+			expect( layoutButton ).toBeInTheDocument();
+
+			// Open the layout menu.
+			await user.click( layoutButton );
+
+			// Table, Grid, and List options must all appear.
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Table' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Grid' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'List' } )
+			).toBeInTheDocument();
+
+			// Table is the default active layout.
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Table' } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Grid' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'List' } )
+			).not.toBeChecked();
+		} );
+	} );
 } );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -39,10 +39,10 @@ const DEFAULT_VIEW = {
 };
 
 const defaultLayouts = {
-	[ LAYOUT_TABLE ]: {},
-	[ LAYOUT_GRID ]: {},
-	[ LAYOUT_LIST ]: {},
-	[ LAYOUT_ACTIVITY ]: {},
+	[ LAYOUT_TABLE ]: true,
+	[ LAYOUT_GRID ]: true,
+	[ LAYOUT_LIST ]: true,
+	[ LAYOUT_ACTIVITY ]: true,
 };
 
 const fields = [

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -715,7 +715,7 @@ const FieldTypeStory = ( {
 						},
 					] }
 					defaultLayouts={ {
-						table: {},
+						table: true,
 					} }
 					selection={ selectedIds.map( ( id ) => id.toString() ) }
 					onChangeSelection={ ( newSelection ) =>

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -527,10 +527,10 @@ export type ViewPickerProps< Item > =
 	| ViewPickerTableProps< Item >;
 
 export interface SupportedLayouts {
-	list?: Omit< ViewList, 'type' >;
-	grid?: Omit< ViewGrid, 'type' >;
-	table?: Omit< ViewTable, 'type' >;
-	activity?: Omit< ViewActivity, 'type' >;
-	pickerGrid?: Omit< ViewPickerGrid, 'type' >;
-	pickerTable?: Omit< ViewPickerTable, 'type' >;
+	list?: Omit< ViewList, 'type' > | true;
+	grid?: Omit< ViewGrid, 'type' > | true;
+	table?: Omit< ViewTable, 'type' > | true;
+	activity?: Omit< ViewActivity, 'type' > | true;
+	pickerGrid?: Omit< ViewPickerGrid, 'type' > | true;
+	pickerTable?: Omit< ViewPickerTable, 'type' > | true;
 }

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -534,3 +534,12 @@ export interface SupportedLayouts {
 	pickerGrid?: Omit< ViewPickerGrid, 'type' > | true;
 	pickerTable?: Omit< ViewPickerTable, 'type' > | true;
 }
+
+export interface NormalizedSupportedLayouts {
+	list?: Omit< ViewList, 'type' >;
+	grid?: Omit< ViewGrid, 'type' >;
+	table?: Omit< ViewTable, 'type' >;
+	activity?: Omit< ViewActivity, 'type' >;
+	pickerGrid?: Omit< ViewPickerGrid, 'type' >;
+	pickerTable?: Omit< ViewPickerTable, 'type' >;
+}

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -214,7 +214,7 @@ export default function DataviewsPatterns() {
 					} }
 					view={ view }
 					onChangeView={ updateView }
-					defaultLayouts={ defaultLayouts ?? {} }
+					defaultLayouts={ defaultLayouts }
 					onReset={ isModified ? resetToDefault : false }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -153,7 +153,7 @@ export default function PageTemplates() {
 					history.navigate( `/wp_template/${ id }?canvas=edit` );
 				} }
 				selection={ selection }
-				defaultLayouts={ defaultLayouts ?? {} }
+				defaultLayouts={ defaultLayouts }
 				onReset={
 					isModified
 						? () => {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -322,7 +322,7 @@ export default function PostList( { postType } ) {
 				} }
 				getItemId={ getItemId }
 				getItemLevel={ getItemLevel }
-				defaultLayouts={ defaultLayouts ?? {} }
+				defaultLayouts={ defaultLayouts }
 				onReset={
 					isModified
 						? () => {

--- a/packages/editor/src/components/post-revisions-panel/index.js
+++ b/packages/editor/src/components/post-revisions-panel/index.js
@@ -25,7 +25,7 @@ import { unlock } from '../../lock-unlock';
 const { Badge } = unlock( componentsPrivateApis );
 const DAY_IN_MILLISECONDS = 86400000;
 const EMPTY_ARRAY = [];
-const defaultLayouts = { activity: {} };
+const defaultLayouts = { activity: true };
 const noop = () => {};
 const paginationInfo = {};
 const view = {

--- a/packages/fields/src/stories/index.story.tsx
+++ b/packages/fields/src/stories/index.story.tsx
@@ -183,12 +183,6 @@ export const DataViewsPreview = () => {
 		totalPages: 1,
 	};
 
-	const defaultLayouts = {
-		table: {},
-		list: {},
-		grid: {},
-	};
-
 	return (
 		<div style={ { padding: '20px' } }>
 			<h2>Fields Package DataViews Preview</h2>
@@ -203,7 +197,6 @@ export const DataViewsPreview = () => {
 				view={ view }
 				onChangeView={ ( nextView: View ) => setView( nextView ) }
 				paginationInfo={ paginationInfo }
-				defaultLayouts={ defaultLayouts }
 			/>
 		</div>
 	);

--- a/packages/media-fields/src/stories/index.story.tsx
+++ b/packages/media-fields/src/stories/index.story.tsx
@@ -386,12 +386,6 @@ export const DataViewsPreview = () => {
 		totalPages: 1,
 	};
 
-	const defaultLayouts = {
-		table: {},
-		list: {},
-		grid: {},
-	};
-
 	return (
 		<div style={ { padding: '20px' } }>
 			<h2>Media Fields DataViews Preview</h2>
@@ -406,7 +400,6 @@ export const DataViewsPreview = () => {
 				view={ view }
 				onChangeView={ ( nextView: View ) => setView( nextView ) }
 				paginationInfo={ paginationInfo }
-				defaultLayouts={ defaultLayouts }
 			/>
 		</div>
 	);

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -38,14 +38,12 @@ export async function loadView( config: ViewConfig ) {
 	const page = queryParams?.page ?? 1;
 	const search = queryParams?.search ?? '';
 
-	const rawLayoutDefaults =
+	const rawDefaults =
 		config.defaultLayouts?.[
 			baseView?.type as keyof typeof config.defaultLayouts
 		];
 	const layoutTypeDefaults =
-		rawLayoutDefaults === true || rawLayoutDefaults === null
-			? {}
-			: rawLayoutDefaults;
+		! rawDefaults || rawDefaults === true ? {} : rawDefaults;
 	const combinedOverrides = { ...layoutTypeDefaults, ...activeViewOverrides };
 
 	return mergeActiveViewOverrides(

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -38,10 +38,14 @@ export async function loadView( config: ViewConfig ) {
 	const page = queryParams?.page ?? 1;
 	const search = queryParams?.search ?? '';
 
-	const layoutTypeDefaults =
+	const rawLayoutDefaults =
 		config.defaultLayouts?.[
 			baseView?.type as keyof typeof config.defaultLayouts
-		] ?? {};
+		];
+	const layoutTypeDefaults =
+		rawLayoutDefaults === true || rawLayoutDefaults === null
+			? {}
+			: rawLayoutDefaults;
 	const combinedOverrides = { ...layoutTypeDefaults, ...activeViewOverrides };
 
 	return mergeActiveViewOverrides(

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -70,15 +70,22 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	);
 	const { set } = useDispatch( preferencesStore );
 
-	const baseView: View = persistedView ?? defaultView ?? {};
+	const baseView: View = useMemo(
+		() => persistedView ?? defaultView ?? {},
+		[ persistedView, defaultView ]
+	);
 	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
 	const search = queryParams?.search ?? baseView.search ?? '';
 
 	const combinedOverrides = useMemo( () => {
-		const layoutTypeDefaults =
+		const rawLayoutDefaults =
 			config.defaultLayouts?.[
 				baseView.type as keyof typeof config.defaultLayouts
-			] ?? {};
+			];
+		const layoutTypeDefaults =
+			rawLayoutDefaults === true || rawLayoutDefaults === null
+				? {}
+				: rawLayoutDefaults;
 		return { ...layoutTypeDefaults, ...activeViewOverrides };
 	}, [ config.defaultLayouts, baseView.type, activeViewOverrides ] );
 

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -78,14 +78,12 @@ export function useView( config: ViewConfig ): UseViewReturn {
 	const search = queryParams?.search ?? baseView.search ?? '';
 
 	const combinedOverrides = useMemo( () => {
-		const rawLayoutDefaults =
+		const rawDefaults =
 			config.defaultLayouts?.[
 				baseView.type as keyof typeof config.defaultLayouts
 			];
 		const layoutTypeDefaults =
-			rawLayoutDefaults === true || rawLayoutDefaults === null
-				? {}
-				: rawLayoutDefaults;
+			! rawDefaults || rawDefaults === true ? {} : rawDefaults;
 		return { ...layoutTypeDefaults, ...activeViewOverrides };
 	}, [ config.defaultLayouts, baseView.type, activeViewOverrides ] );
 

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -220,7 +220,7 @@ export default function BlockGuidelines() {
 						handleRowClick( id );
 					} }
 					defaultLayouts={ {
-						list: {},
+						list: true,
 					} }
 				>
 					<VStack spacing={ 4 }>

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -219,7 +219,7 @@ export default function RevisionHistory() {
 				actions={ actions }
 				isLoading={ isLoading }
 				paginationInfo={ paginationToShow }
-				defaultLayouts={ { table: {} } }
+				defaultLayouts={ { table: true } }
 				getItemId={ ( item ) => String( item.id ) }
 				empty={
 					isLoading && displayedRevisions.length === 0 ? (

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -155,7 +155,7 @@ function NavigationList() {
 						totalPages,
 					} }
 					defaultLayouts={ {
-						list: {},
+						list: true,
 					} }
 					getItemId={ getItemId }
 					selection={ selection }

--- a/routes/pattern-list/view-utils.ts
+++ b/routes/pattern-list/view-utils.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import type { View } from '@wordpress/dataviews';
+import type { SupportedLayouts, View } from '@wordpress/dataviews';
 
 const LAYOUT_GRID = 'grid';
 const LAYOUT_TABLE = 'table';
@@ -41,7 +41,7 @@ export const DEFAULT_VIEWS: {
 	},
 ];
 
-export const DEFAULT_LAYOUTS = {
+export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	[ LAYOUT_TABLE ]: true,
 	[ LAYOUT_GRID ]: {
 		layout: {

--- a/routes/pattern-list/view-utils.ts
+++ b/routes/pattern-list/view-utils.ts
@@ -42,7 +42,7 @@ export const DEFAULT_VIEWS: {
 ];
 
 export const DEFAULT_LAYOUTS = {
-	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_TABLE ]: true,
 	[ LAYOUT_GRID ]: {
 		layout: {
 			badgeFields: [ 'sync-status' ],

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -5,7 +5,7 @@ import { loadView } from '@wordpress/views';
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { Type } from '@wordpress/core-data';
-import type { View, Filter } from '@wordpress/dataviews';
+import type { View, Filter, SupportedLayouts } from '@wordpress/dataviews';
 
 const DEFAULT_VIEW: View = {
 	type: 'table' as const,
@@ -19,12 +19,12 @@ const DEFAULT_VIEW: View = {
 	descriptionField: 'excerpt',
 };
 
-export const DEFAULT_LAYOUTS = {
+export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	table: {
 		layout: {
 			styles: {
 				author: {
-					align: 'start' as const,
+					align: 'start',
 				},
 			},
 		},

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -5,7 +5,12 @@ import { loadView } from '@wordpress/views';
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { Type } from '@wordpress/core-data';
-import type { View, Filter, SupportedLayouts } from '@wordpress/dataviews';
+import type {
+	View,
+	Filter,
+	SupportedLayouts,
+	ViewTable,
+} from '@wordpress/dataviews';
 
 const DEFAULT_VIEW: View = {
 	type: 'table' as const,
@@ -19,16 +24,18 @@ const DEFAULT_VIEW: View = {
 	descriptionField: 'excerpt',
 };
 
-export const DEFAULT_LAYOUTS: SupportedLayouts = {
-	table: {
-		layout: {
-			styles: {
-				author: {
-					align: 'start',
-				},
+const DEFAULT_TABLE_LAYOUT: Omit< ViewTable, 'type' > = {
+	layout: {
+		styles: {
+			author: {
+				align: 'start',
 			},
 		},
 	},
+};
+
+export const DEFAULT_LAYOUTS: SupportedLayouts = {
+	table: DEFAULT_TABLE_LAYOUT,
 	grid: true,
 	list: true,
 };
@@ -74,11 +81,11 @@ export function getActiveViewOverridesForTab(
 ): ActiveViewOverrides {
 	if ( slug === 'all' ) {
 		return {
-			...DEFAULT_LAYOUTS.table,
+			...DEFAULT_TABLE_LAYOUT,
 		};
 	}
 	return {
-		...DEFAULT_LAYOUTS.table,
+		...DEFAULT_TABLE_LAYOUT,
 		filters: [
 			{
 				field: 'status',

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -29,8 +29,8 @@ export const DEFAULT_LAYOUTS = {
 			},
 		},
 	},
-	grid: {},
-	list: {},
+	grid: true,
+	list: true,
 };
 
 export const DEFAULT_VIEWS: {

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -34,7 +34,6 @@ import {
 	DEFAULT_VIEW,
 	getActiveViewOverridesForTab,
 	DEFAULT_VIEWS,
-	DEFAULT_LAYOUTS,
 	viewToQuery,
 } from './view-utils';
 import { previewField } from './fields/preview';
@@ -298,7 +297,6 @@ function TemplatePartList() {
 					totalItems,
 					totalPages,
 				} }
-				defaultLayouts={ DEFAULT_LAYOUTS }
 				getItemId={ getItemId }
 				selection={ selection }
 				onReset={ isModified ? onReset : false }

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -22,12 +22,6 @@ export const DEFAULT_VIEW: View = {
 	mediaField: 'preview',
 };
 
-export const DEFAULT_LAYOUTS = {
-	table: {},
-	grid: {},
-	list: {},
-};
-
 export const DEFAULT_VIEWS: {
 	slug: string;
 	label: string;


### PR DESCRIPTION
## What?

Improves the `defaultLayouts` prop on `DataViews` and `DataViewsPicker`:

- Makes the prop **optional** with sensible defaults (`table`/`grid`/`list` for `DataViews`; `pickerGrid`/`pickerTable` for `DataViewsPicker`).

```tsx
<DataViews
  // Consumers don't have to provide defaultLayouts.
/>
```

- Allows **`true` as a shorthand** to enable a layout without providing configuration.

```tsx
<DataViews
  defaultLayouts={{
    table: true
  }}
```

## Why?

To improve developer experience with the current API:

1. **The prop is required** — consumers that just want the standard layouts must still pass `{ table: {}, grid: {}, list: {} }`.
3. **Enabling a layout without config requires an empty object** — writing `{ table: {} }` obscures the intent ("just enable this layout").

## How?

**Type layer:**
- `SupportedLayouts` now accepts `| true` for each layout key.
- A new `NormalizedSupportedLayouts` type (objects only, no `true`) is used for the context and all downstream consumers.

**Component layer:**
- `DataViews` and `DataViewsPicker` accept an optional `defaultLayouts` with built-in defaults.
- In addition to filtering valid layouts, they now also map `true` → `{}`, so every internarl component (`ViewTypeMenu`, `DataViewsLayout`, etc.) only sees plain objects.

**`@wordpress/views` package:**
- `useView` and `loadView` are independent entry points that receive raw `SupportedLayouts`, so they normalize `true` at their own point of use.

**Consumer cleanup:**
- Removed `?? {}` fallbacks in edit-site consumers (post-list, page-patterns, page-templates).
- Removed redundant `defaultLayouts` props where the new defaults are sufficient (fields/media-fields stories, template-part-list, picker stories).
- Updated remaining call sites to use `true` instead of `{}` where no config is needed.

## Testing Instructions

1. Open Storybook for DataViews and verify:
   - Stories using `true` shorthand render and switch layouts correctly.
   - Stories that omit `defaultLayouts` entirely (e.g. fields, media-fields previews) render with default layouts.
2. In the site editor, verify:
   - Post list, page templates, and page patterns show the correct available layouts.
   - Switching between table/grid/list works as before.
   - Post revisions panel renders the activity layout.

## Use of AI Tools

This PR was authored with assistance from Claude Code (Claude Opus 4.6). All changes were reviewed and validated by the author.
