### PR TITLE
Security: Switch to OIDC trusted publishing for npm packages

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -34,6 +34,7 @@ jobs:
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
+            id-token: write
         environment: WordPress packages
         steps:
             - name: Checkout (for CLI)
@@ -91,14 +92,15 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true
 
+            - name: Upgrade npm to support OIDC trusted publishing
+              run: npm install -g npm@latest
+
             - name: Publish development packages to npm ("next" dist-tag)
               if: ${{ github.event.inputs.release_type == 'development' }}
               run: |
                   cd cli
                   npm ci
                   ./bin/plugin/cli.js npm-next --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish packages based on the latest Gutenberg plugin to npm ("latest" dist-tag)
               if: ${{ github.event.inputs.release_type == 'latest' }}
@@ -106,8 +108,6 @@ jobs:
                   cd cli
                   npm ci
                   ./bin/plugin/cli.js npm-latest --semver minor --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish packages to npm with bug fixes ("latest" dist-tag)
               if: ${{ github.event.inputs.release_type == 'bugfix' }}
@@ -115,15 +115,12 @@ jobs:
                   cd cli
                   npm ci
                   ./bin/plugin/cli.js npm-bugfix --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish packages to npm for WP major version ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd publish
                   npm ci
-                  npx lerna publish patch --dist-tag "wp-$WP_VERSION" --no-private --yes --no-verify-access
+                  npx lerna publish patch --dist-tag "wp-$WP_VERSION" --no-private --yes
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   WP_VERSION: ${{ github.event.inputs.wp_version }}

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -357,12 +357,6 @@ async function publishPackagesToNpm( {
 		cwd: gitWorkingDirectoryPath,
 	} );
 
-	log( '>> Current npm user:' );
-	await command( 'npm whoami', {
-		cwd: gitWorkingDirectoryPath,
-		stdio: 'inherit',
-	} );
-
 	const beforeCommitHash = await SimpleGit(
 		gitWorkingDirectoryPath
 	).revparse( [ '--short', 'HEAD' ] );
