### PR TITLE
Add custom states into the states UI and allow multipl selection

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -549,8 +549,8 @@ Add a page, link, or another item to your navigation. ([Source](https://github.c
 -	**Category:** design
 -	**Parent:** core/navigation
 -	**Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
--	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
--	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
+-	**Supports:** anchor, interactivity (clientNavigation), states (:active, :focus, :hover, @current), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, style, title, type, url
 
 ## Navigation Overlay Close
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -101,7 +101,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Name:** core/button
 -	**Category:** design
 -	**Parent:** core/buttons
--	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, text), dimensions (width), interactivity (clientNavigation), shadow, spacing (padding), splitting, states (:active, :focus, :hover), typography (fontSize, lineHeight, textAlign), ~~alignWide~~, ~~align~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textColor, title, type, url
 
 ## Buttons

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -31,7 +31,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$style = $block['attrs']['style'] ?? array();
+	$style     = $block['attrs']['style'] ?? array();
 	$css_rules = array();
 
 	foreach ( $supported_states as $state ) {

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Block states support for frontend CSS generation.
+ *
+ * Generates scoped CSS for per-instance pseudo-state styles (e.g., :hover, :focus)
+ * declared in block attributes under `style[':hover']`, `style[':focus']`, etc.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders per-instance state styles on the frontend for blocks that declare
+ * `__experimentalStates` support.
+ *
+ * @param string $block_content The block's rendered HTML.
+ * @param array  $block         The block data including blockName and attrs.
+ * @return string Modified block content with injected state styles.
+ */
+function gutenberg_render_block_states_support( $block_content, $block ) {
+	if ( empty( $block['blockName'] ) || empty( $block_content ) ) {
+		return $block_content;
+	}
+
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! $block_type ) {
+		return $block_content;
+	}
+
+	$supported_states = $block_type->supports['__experimentalStates'] ?? null;
+	if ( empty( $supported_states ) || ! is_array( $supported_states ) ) {
+		return $block_content;
+	}
+
+	$style = $block['attrs']['style'] ?? array();
+	$css_rules = array();
+
+	foreach ( $supported_states as $state ) {
+		if ( empty( $style[ $state ] ) || ! is_array( $style[ $state ] ) ) {
+			continue;
+		}
+
+		$compiled = wp_style_engine_get_styles( $style[ $state ] );
+		if ( ! empty( $compiled['css'] ) ) {
+			$css_rules[] = array(
+				'state' => $state,
+				'css'   => $compiled['css'],
+			);
+		}
+	}
+
+	if ( empty( $css_rules ) ) {
+		return $block_content;
+	}
+
+	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
+	$css          = '';
+
+	foreach ( $css_rules as $rule ) {
+		$css .= ".$unique_class$rule[state] { $rule[css] }\n";
+	}
+
+	// Inject the unique class into the first element of the block content.
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+	if ( $processor->next_tag() ) {
+		$processor->add_class( $unique_class );
+		$block_content = $processor->get_updated_html();
+	}
+
+	return '<style>' . $css . '</style>' . $block_content;
+}
+add_filter( 'render_block', 'gutenberg_render_block_states_support', 10, 2 );

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -52,11 +52,35 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	// Map __experimentalStatesElement values to their CSS element selectors.
+	$element_selectors = array(
+		'button' => '.wp-element-button, .wp-block-button__link',
+		'link'   => 'a:where(:not(.wp-element-button))',
+	);
+
+	$states_element  = $block_type->supports['__experimentalStatesElement'] ?? null;
+	$element_css_sel = isset( $states_element ) ? ( $element_selectors[ $states_element ] ?? null ) : null;
+
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
 	$css          = '';
 
 	foreach ( $css_rules as $rule ) {
-		$css .= ".$unique_class$rule[state] { $rule[css] }\n";
+		if ( $element_css_sel ) {
+			// Append pseudo-class to each comma-separated element selector part
+			// and scope them to the unique wrapper class.
+			$parts    = explode( ',', $element_css_sel );
+			$scoped   = array();
+			foreach ( $parts as $part ) {
+				$scoped[] = '.' . $unique_class . ' ' . trim( $part ) . $rule['state'];
+			}
+			$selector = implode( ', ', $scoped );
+		} else {
+			$selector = '.' . $unique_class . $rule['state'];
+		}
+		// Use !important to override utility classes like
+		// .has-accent-3-background-color which are generated with !important.
+		$declarations = str_replace( ';', ' !important;', $rule['css'] );
+		$css         .= "$selector { $declarations }\n";
 	}
 
 	// Inject the unique class into the first element of the block content.

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -2,11 +2,133 @@
 /**
  * Block states support for frontend CSS generation.
  *
- * Generates scoped CSS for per-instance pseudo-state styles (e.g., :hover, :focus)
- * declared in block attributes under `style[':hover']`, `style[':focus']`, etc.
+ * Generates scoped CSS for per-instance state styles (e.g., :hover, :focus,
+ * @current) declared in block attributes under `style[':hover']`,
+ * `style['@current']`, etc.
  *
- * @package WordPress
+ * Custom (`@`-prefixed) states map to a CSS selector fragment via the block's
+ * `selectors.states` meta. Compound states (e.g., `@current` + `:hover`) are
+ * stored nested: `style['@current'][':hover']`.
+ *
+ * @package Gutenberg
  */
+
+/**
+ * Returns the CSS selector suffix for a custom (`@`-prefixed) state, by
+ * looking up `selectors.states` on the block type.
+ *
+ * Example: for `@current` on `core/navigation-link`, where
+ * `selectors.states['@current'] = ".wp-block-navigation .current-menu-item"`,
+ * returns `.current-menu-item` (the last compound selector segment).
+ *
+ * @param WP_Block_Type $block_type The registered block type.
+ * @param string        $state      The custom state key, e.g. `'@current'`.
+ * @return string|null The CSS class selector suffix (e.g. `.current-menu-item`),
+ *                     or null if not declared.
+ */
+function gutenberg_get_custom_state_selector( $block_type, $state ) {
+	$state_selector = $block_type->selectors['states'][ $state ] ?? null;
+	if ( ! $state_selector ) {
+		return null;
+	}
+	/*
+	 * Extract the last compound selector segment (class or pseudo-class).
+	 * ".wp-block-navigation .current-menu-item" → ".current-menu-item"
+	 */
+	if ( preg_match( '/(\.[a-zA-Z0-9_-]+(?:\:[a-zA-Z0-9_-]+)?)\s*$/', $state_selector, $matches ) ) {
+		return $matches[1];
+	}
+	return null;
+}
+
+/**
+ * Collects CSS rule descriptors from the block's `style` attribute for all
+ * supported states, including compound states nested under custom (`@`-prefixed)
+ * keys.
+ *
+ * Returns an array of rule descriptors:
+ * [
+ *   [ 'selector_suffix' => ':hover',               'declarations' => [ 'color' => 'red' ] ],
+ *   [ 'selector_suffix' => '.current-menu-item',   'declarations' => [ 'color' => 'blue' ] ],
+ *   [ 'selector_suffix' => '.current-menu-item:hover', 'declarations' => [ 'color' => 'purple' ] ],
+ * ]
+ *
+ * @param WP_Block_Type $block_type       The registered block type.
+ * @param array         $style            The block's `style` attribute value.
+ * @param array         $supported_states The states declared in `supports.states`.
+ * @return array Array of `[ 'selector_suffix', 'declarations' ]` rule descriptors.
+ */
+function gutenberg_collect_state_css_rules( $block_type, $style, $supported_states ) {
+	$css_rules = array();
+
+	foreach ( $supported_states as $state ) {
+		if ( empty( $style[ $state ] ) || ! is_array( $style[ $state ] ) ) {
+			continue;
+		}
+
+		$state_data = $style[ $state ];
+
+		if ( str_starts_with( $state, '@' ) ) {
+			/*
+			 * Custom class-based state (e.g. `@current`). Resolve its CSS
+			 * selector suffix from the block's `selectors.states` declaration.
+			 */
+			$custom_suffix = gutenberg_get_custom_state_selector( $block_type, $state );
+			if ( ! $custom_suffix ) {
+				continue;
+			}
+
+			/*
+			 * Separate direct style properties from nested pseudo-state
+			 * sub-objects within this custom state. E.g. for `@current`:
+			 *   { "color": {...}, ":hover": { "color": {...} } }
+			 * The "color" key is the direct style; ":hover" is a compound state.
+			 */
+			$direct_styles   = array();
+			$pseudo_sub_keys = array();
+			foreach ( $state_data as $key => $value ) {
+				if ( str_starts_with( $key, ':' ) && is_array( $value ) ) {
+					$pseudo_sub_keys[ $key ] = $value;
+				} else {
+					$direct_styles[ $key ] = $value;
+				}
+			}
+
+			// Direct custom-state styles.
+			if ( ! empty( $direct_styles ) ) {
+				$compiled = wp_style_engine_get_styles( $direct_styles );
+				if ( ! empty( $compiled['declarations'] ) ) {
+					$css_rules[] = array(
+						'selector_suffix' => $custom_suffix,
+						'declarations'    => $compiled['declarations'],
+					);
+				}
+			}
+
+			// Compound states: `@current` + `:hover`, etc.
+			foreach ( $pseudo_sub_keys as $pseudo => $pseudo_styles ) {
+				$compiled = wp_style_engine_get_styles( $pseudo_styles );
+				if ( ! empty( $compiled['declarations'] ) ) {
+					$css_rules[] = array(
+						'selector_suffix' => $custom_suffix . $pseudo,
+						'declarations'    => $compiled['declarations'],
+					);
+				}
+			}
+		} else {
+			// Standard pseudo-selector state (e.g. `:hover`, `:focus`).
+			$compiled = wp_style_engine_get_styles( $state_data );
+			if ( ! empty( $compiled['declarations'] ) ) {
+				$css_rules[] = array(
+					'selector_suffix' => $state,
+					'declarations'    => $compiled['declarations'],
+				);
+			}
+		}
+	}
+
+	return $css_rules;
+}
 
 /**
  * Renders per-instance state styles on the frontend for blocks that declare
@@ -32,21 +154,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	}
 
 	$style     = $block['attrs']['style'] ?? array();
-	$css_rules = array();
-
-	foreach ( $supported_states as $state ) {
-		if ( empty( $style[ $state ] ) || ! is_array( $style[ $state ] ) ) {
-			continue;
-		}
-
-		$compiled = wp_style_engine_get_styles( $style[ $state ] );
-		if ( ! empty( $compiled['declarations'] ) ) {
-			$css_rules[] = array(
-				'state'        => $state,
-				'declarations' => $compiled['declarations'],
-			);
-		}
-	}
+	$css_rules = gutenberg_collect_state_css_rules( $block_type, $style, $supported_states );
 
 	if ( empty( $css_rules ) ) {
 		return $block_content;
@@ -76,7 +184,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 				: $value;
 		}
 		$style_rules[] = array(
-			'selector'     => ".$unique_class{$rule['state']}",
+			'selector'     => ".$unique_class{$rule['selector_suffix']}",
 			'declarations' => $declarations,
 		);
 	}
@@ -89,11 +197,13 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		)
 	);
 
-	// Add the unique class to the interactive element so that state selectors
-	// like `.$unique_class:hover` match directly without needing a descendant.
-	// If the block declares selectors.root with a descendant (e.g. the button
-	// block's ".wp-block-button .wp-block-button__link"), we extract the last
-	// class and walk to that element. Otherwise we fall back to the wrapper.
+	/*
+	 * Add the unique class to the interactive element so that state selectors
+	 * like `.$unique_class:hover` and `.$unique_class.current-menu-item` match
+	 * directly. If the block declares selectors.root with a descendant (e.g. the
+	 * button block's ".wp-block-button .wp-block-button__link"), we extract the
+	 * last class and walk to that element. Otherwise we fall back to the wrapper.
+	 */
 	$root_selector = $block_type->selectors['root'] ?? null;
 	$target_class  = null;
 	if ( $root_selector && preg_match( '/\.([a-zA-Z0-9_-]+)\s*$/', $root_selector, $matches ) ) {

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -60,20 +60,24 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	 * state styles share the same hash class and therefore the same selector, so
 	 * only one CSS rule is emitted. The store is flushed to the page by
 	 * gutenberg_enqueue_stored_styles() rather than injected inline here.
+	 *
+	 * Preset utility classes (e.g. .has-accent-3-background-color) are generated
+	 * with !important, so state styles targeting the same properties must also use
+	 * !important to win. Properties without preset utility classes don't need it.
 	 */
+	$preset_class_properties = array( 'color', 'background-color', 'border-color', 'background', 'font-size', 'font-family' );
+
 	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
-		// Use !important to override utility classes like
-		// .has-accent-3-background-color which are generated with !important.
-		$declarations_with_important = array_map(
-			static function ( $value ) {
-				return rtrim( $value ) . ' !important';
-			},
-			$rule['declarations']
-		);
-		$style_rules[]               = array(
+		$declarations = array();
+		foreach ( $rule['declarations'] as $property => $value ) {
+			$declarations[ $property ] = in_array( $property, $preset_class_properties, true )
+				? $value . ' !important'
+				: $value;
+		}
+		$style_rules[] = array(
 			'selector'     => ".$unique_class{$rule['state']}",
-			'declarations' => $declarations_with_important,
+			'declarations' => $declarations,
 		);
 	}
 

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -52,43 +52,46 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	// Map __experimentalStatesElement values to their CSS element selectors.
-	$element_selectors = array(
-		'button' => '.wp-element-button, .wp-block-button__link',
-		'link'   => 'a:where(:not(.wp-element-button))',
-	);
-
-	$states_element  = $block_type->supports['__experimentalStatesElement'] ?? null;
-	$element_css_sel = isset( $states_element ) ? ( $element_selectors[ $states_element ] ?? null ) : null;
-
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
 	$css          = '';
 
 	foreach ( $css_rules as $rule ) {
-		if ( $element_css_sel ) {
-			// Append pseudo-class to each comma-separated element selector part
-			// and scope them to the unique wrapper class.
-			$parts    = explode( ',', $element_css_sel );
-			$scoped   = array();
-			foreach ( $parts as $part ) {
-				$scoped[] = '.' . $unique_class . ' ' . trim( $part ) . $rule['state'];
-			}
-			$selector = implode( ', ', $scoped );
-		} else {
-			$selector = '.' . $unique_class . $rule['state'];
-		}
 		// Use !important to override utility classes like
 		// .has-accent-3-background-color which are generated with !important.
 		$declarations = str_replace( ';', ' !important;', $rule['css'] );
-		$css         .= "$selector { $declarations }\n";
+		$css         .= ".$unique_class$rule[state] { $declarations }\n";
 	}
 
-	// Inject the unique class into the first element of the block content.
-	$processor = new WP_HTML_Tag_Processor( $block_content );
-	if ( $processor->next_tag() ) {
-		$processor->add_class( $unique_class );
-		$block_content = $processor->get_updated_html();
+	// Add the unique class to the interactive element so that state selectors
+	// like `.$unique_class:hover` match directly without needing a descendant.
+	// If the block declares selectors.root with a descendant (e.g. the button
+	// block's ".wp-block-button .wp-block-button__link"), we extract the last
+	// class and walk to that element. Otherwise we fall back to the wrapper.
+	$root_selector = $block_type->selectors['root'] ?? null;
+	$target_class  = null;
+	if ( $root_selector && preg_match( '/\.([a-zA-Z0-9_-]+)\s*$/', $root_selector, $matches ) ) {
+		$target_class = $matches[1];
 	}
+
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+	$found     = false;
+	if ( $target_class ) {
+		while ( $processor->next_tag() ) {
+			if ( $processor->has_class( $target_class ) ) {
+				$processor->add_class( $unique_class );
+				$found = true;
+				break;
+			}
+		}
+	}
+	if ( ! $found ) {
+		// No target class found or no selectors.root — add to the wrapper.
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+		if ( $processor->next_tag() ) {
+			$processor->add_class( $unique_class );
+		}
+	}
+	$block_content = $processor->get_updated_html();
 
 	return '<style>' . $css . '</style>' . $block_content;
 }

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -40,10 +40,10 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		}
 
 		$compiled = wp_style_engine_get_styles( $style[ $state ] );
-		if ( ! empty( $compiled['css'] ) ) {
+		if ( ! empty( $compiled['declarations'] ) ) {
 			$css_rules[] = array(
-				'state' => $state,
-				'css'   => $compiled['css'],
+				'state'        => $state,
+				'declarations' => $compiled['declarations'],
 			);
 		}
 	}
@@ -53,14 +53,37 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	}
 
 	$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
-	$css          = '';
 
+	/*
+	 * Register each state's CSS rules with the block-supports style engine store.
+	 * The store deduplicates rules by selector — two block instances with identical
+	 * state styles share the same hash class and therefore the same selector, so
+	 * only one CSS rule is emitted. The store is flushed to the page by
+	 * gutenberg_enqueue_stored_styles() rather than injected inline here.
+	 */
+	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
 		// Use !important to override utility classes like
 		// .has-accent-3-background-color which are generated with !important.
-		$declarations = str_replace( ';', ' !important;', $rule['css'] );
-		$css         .= ".$unique_class$rule[state] { $declarations }\n";
+		$declarations_with_important = array_map(
+			static function ( $value ) {
+				return rtrim( $value ) . ' !important';
+			},
+			$rule['declarations']
+		);
+		$style_rules[]               = array(
+			'selector'     => ".$unique_class{$rule['state']}",
+			'declarations' => $declarations_with_important,
+		);
 	}
+
+	gutenberg_style_engine_get_stylesheet_from_css_rules(
+		$style_rules,
+		array(
+			'context'  => 'block-supports',
+			'prettify' => false,
+		)
+	);
 
 	// Add the unique class to the interactive element so that state selectors
 	// like `.$unique_class:hover` match directly without needing a descendant.
@@ -84,8 +107,6 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	} elseif ( $processor->next_tag() ) {
 		$processor->add_class( $unique_class );
 	}
-	$block_content = $processor->get_updated_html();
-
-	return '<style>' . $css . '</style>' . $block_content;
+	return $processor->get_updated_html();
 }
 add_filter( 'render_block', 'gutenberg_render_block_states_support', 10, 2 );

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -74,22 +74,15 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	}
 
 	$processor = new WP_HTML_Tag_Processor( $block_content );
