### PR TITLE
Media Upload Modal: Persist view configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61086,6 +61086,7 @@
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/ui": "file:../ui",
+				"@wordpress/views": "file:../views",
 				"clsx": "^2.1.1"
 			},
 			"engines": {

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 - DataForm: support `isDisabled` field property. [#77090](https://github.com/WordPress/gutenberg/pull/77090)
 - DataViews/DataViewsPicker: simplify `defaultLayouts` property. [#77232](https://github.com/WordPress/gutenberg/pull/77232)
 - DataForm: Show tooltip in edit button in `panel` layout. [#77024](https://github.com/WordPress/gutenberg/pull/77024)
+- DataViewsPicker: Add `onReset` prop to support view reset functionality. [#77288](https://github.com/WordPress/gutenberg/pull/77288)
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -71,6 +71,7 @@ type DataViewsPickerProps< Item > = {
 	};
 	itemListLabel?: string;
 	empty?: ReactNode;
+	onReset?: ( () => void ) | false;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -143,6 +144,7 @@ function DataViewsPicker< Item >( {
 	config = { perPageSizes: [ 10, 20, 50, 100 ] },
 	itemListLabel,
 	empty,
+	onReset,
 }: DataViewsPickerProps< Item > ) {
 	// useData ensures data loading is correct whether infinite scroll is enabled or pagination is used.
 	const { data: displayData, setVisibleEntries } = useData( {
@@ -250,6 +252,7 @@ function DataViewsPicker< Item >( {
 				config,
 				itemListLabel,
 				empty,
+				onReset,
 				hasInitiallyLoaded: true,
 				intersectionObserver,
 			} }

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/ui": "file:../ui",
+		"@wordpress/views": "file:../views",
 		"clsx": "^2.1.1"
 	},
 	"peerDependencies": {

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -24,11 +24,11 @@ import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
 import type {
-	View,
 	Field,
 	ActionButton,
 	SupportedLayouts,
 } from '@wordpress/dataviews';
+import { useView } from '@wordpress/views';
 import { Stack } from '@wordpress/ui';
 import {
 	altTextField,
@@ -193,22 +193,51 @@ export function MediaUploadModal( {
 	const invalidateAttachmentResolutions =
 		useInvalidateAttachmentResolutions();
 
-	// DataViews configuration - allow view updates
-	const [ view, setView ] = useState< View >( () => ( {
-		type: LAYOUT_PICKER_GRID,
-		fields: [],
-		showTitle: false,
-		titleField: 'title',
-		mediaField: 'media_thumbnail',
-		search: '',
-		page: 1,
-		perPage: 50,
-		filters: [],
-		layout: {
-			previewSize: 170,
-			density: 'compact',
+	const defaultLayouts: SupportedLayouts = useMemo(
+		() => ( {
+			[ LAYOUT_PICKER_GRID ]: {
+				fields: [],
+				showTitle: false,
+				layout: {
+					previewSize: 170,
+					density: 'compact',
+				},
+			},
+			[ LAYOUT_PICKER_TABLE ]: {
+				fields: [
+					'filename',
+					'filesize',
+					'media_dimensions',
+					'author',
+					'date',
+				],
+				showTitle: true,
+			},
+		} ),
+		[]
+	);
+
+	// Persist view configuration across sessions via the preferences store.
+	const { view, updateView, isModified, resetToDefault } = useView( {
+		kind: 'postType',
+		name: 'attachment',
+		slug: 'media-modal',
+		defaultView: {
+			type: LAYOUT_PICKER_GRID,
+			fields: [],
+			showTitle: false,
+			titleField: 'title',
+			mediaField: 'media_thumbnail',
+			search: '',
+			page: 1,
+			perPage: 50,
+			filters: [],
+			layout: {
+				previewSize: 170,
+				density: 'compact',
+			},
 		},
-	} ) );
+	} );
 
 	// Build query args based on view properties, similar to PostList
 	const queryArgs = useMemo( () => {
@@ -456,30 +485,6 @@ export function MediaUploadModal( {
 		[ totalItems, totalPages ]
 	);
 
-	const defaultLayouts: SupportedLayouts = useMemo(
-		() => ( {
-			[ LAYOUT_PICKER_GRID ]: {
-				fields: [],
-				showTitle: false,
-				layout: {
-					previewSize: 170,
-					density: 'compact',
-				},
-			},
-			[ LAYOUT_PICKER_TABLE ]: {
-				fields: [
-					'filename',
-					'filesize',
-					'media_dimensions',
-					'author',
-					'date',
-				],
-				showTitle: true,
-			},
-		} ),
-		[]
-	);
-
 	// Build accept attribute from allowedTypes
 	const acceptTypes = useMemo( () => {
 		if ( allowedTypes?.includes( '*' ) ) {
@@ -553,7 +558,7 @@ export function MediaUploadModal( {
 				data={ mediaRecords || [] }
 				fields={ fields }
 				view={ view }
-				onChangeView={ setView }
+				onChangeView={ updateView }
 				actions={ actions }
 				selection={ selection }
 				onChangeSelection={ setSelection }
@@ -562,6 +567,7 @@ export function MediaUploadModal( {
 				defaultLayouts={ defaultLayouts }
 				getItemId={ ( item: RestAttachment ) => String( item.id ) }
 				itemListLabel={ __( 'Media items' ) }
+				onReset={ isModified ? resetToDefault : false }
 			>
 				<Stack
 					direction="row"

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -69,6 +69,27 @@ const NOTICES_CONTEXT = 'media-modal';
 // Notice ID - reused for all upload-related notices to prevent flooding
 const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
 
+const defaultLayouts: SupportedLayouts = {
+	[ LAYOUT_PICKER_GRID ]: {
+		fields: [],
+		showTitle: false,
+		layout: {
+			previewSize: 170,
+			density: 'compact',
+		},
+	},
+	[ LAYOUT_PICKER_TABLE ]: {
+		fields: [
+			'filename',
+			'filesize',
+			'media_dimensions',
+			'author',
+			'date',
+		],
+		showTitle: true,
+	},
+};
+
 interface MediaUploadModalProps {
 	/**
 	 * Array of allowed media types.
@@ -192,30 +213,6 @@ export function MediaUploadModal( {
 		useDispatch( noticesStore );
 	const invalidateAttachmentResolutions =
 		useInvalidateAttachmentResolutions();
-
-	const defaultLayouts: SupportedLayouts = useMemo(
-		() => ( {
-			[ LAYOUT_PICKER_GRID ]: {
-				fields: [],
-				showTitle: false,
-				layout: {
-					previewSize: 170,
-					density: 'compact',
-				},
-			},
-			[ LAYOUT_PICKER_TABLE ]: {
-				fields: [
-					'filename',
-					'filesize',
-					'media_dimensions',
-					'author',
-					'date',
-				],
-				showTitle: true,
-			},
-		} ),
-		[]
-	);
 
 	// Persist view configuration across sessions via the preferences store.
 	const { view, updateView, isModified, resetToDefault } = useView( {

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -27,6 +27,7 @@ import type {
 	Field,
 	ActionButton,
 	SupportedLayouts,
+	View,
 } from '@wordpress/dataviews';
 import { useView } from '@wordpress/views';
 import { Stack } from '@wordpress/ui';
@@ -68,6 +69,22 @@ const NOTICES_CONTEXT = 'media-modal';
 
 // Notice ID - reused for all upload-related notices to prevent flooding
 const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
+
+const defaultView: View = {
+	type: LAYOUT_PICKER_GRID,
+	fields: [],
+	showTitle: false,
+	titleField: 'title',
+	mediaField: 'media_thumbnail',
+	search: '',
+	page: 1,
+	perPage: 50,
+	filters: [],
+	layout: {
+		previewSize: 170,
+		density: 'compact',
+	},
+};
 
 const defaultLayouts: SupportedLayouts = {
 	[ LAYOUT_PICKER_GRID ]: {
@@ -219,21 +236,7 @@ export function MediaUploadModal( {
 		kind: 'postType',
 		name: 'attachment',
 		slug: 'media-modal',
-		defaultView: {
-			type: LAYOUT_PICKER_GRID,
-			fields: [],
-			showTitle: false,
-			titleField: 'title',
-			mediaField: 'media_thumbnail',
-			search: '',
-			page: 1,
-			perPage: 50,
-			filters: [],
-			layout: {
-				previewSize: 170,
-				density: 'compact',
-			},
-		},
+		defaultView,
 	} );
 
 	// Build query args based on view properties, similar to PostList

--- a/packages/media-utils/tsconfig.json
+++ b/packages/media-utils/tsconfig.json
@@ -18,6 +18,7 @@
 		{ "path": "../media-fields" },
 		{ "path": "../notices" },
 		{ "path": "../private-apis" },
-		{ "path": "../ui" }
+		{ "path": "../ui" },
+		{ "path": "../views" }
 	]
 }


### PR DESCRIPTION
## What?

Related to:

* https://github.com/WordPress/gutenberg/pull/75887
* https://github.com/WordPress/gutenberg/issues/76380

In the media modal experiment, persist view configuration across page reloads. This is most obvious when switching between layouts (i.e. table vs grid) where it currently isn't remembered.

## Why?

This is how the Pages screen in the site editor already works, so we're adding consistency to the media modal. But more broadly this came up in reviews of #75887 that it feels unexpected when changing the density for this setting to not be preserved across page reloads.

While this PR doesn't directly address preserving density across layout switching (that's what #76380 describes), this PR lays the general groundwork for persisting views for the media modal itself.

I.e. if someone opens the modal and decides they'd like to use the Table layout instead, then the next time they open the modal on another post or page, that should be remembered (this PR). And, just like with the other layouts, they should be able to reset back to the original state.

## How?

* Add an `onReset` prop to the `DataViewsPicker` component (it turns out we didn't have it)
* Update the media upload modal to use `@wordpress/views` as a dependency and use `useView` for view configuration instead of React state

## Testing Instructions

Activate the media modal experiment:

<img width="958" height="76" alt="image" src="https://github.com/user-attachments/assets/567bbd6c-7150-44f5-b473-f4c869966df3" />

To verify this fix, you can reproduce on trunk:

* Go to edit a post or page and add a featured image. With the modal open, switch to the table layout.
* Reload the editor, and open the modal again, and it'll default to the grid view

With this PR applied:

* Do the above and it should remember your configuration
* You should still be able to make any adjustments to layout and view config as before (e.g. density, preview size, etc)
* You should be able to use the "Reset view" button to get back to the original state.

## Screenshots or screencast <!-- if applicable -->

### Before

Note how table selection is lost after page reload:

https://github.com/user-attachments/assets/8ae0c053-dad7-4b48-9445-1ea17c6d0c57

### After

After page reload, table selection is preserved, and the user can reset the view:

https://github.com/user-attachments/assets/e42bf86a-9e8a-4901-93d7-993460314e85

## Use of AI Tools

Claude Code for making the changes, with a little manual nudging in the editor.