@@ -374,7 +368,7 @@ async function publishPackagesToNpm( {
 		.replace( /[-:T]/g, '' );
 
 	const yesFlag = interactive ? '' : '--yes';
-	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
+
 	if ( releaseType === 'next' ) {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
@@ -390,7 +384,7 @@ async function publishPackagesToNpm( {
 
 		log( '>> Publishing modified packages to npm.' );
 		await command(
-			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
@@ -400,7 +394,7 @@ async function publishPackagesToNpm( {
 		log( '>> Publishing modified packages to npm.' );
 		try {
 			await command(
-				`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
+				`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag }`,
 				{
 					cwd: gitWorkingDirectoryPath,
 					stdio: 'inherit',
@@ -412,7 +406,7 @@ async function publishPackagesToNpm( {
 			);
 			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
 			await command(
-				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag }`,
 				{
 					cwd: gitWorkingDirectoryPath,
 					stdio: 'inherit',
@@ -433,25 +427,19 @@ async function publishPackagesToNpm( {
 
 		log( '>> Publishing modified packages to npm.' );
 		try {
-			await command(
-				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
+			await command( `npx lerna publish from-package ${ yesFlag }`, {
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			} );
 		} catch {
 			log(
 				'>> Trying to finish failed publishing of modified npm packages.'
 			);
 			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
-			await command(
-				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
+			await command( `npx lerna publish from-package ${ yesFlag }`, {
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			} );
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
 				"jest-message-util": "^29.6.2",
 				"jest-watch-typeahead": "2.2.2",
 				"jsonc-parser": "3.3.1",
-				"lerna": "8.1.9",
+				"lerna": "9.0.7",
 				"lint-staged": "10.0.2",
 				"node-fetch": "2.7.0",
 				"npm-run-all": "4.1.5",
@@ -1110,16 +1110,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@appium/support/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@appium/support/node_modules/npmlog": {
@@ -5568,6 +5558,16 @@
 				"tslib": "2"
 			}
 		},
+		"node_modules/@gar/promise-retry": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+			"integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -5662,59 +5662,85 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@inquirer/ansi": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+			"integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.3.tgz",
-			"integrity": "sha512-CEt9B4e8zFOGtc/LYeQx5m8nfqQeG/4oNNv0PUvXGG0mys+wR/WbJ3B4KfSQ4Fcr3AQfpiuFOi3fVvmPfvNbxw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+			"integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/figures": "^1.0.8",
-				"@inquirer/type": "^3.0.1",
-				"ansi-escapes": "^4.3.2",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.0.tgz",
-			"integrity": "sha512-osaBbIMEqVFjTX5exoqPXs6PilWQdjaLhGtMDXMXg/yxkHXNq43GlxGyTA35lK2HpzUgDN+Cjh/2AmqCN0QJpw==",
+			"version": "5.1.21",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+			"integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.1.tgz",
-			"integrity": "sha512-rmZVXy9iZvO3ZStEe/ayuuwIJ23LSF13aPMlLMTQARX6lGUBDHGV8UB5i9MRrfy0+mZwt5/9bdy8llszSD3NQA==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+			"integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/figures": "^1.0.8",
-				"@inquirer/type": "^3.0.1",
-				"ansi-escapes": "^4.3.2",
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
 				"cli-width": "^4.1.0",
 				"mute-stream": "^2.0.0",
 				"signal-exit": "^4.1.0",
-				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^6.2.0",
-				"yoctocolors-cjs": "^2.1.2"
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/core/node_modules/mute-stream": {
@@ -5739,95 +5765,157 @@
 			}
 		},
 		"node_modules/@inquirer/editor": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.0.tgz",
-			"integrity": "sha512-Z3LeGsD3WlItDqLxTPciZDbGtm0wrz7iJGS/uUxSiQxef33ZrBq7LhsXg30P7xrWz1kZX4iGzxxj5SKZmJ8W+w==",
+			"version": "4.2.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+			"integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1",
-				"external-editor": "^3.1.0"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/external-editor": "^1.0.3",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.3.tgz",
-			"integrity": "sha512-MDszqW4HYBpVMmAoy/FA9laLrgo899UAga0itEjsYrBthKieDZNc0e16gdn7N3cQ0DSf/6zsTBZMuDYDQU4ktg==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+			"integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
-			"integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+			"integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.0.tgz",
-			"integrity": "sha512-16B8A9hY741yGXzd8UJ9R8su/fuuyO2e+idd7oVLYjP23wKJ6ILRIIHcnXe8/6AoYgwRS2zp4PNsW/u/iZ24yg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+			"integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.3.tgz",
-			"integrity": "sha512-HA/W4YV+5deKCehIutfGBzNxWH1nhvUC67O4fC9ufSijn72yrYnRmzvC61dwFvlXIG1fQaYWi+cqNE9PaB9n6Q==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+			"integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.3.tgz",
-			"integrity": "sha512-3qWjk6hS0iabG9xx0U1plwQLDBc/HA/hWzLFFatADpR6XfE62LqPr9GpFXBkLU0KQUaIXZ996bNG+2yUvocH8w==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+			"integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1",
-				"ansi-escapes": "^4.3.2"
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/prompts": {
@@ -5855,69 +5943,89 @@
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.3.tgz",
-			"integrity": "sha512-5MhinSzfmOiZlRoPezfbJdfVCZikZs38ja3IOoWe7H1dxL0l3Z2jAUgbBldeyhhOkELdGvPlBfQaNbeLslib1w==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+			"integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/type": "^3.0.1",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.3.tgz",
-			"integrity": "sha512-mQTCbdNolTGvGGVCJSI6afDwiSGTV+fMLPEIMDJgIV6L/s3+RYRpxt6t0DYnqMQmemnZ/Zq0vTIRwoHT1RgcTg==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+			"integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/figures": "^1.0.8",
-				"@inquirer/type": "^3.0.1",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.3.tgz",
-			"integrity": "sha512-OZfKDtDE8+J54JYAFTUGZwvKNfC7W/gFCjDkcsO7HnTH/wljsZo9y/FJquOxMy++DY0+9l9o/MOZ8s5s1j5wmw==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+			"integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.1",
-				"@inquirer/figures": "^1.0.8",
-				"@inquirer/type": "^3.0.1",
-				"ansi-escapes": "^4.3.2",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
-			"integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+			"integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -6008,6 +6116,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+			"integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@isaacs/string-locale-compare": {
@@ -6924,16 +7045,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/path-scurry": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -7028,1023 +7139,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-		},
-		"node_modules/@lerna/create": {
-			"version": "8.1.9",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.1.9.tgz",
-			"integrity": "sha512-DPnl5lPX4v49eVxEbJnAizrpMdMTBz1qykZrAbBul9rfgk531v8oAt+Pm6O/rpAleRombNM7FJb5rYGzBJatOQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@npmcli/arborist": "7.5.4",
-				"@npmcli/package-json": "5.2.0",
-				"@npmcli/run-script": "8.1.0",
-				"@nx/devkit": ">=17.1.2 < 21",
-				"@octokit/plugin-enterprise-rest": "6.0.1",
-				"@octokit/rest": "19.0.11",
-				"aproba": "2.0.0",
-				"byte-size": "8.1.1",
-				"chalk": "4.1.0",
-				"clone-deep": "4.0.1",
-				"cmd-shim": "6.0.3",
-				"color-support": "1.1.3",
-				"columnify": "1.6.0",
-				"console-control-strings": "^1.1.0",
-				"conventional-changelog-core": "5.0.1",
-				"conventional-recommended-bump": "7.0.1",
-				"cosmiconfig": "9.0.0",
-				"dedent": "1.5.3",
-				"execa": "5.0.0",
-				"fs-extra": "^11.2.0",
-				"get-stream": "6.0.0",
-				"git-url-parse": "14.0.0",
-				"glob-parent": "6.0.2",
-				"globby": "11.1.0",
-				"graceful-fs": "4.2.11",
-				"has-unicode": "2.0.1",
-				"ini": "^1.3.8",
-				"init-package-json": "6.0.3",
-				"inquirer": "^8.2.4",
-				"is-ci": "3.0.1",
-				"is-stream": "2.0.0",
-				"js-yaml": "4.1.0",
-				"libnpmpublish": "9.0.9",
-				"load-json-file": "6.2.0",
-				"lodash": "^4.17.21",
-				"make-dir": "4.0.0",
-				"minimatch": "3.0.5",
-				"multimatch": "5.0.0",
-				"node-fetch": "2.6.7",
-				"npm-package-arg": "11.0.2",
-				"npm-packlist": "8.0.2",
-				"npm-registry-fetch": "^17.1.0",
-				"nx": ">=17.1.2 < 21",
-				"p-map": "4.0.0",
-				"p-map-series": "2.1.0",
-				"p-queue": "6.6.2",
-				"p-reduce": "^2.1.0",
-				"pacote": "^18.0.6",
-				"pify": "5.0.0",
-				"read-cmd-shim": "4.0.0",
-				"resolve-from": "5.0.0",
-				"rimraf": "^4.4.1",
-				"semver": "^7.3.4",
-				"set-blocking": "^2.0.0",
-				"signal-exit": "3.0.7",
-				"slash": "^3.0.0",
-				"ssri": "^10.0.6",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"strong-log-transformer": "2.1.0",
-				"tar": "6.2.1",
-				"temp-dir": "1.0.0",
-				"upath": "2.0.1",
-				"uuid": "^10.0.0",
-				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "5.0.1",
-				"wide-align": "1.1.5",
-				"write-file-atomic": "5.0.1",
-				"write-pkg": "4.0.0",
-				"yargs": "17.7.2",
-				"yargs-parser": "21.1.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/auth-token": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-			"integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/core": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-			"integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/auth-token": "^3.0.0",
-				"@octokit/graphql": "^5.0.0",
-				"@octokit/request": "^6.0.0",
-				"@octokit/request-error": "^3.0.0",
-				"@octokit/types": "^9.0.0",
-				"before-after-hook": "^2.2.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/endpoint": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-			"integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^9.0.0",
-				"is-plain-object": "^5.0.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/graphql": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-			"integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/request": "^6.0.0",
-				"@octokit/types": "^9.0.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/openapi-types": {
-			"version": "18.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-			"integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-			"integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/tsconfig": "^1.0.2",
-				"@octokit/types": "^9.2.3"
-			},
-			"engines": {
-				"node": ">= 14"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=4"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-			"integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^10.0.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=3"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-			"integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/request": {
-			"version": "6.2.8",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-			"integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/endpoint": "^7.0.0",
-				"@octokit/request-error": "^3.0.0",
-				"@octokit/types": "^9.0.0",
-				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.7",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/request-error": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-			"integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^9.0.0",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/rest": {
-			"version": "19.0.11",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
-			"integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/core": "^4.2.1",
-				"@octokit/plugin-paginate-rest": "^6.1.2",
-				"@octokit/plugin-request-log": "^1.0.4",
-				"@octokit/plugin-rest-endpoint-methods": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/@octokit/types": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-			"integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/aproba": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@lerna/create/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/@lerna/create/node_modules/before-after-hook": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@lerna/create/node_modules/chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/cli-width": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.1",
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@lerna/create/node_modules/dedent": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-			"integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"babel-plugin-macros": "^3.1.0"
-			},
-			"peerDependenciesMeta": {
-				"babel-plugin-macros": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@lerna/create/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@lerna/create/node_modules/execa": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-			"integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/figures": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.5"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/fs-extra": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/get-stream": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-			"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/glob": {
-			"version": "9.3.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"minimatch": "^8.0.2",
-				"minipass": "^4.2.4",
-				"path-scurry": "^1.6.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/glob/node_modules/minimatch": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-			"integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/glob/node_modules/minipass": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10.17.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/ignore-walk": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
-			"integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minimatch": "^9.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/ignore-walk/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/inquirer": {
-			"version": "8.2.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-			"integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.1.1",
-				"cli-cursor": "^3.1.0",
-				"cli-width": "^3.0.0",
-				"external-editor": "^3.0.3",
-				"figures": "^3.0.0",
-				"lodash": "^4.17.21",
-				"mute-stream": "0.0.8",
-				"ora": "^5.4.1",
-				"run-async": "^2.4.0",
-				"rxjs": "^7.5.5",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"through": "^2.3.6",
-				"wrap-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/inquirer/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/is-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/make-dir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@lerna/create/node_modules/npm-package-arg": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.2.tgz",
-			"integrity": "sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/npm-packlist": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
-			"integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"ignore-walk": "^6.0.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/ora": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^4.1.0",
-				"chalk": "^4.1.0",
-				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.5.0",
-				"is-interactive": "^1.0.0",
-				"is-unicode-supported": "^0.1.0",
-				"log-symbols": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"wcwidth": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/rimraf": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-			"integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^9.2.0"
-			},
-			"bin": {
-				"rimraf": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/rxjs": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/universal-user-agent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@lerna/create/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/upath": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4",
-				"yarn": "*"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/write-file-atomic": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/write-file-atomic/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@lerna/create/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/@mdx-js/react": {
 			"version": "3.1.0",
@@ -8145,891 +7239,1238 @@
 			}
 		},
 		"node_modules/@npmcli/agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
-			"integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+			"integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"agent-base": "^7.1.0",
 				"http-proxy-agent": "^7.0.0",
 				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
+				"lru-cache": "^11.2.1",
 				"socks-proxy-agent": "^8.0.3"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/agent/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/arborist": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-7.5.4.tgz",
-			"integrity": "sha512-nWtIc6QwwoUORCRNzKx4ypHqCk3drI+5aeYdMTQQiRCcn4lOOgfQh7WyZobGYTxXPSq1VwV53lkpN/BRlRk08g==",
+			"version": "9.1.6",
+			"resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.1.6.tgz",
+			"integrity": "sha512-c5Pr3EG8UP5ollkJy2x+UdEQC5sEHe3H9whYn6hb2HJimAKS4zmoJkx5acCiR/g4P38RnCSMlsYQyyHnKYeLvQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/fs": "^3.1.1",
-				"@npmcli/installed-package-contents": "^2.1.0",
-				"@npmcli/map-workspaces": "^3.0.2",
-				"@npmcli/metavuln-calculator": "^7.1.1",
-				"@npmcli/name-from-folder": "^2.0.0",
-				"@npmcli/node-gyp": "^3.0.0",
-				"@npmcli/package-json": "^5.1.0",
-				"@npmcli/query": "^3.1.0",
-				"@npmcli/redact": "^2.0.0",
-				"@npmcli/run-script": "^8.1.0",
-				"bin-links": "^4.0.4",
-				"cacache": "^18.0.3",
+				"@npmcli/fs": "^4.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/metavuln-calculator": "^9.0.2",
+				"@npmcli/name-from-folder": "^3.0.0",
+				"@npmcli/node-gyp": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/query": "^4.0.0",
+				"@npmcli/redact": "^3.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"bin-links": "^5.0.0",
+				"cacache": "^20.0.1",
 				"common-ancestor-path": "^1.0.1",
-				"hosted-git-info": "^7.0.2",
-				"json-parse-even-better-errors": "^3.0.2",
+				"hosted-git-info": "^9.0.0",
 				"json-stringify-nice": "^1.1.4",
-				"lru-cache": "^10.2.2",
-				"minimatch": "^9.0.4",
-				"nopt": "^7.2.1",
-				"npm-install-checks": "^6.2.0",
-				"npm-package-arg": "^11.0.2",
-				"npm-pick-manifest": "^9.0.1",
-				"npm-registry-fetch": "^17.0.1",
-				"pacote": "^18.0.6",
-				"parse-conflict-json": "^3.0.0",
-				"proc-log": "^4.2.0",
-				"proggy": "^2.0.0",
+				"lru-cache": "^11.2.1",
+				"minimatch": "^10.0.3",
+				"nopt": "^8.0.0",
+				"npm-install-checks": "^7.1.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"pacote": "^21.0.2",
+				"parse-conflict-json": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"proggy": "^3.0.0",
 				"promise-all-reject-late": "^1.0.0",
 				"promise-call-limit": "^3.0.1",
-				"read-package-json-fast": "^3.0.2",
 				"semver": "^7.3.7",
-				"ssri": "^10.0.6",
+				"ssri": "^12.0.0",
 				"treeverse": "^3.0.0",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^4.0.0"
 			},
 			"bin": {
 				"arborist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/cacache": {
-			"version": "18.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
+				"@npmcli/fs": "^5.0.0",
 				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
 				"minipass": "^7.0.3",
 				"minipass-collect": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+		"node_modules/@npmcli/arborist/node_modules/cacache/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/cacache/node_modules/ssri": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+		"node_modules/@npmcli/arborist/node_modules/ignore-walk": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+			"integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
 			"dev": true,
-			"license": "MIT",
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^10.0.3"
+			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/@npmcli/arborist/node_modules/npm-bundled": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+			"integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/npm-normalize-package-bin": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+			"integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+		"node_modules/@npmcli/arborist/node_modules/npm-package-arg/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/npm-packlist": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+			"integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"minipass": "^7.0.3"
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-			"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+		"node_modules/@npmcli/arborist/node_modules/npm-packlist/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/pacote": {
+			"version": "21.5.0",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
+			"integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-			"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/fs": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/git": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
-			"integrity": "sha512-liASfw5cqhjNW9UFd+ruwwdEf/lbOAQjLL2XY2dFW/bkJheXDYZgOyul/4gVvEV4BWkTXjYGmDqMw9uegdbJNQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/promise-spawn": "^7.0.0",
-				"ini": "^4.1.3",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^9.0.0",
-				"proc-log": "^4.0.0",
-				"promise-inflight": "^1.0.1",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^4.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/git/node_modules/ini": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/git/node_modules/isexe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@npmcli/git/node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"cacache": "^20.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^13.0.0",
+				"npm-packlist": "^10.0.1",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0",
+				"tar": "^7.4.3"
 			},
 			"bin": {
-				"node-which": "bin/which.js"
+				"pacote": "bin/index.js"
 			},
 			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/installed-package-contents": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.1.0.tgz",
-			"integrity": "sha512-c8UuGLeZpm69BryRykLuKRyKFZYJsZSCT4aVY5ds4omyZqJ172ApzgfKJ5eV/r3HgLdUYgFVe54KSFVjKoe27w==",
+		"node_modules/@npmcli/arborist/node_modules/pacote/node_modules/@npmcli/installed-package-contents": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+			"integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-bundled": "^3.0.0",
-				"npm-normalize-package-bin": "^3.0.0"
+				"npm-bundled": "^5.0.0",
+				"npm-normalize-package-bin": "^5.0.0"
 			},
 			"bin": {
 				"installed-package-contents": "bin/index.js"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-3.0.1.tgz",
-			"integrity": "sha512-+AvaheE/ww1JEwRHOrn4WHNzOxGtVp+adrg2AeZS/7KuxGUYFuBta98wYpfHBbJp6Tg6j1NKSEVHNcfZzJHQwQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-normalize-package-bin": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/installed-package-contents/node_modules/npm-normalize-package-bin": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-			"integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+		"node_modules/@npmcli/arborist/node_modules/pacote/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/map-workspaces": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-3.0.6.tgz",
-			"integrity": "sha512-tkYs0OYnzQm6iIRdfy+LcLBjcKuQCeE5YLb8KnrIlutJfheNaPvPpgoFEyEFgbjzl5PLZ3IA/BWAwRU0eHuQDA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/name-from-folder": "^2.0.0",
-				"glob": "^10.2.2",
-				"minimatch": "^9.0.0",
-				"read-package-json-fast": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@npmcli/map-workspaces/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/map-workspaces/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-7.1.1.tgz",
-			"integrity": "sha512-Nkxf96V0lAx3HCpVda7Vw4P23RILgdi/5K1fmj2tZkWIYLpXAN8k2UVVOsW16TsS5F8Ws2I7Cm+PU1/rsVF47g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cacache": "^18.0.0",
-				"json-parse-even-better-errors": "^3.0.0",
-				"pacote": "^18.0.0",
-				"proc-log": "^4.1.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/cacache": {
-			"version": "18.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+		"node_modules/@npmcli/arborist/node_modules/pacote/node_modules/ssri": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+		"node_modules/@npmcli/arborist/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/ssri": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/arborist/node_modules/validate-npm-package-name": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/fs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+			"integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/git": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+			"integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"ini": "^6.0.0",
+				"lru-cache": "^11.2.1",
+				"npm-pick-manifest": "^11.0.1",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"which": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/ini": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+			"integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/git/node_modules/which": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
 			},
 			"bin": {
-				"glob": "dist/esm/bin.mjs"
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/installed-package-contents": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-3.0.0.tgz",
+			"integrity": "sha512-fkxoPuFGvxyrH+OQzyTkX2LUEamrF4jZSmxjAtPPHHGO0dqsQ8tTKjnIS8SAnPHdk2I03BDtSMR5K/4loKg79Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-bundled": "^4.0.0",
+				"npm-normalize-package-bin": "^4.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "bin/index.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-4.0.0.tgz",
+			"integrity": "sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/installed-package-contents/node_modules/npm-normalize-package-bin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+			"integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+			"integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"glob": "^13.0.0",
+				"minimatch": "^10.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/@npmcli/name-from-folder": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+			"integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+			"integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cacache": "^20.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"pacote": "^21.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/cacache": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^5.0.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+			"integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/@npmcli/metavuln-calculator/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/metavuln-calculator/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-			"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-			"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/name-from-folder": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-2.0.0.tgz",
-			"integrity": "sha512-pwK+BfEBZJbKdNYpHHRTNBwBoqrN/iIMO0AiGvYsp3Hoaq0WbgGSWQR6SCldZovoDpY3yje5lkFUe6gsDgJ2vg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-3.0.0.tgz",
+			"integrity": "sha512-61cDL8LUc9y80fXn+lir+iVt8IS0xHqEKwPu/5jCjxQTVoSCmkXvw4vbMrzAMtmghz3/AkiBjhHkDKUH+kf7kA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/@npmcli/node-gyp": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-3.0.0.tgz",
-			"integrity": "sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-4.0.0.tgz",
+			"integrity": "sha512-+t5DZ6mO/QFh78PByMq1fGSAub/agLJZDRfJRMeOSNCt8s9YVlTjmGpIPwPhvXTGUIJk+WszlT0rQa1W33yzNA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/@npmcli/package-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.0.tgz",
-			"integrity": "sha512-qe/kiqqkW0AGtvBjL8TJKZk/eBBSpnJkUWvHdQ9jM2lKHXRYYJuyNpJPlJw3c8QjC2ow6NZYiLExhUaeJelbxQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.2.tgz",
+			"integrity": "sha512-0ylN3U5htO1SJTmy2YI78PZZjLkKUGg7EKgukb2CRi0kzyoDr0cfjHAzi7kozVhj2V3SxN1oyKqZ2NSo40z00g==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^5.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^7.0.0",
-				"json-parse-even-better-errors": "^3.0.0",
-				"normalize-package-data": "^6.0.0",
-				"proc-log": "^4.0.0",
-				"semver": "^7.5.3"
+				"@npmcli/git": "^7.0.0",
+				"glob": "^11.0.3",
+				"hosted-git-info": "^9.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.5.3",
+				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/@isaacs/cliui": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+			"integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@npmcli/package-json/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
+				"foreground-child": "^3.3.1",
+				"jackspeak": "^4.1.1",
+				"minimatch": "^10.1.1",
 				"minipass": "^7.1.2",
 				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"path-scurry": "^2.0.0"
 			},
 			"bin": {
 				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/package-json/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+		"node_modules/@npmcli/package-json/node_modules/jackspeak": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+			"integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/package-json/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"@isaacs/cliui": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@npmcli/package-json/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/@npmcli/package-json/node_modules/json-parse-even-better-errors": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+			"integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@npmcli/package-json/node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/promise-spawn": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
-			"integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+			"integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"which": "^4.0.0"
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/promise-spawn/node_modules/isexe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@npmcli/promise-spawn/node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^4.0.0"
 			},
 			"bin": {
 				"node-which": "bin/which.js"
 			},
 			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/query": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/query/-/query-3.1.0.tgz",
-			"integrity": "sha512-C/iR0tk7KSKGldibYIB9x8GtO/0Bd0I2mhOaDb8ucQL/bQVTmGoeREaFj64Z5+iCBRf3dQfed0CjJL7I8iTkiQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/query/-/query-4.0.1.tgz",
+			"integrity": "sha512-4OIPFb4weUUwkDXJf4Hh1inAn8neBGq3xsH4ZsAaN6FK3ldrFkH7jSpCc7N9xesi0Sp+EBXJ9eGMDrEww2Ztqw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.10"
+				"postcss-selector-parser": "^7.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/query/node_modules/postcss-selector-parser": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@npmcli/redact": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-2.0.1.tgz",
-			"integrity": "sha512-YgsR5jCQZhVmTJvjduTOIHph0L73pK8xwMVaDY0PatySqVM9AZj93jpoXYSJqfHFxFkN9dmqTw6OiqExsS3LPw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.2.2.tgz",
+			"integrity": "sha512-7VmYAmk4csGv08QzrDKScdzn11jHPFGyqJW39FyPgPuAp3zIaUmuCo1yxw9aGs+NEJuTGQ9Gwqpt93vtJubucg==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/@npmcli/run-script": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-8.1.0.tgz",
-			"integrity": "sha512-y7efHHwghQfk28G2z3tlZ67pLG0XdfYbcVG26r7YIXALRsrVQcTq4/tdenSmdOrEsNahIYA/eh8aEVROWGFUDg==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.3.tgz",
+			"integrity": "sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^3.0.0",
-				"@npmcli/package-json": "^5.0.0",
-				"@npmcli/promise-spawn": "^7.0.0",
-				"node-gyp": "^10.0.0",
-				"proc-log": "^4.0.0",
-				"which": "^4.0.0"
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"node-gyp": "^12.1.0",
+				"proc-log": "^6.0.0",
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@npmcli/run-script/node_modules/@npmcli/node-gyp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+			"integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/run-script/node_modules/isexe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@npmcli/run-script/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": ">=16"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/run-script/node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^4.0.0"
 			},
 			"bin": {
 				"node-which": "bin/which.js"
 			},
 			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@nx/devkit": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.2.1.tgz",
-			"integrity": "sha512-boNTu7Z7oHkYjrYg5Wzg+cQfbEJ2nntRj1eI99w8mp4qz2B4PEEjJOB0BZafR54ZcKpGEbyp/QBB945GsjTUbw==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.6.5.tgz",
+			"integrity": "sha512-9kvAI+kk2pfEXLqS8OyjI9XvWmp+Gdn7jPfxDAz8BOqxMyPy3p5hYl+jc4TIsLOWunAFl8azqrcYsHzEpaWCIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ejs": "^3.1.7",
+				"@zkochan/js-yaml": "0.0.7",
+				"ejs": "5.0.1",
 				"enquirer": "~2.3.6",
-				"ignore": "^5.0.4",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.3",
-				"tmp": "~0.2.1",
+				"minimatch": "10.2.4",
+				"semver": "^7.6.3",
 				"tslib": "^2.3.0",
 				"yargs-parser": "21.1.1"
 			},
 			"peerDependencies": {
-				"nx": ">= 19 <= 21"
+				"nx": ">= 21 <= 23 || ^22.0.0-0"
+			}
+		},
+		"node_modules/@nx/devkit/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@nx/devkit/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@nx/devkit/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@nx/devkit/node_modules/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+		"node_modules/@nx/devkit/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
-			"license": "MIT",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
 			"engines": {
-				"node": ">=14.14"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@nx/devkit/node_modules/yargs-parser": {
@@ -9043,9 +8484,9 @@
 			}
 		},
 		"node_modules/@nx/nx-darwin-arm64": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.2.1.tgz",
-			"integrity": "sha512-nJcyPZfH6Vq4cG6gRnQ8PcnVOLePeT3exzLnQu0I4I2EtCTPyCSRA3gxoGzZ3qZFMQTsCbwv4HYfdx42AXOTAQ==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.6.5.tgz",
+			"integrity": "sha512-qT77Omkg5xQuL2+pDbneX2tI+XW5ZeayMylu7UUgK8OhTrAkJLKjpuYRH4xT5XBipxbDtlxmO3aLS3Ib1pKzJQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -9054,15 +8495,12 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-darwin-x64": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.2.1.tgz",
-			"integrity": "sha512-SEiN8fjEs010ME4PRP8O9f8qG8AMZBGz8hOkF6ZrdlC+iEi4iyAGpgWFq8PKBlpVW4G5gxR91Y7eVaTKAsgH5w==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.6.5.tgz",
+			"integrity": "sha512-9jICxb7vfJ56y/7Yuh3b/n1QJqWxO9xnXKYEs6SO8xPoW/KomVckILGc1C6RQSs6/3ixVJC7k1Dh1wm5tKPFrg==",
 			"cpu": [
 				"x64"
 			],
@@ -9071,15 +8509,12 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-freebsd-x64": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.2.1.tgz",
-			"integrity": "sha512-/yEKS9q17EG2Ci130McvpZM5YUghH1ql9UXWbVmitufn+RQD90hoblkG/B+cxJeZonrdKAjdpLQ+hfVz+FBd/g==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.6.5.tgz",
+			"integrity": "sha512-6B1wEKpqz5dI3AGMqttAVnA6M3DB/besAtuGyQiymK9ROlta1iuWgCcIYwcCQyhLn2Rx7vqj447KKcgCa8HlVw==",
 			"cpu": [
 				"x64"
 			],
@@ -9088,15 +8523,12 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-linux-arm-gnueabihf": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.2.1.tgz",
-			"integrity": "sha512-DPtRjTCJ5++stTGtjqYftCb2c0CNed2s2EZZLQuDP+tikTsLm0d3S3ZaU5eHhqZW35tQuMOVweOfC1nJ3/DTSA==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.6.5.tgz",
+			"integrity": "sha512-xV50B8mnDPboct7JkAHftajI02s+8FszA8WTzhore+YGR+lEKHTLpucwGEaQuMlSdLplH7pQix4B4uK5pcMhZw==",
 			"cpu": [
 				"arm"
 			],
@@ -9105,15 +8537,12 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-linux-arm64-gnu": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.2.1.tgz",
-			"integrity": "sha512-ggGwHOEP6UjXeqv6DtRxizeBnX/zRZi8BRJbEJBwAt1cAUnLlklk8d+Hmjs+j/FlFXBV9f+ylpAqoYkplFR8jg==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.6.5.tgz",
+			"integrity": "sha512-2JkWuMGj+HpW6oPAvU5VdAx1afTnEbiM10Y3YOrl3fipWV4BiP5VDx762QTrfCraP4hl6yqTgvTe7F9xaby+jQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -9122,15 +8551,12 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-linux-arm64-musl": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.2.1.tgz",
-			"integrity": "sha512-HZBGxsBJUFbWVTiyJxqt0tS8tlvp+Tp0D533mGKW75cU0rv9dnmbtTwkkkx+LXqerjSRvNS3Qtj0Uh2w92Vtig==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.6.5.tgz",
+			"integrity": "sha512-Z/zMqFClnEyqDXouJKEPoWVhMQIif5F0YuECWBYjd3ZLwQsXGTItoh+6Wm3XF/nGMA2uLOHyTq/X7iFXQY3RzA==",
 			"cpu": [
 				"arm64"
 			],
@@ -9139,15 +8565,12 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-linux-x64-gnu": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.2.1.tgz",
-			"integrity": "sha512-pTytPwGiPRakqz2PKiWTSRNm9taE1U9n0+kRAAFzbOtzeW+eIoebe5xY5QMoZ+XtIZ6pJM2BUOyMD+/TX57r8Q==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.6.5.tgz",
+			"integrity": "sha512-FlotSyqNnaXSn0K+yWw+hRdYBwusABrPgKLyixfJIYRzsy+xPKN6pON6vZfqGwzuWF/9mEGReRz+iM8PiW0XSg==",
 			"cpu": [
 				"x64"
 			],
@@ -9156,15 +8579,12 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-linux-x64-musl": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.2.1.tgz",
-			"integrity": "sha512-p3egqe5zmwiDl6xSwHi2K9UZWiKbZ/s/j4qV+pZttzMyNPfhohTeP+VwQqjTeQ1hPBl2YhwmmktEPsIPYJG7YA==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.6.5.tgz",
+			"integrity": "sha512-RVOe2qcwhoIx6mxQURPjUfAW5SEOmT2gdhewvdcvX9ICq1hj5B2VarmkhTg0qroO7xiyqOqwq26mCzoV2I3NgQ==",
 			"cpu": [
 				"x64"
 			],
@@ -9173,15 +8593,12 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-win32-arm64-msvc": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.2.1.tgz",
-			"integrity": "sha512-Wujist6k08pjgWWQ1pjXrCArmMgnyIXNVmDP14cWo1KHecBuxNWa9i62PrxQ0K8MLYMcAzLHJxN9t54GzBbd+g==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.6.5.tgz",
+			"integrity": "sha512-ZqurqI8VuYnsr2Kn4K4t+Gx6j/BZdf6qz/6Tv4A7XQQ6oNYVQgTqoNEFj+CCkVaIe6aIdCWpousFLqs+ZgBqYQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -9190,15 +8607,12 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@nx/nx-win32-x64-msvc": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.2.1.tgz",
-			"integrity": "sha512-tsEYfNV2+CWSQmbh9TM8cX5wk6F2QAH0tfvt4topyOOaR40eszW8qc/eDM/kkJ5nj87BbNEqPBQAYFE0AP1OMA==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.6.5.tgz",
+			"integrity": "sha512-i2QFBJIuaYg9BHxrrnBV4O7W9rVL2k0pSIdk/rRp3EYJEU93iUng+qbZiY9wh1xvmXuUCE2G7TRd+8/SG/RFKg==",
 			"cpu": [
 				"x64"
 			],
@@ -9207,10 +8621,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
+			]
 		},
 		"node_modules/@octokit/app": {
 			"version": "14.1.0",
@@ -10216,12 +9627,16 @@
 			}
 		},
 		"node_modules/@octokit/plugin-request-log": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+			"integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
 			"peerDependencies": {
-				"@octokit/core": ">=3"
+				"@octokit/core": "5"
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -10420,12 +9835,6 @@
 			"dependencies": {
 				"@types/node": ">= 8"
 			}
-		},
-		"node_modules/@octokit/tsconfig": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-			"integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-			"dev": true
 		},
 		"node_modules/@octokit/types": {
 			"version": "6.34.0",
@@ -16702,83 +16111,331 @@
 			}
 		},
 		"node_modules/@sigstore/bundle": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
-			"integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+			"integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2"
+				"@sigstore/protobuf-specs": "^0.5.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@sigstore/core": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sigstore/core/-/core-1.1.0.tgz",
-			"integrity": "sha512-JzBqdVIyqm2FRQCulY6nbQzMpJJpSiJ8XXWMhtOX9eKgaXXpfNOF53lzQEjIydlStnd/eFtuC1dW4VYdD93oRg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.0.tgz",
+			"integrity": "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@sigstore/protobuf-specs": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz",
-			"integrity": "sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+			"integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/@sigstore/sign": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
-			"integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+			"integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"make-fetch-happen": "^13.0.1",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1"
+				"@gar/promise-retry": "^1.0.2",
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.0",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"make-fetch-happen": "^15.0.4",
+				"proc-log": "^6.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/@npmcli/redact": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+			"integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/cacache": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^5.0.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
+			"version": "15.0.5",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+			"integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/agent": "^4.0.0",
+				"@npmcli/redact": "^4.0.0",
+				"cacache": "^20.0.1",
+				"http-cache-semantics": "^4.1.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^5.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^1.0.0",
+				"proc-log": "^6.0.0",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/minipass-fetch": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+			"integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^2.0.0",
+				"minizlib": "^3.0.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			},
+			"optionalDependencies": {
+				"iconv-lite": "^0.7.2"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/minipass-sized": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+			"integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@sigstore/sign/node_modules/ssri": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@sigstore/tuf": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.4.tgz",
-			"integrity": "sha512-44vtsveTPUpqhm9NCrbU8CWLe3Vck2HO1PNLw7RIajbB7xhtn5RBPm1VNSCMwqGYHhDsBJG8gDF0q4lgydsJvw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+			"integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"tuf-js": "^2.2.1"
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"tuf-js": "^4.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@sigstore/verify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-1.2.1.tgz",
-			"integrity": "sha512-8iKx79/F73DKbGfRf7+t4dqrc0bRr0thdPrxAtCKWRm/F0tG71i6O1rvlnScncJLLBZHn3h8M3c1BSUAb9yu8g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
+			"integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.1.0",
-				"@sigstore/protobuf-specs": "^0.3.2"
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.1.0",
+				"@sigstore/protobuf-specs": "^0.5.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@sinclair/typebox": {
@@ -17918,40 +17575,53 @@
 			}
 		},
 		"node_modules/@tufjs/models": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.1.tgz",
-			"integrity": "sha512-92F7/SFyufn4DXsha9+QfKnN03JGqtMFMXgSHbZOo8JG59WkTni7UzAouNQDf7AuP9OAMxVOPQcqG3sB7w+kkg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+			"integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.4"
+				"minimatch": "^10.1.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@tufjs/models/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@tufjs/models/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@tufjs/models/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -18390,12 +18060,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
 			"integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
-			"dev": true
-		},
-		"node_modules/@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
 		"node_modules/@types/minimist": {
@@ -19747,16 +19411,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@wdio/config/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@wdio/config/node_modules/normalize-package-data": {
@@ -21376,15 +21030,6 @@
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"license": "MIT"
 		},
-		"node_modules/@wp-playground/blueprints/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@wp-playground/blueprints/node_modules/raw-body": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -21873,15 +21518,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"license": "MIT"
-		},
-		"node_modules/@wp-playground/cli/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/@wp-playground/cli/node_modules/raw-body": {
 			"version": "2.5.3",
@@ -22771,15 +22407,6 @@
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"license": "MIT"
 		},
-		"node_modules/@wp-playground/tools/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@wp-playground/tools/node_modules/raw-body": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -23347,13 +22974,13 @@
 			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
 		},
 		"node_modules/abbrev": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-			"integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+			"integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/abort-controller": {
@@ -24333,16 +23960,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array-differ": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-			"integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/array-flatten": {
@@ -25422,29 +25039,50 @@
 			}
 		},
 		"node_modules/bin-links": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/bin-links/-/bin-links-4.0.4.tgz",
-			"integrity": "sha512-cMtq4W5ZsEwcutJrVId+a/tjt8GSbS+h0oNkdl6+6rBuEv8Ot33Bevj5KPm40t309zuhVic8NjpuL42QCiJWWA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/bin-links/-/bin-links-5.0.0.tgz",
+			"integrity": "sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"cmd-shim": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"read-cmd-shim": "^4.0.0",
-				"write-file-atomic": "^5.0.0"
+				"cmd-shim": "^7.0.0",
+				"npm-normalize-package-bin": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"read-cmd-shim": "^5.0.0",
+				"write-file-atomic": "^6.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/bin-links/node_modules/npm-normalize-package-bin": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-			"integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+		"node_modules/bin-links/node_modules/cmd-shim": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-7.0.0.tgz",
+			"integrity": "sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+			"integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/bin-links/node_modules/read-cmd-shim": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-5.0.0.tgz",
+			"integrity": "sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/bin-links/node_modules/signal-exit": {
@@ -25461,9 +25099,9 @@
 			}
 		},
 		"node_modules/bin-links/node_modules/write-file-atomic": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
