### PR TITLE
Fix Gutenberg_REST_View_Config_Controller_7_1 PHP warnings

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -6,3 +6,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/76823
 * https://github.com/WordPress/gutenberg/pull/76953
 * https://github.com/WordPress/gutenberg/pull/76903
+* https://github.com/WordPress/gutenberg/pull/77290

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -905,7 +905,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 				'slug'  => 'trash',
 				'view'  => array(
 					'type'    => 'table',
-					'layout'  => $default_layouts['table']['layout'] ?? array(),
+					'layout'  => $default_layouts['table']['layout'],
 					'filters' => array(
 						array(
 							'field'    => 'status',
@@ -946,7 +946,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'mediaField' => 'preview',
 			'fields'     => array( 'sync-status' ),
 			'filters'    => array(),
-			'layout'     => $default_layouts['grid']['layout'] ?? array(),
+			'layout'     => $default_layouts['grid']['layout'],
 		);
 	}
 
@@ -975,7 +975,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'mediaField' => 'preview',
 			'fields'     => array( 'author' ),
 			'filters'    => array(),
-			'layout'     => $default_layouts['grid']['layout'] ?? array(),
+			'layout'     => $default_layouts['grid']['layout'],
 		);
 	}
 

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -905,7 +905,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 				'slug'  => 'trash',
 				'view'  => array(
 					'type'    => 'table',
-					'layout'  => $default_layouts['table']['layout'],
+					'layout'  => $default_layouts['table']['layout'] ?? array(),
 					'filters' => array(
 						array(
 							'field'    => 'status',
@@ -946,7 +946,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'mediaField' => 'preview',
 			'fields'     => array( 'sync-status' ),
 			'filters'    => array(),
-			'layout'     => $default_layouts['grid']['layout'],
+			'layout'     => $default_layouts['grid']['layout'] ?? array(),
 		);
 	}
 
@@ -961,7 +961,9 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					),
 				),
 			),
-			'grid'  => array(),
+			'grid'  => array(
+				'layout' => array(),
+			),
 		);
 	}
 
@@ -973,7 +975,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'mediaField' => 'preview',
 			'fields'     => array( 'author' ),
 			'filters'    => array(),
-			'layout'     => $default_layouts['grid']['layout'],
+			'layout'     => $default_layouts['grid']['layout'] ?? array(),
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/76734

 - Fix PHP warning Undefined array key "layout" when requesting view config for            
  wp_template_part — get_default_layouts_for_wp_template_part() was missing the layout key
  in its grid entry                                                                         
  - Add defensive ?? array() fallback at all $default_layouts access sites to prevent     
  similar issues in the future   

## Testing Instructions
1. Verify templates parts page in site editor (through `patterns` menu item) works as before
2. No PHP warnings


## Use of AI Tools
Opus 4.6
