### PR TITLE
Paragraph: Prevent `onEnter` splitting of parent block when insertion of that block type is not allowed

### DIFF
--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -90,12 +90,12 @@ export function useOnEnter( props ) {
 			}
 
 			const defaultBlockName = getDefaultBlockName();
+			const wrapperBlockName = getBlockName( wrapperClientId );
+			const grandparentClientId = getBlockRootClientId( wrapperClientId );
 
 			if (
-				! canInsertBlockType(
-					defaultBlockName,
-					getBlockRootClientId( wrapperClientId )
-				)
+				! canInsertBlockType( defaultBlockName, grandparentClientId ) ||
+				! canInsertBlockType( wrapperBlockName, grandparentClientId )
 			) {
 				return;
 			}
@@ -119,7 +119,7 @@ export function useOnEnter( props ) {
 				insertBlock(
 					createBlock( defaultBlockName ),
 					blockIndex + 1,
-					getBlockRootClientId( wrapperClientId ),
+					grandparentClientId,
 					true
 				);
 			} );

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -579,4 +579,95 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 			expect( await editor.getBlocks() ).toMatchObject( snap2 );
 		} );
 	} );
+
+	test( 'should not split the parent block when the parent block type is not allowed at the grandparent level', async ( {
+		editor,
+		page,
+	} ) => {
+		// Set up a Group with allowedBlocks restricted to only paragraphs,
+		// containing an inner Group with 3 paragraphs.
+		// When pressing Enter twice on "Second" (creating an empty paragraph,
+		// then pressing Enter again), the inner Group should NOT be split
+		// because core/group is not in the outer Group's allowedBlocks.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				allowedBlocks: [ 'core/paragraph' ],
+				layout: { type: 'constrained' },
+			},
+			innerBlocks: [
+				{
+					name: 'core/group',
+					attributes: {
+						layout: { type: 'constrained' },
+					},
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: { content: 'First' },
+						},
+						{
+							name: 'core/paragraph',
+							attributes: { content: 'Second' },
+						},
+						{
+							name: 'core/paragraph',
+							attributes: { content: 'Third' },
+						},
+					],
+				},
+			],
+		} );
+
+		// Click at the end of the "Second" paragraph.
+		const secondParagraph = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+			.filter( { hasText: 'Second' } );
+		await secondParagraph.click();
+		await page.keyboard.press( 'End' );
+
+		// First Enter: splits the paragraph, creating an empty one after "Second".
+		await page.keyboard.press( 'Enter' );
+		// Second Enter: on the now-empty paragraph, should NOT split the
+		// inner Group because core/group is not in the outer Group's allowedBlocks.
+		await page.keyboard.press( 'Enter' );
+
+		// The outer Group should still contain exactly one inner Group.
+		// The inner Group should have the original paragraphs plus the
+		// empty ones created by the Enter presses.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/group',
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: { content: 'First' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: 'Second' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: '' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: '' },
+							},
+							{
+								name: 'core/paragraph',
+								attributes: { content: 'Third' },
+							},
+						],
+					},
+				],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
## What?
Fixes a small issue originally noted here - https://github.com/WordPress/gutenberg/pull/73222#issuecomment-4154295590.

## Why?

The paragraph block has a special `onEnter` behavior originally implemented here - https://github.com/WordPress/gutenberg/pull/40724. When multiple blocks are inside some other containers (group, quote etc.), pressing 'enter' twice on a middle block splits a group in two:

https://user-images.githubusercontent.com/583546/165930803-8f2ef9ee-0064-445f-bd1a-45b9755e5ab0.mp4

In the case of a group container, splitting means inserting a new group after the existing group.

It's possible the group might not be allowed. Unfortunately the existing code in trunk tries to insert the group, fails and then doesn't do anything. That's the behavior noted in https://github.com/WordPress/gutenberg/pull/73222#issuecomment-4154295590 where the content after the split disappears.

## How?
The code does already check `canInsertBlockType` before trying to proceed with the split, but it only checks whether paragraphs can be inserted, so the fix is to augment this by also checking that a new group (or other container block type) can be inserted too. 

## Testing Instructions
1. Add a group, and another group inside that group, then add three paragraphs (1, 2, 3)
2. Select the outer group, go to 'Advanced' -> 'Manage allowed blocks', and set 'Paragraph' as the only allowed block
3. Select paragraph '2' and hit enter twice

In trunk - paragraph 3 disappears.
In this branch - additional paragraphs are inserted before paragraph 3.

## Screenshots or screencast <!-- if applicable -->

#### Before

https://github.com/user-attachments/assets/d6987af3-ffe3-4508-9f9e-a17682a5daa0

#### After

https://github.com/user-attachments/assets/e8dd5846-ee32-44b5-a3d8-9a6630031a06

## Use of AI Tools
OpenCode / Claude