+			"integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -25471,7 +25109,7 @@
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -26393,9 +26031,10 @@
 			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
 		},
 		"node_modules/chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+			"license": "MIT"
 		},
 		"node_modules/check-error": {
 			"version": "2.1.1",
@@ -29972,10 +29611,27 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"version": "16.4.7",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+			"integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
 			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dotenv-expand": {
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dotenv": "^16.4.5"
+			},
 			"engines": {
 				"node": ">=12"
 			},
@@ -30229,19 +29885,16 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"node_modules/ejs": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-			"integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
+			"integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"dependencies": {
-				"jake": "^10.8.5"
-			},
 			"bin": {
 				"ejs": "bin/cli.js"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=0.12.18"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -31851,9 +31504,9 @@
 			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA=="
 		},
 		"node_modules/exponential-backoff": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-			"integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -32026,31 +31679,6 @@
 			"dev": true,
 			"dependencies": {
 				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"license": "MIT",
-			"dependencies": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/external-editor/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -32364,37 +31992,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"node_modules/filelist": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-			"dev": true,
-			"dependencies": {
-				"minimatch": "^5.0.1"
-			}
-		},
-		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/filename-reserved-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -32652,6 +32249,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^2.0.0"
 			},
@@ -32726,15 +32324,16 @@
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
 			"funding": [
 				{
 					"type": "individual",
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -32806,9 +32405,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -32946,15 +32545,16 @@
 			}
 		},
 		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"minipass": "^3.0.0"
