### PR TITLE
Global Styles: Renamed focus visible label

### DIFF
--- a/packages/global-styles-ui/src/utils.ts
+++ b/packages/global-styles-ui/src/utils.ts
@@ -24,7 +24,7 @@ export const VALID_ELEMENT_STATES: Record< string, StateDefinition[] > = {
 		{ value: ':visited', label: __( 'Visited' ) },
 		{ value: ':hover', label: __( 'Hover' ) },
 		{ value: ':focus', label: __( 'Focus' ) },
-		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+		{ value: ':focus-visible', label: __( 'Focus-visible' ) },
 		{ value: ':active', label: __( 'Active' ) },
 	],
 	button: [
@@ -33,7 +33,7 @@ export const VALID_ELEMENT_STATES: Record< string, StateDefinition[] > = {
 		{ value: ':visited', label: __( 'Visited' ) },
 		{ value: ':hover', label: __( 'Hover' ) },
 		{ value: ':focus', label: __( 'Focus' ) },
-		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+		{ value: ':focus-visible', label: __( 'Focus-visible' ) },
 		{ value: ':active', label: __( 'Active' ) },
 	],
 };
@@ -46,7 +46,7 @@ export const VALID_BLOCK_STATES: Record< string, StateDefinition[] > = {
 	'core/button': [
 		{ value: ':hover', label: __( 'Hover' ) },
 		{ value: ':focus', label: __( 'Focus' ) },
-		{ value: ':focus-visible', label: __( 'Focus Visible' ) },
+		{ value: ':focus-visible', label: __( 'Focus-visible' ) },
 		{ value: ':active', label: __( 'Active' ) },
 	],
 };


### PR DESCRIPTION
This PR renames the label for focus visible to "Focus-visible" after some feedback from @jasmussen.

To test go to Global Styles and check the dropdown for states on the buton block

<img width="976" height="503" alt="Screenshot 2026-04-14 at 10 13 54" src="https://github.com/user-attachments/assets/cc1a4b00-b0b7-4f56-8ddc-861fddd4e04d" />
