### PR TITLE
Add overlay backdrop with click-outside-to-close and blur support.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -539,7 +539,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackdrop, overlayBackdropBlur, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -59,6 +59,14 @@
 		"overlay": {
 			"type": "string"
 		},
+		"overlayBackdrop": {
+			"type": "boolean",
+			"default": true
+		},
+		"overlayBackdropBlur": {
+			"type": "number",
+			"default": 0
+		},
 		"icon": {
 			"type": "string",
 			"default": "handle"

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -923,6 +923,7 @@ function Navigation( {
 						overlayMenu={ overlayMenu }
 						overlay={ overlay }
 						setAttributes={ setAttributes }
+						attributes={ attributes }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
 						overlayMenuPreview={ overlayMenuPreview }
 						setOverlayMenuPreview={ setOverlayMenuPreview }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -4,6 +4,8 @@
 import {
 	PanelBody,
 	__experimentalVStack as VStack,
+	ToggleControl,
+	RangeControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -23,6 +25,7 @@ import OverlayPreview from './overlay-preview';
  * @param {string}   props.overlayMenu               Overlay menu setting ('never', 'mobile', 'always').
  * @param {string}   props.overlay                   Currently selected overlay template part ID.
  * @param {Function} props.setAttributes             Function to update block attributes.
+ * @param {Object}   props.attributes                Block attributes object.
  * @param {Function} props.onNavigateToEntityRecord  Function to navigate to template part editor.
  * @param {boolean}  props.overlayMenuPreview        Whether overlay menu preview is open.
  * @param {Function} props.setOverlayMenuPreview     Function to toggle overlay menu preview.
@@ -39,6 +42,7 @@ export default function OverlayPanel( {
 	overlayMenu,
 	overlay,
 	setAttributes,
+	attributes,
 	onNavigateToEntityRecord,
 	overlayMenuPreview,
 	setOverlayMenuPreview,
@@ -59,6 +63,32 @@ export default function OverlayPanel( {
 					overlayMenu={ overlayMenu }
 					setAttributes={ setAttributes }
 				/>
+
+				{ overlayMenu !== 'never' && (
+					<>
+						<ToggleControl
+							label={ __( 'Enable backdrop' ) }
+							checked={ attributes.overlayBackdrop }
+							onChange={ ( value ) =>
+								setAttributes( { overlayBackdrop: value } )
+							}
+						/>
+						{ attributes.overlayBackdrop && (
+							<RangeControl
+								label={ __( 'Backdrop blur' ) }
+								value={ attributes.overlayBackdropBlur }
+								onChange={ ( value ) =>
+									setAttributes( {
+										overlayBackdropBlur: value,
+									} )
+								}
+								min={ 0 }
+								max={ 20 }
+								__next40pxDefaultSize
+							/>
+						) }
+					</>
+				) }
 
 				{ overlayMenu !== 'never' && (
 					<OverlayMenuPreviewButton

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -789,9 +789,24 @@ class WP_Navigation_Block_Renderer {
 			);
 		}
 
+		$blur = isset( $attributes['overlayBackdropBlur'] )
+			? intval( $attributes['overlayBackdropBlur'] )
+			: 0;
+
+		$blur_style = $blur
+			? sprintf(
+				'style="backdrop-filter: blur(%1$dpx); -webkit-backdrop-filter: blur(%1$dpx);"',
+				$blur
+			)
+			: '';
+
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
-				<div class="%5$s" %7$s id="%1$s" %11$s>
+				<div class="%5$s" %7$s id="%1$s" %11$s %16$s>
+					<div 
+						class="wp-block-navigation__overlay-backdrop"
+						data-wp-on--click="actions.closeMenuOnClick"
+					></div>
 					<div class="wp-block-navigation__responsive-close" tabindex="-1">
 						<div class="wp-block-navigation__responsive-dialog" %12$s>
 							%13$s
@@ -816,7 +831,8 @@ class WP_Navigation_Block_Renderer {
 			$responsive_dialog_directives,
 			$close_button_markup,
 			$responsive_container_content_directives,
-			$has_custom_overlay ? $custom_overlay_markup : ''
+			$has_custom_overlay ? $custom_overlay_markup : '',
+			$blur_style
 		);
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -789,9 +789,12 @@ class WP_Navigation_Block_Renderer {
 			);
 		}
 
-		$blur = isset( $attributes['overlayBackdropBlur'] )
-			? intval( $attributes['overlayBackdropBlur'] )
-			: 0;
+		$has_backdrop = ! empty( $attributes['overlayBackdrop'] );
+		$blur         = $has_backdrop ? intval( $attributes['overlayBackdropBlur'] ?? 0 ) : 0;
+
+		$backdrop_markup = $has_backdrop
+			? '<div class="wp-block-navigation__overlay-backdrop" data-wp-on--click="actions.closeMenuOnClick"></div>'
+			: '';
 
 		$blur_style = $blur
 			? sprintf(
@@ -803,10 +806,7 @@ class WP_Navigation_Block_Renderer {
 		return sprintf(
 			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
 				<div class="%5$s" %7$s id="%1$s" %11$s %16$s>
-					<div 
-						class="wp-block-navigation__overlay-backdrop"
-						data-wp-on--click="actions.closeMenuOnClick"
-					></div>
+					%17$s
 					<div class="wp-block-navigation__responsive-close" tabindex="-1">
 						<div class="wp-block-navigation__responsive-dialog" %12$s>
 							%13$s
@@ -832,7 +832,8 @@ class WP_Navigation_Block_Renderer {
 			$close_button_markup,
 			$responsive_container_content_directives,
 			$has_custom_overlay ? $custom_overlay_markup : '',
-			$blur_style
+			$blur_style,
+			$backdrop_markup
 		);
 	}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -679,6 +679,10 @@ button.wp-block-navigation-item__content {
 				left: auto;
 			}
 		}
+
+		.wp-block-navigation__overlay-backdrop {
+			display: block;
+		}
 	}
 
 	// Custom overlay container visibility.
@@ -741,6 +745,12 @@ button.wp-block-navigation-item__content {
 			}
 		}
 	}
+
+	.wp-block-navigation__overlay-backdrop {
+		position: fixed;
+		inset: 0;
+		background-color: rgba(0, 0, 0, 0.1);
+	}
 }
 
 // Default menu background and font color.
@@ -755,6 +765,9 @@ button.wp-block-navigation-item__content {
 	color: #000;
 }
 
+.wp-block-navigation__overlay-backdrop {
+	display: none;
+}
 
 // Overlay menu toggle button label
 .wp-block-navigation__toggle_button_label {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -122,6 +122,23 @@ const { state, actions } = store(
 				actions.closeMenu( 'click' );
 				actions.closeMenu( 'focus' );
 			},
+			closeMenuOnBackdropClick( event ) {
+				const ctx = getContext();
+				if ( ctx.type !== 'overlay' ) {
+					return;
+				}
+				const { ref } = getElement();
+				const content = ref.querySelector(
+					'.wp-block-navigation__responsive-container-content'
+				);
+
+				if ( content?.contains( event.target ) ) {
+					return;
+				}
+
+				actions.closeMenu( 'click' );
+				actions.closeMenu( 'focus' );
+			},
 			openMenuOnFocus() {
 				actions.openMenu( 'focus' );
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #75214

Adds a backdrop layer to the Navigation block overlay that:
- Closes the menu when clicking outside the content
- Supports configurable background blur using backdrop-filter

## Why?
This enables common overlay navigation designs where:
- Clicking outside closes the menu
- Background content is visually separated via blur

## How?
- Added new attributes: overlayBackdrop, overlayBackdropBlur
- Added click handler for closing overlay

## Testing Instructions
1. Add Navigation block with overlay
2. Enable backdrop
3. Set blur
4. Open menu:
   - Clicking outside closes it
   - Blur is visible

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2940" height="1422" alt="image" src="https://github.com/user-attachments/assets/867e327d-33a3-4fe3-a2ff-a8ff2bafc2db" />| <img width="2938" height="1426" alt="image" src="https://github.com/user-attachments/assets/0810e26b-e492-45ea-9947-df303f4bc788" /> |