+				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/fs-monkey": {
@@ -33567,6 +33167,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
 			"integrity": "sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==",
+			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -33595,20 +33196,11 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/git-remote-origin-url/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/git-semver-tags": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-5.0.1.tgz",
 			"integrity": "sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==",
+			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -34906,61 +34498,104 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"node_modules/init-package-json": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-6.0.3.tgz",
-			"integrity": "sha512-Zfeb5ol+H+eqJWHTaGca9BovufyGeIfr4zaaBorPmJBMrJ+KBnN+kQx2ZtXdsotUTgldHmHQV44xvUWOUA7E2w==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-8.2.2.tgz",
+			"integrity": "sha512-pXVMn67Jdw2hPKLCuJZj62NC9B2OIDd1R3JwZXTHXuEnfN3Uq5kJbKOSld6YEU+KOGfMD82EzxFTYz5o0SSJoA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/package-json": "^5.0.0",
-				"npm-package-arg": "^11.0.0",
-				"promzard": "^1.0.0",
-				"read": "^3.0.1",
-				"semver": "^7.3.5",
+				"@npmcli/package-json": "^7.0.0",
+				"npm-package-arg": "^13.0.0",
+				"promzard": "^2.0.0",
+				"read": "^4.0.0",
+				"semver": "^7.7.2",
 				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^6.0.2"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/init-package-json/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/init-package-json/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/init-package-json/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/init-package-json/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+		"node_modules/init-package-json/node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/init-package-json/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/init-package-json/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/init-package-json/node_modules/validate-npm-package-name": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
