### PR TITLE
Resolve package-lock.json inconsistency for @babel/eslint-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1502,6 +1502,33 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/@babel/eslint-parser": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
+			"integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0",
+				"eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+			}
+		},
+		"node_modules/@babel/eslint-parser/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/@babel/generator": {
 			"version": "7.28.6",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
@@ -60166,24 +60193,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"packages/eslint-plugin/node_modules/@babel/eslint-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
-			"integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
-			"license": "MIT",
-			"dependencies": {
-				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-				"eslint-visitor-keys": "^2.1.0",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.11.0",
-				"eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
 			}
 		},
 		"packages/eslint-plugin/node_modules/@es-joy/jsdoccomment": {


### PR DESCRIPTION
## What?
Follow up to #76654.

Resolve a `package-lock.json` inconsistency for `@babel/eslint-parser` so that `npm ci` succeeds on `trunk`.

## Why?
The ESLint v10 upgrade (#76654) bumped `@babel/eslint-parser` to `^7.28.6` in `packages/eslint-plugin/package.json`, but `package-lock.json` was left resolving to `7.25.7`. As a result, `npm ci` on `trunk` fails with:

```
npm error Missing: @babel/eslint-parser@7.28.6 from lock file
npm error Missing: semver@6.3.1 from lock file
```

## How?
Ran `npm install` locally to regenerate `package-lock.json`

## Use of AI Tools
Claude Code was used to investigate the CI failure, identify the lock file mismatch, and draft this PR description. All changes were reviewed by the author.