-	$found     = false;
 	if ( $target_class ) {
 		while ( $processor->next_tag() ) {
 			if ( $processor->has_class( $target_class ) ) {
 				$processor->add_class( $unique_class );
-				$found = true;
 				break;
 			}
 		}
-	}
-	if ( ! $found ) {
-		// No target class found or no selectors.root — add to the wrapper.
-		$processor = new WP_HTML_Tag_Processor( $block_content );
-		if ( $processor->next_tag() ) {
-			$processor->add_class( $unique_class );
-		}
+	} elseif ( $processor->next_tag() ) {
+		$processor->add_class( $unique_class );
 	}
 	$block_content = $processor->get_updated_html();
 

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -10,7 +10,7 @@
 
 /**
  * Renders per-instance state styles on the frontend for blocks that declare
- * `__experimentalStates` support.
+ * `states` support.
  *
  * @param string $block_content The block's rendered HTML.
  * @param array  $block         The block data including blockName and attrs.
@@ -26,7 +26,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$supported_states = $block_type->supports['__experimentalStates'] ?? null;
+	$supported_states = $block_type->supports['states'] ?? null;
 	if ( empty( $supported_states ) || ! is_array( $supported_states ) ) {
 		return $block_content;
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -201,6 +201,7 @@ require __DIR__ . '/block-supports/aria-label.php';
 require __DIR__ . '/block-supports/anchor.php';
 require __DIR__ . '/block-supports/block-visibility.php';
 require __DIR__ . '/block-supports/custom-css.php';
+require __DIR__ . '/block-supports/states.php';
 
 // Client-side media processing.
 require_once __DIR__ . '/media/load.php';

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -12,6 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	createSlotFill,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -33,6 +34,9 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 
 const { Badge } = unlock( componentsPrivateApis );
+
+export const { Fill: BlockCardControlsFill, Slot: BlockCardControlsSlot } =
+	createSlotFill( 'BlockCardControls' );
 
 function OptionalParentSelectButton( { children, onClick } ) {
 	if ( ! onClick ) {
@@ -151,58 +155,65 @@ function BlockCard( {
 			) }
 		>
 			<VStack>
-				<HStack justify="flex-start" spacing={ 0 }>
-					{ parentBlockClientId && (
-						<Button
-							onClick={ () => selectBlock( parentBlockClientId ) }
-							label={
-								parentBlockName
-									? sprintf(
-											/* translators: %s: The name of the parent block. */
-											__( 'Go to "%s" block' ),
-											getBlockType( parentBlockName )
-												?.title
-									  )
-									: __( 'Go to parent block' )
+				<HStack justify="space-between" spacing={ 0 }>
+					<HStack justify="flex-start" spacing={ 0 }>
+						{ parentBlockClientId && (
+							<Button
+								onClick={ () =>
+									selectBlock( parentBlockClientId )
+								}
+								label={
+									parentBlockName
+										? sprintf(
+												/* translators: %s: The name of the parent block. */
+												__( 'Go to "%s" block' ),
+												getBlockType( parentBlockName )
+													?.title
+										  )
+										: __( 'Go to parent block' )
+								}
+								style={
+									// TODO: This style override is also used in ToolsPanelHeader.
+									// It should be supported out-of-the-box by Button.
+									{ minWidth: 24, padding: 0 }
+								}
+								icon={ isRTL() ? chevronRight : chevronLeft }
+								size="small"
+							/>
+						) }
+						{ isChild && (
+							<span className="block-editor-block-card__child-indicator-icon">
+								<Icon
+									icon={ isRTL() ? arrowLeft : arrowRight }
+								/>
+							</span>
+						) }
+						<OptionalParentSelectButton
+							onClick={
+								parentClientId
+									? () => {
+											selectBlock( parentClientId );
+									  }
+									: undefined
 							}