+			"integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/inline-style-parser": {
@@ -34968,6 +34603,83 @@
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
 			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
 			"license": "MIT"
+		},
+		"node_modules/inquirer": {
+			"version": "12.9.6",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
+			"integrity": "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.0",
+				"@inquirer/core": "^10.2.2",
+				"@inquirer/prompts": "^7.8.6",
+				"@inquirer/type": "^3.0.8",
+				"mute-stream": "^2.0.0",
+				"run-async": "^4.0.5",
+				"rxjs": "^7.8.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/inquirer/node_modules/@inquirer/prompts": {
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+			"integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^4.3.2",
+				"@inquirer/confirm": "^5.1.21",
+				"@inquirer/editor": "^4.2.23",
+				"@inquirer/expand": "^4.0.23",
+				"@inquirer/input": "^4.3.1",
+				"@inquirer/number": "^3.0.23",
+				"@inquirer/password": "^4.0.23",
+				"@inquirer/rawlist": "^4.1.11",
+				"@inquirer/search": "^3.2.2",
+				"@inquirer/select": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/inquirer/node_modules/mute-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/inquirer/node_modules/rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
 		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
@@ -35467,13 +35179,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-lambda": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/is-map": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -35644,9 +35349,9 @@
 			}
 		},
 		"node_modules/is-ssh": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-			"integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+			"integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -35984,24 +35689,6 @@
 			},
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/jake": {
-			"version": "10.8.7",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
-			"integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
-			"dev": true,
-			"dependencies": {
-				"async": "^3.2.3",
-				"chalk": "^4.0.2",
-				"filelist": "^1.0.4",
-				"minimatch": "^3.1.2"
-			},
-			"bin": {
-				"jake": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/javascript-natural-sort": {
@@ -37517,7 +37204,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/json2md": {
 			"version": "2.0.1",
@@ -37784,23 +37472,22 @@
 			}
 		},
 		"node_modules/lerna": {
-			"version": "8.1.9",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-8.1.9.tgz",
-			"integrity": "sha512-ZRFlRUBB2obm+GkbTR7EbgTMuAdni6iwtTQTMy7LIrQ4UInG44LyfRepljtgUxh4HA0ltzsvWfPkd5J1DKGCeQ==",
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-9.0.7.tgz",
+			"integrity": "sha512-PMjbSWYfwL1yZ5c1D2PZuFyzmtYhLdn0f76uG8L25g6eYy34j+2jPb4Q6USx1UJvxVtxkdVEeAAWS/WxgJ8VZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@lerna/create": "8.1.9",
-				"@npmcli/arborist": "7.5.4",
-				"@npmcli/package-json": "5.2.0",
-				"@npmcli/run-script": "8.1.0",
-				"@nx/devkit": ">=17.1.2 < 21",
+				"@npmcli/arborist": "9.1.6",
+				"@npmcli/package-json": "7.0.2",
+				"@npmcli/run-script": "10.0.3",
+				"@nx/devkit": ">=21.5.2 < 23.0.0",
 				"@octokit/plugin-enterprise-rest": "6.0.1",
-				"@octokit/rest": "19.0.11",
+				"@octokit/rest": "20.1.2",
 				"aproba": "2.0.0",
 				"byte-size": "8.1.1",
 				"chalk": "4.1.0",
-				"clone-deep": "4.0.1",
+				"ci-info": "4.3.1",
 				"cmd-shim": "6.0.3",
 				"color-support": "1.1.3",
 				"columnify": "1.6.0",
@@ -37813,62 +37500,48 @@
 				"envinfo": "7.13.0",
 				"execa": "5.0.0",
 				"fs-extra": "^11.2.0",
-				"get-port": "5.1.1",
 				"get-stream": "6.0.0",
 				"git-url-parse": "14.0.0",
 				"glob-parent": "6.0.2",
-				"globby": "11.1.0",
-				"graceful-fs": "4.2.11",
 				"has-unicode": "2.0.1",
 				"import-local": "3.1.0",
 				"ini": "^1.3.8",
-				"init-package-json": "6.0.3",
-				"inquirer": "^8.2.4",
+				"init-package-json": "8.2.2",
+				"inquirer": "12.9.6",
 				"is-ci": "3.0.1",
-				"is-stream": "2.0.0",
-				"jest-diff": ">=29.4.3 < 30",
-				"js-yaml": "4.1.0",
-				"libnpmaccess": "8.0.6",
-				"libnpmpublish": "9.0.9",
+				"jest-diff": ">=30.0.0 < 31",
+				"js-yaml": "4.1.1",
+				"libnpmaccess": "10.0.3",
+				"libnpmpublish": "11.1.2",
 				"load-json-file": "6.2.0",
-				"lodash": "^4.17.21",
-				"make-dir": "4.0.0",
-				"minimatch": "3.0.5",
-				"multimatch": "5.0.0",
-				"node-fetch": "2.6.7",
-				"npm-package-arg": "11.0.2",
-				"npm-packlist": "8.0.2",
-				"npm-registry-fetch": "^17.1.0",
-				"nx": ">=17.1.2 < 21",
+				"make-fetch-happen": "15.0.2",
+				"minimatch": "3.1.4",
+				"npm-package-arg": "13.0.1",
+				"npm-packlist": "10.0.3",
+				"npm-registry-fetch": "19.1.0",
+				"nx": ">=21.5.3 < 23.0.0",
 				"p-map": "4.0.0",
 				"p-map-series": "2.1.0",
 				"p-pipe": "3.1.0",
 				"p-queue": "6.6.2",
 				"p-reduce": "2.1.0",
 				"p-waterfall": "2.1.1",
-				"pacote": "^18.0.6",
-				"pify": "5.0.0",
+				"pacote": "21.0.1",
 				"read-cmd-shim": "4.0.0",
-				"resolve-from": "5.0.0",
-				"rimraf": "^4.4.1",
-				"semver": "^7.3.8",
-				"set-blocking": "^2.0.0",
+				"semver": "7.7.2",
 				"signal-exit": "3.0.7",
 				"slash": "3.0.0",
-				"ssri": "^10.0.6",
+				"ssri": "12.0.0",
 				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"strong-log-transformer": "2.1.0",
-				"tar": "6.2.1",
-				"temp-dir": "1.0.0",
+				"tar": "7.5.11",
+				"through": "2.3.8",
+				"tinyglobby": "0.2.12",
 				"typescript": ">=3 < 6",
 				"upath": "2.0.1",
-				"uuid": "^10.0.0",
 				"validate-npm-package-license": "3.0.4",
-				"validate-npm-package-name": "5.0.1",
+				"validate-npm-package-name": "6.0.2",
 				"wide-align": "1.1.5",
 				"write-file-atomic": "5.0.1",
-				"write-pkg": "4.0.0",
 				"yargs": "17.7.2",
 				"yargs-parser": "21.1.1"
 			},
@@ -37876,164 +37549,192 @@
 				"lerna": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/lerna/node_modules/@jest/diff-sequences": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/lerna/node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/auth-token": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-			"integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/core": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-			"integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-token": "^3.0.0",
-				"@octokit/graphql": "^5.0.0",
-				"@octokit/request": "^6.0.0",
-				"@octokit/request-error": "^3.0.0",
-				"@octokit/types": "^9.0.0",
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
 				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/endpoint": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-			"integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^9.0.0",
