### PR TITLE
Global Styles: Add support for background images via URL

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -12,6 +12,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
 	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
 	DropZone,
 	FlexBlock,
 	FocalPointPicker,
@@ -265,6 +266,58 @@ function LoadingSpinner() {
 		</Placeholder>
 	);
 }
+function BackgroundImageURLInput( { url, onApply, onClose } ) {
+	const [ inputValue, setInputValue ] = useState( url ?? '' );
+
+	const handleApply = () => {
+		onApply( inputValue );
+		onClose();
+	};
+
+	const handleKeyDown = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			handleApply();
+		}
+		if ( event.key === 'Escape' ) {
+			onClose();
+		}
+	};
+
+	return (
+		<VStack
+			spacing={ 3 }
+			className="block-editor-global-styles-background-panel__url-input-container"
+		>
+			<InputControl
+				label={ __( 'Image URL' ) }
+				value={ inputValue }
+				placeholder={ __( 'Paste or type URL' ) }
+				onChange={ ( val ) => setInputValue( val ?? '' ) }
+				onKeyDown={ handleKeyDown }
+				type="url"
+				size="__unstable-large"
+			/>
+			<HStack justify="flex-start" spacing={ 2 }>
+				<Button
+					variant="primary"
+					onClick={ handleApply }
+					disabled={ ! inputValue }
+					accessibleWhenDisabled
+					__next40pxDefaultSize
+				>
+					{ __( 'Apply' ) }
+				</Button>
+				<Button
+					variant="tertiary"
+					onClick={ onClose }
+					__next40pxDefaultSize
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}
 
 function BackgroundImageControls( {
 	onChange,
@@ -277,6 +330,10 @@ function BackgroundImageControls( {
 	containerRef,
 } ) {
 	const [ isUploading, setIsUploading ] = useState( false );
+
+	// Controls visibility of the inline URL input, replacing MediaReplaceFlow.
+	const [ isURLInputVisible, setIsURLInputVisible ] = useState( false );
+
 	const { getSettings } = useSelect( blockEditorStore );
 
 	const { id, title, url } = style?.background?.backgroundImage || {
@@ -353,6 +410,31 @@ function BackgroundImageControls( {
 		focusToggleButton( containerRef );
 	};
 
+	/**
+	 * Handles applying a URL-sourced background image.
+	 * Stored as `{ url, source: 'url' }` with no `id`, distinguishing it
+	 * from a media-library image (`{ id, url, source: 'file' }`).
+	 *
+	 * @param {string} newURL The URL entered by the user.
+	 */
+	const onSelectURL = ( newURL ) => {
+		if ( ! newURL ) {
+			resetBackgroundImage();
+			return;
+		}
+		onChange(
+			setImmutably( style, [ 'background' ], {
+				...style?.background,
+				backgroundImage: {
+					url: newURL,
+					source: 'url',
+				},
+			} )
+		);
+		// Focus the toggle button after applying, same as onSelectMedia.
+		focusToggleButton( containerRef );
+	};
+
 	// Drag and drop callback, restricting image to one.
 	const onFilesDrop = ( filesList ) => {
 		getSettings().mediaUpload( {
@@ -375,51 +457,77 @@ function BackgroundImageControls( {
 			} )
 		);
 	const canRemove = ! hasValue && hasBackgroundImageValue( inheritedValue );
+
+	// Resolve current URL regardless of storage format.
+	const currentURL =
+		typeof style?.background?.backgroundImage === 'string'
+			? style.background.backgroundImage
+			: style?.background?.backgroundImage?.url;
+
 	const imgLabel = title || getFilename( url ) || __( 'Image' );
 
 	return (
 		<div className="block-editor-global-styles-background-panel__image-tools-panel-item">
 			{ isUploading && <LoadingSpinner /> }
-			<MediaReplaceFlow
-				mediaId={ id }
-				mediaURL={ url }
-				allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
-				accept="image/*"
-				onSelect={ onSelectMedia }
-				popoverProps={ {
-					className: clsx( {
-						'block-editor-global-styles-background-panel__media-replace-popover':
-							displayInPanel,
-					} ),
-				} }
-				name={
-					<InspectorImagePreviewItem
-						imgUrl={ url }
-						filename={ title }
-						label={ imgLabel }
-					/>
-				}
-				renderToggle={ ( props ) => (
-					<Button { ...props } __next40pxDefaultSize />
-				) }
-				onError={ onUploadError }
-				onReset={ () => {
-					focusToggleButton( containerRef );
-					onResetImage();
-				} }
-			>
-				{ canRemove && (
-					<MenuItem
-						onClick={ () => {
-							focusToggleButton( containerRef );
-							onRemove();
-							onRemoveImage();
-						} }
-					>
-						{ __( 'Remove' ) }
+			{ isURLInputVisible ? (
+				/*
+				 * Replace the MediaReplaceFlow button with the inline URL
+				 * input when the user clicks "Use image URL".
+				 */
+				<BackgroundImageURLInput
+					url={ currentURL }
+					onApply={ onSelectURL }
+					onClose={ () => setIsURLInputVisible( false ) }
+				/>
+			) : (
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ url }
+					allowedTypes={ [ IMAGE_BACKGROUND_TYPE ] }
+					accept="image/*"
+					onSelect={ onSelectMedia }
+					popoverProps={ {
+						className: clsx( {
+							'block-editor-global-styles-background-panel__media-replace-popover':
+								displayInPanel,
+						} ),
+					} }
+					name={
+						<InspectorImagePreviewItem
+							imgUrl={ url }
+							filename={ title }
+							label={ imgLabel }
+						/>
+					}
+					renderToggle={ ( props ) => (
+						<Button { ...props } __next40pxDefaultSize />
+					) }
+					onError={ onUploadError }
+					onReset={ () => {
+						focusToggleButton( containerRef );
+						onResetImage();
+					} }
+				>
+					{ /*
+					 * "Use image URL" appears in the MediaReplaceFlow popover
+					 * alongside Upload / Media Library options.
+					 */ }
+					<MenuItem onClick={ () => setIsURLInputVisible( true ) }>
+						{ __( 'Use image URL' ) }
 					</MenuItem>
-				) }
-			</MediaReplaceFlow>
+					{ canRemove && (
+						<MenuItem
+							onClick={ () => {
+								focusToggleButton( containerRef );
+								onRemove();
+								onRemoveImage();
+							} }
+						>
+							{ __( 'Remove' ) }
+						</MenuItem>
+					) }
+				</MediaReplaceFlow>
+			) }
 			<DropZone
 				onFilesDrop={ onFilesDrop }
 				label={ __( 'Drop to upload' ) }

--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -173,3 +173,7 @@
 		margin-left: $grid-unit-30 - $grid-unit-10;
 	}
 }
+
+.block-editor-global-styles-background-panel__url-input-container {
+	padding: 10px;
+}


### PR DESCRIPTION
## What?
Part of: https://github.com/WordPress/gutenberg/issues/54336

Adds support for setting a background image via an external URL in the global Styles background panel, alongside the existing Upload and Media Library options.

## Why?
Previously, users could only set a background image by uploading a file or selecting one from the Media Library. This excluded common use cases such as referencing externally hosted images or CDN URLs. The block-level background image already partially supported URL strings (via theme.json), but there was no UI to set them from the editor.

## Testing Instructions
1. Open the Site Editor or a post/page with a block that supports background images.
2. In the Styles panel, open **Background image**.
3. Click the background image selector button to open the `MediaReplaceFlow` popover.
4. Confirm a new **"Use image URL"** option appears alongside Upload and Media Library.
5. Click **"Use image URL"**, the popover is replaced with a URL input field.
6. Paste or type an external image URL (e.g. `https://example.com/image.jpg`).
7. Click **Apply** (or press Enter), the background image is set and the input is dismissed.
8. Confirm the image renders correctly as the background.

## Screenshots or screencast
https://github.com/user-attachments/assets/a722ce93-072f-423c-872f-978c07d5a296



## Use of AI Tools

Claude (Anthropic) was used to assist with implementation details and code structure. All generated code has been reviewed and tested.
