### PR TITLE
fix: update breadcrumb logic to simplify taxonomy term handling

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -38,51 +38,49 @@ export default function BreadcrumbEdit( {
 		prefersTaxonomy,
 		showOnHomePage,
 	} = attributes;
-	const {
-		post,
-		postTypeHasTaxonomies,
-		hasTermsAssigned,
-		isLoading,
-	} = useSelect(
-		( select ) => {
-			if ( ! postType ) {
-				return {};
-			}
-			const _post = select( coreStore ).getEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			const postTypeObject = select( coreStore ).getPostType( postType );
-			const _postTypeHasTaxonomies =
-				postTypeObject && postTypeObject.taxonomies.length;
-			let taxonomies;
-			if ( _postTypeHasTaxonomies ) {
-				taxonomies = select( coreStore ).getTaxonomies( {
-					type: postType,
-					per_page: -1,
-				} );
-			}
-			return {
-				post: _post,
-				postTypeHasTaxonomies: _postTypeHasTaxonomies,
-				hasTermsAssigned:
-					_post &&
-					( taxonomies || [] )
-						.filter(
-							( { visibility } ) => visibility?.publicly_queryable
-						)
-						.some( ( taxonomy ) => {
-							return !! _post[ taxonomy.rest_base ]?.length;
-						} ),
-				isLoading:
-					( postId && ! _post ) ||
-					! postTypeObject ||
-					( _postTypeHasTaxonomies && ! taxonomies ),
-			};
-		},
-		[ postType, postId ]
-	);
+	const { post, postTypeHasTaxonomies, hasTermsAssigned, isLoading } =
+		useSelect(
+			( select ) => {
+				if ( ! postType ) {
+					return {};
+				}
+				const _post = select( coreStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				const postTypeObject =
+					select( coreStore ).getPostType( postType );
+				const _postTypeHasTaxonomies =
+					postTypeObject && postTypeObject.taxonomies.length;
+				let taxonomies;
+				if ( _postTypeHasTaxonomies ) {
+					taxonomies = select( coreStore ).getTaxonomies( {
+						type: postType,
+						per_page: -1,
+					} );
+				}
+				return {
+					post: _post,
+					postTypeHasTaxonomies: _postTypeHasTaxonomies,
+					hasTermsAssigned:
+						_post &&
+						( taxonomies || [] )
+							.filter(
+								( { visibility } ) =>
+									visibility?.publicly_queryable
+							)
+							.some( ( taxonomy ) => {
+								return !! _post[ taxonomy.rest_base ]?.length;
+							} ),
+					isLoading:
+						( postId && ! _post ) ||
+						! postTypeObject ||
+						( _postTypeHasTaxonomies && ! taxonomies ),
+				};
+			},
+			[ postType, postId ]
+		);
 
 	/**
 	 * Counter used to cache-bust `useServerSideRender`.

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -40,7 +40,6 @@ export default function BreadcrumbEdit( {
 	} = attributes;
 	const {
 		post,
-		isPostTypeHierarchical,
 		postTypeHasTaxonomies,
 		hasTermsAssigned,
 		isLoading,
@@ -66,7 +65,6 @@ export default function BreadcrumbEdit( {
 			}
 			return {
 				post: _post,
-				isPostTypeHierarchical: postTypeObject?.hierarchical,
 				postTypeHasTaxonomies: _postTypeHasTaxonomies,
 				hasTermsAssigned:
 					_post &&
@@ -140,16 +138,12 @@ export default function BreadcrumbEdit( {
 	}
 
 	// Try to determine breadcrumb type for more accurate previews.
+	// Whether to show taxonomy terms is always controlled by the attribute.
+	// Post types without any taxonomies can only use a hierarchical ancestor trail.
 	let _showTerms;
-	// Some non-hierarchical post types (e.g., attachments) can have parents.
-	// Use hierarchical breadcrumbs if a parent exists, otherwise use taxonomy breadcrumbs.
-	if ( ! isPostTypeHierarchical && ! post?.parent ) {
-		_showTerms = true;
-	} else if ( ! postTypeHasTaxonomies ) {
-		// Hierarchical post type without taxonomies can only use ancestors.
+	if ( ! postTypeHasTaxonomies ) {
 		_showTerms = false;
 	} else {
-		// For hierarchical post types with taxonomies, use the attribute.
 		_showTerms = prefersTaxonomy;
 	}
 	let placeholder = null;
@@ -162,7 +156,6 @@ export default function BreadcrumbEdit( {
 		// This is needed because when we are showing the template in post editor we
 		// want to show the real breadcrumbs if we have the post type.
 		( templateSlug && ! postType ) ||
-		( ! _showTerms && ! isPostTypeHierarchical ) ||
 		( _showTerms && ! hasTermsAssigned );
 	if ( showPlaceholder ) {
 		const placeholderItems = [];
@@ -294,13 +287,13 @@ export default function BreadcrumbEdit( {
 					) }
 				/>
 				<CheckboxControl
-					label={ __( 'Prefer taxonomy terms' ) }
+					label={ __( 'Show taxonomy terms' ) }
 					checked={ prefersTaxonomy }
 					onChange={ ( value ) =>
 						setAttributes( { prefersTaxonomy: value } )
 					}
 					help={ __(
-						'The exact type of breadcrumbs shown will vary automatically depending on the page in which this block is displayed. In the specific case of a hierarchical post type with taxonomies, the breadcrumbs can either reflect its post hierarchy (default) or the hierarchy of its assigned taxonomy terms.'
+						'When enabled, taxonomy terms (e.g. categories) are included in the breadcrumb trail. For hierarchical post types, this replaces the default post ancestor hierarchy with the taxonomy term hierarchy.'
 					) }
 				/>
 			</InspectorControls>

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -104,12 +104,11 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		}
 
 		// Determine breadcrumb type.
-		// Some non-hierarchical post types (e.g., attachments) can have parents.
-		// Use hierarchical breadcrumbs if a parent exists, otherwise use taxonomy breadcrumbs.
-		$show_terms = false;
-		if ( ! is_post_type_hierarchical( $post_type ) && ! $post_parent ) {
-			$show_terms = true;
-		} elseif ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
+		// Post types with no registered taxonomies can only use a hierarchical ancestor
+		// trail (or none, for non-hierarchical types). For all other cases, whether to
+		// include taxonomy terms is controlled by the 'prefersTaxonomy' attribute, which
+		// defaults to false so terms are hidden by default on singular post templates.
+		if ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
 			$show_terms = false;
 		} else {
 			$show_terms = $attributes['prefersTaxonomy'];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #75389

Add a "Show taxonomy terms" toggle to the Breadcrumbs block that controls whether taxonomy terms (e.g. categories) appear in the breadcrumb trail on singular post templates. Terms are now hidden by default.

## Why?
When a post had an assigned hierarchical taxonomy (e.g. a category), the Breadcrumbs block would unconditionally include the term in the trail (e.g. `Home / Blog / Category / Post Title`). There was no way for users to remove this term from within the editor, and the `prefersTaxonomy` attribute — which was intended to opt in to term-based breadcrumbs — had no effect for non-hierarchical post types because terms were always forced on.

## How?
**PHP (`index.php`):** Removed the branch that forced `$show_terms = true` for non-hierarchical post types (e.g. regular posts). Now `$show_terms` is uniformly determined by `$attributes['prefersTaxonomy']` (default: `false`) for all post types that have registered taxonomies. Post types with no taxonomies continue to use the hierarchical ancestor trail.

**JS (`edit.js`):** Mirrored the same logic in the editor preview. `_showTerms` now always follows `prefersTaxonomy` regardless of post type hierarchy. Removed the `( ! _showTerms && ! isPostTypeHierarchical )` condition from `showPlaceholder` (which incorrectly forced a placeholder for non-hierarchical types) and removed the now-unused `isPostTypeHierarchical` selector value.

**UI:** Renamed the inspector control from "Prefer taxonomy terms" → "Show taxonomy terms" with updated help text reflecting that the setting now applies to all post types, not just as a tie-breaker for hierarchical ones.

## Testing Instructions

1. Activate a block theme (e.g. Twenty Twenty-Five).
2. Go to **Posts → Add New**, create a post, and assign it one or more categories.
3. Open the **Single Post** template (Site Editor → Templates → Single Post).
4. Insert the **Breadcrumbs** block.
5. Preview the post — breadcrumbs should read `Home / Blog / Post Title` with **no category** in between.
6. In the block inspector under **Advanced**, check **Show taxonomy terms**.
7. Preview again — breadcrumbs should now read `Home / Blog / Category / Post Title`.
8. Repeat steps 2–7 with a custom non-hierarchical post type that has an assigned taxonomy to verify consistent behaviour.
9. Verify that a **hierarchical post type** (e.g. Pages) with no `prefersTaxonomy` still shows the ancestor hierarchy (Page Parent / Page Title) unchanged.

### Testing Instructions for Keyboard

1. Focus the Breadcrumbs block in the editor.
2. Open the block inspector with `Tab` / `Shift+Tab`.
3. Navigate to the **Advanced** panel and expand it with `Enter`.
4. Tab to the **Show taxonomy terms** checkbox and toggle it with `Space`.
5. Confirm the editor preview updates accordingly.

## Screenshots or screencast

|Before|After|
|-|-|
|`Home / Blog / Category / Post Title` (term always present, no way to remove)|`Home / Blog / Post Title` (default) — term shown only when "Show taxonomy terms" is enabled|
| <img width="252" height="204" alt="image" src="https://github.com/user-attachments/assets/d3f09419-e2f0-4965-b800-1bcce26ba761" /> | <img width="255" height="155" alt="image" src="https://github.com/user-attachments/assets/156757bb-cf14-4011-aa11-77ce26cf8f17" /> |
| <img width="339" height="70" alt="image" src="https://github.com/user-attachments/assets/26eded2a-5848-4554-a144-1d046de24ccd" /> | <img width="263" height="43" alt="image" src="https://github.com/user-attachments/assets/03358ae1-a4f6-4cdd-b835-9617416b32b6" /> |


## Use of AI Tools

This PR was authored with the assistance of GitHub Copilot (Claude Sonnet 4.6) for code generation and review. All changes were reviewed and validated by the contributor.