### PR TITLE
FormTokenField: remove unnecessary styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Code Quality
 
 -   `Textarea`: remove unnecessary style [#77221](https://github.com/WordPress/gutenberg/pull/77221).
+-   `FormTokenField`: remove unnecessary style [#77263](https://github.com/WordPress/gutenberg/pull/77263).
 
 ## 32.5.0 (2026-04-01)
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -14,7 +14,6 @@
 		background: $components-color-gray-100;
 		border-color: $components-color-gray-400;
 		cursor: default;
-		opacity: 1;
 	}
 
 	&.is-active {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/77137#discussion_r3064631077

## What?

Removes unnecessary `opacity` style rule.

## Why?

It's unnecessary, [see](https://github.com/WordPress/gutenberg/pull/77137#discussion_r3064631077).

## Testing Instructions

- Go to Storybook > DataViews > DataForm > Layout regular.
- In the storybook's control sidebar, set controls to disabled.
- Make sure the color is still respected in a few browsers (chrome, firefox, safari).
