### PR TITLE
RTC: Fix disconnect dialog due to uneditable entity

### DIFF
--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -85,6 +85,62 @@ interface RoomState {
 	updateQueue: UpdateQueue;
 }
 
+/**
+ * Check if an error is a forbidden (403) response from the WordPress REST
+ * API. These errors have a `data.status` property set by WP_Error.
+ *
+ * Only targets 403 (permission denied for a specific entity), not 401
+ * (not logged in) which should still surface as a connection error.
+ *
+ * @param error The caught error to inspect.
+ */
+function isForbiddenError( error: unknown ): boolean {
+	if ( ! error || typeof error !== 'object' || ! ( 'data' in error ) ) {
+		return false;
+	}
+
+	const data = ( error as Record< string, unknown > ).data;
+	if ( ! data || typeof data !== 'object' || ! ( 'status' in data ) ) {
+		return false;
+	}
+
+	return ( data as Record< string, unknown > ).status === 403;
+}
+
+/**
+ * Try to identify which room caused a forbidden error by checking if any
+ * room name from the request appears in the error message. The WordPress
+ * REST API includes the room name in per-entity permission errors (e.g.
+ * "You do not have permission to sync this entity: postType/post:123.").
+ * Room names are never translated, so substring matching is reliable.
+ *
+ * Returns the room name if found, or null for generic auth failures
+ * (e.g. "not logged in") where no specific room is identified.
+ *
+ * @param error The caught error to inspect.
+ * @param rooms The room names from the request payload.
+ */
+function identifyForbiddenRoom(
+	error: unknown,
+	rooms: string[]
+): string | null {
+	const message =
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		typeof ( error as Record< string, unknown > ).message === 'string'
+			? ( ( error as Record< string, unknown > ).message as string )
+			: '';
+
+	for ( const room of rooms ) {
+		if ( message.includes( room ) ) {
+			return room;
+		}
+	}
+
+	return null;
+}
+
 const roomStates: Map< string, RoomState > = new Map();
 
 /**
@@ -523,71 +579,131 @@ function poll(): void {
 				pollInterval = POLLING_INTERVAL_BACKGROUND_TAB_IN_MS;
 			}
 		} catch ( error ) {
-			// Use the explicit retry delay schedule for backoff.
-			consecutiveFailures++;
-			const retrySchedule = hasCollaborators
-				? ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS
-				: ERROR_RETRY_DELAYS_SOLO_MS;
-			if ( consecutiveFailures <= retrySchedule.length ) {
-				pollInterval = retrySchedule[ consecutiveFailures - 1 ];
-			} else {
-				pollInterval = DISCONNECT_DIALOG_RETRY_MS;
-			}
-
-			// After a manual retry, use a shorter interval for one cycle.
-			if ( isManualRetry ) {
-				pollInterval = MANUAL_RETRY_INTERVAL_MS;
-				isManualRetry = false;
-			}
-
-			// Recover from the failed request. We don't know whether the server stored
-			// our updates before the error occurred (e.g. a network timeout after a
-			// successful write). Re-sending the same updates via restore() would
-			// duplicate them on the server and cause unbounded storage growth.
-			//
-			// Instead, for rooms that had outgoing updates, replace the queue with a
-			// single compaction (full document state). This is idempotent: if the
-			// server already stored the updates, the compaction safely supersedes
-			// them; if it didn't, the compaction includes them. Updates not seen by
-			// this client are preserved in both cases.
-			for ( const room of payload.rooms ) {
-				if ( ! roomStates.has( room.room ) ) {
-					continue;
-				}
-
-				const state = roomStates.get( room.room )!;
-
-				if ( room.updates.length > 0 && state.endCursor > 0 ) {
-					state.updateQueue.clear();
-					state.updateQueue.add( state.createCompactionUpdate() );
-				} else if ( room.updates.length > 0 ) {
-					state.updateQueue.restore( room.updates );
-				}
-
-				state.log(
-					'Error posting sync update, will retry with backoff',
-					{ error, nextPoll: pollInterval },
-					'error',
-					true // force
+			// A 403 response means the user does not have permission to
+			// sync a specific entity. Silently unregister the affected
+			// room(s) — treat it as if sync was never supported.
+			if ( isForbiddenError( error ) ) {
+				const forbiddenRoom = identifyForbiddenRoom(
+					error,
+					payload.rooms.map( ( r ) => r.room )
 				);
-			}
 
-			// Don't report disconnected status when the request was aborted
-			// due to page unload (e.g. during a refresh) to avoid briefly
-			// flashing the disconnect dialog before the new page loads.
-			if ( ! isUnloadPending ) {
-				const backgroundRetriesFailed =
-					consecutiveFailures > retrySchedule.length;
+				if ( forbiddenRoom ) {
+					// A specific room was denied — unregister only that room.
+					const state = roomStates.get( forbiddenRoom );
+					if ( state ) {
+						state.log(
+							'Permission denied, unregistering room',
+							{ error },
+							'error',
+							true // force
+						);
+						unregisterRoom( forbiddenRoom );
+					}
 
-				roomStates.forEach( ( state ) => {
-					state.onStatusChange( {
-						status: 'disconnected',
-						canManuallyRetry: true,
-						consecutiveFailures,
-						backgroundRetriesFailed,
-						willAutoRetryInMs: pollInterval,
+					// Restore updates for remaining rooms so they can
+					// be retried on the next poll cycle.
+					for ( const room of payload.rooms ) {
+						if (
+							room.room === forbiddenRoom ||
+							! roomStates.has( room.room )
+						) {
+							continue;
+						}
+						const remainingState = roomStates.get( room.room )!;
+						if ( room.updates.length > 0 ) {
+							remainingState.updateQueue.restore( room.updates );
+						}
+					}
+				} else {
+					// Generic auth failure (e.g. not logged in) —
+					// unregister all rooms.
+					const rooms = [ ...roomStates.keys() ];
+					for ( const room of rooms ) {
+						const state = roomStates.get( room );
+						if ( state ) {
+							state.log(
+								'Permission denied, unregistering room',
+								{ error },
+								'error',
+								true // force
+							);
+							unregisterRoom( room );
+						}
+					}
+				}
+
+				// If all rooms are gone, stop polling.
+				if ( roomStates.size === 0 ) {
+					return;
+				}
+			} else {
+				// Use the explicit retry delay schedule for backoff.
+				consecutiveFailures++;
+				const retrySchedule = hasCollaborators
+					? ERROR_RETRY_DELAYS_WITH_COLLABORATORS_MS
+					: ERROR_RETRY_DELAYS_SOLO_MS;
+				if ( consecutiveFailures <= retrySchedule.length ) {
+					pollInterval = retrySchedule[ consecutiveFailures - 1 ];
+				} else {
+					pollInterval = DISCONNECT_DIALOG_RETRY_MS;
+				}
+
+				// After a manual retry, use a shorter interval for one cycle.
+				if ( isManualRetry ) {
+					pollInterval = MANUAL_RETRY_INTERVAL_MS;
+					isManualRetry = false;
+				}
+
+				// Recover from the failed request. We don't know whether the server stored
+				// our updates before the error occurred (e.g. a network timeout after a
+				// successful write). Re-sending the same updates via restore() would
+				// duplicate them on the server and cause unbounded storage growth.
+				//
+				// Instead, for rooms that had outgoing updates, replace the queue with a
+				// single compaction (full document state). This is idempotent: if the
+				// server already stored the updates, the compaction safely supersedes
+				// them; if it didn't, the compaction includes them. Updates not seen by
+				// this client are preserved in both cases.
+				for ( const room of payload.rooms ) {
+					if ( ! roomStates.has( room.room ) ) {
+						continue;
+					}
+
+					const state = roomStates.get( room.room )!;
+
+					if ( room.updates.length > 0 && state.endCursor > 0 ) {
+						state.updateQueue.clear();
+						state.updateQueue.add( state.createCompactionUpdate() );
+					} else if ( room.updates.length > 0 ) {
+						state.updateQueue.restore( room.updates );
+					}
+
+					state.log(
+						'Error posting sync update, will retry with backoff',
+						{ error, nextPoll: pollInterval },
+						'error',
+						true // force
+					);
+				}
+
+				// Don't report disconnected status when the request was aborted
+				// due to page unload (e.g. during a refresh) to avoid briefly
+				// flashing the disconnect dialog before the new page loads.
+				if ( ! isUnloadPending ) {
+					const backgroundRetriesFailed =
+						consecutiveFailures > retrySchedule.length;
+
+					roomStates.forEach( ( state ) => {
+						state.onStatusChange( {
+							status: 'disconnected',
+							canManuallyRetry: true,
+							consecutiveFailures,
+							backgroundRetriesFailed,
+							willAutoRetryInMs: pollInterval,
+						} );
 					} );
-				} );
+				}
 			}
 		}
 

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -588,6 +588,10 @@ function poll(): void {
 					payload.rooms.map( ( r ) => r.room )
 				);
 
+				// Skip the disconnect signal in both branches: the server
+				// rejected our sync request before any awareness was written,
+				// so there is nothing on the server to clean up and the
+				// signal would just generate another 403.
 				if ( forbiddenRoom ) {
 					// A specific room was denied — unregister only that room.
 					const state = roomStates.get( forbiddenRoom );
@@ -598,7 +602,9 @@ function poll(): void {
 							'error',
 							true // force
 						);
-						unregisterRoom( forbiddenRoom );
+						unregisterRoom( forbiddenRoom, {
+							sendDisconnectSignal: false,
+						} );
 					}
 
 					// Restore updates for remaining rooms so they can
@@ -628,7 +634,9 @@ function poll(): void {
 								'error',
 								true // force
 							);
-							unregisterRoom( room );
+							unregisterRoom( room, {
+								sendDisconnectSignal: false,
+							} );
 						}
 					}
 				}
@@ -843,22 +851,28 @@ function registerRoom( {
 	}
 }
 
-function unregisterRoom( room: string ): void {
+function unregisterRoom(
+	room: string,
+	{ sendDisconnectSignal = true }: { sendDisconnectSignal?: boolean } = {}
+): void {
 	const state = roomStates.get( room );
 	if ( state ) {
-		// Send a disconnect signal so the server removes this client's
-		// awareness entry immediately instead of waiting for the timeout.
-		const rooms = [
-			{
-				after: 0,
-				awareness: null,
-				client_id: state.clientId,
-				room,
-				updates: [],
-			},
-		];
+		if ( sendDisconnectSignal ) {
+			// Send a disconnect signal so the server removes this client's
+			// awareness entry immediately instead of waiting for the timeout.
+			const rooms = [
+				{
+					after: 0,
+					awareness: null,
+					client_id: state.clientId,
+					room,
+					updates: [],
+				},
+			];
 
-		postSyncUpdateNonBlocking( { rooms } );
+			postSyncUpdateNonBlocking( { rooms } );
+		}
+
 		state.unregister();
 		roomStates.delete( room );
 	}

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -58,7 +58,10 @@ type LogFunction = (
 interface PollingManager {
 	registerRoom: ( options: RegisterRoomOptions ) => void;
 	retryNow: () => void;
-	unregisterRoom: ( room: string ) => void;
+	unregisterRoom: (
+		room: string,
+		options?: { sendDisconnectSignal?: boolean }
+	) => void;
 }
 
 interface RegisterRoomOptions {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -141,6 +141,68 @@ function identifyForbiddenRoom(
 	return null;
 }
 
+/**
+ * Handle a 403 from the sync endpoint. Silently unregisters the affected
+ * rooms, and restores pending updates for the remaining rooms so they retry on
+ * the next poll cycle.
+ *
+ * @param error          The forbidden error, narrowed via isForbiddenError.
+ * @param requestedRooms The rooms that were in the failing request.
+ */
+function handleForbiddenError(
+	error: WPRestError,
+	requestedRooms: SyncPayload[ 'rooms' ]
+): void {
+	const forbiddenRoom = identifyForbiddenRoom(
+		error,
+		requestedRooms.map( ( r ) => r.room )
+	);
+
+	if ( forbiddenRoom ) {
+		// A specific room was denied — unregister only that room.
+		const state = roomStates.get( forbiddenRoom );
+		if ( state ) {
+			state.log(
+				'Permission denied, unregistering room',
+				{ error },
+				'error',
+				true // force
+			);
+			unregisterRoom( forbiddenRoom, { sendDisconnectSignal: false } );
+		}
+
+		// Restore updates for remaining rooms so they can be retried on
+		// the next poll cycle.
+		for ( const room of requestedRooms ) {
+			if (
+				room.room === forbiddenRoom ||
+				! roomStates.has( room.room )
+			) {
+				continue;
+			}
+			const remainingState = roomStates.get( room.room )!;
+			if ( room.updates.length > 0 ) {
+				remainingState.updateQueue.restore( room.updates );
+			}
+		}
+	} else {
+		// Generic auth failure (e.g. not logged in) — unregister all rooms.
+		const rooms = [ ...roomStates.keys() ];
+		for ( const room of rooms ) {
+			const state = roomStates.get( room );
+			if ( state ) {
+				state.log(
+					'Permission denied, unregistering room',
+					{ error },
+					'error',
+					true // force
+				);
+				unregisterRoom( room, { sendDisconnectSignal: false } );
+			}
+		}
+	}
+}
+
 const roomStates: Map< string, RoomState > = new Map();
 
 /**
@@ -581,68 +643,13 @@ function poll(): void {
 		} catch ( error ) {
 			// A 403 response means the user does not have permission to
 			// sync a specific entity. Silently unregister the affected
-			// room(s).
+			// room(s) and let polling continue for the rest.
 			if ( isForbiddenError( error ) ) {
-				const forbiddenRoom = identifyForbiddenRoom(
-					error,
-					payload.rooms.map( ( r ) => r.room )
-				);
+				handleForbiddenError( error, payload.rooms );
 
-				// Skip the disconnect signal in both branches: the server
-				// rejected our sync request before any awareness was written,
-				// so there is nothing on the server to clean up and the
-				// signal would just generate another 403.
-				if ( forbiddenRoom ) {
-					// A specific room was denied — unregister only that room.
-					const state = roomStates.get( forbiddenRoom );
-					if ( state ) {
-						state.log(
-							'Permission denied, unregistering room',
-							{ error },
-							'error',
-							true // force
-						);
-						unregisterRoom( forbiddenRoom, {
-							sendDisconnectSignal: false,
-						} );
-					}
-
-					// Restore updates for remaining rooms so they can
-					// be retried on the next poll cycle.
-					for ( const room of payload.rooms ) {
-						if (
-							room.room === forbiddenRoom ||
-							! roomStates.has( room.room )
-						) {
-							continue;
-						}
-						const remainingState = roomStates.get( room.room )!;
-						if ( room.updates.length > 0 ) {
-							remainingState.updateQueue.restore( room.updates );
-						}
-					}
-				} else {
-					// Generic auth failure (e.g. not logged in) —
-					// unregister all rooms.
-					const rooms = [ ...roomStates.keys() ];
-					for ( const room of rooms ) {
-						const state = roomStates.get( room );
-						if ( state ) {
-							state.log(
-								'Permission denied, unregistering room',
-								{ error },
-								'error',
-								true // force
-							);
-							unregisterRoom( room, {
-								sendDisconnectSignal: false,
-							} );
-						}
-					}
-				}
-
-				// If all rooms are gone, stop polling. Reset isPolling so
-				// that a future registerRoom() call can start a new poll cycle.
+				// If every room was unregistered, stop the poll loop
+				// instead of scheduling another tick. Reset isPolling
+				// so a future registerRoom() call can restart it.
 				if ( roomStates.size === 0 ) {
 					isPolling = false;
 					return;

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -86,25 +86,24 @@ interface RoomState {
 }
 
 /**
+ * Minimal shape of a WordPress REST API error as it arrives on the client
+ * via apiFetch. WP_Error is serialized to JSON with a `data.status` field
+ * containing the HTTP status code; `code` and `message` are best-effort.
+ */
+interface WPRestError {
+	code?: string;
+	message?: string;
+	data: { status: number };
+}
+
+/**
  * Check if an error is a forbidden (403) response from the WordPress REST
  * API. These errors have a `data.status` property set by WP_Error.
  *
- * Only targets 403 (permission denied for a specific entity), not 401
- * (not logged in) which should still surface as a connection error.
- *
  * @param error The caught error to inspect.
  */