-							style={
-								// TODO: This style override is also used in ToolsPanelHeader.
-								// It should be supported out-of-the-box by Button.
-								{ minWidth: 24, padding: 0 }
-							}
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							size="small"
-						/>
-					) }
-					{ isChild && (
-						<span className="block-editor-block-card__child-indicator-icon">
-							<Icon icon={ isRTL() ? arrowLeft : arrowRight } />
-						</span>
-					) }
-					<OptionalParentSelectButton
-						onClick={
-							parentClientId
-								? () => {
-										selectBlock( parentClientId );
-								  }
-								: undefined
-						}
-					>
-						<BlockIcon icon={ icon } showColors />
-						<VStack spacing={ 1 }>
-							<TitleElement className="block-editor-block-card__title">
-								<span className="block-editor-block-card__name">
-									{ !! name?.length ? name : title }
-								</span>
-								{ ! parentClientId &&
-									! isChild &&
-									!! name?.length && (
-										<Badge>{ title }</Badge>
-									) }
-							</TitleElement>
-							{ children }
-						</VStack>
-					</OptionalParentSelectButton>
+						>
+							<BlockIcon icon={ icon } showColors />
+							<VStack spacing={ 1 }>
+								<TitleElement className="block-editor-block-card__title">
+									<span className="block-editor-block-card__name">
+										{ !! name?.length ? name : title }
+									</span>
+									{ ! parentClientId &&
+										! isChild &&
+										!! name?.length && (
+											<Badge>{ title }</Badge>
+										) }
+								</TitleElement>
+								{ children }
+							</VStack>
+						</OptionalParentSelectButton>
+					</HStack>
+					<BlockCardControlsSlot />
 				</HStack>
 				{ ! parentClientId && ! isChild && description && (
 					<Text className="block-editor-block-card__description">

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -35,8 +35,9 @@ import BlockIcon from '../block-icon';
 
 const { Badge } = unlock( componentsPrivateApis );
 
+const BlockCardControlsKey = Symbol( 'BlockCardControls' );
 export const { Fill: BlockCardControlsFill, Slot: BlockCardControlsSlot } =
-	createSlotFill( 'BlockCardControls' );
+	createSlotFill( BlockCardControlsKey );
 
 function OptionalParentSelectButton( { children, onClick } ) {
 	if ( ! onClick ) {

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -25,6 +25,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockStyles from '../block-styles';
 import { ListViewContentPopover } from '../inspector-controls/list-view-content-popover';
 import InspectorControls from '../inspector-controls';
+import { BlockInspectorPreTabsSlot } from './inspector-pre-tabs-slot-fill';
 import { default as InspectorControlsTabs } from '../inspector-controls-tabs';
 import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-controls-tabs';
 import InspectorControlsLastItem from '../inspector-controls/last-item';
@@ -351,6 +352,7 @@ const BlockInspectorSingleBlock = ( {
 			<ViewportVisibilityInfo clientId={ renderedBlockClientId } />
 			<EditContents clientId={ renderedBlockClientId } />
 			<BlockVariationTransforms blockClientId={ renderedBlockClientId } />
+			<BlockInspectorPreTabsSlot />
 			{ hasMultipleTabs && (
 				<>
 					<InspectorControlsTabs

--- a/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
+++ b/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+export const {
+	Fill: BlockInspectorPreTabsFill,
+	Slot: BlockInspectorPreTabsSlot,
+} = createSlotFill( 'BlockInspectorPreTabs' );

--- a/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
+++ b/packages/block-editor/src/components/block-inspector/inspector-pre-tabs-slot-fill.js
@@ -3,7 +3,9 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
+const BlockInspectorPreTabsKey = Symbol( 'BlockInspectorPreTabs' );
+
 export const {
 	Fill: BlockInspectorPreTabsFill,
 	Slot: BlockInspectorPreTabsSlot,
-} = createSlotFill( 'BlockInspectorPreTabs' );
+} = createSlotFill( BlockInspectorPreTabsKey );

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -6,19 +6,28 @@ import { check, chevronDown, moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 
 /**
- * State control for managing block state styles (hover, focus, etc.).
- * Displays a dropdown menu to select between different states.
+ * State control for managing block state styles (hover, focus, current, etc.).
+ *
+ * Displays a dropdown that allows selecting one or more states. States are
+ * split into two groups by their prefix:
+ *   - Pseudo-selector states (`:hover`, `:focus`, `:active`, …)
+ *   - Custom class-based states (`@current`, …)
+ *
+ * Multiple states may be selected simultaneously to style compound states,
+ * e.g. `@current` + `:hover` produces styles for `.current-menu-item:hover`.
+ * Custom states are always stored before pseudo-selector states in the value
+ * array since they represent the outer nesting level in the style object.
  *
  * @param {Object}   props          Component props.
- * @param {Array}    props.states   Array of available states with value and label.
- * @param {string}   props.value    Currently selected state value.
- * @param {Function} props.onChange Callback when selection changes.
- * @param {boolean}  props.showText Whether to show text label on the toggle. Default true.
- * @return {Element|null} State control component.
+ * @param {Array}    props.states   Array of available states `{ value, label }`.
+ * @param {string[]} props.value    Currently selected state values.
+ * @param {Function} props.onChange Callback receiving the updated `string[]`.
+ * @param {boolean}  props.showText Whether to show a text label on the toggle.
+ * @return {Element|null} State control component, or null if no states.
  */
 export default function StateControl( {
 	states = [],
-	value = 'default',
+	value = [],
 	onChange,
 	showText = true,
 } ) {
@@ -26,21 +35,56 @@ export default function StateControl( {
 		return null;
 	}
 
-	const stateOptions = [
-		{ label: __( 'Default' ), value: 'default' },
-		...states.map( ( state ) => ( {
-			label: state.label,
-			value: state.value,
-		} ) ),
-	];
+	const pseudoStates = states.filter( ( s ) => ! s.value.startsWith( '@' ) );
+	const customStates = states.filter( ( s ) => s.value.startsWith( '@' ) );
 
-	const getCurrentStateLabel = () => {
-		const currentOption = stateOptions.find(
-			( option ) => option.value === value
-		);
-		return currentOption?.label || __( 'Default' );
-	};
+	const selectedPseudo = value.filter( ( v ) => ! v.startsWith( '@' ) );
+	const selectedCustom = value.filter( ( v ) => v.startsWith( '@' ) );
 
+	/*
+	 * Toggle a state in or out of the selection. Custom states are always
+	 * placed before pseudo-selector states in the array so that path
+	 * traversal (e.g. style['@current'][':hover']) is consistent.
+	 */
+	function toggleState( stateValue ) {
+		const isAlreadySelected = value.includes( stateValue );
+		if ( isAlreadySelected ) {
+			onChange( value.filter( ( v ) => v !== stateValue ) );
+			return;
+		}
+		const isCustom = stateValue.startsWith( '@' );
+		if ( isCustom ) {
+			onChange( [ stateValue, ...selectedPseudo ] );
+		} else {
+			onChange( [ ...selectedCustom, stateValue ] );
+		}
+	}
+
+	function getCurrentLabel() {
+		if ( value.length === 0 ) {
+			return __( 'Default' );
+		}
+		const customLabel =
+			selectedCustom.length > 0
+				? states.find( ( s ) => s.value === selectedCustom[ 0 ] )?.label
+				: null;
+		const pseudoLabel =
+			selectedPseudo.length > 0
+				? states.find( ( s ) => s.value === selectedPseudo[ 0 ] )?.label
+				: null;
+
+		if ( customLabel && pseudoLabel ) {
+			return sprintf(
+				/* translators: 1: item state label (e.g. "Current"), 2: interaction label (e.g. "Hover") */
+				__( '%1$s: %2$s' ),
+				customLabel,
+				pseudoLabel
+			);
+		}
+		return customLabel || pseudoLabel || __( 'Default' );
+	}
+
+	const label = getCurrentLabel();
 	const icon = showText ? chevronDown : moreVertical;
 	const toggleProps = showText
 		? { size: 'compact', variant: 'tertiary', iconPosition: 'right' }
@@ -50,28 +94,65 @@ export default function StateControl( {
 		<DropdownMenu
 			icon={ icon }
 			label={ sprintf(
-				/* translators: %s: Current state (e.g. "Hover", "Focus") */
+				/* translators: %s: current state label (e.g. "Hover", "Current: Focus") */
 				__( 'State: %s' ),
-				getCurrentStateLabel()
+				label
 			) }
-			text={ showText ? getCurrentStateLabel() : undefined }
+			text={ showText ? label : undefined }
 			toggleProps={ toggleProps }
 		>
 			{ ( { onClose } ) => (
-				<MenuGroup label={ __( 'State' ) }>
-					{ stateOptions.map( ( option ) => (
+				<>
+					<MenuGroup>
 						<MenuItem
-							key={ option.value }
 							onClick={ () => {
-								onChange( option.value );
+								onChange( [] );
 								onClose();
 							} }
-							icon={ value === option.value ? check : null }
+							icon={ value.length === 0 ? check : null }
 						>
-							{ option.label }
+							{ __( 'Default' ) }
 						</MenuItem>
-					) ) }
-				</MenuGroup>
+					</MenuGroup>
+					{ pseudoStates.length > 0 && (
+						<MenuGroup label={ __( 'States' ) }>
+							{ pseudoStates.map( ( option ) => (
+								<MenuItem
+									key={ option.value }
+									onClick={ () =>
+										toggleState( option.value )
+									}
+									icon={
+										value.includes( option.value )
+											? check
+											: null
+									}
+								>
+									{ option.label }
+								</MenuItem>
+							) ) }
+						</MenuGroup>
+					) }
+					{ customStates.length > 0 && (
+						<MenuGroup label={ __( 'Item' ) }>
+							{ customStates.map( ( option ) => (
+								<MenuItem
+									key={ option.value }
+									onClick={ () =>
+										toggleState( option.value )
+									}
+									icon={
+										value.includes( option.value )
+											? check
+											: null
+									}
+								>
+									{ option.label }
+								</MenuItem>
+							) ) }
+						</MenuGroup>
+					) }
+				</>
 			) }
 		</DropdownMenu>
 	);

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { check, chevronDown } from '@wordpress/icons';
+import { check, chevronDown, moreVertical } from '@wordpress/icons';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 
 /**
@@ -13,12 +13,14 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
  * @param {Array}    props.states   Array of available states with value and label.
  * @param {string}   props.value    Currently selected state value.
  * @param {Function} props.onChange Callback when selection changes.
+ * @param {boolean}  props.showText Whether to show text label on the toggle. Default true.
  * @return {Element|null} State control component.
  */
 export default function StateControl( {
 	states = [],
 	value = 'default',
 	onChange,
+	showText = true,
 } ) {
 	if ( ! states || states.length === 0 ) {
 		return null;
@@ -39,20 +41,21 @@ export default function StateControl( {
 		return currentOption?.label || __( 'Default' );
 	};
 
+	const icon = showText ? chevronDown : moreVertical;
+	const toggleProps = showText
+		? { size: 'compact', variant: 'tertiary', iconPosition: 'right' }
+		: { size: 'compact', variant: 'tertiary' };
+
 	return (
 		<DropdownMenu
-			icon={ chevronDown }
+			icon={ icon }
 			label={ sprintf(
 				/* translators: %s: Current state (e.g. "Hover", "Focus") */
 				__( 'State: %s' ),
 				getCurrentStateLabel()
 			) }
-			text={ getCurrentStateLabel() }
-			toggleProps={ {
-				size: 'compact',
-				variant: 'tertiary',
-				iconPosition: 'right',
-			} }
+			text={ showText ? getCurrentStateLabel() : undefined }
+			toggleProps={ toggleProps }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup label={ __( 'State' ) }>

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -124,9 +124,9 @@ export function getBackgroundImageClasses( style ) {
 function BackgroundInspectorControl( {
 	children,
 	backgroundGradientSupported = false,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 	const resetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
@@ -172,7 +172,7 @@ export function BackgroundImagePanel( {
 	name,
 	setAttributes,
 	settings,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
 	const { className, inheritedValue } = useSelect(
 		( select ) => {
@@ -197,7 +197,7 @@ export function BackgroundImagePanel( {
 	);
 
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 
 	const backgroundGradientSupported = hasBackgroundSupport(
 		name,

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -123,9 +123,23 @@ export function getBackgroundImageClasses( style ) {
 function BackgroundInspectorControl( {
 	children,
 	backgroundGradientSupported = false,
+	selectedState = 'default',
 } ) {
+	const isStateSelected = selectedState !== 'default';
 	const resetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return {
+					...attributes,
+					style: cleanEmptyObject( {
+						...attributes.style,
+						[ selectedState ]: {
+							...attributes.style?.[ selectedState ],
+							background: undefined,
+						},
+					} ),
+				};
+			}
 			const updatedClassName = attributes.className?.includes(
 				'has-background'
 			)
@@ -149,7 +163,7 @@ function BackgroundInspectorControl( {
 				} ),
 			};
 		},
-		[ backgroundGradientSupported ]
+		[ backgroundGradientSupported, isStateSelected, selectedState ]
 	);
 	return (
 		<InspectorControls group="background" resetAllFilter={ resetAllFilter }>
@@ -200,11 +214,12 @@ export function BackgroundImagePanel( {
 		( { children } ) => (
 			<BackgroundInspectorControl
 				backgroundGradientSupported={ backgroundGradientSupported }
+				selectedState={ selectedState }
 			>
 				{ children }
 			</BackgroundInspectorControl>
 		),
-		[ backgroundGradientSupported ]
+		[ backgroundGradientSupported, selectedState ]
 	);
 
 	if (
@@ -214,9 +229,9 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	const isStateMode = selectedState && selectedState !== 'default';
-	const value = isStateMode ? style?.[ selectedState ] : style;
-	const onChange = isStateMode
+	const isStateSelected = selectedState && selectedState !== 'default';
+	const value = isStateSelected ? style?.[ selectedState ] : style;
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -23,6 +23,7 @@ import {
 	hasBackgroundGradientValue,
 } from '../components/global-styles/background-panel';
 import { globalStylesDataKey } from '../store/private-keys';
+import { useBlockStateProps } from './state-utils';
 
 export const BACKGROUND_SUPPORT_KEY = 'background';
 
@@ -222,6 +223,13 @@ export function BackgroundImagePanel( {
 		[ backgroundGradientSupported, selectedState ]
 	);
 
+	// Must be declared before the early return to follow Rules of Hooks.
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	if (
 		! useHasBackgroundPanel( settings ) ||
 		! hasBackgroundSupport( name )
@@ -229,16 +237,8 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	const isStateSelected = selectedState && selectedState !== 'default';
-	const value = isStateSelected ? style?.[ selectedState ] : style;
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				const isMigrating =
 					backgroundGradientSupported && !! style?.color?.gradient;
@@ -263,7 +263,10 @@ export function BackgroundImagePanel( {
 				// Conversely, if the gradient is cleared and has-background was added
 				// during a previous migration, remove it so it does not linger.
 				if ( isMigrating && !! newStyle?.background?.gradient ) {
-					newAttributes.className = clsx( className, 'has-background' );
+					newAttributes.className = clsx(
+						className,
+						'has-background'
+					);
 				} else if (
 					! newStyle?.background?.gradient &&
 					className?.includes( 'has-background' )
@@ -276,7 +279,7 @@ export function BackgroundImagePanel( {
 				}
 
 				setAttributes( newAttributes );
-			};
+		  };
 
 	// When background.gradient is supported but not yet explicitly set, fall
 	// back to color.gradient for display. Any write from this panel migrates
@@ -318,7 +321,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ isStateMode ? value : styleValue }
+			value={ isStateSelected ? stateValue : styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -14,6 +14,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
+import { useBlockEditContext } from '../components/block-edit/context';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
 import {
@@ -23,7 +24,7 @@ import {
 	hasBackgroundGradientValue,
 } from '../components/global-styles/background-panel';
 import { globalStylesDataKey } from '../store/private-keys';
-import { useBlockStateProps } from './state-utils';
+import { useBlockStyle } from './use-block-style';
 
 export const BACKGROUND_SUPPORT_KEY = 'background';
 
@@ -176,18 +177,16 @@ function BackgroundInspectorControl( {
 export function BackgroundImagePanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
-	const { style, className, inheritedValue } = useSelect(
+	const { className, inheritedValue } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
 				select( blockEditorStore );
 			const _settings = getSettings();
 			const blockAttributes = getBlockAttributes( clientId );
 			return {
-				style: blockAttributes?.style,
 				className: blockAttributes?.className,
 				/*
 				 * To ensure we pass down the right inherited values:
@@ -202,6 +201,10 @@ export function BackgroundImagePanel( {
 		},
 		[ clientId, name ]
 	);
+
+	const { setAttributes } = useBlockEditContext();
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const backgroundGradientSupported = hasBackgroundSupport(
 		name,
@@ -223,13 +226,6 @@ export function BackgroundImagePanel( {
 		[ backgroundGradientSupported, selectedState ]
 	);
 
-	// Must be declared before the early return to follow Rules of Hooks.
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
-
 	if (
 		! useHasBackgroundPanel( settings ) ||
 		! hasBackgroundSupport( name )
@@ -238,7 +234,7 @@ export function BackgroundImagePanel( {
 	}
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				const isMigrating =
 					backgroundGradientSupported && !! style?.color?.gradient;
@@ -321,7 +317,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ isStateSelected ? stateValue : styleValue }
+			value={ isStateSelected ? style : styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -163,6 +163,7 @@ export function BackgroundImagePanel( {
 	name,
 	setAttributes,
 	settings,
+	selectedState = 'default',
 } ) {
 	const { style, className, inheritedValue } = useSelect(
 		( select ) => {
@@ -213,44 +214,54 @@ export function BackgroundImagePanel( {
 		return null;
 	}
 
-	const onChange = ( newStyle ) => {
-		const isMigrating =
-			backgroundGradientSupported && !! style?.color?.gradient;
-		const newAttributes = {
-			style: cleanEmptyObject(
-				backgroundGradientSupported
-					? {
-							...newStyle,
-							color: {
-								...newStyle?.color,
-								gradient: undefined,
-							},
-					  }
-					: newStyle
-			),
-		};
+	const isStateMode = selectedState && selectedState !== 'default';
+	const value = isStateMode ? style?.[ selectedState ] : style;
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				const isMigrating =
+					backgroundGradientSupported && !! style?.color?.gradient;
+				const newAttributes = {
+					style: cleanEmptyObject(
+						backgroundGradientSupported
+							? {
+									...newStyle,
+									color: {
+										...newStyle?.color,
+										gradient: undefined,
+									},
+							  }
+							: newStyle
+					),
+				};
 
-		// When migrating from color.gradient to background.gradient, preserve
-		// the has-background class so existing styles relying on it (e.g.
-		// theme padding) are not silently broken. Only add the class when a
-		// gradient value is being set — not when it is being cleared/reset.
-		// Conversely, if the gradient is cleared and has-background was added
-		// during a previous migration, remove it so it does not linger.
-		if ( isMigrating && !! newStyle?.background?.gradient ) {
-			newAttributes.className = clsx( className, 'has-background' );
-		} else if (
-			! newStyle?.background?.gradient &&
-			className?.includes( 'has-background' )
-		) {
-			newAttributes.className =
-				className
-					.split( ' ' )
-					.filter( ( c ) => c !== 'has-background' )
-					.join( ' ' ) || undefined;
-		}
+				// When migrating from color.gradient to background.gradient, preserve
+				// the has-background class so existing styles relying on it (e.g.
+				// theme padding) are not silently broken. Only add the class when a
+				// gradient value is being set — not when it is being cleared/reset.
+				// Conversely, if the gradient is cleared and has-background was added
+				// during a previous migration, remove it so it does not linger.
+				if ( isMigrating && !! newStyle?.background?.gradient ) {
+					newAttributes.className = clsx( className, 'has-background' );
+				} else if (
+					! newStyle?.background?.gradient &&
+					className?.includes( 'has-background' )
+				) {
+					newAttributes.className =
+						className
+							.split( ' ' )
+							.filter( ( c ) => c !== 'has-background' )
+							.join( ' ' ) || undefined;
+				}
 
-		setAttributes( newAttributes );
-	};
+				setAttributes( newAttributes );
+			};
 
 	// When background.gradient is supported but not yet explicitly set, fall
 	// back to color.gradient for display. Any write from this panel migrates
@@ -292,7 +303,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={ styleValue }
+			value={ isStateMode ? value : styleValue }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -14,7 +14,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
 import {
 	default as StylesBackgroundPanel,
@@ -130,16 +130,10 @@ function BackgroundInspectorControl( {
 	const resetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
-				return {
-					...attributes,
-					style: cleanEmptyObject( {
-						...attributes.style,
-						[ selectedState ]: {
-							...attributes.style?.[ selectedState ],
-							background: undefined,
-						},
-					} ),
-				};
+				return buildStateResetAllFilter( selectedState, ( style ) => ( {
+					...style,
+					background: undefined,
+				} ) )( attributes );
 			}
 			const updatedClassName = attributes.className?.includes(
 				'has-background'

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -14,7 +14,6 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
-import { useBlockEditContext } from '../components/block-edit/context';
 import { cleanEmptyObject } from './utils';
 import { store as blockEditorStore } from '../store';
 import {
@@ -177,6 +176,7 @@ function BackgroundInspectorControl( {
 export function BackgroundImagePanel( {
 	clientId,
 	name,
+	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
@@ -202,7 +202,6 @@ export function BackgroundImagePanel( {
 		[ clientId, name ]
 	);
 
-	const { setAttributes } = useBlockEditContext();
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
 	const isStateSelected = selectedState !== 'default';
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -122,9 +122,9 @@ function BordersInspectorControl( {
 	label,
 	children,
 	resetAllFilter,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
@@ -159,7 +159,7 @@ export function BorderPanel( {
 	name,
 	setAttributes,
 	settings,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
 	const { borderColor } = useSelect(
@@ -176,7 +176,7 @@ export function BorderPanel( {
 	);
 
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,7 +31,8 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { useBlockStateProps } from './state-utils';
+import { useBlockEditContext } from '../components/block-edit/context';
+import { useBlockStyle } from './use-block-style';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -157,39 +158,36 @@ function BordersInspectorControl( {
 export function BorderPanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const { style, borderColor } = useSelect(
+	const { borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
 				return {};
 			}
-			const { style: _style, borderColor: _borderColor } =
+			const { borderColor: _borderColor } =
 				select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-			return { style: _style, borderColor: _borderColor };
+			return { borderColor: _borderColor };
 		},
 		[ clientId, isEnabled ]
 	);
 
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
+	const { setAttributes } = useBlockEditContext();
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return stateValue;
+			return style;
 		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ isStateSelected, stateValue, style, borderColor ] );
+	}, [ isStateSelected, style, borderColor ] );
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,7 +31,6 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { useBlockEditContext } from '../components/block-edit/context';
 import { useBlockStyle } from './use-block-style';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
@@ -158,6 +157,7 @@ function BordersInspectorControl( {
 export function BorderPanel( {
 	clientId,
 	name,
+	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
@@ -175,7 +175,6 @@ export function BorderPanel( {
 		[ clientId, isEnabled ]
 	);
 
-	const { setAttributes } = useBlockEditContext();
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
 	const isStateSelected = selectedState !== 'default';
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,6 +31,7 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
+import { useBlockStateProps } from './state-utils';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -161,7 +162,6 @@ export function BorderPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const { style, borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -174,21 +174,22 @@ export function BorderPanel( {
 		},
 		[ clientId, isEnabled ]
 	);
+
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return style?.[ selectedState ];
+			return stateValue;
 		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ isStateSelected, selectedState, style, borderColor ] );
+	}, [ isStateSelected, stateValue, style, borderColor ] );
 
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -11,6 +11,7 @@ import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/com
 import { Platform, useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -29,7 +30,6 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { __ } from '@wordpress/i18n';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
@@ -140,8 +140,15 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 	);
 }
 
-export function BorderPanel( { clientId, name, setAttributes, settings } ) {
+export function BorderPanel( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	selectedState = 'default',
+} ) {
 	const isEnabled = useHasBorderPanel( settings );
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
 	const { style, borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -155,12 +162,23 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
+		if ( isStateMode ) {
+			return style?.[ selectedState ];
+		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ style, borderColor ] );
+	}, [ isStateMode, selectedState, style, borderColor ] );
 
-	const onChange = ( newStyle ) => {
-		setAttributes( styleToAttributes( newStyle ) );
-	};
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				setAttributes( styleToAttributes( newStyle ) );
+		  };
 
 	if ( ! isEnabled ) {
 		return null;

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -23,6 +23,7 @@ import {
 	cleanEmptyObject,
 	shouldSkipSerialization,
 	useBlockSettings,
+	buildStateResetAllFilter,
 } from './utils';
 import {
 	useHasBorderPanel,
@@ -116,9 +117,21 @@ function attributesToStyle( attributes ) {
 	};
 }
 
-function BordersInspectorControl( { label, children, resetAllFilter } ) {
+function BordersInspectorControl( {
+	label,
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributesToStyle( attributes );
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -126,7 +139,7 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 				...styleToAttributes( updatedStyle ),
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -148,7 +161,7 @@ export function BorderPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const { style, borderColor } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -162,13 +175,13 @@ export function BorderPanel( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
-		if ( isStateMode ) {
+		if ( isStateSelected ) {
 			return style?.[ selectedState ];
 		}
 		return attributesToStyle( { style, borderColor } );
-	}, [ isStateMode, selectedState, style, borderColor ] );
+	}, [ isStateSelected, selectedState, style, borderColor ] );
 
-	const onChange = isStateMode
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -179,6 +192,19 @@ export function BorderPanel( {
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };
+
+	const BorderWrapper = useMemo(
+		() =>
+			function BorderWrapperComponent( props ) {
+				return (
+					<BordersInspectorControl
+						{ ...props }
+						selectedState={ selectedState }
+					/>
+				);
+			},
+		[ selectedState ]
+	);
 
 	if ( ! isEnabled ) {
 		return null;
@@ -197,7 +223,7 @@ export function BorderPanel( {
 
 	return (
 		<StylesBorderPanel
-			as={ BordersInspectorControl }
+			as={ BorderWrapper }
 			panelId={ clientId }
 			settings={ settings }
 			value={ value }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -34,7 +34,7 @@ import {
 } from '../components/global-styles/color-panel';
 import BlockColorContrastChecker from './contrast-checker';
 import { store as blockEditorStore } from '../store';
-import { useBlockStateProps } from './state-utils';
+import { useBlockStyle } from './use-block-style';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
@@ -285,20 +285,18 @@ export function ColorEdit( {
 } ) {
 	const isEnabled = useHasColorPanel( settings );
 
-	const { style, textColor, backgroundColor, gradient } = useSelect(
+	const { textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
 				return {};
 			}
 			const {
-				style: _style,
 				textColor: _textColor,
 				backgroundColor: _backgroundColor,
 				gradient: _gradient,
 			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 			return {
-				style: _style,
 				textColor: _textColor,
 				backgroundColor: _backgroundColor,
 				gradient: _gradient,
@@ -307,15 +305,12 @@ export function ColorEdit( {
 		[ clientId, isEnabled ]
 	);
 
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return stateValue;
+			return style;
 		}
 		return attributesToStyle( {
 			style,
@@ -323,17 +318,10 @@ export function ColorEdit( {
 			backgroundColor,
 			gradient,
 		} );
-	}, [
-		isStateSelected,
-		stateValue,
-		style,
-		textColor,
-		backgroundColor,
-		gradient,
-	] );
+	}, [ isStateSelected, style, textColor, backgroundColor, gradient ] );
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -268,8 +268,10 @@ export function ColorEdit( {
 	asWrapper,
 	label,
 	defaultControls,
+	selectedState = 'default',
 } ) {
 	const isEnabled = useHasColorPanel( settings );
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
@@ -293,17 +295,35 @@ export function ColorEdit( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
+		if ( isStateMode ) {
+			return style?.[ selectedState ];
+		}
 		return attributesToStyle( {
 			style,
 			textColor,
 			backgroundColor,
 			gradient,
 		} );
-	}, [ style, textColor, backgroundColor, gradient ] );
+	}, [
+		isStateMode,
+		selectedState,
+		style,
+		textColor,
+		backgroundColor,
+		gradient,
+	] );
 
-	const onChange = ( newStyle ) => {
-		setAttributes( styleToAttributes( newStyle ) );
-	};
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				setAttributes( styleToAttributes( newStyle ) );
+		  };
 
 	if ( ! isEnabled ) {
 		return null;
@@ -317,6 +337,7 @@ export function ColorEdit( {
 		  ] );
 
 	const enableContrastChecking =
+		! isStateMode &&
 		Platform.OS === 'web' &&
 		! value?.color?.gradient &&
 		( settings?.color?.text || settings?.color?.link ) &&

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -23,6 +23,7 @@ import {
 	cleanEmptyObject,
 	transformStyles,
 	shouldSkipSerialization,
+	buildStateResetAllFilter,
 } from './utils';
 import { getBackgroundImageClasses } from './background';
 import { useSettings } from '../components/use-settings';
@@ -237,9 +238,20 @@ function attributesToStyle( attributes ) {
 	};
 }
 
-function ColorInspectorControl( { children, resetAllFilter } ) {
+function ColorInspectorControl( {
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributesToStyle( attributes );
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -247,7 +259,7 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 				...styleToAttributes( updatedStyle ),
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -271,7 +283,7 @@ export function ColorEdit( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasColorPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
@@ -295,7 +307,7 @@ export function ColorEdit( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
-		if ( isStateMode ) {
+		if ( isStateSelected ) {
 			return style?.[ selectedState ];
 		}
 		return attributesToStyle( {
@@ -305,7 +317,7 @@ export function ColorEdit( {
 			gradient,
 		} );
 	}, [
-		isStateMode,
+		isStateSelected,
 		selectedState,
 		style,
 		textColor,
@@ -313,7 +325,7 @@ export function ColorEdit( {
 		gradient,
 	] );
 
-	const onChange = isStateMode
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -324,6 +336,14 @@ export function ColorEdit( {
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };
+
+	const Wrapper = useMemo( () => {
+		const Base = asWrapper || ColorInspectorControl;
+		function ColorWrapper( props ) {
+			return <Base { ...props } selectedState={ selectedState } />;
+		}
+		return ColorWrapper;
+	}, [ asWrapper, selectedState ] );
 
 	if ( ! isEnabled ) {
 		return null;
@@ -337,7 +357,7 @@ export function ColorEdit( {
 		  ] );
 
 	const enableContrastChecking =
-		! isStateMode &&
+		! isStateSelected &&
 		Platform.OS === 'web' &&
 		! value?.color?.gradient &&
 		( settings?.color?.text || settings?.color?.link ) &&
@@ -349,9 +369,6 @@ export function ColorEdit( {
 				COLOR_SUPPORT_KEY,
 				'enableContrastChecker',
 			] );
-
-	// Use provided wrapper or default to ColorInspectorControl
-	const Wrapper = asWrapper || ColorInspectorControl;
 
 	return (
 		<StylesColorPanel

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -242,9 +242,9 @@ function attributesToStyle( attributes ) {
 function ColorInspectorControl( {
 	children,
 	resetAllFilter,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
@@ -281,7 +281,7 @@ export function ColorEdit( {
 	asWrapper,
 	label,
 	defaultControls,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
 	const isEnabled = useHasColorPanel( settings );
 
@@ -306,7 +306,7 @@ export function ColorEdit( {
 	);
 
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -34,6 +34,7 @@ import {
 } from '../components/global-styles/color-panel';
 import BlockColorContrastChecker from './contrast-checker';
 import { store as blockEditorStore } from '../store';
+import { useBlockStateProps } from './state-utils';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
@@ -283,7 +284,6 @@ export function ColorEdit( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasColorPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, textColor, backgroundColor, gradient } = useSelect(
 		( select ) => {
@@ -306,9 +306,16 @@ export function ColorEdit( {
 		},
 		[ clientId, isEnabled ]
 	);
+
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return style?.[ selectedState ];
+			return stateValue;
 		}
 		return attributesToStyle( {
 			style,
@@ -318,7 +325,7 @@ export function ColorEdit( {
 		} );
 	}, [
 		isStateSelected,
-		selectedState,
+		stateValue,
 		style,
 		textColor,
 		backgroundColor,
@@ -326,13 +333,7 @@ export function ColorEdit( {
 	] );
 
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				setAttributes( styleToAttributes( newStyle ) );
 		  };

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -6,7 +6,13 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { Platform, useState, useEffect, useCallback } from '@wordpress/element';
+import {
+	Platform,
+	useState,
+	useEffect,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
@@ -22,7 +28,11 @@ import {
 import { MarginVisualizer, PaddingVisualizer } from './spacing-visualizer';
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
-import { cleanEmptyObject, shouldSkipSerialization } from './utils';
+import {
+	cleanEmptyObject,
+	shouldSkipSerialization,
+	buildStateResetAllFilter,
+} from './utils';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -45,9 +55,20 @@ function useVisualizer() {
 	return [ property, setProperty ];
 }
 
-function DimensionsInspectorControl( { children, resetAllFilter } ) {
+function DimensionsInspectorControl( {
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributes.style;
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -55,7 +76,7 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 				style: updatedStyle,
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -76,7 +97,7 @@ export function DimensionsPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const style = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -91,8 +112,8 @@ export function DimensionsPanel( {
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 
-	const value = isStateMode ? style?.[ selectedState ] : style;
-	const onChange = isStateMode
+	const value = isStateSelected ? style?.[ selectedState ] : style;
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -104,6 +125,19 @@ export function DimensionsPanel( {
 				setAttributes( {
 					style: cleanEmptyObject( newStyle ),
 				} );
+
+	const DimensionsWrapper = useMemo(
+		() =>
+			function DimensionsWrapperComponent( props ) {
+				return (
+					<DimensionsInspectorControl
+						{ ...props }
+						selectedState={ selectedState }
+					/>
+				);
+			},
+		[ selectedState ]
+	);
 
 	if ( ! isEnabled ) {
 		return null;
@@ -125,15 +159,17 @@ export function DimensionsPanel( {
 	return (
 		<>
 			<StylesDimensionsPanel
-				as={ DimensionsInspectorControl }
+				as={ DimensionsWrapper }
 				panelId={ clientId }
 				settings={ settings }
 				value={ value }
 				onChange={ onChange }
 				defaultControls={ defaultControls }
-				onVisualize={ isStateMode ? undefined : setVisualizedProperty }
+				onVisualize={
+					isStateSelected ? undefined : setVisualizedProperty
+				}
 			/>
-			{ ! isStateMode &&
+			{ ! isStateSelected &&
 				!! settings?.spacing?.padding &&
 				visualizedProperty === 'padding' && (
 					<PaddingVisualizer
@@ -142,7 +178,7 @@ export function DimensionsPanel( {
 						value={ value }
 					/>
 				) }
-			{ ! isStateMode &&
+			{ ! isStateSelected &&
 				!! settings?.spacing?.margin &&
 				visualizedProperty === 'margin' && (
 					<MarginVisualizer

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -33,6 +33,7 @@ import {
 	shouldSkipSerialization,
 	buildStateResetAllFilter,
 } from './utils';
+import { useBlockStateProps } from './state-utils';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -97,7 +98,6 @@ export function DimensionsPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 	const style = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
@@ -112,15 +112,15 @@ export function DimensionsPanel( {
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 
-	const value = isStateSelected ? style?.[ selectedState ] : style;
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
+	const value = isStateSelected ? stateValue : style;
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( newStyle ),

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -13,7 +13,7 @@ import {
 	useCallback,
 	useMemo,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
@@ -28,12 +28,8 @@ import {
 import { MarginVisualizer, PaddingVisualizer } from './spacing-visualizer';
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
-import {
-	cleanEmptyObject,
-	shouldSkipSerialization,
-	buildStateResetAllFilter,
-} from './utils';
-import { useBlockStateProps } from './state-utils';
+import { shouldSkipSerialization, buildStateResetAllFilter } from './utils';
+import { useBlockStyle } from './use-block-style';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -93,38 +89,13 @@ function DimensionsInspectorControl( {
 export function DimensionsPanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const style = useSelect(
-		( select ) => {
-			// Early return to avoid subscription when disabled
-			if ( ! isEnabled ) {
-				return undefined;
-			}
-			return select( blockEditorStore ).getBlockAttributes( clientId )
-				?.style;
-		},
-		[ clientId, isEnabled ]
-	);
-
+	const isStateSelected = selectedState !== 'default';
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
-
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
-
-	const value = isStateSelected ? stateValue : style;
-	const onChange = isStateSelected
-		? stateOnChange
-		: ( newStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( newStyle ),
-				} );
+	const [ value, onChange ] = useBlockStyle( null, selectedState );
 
 	const DimensionsWrapper = useMemo(
 		() =>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -68,9 +68,16 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
+export function DimensionsPanel( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	selectedState = 'default',
+} ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const value = useSelect(
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const style = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
@@ -83,11 +90,20 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 	);
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
-	const onChange = ( newStyle ) => {
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
-	};
+
+	const value = isStateMode ? style?.[ selectedState ] : style;
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( newStyle ),
+				} );
 
 	if ( ! isEnabled ) {
 		return null;
@@ -115,9 +131,10 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 				value={ value }
 				onChange={ onChange }
 				defaultControls={ defaultControls }
-				onVisualize={ setVisualizedProperty }
+				onVisualize={ isStateMode ? undefined : setVisualizedProperty }
 			/>
-			{ !! settings?.spacing?.padding &&
+			{ ! isStateMode &&
+				!! settings?.spacing?.padding &&
 				visualizedProperty === 'padding' && (
 					<PaddingVisualizer
 						forceShow={ visualizedProperty === 'padding' }
@@ -125,7 +142,8 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 						value={ value }
 					/>
 				) }
-			{ !! settings?.spacing?.margin &&
+			{ ! isStateMode &&
+				!! settings?.spacing?.margin &&
 				visualizedProperty === 'margin' && (
 					<MarginVisualizer
 						forceShow={ visualizedProperty === 'margin' }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -55,9 +55,9 @@ function useVisualizer() {
 function DimensionsInspectorControl( {
 	children,
 	resetAllFilter,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
@@ -90,10 +90,10 @@ export function DimensionsPanel( {
 	clientId,
 	name,
 	settings,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 	const [ value, onChange ] = useBlockStyle( null, selectedState );
 

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -2,11 +2,35 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { scopeSelector } from '../components/global-styles/utils';
+
+/**
+ * Recursively removes undefined and empty-object values.
+ * Duplicated here to avoid a circular dependency with ./utils.
+ *
+ * @param {*} object
+ * @return {*} Cleaned value.
+ */
+function cleanEmptyObject( object ) {
+	if (
+		object === null ||
+		typeof object !== 'object' ||
+		Array.isArray( object )
+	) {
+		return object;
+	}
+	const cleanedNestedObjects = Object.entries( object )
+		.map( ( [ key, value ] ) => [ key, cleanEmptyObject( value ) ] )
+		.filter( ( [ , value ] ) => value !== undefined );
+	return ! cleanedNestedObjects.length
+		? undefined
+		: Object.fromEntries( cleanedNestedObjects );
+}
 
 /**
  * Given a block's `selectors.root` value, returns the part of the selector
@@ -82,4 +106,37 @@ export function buildCanvasStateSelector( clientId, name ) {
 		}
 	}
 	return `[data-block="${ clientId }"]`;
+}
+
+/**
+ * Shared hook for block style panels that support interactive states
+ * (hover, focus, active). Encapsulates the repeated boilerplate for
+ * determining whether a state is selected, reading the scoped style value,
+ * and building the state-scoped onChange handler.
+ *
+ * @param {Object}   options
+ * @param {string}   options.selectedState Currently selected state, e.g. ':hover'. Defaults to 'default'.
+ * @param {Object}   options.style         The block's `style` attribute.
+ * @param {Function} options.setAttributes The block's setAttributes function.
+ * @return {{ isStateSelected: boolean, stateValue: Object|undefined, stateOnChange: Function }} State props.
+ */
+export function useBlockStateProps( { selectedState, style, setAttributes } ) {
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
+
+	const stateOnChange = useCallback(
+		( newStateStyle ) =>
+			setAttributes( {
+				style: cleanEmptyObject( {
+					...style,
+					[ selectedState ]: newStateStyle,
+				} ),
+			} ),
+		[ setAttributes, style, selectedState ]
+	);
+
+	return {
+		isStateSelected,
+		stateValue: isStateSelected ? style?.[ selectedState ] : undefined,
+		stateOnChange,
+	};
 }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __EXPERIMENTAL_ELEMENTS as ELEMENTS } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { scopeSelector } from '../components/global-styles/utils';
+
+export const STATES_ELEMENT_SUPPORT_KEY = '__experimentalStatesElement';
+
+/**
+ * Builds the scoped CSS selector for a block state (e.g. :hover, :focus).
+ *
+ * When the block declares `__experimentalStatesElement` pointing to a known
+ * ELEMENTS key (e.g. "button"), the pseudo-class is appended to each
+ * comma-separated element selector part and the result is scoped under
+ * `baseSelector`. Otherwise falls back to appending the state directly to
+ * `baseSelector` (i.e. the block wrapper).
+ *
+ * @param {string}      baseSelector  The block-instance scoping class selector.
+ * @param {string|null} statesElement Value of `__experimentalStatesElement` support, or null.
+ * @param {string}      state         The pseudo-class string, e.g. ":hover".
+ * @return {string} The fully-scoped CSS selector for this state.
+ */
+export function buildStateSelector( baseSelector, statesElement, state ) {
+	if ( statesElement && ELEMENTS[ statesElement ] ) {
+		const elementParts = ELEMENTS[ statesElement ]
+			.split( ',' )
+			.map( ( part ) => part.trim() + state )
+			.join( ', ' );
+		return scopeSelector( baseSelector, elementParts );
+	}
+	return `${ baseSelector }${ state }`;
+}

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -2,35 +2,11 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
-import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { scopeSelector } from '../components/global-styles/utils';
-
-/**
- * Recursively removes undefined and empty-object values.
- * Duplicated here to avoid a circular dependency with ./utils.
- *
- * @param {*} object
- * @return {*} Cleaned value.
- */
-function cleanEmptyObject( object ) {
-	if (
-		object === null ||
-		typeof object !== 'object' ||
-		Array.isArray( object )
-	) {
-		return object;
-	}
-	const cleanedNestedObjects = Object.entries( object )
-		.map( ( [ key, value ] ) => [ key, cleanEmptyObject( value ) ] )
-		.filter( ( [ , value ] ) => value !== undefined );
-	return ! cleanedNestedObjects.length
-		? undefined
-		: Object.fromEntries( cleanedNestedObjects );
-}
 
 /**
  * Given a block's `selectors.root` value, returns the part of the selector
@@ -106,37 +82,4 @@ export function buildCanvasStateSelector( clientId, name ) {
 		}
 	}
 	return `[data-block="${ clientId }"]`;
-}
-
-/**
- * Shared hook for block style panels that support interactive states
- * (hover, focus, active). Encapsulates the repeated boilerplate for
- * determining whether a state is selected, reading the scoped style value,
- * and building the state-scoped onChange handler.
- *
- * @param {Object}   options
- * @param {string}   options.selectedState Currently selected state, e.g. ':hover'. Defaults to 'default'.
- * @param {Object}   options.style         The block's `style` attribute.
- * @param {Function} options.setAttributes The block's setAttributes function.
- * @return {{ isStateSelected: boolean, stateValue: Object|undefined, stateOnChange: Function }} State props.
- */
-export function useBlockStateProps( { selectedState, style, setAttributes } ) {
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
-
-	const stateOnChange = useCallback(
-		( newStateStyle ) =>
-			setAttributes( {
-				style: cleanEmptyObject( {
-					...style,
-					[ selectedState ]: newStateStyle,
-				} ),
-			} ),
-		[ setAttributes, style, selectedState ]
-	);
-
-	return {
-		isStateSelected,
-		stateValue: isStateSelected ? style?.[ selectedState ] : undefined,
-		stateOnChange,
-	};
 }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -1,36 +1,61 @@
 /**
  * WordPress dependencies
  */
-import { __EXPERIMENTAL_ELEMENTS as ELEMENTS } from '@wordpress/blocks';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { scopeSelector } from '../components/global-styles/utils';
 
-export const STATES_ELEMENT_SUPPORT_KEY = '__experimentalStatesElement';
+/**
+ * Given a block's `selectors.root` value, returns the part of the selector
+ * that is relative to the block wrapper — i.e., everything after the first
+ * compound selector segment.
+ *
+ * Examples:
+ *   ".wp-block-button .wp-block-button__link" → ".wp-block-button__link"
+ *   ".wp-block-foo > .inner"                 → "> .inner"
+ *   ".wp-block-foo"                          → null (no descendant)
+ *
+ * @param {string} rootSelector The block's `selectors.root` value.
+ * @return {string|null} Relative selector, or null if rootSelector targets the wrapper itself.
+ */
+export function getRelativeRootSelector( rootSelector ) {
+	// Match everything after the first compound selector (up to the first
+	// whitespace or combinator character).
+	// Require at least one combinator character (space, >, +, ~) between the
+	// first compound selector and the rest. Without this anchor, a greedy
+	// quantifier would backtrack into the first token and produce false matches.
+	const match = rootSelector.trim().match( /^[^ >+~]+[ >+~](.*)$/ );
+	if ( ! match ) {
+		return null;
+	}
+	const rest = match[ 1 ].trim();
+	return rest || null;
+}
 
 /**
  * Builds the scoped CSS selector for a block state (e.g. :hover, :focus).
  *
- * When the block declares `__experimentalStatesElement` pointing to a known
- * ELEMENTS key (e.g. "button"), the pseudo-class is appended to each
- * comma-separated element selector part and the result is scoped under
- * `baseSelector`. Otherwise falls back to appending the state directly to
- * `baseSelector` (i.e. the block wrapper).
+ * Uses the block's `selectors.root` to determine which element the state
+ * pseudo-class should apply to. If `selectors.root` describes a descendant
+ * element (e.g. ".wp-block-button .wp-block-button__link"), the relative
+ * portion (".wp-block-button__link") is scoped under `baseSelector`. If no
+ * descendant is present, falls back to appending the state to `baseSelector`.
  *
- * @param {string}      baseSelector  The block-instance scoping class selector.
- * @param {string|null} statesElement Value of `__experimentalStatesElement` support, or null.
- * @param {string}      state         The pseudo-class string, e.g. ":hover".
+ * @param {string} baseSelector The block-instance scoping class selector.
+ * @param {string} name         The block name, used to look up selectors.
+ * @param {string} state        The pseudo-class string, e.g. ":hover".
  * @return {string} The fully-scoped CSS selector for this state.
  */
-export function buildStateSelector( baseSelector, statesElement, state ) {
-	if ( statesElement && ELEMENTS[ statesElement ] ) {
-		const elementParts = ELEMENTS[ statesElement ]
-			.split( ',' )
-			.map( ( part ) => part.trim() + state )
-			.join( ', ' );
-		return scopeSelector( baseSelector, elementParts );
+export function buildStateSelector( baseSelector, name, state ) {
+	const rootSelector = getBlockType( name )?.selectors?.root;
+	if ( rootSelector ) {
+		const relativeSelector = getRelativeRootSelector( rootSelector );
+		if ( relativeSelector ) {
+			return scopeSelector( baseSelector, relativeSelector + state );
+		}
 	}
 	return `${ baseSelector }${ state }`;
 }

--- a/packages/block-editor/src/hooks/state-utils.js
+++ b/packages/block-editor/src/hooks/state-utils.js
@@ -59,3 +59,27 @@ export function buildStateSelector( baseSelector, name, state ) {
 	}
 	return `${ baseSelector }${ state }`;
 }
+
+/**
+ * Builds the CSS selector used to preview a state on the editor canvas,
+ * scoped to a specific block instance via its `data-block` attribute.
+ *
+ * For blocks whose `selectors.root` targets a descendant element
+ * (e.g. ".wp-block-button .wp-block-button__link"), the selector targets
+ * that descendant inside the block wrapper. Otherwise it targets the wrapper
+ * itself.
+ *
+ * @param {string} clientId The block's clientId.
+ * @param {string} name     The block name, used to look up selectors.
+ * @return {string} CSS selector scoped to this block instance.
+ */
+export function buildCanvasStateSelector( clientId, name ) {
+	const rootSelector = getBlockType( name )?.selectors?.root;
+	if ( rootSelector ) {
+		const relativeSelector = getRelativeRootSelector( rootSelector );
+		if ( relativeSelector ) {
+			return `[data-block="${ clientId }"] ${ relativeSelector }`;
+		}
+	}
+	return `[data-block="${ clientId }"]`;
+}

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import StateControl from '../components/global-styles/state-control';
 import { BlockCardControlsFill } from '../components/block-card';
 
-export const STATES_SUPPORT_KEY = '__experimentalStates';
+export const STATES_SUPPORT_KEY = 'states';
 
 export const STATE_LABELS = {
 	':hover': __( 'Hover' ),
@@ -20,7 +20,7 @@ export const STATE_LABELS = {
 
 /**
  * Renders a state selector (hover, focus, active) in the block card header.
- * Only shown for blocks that declare `__experimentalStates` support.
+ * Only shown for blocks that declare `states` support.
  *
  * @param {Object}   props          Component props.
  * @param {string}   props.name     Block name.

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -12,27 +12,55 @@ import { BlockCardControlsFill } from '../components/block-card';
 
 export const STATES_SUPPORT_KEY = 'states';
 
+/** Labels for CSS pseudo-selector states. */
 export const STATE_LABELS = {
 	':hover': __( 'Hover' ),
 	':focus': __( 'Focus' ),
 	':active': __( 'Active' ),
 };
 
+/** Labels for custom (`@`-prefixed) states. */
+export const CUSTOM_STATE_LABELS = {
+	'@current': __( 'Current' ),
+};
+
 /**
- * Renders a state selector (hover, focus, active) in the block card header.
- * Only shown for blocks that declare `states` support.
+ * Returns true if the state value is a CSS pseudo-selector (starts with `:`).
+ *
+ * @param {string} state State value, e.g. ':hover' or '@current'.
+ * @return {boolean} Whether the state is a pseudo-selector.
+ */
+export function isPseudoState( state ) {
+	return state.startsWith( ':' );
+}
+
+/**
+ * Returns true if the state value is a custom class-based state (starts with `@`).
+ *
+ * @param {string} state State value, e.g. '@current'.
+ * @return {boolean} Whether the state is a custom state.
+ */
+export function isCustomState( state ) {
+	return state.startsWith( '@' );
+}
+
+/**
+ * Renders a state selector (hover, focus, active, current…) in the block card
+ * header. Only shown for blocks that declare `states` support.
  *
  * @param {Object}   props          Component props.
  * @param {string}   props.name     Block name.
- * @param {string}   props.value    Currently selected state value.
+ * @param {string[]} props.value    Currently selected state values.
  * @param {Function} props.onChange Callback when selection changes.
  * @return {Element|null} State control component, or null if not applicable.
  */
 export function BlockStatesControl( { name, value, onChange } ) {
 	const validStates = getBlockSupport( name, STATES_SUPPORT_KEY ) ?? [];
+
+	const allLabels = { ...STATE_LABELS, ...CUSTOM_STATE_LABELS };
 	const stateOptions = validStates
-		.filter( ( state ) => STATE_LABELS[ state ] )
-		.map( ( state ) => ( { value: state, label: STATE_LABELS[ state ] } ) );
+		.filter( ( state ) => allLabels[ state ] )
+		.map( ( state ) => ( { value: state, label: allLabels[ state ] } ) );
 
 	if ( ! stateOptions.length ) {
 		return null;

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
-import { privateApis as blockEditorPrivateApis } from '../private-apis';
+import StateControl from '../components/global-styles/state-control';
+import { BlockCardControlsFill } from '../components/block-card';
 
 export const STATES_SUPPORT_KEY = '__experimentalStates';
 
@@ -17,10 +17,6 @@ export const STATE_LABELS = {
 	':focus': __( 'Focus' ),
 	':active': __( 'Active' ),
 };
-
-const { StateControl, BlockCardControlsFill } = unlock(
-	blockEditorPrivateApis
-);
 
 /**
  * Renders a state selector (hover, focus, active) in the block card header.

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import { privateApis as blockEditorPrivateApis } from '../private-apis';
+
+export const STATES_SUPPORT_KEY = '__experimentalStates';
+
+export const STATE_LABELS = {
+	':hover': __( 'Hover' ),
+	':focus': __( 'Focus' ),
+	':active': __( 'Active' ),
+};
+
+const { StateControl, BlockCardControlsFill } = unlock(
+	blockEditorPrivateApis
+);
+
+/**
+ * Renders a state selector (hover, focus, active) in the block card header.
+ * Only shown for blocks that declare `__experimentalStates` support.
+ *
+ * @param {Object}   props          Component props.
+ * @param {string}   props.name     Block name.
+ * @param {string}   props.value    Currently selected state value.
+ * @param {Function} props.onChange Callback when selection changes.
+ * @return {Element|null} State control component, or null if not applicable.
+ */
+export function BlockStatesControl( { name, value, onChange } ) {
+	const validStates = getBlockSupport( name, STATES_SUPPORT_KEY ) ?? [];
+	const stateOptions = validStates
+		.filter( ( state ) => STATE_LABELS[ state ] )
+		.map( ( state ) => ( { value: state, label: STATE_LABELS[ state ] } ) );
+
+	if ( ! stateOptions.length ) {
+		return null;
+	}
+
+	return (
+		<BlockCardControlsFill>
+			<StateControl
+				states={ stateOptions }
+				value={ value }
+				onChange={ onChange }
+				showText={ false }
+			/>
+		</BlockCardControlsFill>
+	);
+}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -34,7 +36,11 @@ import {
 	useBlockSettings,
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
-import { buildStateSelector } from './state-utils';
+import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
+import { unlock } from '../lock-unlock';
+import { privateApis as blockEditorPrivateApis } from '../private-apis';
+
+const { BlockInspectorPreTabsFill } = unlock( blockEditorPrivateApis );
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
@@ -340,6 +346,27 @@ function BlockStyleControls( {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const blockEditingMode = useBlockEditingMode();
 	const [ selectedState, setSelectedState ] = useState( 'default' );
+	const [ showStateOnCanvas, setShowStateOnCanvas ] = useState( true );
+
+	// Inject state styles onto the editor canvas so the selected state is
+	// visible while editing. Scoped to this block instance via data-block so
+	// other blocks of the same type are not affected. Must be called before
+	// any early returns because it is a hook.
+	const canvasStateCSS = useMemo( () => {
+		if ( ! showStateOnCanvas || selectedState === 'default' ) {
+			return undefined;
+		}
+		const stateValue = style?.[ selectedState ];
+		if ( ! stateValue ) {
+			return undefined;
+		}
+		const selector = buildCanvasStateSelector( clientId, name );
+		const css = compileCSS( stateValue, { selector } );
+		// Use !important to override utility classes (e.g. has-accent-3-color)
+		// that the block's default color support generates with !important.
+		return css ? css.replace( /;/g, ' !important;' ) : undefined;
+	}, [ showStateOnCanvas, selectedState, style, clientId, name ] );
+	useStyleOverride( { css: canvasStateCSS } );
 
 	if ( blockEditingMode !== 'default' ) {
 		return null;
@@ -378,6 +405,16 @@ function BlockStyleControls( {
 		return (
 			<>
 				{ statesControl }
+				<BlockInspectorPreTabsFill>
+					<div style={ { padding: '8px 16px' } }>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show state on canvas' ) }
+							checked={ showStateOnCanvas }
+							onChange={ setShowStateOnCanvas }
+						/>
+					</div>
+				</BlockInspectorPreTabsFill>
 				<InspectorControls>
 					<StylesColorPanel
 						value={ stateValue }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -30,7 +30,6 @@ import {
 	DimensionsPanel,
 } from './dimensions';
 import {
-	cleanEmptyObject,
 	shouldSkipSerialization,
 	useStyleOverride,
 	useBlockSettings,
@@ -38,14 +37,8 @@ import {
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
 import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
 import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
-import StylesColorPanel from '../components/global-styles/color-panel';
-import StylesTypographyPanel from '../components/global-styles/typography-panel';
-import StylesBorderPanel from '../components/global-styles/border-panel';
-import StylesDimensionsPanel from '../components/global-styles/dimensions-panel';
-import StylesBackgroundPanel from '../components/global-styles/background-panel';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
-import InspectorControls from '../components/inspector-controls';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -389,18 +382,7 @@ function BlockStyleControls( {
 		/>
 	);
 
-	// For non-default states, use Global Styles panels which accept explicit
-	// value/onChange props so we can route saves to the state-specific sub-key.
 	if ( selectedState !== 'default' ) {
-		const stateValue = style?.[ selectedState ] || {};
-		const setStateStyle = ( newStyle ) =>
-			setAttributes( {
-				style: cleanEmptyObject( {
-					...style,
-					[ selectedState ]: newStyle,
-				} ),
-			} );
-
 		return (
 			<>
 				{ statesControl }
@@ -414,44 +396,41 @@ function BlockStyleControls( {
 						/>
 					</div>
 				</BlockInspectorPreTabsFill>
-				<InspectorControls>
-					<StylesColorPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-					<StylesBackgroundPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-					<StylesTypographyPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-					<StylesBorderPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-						name={ name }
-					/>
-					<StylesDimensionsPanel
-						value={ stateValue }
-						inheritedValue={ stateValue }
-						onChange={ setStateStyle }
-						settings={ panelSettings }
-						panelId={ clientId }
-					/>
-				</InspectorControls>
+				<ColorEdit
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<BackgroundImagePanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<TypographyPanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<BorderPanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
+				<DimensionsPanel
+					clientId={ clientId }
+					name={ name }
+					setAttributes={ setAttributes }
+					settings={ panelSettings }
+					selectedState={ selectedState }
+				/>
 			</>
 		);
 	}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -28,12 +28,18 @@ import {
 	DimensionsPanel,
 } from './dimensions';
 import {
+	cleanEmptyObject,
 	shouldSkipSerialization,
 	useStyleOverride,
 	useBlockSettings,
 } from './utils';
+import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
+import StylesColorPanel from '../components/global-styles/color-panel';
+import StylesTypographyPanel from '../components/global-styles/typography-panel';
+import StylesBorderPanel from '../components/global-styles/border-panel';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import InspectorControls from '../components/inspector-controls';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -327,29 +333,88 @@ function BlockStyleControls( {
 	clientId,
 	name,
 	setAttributes,
+	style,
 	__unstableParentLayout,
 } ) {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const blockEditingMode = useBlockEditingMode();
+	const [ selectedState, setSelectedState ] = useState( 'default' );
+
+	if ( blockEditingMode !== 'default' ) {
+		return null;
+	}
+
+	const panelSettings = {
+		...settings,
+		typography: {
+			...settings.typography,
+			// The text alignment UI for individual blocks is rendered in
+			// the block toolbar, so disable it here.
+			textAlign: false,
+		},
+	};
+
+	const statesControl = (
+		<BlockStatesControl
+			name={ name }
+			value={ selectedState }
+			onChange={ setSelectedState }
+		/>
+	);
+
+	// For non-default states, use Global Styles panels which accept explicit
+	// value/onChange props so we can route saves to the state-specific sub-key.
+	if ( selectedState !== 'default' ) {
+		const stateValue = style?.[ selectedState ] || {};
+		const setStateStyle = ( newStyle ) =>
+			setAttributes( {
+				style: cleanEmptyObject( {
+					...style,
+					[ selectedState ]: newStyle,
+				} ),
+			} );
+
+		return (
+			<>
+				{ statesControl }
+				<InspectorControls>
+					<StylesColorPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+					/>
+					<StylesTypographyPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+					/>
+					<StylesBorderPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+						name={ name }
+					/>
+				</InspectorControls>
+			</>
+		);
+	}
+
 	const passedProps = {
 		clientId,
 		name,
 		setAttributes,
-		settings: {
-			...settings,
-			typography: {
-				...settings.typography,
-				// The text alignment UI for individual blocks is rendered in
-				// the block toolbar, so disable it here.
-				textAlign: false,
-			},
-		},
+		settings: panelSettings,
 	};
-	if ( blockEditingMode !== 'default' ) {
-		return null;
-	}
+
 	return (
 		<>
+			{ statesControl }
 			<ColorEdit { ...passedProps } />
 			<BackgroundImagePanel { ...passedProps } />
 			<TypographyPanel { ...passedProps } />
@@ -392,74 +457,91 @@ function useBlockProps( { name, style } ) {
 	const blockElementStyles = style?.elements;
 
 	const styles = useMemo( () => {
-		if ( ! blockElementStyles ) {
-			return;
-		}
-
 		const elementCSSRules = [];
 
-		elementTypes.forEach( ( { elementType, pseudo, elements } ) => {
-			const skipSerialization = shouldSkipSerialization(
-				name,
-				COLOR_SUPPORT_KEY,
-				elementType
-			);
-
-			if ( skipSerialization ) {
-				return;
-			}
-
-			const elementStyles = blockElementStyles?.[ elementType ];
-
-			// Process primary element type styles.
-			if ( elementStyles ) {
-				const selector = scopeSelector(
-					baseElementSelector,
-					ELEMENTS[ elementType ]
+		if ( blockElementStyles ) {
+			elementTypes.forEach( ( { elementType, pseudo, elements } ) => {
+				const skipSerialization = shouldSkipSerialization(
+					name,
+					COLOR_SUPPORT_KEY,
+					elementType
 				);
 
-				elementCSSRules.push(
-					compileCSS( elementStyles, { selector } )
-				);
+				if ( skipSerialization ) {
+					return;
+				}
 
-				// Process any interactive states for the element type.
-				if ( pseudo ) {
-					pseudo.forEach( ( pseudoSelector ) => {
-						if ( elementStyles[ pseudoSelector ] ) {
+				const elementStyles = blockElementStyles?.[ elementType ];
+
+				// Process primary element type styles.
+				if ( elementStyles ) {
+					const selector = scopeSelector(
+						baseElementSelector,
+						ELEMENTS[ elementType ]
+					);
+
+					elementCSSRules.push(
+						compileCSS( elementStyles, { selector } )
+					);
+
+					// Process any interactive states for the element type.
+					if ( pseudo ) {
+						pseudo.forEach( ( pseudoSelector ) => {
+							if ( elementStyles[ pseudoSelector ] ) {
+								elementCSSRules.push(
+									compileCSS(
+										elementStyles[ pseudoSelector ],
+										{
+											selector: scopeSelector(
+												baseElementSelector,
+												`${ ELEMENTS[ elementType ] }${ pseudoSelector }`
+											),
+										}
+									)
+								);
+							}
+						} );
+					}
+				}
+
+				// Process related elements e.g. h1-h6 for headings
+				if ( elements ) {
+					elements.forEach( ( element ) => {
+						if ( blockElementStyles[ element ] ) {
 							elementCSSRules.push(
-								compileCSS( elementStyles[ pseudoSelector ], {
+								compileCSS( blockElementStyles[ element ], {
 									selector: scopeSelector(
 										baseElementSelector,
-										`${ ELEMENTS[ elementType ] }${ pseudoSelector }`
+										ELEMENTS[ element ]
 									),
 								} )
 							);
 						}
 					} );
 				}
-			}
+			} );
+		}
 
-			// Process related elements e.g. h1-h6 for headings
-			if ( elements ) {
-				elements.forEach( ( element ) => {
-					if ( blockElementStyles[ element ] ) {
-						elementCSSRules.push(
-							compileCSS( blockElementStyles[ element ], {
-								selector: scopeSelector(
-									baseElementSelector,
-									ELEMENTS[ element ]
-								),
-							} )
-						);
+		// Generate per-instance state CSS (e.g., :hover, :focus).
+		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
+		if ( validStates ) {
+			validStates.forEach( ( state ) => {
+				const stateStyles = style?.[ state ];
+				if ( stateStyles ) {
+					const css = compileCSS( stateStyles, {
+						selector: `${ baseElementSelector }${ state }`,
+					} );
+					if ( css ) {
+						elementCSSRules.push( css );
 					}
-				} );
-			}
-		} );
+				}
+			} );
+		}
 
 		return elementCSSRules.length > 0
 			? elementCSSRules.join( '' )
 			: undefined;
-	}, [ baseElementSelector, blockElementStyles, name ] );
+	}, [ baseElementSelector, blockElementStyles, name, style ] );
 
 	useStyleOverride( { css: styles } );
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import {
@@ -387,14 +390,13 @@ function BlockStyleControls( {
 			<>
 				{ statesControl }
 				<BlockInspectorPreTabsFill>
-					<div style={ { padding: '8px 16px' } }>
+					<Spacer paddingX={ 4 } paddingY={ 2 }>
 						<ToggleControl
-							__nextHasNoMarginBottom
 							label={ __( 'Show state on canvas' ) }
 							checked={ showStateOnCanvas }
 							onChange={ setShowStateOnCanvas }
 						/>
-					</div>
+					</Spacer>
 				</BlockInspectorPreTabsFill>
 				<ColorEdit
 					clientId={ clientId }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -34,6 +34,7 @@ import {
 	useBlockSettings,
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
+import { buildStateSelector, STATES_ELEMENT_SUPPORT_KEY } from './state-utils';
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
@@ -525,12 +526,25 @@ function useBlockProps( { name, style } ) {
 		// Generate per-instance state CSS (e.g., :hover, :focus).
 		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
 		if ( validStates ) {
+			const statesElement = getBlockSupport(
+				name,
+				STATES_ELEMENT_SUPPORT_KEY
+			);
 			validStates.forEach( ( state ) => {
 				const stateStyles = style?.[ state ];
 				if ( stateStyles ) {
-					const css = compileCSS( stateStyles, {
-						selector: `${ baseElementSelector }${ state }`,
-					} );
+					const selector = buildStateSelector(
+						baseElementSelector,
+						statesElement,
+						state
+					);
+					// State styles use !important to override utility classes
+					// like .has-accent-3-background-color which the block's
+					// default color support generates with !important.
+					const css = compileCSS( stateStyles, { selector } ).replace(
+						/;/g,
+						' !important;'
+					);
 					if ( css ) {
 						elementCSSRules.push( css );
 					}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -41,6 +41,8 @@ import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspect
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
+import StylesDimensionsPanel from '../components/global-styles/dimensions-panel';
+import StylesBackgroundPanel from '../components/global-styles/background-panel';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import InspectorControls from '../components/inspector-controls';
@@ -420,6 +422,13 @@ function BlockStyleControls( {
 						settings={ panelSettings }
 						panelId={ clientId }
 					/>
+					<StylesBackgroundPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
+					/>
 					<StylesTypographyPanel
 						value={ stateValue }
 						inheritedValue={ stateValue }
@@ -434,6 +443,13 @@ function BlockStyleControls( {
 						settings={ panelSettings }
 						panelId={ clientId }
 						name={ name }
+					/>
+					<StylesDimensionsPanel
+						value={ stateValue }
+						inheritedValue={ stateValue }
+						onChange={ setStateStyle }
+						settings={ panelSettings }
+						panelId={ clientId }
 					/>
 				</InspectorControls>
 			</>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -37,10 +37,7 @@ import {
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
 import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
-import { unlock } from '../lock-unlock';
-import { privateApis as blockEditorPrivateApis } from '../private-apis';
-
-const { BlockInspectorPreTabsFill } = unlock( blockEditorPrivateApis );
+import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -42,6 +42,7 @@ import { buildStateSelector, buildCanvasStateSelector } from './state-utils';
 import { BlockInspectorPreTabsFill } from '../components/block-inspector/inspector-pre-tabs-slot-fill';
 import { scopeSelector } from '../components/global-styles/utils';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import { getValueFromObjectPath } from '../utils/object';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -340,18 +341,20 @@ function BlockStyleControls( {
 } ) {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const blockEditingMode = useBlockEditingMode();
-	const [ selectedState, setSelectedState ] = useState( 'default' );
+	const [ selectedState, setSelectedState ] = useState( [] );
 	const [ showStateOnCanvas, setShowStateOnCanvas ] = useState( true );
+
+	const isStateSelected = selectedState.length > 0;
 
 	// Inject state styles onto the editor canvas so the selected state is
 	// visible while editing. Scoped to this block instance via data-block so
 	// other blocks of the same type are not affected. Must be called before
 	// any early returns because it is a hook.
 	const canvasStateCSS = useMemo( () => {
-		if ( ! showStateOnCanvas || selectedState === 'default' ) {
+		if ( ! showStateOnCanvas || ! isStateSelected ) {
 			return undefined;
 		}
-		const stateValue = style?.[ selectedState ];
+		const stateValue = getValueFromObjectPath( style, selectedState );
 		if ( ! stateValue ) {
 			return undefined;
 		}
@@ -360,7 +363,14 @@ function BlockStyleControls( {
 		// Use !important to override utility classes (e.g. has-accent-3-color)
 		// that the block's default color support generates with !important.
 		return css ? css.replace( /;/g, ' !important;' ) : undefined;
-	}, [ showStateOnCanvas, selectedState, style, clientId, name ] );
+	}, [
+		showStateOnCanvas,
+		isStateSelected,
+		selectedState,
+		style,
+		clientId,
+		name,
+	] );
 	useStyleOverride( { css: canvasStateCSS } );
 
 	if ( blockEditingMode !== 'default' ) {
@@ -392,7 +402,7 @@ function BlockStyleControls( {
 				value={ selectedState }
 				onChange={ setSelectedState }
 			/>
-			{ selectedState !== 'default' && (
+			{ isStateSelected && (
 				<BlockInspectorPreTabsFill>
 					<Spacer paddingX={ 4 } paddingY={ 2 }>
 						<ToggleControl
@@ -510,29 +520,32 @@ function useBlockProps( { name, style } ) {
 			} );
 		}
 
-		// Generate per-instance state CSS (e.g., :hover, :focus).
+		// Generate per-instance state CSS for pseudo-selector states (e.g., :hover, :focus).
+		// Custom class-based states (e.g., @current) require server-side context to
+		// determine which items are "current", so they are skipped here.
 		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
 		if ( validStates ) {
-			validStates.forEach( ( state ) => {
-				const stateStyles = style?.[ state ];
-				if ( stateStyles ) {
-					const selector = buildStateSelector(
-						baseElementSelector,
-						name,
-						state
-					);
-					// State styles use !important to override utility classes
-					// like .has-accent-3-background-color which the block's
-					// default color support generates with !important.
-					const css = compileCSS( stateStyles, { selector } ).replace(
-						/;/g,
-						' !important;'
-					);
-					if ( css ) {
-						elementCSSRules.push( css );
+			validStates
+				.filter( ( state ) => state.startsWith( ':' ) )
+				.forEach( ( state ) => {
+					const stateStyles = style?.[ state ];
+					if ( stateStyles ) {
+						const selector = buildStateSelector(
+							baseElementSelector,
+							name,
+							state
+						);
+						// State styles use !important to override utility classes
+						// like .has-accent-3-background-color which the block's
+						// default color support generates with !important.
+						const css = compileCSS( stateStyles, {
+							selector,
+						} ).replace( /;/g, ' !important;' );
+						if ( css ) {
+							elementCSSRules.push( css );
+						}
 					}
-				}
-			} );
+				} );
 		}
 
 		return elementCSSRules.length > 0

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -34,7 +34,7 @@ import {
 	useBlockSettings,
 } from './utils';
 import { BlockStatesControl, STATES_SUPPORT_KEY } from './states';
-import { buildStateSelector, STATES_ELEMENT_SUPPORT_KEY } from './state-utils';
+import { buildStateSelector } from './state-utils';
 import StylesColorPanel from '../components/global-styles/color-panel';
 import StylesTypographyPanel from '../components/global-styles/typography-panel';
 import StylesBorderPanel from '../components/global-styles/border-panel';
@@ -526,16 +526,12 @@ function useBlockProps( { name, style } ) {
 		// Generate per-instance state CSS (e.g., :hover, :focus).
 		const validStates = getBlockSupport( name, STATES_SUPPORT_KEY );
 		if ( validStates ) {
-			const statesElement = getBlockSupport(
-				name,
-				STATES_ELEMENT_SUPPORT_KEY
-			);
 			validStates.forEach( ( state ) => {
 				const stateStyles = style?.[ state ];
 				if ( stateStyles ) {
 					const selector = buildStateSelector(
 						baseElementSelector,
-						statesElement,
+						name,
 						state
 					);
 					// State styles use !important to override utility classes

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -377,18 +377,22 @@ function BlockStyleControls( {
 		},
 	};
 
-	const statesControl = (
-		<BlockStatesControl
-			name={ name }
-			value={ selectedState }
-			onChange={ setSelectedState }
-		/>
-	);
+	const passedProps = {
+		clientId,
+		name,
+		setAttributes,
+		settings: panelSettings,
+		selectedState,
+	};
 
-	if ( selectedState !== 'default' ) {
-		return (
-			<>
-				{ statesControl }
+	return (
+		<>
+			<BlockStatesControl
+				name={ name }
+				value={ selectedState }
+				onChange={ setSelectedState }
+			/>
+			{ selectedState !== 'default' && (
 				<BlockInspectorPreTabsFill>
 					<Spacer paddingX={ 4 } paddingY={ 2 }>
 						<ToggleControl
@@ -398,55 +402,7 @@ function BlockStyleControls( {
 						/>
 					</Spacer>
 				</BlockInspectorPreTabsFill>
-				<ColorEdit
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<BackgroundImagePanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<TypographyPanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<BorderPanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-				<DimensionsPanel
-					clientId={ clientId }
-					name={ name }
-					setAttributes={ setAttributes }
-					settings={ panelSettings }
-					selectedState={ selectedState }
-				/>
-			</>
-		);
-	}
-
-	const passedProps = {
-		clientId,
-		name,
-		setAttributes,
-		settings: panelSettings,
-	};
-
-	return (
-		<>
-			{ statesControl }
+			) }
 			<ColorEdit { ...passedProps } />
 			<BackgroundImagePanel { ...passedProps } />
 			<TypographyPanel { ...passedProps } />

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import { buildStateSelector } from '../state-utils';
+
+describe( 'buildStateSelector', () => {
+	const BASE = '.wp-elements-abc123';
+
+	it( 'scopes state to each element selector part when statesElement is "button"', () => {
+		// ELEMENTS['button'] = '.wp-element-button, .wp-block-button__link'
+		expect( buildStateSelector( BASE, 'button', ':hover' ) ).toBe(
+			`${ BASE } .wp-element-button:hover, ${ BASE } .wp-block-button__link:hover`
+		);
+	} );
+
+	it( 'works for :focus and :active states', () => {
+		expect( buildStateSelector( BASE, 'button', ':focus' ) ).toBe(
+			`${ BASE } .wp-element-button:focus, ${ BASE } .wp-block-button__link:focus`
+		);
+		expect( buildStateSelector( BASE, 'button', ':active' ) ).toBe(
+			`${ BASE } .wp-element-button:active, ${ BASE } .wp-block-button__link:active`
+		);
+	} );
+
+	it( 'scopes state to the single element selector when statesElement is "link"', () => {
+		// ELEMENTS['link'] = 'a:where(:not(.wp-element-button))'
+		expect( buildStateSelector( BASE, 'link', ':hover' ) ).toBe(
+			`${ BASE } a:where(:not(.wp-element-button)):hover`
+		);
+	} );
+
+	it( 'falls back to appending state to the base selector when statesElement is null', () => {
+		expect( buildStateSelector( BASE, null, ':hover' ) ).toBe(
+			`${ BASE }:hover`
+		);
+	} );
+
+	it( 'falls back to appending state to the base selector when statesElement is undefined', () => {
+		expect( buildStateSelector( BASE, undefined, ':hover' ) ).toBe(
+			`${ BASE }:hover`
+		);
+	} );
+
+	it( 'falls back to appending state to the base selector when statesElement has no matching ELEMENTS entry', () => {
+		expect( buildStateSelector( BASE, 'unknown-element', ':hover' ) ).toBe(
+			`${ BASE }:hover`
+		);
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -1,48 +1,90 @@
 /**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
-import { buildStateSelector } from '../state-utils';
+import { getRelativeRootSelector, buildStateSelector } from '../state-utils';
+
+describe( 'getRelativeRootSelector', () => {
+	it( 'returns the descendant part of a space-combinator selector', () => {
+		expect(
+			getRelativeRootSelector( '.wp-block-button .wp-block-button__link' )
+		).toBe( '.wp-block-button__link' );
+	} );
+
+	it( 'preserves explicit child combinators', () => {
+		expect( getRelativeRootSelector( '.wp-block-foo > .inner' ) ).toBe(
+			'> .inner'
+		);
+	} );
+
+	it( 'preserves multi-level descendants', () => {
+		expect( getRelativeRootSelector( '.wp-block-foo .bar .baz' ) ).toBe(
+			'.bar .baz'
+		);
+	} );
+
+	it( 'returns null for a single-class selector', () => {
+		expect( getRelativeRootSelector( '.wp-block-foo' ) ).toBeNull();
+	} );
+} );
 
 describe( 'buildStateSelector', () => {
 	const BASE = '.wp-elements-abc123';
 
-	it( 'scopes state to each element selector part when statesElement is "button"', () => {
-		// ELEMENTS['button'] = '.wp-element-button, .wp-block-button__link'
-		expect( buildStateSelector( BASE, 'button', ':hover' ) ).toBe(
-			`${ BASE } .wp-element-button:hover, ${ BASE } .wp-block-button__link:hover`
+	beforeEach( () => {
+		registerBlockType( 'test/button', {
+			apiVersion: 3,
+			title: 'Button',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			selectors: {
+				root: '.wp-block-button .wp-block-button__link',
+			},
+		} );
+		registerBlockType( 'test/plain', {
+			apiVersion: 3,
+			title: 'Plain',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+		} );
+	} );
+
+	afterEach( () => {
+		unregisterBlockType( 'test/button' );
+		unregisterBlockType( 'test/plain' );
+	} );
+
+	it( 'scopes state to the descendant element from selectors.root', () => {
+		expect( buildStateSelector( BASE, 'test/button', ':hover' ) ).toBe(
+			`${ BASE } .wp-block-button__link:hover`
 		);
 	} );
 
 	it( 'works for :focus and :active states', () => {
-		expect( buildStateSelector( BASE, 'button', ':focus' ) ).toBe(
-			`${ BASE } .wp-element-button:focus, ${ BASE } .wp-block-button__link:focus`
+		expect( buildStateSelector( BASE, 'test/button', ':focus' ) ).toBe(
+			`${ BASE } .wp-block-button__link:focus`
 		);
-		expect( buildStateSelector( BASE, 'button', ':active' ) ).toBe(
-			`${ BASE } .wp-element-button:active, ${ BASE } .wp-block-button__link:active`
-		);
-	} );
-
-	it( 'scopes state to the single element selector when statesElement is "link"', () => {
-		// ELEMENTS['link'] = 'a:where(:not(.wp-element-button))'
-		expect( buildStateSelector( BASE, 'link', ':hover' ) ).toBe(
-			`${ BASE } a:where(:not(.wp-element-button)):hover`
+		expect( buildStateSelector( BASE, 'test/button', ':active' ) ).toBe(
+			`${ BASE } .wp-block-button__link:active`
 		);
 	} );
 
-	it( 'falls back to appending state to the base selector when statesElement is null', () => {
-		expect( buildStateSelector( BASE, null, ':hover' ) ).toBe(
+	it( 'falls back to appending state to the base selector when block has no selectors.root', () => {
+		expect( buildStateSelector( BASE, 'test/plain', ':hover' ) ).toBe(
 			`${ BASE }:hover`
 		);
 	} );
 
-	it( 'falls back to appending state to the base selector when statesElement is undefined', () => {
-		expect( buildStateSelector( BASE, undefined, ':hover' ) ).toBe(
-			`${ BASE }:hover`
-		);
-	} );
-
-	it( 'falls back to appending state to the base selector when statesElement has no matching ELEMENTS entry', () => {
-		expect( buildStateSelector( BASE, 'unknown-element', ':hover' ) ).toBe(
+	it( 'falls back to appending state to the base selector for an unknown block name', () => {
+		expect( buildStateSelector( BASE, 'test/unknown', ':hover' ) ).toBe(
 			`${ BASE }:hover`
 		);
 	} );

--- a/packages/block-editor/src/hooks/test/use-block-style.js
+++ b/packages/block-editor/src/hooks/test/use-block-style.js
@@ -35,9 +35,11 @@ describe( 'useBlockStyle', () => {
 		} );
 	} );
 
-	afterAll( () => {
+	afterAll( async () => {
 		unregisterBlockType( 'test/style-block' );
-		dispatch( blockEditorStore ).resetBlocks( [] );
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [] );
+		} );
 	} );
 
 	let clientId;
@@ -48,12 +50,16 @@ describe( 'useBlockStyle', () => {
 				':hover': { color: { text: '#ff0000' } },
 			},
 		} );
-		await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		} );
 		clientId = block.clientId;
 	} );
 
-	afterEach( () => {
-		dispatch( blockEditorStore ).resetBlocks( [] );
+	afterEach( async () => {
+		await act( async () => {
+			await dispatch( blockEditorStore ).resetBlocks( [] );
+		} );
 	} );
 
 	function makeWrapper( id ) {

--- a/packages/block-editor/src/hooks/test/use-block-style.js
+++ b/packages/block-editor/src/hooks/test/use-block-style.js
@@ -1,0 +1,192 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+import {
+	createBlock,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { dispatch, select } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockStyle } from '../use-block-style';
+import { BlockEditContextProvider } from '../../components/block-edit/context';
+
+describe( 'useBlockStyle', () => {
+	beforeAll( () => {
+		registerBlockType( 'test/style-block', {
+			apiVersion: 3,
+			title: 'Style Block',
+			category: 'text',
+			attributes: {
+				style: { type: 'object' },
+			},
+			edit: () => null,
+			save: () => null,
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'test/style-block' );
+		dispatch( blockEditorStore ).resetBlocks( [] );
+	} );
+
+	let clientId;
+	beforeEach( async () => {
+		const block = createBlock( 'test/style-block', {
+			style: {
+				color: { text: '#000000' },
+				':hover': { color: { text: '#ff0000' } },
+			},
+		} );
+		await dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		clientId = block.clientId;
+	} );
+
+	afterEach( () => {
+		dispatch( blockEditorStore ).resetBlocks( [] );
+	} );
+
+	function makeWrapper( id ) {
+		return function Wrapper( { children } ) {
+			return createElement(
+				BlockEditContextProvider,
+				{
+					value: {
+						clientId: id,
+						name: 'test/style-block',
+						isSelected: true,
+					},
+				},
+				children
+			);
+		};
+	}
+
+	describe( 'reading values', () => {
+		it( 'reads a value from the default state via dot-notation path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'reads a value from the default state via array path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( [ 'color', 'text' ] ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'treats state "default" the same as no state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', 'default' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#000000' );
+		} );
+
+		it( 'reads a value scoped to a pseudo-state via dot-notation path', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toBe( '#ff0000' );
+		} );
+
+		it( 'reads the full state sub-object when path is null', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( null, ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			expect( result.current[ 0 ] ).toEqual( {
+				color: { text: '#ff0000' },
+			} );
+		} );
+	} );
+
+	describe( 'writing values', () => {
+		it( 'writes a value to the default state without affecting pseudo-state styles', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#ffffff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style.color.text ).toBe( '#ffffff' );
+			expect( style[ ':hover' ].color.text ).toBe( '#ff0000' );
+		} );
+
+		it( 'writes a value to a pseudo-state without affecting the default state', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( '#0000ff' );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ].color.text ).toBe( '#0000ff' );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'replaces the full state sub-object when path is null', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( null, ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( { color: { text: '#0000ff' } } );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ] ).toEqual( {
+				color: { text: '#0000ff' },
+			} );
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+
+		it( 'removes the state key when the last value inside it is cleared', () => {
+			const { result } = renderHook(
+				() => useBlockStyle( 'color.text', ':hover' ),
+				{ wrapper: makeWrapper( clientId ) }
+			);
+
+			act( () => {
+				result.current[ 1 ]( undefined );
+			} );
+
+			const { style } =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			expect( style[ ':hover' ] ).toBeUndefined();
+			// Default-state styles must be left intact.
+			expect( style.color.text ).toBe( '#000000' );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/utils.js
+++ b/packages/block-editor/src/hooks/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { cleanEmptyObject } from '../utils';
+import { cleanEmptyObject, buildStateResetAllFilter } from '../utils';
 
 describe( 'cleanEmptyObject', () => {
 	it( 'should remove nested keys', () => {
@@ -28,5 +28,72 @@ describe( 'cleanEmptyObject', () => {
 		expect( cleanEmptyObject( { color: { text: '' } } ) ).not.toEqual(
 			undefined
 		);
+	} );
+} );
+
+describe( 'buildStateResetAllFilter', () => {
+	it( 'should clear only the selected state styles and leave default styles intact', () => {
+		const innerReset = ( style ) => ( { ...style, color: undefined } );
+		const attributes = {
+			style: {
+				color: { text: '#000000' },
+				':hover': { color: { text: '#ff0000' } },
+			},
+		};
+
+		const result = buildStateResetAllFilter(
+			':hover',
+			innerReset
+		)( attributes );
+
+		expect( result.style[ ':hover' ] ).toBeUndefined();
+		expect( result.style.color ).toEqual( { text: '#000000' } );
+	} );
+
+	it( 'should not affect other state keys', () => {
+		const innerReset = () => ( {} );
+		const attributes = {
+			style: {
+				':hover': { color: { text: '#ff0000' } },
+				':focus': { color: { text: '#0000ff' } },
+			},
+		};
+
+		const result = buildStateResetAllFilter(
+			':hover',
+			innerReset
+		)( attributes );
+
+		expect( result.style[ ':hover' ] ).toBeUndefined();
+		expect( result.style[ ':focus' ] ).toEqual( {
+			color: { text: '#0000ff' },
+		} );
+	} );
+
+	it( 'should remove the state key entirely when inner reset returns an empty object', () => {
+		const innerReset = () => ( {} );
+		const attributes = {
+			style: {
+				':hover': { color: { text: '#ff0000' } },
+			},
+		};
+
+		const result = buildStateResetAllFilter(
+			':hover',
+			innerReset
+		)( attributes );
+
+		expect( result.style ).toBeUndefined();
+	} );
+
+	it( 'should call the inner reset with an empty object when no state styles exist', () => {
+		const innerReset = jest.fn( ( style ) => style );
+		const attributes = {
+			style: { color: { text: '#000000' } },
+		};
+
+		buildStateResetAllFilter( ':hover', innerReset )( attributes );
+
+		expect( innerReset ).toHaveBeenCalledWith( {} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,6 +21,7 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
+import { useBlockStateProps } from './state-utils';
 
 function omit( object, keys ) {
 	return Object.fromEntries(
@@ -135,7 +136,6 @@ export function TypographyPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
-	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
@@ -158,21 +158,22 @@ export function TypographyPanel( {
 		},
 		[ clientId, isEnabled ]
 	);
+
+	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
+		selectedState,
+		style,
+		setAttributes,
+	} );
+
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return style?.[ selectedState ];
+			return stateValue;
 		}
 		return attributesToStyle( { style, fontFamily, fontSize } );
-	}, [ isStateSelected, selectedState, style, fontSize, fontFamily ] );
+	}, [ isStateSelected, stateValue, style, fontSize, fontFamily ] );
 
 	const onChange = isStateSelected
-		? ( newStateStyle ) =>
-				setAttributes( {
-					style: cleanEmptyObject( {
-						...style,
-						[ selectedState ]: newStateStyle,
-					} ),
-				} )
+		? stateOnChange
 		: ( newStyle ) => {
 				const newAttributes = styleToAttributes( newStyle );
 

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -19,7 +19,7 @@ import { FONT_FAMILY_SUPPORT_KEY } from './font-family';
 import { FONT_SIZE_SUPPORT_KEY } from './font-size';
 import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
 
 function omit( object, keys ) {
@@ -93,9 +93,20 @@ function attributesToStyle( attributes ) {
 	};
 }
 
-function TypographyInspectorControl( { children, resetAllFilter } ) {
+function TypographyInspectorControl( {
+	children,
+	resetAllFilter,
+	selectedState = 'default',
+} ) {
+	const isStateSelected = selectedState !== 'default';
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
+			if ( isStateSelected ) {
+				return buildStateResetAllFilter(
+					selectedState,
+					resetAllFilter
+				)( attributes );
+			}
 			const existingStyle = attributesToStyle( attributes );
 			const updatedStyle = resetAllFilter( existingStyle );
 			return {
@@ -103,7 +114,7 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 				...styleToAttributes( updatedStyle ),
 			};
 		},
-		[ resetAllFilter ]
+		[ isStateSelected, selectedState, resetAllFilter ]
 	);
 
 	return (
@@ -124,7 +135,7 @@ export function TypographyPanel( {
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
-	const isStateMode = !! ( selectedState && selectedState !== 'default' );
+	const isStateSelected = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
@@ -148,13 +159,13 @@ export function TypographyPanel( {
 		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
-		if ( isStateMode ) {
+		if ( isStateSelected ) {
 			return style?.[ selectedState ];
 		}
 		return attributesToStyle( { style, fontFamily, fontSize } );
-	}, [ isStateMode, selectedState, style, fontSize, fontFamily ] );
+	}, [ isStateSelected, selectedState, style, fontSize, fontFamily ] );
 
-	const onChange = isStateMode
+	const onChange = isStateSelected
 		? ( newStateStyle ) =>
 				setAttributes( {
 					style: cleanEmptyObject( {
@@ -176,6 +187,19 @@ export function TypographyPanel( {
 				setAttributes( newAttributes );
 		  };
 
+	const TypographyWrapper = useMemo(
+		() =>
+			function TypographyWrapperComponent( props ) {
+				return (
+					<TypographyInspectorControl
+						{ ...props }
+						selectedState={ selectedState }
+					/>
+				);
+			},
+		[ selectedState ]
+	);
+
 	if ( ! isEnabled ) {
 		return null;
 	}
@@ -187,7 +211,7 @@ export function TypographyPanel( {
 
 	return (
 		<StylesTypographyPanel
-			as={ TypographyInspectorControl }
+			as={ TypographyWrapper }
 			panelId={ clientId }
 			settings={ settings }
 			value={ value }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,7 +21,8 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
-import { useBlockStateProps } from './state-utils';
+import { useBlockEditContext } from '../components/block-edit/context';
+import { useBlockStyle } from './use-block-style';
 
 function omit( object, keys ) {
 	return Object.fromEntries(
@@ -131,26 +132,23 @@ function TypographyInspectorControl( {
 export function TypographyPanel( {
 	clientId,
 	name,
-	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
 
-	const { style, fontFamily, fontSize, fitText } = useSelect(
+	const { fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled.
 			if ( ! isEnabled ) {
 				return {};
 			}
 			const {
-				style: _style,
 				fontFamily: _fontFamily,
 				fontSize: _fontSize,
 				fitText: _fitText,
 			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 			return {
-				style: _style,
 				fontFamily: _fontFamily,
 				fontSize: _fontSize,
 				fitText: _fitText,
@@ -159,25 +157,23 @@ export function TypographyPanel( {
 		[ clientId, isEnabled ]
 	);
 
-	const { isStateSelected, stateValue, stateOnChange } = useBlockStateProps( {
-		selectedState,
-		style,
-		setAttributes,
-	} );
+	const { setAttributes } = useBlockEditContext();
+	const [ style, setStyle ] = useBlockStyle( null, selectedState );
+	const isStateSelected = selectedState !== 'default';
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
-			return stateValue;
+			return style;
 		}
 		return attributesToStyle( { style, fontFamily, fontSize } );
-	}, [ isStateSelected, stateValue, style, fontSize, fontFamily ] );
+	}, [ isStateSelected, style, fontSize, fontFamily ] );
 
 	const onChange = isStateSelected
-		? stateOnChange
+		? setStyle
 		: ( newStyle ) => {
 				const newAttributes = styleToAttributes( newStyle );
 
-				// If setting a font size and fitText is currently enabled, disable it
+				// If setting a font size and fitText is currently enabled, disable it.
 				const hasFontSize =
 					newAttributes.fontSize ||
 					newAttributes.style?.typography?.fontSize;

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -116,8 +116,15 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
+export function TypographyPanel( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	selectedState = 'default',
+} ) {
 	const isEnabled = useHasTypographyPanel( settings );
+	const isStateMode = !! ( selectedState && selectedState !== 'default' );
 
 	const { style, fontFamily, fontSize, fitText } = useSelect(
 		( select ) => {
@@ -140,23 +147,34 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 		},
 		[ clientId, isEnabled ]
 	);
-	const value = useMemo(
-		() => attributesToStyle( { style, fontFamily, fontSize } ),
-		[ style, fontSize, fontFamily ]
-	);
-
-	const onChange = ( newStyle ) => {
-		const newAttributes = styleToAttributes( newStyle );
-
-		// If setting a font size and fitText is currently enabled, disable it
-		const hasFontSize =
-			newAttributes.fontSize || newAttributes.style?.typography?.fontSize;
-		if ( hasFontSize && fitText ) {
-			newAttributes.fitText = undefined;
+	const value = useMemo( () => {
+		if ( isStateMode ) {
+			return style?.[ selectedState ];
 		}
+		return attributesToStyle( { style, fontFamily, fontSize } );
+	}, [ isStateMode, selectedState, style, fontSize, fontFamily ] );
 
-		setAttributes( newAttributes );
-	};
+	const onChange = isStateMode
+		? ( newStateStyle ) =>
+				setAttributes( {
+					style: cleanEmptyObject( {
+						...style,
+						[ selectedState ]: newStateStyle,
+					} ),
+				} )
+		: ( newStyle ) => {
+				const newAttributes = styleToAttributes( newStyle );
+
+				// If setting a font size and fitText is currently enabled, disable it
+				const hasFontSize =
+					newAttributes.fontSize ||
+					newAttributes.style?.typography?.fontSize;
+				if ( hasFontSize && fitText ) {
+					newAttributes.fitText = undefined;
+				}
+
+				setAttributes( newAttributes );
+		  };
 
 	if ( ! isEnabled ) {
 		return null;

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,7 +21,6 @@ import { TEXT_ALIGN_SUPPORT_KEY } from './text-align';
 import { FIT_TEXT_SUPPORT_KEY } from './fit-text';
 import { cleanEmptyObject, buildStateResetAllFilter } from './utils';
 import { store as blockEditorStore } from '../store';
-import { useBlockEditContext } from '../components/block-edit/context';
 import { useBlockStyle } from './use-block-style';
 
 function omit( object, keys ) {
@@ -132,6 +131,7 @@ function TypographyInspectorControl( {
 export function TypographyPanel( {
 	clientId,
 	name,
+	setAttributes,
 	settings,
 	selectedState = 'default',
 } ) {
@@ -157,7 +157,6 @@ export function TypographyPanel( {
 		[ clientId, isEnabled ]
 	);
 
-	const { setAttributes } = useBlockEditContext();
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
 	const isStateSelected = selectedState !== 'default';
 

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -97,9 +97,9 @@ function attributesToStyle( attributes ) {
 function TypographyInspectorControl( {
 	children,
 	resetAllFilter,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 	const attributesResetAllFilter = useCallback(
 		( attributes ) => {
 			if ( isStateSelected ) {
@@ -133,7 +133,7 @@ export function TypographyPanel( {
 	name,
 	setAttributes,
 	settings,
-	selectedState = 'default',
+	selectedState = [],
 } ) {
 	const isEnabled = useHasTypographyPanel( settings );
 
@@ -158,7 +158,7 @@ export function TypographyPanel( {
 	);
 
 	const [ style, setStyle ] = useBlockStyle( null, selectedState );
-	const isStateSelected = selectedState !== 'default';
+	const isStateSelected = selectedState.length > 0;
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -26,12 +26,16 @@ import { cleanEmptyObject } from './utils';
  *   `useBlockStyle( 'color', '@current' )`     — `style['@current'].color`
  *   `useBlockStyle( 'color', ':hover:focus' )` — compound state
  *
+ * Omit `path` (or pass `null`) to read and write the full style object for
+ * that state context, e.g. `useBlockStyle( null, ':hover' )` returns the
+ * entire `style[':hover']` sub-object.
+ *
  * Keeping state separate from the path means no heuristic is needed to
  * distinguish state keys from style property names, regardless of the
  * state format convention used.
  *
- * @param {string|string[]} path  Dot-separated path into the `style` object.
- * @param {string}          state Optional state key, e.g. `':hover'` or `'@current'`. Omit for default styles.
+ * @param {string|string[]|null} path  Dot-separated path into the `style` object, or `null` for the root.
+ * @param {string}               state Optional state key, e.g. `':hover'` or `'@current'`. Omit or pass `'default'` for base styles.
  * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
  */
 export function useBlockStyle( path, state ) {
@@ -44,7 +48,14 @@ export function useBlockStyle( path, state ) {
 	);
 
 	const pathArray = useMemo( () => {
-		const stylePath = Array.isArray( path ) ? path : path.split( '.' );
+		let stylePath;
+		if ( ! path ) {
+			stylePath = [];
+		} else if ( Array.isArray( path ) ) {
+			stylePath = path;
+		} else {
+			stylePath = path.split( '.' );
+		}
 		return state && state !== 'default'
 			? [ state, ...stylePath ]
 			: stylePath;
@@ -57,10 +68,13 @@ export function useBlockStyle( path, state ) {
 
 	const setValue = useCallback(
 		( newValue ) => {
+			// Empty path means the caller wants to replace the style root (or
+			// the full state sub-object) wholesale rather than a nested key.
+			const newStyle = pathArray.length
+				? setImmutably( style ?? {}, pathArray, newValue )
+				: newValue;
 			setAttributes( {
-				style: cleanEmptyObject(
-					setImmutably( style ?? {}, pathArray, newValue )
-				),
+				style: cleanEmptyObject( newStyle ),
 			} );
 		},
 		[ setAttributes, style, pathArray ]

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -34,8 +34,10 @@ import { cleanEmptyObject } from './utils';
  * distinguish state keys from style property names, regardless of the
  * state format convention used.
  *
- * @param {string|string[]|null} path  Dot-separated path into the `style` object, or `null` for the root.
- * @param {string}               state Optional state key, e.g. `':hover'` or `'@current'`. Omit or pass `'default'` for base styles.
+ * @param {string|string[]|null}      path  Dot-separated path into the `style` object, or `null` for the root.
+ * @param {string|string[]|undefined} state Optional state key or array of keys for compound states,
+ *                                          e.g. `':hover'`, `'@current'`, or `[ '@current', ':hover' ]`.
+ *                                          Omit or pass an empty array for base styles.
  * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
  */
 export function useBlockStyle( path, state ) {
@@ -57,9 +59,17 @@ export function useBlockStyle( path, state ) {
 		} else {
 			stylePath = path.split( '.' );
 		}
-		return state && state !== 'default'
-			? [ state, ...stylePath ]
-			: stylePath;
+		// state can be a string, a string[], or undefined/empty.
+		// Normalize to an array of segments to prepend.
+		let stateSegments;
+		if ( Array.isArray( state ) ) {
+			stateSegments = state;
+		} else if ( state && state !== 'default' ) {
+			stateSegments = [ state ];
+		} else {
+			stateSegments = [];
+		}
+		return [ ...stateSegments, ...stylePath ];
 	}, [ path, state ] );
 
 	const value = useMemo(

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,7 +39,8 @@ import { cleanEmptyObject } from './utils';
  * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
  */
 export function useBlockStyle( path, state ) {
-	const { clientId, setAttributes } = useBlockEditContext();
+	const { clientId } = useBlockEditContext();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const style = useSelect(
 		( select ) =>
@@ -73,11 +74,11 @@ export function useBlockStyle( path, state ) {
 			const newStyle = pathArray.length
 				? setImmutably( style ?? {}, pathArray, newValue )
 				: newValue;
-			setAttributes( {
+			updateBlockAttributes( clientId, {
 				style: cleanEmptyObject( newStyle ),
 			} );
 		},
-		[ setAttributes, style, pathArray ]
+		[ updateBlockAttributes, clientId, style, pathArray ]
 	);
 
 	return [ value, setValue ];

--- a/packages/block-editor/src/hooks/use-block-style.js
+++ b/packages/block-editor/src/hooks/use-block-style.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../components/block-edit/context';
+import { store as blockEditorStore } from '../store';
+import { getValueFromObjectPath, setImmutably } from '../utils/object';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Returns a `[value, setter]` pair for a path within a block's `style`
+ * attribute. Works like `useStyle` in Global Styles but reads from the
+ * current block instance's attributes instead of `theme.json`.
+ *
+ * Path uses dot notation into the style object, e.g. `'color'` or
+ * `'typography.fontSize'`. Pass a separate `state` argument to scope to a
+ * pseudo-state or custom state — the state key becomes the first segment of
+ * the storage path:
+ *
+ *   `useBlockStyle( 'color', ':hover' )`       — `style[':hover'].color`
+ *   `useBlockStyle( 'color', '@current' )`     — `style['@current'].color`
+ *   `useBlockStyle( 'color', ':hover:focus' )` — compound state
+ *
+ * Keeping state separate from the path means no heuristic is needed to
+ * distinguish state keys from style property names, regardless of the
+ * state format convention used.
+ *
+ * @param {string|string[]} path  Dot-separated path into the `style` object.
+ * @param {string}          state Optional state key, e.g. `':hover'` or `'@current'`. Omit for default styles.
+ * @return {[*, Function]} Tuple of `[currentValue, setValue]`.
+ */
+export function useBlockStyle( path, state ) {
+	const { clientId, setAttributes } = useBlockEditContext();
+
+	const style = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
+		[ clientId ]
+	);
+
+	const pathArray = useMemo( () => {
+		const stylePath = Array.isArray( path ) ? path : path.split( '.' );
+		return state && state !== 'default'
+			? [ state, ...stylePath ]
+			: stylePath;
+	}, [ path, state ] );
+
+	const value = useMemo(
+		() => getValueFromObjectPath( style, pathArray ),
+		[ style, pathArray ]
+	);
+
+	const setValue = useCallback(
+		( newValue ) => {
+			setAttributes( {
+				style: cleanEmptyObject(
+					setImmutably( style ?? {}, pathArray, newValue )
+				),
+			} );
+		},
+		[ setAttributes, style, pathArray ]
+	);
+
+	return [ value, setValue ];
+}

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -50,6 +50,30 @@ export const cleanEmptyObject = ( object ) => {
 		: Object.fromEntries( cleanedNestedObjects );
 };
 
+/**
+ * Builds a `resetAllFilter` for use with `<InspectorControls>` when a
+ * non-default interactive state (e.g. `:hover`) is active. Rather than
+ * resetting the whole block style object, it scopes the reset to the
+ * sub-key that stores styles for that state, leaving default styles intact.
+ *
+ * @param {string}   selectedState    The active state key, e.g. ':hover'.
+ * @param {Function} innerResetFilter The panel's own resetAllFilter callback.
+ * @return {Function} A filter that takes block `attributes` and returns updated attributes.
+ */
+export function buildStateResetAllFilter( selectedState, innerResetFilter ) {
+	return ( attributes ) => {
+		const existingStateStyle = attributes.style?.[ selectedState ] || {};
+		const updatedStateStyle = innerResetFilter( existingStateStyle );
+		return {
+			...attributes,
+			style: cleanEmptyObject( {
+				...attributes.style,
+				[ selectedState ]: updatedStateStyle,
+			} ),
+		};
+	};
+}
+
 export function transformStyles(
 	activeSupports,
 	migrationPaths,

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -56,20 +56,30 @@ export const cleanEmptyObject = ( object ) => {
  * resetting the whole block style object, it scopes the reset to the
  * sub-key that stores styles for that state, leaving default styles intact.
  *
- * @param {string}   selectedState    The active state key, e.g. ':hover'.
- * @param {Function} innerResetFilter The panel's own resetAllFilter callback.
+ * Supports compound states as an array (e.g. `[ '@current', ':hover' ]`),
+ * which are stored as nested objects in the `style` attribute.
+ *
+ * @param {string|string[]} selectedState    The active state key or array of keys.
+ * @param {Function}        innerResetFilter The panel's own resetAllFilter callback.
  * @return {Function} A filter that takes block `attributes` and returns updated attributes.
  */
 export function buildStateResetAllFilter( selectedState, innerResetFilter ) {
 	return ( attributes ) => {
-		const existingStateStyle = attributes.style?.[ selectedState ] || {};
+		const statePath = Array.isArray( selectedState )
+			? selectedState
+			: [ selectedState ];
+		const existingStateStyle =
+			getValueFromObjectPath( attributes.style, statePath ) || {};
 		const updatedStateStyle = innerResetFilter( existingStateStyle );
 		return {
 			...attributes,
-			style: cleanEmptyObject( {
-				...attributes.style,
-				[ selectedState ]: updatedStateStyle,
-			} ),
+			style: cleanEmptyObject(
+				setImmutably(
+					attributes.style ?? {},
+					statePath,
+					updatedStateStyle
+				)
+			),
 		};
 	};
 }

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -75,6 +75,7 @@ import {
 	isRelativePath,
 } from './components/link-control/is-url-like';
 import { BlockCardControlsFill } from './components/block-card';
+import { BlockInspectorPreTabsFill } from './components/block-inspector/inspector-pre-tabs-slot-fill';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -143,4 +144,5 @@ lock( privateApis, {
 	isHashLink,
 	isRelativePath,
 	BlockCardControlsFill,
+	BlockInspectorPreTabsFill,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -74,8 +74,6 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
-import { BlockCardControlsFill } from './components/block-card';
-import { BlockInspectorPreTabsFill } from './components/block-inspector/inspector-pre-tabs-slot-fill';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -143,6 +141,4 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
-	BlockCardControlsFill,
-	BlockInspectorPreTabsFill,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -74,6 +74,7 @@ import {
 	isHashLink,
 	isRelativePath,
 } from './components/link-control/is-url-like';
+import { BlockCardControlsFill } from './components/block-card';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -141,4 +142,5 @@ lock( privateApis, {
 	useListViewPanelState,
 	isHashLink,
 	isRelativePath,
+	BlockCardControlsFill,
 } );

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -138,8 +138,7 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"__experimentalStates": [ ":hover", ":focus", ":active" ],
-		"__experimentalStatesElement": "button"
+		"__experimentalStates": [ ":hover", ":focus", ":active" ]
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -138,7 +138,8 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"__experimentalStates": [ ":hover", ":focus", ":active" ]
+		"__experimentalStates": [ ":hover", ":focus", ":active" ],
+		"__experimentalStatesElement": "button"
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -138,7 +138,7 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"__experimentalStates": [ ":hover", ":focus", ":active" ]
+		"states": [ ":hover", ":focus", ":active" ]
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -137,7 +137,8 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"__experimentalStates": [ ":hover", ":focus", ":active" ]
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -45,6 +45,9 @@
 		},
 		"isTopLevelLink": {
 			"type": "boolean"
+		},
+		"style": {
+			"type": "object"
 		}
 	},
 	"usesContext": [
@@ -83,7 +86,8 @@
 		"renaming": false,
 		"interactivity": {
 			"clientNavigation": true
-		}
+		},
+		"states": [ ":hover", ":focus", ":active", "@current" ]
 	},
 	"selectors": {
 		"states": {

--- a/packages/global-styles-ui/src/block-preview-panel.tsx
+++ b/packages/global-styles-ui/src/block-preview-panel.tsx
@@ -17,14 +17,14 @@ import { getVariationClassName } from './utils';
 interface BlockPreviewPanelProps {
 	name: string;
 	variation?: string;
-	selectedState?: string;
+	selectedState?: string[];
 	stateStyles?: any;
 }
 
 const BlockPreviewPanel = ( {
 	name,
 	variation = '',
-	selectedState = 'default',
+	selectedState = [],
 	stateStyles,
 }: BlockPreviewPanelProps ) => {
 	const blockExample = getBlockType( name )?.example;
@@ -49,7 +49,7 @@ const BlockPreviewPanel = ( {
 
 	// Generate CSS for the selected state.
 	const stateCSS = useMemo( () => {
-		if ( selectedState === 'default' || ! stateStyles ) {
+		if ( ! selectedState?.length || ! stateStyles ) {
 			return '';
 		}
 

--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -36,21 +36,25 @@ extend( [ a11yPlugin ] );
  * @param blockName          The name of the block, if applicable.
  * @param readFrom           Which source to read from: "base" (theme), "user" (customizations), or "merged" (final result).
  * @param shouldDecodeEncode Whether to decode and encode the style value.
- * @param state              Optional pseudo-selector state (e.g. `:hover`, `:focus`). When provided,
- *                           reads from and writes to the state sub-object automatically.
+ * @param state              Optional state key or array of keys for compound states
+ *                           (e.g. `:hover`, `@current`, or `[ '@current', ':hover' ]`).
+ *                           When provided, reads from and writes to the nested state
+ *                           sub-object automatically. Pass an empty array or omit for
+ *                           base (default) styles.
  * @return An array containing the style value and a function to set the style
  * value.
  *
  * @example
  * const [ color, setColor ] = useStyle<string>( 'color.text', 'core/button', 'merged' );
  * const [ hoverColor, setHoverColor ] = useStyle<string>( 'color.text', 'core/button', 'user', true, ':hover' );
+ * const [ compoundColor, setCompoundColor ] = useStyle<string>( 'color.text', 'core/navigation-link', 'user', true, [ '@current', ':hover' ] );
  */
 export function useStyle< T = any >(
 	path: string,
 	blockName?: string,
 	readFrom: 'base' | 'user' | 'merged' = 'merged',
 	shouldDecodeEncode: boolean = true,
-	state?: string
+	state?: string | string[]
 ) {
 	const { user, base, merged, onChange } = useContext( GlobalStylesContext );
 
@@ -68,26 +72,51 @@ export function useStyle< T = any >(
 			blockName,
 			shouldDecodeEncode
 		);
-		if ( state ) {
-			return ( rawValue as any )?.[ state ] ?? {};
+		if ( ! state || ( Array.isArray( state ) && state.length === 0 ) ) {
+			return rawValue;
 		}
-		return rawValue;
+		const segments = Array.isArray( state ) ? state : [ state ];
+		let value: any = rawValue;
+		for ( const segment of segments ) {
+			value = value?.[ segment ] ?? {};
+		}
+		return value;
 	}, [ sourceValue, path, blockName, shouldDecodeEncode, state ] );
 
 	const setStyleValue = useCallback(
 		( newValue: T | undefined ) => {
 			let valueToSet: any = newValue;
-			if ( state ) {
-				const fullCurrentValue = getStyle(
+			let segments: string[];
+			if ( Array.isArray( state ) ) {
+				segments = state;
+			} else if ( state ) {
+				segments = [ state ];
+			} else {
+				segments = [];
+			}
+			if ( segments.length > 0 ) {
+				const fullCurrentValue: any = getStyle(
 					user,
 					path,
 					blockName,
 					false
 				);
-				valueToSet = {
-					...( fullCurrentValue as object ),
-					[ state ]: newValue,
-				};
+				if ( segments.length === 1 ) {
+					valueToSet = {
+						...( fullCurrentValue ?? {} ),
+						[ segments[ 0 ] ]: newValue,
+					};
+				} else {
+					// Build nested update for compound states (e.g. ['@current', ':hover']).
+					valueToSet = { ...( fullCurrentValue ?? {} ) };
+					let cursor: any = valueToSet;
+					for ( let i = 0; i < segments.length - 1; i++ ) {
+						const key = segments[ i ];
+						cursor[ key ] = { ...( cursor[ key ] ?? {} ) };
+						cursor = cursor[ key ];
+					}
+					cursor[ segments[ segments.length - 1 ] ] = newValue;
+				}
 			}
 			const newGlobalStyles = setStyle< any >(
 				user,

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -110,24 +110,23 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 	}
 	const prefix = prefixParts.join( '.' );
 
-	// State selector state
-	const [ selectedState, setSelectedState ] = useState< string >( 'default' );
+	// State selector state — empty array means "default" (no state selected).
+	const [ selectedState, setSelectedState ] = useState< string[] >( [] );
 	const validStates = useMemo( () => getValidStates( name ), [ name ] );
 
-	const stateParam = selectedState !== 'default' ? selectedState : undefined;
 	const [ style, setStyle ] = useStyle(
 		prefix,
 		name,
 		'user',
 		false,
-		stateParam
+		selectedState
 	);
 	const [ inheritedStyle ] = useStyle(
 		prefix,
 		name,
 		'merged',
 		false,
-		stateParam
+		selectedState
 	);
 
 	const [ userSettings ] = useSetting( '', name, 'user' );
@@ -334,7 +333,7 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 				name={ name }
 				variation={ variation }
 				selectedState={ selectedState }
-				stateStyles={ selectedState !== 'default' ? style : undefined }
+				stateStyles={ selectedState.length > 0 ? style : undefined }
 			/>
 			{ hasVariationsPanel && (
 				<div className="global-styles-ui-screen-variations">

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -28,8 +28,8 @@ interface ScreenHeaderProps {
 	description?: string | React.ReactElement;
 	onBack?: () => void;
 	states?: StateDefinition[];
-	selectedState?: string;
-	onChangeState?: ( value: string ) => void;
+	selectedState?: string[];
+	onChangeState?: ( value: string[] ) => void;
 }
 
 export function ScreenHeader( {
@@ -37,7 +37,7 @@ export function ScreenHeader( {
 	description,
 	onBack,
 	states,
-	selectedState = 'default',
+	selectedState = [],
 	onChangeState,
 }: ScreenHeaderProps ) {
 	return (

--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -49,6 +49,12 @@ export const VALID_BLOCK_STATES: Record< string, StateDefinition[] > = {
 		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
 		{ value: ':active', label: __( 'Active' ) },
 	],
+	'core/navigation-link': [
+		{ value: ':hover', label: __( 'Hover' ) },
+		{ value: ':focus', label: __( 'Focus' ) },
+		{ value: ':active', label: __( 'Active' ) },
+		{ value: '@current', label: __( 'Current' ) },
+	],
 };
 
 /**

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -25,7 +25,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers a block with `__experimentalStates` support.
+	 * Registers a block with `states` support.
 	 *
 	 * @param string $block_name Block name.
 	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
@@ -39,7 +39,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 				'style' => array( 'type' => 'object' ),
 			),
 			'supports'    => array(
-				'__experimentalStates' => array( ':hover', ':focus', ':active' ),
+				'states' => array( ':hover', ':focus', ':active' ),
 			),
 		);
 		if ( ! empty( $selectors ) ) {
@@ -123,7 +123,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that block content is returned unchanged when `__experimentalStates` support is not declared.
+	 * Tests that block content is returned unchanged when `states` support is not declared.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1,0 +1,532 @@
+<?php
+/**
+ * Tests the states block support.
+ *
+ * @package gutenberg
+ */
+
+class WP_Block_Supports_States_Test extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		if ( $this->test_block_name ) {
+			unregister_block_type( $this->test_block_name );
+		}
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a block with `__experimentalStates` support.
+	 *
+	 * @param string $block_name Block name.
+	 * @param array  $selectors  Optional block selectors (e.g. `['root' => '.foo .bar']`).
+	 * @return WP_Block_Type
+	 */
+	private function register_block_with_states( $block_name, $selectors = array() ) {
+		$this->test_block_name = $block_name;
+		$args                  = array(
+			'api_version' => 3,
+			'attributes'  => array(
+				'style' => array( 'type' => 'object' ),
+			),
+			'supports'    => array(
+				'__experimentalStates' => array( ':hover', ':focus', ':active' ),
+			),
+		);
+		if ( ! empty( $selectors ) ) {
+			$args['selectors'] = $selectors;
+		}
+		register_block_type( $block_name, $args );
+
+		return WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+	}
+
+	/**
+	 * Mirrors the CSS-building logic in gutenberg_render_block_states_support()
+	 * to produce the expected `<style>` tag and unique scoped class name for a
+	 * given map of state => style arrays.
+	 *
+	 * @param array $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
+	 * @return array { style_tag: string, unique_class: string }
+	 */
+	private function build_expected_state_output( $state_styles ) {
+		$css_rules = array();
+		foreach ( $state_styles as $state => $style ) {
+			$compiled = wp_style_engine_get_styles( $style );
+			if ( ! empty( $compiled['css'] ) ) {
+				$css_rules[] = array(
+					'state' => $state,
+					'css'   => $compiled['css'],
+				);
+			}
+		}
+
+		$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
+		$css          = '';
+		foreach ( $css_rules as $rule ) {
+			$declarations = str_replace( ';', ' !important;', $rule['css'] );
+			$css         .= ".$unique_class$rule[state] { $declarations }\n";
+		}
+
+		return array(
+			'style_tag'    => '<style>' . $css . '</style>',
+			'unique_class' => $unique_class,
+		);
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when the block name is missing.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_block_name_missing() {
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => '',
+			'attrs'     => array(),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when content is empty.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_block_content_empty() {
+		$this->register_block_with_states( 'test/states-empty-content' );
+
+		$block = array(
+			'blockName' => 'test/states-empty-content',
+			'attrs'     => array(
+				'style' => array(
+					':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( '', $block );
+
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when `__experimentalStates` support is not declared.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_states_support_not_declared() {
+		$this->test_block_name = 'test/no-states-support';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array( 'type' => 'object' ),
+				),
+				'supports'    => array(),
+			)
+		);
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'test/no-states-support',
+			'attrs'     => array(
+				'style' => array(
+					':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when no state styles are set.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_no_state_styles_set() {
+		$this->register_block_with_states( 'test/states-no-state-style' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'test/states-no-state-style',
+			'attrs'     => array(
+				'style' => array(
+					'color' => array( 'text' => '#000000' ),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that block content is returned unchanged when the state key is an empty array.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_returns_unchanged_when_state_style_is_empty_array() {
+		$this->register_block_with_states( 'test/states-empty-hover' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$block         = array(
+			'blockName' => 'test/states-empty-hover',
+			'attrs'     => array(
+				'style' => array(
+					':hover' => array(),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Tests that hover text color generates a scoped style tag with !important.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_text_color_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-text-color' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'text' => '#e6ffe8' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-hover-text-color',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover background color generates a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_background_color_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-bg-color' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'background' => '#ff00d0' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-hover-bg-color',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover text and background color both appear in a single rule.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_text_and_background_color_in_same_rule() {
+		$this->register_block_with_states( 'test/states-hover-both-colors' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'color' => array(
+					'background' => '#ff00d0',
+					'text'       => '#e6ffe8',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-both-colors',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that a font family stored as a preset reference is resolved to a CSS
+	 * custom property in the generated style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_font_family_preset_reference_generates_css_custom_property() {
+		$this->register_block_with_states( 'test/states-hover-font-family' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'typography' => array( 'fontFamily' => 'var:preset|font-family|heading' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-font-family',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover font size generates a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_font_size_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-font-size' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'typography' => array( 'fontSize' => '1.5rem' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-font-size',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover border width and color generate a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_border_width_and_color_generate_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-border' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'border' => array(
+					'width' => '2px',
+					'color' => '#000000',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-border',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover border radius generates a scoped style tag.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_hover_border_radius_generates_scoped_css() {
+		$this->register_block_with_states( 'test/states-hover-border-radius' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array(
+				'border' => array( 'radius' => '8px' ),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-hover-border-radius',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that multiple states each generate a separate scoped CSS rule.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_multiple_states_generate_separate_css_rules() {
+		$this->register_block_with_states( 'test/states-multiple' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array(
+			':hover' => array( 'color' => array( 'text' => '#ff0000' ) ),
+			':focus' => array( 'color' => array( 'text' => '#00ff00' ) ),
+		);
+		$block         = array(
+			'blockName' => 'test/states-multiple',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the unique scoped class is added to the wrapper element for a
+	 * block with no descendant root selector.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_unique_class_is_added_to_wrapper_when_no_root_selector() {
+		$this->register_block_with_states( 'test/states-wrapper' );
+
+		$block_content = '<div class="wp-block-test">Hello</div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'text' => '#ff0000' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-wrapper',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that the unique scoped class is added to the descendant element (not
+	 * the wrapper) for a block whose `selectors.root` targets a descendant, so
+	 * that `.wp-states-XXXX:hover` matches correctly.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_unique_class_is_added_to_descendant_not_wrapper_when_root_selector_has_descendant() {
+		$this->register_block_with_states(
+			'test/states-descendant',
+			array( 'root' => '.wp-block-button .wp-block-button__link' )
+		);
+
+		$block_content = '<div class="wp-block-button"><a class="wp-block-button__link">Click me</a></div>';
+		$state_styles  = array( ':hover' => array( 'color' => array( 'background' => '#ff00d0' ) ) );
+		$block         = array(
+			'blockName' => 'test/states-descendant',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link ' . $parts['unique_class'] . '">Click me</a></div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Integration test using the exact block markup and style attribute captured
+	 * from a core/button block in the editor with Twenty Twenty-Four theme.
+	 * Covers color, typography (preset font family reference), and class injection
+	 * onto the descendant element.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_button_like_block_with_hover_color_and_font_family_preset() {
+		$this->register_block_with_states(
+			'test/states-button-full',
+			array( 'root' => '.wp-block-button .wp-block-button__link' )
+		);
+
+		$block_content = '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button" style="color:#bdfffb">Button 2 outline</a></div>';
+		$state_styles  = array(
+			':hover' => array(
+				'color'      => array(
+					'background' => '#ff00d0',
+					'text'       => '#e6ffe8',
+				),
+				// Font family is stored as a preset reference by the editor.
+				'typography' => array(
+					'fontFamily' => 'var:preset|font-family|heading',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-button-full',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button ' . $parts['unique_class'] . '" style="color:#bdfffb">Button 2 outline</a></div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that hover border styles on a button-like block are scoped to the
+	 * descendant element.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_button_like_block_with_hover_border() {
+		$this->register_block_with_states(
+			'test/states-button-border',
+			array( 'root' => '.wp-block-button .wp-block-button__link' )
+		);
+
+		$block_content = '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Click</a></div>';
+		$state_styles  = array(
+			':hover' => array(
+				'border' => array(
+					'color' => '#0000ff',
+					'width' => '3px',
+					'style' => 'dashed',
+				),
+			),
+		);
+		$block         = array(
+			'blockName' => 'test/states-button-border',
+			'attrs'     => array( 'style' => $state_styles ),
+		);
+
+		$parts    = $this->build_expected_state_output( $state_styles );
+		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button ' . $parts['unique_class'] . '">Click</a></div>';
+		$actual   = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -484,7 +484,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$block         = array(
+		$block = array(
 			'blockName' => 'test/states-button-full',
 			'attrs'     => array( 'style' => $state_styles ),
 		);

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -52,34 +52,26 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 
 	/**
 	 * Mirrors the CSS-building logic in gutenberg_render_block_states_support()
-	 * to produce the expected `<style>` tag and unique scoped class name for a
-	 * given map of state => style arrays.
+	 * to produce the unique scoped class name for a given map of state => style arrays.
+	 * CSS is now registered with the style engine store rather than injected inline.
 	 *
 	 * @param array $state_styles Map of state to style array (e.g. `[':hover' => ['color' => [...]]]`).
-	 * @return array { style_tag: string, unique_class: string }
+	 * @return array { unique_class: string }
 	 */
 	private function build_expected_state_output( $state_styles ) {
 		$css_rules = array();
 		foreach ( $state_styles as $state => $style ) {
 			$compiled = wp_style_engine_get_styles( $style );
-			if ( ! empty( $compiled['css'] ) ) {
+			if ( ! empty( $compiled['declarations'] ) ) {
 				$css_rules[] = array(
-					'state' => $state,
-					'css'   => $compiled['css'],
+					'state'        => $state,
+					'declarations' => $compiled['declarations'],
 				);
 			}
 		}
 
-		$unique_class = 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 );
-		$css          = '';
-		foreach ( $css_rules as $rule ) {
-			$declarations = str_replace( ';', ' !important;', $rule['css'] );
-			$css         .= ".$unique_class$rule[state] { $declarations }\n";
-		}
-
 		return array(
-			'style_tag'    => '<style>' . $css . '</style>',
-			'unique_class' => $unique_class,
+			'unique_class' => 'wp-states-' . substr( md5( wp_json_encode( $css_rules ) ), 0, 8 ),
 		);
 	}
 
@@ -202,7 +194,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that hover text color generates a scoped style tag with !important.
+	 * Tests that hover text color generates scoped CSS with !important.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -217,14 +209,14 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Tests that hover background color generates a scoped style tag.
+	 * Tests that hover background color generates scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -239,7 +231,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -268,7 +260,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -295,14 +287,14 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Tests that hover font size generates a scoped style tag.
+	 * Tests that hover font size generates scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -321,7 +313,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -350,14 +342,14 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Tests that hover border radius generates a scoped style tag.
+	 * Tests that hover border radius generates scoped CSS.
 	 *
 	 * @covers ::gutenberg_render_block_states_support
 	 */
@@ -376,7 +368,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -401,7 +393,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -424,7 +416,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
+		$expected = '<div class="wp-block-test ' . $parts['unique_class'] . '">Hello</div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -451,7 +443,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link ' . $parts['unique_class'] . '">Click me</a></div>';
+		$expected = '<div class="wp-block-button"><a class="wp-block-button__link ' . $parts['unique_class'] . '">Click me</a></div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -490,7 +482,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button ' . $parts['unique_class'] . '" style="color:#bdfffb">Button 2 outline</a></div>';
+		$expected = '<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-accent-4-background-color has-text-color has-background has-link-color wp-element-button ' . $parts['unique_class'] . '" style="color:#bdfffb">Button 2 outline</a></div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );
@@ -524,7 +516,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 
 		$parts    = $this->build_expected_state_output( $state_styles );
-		$expected = $parts['style_tag'] . '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button ' . $parts['unique_class'] . '">Click</a></div>';
+		$expected = '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button ' . $parts['unique_class'] . '">Click</a></div>';
 		$actual   = gutenberg_render_block_states_support( $block_content, $block );
 
 		$this->assertSame( $expected, $actual );

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -608,6 +608,13 @@
 						}
 					}
 				},
+				"states": {
+					"description": "An array of interactive pseudo-states (e.g. \":hover\", \":focus\", \":active\") for which the block supports per-instance style overrides. Custom state keys are also supported for future extensibility.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"shadow": {
 					"description": "Allow blocks to define a box shadow.",
 					"oneOf": [


### PR DESCRIPTION
WIP

Built with https://github.com/WordPress/gutenberg/pull/76491 as a base to test implementing current + pseudo states on the nav link block. In the specific case of the nav link block up until know we have styled hover (and others) using the link element, not directly on the block. For the purposes of testing, I have changed that on this pr, since we don't have other blocks we can test @current on yet. This PR could be changed to affect the tabs or accordion blocks instead /cc @mikachan 

AI summary:

  UI (state selection dropdown — multi-select with compound support):
  - state-control.js — Rewritten as multi-select with grouped sections ("States" and "Item"), value: string[], handles compound
  selections
  - states.js — Added @current support, isPseudoState/isCustomState helpers, CUSTOM_STATE_LABELS

  Block instance styling (single block inspector):
  - use-block-style.js — state param now accepts string | string[]; compound state arrays navigate nested paths
  - utils.js — buildStateResetAllFilter accepts string | string[]; uses getValueFromObjectPath/setImmutably for nested compound state
  resets
  - style.js — selectedState changed from 'default' to []; all checks updated; canvas preview uses getValueFromObjectPath; editor CSS
  generation skips @current (requires runtime context)
  - Panel hooks (color, border, typography, dimensions, background) — selectedState default and isStateSelected checks updated

  Global Styles UI:
  - utils.ts — core/navigation-link added to VALID_BLOCK_STATES with :hover, :focus, :active, @current
  - hooks.ts — useStyle accepts state?: string | string[]; reads/writes nested compound state paths
  - screen-block.tsx — selectedState is now string[]; passed directly to useStyle
  - screen-header.tsx / block-preview-panel.tsx — Types updated to string[]

  Block declaration:
  - navigation-link/block.json — states support + style attribute declared

  PHP (frontend CSS):
  - lib/block-supports/states.php — Extended to handle @current custom states via selectors.states, and compound states nested at
  style['@current'][':hover']; generates .wp-states-X.current-menu-item { ... } and .wp-states-X.current-menu-item:hover { ... }.
  ~~Inline <style> tags~~ → now uses the style engine store (context: block-supports, matching layout.php/position.php) for
  deduplication and consolidated output. !important scoped to only the 6 CSS properties that have preset utility class conflicts.