### PR TITLE
Edit Site: Move show-icon-labels handling to specific edit-site call sites

### DIFF
--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -52,23 +52,3 @@
 		padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
 	}
 }
-
-// Show button text labels when preference is enabled.
-.show-icon-labels {
-	.admin-ui-page__header-actions {
-		.components-button.has-icon {
-			width: auto;
-			padding: 0 var(--wpds-dimension-padding-xs);
-
-			// Hide the button icons when labels are set to display...
-			svg {
-				display: none;
-			}
-			// ... and display labels.
-			&::after {
-				content: attr(aria-label);
-				font-size: var(--wpds-typography-font-size-sm);
-			}
-		}
-	}
-}

--- a/packages/edit-site/src/components/page-patterns/actions.js
+++ b/packages/edit-site/src/components/page-patterns/actions.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	DropdownMenu,
-	MenuGroup,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 
@@ -28,7 +24,7 @@ export default function PatternsActions( { categoryId, type } ) {
 	}
 
 	return (
-		<HStack className="edit-site-page-patterns-dataviews__header-actions">
+		<>
 			<AddNewPattern />
 			{ !! patternCategory?.id && (
 				<DropdownMenu
@@ -53,6 +49,6 @@ export default function PatternsActions( { categoryId, type } ) {
 					) }
 				</DropdownMenu>
 			) }
-		</HStack>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/page-patterns/actions.js
+++ b/packages/edit-site/src/components/page-patterns/actions.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { DropdownMenu, MenuGroup } from '@wordpress/components';
+import {
+	DropdownMenu,
+	MenuGroup,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 
@@ -24,7 +28,7 @@ export default function PatternsActions( { categoryId, type } ) {
 	}
 
 	return (
-		<>
+		<HStack className="edit-site-page-patterns-dataviews__header-actions">
 			<AddNewPattern />
 			{ !! patternCategory?.id && (
 				<DropdownMenu
@@ -49,6 +53,6 @@ export default function PatternsActions( { categoryId, type } ) {
 					) }
 				</DropdownMenu>
 			) }
-		</>
+		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -115,3 +115,23 @@
 		padding-right: $grid-unit-30;
 	}
 }
+
+// Show button text labels when preference is enabled.
+.show-icon-labels {
+	.edit-site-page-patterns-dataviews__header-actions {
+		.components-button.has-icon {
+			width: auto;
+			padding: 0 var(--wpds-dimension-padding-xs);
+
+			// Hide the button icons when labels are set to display...
+			svg {
+				display: none;
+			}
+			// ... and display labels.
+			&::after {
+				content: attr(aria-label);
+				font-size: var(--wpds-typography-font-size-sm);
+			}
+		}
+	}
+}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -118,20 +118,18 @@
 
 // Show button text labels when preference is enabled.
 .show-icon-labels {
-	.edit-site-page-patterns-dataviews__header-actions {
-		.components-button.has-icon {
-			width: auto;
-			padding: 0 var(--wpds-dimension-padding-xs);
+	.edit-site-patterns__button.has-icon {
+		width: auto;
+		padding: 0 var(--wpds-dimension-padding-xs);
 
-			// Hide the button icons when labels are set to display...
-			svg {
-				display: none;
-			}
-			// ... and display labels.
-			&::after {
-				content: attr(aria-label);
-				font-size: var(--wpds-typography-font-size-sm);
-			}
+		// Hide the button icons when labels are set to display...
+		svg {
+			display: none;
+		}
+		// ... and display labels.
+		&::after {
+			content: attr(aria-label);
+			font-size: var(--wpds-typography-font-size-sm);
 		}
 	}
 }

--- a/packages/edit-site/src/components/sidebar-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles/index.js
@@ -31,7 +31,7 @@ const GlobalStylesPageActions = ( {
 	const history = useHistory();
 
 	return (
-		<HStack>
+		<HStack className="edit-site-styles__header-actions">
 			<Button
 				isPressed={ isStyleBookOpened }
 				icon={ seen }

--- a/packages/edit-site/src/components/sidebar-global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar-global-styles/style.scss
@@ -29,3 +29,22 @@
 	}
 }
 
+// Show button text labels when preference is enabled.
+.show-icon-labels {
+	.edit-site-styles__header-actions {
+		.components-button.has-icon {
+			width: auto;
+			padding: 0 var(--wpds-dimension-padding-xs);
+
+			// Hide the button icons when labels are set to display...
+			svg {
+				display: none;
+			}
+			// ... and display labels.
+			&::after {
+				content: attr(aria-label);
+				font-size: var(--wpds-typography-font-size-sm);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/77088

This PR extracts the `show-icon-labels` class handling from the shared/global location and moves it to the specific edit-site call sites that actually require it. This is a preparatory refactoring to simplify an upcoming larger change and ensure proper separation of concerns.

## Why?
1. **Proper encapsulation**: Since admin-ui doesn't add the show-icon-labels class itself, it shouldn't need to manage or know about it
2. **Avoid overflow risks**: Global handling of this class presents overflow risks that are safer to manage locally at the specific call sites where it's actually applied
3. **Reduce PR scope**: Extracting this refactoring first allows the main PR to focus on its primary functional changes without mixing them with component cleanup

## How?
- Removed `show-icon-labels` class handling from admin-ui
- Added explicit `show-icon-labels` class management to the two specific edit-site instances that depend on it

## Testing Instructions
1. Enable the "Show button text labels" preference.
2. Navigate to Appearance → Editor → Styles, and verify header actions display text labels.
3. Navigate to Appearance → Editor → Patterns → Custom Pattern, and verify header actions display text labels.

## Use of AI Tools

Used Claude Sonnet 4.6 to review the changes