### PR TITLE
Core Abilities: Export initialization promise as `ready`

### DIFF
--- a/packages/core-abilities/README.md
+++ b/packages/core-abilities/README.md
@@ -29,6 +29,18 @@ Simply import the package to initialize the WordPress abilities:
 import '@wordpress/core-abilities';
 ```
 
+Initialization is asynchronous because categories and abilities are fetched from the REST API. To wait for registration to finish before calling `getAbilities()` or `executeAbility()`, await the exported `ready` promise:
+
+```js
+import { ready } from '@wordpress/core-abilities';
+import { getAbilities, executeAbility } from '@wordpress/abilities';
+
+await ready;
+
+console.log( getAbilities() );
+console.log( await executeAbility( 'core/get-site-info' ) );
+```
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/core-abilities/src/index.ts
+++ b/packages/core-abilities/src/index.ts
@@ -142,5 +142,5 @@ async function initialize(): Promise< void > {
 	await initializeAbilities();
 }
 
-// Auto-initialize on import
-initialize();
+// Auto-initialize on import.
+export const ready: Promise< void > = initialize();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #77253

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

REST API calls to fetch the Abilities API endpoints must currently finish before modules may interact with `getAbilities()` or `executeAbility()`.

## How?

This exports the `Promise` return value from the `initialize` function as `ready` so that modules can await on that to resolve before attempting to access abilities. 

## Testing Instructions

Add a plugin that does the following:

```php
add_action( 'admin_enqueue_scripts', static function(): void {
	wp_register_script(
		'abilities-test',
		false,
		array(),
		false,
		array(
			'module_dependencies' => array(
				'@wordpress/core-abilities',
				'@wordpress/abilities'
			),
		)
	);
	wp_enqueue_script( 'abilities-test' );

	add_action( 'admin_print_footer_scripts', function () {
		wp_print_inline_script_tag(
			<<<'JS'
				import { ready } from '@wordpress/core-abilities';
				import { getAbilities, executeAbility } from '@wordpress/abilities';
				await ready; // ✨ NEW!

				console.log( getAbilities() );

				console.info( await executeAbility( "core/get-site-info" ) );
			JS,
			array( 'type' => 'module' )
		);
	} );
} );
```

You should see a list of the abilities successfully logged along with the site info.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Sonnet 4.6 was used to propose a solution and implement the fix.