### PR TITLE
RTC: Fix collaborator cursor rendering in table cells

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -631,6 +631,7 @@ const Cell = memo( function ( {
 			) }
 		>
 			<RichText
+				identifier={ `${ name }[${ rowIndex }].cells[${ columnIndex }].content` }
 				value={ content }
 				onChange={ onChange }
 				onFocus={ () => {

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -224,7 +224,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	 * Resolve a selection state to a text index and block client ID.
 	 *
 	 * For text-based selections, navigates up from the resolved Y.Text via
-	 * AbstractType.parent to find the containing block, then resolves the
+	 * parent chain to find the containing block, then resolves the
 	 * local clientId via the block's tree path.
 	 * For WholeBlock selections, resolves the block's relative position and
 	 * then finds the local clientId via tree path.
@@ -234,14 +234,19 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 	 * clientIds (e.g. in "Show Template" mode where blocks are cloned).
 	 *
 	 * @param selection - The selection state.
-	 * @return The rich-text offset and block client ID, or nulls if not resolvable.
+	 * @return The rich-text offset, block client ID, and attribute key path.
 	 */
 	public convertSelectionStateToAbsolute( selection: SelectionState ): {
 		richTextOffset: number | null;
 		localClientId: string | null;
+		attributeKey: string | null;
 	} {
 		if ( selection.type === SelectionType.None ) {
-			return { richTextOffset: null, localClientId: null };
+			return {
+				richTextOffset: null,
+				localClientId: null,
+				attributeKey: null,
+			};
 		}
 
 		if ( selection.type === SelectionType.WholeBlock ) {
@@ -264,7 +269,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 				}
 			}
 
-			return { richTextOffset: null, localClientId };
+			return { richTextOffset: null, localClientId, attributeKey: null };
 		}
 
 		// Text-based selections: resolve cursor position and navigate up.
@@ -279,13 +284,57 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 		);
 
 		if ( ! absolutePosition ) {
-			return { richTextOffset: null, localClientId: null };
+			return {
+				richTextOffset: null,
+				localClientId: null,
+				attributeKey: null,
+			};
 		}
 
-		// Navigate up: Y.Text -> attributes Y.Map -> block Y.Map
-		const yType = absolutePosition.type.parent?.parent;
-		const path =
-			yType instanceof Y.Map ? getBlockPathInYdoc( yType ) : null;
+		// Navigate up from Y.Text to find the block and its attribute path.
+		let current: Y.AbstractType< any > | null = absolutePosition.type;
+		let blockMap: Y.Map< unknown > | null = null;
+		const pathParts: string[] = [];
+		let pendingIndex: number | null = null;
+
+		while ( current && current.parent ) {
+			const parent = current.parent;
+			if ( parent instanceof Y.Map ) {
+				let foundKey: string | null = null;
+				for ( const key of parent.keys() ) {
+					if ( parent.get( key ) === current ) {
+						foundKey = key;
+						break;
+					}
+				}
+
+				if ( foundKey ) {
+					if (
+						foundKey === 'attributes' &&
+						parent.has( 'clientId' )
+					) {
+						blockMap = parent;
+						break;
+					}
+					let part = foundKey;
+					if ( pendingIndex !== null ) {
+						part += `[${ pendingIndex }]`;
+						pendingIndex = null;
+					}
+					pathParts.unshift( part );
+				}
+			} else if ( parent instanceof Y.Array ) {
+				for ( let i = 0; i < parent.length; i++ ) {
+					if ( parent.get( i ) === current ) {
+						pendingIndex = i;
+						break;
+					}
+				}
+			}
+			current = parent;
+		}
+
+		const path = blockMap ? getBlockPathInYdoc( blockMap ) : null;
 		const localClientId = path ? resolveBlockClientIdByPath( path ) : null;
 
 		return {
@@ -294,6 +343,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 				absolutePosition.index
 			),
 			localClientId,
+			attributeKey: pathParts.join( '.' ) || null,
 		};
 	}
 

--- a/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
@@ -295,6 +295,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 			expect( result.current( mockSelection ) ).toEqual( {
 				richTextOffset: null,
 				localClientId: null,
+				attributeKey: null,
 			} );
 		} );
 
