### PR TITLE
RTC: Fix button flickering on retry dialog

### DIFF
--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -45,6 +45,8 @@ const INITIAL_DISCONNECTED_DEBOUNCE_MS = 20000;
 export function SyncConnectionErrorModal() {
 	const [ hasInitialized, setHasInitialized ] = useState( false );
 	const [ showModal, setShowModal ] = useState( false );
+	const [ isManualRetryAvailable, setIsManualRetryAvailable ] =
+		useState( false );
 
 	const { connectionStatus, isCollaborationEnabled, postType } = useSelect(
 		( selectFn ) => {
@@ -81,6 +83,22 @@ export function SyncConnectionErrorModal() {
 
 		return () => clearTimeout( timeout );
 	}, [] );
+
+	// Track retry availability separately from the raw connection status.
+	// The polling manager briefly emits `{ status: 'connecting' }` without
+	// `canManuallyRetry` when a retry is kicked off, which would otherwise
+	//  unmount the Retry button briefly.
+	useEffect( () => {
+		if ( 'connecting' === connectionStatus?.status ) {
+			return;
+		}
+
+		setIsManualRetryAvailable(
+			connectionStatus !== null &&
+				'canManuallyRetry' in connectionStatus &&
+				connectionStatus.canManuallyRetry === true
+		);
+	}, [ connectionStatus ] );
 
 	// Show the modal when disconnected and either retries are exhausted or
 	// no retry is available (unrecoverable error). Hide on reconnect.
@@ -145,15 +163,12 @@ export function SyncConnectionErrorModal() {
 		return null;
 	}
 
-	const manualRetry =
-		connectionStatus &&
-		'canManuallyRetry' in connectionStatus &&
-		connectionStatus.canManuallyRetry
-			? () => {
-					onManualRetry();
-					retrySyncConnection();
-			  }
-			: undefined;
+	const manualRetry = isManualRetryAvailable
+		? () => {
+				onManualRetry();
+				retrySyncConnection();
+		  }
+		: undefined;
 
 	const messages = getSyncErrorMessages( error );
 


### PR DESCRIPTION
## What?

Small fix for an issue that causes the disconnect dialog buttons to briefly flicker when "Retry" is clicked:

---

![retry-dialog-flickering](https://github.com/user-attachments/assets/22c4ab9d-cd56-42c8-9475-e1e129a96a58)

---

After the fix, the layout is stabilized:

---

![retry-dialog-fixed](https://github.com/user-attachments/assets/b021567e-2435-4440-965b-bc5de6c50dd5)

---

## Why?

Avoid an annoying layout flicker when retrying.

## How?

The retry button rendering is gated on `manualRetry`, which checks for the connection's `canManuallyRetry` value. During the `connecting` status `canManuallyRetry` is briefly not present, which caused the button to disappear.

The changes in this PR add `isManualRetryAvailable`, which essentially works the same but ignores the `connecting` state so the button stays in place.

## Testing Instructions

1. Open a post
2. In DevTools, set network mode to "Offline"
3. Wait 30 seconds for the disconnected dialog to appear
4. Click "Retry". Ensure it doesn't flicker.


## Use of AI Tools

Used: Claude
For: Implementation