### PR TITLE
AGENTS.md: Add design system package guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Key rules:
 -   **Never hardcode colors, spacing, or typography values.** Always reference `--wpds-*` tokens from `@wordpress/theme`. If a token doesn't exist for your use case, that's a gap worth reporting — not a reason to use a raw value.
 -   **Prefer `@wordpress/ui` over `@wordpress/components`.** The `/ui` package is the design system implementation; `/components` is a legacy collection being incrementally replaced. When both packages export a component with the same purpose, use the `/ui` version.
 -   **`@wordpress/components` uses a different styling system.** It consumes Sass variables from `@wordpress/base-styles`, not `--wpds-*` tokens. Mixing `/ui` and `/components` on the same page may produce minor visual inconsistencies.
+-   **Two CSS custom property namespaces coexist in Gutenberg.** `--wp--preset--*` properties (from `theme.json`) are for block rendering and front-end styles. `--wpds-*` properties (from `@wordpress/theme`) are for admin UI and design system components. Use `--wp--preset--*` when working on blocks and the editor canvas; use `--wpds-*` when working on admin chrome, settings pages, and design system components.
 
 ## Common pitfalls
 
@@ -92,6 +93,8 @@ Key rules:
 -   Avoid using private APIs in bundled packages (packages without `wpScript` or `wpModuleExports`). Private APIs are intended for Core usage; bundled packages may also be imported via npm into plugin scripts, causing incompatibilities.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
 -   `@wordpress/build` (`packages/wp-build`) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
+-   Importing `@wordpress/dataviews` registers a `@wordpress/data` store at import time. Removing a `<DataViews>` usage without removing the `import` still ships the store registry. Be intentional about adding and removing DataViews imports.
+-   `@wordpress/ui` uses CSS Modules with `--wpds-*` tokens. `@wordpress/components` uses Emotion (CSS-in-JS) with Sass variables from `@wordpress/base-styles`. When modifying components, use the styling approach of the package you're working in — don't introduce Emotion into `/ui` or CSS Modules into `/components`.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,25 @@ vendor/bin/phpcbf <path_to_php_file.php>
 
 For full architecture details, see `docs/explanations/architecture/`.
 
+## Design system package guide
+
+The WordPress Design System spans several packages. When building or modifying UI, use the most specific package available:
+
+| Package | Role | Use for |
+|---|---|---|
+| `@wordpress/theme` | Design tokens | Colors, spacing, typography, radii, shadows, elevation via `--wpds-*` CSS custom properties. Source of truth for every visual value. |
+| `@wordpress/ui` | UI primitives | The preferred component library (e.g., AlertDialog, Badge, Button, Card, Dialog, EmptyState, Form, Icon, IconButton, Link, Notice, Popover, Stack, Tabs, Text, Tooltip). |
+| `@wordpress/icons` | Iconography | SVG icons consumed via `<Icon icon={iconName} />`. |
+| `@wordpress/admin-ui` | Page chrome | High-level layout (e.g., Page, Breadcrumbs, NavigableRegion). |
+| `@wordpress/dataviews` | Data UI | DataViews (tables, grids, lists with filtering, sorting, bulk actions) and DataForm (structured form rendering from field definitions). |
+| `@wordpress/components` | Legacy components | Only use when the component you need is not yet in `@wordpress/ui` (e.g., CheckboxControl, RadioControl, ToggleControl, ColorPicker, DatePicker). Prefer `@wordpress/ui` when both packages offer the same component. |
+
+Key rules:
+
+-   **Never hardcode colors, spacing, or typography values.** Always reference `--wpds-*` tokens from `@wordpress/theme`. If a token doesn't exist for your use case, that's a gap worth reporting — not a reason to use a raw value.
+-   **Prefer `@wordpress/ui` over `@wordpress/components`.** The `/ui` package is the design system implementation; `/components` is a legacy collection being incrementally replaced. When both packages export a component with the same purpose, use the `/ui` version.
+-   **`@wordpress/components` uses a different styling system.** It consumes Sass variables from `@wordpress/base-styles`, not `--wpds-*` tokens. Mixing `/ui` and `/components` on the same page may produce minor visual inconsistencies.
+
 ## Common pitfalls
 
 -   PHP features in `lib/compat/` MUST target a specific `wordpress-X.Y/` subdirectory.


### PR DESCRIPTION
## Description

Adds a "Design system package guide" section and two new common pitfalls to `AGENTS.md`, helping AI agents work correctly with WordPress Design System packages.

### Design system package guide (new section)

- A package-to-role mapping table covering `@wordpress/theme`, `@wordpress/ui`, `@wordpress/icons`, `@wordpress/admin-ui`, `@wordpress/dataviews`, and `@wordpress/components`
- Key rules for token usage, package preference, and the relationship between the two styling systems
- Clarification of when to use `--wp--preset--*` (block rendering / front-end) vs. `--wpds-*` (admin UI / design system components) — two CSS custom property namespaces that coexist in Gutenberg

### Common pitfalls (new bullets)

- `@wordpress/dataviews` registers a `@wordpress/data` store at import time; removing a `<DataViews>` usage without removing the `import` still ships the store registry
- `@wordpress/ui` and `@wordpress/components` use different styling systems (CSS Modules vs. Emotion) — contributors should match the styling approach of the package they're working in

## Motivation

This addresses a recurring problem where AI agents working with Gutenberg:
- Pick components from `@wordpress/components` or `@wordpress/ui` at random, requiring manual cleanup
- Fabricate design tokens that sound plausible but don't exist, instead of referencing `@wordpress/theme`
- Confuse the two CSS custom property namespaces (`--wp--preset--*` vs. `--wpds-*`)
- Don't know when to fall back from `/ui` to `/components` (or when not to)

These patterns were observed across multiple prototyping projects that stress-tested the WPDS packages. The component lists in the table use "e.g." so they remain accurate as new components are added.

Part of #77205.

## Testing Instructions

This is a documentation-only change to `AGENTS.md`. No code, tests, or build changes.

### Pre-merge Checklist

- [x] Change is documentation-only
- [x] Component lists use "e.g." to stay future-proof
- [x] New section placed after "Architectural decisions", before "Common pitfalls"
- [x] New pitfall bullets match the style of existing ones
- [x] Formatting matches the existing file style

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>