-				"is-plain-object": "^5.0.0",
+				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/graphql": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-			"integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^6.0.0",
-				"@octokit/types": "^9.0.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/openapi-types": {
-			"version": "18.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-			"integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
-			"dev": true
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lerna/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-			"integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+			"version": "11.4.4-cjs.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+			"integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/tsconfig": "^1.0.2",
-				"@octokit/types": "^9.2.3"
+				"@octokit/types": "^13.7.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=4"
+				"@octokit/core": "5"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-			"integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+			"version": "13.3.2-cjs.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+			"integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^10.0.0"
+				"@octokit/types": "^13.8.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=3"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-			"integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^18.0.0"
+				"@octokit/core": "^5"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/request": {
-			"version": "6.2.8",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-			"integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^7.0.0",
-				"@octokit/request-error": "^3.0.0",
-				"@octokit/types": "^9.0.0",
-				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.7",
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/request-error": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-			"integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^9.0.0",
+				"@octokit/types": "^13.1.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/rest": {
-			"version": "19.0.11",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
-			"integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
+			"version": "20.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+			"integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/core": "^4.2.1",
-				"@octokit/plugin-paginate-rest": "^6.1.2",
-				"@octokit/plugin-request-log": "^1.0.4",
-				"@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+				"@octokit/core": "^5.0.2",
+				"@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+				"@octokit/plugin-request-log": "^4.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/lerna/node_modules/@octokit/types": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-			"integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^18.0.0"
+				"@octokit/openapi-types": "^24.2.0"
 			}
+		},
+		"node_modules/lerna/node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lerna/node_modules/aproba": {
 			"version": "2.0.0",
@@ -38049,17 +37750,29 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/lerna/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/lerna/node_modules/before-after-hook": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
 			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/lerna/node_modules/chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -38071,25 +37784,20 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/lerna/node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+		"node_modules/lerna/node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
 			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/lerna/node_modules/cli-width": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10"
 			}
 		},
 		"node_modules/lerna/node_modules/cosmiconfig": {
@@ -38138,7 +37846,8 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lerna/node_modules/execa": {
 			"version": "5.0.0",
@@ -38163,19 +37872,22 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
-		"node_modules/lerna/node_modules/figures": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+		"node_modules/lerna/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^1.0.5"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12.0.0"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/lerna/node_modules/fs-extra": {
@@ -38204,25 +37916,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lerna/node_modules/glob": {
-			"version": "9.3.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"minimatch": "^8.0.2",
-				"minipass": "^4.2.4",
-				"path-scurry": "^1.6.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/lerna/node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -38236,62 +37929,27 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/lerna/node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/glob/node_modules/minimatch": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-			"integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/lerna/node_modules/glob/node_modules/minipass": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/lerna/node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/lerna/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/lerna/node_modules/human-signals": {
@@ -38304,84 +37962,45 @@
 			}
 		},
 		"node_modules/lerna/node_modules/ignore-walk": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
-			"integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+			"integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"minimatch": "^9.0.0"
+				"minimatch": "^10.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/lerna/node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/lerna/node_modules/ignore-walk/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/lerna/node_modules/inquirer": {
-			"version": "8.2.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-			"integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.1.1",
-				"cli-cursor": "^3.1.0",
-				"cli-width": "^3.0.0",
-				"external-editor": "^3.0.3",
-				"figures": "^3.0.0",
-				"lodash": "^4.17.21",
-				"mute-stream": "0.0.8",
-				"ora": "^5.4.1",
-				"run-async": "^2.4.0",
-				"rxjs": "^7.5.5",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"through": "^2.3.6",
-				"wrap-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/inquirer/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/lerna/node_modules/is-ci": {
@@ -38396,11 +38015,28 @@
 				"is-ci": "bin.js"
 			}
 		},
+		"node_modules/lerna/node_modules/is-ci/node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/lerna/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -38414,10 +38050,43 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lerna/node_modules/jest-diff": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/lerna/node_modules/jest-diff/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/lerna/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -38439,20 +38108,14 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/lerna/node_modules/make-dir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+		"node_modules/lerna/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver": "^7.5.3"
-			},
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/lerna/node_modules/mimic-fn": {
@@ -38465,10 +38128,11 @@
 			}
 		},
 		"node_modules/lerna/node_modules/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+			"integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -38476,64 +38140,44 @@
 				"node": "*"
 			}
 		},
-		"node_modules/lerna/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/lerna/node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/lerna/node_modules/npm-package-arg": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.2.tgz",
-			"integrity": "sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.1.tgz",
+			"integrity": "sha512-6zqls5xFvJbgFjB1B2U6yITtyGBjDBORB7suI4zA4T/sZ1OmkMFlaQSNB/4K0LtXNA1t4OprAFxPisadK5O2ag==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^6.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/lerna/node_modules/npm-packlist": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
-			"integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.3.tgz",
+			"integrity": "sha512-zPukTwJMOu5X5uvm0fztwS5Zxyvmk38H/LfidkOMt3gbZVCyro2cD/ETzwzVPcWZA3JOyPznfUN/nkyFiyUbxg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"ignore-walk": "^6.0.4"
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/lerna/node_modules/npm-packlist/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/lerna/node_modules/npm-run-path": {
@@ -38563,29 +38207,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lerna/node_modules/ora": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-			"dev": true,
-			"dependencies": {
-				"bl": "^4.1.0",
-				"chalk": "^4.1.0",
-				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.5.0",
-				"is-interactive": "^1.0.0",
-				"is-unicode-supported": "^0.1.0",
-				"log-symbols": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"wcwidth": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/lerna/node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -38595,67 +38216,78 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/lerna/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+		"node_modules/lerna/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lerna/node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lerna/node_modules/rimraf": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-			"integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^9.2.0"
-			},
-			"bin": {
-				"rimraf": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=14"
+				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/lerna/node_modules/rxjs": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+		"node_modules/lerna/node_modules/pretty-format": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"tslib": "^2.1.0"
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/lerna/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/lerna/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lerna/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/lerna/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/lerna/node_modules/string-width": {
@@ -38663,6 +38295,7 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -38677,11 +38310,29 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/lerna/node_modules/tinyglobby": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+			"integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.3",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
 		"node_modules/lerna/node_modules/typescript": {
@@ -38702,7 +38353,8 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
 			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/lerna/node_modules/universalify": {
 			"version": "2.0.1",
@@ -38723,28 +38375,14 @@
 				"yarn": "*"
 			}
 		},
-		"node_modules/lerna/node_modules/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/lerna/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
+			"integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/lerna/node_modules/write-file-atomic": {
@@ -38824,82 +38462,102 @@
 			}
 		},
 		"node_modules/libnpmaccess": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-8.0.6.tgz",
-			"integrity": "sha512-uM8DHDEfYG6G5gVivVl+yQd4pH3uRclHC59lzIbSvy7b5FEwR+mU49Zq1jEyRtRFv7+M99mUW9S0wL/4laT4lw==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-10.0.3.tgz",
+			"integrity": "sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^11.0.2",
-				"npm-registry-fetch": "^17.0.1"
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/libnpmaccess/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/libnpmaccess/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/libnpmaccess/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/libnpmaccess/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/libnpmaccess/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/libnpmpublish": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-9.0.9.tgz",
-			"integrity": "sha512-26zzwoBNAvX9AWOPiqqF6FG4HrSCPsHFkQm7nT+xU1ggAujL/eae81RnCv4CJ2In9q9fh10B88sYSzKCUh/Ghg==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.1.2.tgz",
+			"integrity": "sha512-tNcU3cLH7toloAzhOOrBDhjzgbxpyuYvkf+BPPnnJCdc5EIcdJ8JcT+SglvCQKKyZ6m9dVXtCVlJcA6csxKdEA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
+				"@npmcli/package-json": "^7.0.0",
 				"ci-info": "^4.0.0",
-				"normalize-package-data": "^6.0.1",
-				"npm-package-arg": "^11.0.2",
-				"npm-registry-fetch": "^17.0.1",
-				"proc-log": "^4.2.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.7",
-				"sigstore": "^2.2.0",
-				"ssri": "^10.0.6"
+				"sigstore": "^4.0.0",
+				"ssri": "^12.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/libnpmpublish/node_modules/ci-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
-			"integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -38913,80 +38571,75 @@
 			}
 		},
 		"node_modules/libnpmpublish/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/libnpmpublish/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/libnpmpublish/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/libnpmpublish/node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/libnpmpublish/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/libnpmpublish/node_modules/npm-package-arg/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/libnpmpublish/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/libnpmpublish/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/lie": {
@@ -39716,6 +39369,7 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -40232,160 +39886,194 @@
 			"dev": true
 		},
 		"node_modules/make-fetch-happen": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-			"integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+			"version": "15.0.2",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.2.tgz",
+			"integrity": "sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
+				"@npmcli/agent": "^4.0.0",
+				"cacache": "^20.0.1",
 				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
+				"minipass-fetch": "^4.0.0",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
+				"negotiator": "^1.0.0",
+				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
+				"ssri": "^12.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/make-fetch-happen/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/make-fetch-happen/node_modules/cacache": {
-			"version": "18.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
+				"@npmcli/fs": "^5.0.0",
 				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
 				"minipass": "^7.0.3",
 				"minipass-collect": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/make-fetch-happen/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+		"node_modules/make-fetch-happen/node_modules/cacache/node_modules/ssri": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/make-fetch-happen/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/make-fetch-happen/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/make-fetch-happen/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/make-fetch-happen/node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/make-fetch-happen/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/make-fetch-happen/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-			"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/make-fetch-happen/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-			"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/makeerror": {
@@ -41856,15 +41544,12 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/minipass-collect": {
@@ -41880,55 +41565,48 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/minipass-collect/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/minipass-fetch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-			"integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+			"integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minipass": "^7.0.3",
 				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
+				"minizlib": "^3.0.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			},
 			"optionalDependencies": {
 				"encoding": "^0.1.13"
 			}
 		},
-		"node_modules/minipass-fetch/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+			"integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/minipass-flush/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/minipass-pipeline": {
@@ -41939,6 +41617,19 @@
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-pipeline/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -41957,17 +41648,30 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+		"node_modules/minipass-sized/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"minipass": "^3.0.0",
 				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=8"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/mississippi": {
@@ -42264,46 +41968,6 @@
 			},
 			"bin": {
 				"multicast-dns": "cli.js"
-			}
-		},
-		"node_modules/multimatch": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
-			"integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/minimatch": "^3.0.3",
-				"array-differ": "^3.0.0",
-				"array-union": "^2.1.0",
-				"arrify": "^2.0.1",
-				"minimatch": "^3.0.4"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/multimatch/node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/multimatch/node_modules/arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/mustache": {
@@ -42619,111 +42283,90 @@
 			}
 		},
 		"node_modules/node-gyp": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
