### PR TITLE
Fix(Pattern): Custom category in site editor does not display pattern actions

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -185,7 +185,7 @@ export default function DataviewsPatterns() {
 				actions={
 					<PatternsActions
 						categoryId={ categoryId }
-						postType={ postType }
+						type={ postType }
 					/>
 				}
 			>


### PR DESCRIPTION
## What?

Closes #77250 

This PR restores the visibility of Pattern Actions (e.g., rename and delete) for custom pattern categories in the Site Editor.

## Why?

Pattern Actions were not appearing for custom patterns in the latest Trunk due to a prop mismatch. The PatternsActions component expects a type prop, but postType was being passed instead.

## How?

This PR updates the prop passed to the PatternsActions component from postType to type, aligning it with the component’s expected API. This ensures that Pattern Actions are correctly rendered for custom pattern categories.

Ref:
https://github.com/WordPress/gutenberg/blob/da3570279a63c4003a7242365b173cd25e2453b0/packages/edit-site/src/components/page-patterns/actions.js#L17

## Testing Instructions
1. Navigate to Site Editor → Patterns
2. Create a new pattern with a custom category
3. Navigate to the custom category
4. Observe that the options to rename/delete the custom category are available

## Screenshots 

|Before|After|
|-|-|
|<img width="1906" height="823" alt="bug" src="https://github.com/user-attachments/assets/2fd9a89e-19ff-45d1-a336-3f9d31334f50" />|<img width="1906" height="823" alt="after" src="https://github.com/user-attachments/assets/936cbe75-3d92-426a-83d1-aa37bbc946b4" />|

## Use of AI Tools
No AI Tools used.
