### PR TITLE
Guidelines: Try removing the jsxRuntime pragma and see what happens

### DIFF
--- a/routes/content-guidelines/components/action-item.tsx
+++ b/routes/content-guidelines/components/action-item.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/components/block-guideline-modal.tsx
+++ b/routes/content-guidelines/components/block-guideline-modal.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/components/block-guidelines.tsx
+++ b/routes/content-guidelines/components/block-guidelines.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/components/guideline-accordion-form.tsx
+++ b/routes/content-guidelines/components/guideline-accordion-form.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/components/guideline-accordion.tsx
+++ b/routes/content-guidelines/components/guideline-accordion.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/components/guideline-actions-section.tsx
+++ b/routes/content-guidelines/components/guideline-actions-section.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/components/revision-history.tsx
+++ b/routes/content-guidelines/components/revision-history.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */

--- a/routes/content-guidelines/stage.tsx
+++ b/routes/content-guidelines/stage.tsx
@@ -1,5 +1,3 @@
-/* @jsxRuntime automatic */
-
 /**
  * WordPress dependencies
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follows the discussion in:

* https://github.com/WordPress/gutenberg/pull/76560#discussion_r3064225296

Try removing the `jsxRuntime` pragma at the top of the `.tsx` file in the content guidelines route.

## Why?

These shouldn't (at least in theory) be required as the value should be set in both babel and the wp-build scripts:

https://github.com/WordPress/gutenberg/blob/4f8528190f015517d7cc46db0c27b5166d3a2fa3/packages/babel-preset-default/index.js#L91

https://github.com/WordPress/gutenberg/blob/a473a4cbb07a650238d5ec11a0f9538db814ab30/packages/wp-build/lib/build.mjs#L1349

So, this PR is here to try out removing them to see if and where we wind up with a linting issue (and so we can then resolve it). I'm curious to do this because we didn't need the pragma anywhere else in Gutenberg, so we might have missed something somewhere 😄 

## How?

* Just remove it from the files

## Testing Instructions

Smoke test that the guidelines experiment works as on trunk. 

## Use of AI Tools

I got Claude Code to remove the lines and to help me to try to reproduce the linting issue reported. I couldn't reproduce it locally, so now trying it out in this PR.