### PR TITLE
getMergedItemsIds: receive full page bigger than perPage

### DIFF
--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -51,6 +51,7 @@ export function getMergedItemIds(
 	}
 
 	const nextItemIdsStartIndex = offset ?? ( page - 1 ) * perPage;
+	const nextItemIdsRange = Math.max( perPage, nextItemIds.length );
 
 	// If later page has already been received, default to the larger known
 	// size of the existing array, else calculate as extending the existing.
@@ -67,7 +68,8 @@ export function getMergedItemIds(
 		// We need to check against the possible maximum upper boundary because
 		// a page could receive fewer than what was previously stored.
 		const isInNextItemsRange =
-			i >= nextItemIdsStartIndex && i < nextItemIdsStartIndex + perPage;
+			i >= nextItemIdsStartIndex &&
+			i < nextItemIdsStartIndex + nextItemIdsRange;
 		if ( isInNextItemsRange ) {
 			mergedItemIds[ i ] = nextItemIds[ i - nextItemIdsStartIndex ];
 		} else {

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -100,6 +100,13 @@ describe( 'getMergedItemIds', () => {
 
 		expect( result ).toEqual( [ 1, 2, 9, undefined, 5, 6 ] );
 	} );
+
+	it( 'should keep all received IDs when response exceeds default perPage', () => {
+		const nextItemIds = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ];
+		const result = getMergedItemIds( [], nextItemIds );
+
+		expect( result ).toEqual( nextItemIds );
+	} );
 } );
 
 describe( 'itemIsComplete', () => {


### PR DESCRIPTION
Fixes an issue reported by @t-hamano in https://github.com/WordPress/gutenberg/pull/76406#issuecomment-4234235607. It's a regression from #76406 and #76808. The problem is that when the `receiveQueries` reducer receives a page of results that is longer than the `perPage` value, it should ignore the smaller `perPage` (it's often just a default value) and receive the full page instead.

This manifests in the `getEntityRecords( 'root', 'icon' )` query where the REST endpoint returns 88 results and the default `perPage` is just 10. We should receive the full 88-item array.

**How to test:**
Insert an `icon` block and click on "Choose icon". In the modal that opens, there should be all available icons, not just the first 10.