-function isForbiddenError( error: unknown ): boolean {
-	if ( ! error || typeof error !== 'object' || ! ( 'data' in error ) ) {
-		return false;
-	}
-
-	const data = ( error as Record< string, unknown > ).data;
-	if ( ! data || typeof data !== 'object' || ! ( 'status' in data ) ) {
-		return false;
-	}
-
-	return ( data as Record< string, unknown > ).status === 403;
+function isForbiddenError( error: unknown ): error is WPRestError {
+	return ( error as WPRestError | undefined )?.data?.status === 403;
 }
 
 /**
@@ -117,20 +116,14 @@ function isForbiddenError( error: unknown ): boolean {
  * Returns the room name if found, or null for generic auth failures
  * (e.g. "not logged in") where no specific room is identified.
  *
- * @param error The caught error to inspect.
+ * @param error The forbidden error, narrowed via isForbiddenError.
  * @param rooms The room names from the request payload.
  */
 function identifyForbiddenRoom(
-	error: unknown,
+	error: WPRestError,
 	rooms: string[]
 ): string | null {
-	const message =
-		error &&
-		typeof error === 'object' &&
-		'message' in error &&
-		typeof ( error as Record< string, unknown > ).message === 'string'
-			? ( ( error as Record< string, unknown > ).message as string )
-			: '';
+	const message = typeof error.message === 'string' ? error.message : '';
 
 	// Sort rooms by length descending so the longest match wins. Room names
 	// embed numeric IDs (e.g. "postType/post:1", "postType/post:10"), and a
@@ -588,7 +581,7 @@ function poll(): void {
 		} catch ( error ) {
 			// A 403 response means the user does not have permission to
 			// sync a specific entity. Silently unregister the affected
-			// room(s) — treat it as if sync was never supported.
+			// room(s).
 			if ( isForbiddenError( error ) ) {
 				const forbiddenRoom = identifyForbiddenRoom(
 					error,

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -633,8 +633,10 @@ function poll(): void {
 					}
 				}
 
-				// If all rooms are gone, stop polling.
+				// If all rooms are gone, stop polling. Reset isPolling so
+				// that a future registerRoom() call can start a new poll cycle.
 				if ( roomStates.size === 0 ) {
+					isPolling = false;
 					return;
 				}
 			} else {

--- a/packages/sync/src/providers/http-polling/polling-manager.ts
+++ b/packages/sync/src/providers/http-polling/polling-manager.ts
@@ -132,7 +132,14 @@ function identifyForbiddenRoom(
 			? ( ( error as Record< string, unknown > ).message as string )
 			: '';
 
-	for ( const room of rooms ) {
+	// Sort rooms by length descending so the longest match wins. Room names
+	// embed numeric IDs (e.g. "postType/post:1", "postType/post:10"), and a
+	// shorter name can be a substring of a longer one. Without sorting, the
+	// iteration order is the room registration order, so a 403 referencing
+	// "postType/post:10" could incorrectly match "postType/post:1" first.
+	const sortedRooms = [ ...rooms ].sort( ( a, b ) => b.length - a.length );
+
+	for ( const room of sortedRooms ) {
 		if ( message.includes( room ) ) {
 			return room;
 		}

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1195,6 +1195,36 @@ describe( 'polling-manager', () => {
 			expect( remainingRoomNames ).not.toContain( 'postType/post:10' );
 		} );
 
+		it( 'does not send a disconnect signal when unregistering a forbidden room', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Next poll: 403 referencing the only registered room.
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_cannot_edit',
+				message:
+					'You do not have permission to sync this entity: test-room.',
+				data: { status: 403 },
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// The server already denied the sync request, so our awareness
+			// was never stored. No disconnect signal should be sent.
+			expect( mockPostSyncUpdateNonBlocking ).not.toHaveBeenCalled();
+		} );
+
 		it( 'resumes polling for a newly-registered room after a 403 unregistered all rooms', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -62,7 +62,10 @@ interface PollingManager {
 		onStatusChange: () => void;
 		onSync: () => void;
 	} ) => void;
-	unregisterRoom: ( room: string ) => void;
+	unregisterRoom: (
+		room: string,
+		options?: { sendDisconnectSignal?: boolean }
+	) => void;
 }
 
 function createDeferred< T >() {

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1119,5 +1119,57 @@ describe( 'polling-manager', () => {
 			await jest.advanceTimersByTimeAsync( 2000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
+
+		it( 'resumes polling for a newly-registered room after a 403 unregistered all rooms', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Next poll: 403 referencing the only registered room.
+			// All rooms get unregistered and the poll loop stops.
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_cannot_edit',
+				message:
+					'You do not have permission to sync this entity: test-room.',
+				data: { status: 403 },
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// Register a brand-new room. This should kick off a fresh poll
+			// cycle — but only if isPolling was reset when the previous
+			// cycle stopped.
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'new-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			pollingManager.registerRoom( {
+				room: 'new-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+		} );
 	} );
 } );

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -1120,6 +1120,81 @@ describe( 'polling-manager', () => {
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 
+		it( 'unregisters the correct room when room names share a prefix', async () => {
+			// Register the shorter-named room first so that, without the
+			// length-descending sort in identifyForbiddenRoom, the iteration
+			// order would match "postType/post:1" as a substring of
+			// "postType/post:10" and unregister the wrong room.
+			const twoRoomResponse = {
+				rooms: [
+					{
+						room: 'postType/post:1',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+					{
+						room: 'postType/post:10',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			};
+			mockPostSyncUpdate.mockResolvedValueOnce( twoRoomResponse );
+
+			pollingManager.registerRoom( {
+				room: 'postType/post:1',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+			pollingManager.registerRoom( {
+				room: 'postType/post:10',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Next poll: 403 referencing the longer-named room.
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_cannot_edit',
+				message:
+					'You do not have permission to sync this entity: postType/post:10.',
+				data: { status: 403 },
+			} );
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'postType/post:1',
+						end_cursor: 2,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// The next poll's payload should still include the shorter
+			// room and exclude the (correctly identified) longer one.
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+			const lastPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ] as {
+				rooms: { room: string }[];
+			};
+			const remainingRoomNames = lastPayload.rooms.map( ( r ) => r.room );
+			expect( remainingRoomNames ).toContain( 'postType/post:1' );
+			expect( remainingRoomNames ).not.toContain( 'postType/post:10' );
+		} );
+
 		it( 'resumes polling for a newly-registered room after a 403 unregistered all rooms', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -973,4 +973,151 @@ describe( 'polling-manager', () => {
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
+
+	describe( 'forbidden error handling', () => {
+		it( 'silently unregisters only the forbidden room on a 403', async () => {
+			// Respond with two rooms on the first poll.
+			const twoRoomResponse = {
+				rooms: [
+					{
+						room: 'test-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+					{
+						room: 'other-room',
+						end_cursor: 1,
+						awareness: {},
+						updates: [],
+					},
+				],
+			};
+			mockPostSyncUpdate.mockResolvedValueOnce( twoRoomResponse );
+
+			const onStatusChangeA = jest.fn();
+			const onStatusChangeB = jest.fn();
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: onStatusChangeA,
+				onSync: jest.fn(),
+			} );
+			pollingManager.registerRoom( {
+				room: 'other-room',
+				doc: createMockDoc( 2 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: onStatusChangeB,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
+
+			// Second poll: 403 referencing only test-room.
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_cannot_edit',
+				message:
+					'You do not have permission to sync this entity: test-room.',
+				data: { status: 403 },
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// No error should be emitted — the room is silently removed.
+			expect( onStatusChangeA ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.anything(),
+				} )
+			);
+
+			// The other room should be unaffected.
+			expect( onStatusChangeB ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					error: expect.anything(),
+				} )
+			);
+
+			// Polling should continue for the remaining room.
+			mockPostSyncUpdate.mockResolvedValueOnce( {
+				rooms: [
+					{
+						room: 'other-room',
+						end_cursor: 2,
+						awareness: {},
+						updates: [],
+					},
+				],
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'retries normally on a 401 (not treated as forbidden)', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+
+			const onStatusChange = jest.fn();
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange,
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			// Fail with a 401 — should go through normal retry path.
+			mockPostSyncUpdate.mockRejectedValueOnce( {
+				code: 'rest_not_logged_in',
+				message: 'You are not currently logged in.',
+				data: { status: 401 },
+			} );
+			await jest.advanceTimersByTimeAsync( 4000 );
+
+			// Should emit a disconnected status (normal error handling).
+			expect( onStatusChange ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					status: 'disconnected',
+					canManuallyRetry: true,
+				} )
+			);
+
+			// Should retry after backoff (2000ms for solo first failure).
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'still retries on non-forbidden errors', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+
+			pollingManager.registerRoom( {
+				room: 'test-room',
+				doc: createMockDoc( 1 ),
+				awareness: createMockAwareness(),
+				log: jest.fn(),
+				onStatusChange: jest.fn(),
+				onSync: jest.fn(),
+			} );
+
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			// Fail with a generic network error (no data.status).
+			mockPostSyncUpdate.mockRejectedValueOnce(
+				new Error( 'Network error' )
+			);
+			await jest.advanceTimersByTimeAsync( 4000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
+
+			// Should retry after backoff (2000ms for solo first failure).
+			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

Modify the HTTP polling sync provider to recognize per-entity 403s from the sync endpoint and unregister the affected rooms. Previously these 403s went through the normal retry/backoff path and eventually popped the "Connection lost" disconnect modal, even though only one entity in the session was actually unsyncable.

Here's a fast reproduction on `wp-env`'s default environment by using a user with `editor` permissions. Open a page as the editor, enable "Show Template", and see a disconnection dialog after a few seconds:

https://github.com/user-attachments/assets/9d48c187-b4b0-4049-98af-bdcc8e5e390a

## Why?

When an editor opens a Page that includes a `wp_template_part` (like by toggling "Show template" in the sidebar), the page loads fine but the sync polling provider tries to register the template part for sync. The editor role doesn't have `edit_theme_options`, so the server returns a 403 for that specific room. The provider treated this the same as a network error, eventually ending in the disconnect modal even though the user does not need the ability to edit the template.

The correct behavior is to treat permission denials as per-entity for entities that can be skipped.

## How?

The provider's error block now checks the error before treating the request as a failure and retrying. We substring match on the error returned by WordPress. An ideal future solution would be to return this data from the [`WP_HTTP_Polling_Sync_Server`](https://github.com/WordPress/wordpress-develop/blob/80433208a67206b6413f7fa4f7d5f68c72f2a15c/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php#L245) (maybe as `unauthorizedRooms: [...]`). For now, this allows us to address the issue client-side and we can later improve on `WP_HTTP_Polling_Sync_Server` by returning all affected entities. [This issue](https://github.com/WordPress/gutenberg/issues/77243) will track that future work.

This also fixes an issue where we were sending awareness disconnects for failed entities, resulting in two `403`s instead of one. The fix was to add a `sendDisconnectSignal` parameter to `unregisterRoom()`, and ensure that failed auth doesn't send the awareness disconnect signal.

## Testing Instructions

This is a bit tricky as mentioned above because `WP_HTTP_Polling_Sync_Server` ships with WordPress and we can't easily override it in Gutenberg. The tests below use `wp-env` and manually patch the sync server that ships with WordPress.

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
3. Log in with an Editor role.
4. Go to Pages and open an existing page.
5. In the sidebar, switch to the "Page" tab and scroll to the Template panel, click the template name, and toggle "Show template" to on.
6. Wait ~30 seconds. Confirm the "Connection lost" modal does **not** appear and the editor remains usable.
7. Check network logs and see `/updates` briefly respond with `403`, then after rooms are removed return to `200` responses.

Unit tests can be run via:

```bash
npm run test:unit -- --testPathPattern='packages/sync/src/providers/http-polling/test/polling-manager'
```

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: The whole process.