@@ -309,6 +310,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 			mockAwareness.convertSelectionStateToAbsolute.mockReturnValue( {
 				richTextOffset: 10,
 				localClientId: 'block-1',
+				attributeKey: 'content',
 			} );
 
 			const { result } = renderHook( () =>
@@ -323,6 +325,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 			expect( position ).toEqual( {
 				richTextOffset: 10,
 				localClientId: 'block-1',
+				attributeKey: 'content',
 			} );
 		} );
 	} );

--- a/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/use-post-editor-awareness-state.ts
@@ -27,6 +27,7 @@ interface AwarenessState {
 const defaultResolvedSelection: ResolvedSelection = {
 	richTextOffset: null,
 	localClientId: null,
+	attributeKey: null,
 };
 
 const defaultState: AwarenessState = {

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -135,4 +135,5 @@ export type SelectionState =
 export interface ResolvedSelection {
 	richTextOffset: number | null;
 	localClientId: string | null;
+	attributeKey: string | null;
 }

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -148,6 +148,52 @@ export function getSelectionState(
 }
 
 /**
+ * Navigate a Yjs type hierarchy by a string path, supporting both Map keys
+ * and Array indices.
+ *
+ * Example: "body[0].cells[0].content"
+ *
+ * @param root - The starting Yjs type.
+ * @param path - The string path to navigate.
+ * @return The Yjs type at the path, or undefined if not found.
+ */
+function getYjsValueByPath(
+	root: Y.AbstractType< any >,
+	path: string
+): Y.AbstractType< any > | undefined {
+	const parts = path.split( '.' );
+	let current: any = root;
+
+	for ( const part of parts ) {
+		// Handle array access like "body[0]"
+		const arrayMatch = part.match( /^(.+)\[(\d+)\]$/ );
+		if ( arrayMatch ) {
+			const [ , key, index ] = arrayMatch;
+			if ( ! ( current instanceof Y.Map ) ) {
+				return undefined;
+			}
+			current = current.get( key );
+			if ( ! ( current instanceof Y.Array ) ) {
+				return undefined;
+			}
+			current = current.get( parseInt( index, 10 ) );
+		} else {
+			// Handle simple Map key
+			if ( ! ( current instanceof Y.Map ) ) {
+				return undefined;
+			}
+			current = current.get( part );
+		}
+
+		if ( ! current ) {
+			return undefined;
+		}
+	}
+
+	return current instanceof Y.AbstractType ? current : undefined;
+}
+
+/**
  * Get the cursor position from a selection.
  *
  * @param selection - The selection.
@@ -169,7 +215,14 @@ function getCursorPosition(
 	}
 
 	const attributes = block.get( 'attributes' );
-	const currentYText = attributes?.get( selection.attributeKey );
+	if ( ! attributes ) {
+		return null;
+	}
+
+	const currentYText = getYjsValueByPath(
+		attributes,
+		selection.attributeKey
+	);
 
 	// If the attribute is not a Y.Text, return null.
 	if ( ! ( currentYText instanceof Y.Text ) ) {

--- a/packages/editor/src/components/collaborators-overlay/compute-selection.ts
+++ b/packages/editor/src/components/collaborators-overlay/compute-selection.ts
@@ -92,7 +92,8 @@ function computeCursorOnly(
 			start.richTextOffset,
 			blockElement,
 			overlayContext.editorDocument,
-			overlayContext.overlayRect
+			overlayContext.overlayRect,
+			start.attributeKey
 		),
 	};
 }
@@ -150,7 +151,8 @@ function computeTextSelection(
 				activeEnd.richTextOffset,
 				activeEndBlock,
 				overlayContext.editorDocument,
-				overlayContext.overlayRect
+				overlayContext.overlayRect,
+				activeEnd.attributeKey
 			),
 			selectionRects: allRects,
 		};
@@ -167,7 +169,8 @@ function computeTextSelection(
 			start.richTextOffset,
 			startBlock,
 			overlayContext.editorDocument,
-			overlayContext.overlayRect
+			overlayContext.overlayRect,
+			start.attributeKey
 		),
 	};
 }
@@ -203,7 +206,8 @@ function computeSingleBlockRects(
 				start.richTextOffset,
 				end.richTextOffset,
 				overlayContext.editorDocument,
-				overlayContext.overlayRect
+				overlayContext.overlayRect,
+				start.attributeKey
 			) ?? [],
 		blockElement,
 	};
@@ -265,7 +269,8 @@ function computeMultiBlockRects(
 		docFirst.richTextOffset,
 		Number.MAX_SAFE_INTEGER,
 		overlayContext.editorDocument,
-		overlayContext.overlayRect
+		overlayContext.overlayRect,
+		docFirst.attributeKey
 	);
 	if ( startRects ) {
 		allRects.push( ...startRects );
@@ -292,7 +297,8 @@ function computeMultiBlockRects(
 		0,
 		docLast.richTextOffset,
 		overlayContext.editorDocument,
-		overlayContext.overlayRect
+		overlayContext.overlayRect,
+		docLast.attributeKey
 	);
 	if ( endRects ) {
 		allRects.push( ...endRects );

--- a/packages/editor/src/components/collaborators-overlay/cursor-dom-utils.ts
+++ b/packages/editor/src/components/collaborators-overlay/cursor-dom-utils.ts
@@ -20,13 +20,15 @@ const MAX_NODE_OFFSET_COUNT = 500;
  * @param blockElement          - The block element (or null if deleted)
  * @param editorDocument        - The editor document
  * @param overlayRect           - Pre-computed bounding rect of the overlay element
+ * @param attributeKey          - Optional attribute key to find a specific RichText area
  * @return The position of the cursor
  */
 export const getCursorPosition = (
 	absolutePositionIndex: number | null,
 	blockElement: HTMLElement | null,
 	editorDocument: Document,
-	overlayRect: DOMRect
+	overlayRect: DOMRect,
+	attributeKey: string | null = null
 ): CursorCoords | null => {
 	if ( absolutePositionIndex === null || ! blockElement ) {
 		return null;
@@ -37,7 +39,8 @@ export const getCursorPosition = (
 			blockElement,
 			absolutePositionIndex,
 			editorDocument,
-			overlayRect
+			overlayRect,
+			attributeKey
 		) ?? null
 	);
 };
@@ -49,18 +52,21 @@ export const getCursorPosition = (
  * @param charOffset     - The character offset
  * @param editorDocument - The editor document
  * @param overlayRect    - Pre-computed bounding rect of the overlay element
+ * @param attributeKey   - Optional attribute key to find a specific RichText area
  * @return The position of the cursor
  */
 const getOffsetPositionInBlock = (
 	blockElement: HTMLElement,
 	charOffset: number,
 	editorDocument: Document,
-	overlayRect: DOMRect
+	overlayRect: DOMRect,
+	attributeKey: string | null = null
 ) => {
 	const { node, offset } = findInnerBlockOffset(
 		blockElement,
 		charOffset,
-		editorDocument
+		editorDocument,
+		attributeKey
 	);
 
 	const cursorRange = editorDocument.createRange();
@@ -117,6 +123,7 @@ const getOffsetPositionInBlock = (
  * @param endOffset      - End character offset within the block
  * @param editorDocument - The editor document
  * @param overlayRect    - Pre-computed bounding rect of the overlay element
+ * @param attributeKey   - Optional attribute key to find a specific RichText area
  * @return Array of selection rectangles relative to the overlay, or null on failure
  */
 export const getSelectionRects = (
@@ -124,7 +131,8 @@ export const getSelectionRects = (
 	startOffset: number,
 	endOffset: number,
 	editorDocument: Document,
-	overlayRect: DOMRect
+	overlayRect: DOMRect,
+	attributeKey: string | null = null
 ): SelectionRect[] | null => {
 	// Normalize direction.
 	let normalizedStart = startOffset;
@@ -136,12 +144,14 @@ export const getSelectionRects = (
 	const startPos = findInnerBlockOffset(
 		blockElement,
 		normalizedStart,
-		editorDocument
+		editorDocument,
+		attributeKey
 	);
 	const endPos = findInnerBlockOffset(
 		blockElement,
 		normalizedEnd,
-		editorDocument
+		editorDocument,
+		attributeKey
 	);
 
 	const range = editorDocument.createRange();
@@ -284,15 +294,28 @@ export const getBlocksBetween = (
  * @param blockElement   - The block element
  * @param offset         - The character offset
  * @param editorDocument - The editor document
+ * @param attributeKey   - Optional attribute key to find a specific RichText area
  * @return The node and offset of the character at the offset
  */
 export const findInnerBlockOffset = (
 	blockElement: HTMLElement,
 	offset: number,
-	editorDocument: Document
+	editorDocument: Document,
+	attributeKey: string | null = null
 ) => {
+	let root: HTMLElement = blockElement;
+
+	if ( attributeKey ) {
+		const richTextElement = blockElement.querySelector< HTMLElement >(
+			`[data-wp-block-attribute-key="${ attributeKey }"]`
+		);
+		if ( richTextElement ) {
+			root = richTextElement;
+		}
+	}
+
 	const treeWalker = editorDocument.createTreeWalker(
-		blockElement,
+		root,
 		NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT // eslint-disable-line no-bitwise
 	);
 
@@ -310,7 +333,7 @@ export const findInnerBlockOffset = (
 			if ( lastTextNode ) {
 				return { node: lastTextNode, offset: 0 };
 			}
-			return { node: blockElement, offset: 0 };
+			return { node: root, offset: 0 };
 		}
 
 		const nodeLength = node.nodeValue?.length ?? 0;
@@ -333,7 +356,7 @@ export const findInnerBlockOffset = (
 						};
 					}
 					// Just in case, if there's no last text node, return the beginning of the block.
-					return { node: blockElement, offset: 0 };
+					return { node: root, offset: 0 };
 				}
 
 				// The <br> is before the target offset. Count it as a single character.
@@ -368,7 +391,7 @@ export const findInnerBlockOffset = (
 	}
 
 	// We didn't find any text nodes. Return the beginning of the block.
-	return { node: blockElement, offset: 0 };
+	return { node: root, offset: 0 };
 };
 
 /**

--- a/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
+++ b/packages/editor/src/components/collaborators-overlay/use-render-cursors.ts
@@ -106,6 +106,7 @@ export function useRenderCursors(
 			let start: ResolvedSelection = {
 				richTextOffset: null,
 				localClientId: null,
+				attributeKey: null,
 			};
 			let end: ResolvedSelection | undefined;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #76812 <!-- #ISSUE-NUMBER or URL -->

This PR fixes an issue where collaborator cursors fail to render in Table block cells during a Real-Time Collaboration (RTC) session. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Depth Failure: To get the block Y.Map the code checked 2 levels: `Y.Text -> attributes Y.Map -> block Y.Map`. While this works for other blocks, Table text is buried much deeper (inside Rows and Cells). The original logic would stop too early, fail to find the block ID, and return null.
-  No Cell Identity: The individual Table cells didn't have a unique ID in the HTML (No identifier). This meant the cursor overlay had no way to know which cell a user was typing in.
- Offset Errors: Searching the entire table instead of a specific cell caused character counts to shift, making cursors appear in the wrong position or vanish


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated the selection flow to handle deep nesting:
-  In `post-editor-awareness.ts`  replaced the fixed 2-level check with a while loop. This loop walks up the data tree until it finds the block ID.
- Added a unique identifier to each Table cell's RichText component. This adds a `data-wp-block-attribute-key` to the HTML so the cell can be identified. 
- Added function `getYjsValueByPath`  to get the Y.Text object  for that specific cell using the attributetKey like `body[0].cells[1].content`.
-  Updated the rendering logic in `cursor-dom-utils.ts` to use the `attributeKey`. Instead of searching the whole table, it now jumps directly to the specific cell element before counting characters.
- Updated the `ResolvedSelection` type and the selection resolver to include the `attributeKey`, ensuring the cell's address is passed correctly.
   

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
   1. Open a post in two different browser windows.
   2. Add a Table block and create a few rows and columns.
   3. In Window A, click into any cell and start typing.
   4. Verify: In Window B, the colored cursor for User A should appear exactly in the correct cell.
   5. Move to different cells and verify the cursor follows accurately to each one.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/76754a2c-5780-4689-92da-e4ba2acf0961" > | <video src= "https://github.com/user-attachments/assets/7542f12a-945b-4474-a3b7-bc46c6dc73cd" > |


## Use of AI Tools
Drafted with Gemini assistance and reviewed it before submission
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
