### PR TITLE
Block Visibility: remove stale toolbar icon when block is shown again

### DIFF
--- a/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-toolbar.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { useRef, useEffect } from '@wordpress/element';
 import { seen, unseen } from '@wordpress/icons';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -15,12 +14,20 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export default function BlockVisibilityViewportToolbar( { clientIds } ) {
-	const hasBlockVisibilityButtonShownRef = useRef( false );
-	const { canToggleBlockVisibility, areBlocksHiddenAnywhere } = useSelect(
+	const {
+		canToggleBlockVisibility,
+		areBlocksHiddenAnywhere,
+		isViewportModalOpenForSelection,
+	} = useSelect(
 		( select ) => {
-			const { getBlocksByClientId, getBlockName, isBlockHiddenAnywhere } =
-				unlock( select( blockEditorStore ) );
+			const {
+				getBlocksByClientId,
+				getBlockName,
+				isBlockHiddenAnywhere,
+				getViewportModalClientIds,
+			} = unlock( select( blockEditorStore ) );
 			const _blocks = getBlocksByClientId( clientIds );
+			const viewportModalClientIds = getViewportModalClientIds();
 			return {
 				canToggleBlockVisibility: _blocks.every( ( { clientId } ) =>
 					hasBlockSupport(
@@ -32,6 +39,13 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 				areBlocksHiddenAnywhere: clientIds?.every( ( clientId ) =>
 					isBlockHiddenAnywhere( clientId )
 				),
+				isViewportModalOpenForSelection:
+					Array.isArray( viewportModalClientIds ) &&
+					Array.isArray( clientIds ) &&
+					viewportModalClientIds.length === clientIds.length &&
+					viewportModalClientIds.every( ( modalClientId ) =>
+						clientIds.includes( modalClientId )
+					),
 			};
 		},
 
@@ -39,23 +53,7 @@ export default function BlockVisibilityViewportToolbar( { clientIds } ) {
 	);
 	const blockEditorDispatch = useDispatch( blockEditorStore );
 
-	/*
-	 * If the block visibility button has been shown, we don't want to
-	 * remove it from the toolbar until the toolbar is rendered again
-	 * without it. Removing it beforehand can cause focus loss issues.
-	 * It needs to return focus from whence it came, and to do that,
-	 * we need to leave the button in the toolbar.
-	 */
-	useEffect( () => {
-		if ( areBlocksHiddenAnywhere ) {
-			hasBlockVisibilityButtonShownRef.current = true;
-		}
-	}, [ areBlocksHiddenAnywhere ] );
-
-	if (
-		! areBlocksHiddenAnywhere &&
-		! hasBlockVisibilityButtonShownRef.current
-	) {
+	if ( ! areBlocksHiddenAnywhere && ! isViewportModalOpenForSelection ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
Fixes a UI state bug where the Block Visibility icon in the block toolbar remained visible after visibility settings were cleared and the block became visible again.

Fixes #77237.

## Why?
The issue reported that:
1. Hiding a block correctly shows visibility indicators.
2. Showing the same block again removes the List View indicator.
3. The toolbar indicator incorrectly remains visible.

This creates inconsistent UI feedback and can confuse users about the actual visibility state.

## How?
1. Updated toolbar rendering logic in viewport-toolbar.js to remove stale latched state.
2. Kept focus-safe behavior by retaining the button only while the visibility modal is open for the same block selection.
3. Added regression tests in packages/block-editor/src/components/block-visibility/test/viewport-toolbar.js to verify:
- the icon is removed after hidden -> visible transition when modal is closed
- the icon remains while modal is open

## Testing Instructions
1. Open the editor and select a block with visibility support.
2. Hide the block via block visibility controls.
3. Confirm the visibility icon appears in List View and in toolbar.
4. Show the same block again.
5. Close the visibility modal.
6. Confirm both indicators are removed.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/42e487ca-0795-46ea-8caf-c1063dc1c412


After:

https://github.com/user-attachments/assets/1d463e7d-a0f3-4fc9-9a1b-1c85a5c29006


