### PR TITLE
Media & Text: Fix block transformation when pasting images/videos

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useRef } from '@wordpress/element';
 import {
 	BlockControls,
@@ -30,10 +30,10 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { isBlobURL, getBlobTypeByURL } from '@wordpress/blob';
+import { isBlobURL, getBlobTypeByURL, createBlobURL } from '@wordpress/blob';
 import { pullLeft, pullRight } from '@wordpress/icons';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-
+import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
@@ -479,9 +479,56 @@ function MediaTextEdit( {
 		</ToolsPanel>
 	);
 
+	const { mediaUpload } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return {
+			mediaUpload: getSettings().mediaUpload,
+		};
+	}, [] );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const onPaste = ( event ) => {
+		const files = event.clipboardData?.files;
+		if ( files && files.length > 0 ) {
+			const mediaFiles = Array.from( files ).filter(
+				( f ) =>
+					f.type.startsWith( 'image/' ) ||
+					f.type.startsWith( 'video/' )
+			);
+			if ( mediaFiles.length > 0 ) {
+				event.preventDefault();
+
+				if ( ! mediaUpload ) {
+					createErrorNotice(
+						__(
+							'To edit this block, you need permission to upload media.'
+						),
+						{ type: 'snackbar' }
+					);
+					return;
+				}
+
+				const file = mediaFiles[ 0 ];
+				onSelectMedia( { url: createBlobURL( file ) } );
+				mediaUpload( {
+					allowedTypes: [ 'image', 'video' ],
+					filesList: [ file ],
+					onFileChange: ( [ media ] ) => {
+						if ( media ) {
+							onSelectMedia( media );
+						}
+					},
+					onError: ( message ) =>
+						createErrorNotice( message, { type: 'snackbar' } ),
+				} );
+			}
+		}
+	};
+
 	const blockProps = useBlockProps( {
 		className: classNames,
 		style,
+		onPaste,
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps(


### PR DESCRIPTION
## What?

Closes #56062 

This PR fixes the behavior when pasting images or videos into a **Media & Text** block. It ensures that pasted media is correctly assigned to the block's media area instead of transforming the entire block into an **Image** block or appending the image inline into the text section.

## Why?

Previously, pasting an image while a **Media & Text** block was selected would trigger the global block editor's "smart paste" logic, which often converted the selected block into a standalone **Image** block. If pasting while focused on the text area, the nested `RichText` component would either ignore the file or attempt to insert it as a child.

## How?

1. **Event Interception**: Added an `onPaste` event handler to the `useBlockProps` of the outermost wrapper in the `MediaTextEdit` component.
2. **Media Detection**: The handler checks the clipboard for files and filters for `image/*` or `video/*` mime types.
3. **Local Handling**: If media files are detected, `event.preventDefault()` is called to stop the event from bubbling up to the global Gutenberg paste handler.
4. **Direct Upload**: The first detected file is instantly shown as a transient blob URL (using `createBlobURL`) and then uploaded via the editor's `mediaUpload` setting, finally updating the block attributes through the existing `onSelectMedia` callback.
5. **Notice Integration**: Any upload errors are caught and displayed as snackbar notices using the standard `@wordpress/notices` store.

## Testing Instructions

1. Navigate to the Post Editor.
2. Insert a **Media & Text** block.
3. Copy an image from your computer or another browser tab.
4. With the **Media & Text** block selected (either the whole block or internally focused on the paragraph), paste the image.
5. Confirm that the image is correctly uploaded and placed into the block's media container and that the block itself does *not* transform into an **Image** block.
6. Verify that pasting plain text still works as expected in the text portion.

## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/f7a6f845-e0ef-42bf-9c72-d2b5558db829

### After

https://github.com/user-attachments/assets/1df24310-90f5-4ed8-b370-c19bac299817

## Use of AI Tools

Used AI assistance to identify the event bubbling conflict and verify implemented local interception logic. All changes were manually reviewed and tested for compatibility with the existing `Media & Text` block architecture.