-			"integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
+			"version": "12.2.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+			"integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
-				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^13.0.0",
-				"nopt": "^7.0.0",
-				"proc-log": "^4.1.0",
+				"make-fetch-happen": "^15.0.0",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"tar": "^6.2.1",
-				"which": "^4.0.0"
+				"tar": "^7.5.4",
+				"tinyglobby": "^0.2.12",
+				"which": "^6.0.0"
 			},
 			"bin": {
 				"node-gyp": "bin/node-gyp.js"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/node-gyp/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/node-gyp/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+		"node_modules/node-gyp/node_modules/abbrev": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+			"integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
 			"dev": true,
 			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/node-gyp/node_modules/isexe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			}
 		},
-		"node_modules/node-gyp/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+		"node_modules/node-gyp/node_modules/nopt": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+			"integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"abbrev": "^4.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/node-gyp/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/node-gyp/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/node-gyp/node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^4.0.0"
 			},
 			"bin": {
 				"node-which": "bin/which.js"
 			},
 			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/node-int64": {
@@ -42768,13 +42411,6 @@
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
 			"dev": true
 		},
-		"node_modules/node-machine-id": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-			"integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -42794,19 +42430,19 @@
 			}
 		},
 		"node_modules/nopt": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-			"integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+			"integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"abbrev": "^2.0.0"
+				"abbrev": "^3.0.0"
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/normalize-package-data": {
@@ -42874,16 +42510,16 @@
 			}
 		},
 		"node_modules/npm-install-checks": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
-			"integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-7.1.2.tgz",
+			"integrity": "sha512-z9HJBCYw9Zr8BqXcllKIs5nI+QggAImbBdHphOzVYrz2CB4iQ6FzWyKmlqDZua+51nAu7FcemlbTc9VgQN5XDQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"semver": "^7.1.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm-normalize-package-bin": {
@@ -43139,137 +42775,180 @@
 			}
 		},
 		"node_modules/npm-pick-manifest": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
-			"integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+			"integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-install-checks": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"npm-package-arg": "^11.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm-pick-manifest/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/npm-pick-manifest/node_modules/npm-install-checks": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+			"integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"semver": "^7.1.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-			"integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+			"integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm-pick-manifest/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-registry-fetch": {
-			"version": "17.1.0",
-			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-17.1.0.tgz",
-			"integrity": "sha512-5+bKQRH0J1xG1uZ1zMNvxW0VEyoNWgJpY9UDuluPFLKDfJ9u2JmmjmTJV1srBGQOROfdBMiVvnH2Zvpbm+xkVA==",
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.0.tgz",
+			"integrity": "sha512-xyZLfs7TxPu/WKjHUs0jZOPinzBAI32kEUel6za0vH+JUTnFZ5zbHI1ZoGZRDm6oMjADtrli6FxtMlk/5ABPNw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/redact": "^2.0.0",
+				"@npmcli/redact": "^3.0.0",
 				"jsonparse": "^1.3.1",
-				"make-fetch-happen": "^13.0.0",
+				"make-fetch-happen": "^15.0.0",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minizlib": "^2.1.2",
-				"npm-package-arg": "^11.0.0",
-				"proc-log": "^4.0.0"
+				"minipass-fetch": "^4.0.0",
+				"minizlib": "^3.0.1",
+				"npm-package-arg": "^13.0.0",
+				"proc-log": "^5.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/npm-registry-fetch/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/npm-registry-fetch/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/npm-registry-fetch/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/npm-registry-fetch/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+		"node_modules/npm-registry-fetch/node_modules/npm-package-arg/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm-registry-fetch/node_modules/validate-npm-package-name": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-run-all": {
@@ -43453,9 +43132,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nx": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/nx/-/nx-20.2.1.tgz",
-			"integrity": "sha512-zUw1DT9BW2ajbDZgcUFKfysGqrbJwsMRjPxT6GthuqcLtDc2iJi3+/UBTLsITSeiw4Za4qPVxjaK4+yma9Ju5w==",
+			"version": "22.6.5",
+			"resolved": "https://registry.npmjs.org/nx/-/nx-22.6.5.tgz",
+			"integrity": "sha512-VRKhDAt684dXNSz9MNjE7MekkCfQF41P2PSx5jEWQjDEP1Z4jFZbyeygWs5ZyOroG7/n0MoWAJTe6ftvIcBOAg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -43464,30 +43143,33 @@
 				"@yarnpkg/lockfile": "^1.1.0",
 				"@yarnpkg/parsers": "3.0.2",
 				"@zkochan/js-yaml": "0.0.7",
-				"axios": "^1.7.4",
-				"chalk": "^4.1.0",
+				"axios": "1.15.0",
 				"cli-cursor": "3.1.0",
 				"cli-spinners": "2.6.1",
 				"cliui": "^8.0.1",
 				"dotenv": "~16.4.5",
 				"dotenv-expand": "~11.0.6",
+				"ejs": "5.0.1",
 				"enquirer": "~2.3.6",
 				"figures": "3.2.0",
 				"flat": "^5.0.2",
 				"front-matter": "^4.0.2",
-				"ignore": "^5.0.4",
-				"jest-diff": "^29.4.1",
+				"ignore": "^7.0.5",
+				"jest-diff": "^30.0.2",
 				"jsonc-parser": "3.2.0",
 				"lines-and-columns": "2.0.3",
-				"minimatch": "9.0.3",
-				"node-machine-id": "1.1.12",
+				"minimatch": "10.2.4",
 				"npm-run-path": "^4.0.1",
 				"open": "^8.4.0",
 				"ora": "5.3.0",
-				"semver": "^7.5.3",
+				"picocolors": "^1.1.0",
+				"resolve.exports": "2.0.3",
+				"semver": "^7.6.3",
+				"smol-toml": "1.6.1",
 				"string-width": "^4.2.3",
 				"tar-stream": "~2.2.0",
 				"tmp": "~0.2.1",
+				"tree-kill": "^1.2.2",
 				"tsconfig-paths": "^4.1.2",
 				"tslib": "^2.3.0",
 				"yaml": "^2.6.0",
@@ -43499,20 +43181,20 @@
 				"nx-cloud": "bin/nx-cloud.js"
 			},
 			"optionalDependencies": {
-				"@nx/nx-darwin-arm64": "20.2.1",
-				"@nx/nx-darwin-x64": "20.2.1",
-				"@nx/nx-freebsd-x64": "20.2.1",
-				"@nx/nx-linux-arm-gnueabihf": "20.2.1",
-				"@nx/nx-linux-arm64-gnu": "20.2.1",
-				"@nx/nx-linux-arm64-musl": "20.2.1",
-				"@nx/nx-linux-x64-gnu": "20.2.1",
-				"@nx/nx-linux-x64-musl": "20.2.1",
-				"@nx/nx-win32-arm64-msvc": "20.2.1",
-				"@nx/nx-win32-x64-msvc": "20.2.1"
+				"@nx/nx-darwin-arm64": "22.6.5",
+				"@nx/nx-darwin-x64": "22.6.5",
+				"@nx/nx-freebsd-x64": "22.6.5",
+				"@nx/nx-linux-arm-gnueabihf": "22.6.5",
+				"@nx/nx-linux-arm64-gnu": "22.6.5",
+				"@nx/nx-linux-arm64-musl": "22.6.5",
+				"@nx/nx-linux-x64-gnu": "22.6.5",
+				"@nx/nx-linux-x64-musl": "22.6.5",
+				"@nx/nx-win32-arm64-msvc": "22.6.5",
+				"@nx/nx-win32-x64-msvc": "22.6.5"
 			},
 			"peerDependencies": {
-				"@swc-node/register": "^1.8.0",
-				"@swc/core": "^1.3.85"
+				"@swc-node/register": "^1.11.1",
+				"@swc/core": "^1.15.8"
 			},
 			"peerDependenciesMeta": {
 				"@swc-node/register": {
@@ -43523,26 +43205,86 @@
 				}
 			}
 		},
-		"node_modules/nx/node_modules/axios": {
-			"version": "1.7.9",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-			"integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+		"node_modules/nx/node_modules/@jest/diff-sequences": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/nx/node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/nx/node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nx/node_modules/axios": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/nx/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/nx/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/nx/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/nx/node_modules/cli-cursor": {
@@ -43573,22 +43315,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/nx/node_modules/dotenv-expand": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dotenv": "^16.4.5"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
 		"node_modules/nx/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -43612,6 +43338,26 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/nx/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nx/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/nx/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -43633,6 +43379,22 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/nx/node_modules/jest-diff": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/nx/node_modules/jsonc-parser": {
@@ -43663,16 +43425,16 @@
 			}
 		},
 		"node_modules/nx/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -43758,6 +43520,51 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/nx/node_modules/pretty-format": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/nx/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/nx/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nx/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/nx/node_modules/restore-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -43770,6 +43577,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/nx/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/nx/node_modules/string-width": {
@@ -43797,10 +43617,23 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/nx/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/nx/node_modules/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -43841,16 +43674,19 @@
 			}
 		},
 		"node_modules/nx/node_modules/yaml": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-			"integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/nx/node_modules/yargs-parser": {
@@ -44585,6 +44421,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -44642,6 +44479,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^1.1.0"
 			},
@@ -44654,6 +44492,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-try": "^1.0.0"
 			},
@@ -44666,6 +44505,7 @@
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
 			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"aggregate-error": "^3.0.0"
 			},
@@ -44764,6 +44604,7 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -44843,233 +44684,433 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/pacote": {
-			"version": "18.0.6",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-18.0.6.tgz",
-			"integrity": "sha512-+eK3G27SMwsB8kLIuj4h1FUhHtwiEUo21Tw8wNjmvdlpOEr613edv+8FUsTj/4F/VN5ywGE19X18N7CC2EJk6A==",
+			"version": "21.0.1",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.1.tgz",
+			"integrity": "sha512-LHGIUQUrcDIJUej53KJz1BPvUuHrItrR2yrnN0Kl9657cJ0ZT6QJHk9wWPBnQZhYT5KLyZWrk9jaYc2aKDu4yw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^5.0.0",
-				"@npmcli/installed-package-contents": "^2.0.1",
-				"@npmcli/package-json": "^5.1.0",
-				"@npmcli/promise-spawn": "^7.0.0",
-				"@npmcli/run-script": "^8.0.0",
-				"cacache": "^18.0.0",
+				"@npmcli/git": "^6.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"cacache": "^20.0.0",
 				"fs-minipass": "^3.0.0",
 				"minipass": "^7.0.2",
