### PR TITLE
Show media upload progress in the post panel

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1478,6 +1478,16 @@ _Returns_
 
 -   `React.ReactNode`: The component to be rendered.
 
+### PostUploadIndicator
+
+Renders a compact upload progress indicator inside the post summary sidebar while one or more client-side media uploads are in progress.
+
+Mirrors the Media Library's "Uploading" pattern: a progress bar, a completed / total count, and the filename of the item currently being processed. Returns `null` when the upload queue is empty so it adds no DOM clutter in the common case.
+
+_Returns_
+
+-   `JSX.Element|null`: The rendered indicator, or null when idle.
+
 ### PostURL
 
 Renders the `PostURL` component.

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -82,6 +82,7 @@ export { default as PostTitle } from './post-title';
 export { default as PostTitleRaw } from './post-title/post-title-raw';
 export { default as PostTrash } from './post-trash';
 export { default as PostTrashCheck } from './post-trash/check';
+export { default as PostUploadIndicator } from './post-upload-indicator';
 export { default as PostTypeSupportCheck } from './post-type-support-check';
 export { default as PostURL } from './post-url';
 export { default as PostURLCheck } from './post-url/check';

--- a/packages/editor/src/components/post-upload-indicator/index.js
+++ b/packages/editor/src/components/post-upload-indicator/index.js
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import {
+	ProgressBar,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { usePrevious } from '@wordpress/compose';
+import { store as uploadStore } from '@wordpress/upload-media';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import PostPanelRow from '../post-panel-row';
+
+/**
+ * Renders a compact upload progress indicator inside the post summary
+ * sidebar while one or more client-side media uploads are in progress.
+ *
+ * Mirrors the Media Library's "Uploading" pattern: a progress bar, a
+ * completed / total count, and the filename of the item currently being
+ * processed. Returns `null` when the upload queue is empty so it adds no
+ * DOM clutter in the common case.
+ *
+ * @return {JSX.Element|null} The rendered indicator, or null when idle.
+ */
+export default function PostUploadIndicator() {
+	// `__clientSideMediaProcessing` is the runtime gate used throughout the
+	// editor (see use-upload-save-lock.js and block-library/image/edit.js).
+	// Short-circuit when CSM is disabled so we don't subscribe to a store
+	// that will never change.
+	const summary = useSelect( ( select ) => {
+		if ( ! window.__clientSideMediaProcessing ) {
+			return null;
+		}
+		return select( uploadStore ).getUploadProgressSummary();
+	}, [] );
+
+	// Announce start and completion transitions to assistive technology
+	// without chattering on every progress tick.
+	const isUploading = !! summary;
+	const wasUploading = usePrevious( isUploading );
+	useEffect( () => {
+		if ( isUploading && ! wasUploading ) {
+			speak( __( 'Media upload started' ), 'polite' );
+		} else if ( ! isUploading && wasUploading ) {
+			speak( __( 'Media upload complete' ), 'polite' );
+		}
+	}, [ isUploading, wasUploading ] );
+
+	if ( ! summary ) {
+		return null;
+	}
+
+	const { total, completed, progress, currentFilename } = summary;
+
+	const countLabel = sprintf(
+		/* translators: 1: number of completed uploads, 2: total uploads. */
+		__( '%1$d / %2$d' ),
+		completed,
+		total
+	);
+
+	const ariaLabel = currentFilename
+		? sprintf(
+				/* translators: 1: completed count, 2: total count, 3: filename. */
+				__( 'Uploading media: %1$d of %2$d, currently %3$s' ),
+				completed,
+				total,
+				currentFilename
+		  )
+		: sprintf(
+				/* translators: 1: completed count, 2: total count. */
+				__( 'Uploading media: %1$d of %2$d' ),
+				completed,
+				total
+		  );
+
+	return (
+		<PostPanelRow
+			className="editor-post-upload-indicator"
+			label={ __( 'Uploading' ) }
+		>
+			<VStack
+				spacing={ 1 }
+				className="editor-post-upload-indicator__content"
+			>
+				<ProgressBar value={ progress } aria-label={ ariaLabel } />
+				<span
+					role="status"
+					className="editor-post-upload-indicator__meta"
+				>
+					{ countLabel }
+					{ currentFilename && (
+						<>
+							{ ' \u2014 ' }
+							<span
+								className="editor-post-upload-indicator__filename"
+								title={ currentFilename }
+							>
+								{ currentFilename }
+							</span>
+						</>
+					) }
+				</span>
+			</VStack>
+		</PostPanelRow>
+	);
+}

--- a/packages/editor/src/components/post-upload-indicator/style.scss
+++ b/packages/editor/src/components/post-upload-indicator/style.scss
@@ -1,0 +1,24 @@
+.editor-post-upload-indicator {
+	.editor-post-panel__row-control {
+		flex-grow: 1;
+	}
+
+	&__content {
+		width: 100%;
+	}
+
+	&__meta {
+		display: block;
+		font-size: 12px;
+		color: $gray-700;
+	}
+
+	&__filename {
+		display: inline-block;
+		max-width: 18ch;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		vertical-align: bottom;
+	}
+}

--- a/packages/editor/src/components/post-upload-indicator/style.scss
+++ b/packages/editor/src/components/post-upload-indicator/style.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/colors" as *;
+
 .editor-post-upload-indicator {
 	.editor-post-panel__row-control {
 		flex-grow: 1;

--- a/packages/editor/src/components/post-upload-indicator/test/index.js
+++ b/packages/editor/src/components/post-upload-indicator/test/index.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import PostUploadIndicator from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+function mockSummary( summary ) {
+	useSelect.mockImplementation( ( cb ) =>
+		cb( () => ( {
+			getUploadProgressSummary: () => summary,
+		} ) )
+	);
+}
+
+describe( 'PostUploadIndicator', () => {
+	const originalFlag = window.__clientSideMediaProcessing;
+
+	beforeEach( () => {
+		window.__clientSideMediaProcessing = true;
+		speak.mockClear();
+	} );
+
+	afterAll( () => {
+		window.__clientSideMediaProcessing = originalFlag;
+	} );
+
+	it( 'renders nothing when the upload queue is empty', () => {
+		mockSummary( null );
+		const { container } = render( <PostUploadIndicator /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when client-side media processing is disabled', () => {
+		window.__clientSideMediaProcessing = false;
+		mockSummary( {
+			total: 2,
+			completed: 0,
+			progress: 0,
+			currentFilename: 'foo.jpg',
+		} );
+		const { container } = render( <PostUploadIndicator /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows the label, count and filename when uploading', () => {
+		mockSummary( {
+			total: 10,
+			completed: 3,
+			progress: 30,
+			currentFilename: 'kitten.jpg',
+		} );
+		render( <PostUploadIndicator /> );
+		expect( screen.getByText( 'Uploading' ) ).toBeVisible();
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
+			'3 / 10 — kitten.jpg'
+		);
+	} );
+
+	it( 'omits the filename when none is provided', () => {
+		mockSummary( {
+			total: 1,
+			completed: 0,
+			progress: 0,
+		} );
+		render( <PostUploadIndicator /> );
+		const status = screen.getByRole( 'status' );
+		expect( status ).toHaveTextContent( '0 / 1' );
+		expect( status ).not.toHaveTextContent( /—/ );
+	} );
+
+	it( 'gives the progress bar a descriptive aria-label with counts and filename', () => {
+		mockSummary( {
+			total: 5,
+			completed: 2,
+			progress: 40,
+			currentFilename: 'photo.png',
+		} );
+		render( <PostUploadIndicator /> );
+		expect(
+			screen.getByRole( 'progressbar', {
+				name: /Uploading media: 2 of 5, currently photo\.png/,
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'announces start and completion via speak()', () => {
+		mockSummary( null );
+		const { rerender } = render( <PostUploadIndicator /> );
+		expect( speak ).not.toHaveBeenCalled();
+
+		mockSummary( {
+			total: 2,
+			completed: 0,
+			progress: 0,
+			currentFilename: 'a.jpg',
+		} );
+		rerender( <PostUploadIndicator /> );
+		expect( speak ).toHaveBeenCalledWith(
+			'Media upload started',
+			'polite'
+		);
+
+		mockSummary( null );
+		rerender( <PostUploadIndicator /> );
+		expect( speak ).toHaveBeenCalledWith(
+			'Media upload complete',
+			'polite'
+		);
+	} );
+} );

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -28,6 +28,7 @@ import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
 import PostSyncStatus from '../post-sync-status';
 import PostTemplatePanel from '../post-template/panel';
+import PostUploadIndicator from '../post-upload-indicator';
 import PostURLPanel from '../post-url/panel';
 import BlogTitle from '../blog-title';
 import PostsPerPage from '../posts-per-page';
@@ -98,6 +99,7 @@ function ClassicPostSummary( { onActionPerformed } ) {
 							/>
 							<PostFeaturedImagePanel withPanelBody={ false } />
 							<PostExcerptPanel />
+							<PostUploadIndicator />
 							<VStack spacing={ 1 }>
 								<PostContentInformation />
 								<PostLastEditedPanel />

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -55,6 +55,7 @@
 @use "./components/post-url/style.scss" as *;
 @use "./components/posts-per-page/style.scss" as *;
 @use "./components/post-trash/style.scss" as *;
+@use "./components/post-upload-indicator/style.scss" as *;
 @use "./components/preview-dropdown/style.scss" as *;
 @use "./components/resizable-editor/style.scss" as *;
 @use "./components/save-publish-panels/style.scss" as *;

--- a/packages/upload-media/README.md
+++ b/packages/upload-media/README.md
@@ -107,6 +107,20 @@ _Returns_
 
 -   `Settings`: Settings
 
+#### getUploadProgressSummary
+
+Returns a summary of the current upload queue, or `null` when the queue is empty. Intended for a single high-level progress indicator rather than a per-item list.
+
+The overall `progress` prefers the average of per-item `progress` values when every item has one; otherwise it falls back to `completed / total` so the bar still advances meaningfully before per-item progress is wired through the upload pipeline.
+
+_Parameters_
+
+-   _state_ `State`: Upload state.
+
+_Returns_
+
+-   `UploadProgressSummary | null`: Summary of the current upload queue, or null when idle.
+
 #### isUploading
 
 Determines whether any upload is currently in progress.

--- a/packages/upload-media/src/store/selectors.ts
+++ b/packages/upload-media/src/store/selectors.ts
@@ -1,7 +1,23 @@
 /**
  * Internal dependencies
  */
+import { ItemStatus, OperationType } from './types';
 import type { QueueItem, Settings, State } from './types';
+
+/**
+ * Summary of the current upload queue, suitable for rendering a single
+ * high-level progress indicator (count, overall percentage, current filename).
+ */
+export interface UploadProgressSummary {
+	/** Total number of items currently in the queue. */
+	total: number;
+	/** Number of items that have finished uploading. */
+	completed: number;
+	/** Approximate overall progress across the batch, 0–100. */
+	progress: number;
+	/** File name of the item currently being processed, if any. */
+	currentFilename?: string;
+}
 
 /**
  * Returns all items currently being uploaded.
@@ -64,4 +80,66 @@ export function isUploadingById( state: State, attachmentId: number ): boolean {
  */
 export function getSettings( state: State ): Settings {
 	return state.settings;
+}
+
+/**
+ * Returns a summary of the current upload queue, or `null` when the queue is
+ * empty. Intended for a single high-level progress indicator rather than a
+ * per-item list.
+ *
+ * The overall `progress` prefers the average of per-item `progress` values
+ * when every item has one; otherwise it falls back to `completed / total`
+ * so the bar still advances meaningfully before per-item progress is wired
+ * through the upload pipeline.
+ *
+ * @param state Upload state.
+ *
+ * @return Summary of the current upload queue, or null when idle.
+ */
+export function getUploadProgressSummary(
+	state: State
+): UploadProgressSummary | null {
+	const items = state.queue;
+	if ( items.length === 0 ) {
+		return null;
+	}
+
+	const total = items.length;
+	const completed = items.filter(
+		( item ) => item.status === ItemStatus.Uploaded
+	).length;
+
+	// Prefer the item currently in the UPLOAD operation; fall back to the
+	// first non-uploaded, non-errored item so there is still something to
+	// label while preparatory operations (resize, transcode) run.
+	const current =
+		items.find(
+			( item ) =>
+				item.currentOperation === OperationType.Upload &&
+				item.status !== ItemStatus.Uploaded
+		) ??
+		items.find(
+			( item ) =>
+				item.status !== ItemStatus.Uploaded &&
+				item.status !== ItemStatus.Error
+		);
+
+	const progressValues = items
+		.map( ( item ) => item.progress )
+		.filter( ( value ): value is number => typeof value === 'number' );
+
+	const progress =
+		progressValues.length === items.length
+			? Math.round(
+					progressValues.reduce( ( sum, value ) => sum + value, 0 ) /
+						items.length
+			  )
+			: Math.round( ( completed / total ) * 100 );
+
+	return {
+		total,
+		completed,
+		progress,
+		currentFilename: current?.file.name,
+	};
 }

--- a/packages/upload-media/src/store/test/selectors.ts
+++ b/packages/upload-media/src/store/test/selectors.ts
@@ -3,6 +3,7 @@
  */
 import {
 	getItems,
+	getUploadProgressSummary,
 	isUploading,
 	isUploadingById,
 	isUploadingByUrl,
@@ -421,6 +422,115 @@ describe( 'selectors', () => {
 			expect( hasPendingItemsByParentId( state, 'parent-1' ) ).toBe(
 				false
 			);
+		} );
+	} );
+
+	describe( 'getUploadProgressSummary', () => {
+		const makeItem = ( overrides: Partial< QueueItem > ): QueueItem =>
+			( {
+				id: 'id',
+				status: ItemStatus.Processing,
+				file: new File( [ '' ], 'file.jpg' ),
+				...overrides,
+			} ) as QueueItem;
+
+		const makeState = ( queue: QueueItem[] ): State => ( {
+			queue,
+			queueStatus: 'active',
+			blobUrls: {},
+			settings: {
+				mediaUpload: jest.fn(),
+			},
+		} );
+
+		it( 'returns null when the queue is empty', () => {
+			expect( getUploadProgressSummary( makeState( [] ) ) ).toBeNull();
+		} );
+
+		it( 'returns counts and the current filename for a single item', () => {
+			const state = makeState( [
+				makeItem( {
+					id: '1',
+					status: ItemStatus.Processing,
+					currentOperation: OperationType.Upload,
+					file: new File( [ '' ], 'kitten.jpg' ),
+				} ),
+			] );
+
+			expect( getUploadProgressSummary( state ) ).toEqual( {
+				total: 1,
+				completed: 0,
+				progress: 0,
+				currentFilename: 'kitten.jpg',
+			} );
+		} );
+
+		it( 'derives progress from completed / total when per-item progress is missing', () => {
+			const queue: QueueItem[] = [];
+			for ( let i = 0; i < 10; i++ ) {
+				queue.push(
+					makeItem( {
+						id: String( i ),
+						status:
+							i < 3 ? ItemStatus.Uploaded : ItemStatus.Processing,
+						currentOperation:
+							i === 3 ? OperationType.Upload : undefined,
+						file: new File( [ '' ], `img-${ i }.jpg` ),
+					} )
+				);
+			}
+
+			const summary = getUploadProgressSummary( makeState( queue ) );
+			expect( summary ).toEqual( {
+				total: 10,
+				completed: 3,
+				progress: 30,
+				currentFilename: 'img-3.jpg',
+			} );
+		} );
+
+		it( 'averages per-item progress when every item reports it', () => {
+			const state = makeState( [
+				makeItem( {
+					id: '1',
+					status: ItemStatus.Processing,
+					progress: 80,
+					file: new File( [ '' ], 'a.jpg' ),
+				} ),
+				makeItem( {
+					id: '2',
+					status: ItemStatus.Processing,
+					progress: 20,
+					currentOperation: OperationType.Upload,
+					file: new File( [ '' ], 'b.jpg' ),
+				} ),
+			] );
+
+			const summary = getUploadProgressSummary( state );
+			expect( summary ).toMatchObject( {
+				total: 2,
+				completed: 0,
+				progress: 50,
+				currentFilename: 'b.jpg',
+			} );
+		} );
+
+		it( 'skips errored items when picking the current filename', () => {
+			const state = makeState( [
+				makeItem( {
+					id: '1',
+					status: ItemStatus.Error,
+					file: new File( [ '' ], 'broken.jpg' ),
+				} ),
+				makeItem( {
+					id: '2',
+					status: ItemStatus.Processing,
+					file: new File( [ '' ], 'good.jpg' ),
+				} ),
+			] );
+
+			const summary = getUploadProgressSummary( state );
+			expect( summary?.currentFilename ).toBe( 'good.jpg' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Adds a compact upload progress indicator to the editor's post summary sidebar, so users can see how media uploads are progressing without leaving the editor. Mirrors the pattern already used in the Media Library's upload panel.

Closes #77241. Related to parent #76756 and progress-tracking work in #74362 / #74363.

## Why?

Today, when uploading an image or a batch of images, there is no centralized indication of overall upload progress — just per-block spinners. The Media Library already solves this nicely; this brings the same affordance into the editor's post panel.

## How?

- **New public selector** `getUploadProgressSummary` in `@wordpress/upload-media` returns `{ total, completed, progress, currentFilename }` or `null`. It prefers averaged per-item progress when every item has one, and falls back to `completed / total` so the bar still advances before per-item progress is wired through the pipeline (#74362).
- **New `PostUploadIndicator`** component in `@wordpress/editor`:
  - Renders a `PostPanelRow` labeled "Uploading" with a `ProgressBar` and a `completed / total — filename` readout.
  - Gated by the existing `window.__clientSideMediaProcessing` runtime flag used elsewhere in the editor.
  - Uses a `role="status"` live region for polite progress updates and `wp.a11y.speak()` to announce start and completion transitions (avoids chatter on every percentage tick).
  - Returns \`null\` when idle, so it contributes nothing to the DOM in the common case.
- **Mounted** in `ClassicPostSummary` as a direct child of the outer `VStack spacing={ 4 }`, not inside the status-rows stack — keeps it visible even when the post status panel is programmatically removed, and visually separates it from post metadata rows.

## Testing Instructions

1. Open a new post and drop a batch of 5–10 images into the editor canvas.
2. Confirm that the post panel sidebar shows an "Uploading" row with a progress bar, an `n / total` count, and the filename of the active file.
3. Confirm the row disappears when the queue drains.
4. With a screen reader active, confirm that "Media upload started" and "Media upload complete" are announced once each at the boundaries, and progress updates are announced politely without interrupting.
5. Upload a single image and confirm the indicator appears briefly and disappears cleanly.

### Automated tests

- \`npm run test:unit -- packages/upload-media/src/store/test/selectors.ts packages/editor/src/components/post-upload-indicator/test/index.js\` — 25 tests passing.

## Acceptance criteria (from #77241)

- [x] Progress indicator appears in the post panel while media uploads are in progress
- [x] Shows a progress bar reflecting approximate overall progress
- [x] Shows a high level completed / total count (e.g. \`6 / 10\`)
- [x] Hidden when no uploads are in progress
- [x] Accessible: descriptive \`aria-label\` on the progress bar, \`role="status"\` live region, \`wp.a11y.speak\` announcements on start / completion
- [x] Works for single and batch uploads
- [x] Visual style is consistent with existing Gutenberg post-panel rows

## Screencasts

### Multiple images

https://github.com/user-attachments/assets/13235d15-121e-4c23-82e4-a37c5a2e2f29



### Single image


https://github.com/user-attachments/assets/03c69536-a939-45e7-9ec7-f87a77fc2cf7




## Out of scope

- **Per-item progress accuracy** — depends on \`updateItemProgress\` being dispatched from the upload pipeline (tracked in #74362). The selector falls back to \`completed / total\` today and will automatically pick up finer-grained progress once that lands.
- **Error / retry UI in the indicator** — covered by #74366.
- **Site Editor / non-post contexts** — can be ported in a follow-up.