-				"npm-package-arg": "^11.0.0",
-				"npm-packlist": "^8.0.0",
-				"npm-pick-manifest": "^9.0.0",
-				"npm-registry-fetch": "^17.0.0",
-				"proc-log": "^4.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-packlist": "^10.0.1",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
-				"sigstore": "^2.2.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11"
+				"sigstore": "^4.0.0",
+				"ssri": "^12.0.0",
+				"tar": "^7.4.3"
 			},
 			"bin": {
 				"pacote": "bin/index.js"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/pacote/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/pacote/node_modules/cacache": {
-			"version": "18.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-			"integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+		"node_modules/pacote/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/@npmcli/git": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
+			"integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/promise-spawn": "^8.0.0",
+				"ini": "^5.0.0",
 				"lru-cache": "^10.0.1",
+				"npm-pick-manifest": "^10.0.0",
+				"proc-log": "^5.0.0",
+				"promise-retry": "^2.0.1",
+				"semver": "^7.3.5",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/pacote/node_modules/@npmcli/promise-spawn": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-8.0.3.tgz",
+			"integrity": "sha512-Yb00SWaL4F8w+K8YGhQ55+xE4RUNdMHV43WZGsiTM92gS+lC0mGsn7I4hLug7pbao035S6bj3Y3w0cUNGLfmkg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/pacote/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/pacote/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/pacote/node_modules/cacache": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^5.0.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
 				"minipass": "^7.0.3",
 				"minipass-collect": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/pacote/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+		"node_modules/pacote/node_modules/cacache/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/pacote/node_modules/cacache/node_modules/ssri": {
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/pacote/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/pacote/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/hosted-git-info/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/pacote/node_modules/ignore-walk": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+			"integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^10.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/ini": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+			"integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/pacote/node_modules/isexe": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/pacote/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-normalize-package-bin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+			"integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-package-arg": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-package-arg/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-packlist": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+			"integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-packlist/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-pick-manifest": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
+			"integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-install-checks": "^7.1.0",
+				"npm-normalize-package-bin": "^4.0.0",
+				"npm-package-arg": "^12.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/pacote/node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^10.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/pacote/node_modules/ignore-walk": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
-			"integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
+		"node_modules/pacote/node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
+			"integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"minimatch": "^9.0.0"
+				"hosted-git-info": "^8.0.0",
+				"proc-log": "^5.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^6.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/pacote/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+		"node_modules/pacote/node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
+			"integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
 			"dev": true,
 			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/pacote/node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pacote/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/pacote/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+		"node_modules/pacote/node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-package-arg": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-packlist": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
-			"integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"ignore-walk": "^6.0.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/pacote/node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/pacote/node_modules/unique-filename": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-			"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/pacote/node_modules/unique-slug": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-			"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/pacote/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/pacote/node_modules/which": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/pako": {
@@ -45128,28 +45169,28 @@
 			"integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
 		},
 		"node_modules/parse-conflict-json": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-3.0.1.tgz",
-			"integrity": "sha512-01TvEktc68vwbJOtWZluyWeVGWjP+bZwXtPDMQVbBKzbJ/vZBif0L69KH1+cHv1SZ6e0FKLvjyHe8mqsIqYOmw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-4.0.0.tgz",
+			"integrity": "sha512-37CN2VtcuvKgHUs8+0b1uJeEsbGn61GRHz469C94P5xiOoqpDYJYwjg4RY9Vmz39WyZAVkR5++nbJwLMIgOCnQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^3.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
 				"just-diff": "^6.0.0",
 				"just-diff-apply": "^5.2.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/parse-conflict-json/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
+			"integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/parse-entities": {
@@ -45209,9 +45250,9 @@
 			}
 		},
 		"node_modules/parse-path": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-			"integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+			"integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -45543,15 +45584,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/path-scurry/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -45694,16 +45726,12 @@
 			}
 		},
 		"node_modules/pify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-			"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-			"dev": true,
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/pirates": {
@@ -46664,13 +46692,13 @@
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
 		},
 		"node_modules/proc-log": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-			"integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+			"integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/process": {
@@ -46688,13 +46716,13 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"node_modules/proggy": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/proggy/-/proggy-2.0.0.tgz",
-			"integrity": "sha512-69agxLtnI8xBs9gUGqEnK26UfiexpHy+KUpBQWabiytQjnn5wFY8rklAi7GRfABIuPNnQ/ik48+LGLkYYJcy4A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/proggy/-/proggy-3.0.0.tgz",
+			"integrity": "sha512-QE8RApCM3IaRRxVzxrjbgNMpQEX6Wu0p0KBeoSiSEw5/bsGwZHsshF4LCxH2jp/r6BU+bqA3LrMDEYNfJnpD8Q==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/progress": {
@@ -46766,16 +46794,16 @@
 			}
 		},
 		"node_modules/promzard": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/promzard/-/promzard-1.0.2.tgz",
-			"integrity": "sha512-2FPputGL+mP3jJ3UZg/Dl9YOkovB7DX0oOr+ck5QbZ5MtORtds8k/BZdn+02peDLI8/YWbmzx34k5fA+fHvCVQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/promzard/-/promzard-2.0.0.tgz",
+			"integrity": "sha512-Ncd0vyS2eXGOjchIRg6PVCYKetJYrW1BSbbIo+bKdig61TB6nH2RQNF2uP+qMpsI73L/jURLWojcw8JNIKZ3gg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"read": "^3.0.1"
+				"read": "^4.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/prop-types": {
@@ -46789,9 +46817,9 @@
 			}
 		},
 		"node_modules/protocols": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-			"integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+			"integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -48228,16 +48256,16 @@
 			}
 		},
 		"node_modules/read": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/read/-/read-3.0.1.tgz",
-			"integrity": "sha512-SLBrDU/Srs/9EoWhU5GdbAoxG1GzpQHo/6qiGItaoLJ1thmYpcNIM1qISEUvyHBzfGlWIyd6p2DNi1oV1VmAuw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/read/-/read-4.1.0.tgz",
+			"integrity": "sha512-uRfX6K+f+R8OOrYScaM3ixPY4erg69f8DN6pgTvMcA9iRc8iDhwrA4m3Yu8YYKsXJgVvum+m8PkRboZwwuLzYA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"mute-stream": "^1.0.0"
+				"mute-stream": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/read-cache": {
@@ -48249,53 +48277,10 @@
 				"pify": "^2.3.0"
 			}
 		},
-		"node_modules/read-cache/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/read-cmd-shim": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-4.0.0.tgz",
 			"integrity": "sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/read-package-json-fast": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
-			"integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"json-parse-even-better-errors": "^3.0.0",
-				"npm-normalize-package-bin": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/read-package-json-fast/node_modules/npm-normalize-package-bin": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-			"integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -48405,13 +48390,13 @@
 			}
 		},
 		"node_modules/read/node_modules/mute-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -48950,9 +48935,10 @@
 			"deprecated": "https://github.com/lydell/resolve-url#deprecated"
 		},
 		"node_modules/resolve.exports": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+			"integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -49089,15 +49075,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rimraf/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/ripemd160": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
@@ -49210,10 +49187,11 @@
 			}
 		},
 		"node_modules/run-async": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+			"integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -50795,21 +50773,21 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
 		"node_modules/sigstore": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.3.1.tgz",
-			"integrity": "sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
+			"integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"@sigstore/sign": "^2.3.2",
-				"@sigstore/tuf": "^2.3.4",
-				"@sigstore/verify": "^1.2.1"
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.1.0",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"@sigstore/sign": "^4.1.0",
+				"@sigstore/tuf": "^4.0.1",
+				"@sigstore/verify": "^3.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/simple-concat": {
@@ -50931,6 +50909,19 @@
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/smol-toml": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
 			}
 		},
 		"node_modules/snake-case": {
@@ -52120,24 +52111,6 @@
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
 			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
-		"node_modules/strong-log-transformer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
-			"integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"duplexer": "^0.1.1",
-				"minimist": "^1.2.0",
-				"through": "^2.3.4"
-			},
-			"bin": {
-				"sl-log-transformer": "bin/sl-log-transformer.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/style-loader": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
@@ -52832,21 +52805,20 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+			"integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/tar-fs": {
@@ -52906,36 +52878,23 @@
 			}
 		},
 		"node_modules/tar/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
-		"node_modules/tar/node_modules/minipass": {
+		"node_modules/tar/node_modules/yallist": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/tar/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/teen_process": {
@@ -53007,16 +52966,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/temp-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/temp/node_modules/glob": {
@@ -53410,6 +53359,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"dependencies": {
 				"os-tmpdir": "~1.0.2"
 			},
@@ -53750,19 +53700,44 @@
 			"dev": true
 		},
 		"node_modules/tuf-js": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.1.tgz",
-			"integrity": "sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+			"integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tufjs/models": "2.0.1",
-				"debug": "^4.3.4",
-				"make-fetch-happen": "^13.0.1"
+				"@tufjs/models": "4.1.0",
+				"debug": "^4.4.3",
+				"make-fetch-happen": "^15.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
+		},
+		"node_modules/tuf-js/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tuf-js/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
@@ -55160,11 +55135,14 @@
 			}
 		},
 		"node_modules/walk-up-path": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
-			"integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+			"integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/walker": {
 			"version": "1.0.8",
@@ -57674,9 +57652,9 @@
 			}
 		},
 		"node_modules/yoctocolors-cjs": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+			"integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"jest-message-util": "^29.6.2",
 		"jest-watch-typeahead": "2.2.2",
 		"jsonc-parser": "3.3.1",
-		"lerna": "8.1.9",
+		"lerna": "9.0.7",
 		"lint-staged": "10.0.2",
 		"node-fetch": "2.7.0",
 		"npm-run-all": "4.1.5",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #77227 

Switches npm package publishing for all `@wordpress` packages from long-lived token authentication to OIDC trusted publishing.

## Why?
Long-lived npm tokens (stored as `NPM_TOKEN`) represent a persistent security risk they can be compromised, accidentally exposed in logs, or require manual rotation. Given the recent supply chain attacks on the npm ecosystem, this is the right time to eliminate them.

## How?
- Added `id-token: write` permission to the job (required for GitHub Actions to generate OIDC tokens)
- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from all four publish steps (`development`, `latest`, `bugfix`, `wp`)
- Removed `--no-verify-access` from the `wp` release type's direct `lerna publish` call
- Removed `npm whoami` — this requires a persistent auth session and  is not meaningful with short-lived OIDC tokens.
- Upgraded `lerna` from `8.1.9` to `9.0.7` — OIDC trusted publishing support was added in Lerna v9.0.0.
  
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
