### PR TITLE
UI: use Text component for Badge typography

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -28,7 +28,6 @@
 -   `Dialog`, `AlertDialog`, `Tooltip`, `Select`: Add `container` prop to `Popup` for custom portal targets ([#77163](https://github.com/WordPress/gutenberg/pull/77163)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
 -   `VisuallyHidden`: Improve Storybook stories and documentation for the `render` prop composition pattern.
--   `Badge`: Use `Text` component for typography ([#77295](https://github.com/WordPress/gutenberg/pull/77295)).
 
 ### Internal
 
@@ -36,6 +35,7 @@
 -   Normalize `render` prop handling across components and document conventions in `CONTRIBUTING.md` ([#77160](https://github.com/WordPress/gutenberg/pull/77160)).
 -   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
 -   `Field.Label`, `Fieldset.Legend`, `Field.Details`: Refactor `VisuallyHidden` composition to preserve semantic HTML elements when visually hiding content.
+-   `Badge`: Use `Text` component for typography ([#77295](https://github.com/WordPress/gutenberg/pull/77295)).
 
 ## 0.10.0 (2026-04-01)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `Dialog`, `AlertDialog`, `Tooltip`, `Select`: Add `container` prop to `Popup` for custom portal targets ([#77163](https://github.com/WordPress/gutenberg/pull/77163)).
 -   Add defensive styles against global WordPress stylesheets like common.css and forms.css ([#76783](https://github.com/WordPress/gutenberg/pull/76783)).
 -   `VisuallyHidden`: Improve Storybook stories and documentation for the `render` prop composition pattern.
+-   `Badge`: Use `Text` component for typography ([#77295](https://github.com/WordPress/gutenberg/pull/77295)).
 
 ### Internal
 

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -1,4 +1,3 @@
-import { mergeProps } from '@base-ui/react';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { type BadgeProps } from './types';
@@ -9,28 +8,19 @@ import { Text } from '../text';
  * A badge component for displaying labels with semantic intent.
  */
 export const Badge = forwardRef< HTMLSpanElement, BadgeProps >( function Badge(
-	{ children, intent = 'none', render, className, ...props },
+	{ intent = 'none', className, ...props },
 	ref
 ) {
 	return (
 		<Text
+			ref={ ref }
 			variant="body-sm"
-			render={
-				render ?? (
-					<span
-						ref={ ref }
-						{ ...mergeProps( props, {
-							className: clsx(
-								styles.badge,
-								styles[ `is-${ intent }-intent` ],
-								className
-							),
-						} ) }
-					/>
-				)
-			}
-		>
-			{ children }
-		</Text>
+			className={ clsx(
+				styles.badge,
+				styles[ `is-${ intent }-intent` ],
+				className
+			) }
+			{ ...props }
+		/>
 	);
 } );

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -1,8 +1,9 @@
-import { useRender, mergeProps } from '@base-ui/react';
+import { mergeProps } from '@base-ui/react';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { type BadgeProps } from './types';
 import styles from './style.module.css';
+import { Text } from '../text';
 
 /**
  * A badge component for displaying labels with semantic intent.
@@ -11,19 +12,25 @@ export const Badge = forwardRef< HTMLSpanElement, BadgeProps >( function Badge(
 	{ children, intent = 'none', render, className, ...props },
 	ref
 ) {
-	const element = useRender( {
-		render,
-		defaultTagName: 'span',
-		ref,
-		props: mergeProps< 'span' >( props, {
-			className: clsx(
-				styles.badge,
-				styles[ `is-${ intent }-intent` ],
-				className
-			),
-			children,
-		} ),
-	} );
-
-	return element;
+	return (
+		<Text
+			variant="body-sm"
+			render={
+				render ?? (
+					<span
+						ref={ ref }
+						{ ...mergeProps( props, {
+							className: clsx(
+								styles.badge,
+								styles[ `is-${ intent }-intent` ],
+								className
+							),
+						} ) }
+					/>
+				)
+			}
+		>
+			{ children }
+		</Text>
+	);
 } );

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -14,13 +14,13 @@ export const Badge = forwardRef< HTMLSpanElement, BadgeProps >( function Badge(
 	return (
 		<Text
 			ref={ ref }
-			variant="body-sm"
 			className={ clsx(
 				styles.badge,
 				styles[ `is-${ intent }-intent` ],
 				className
 			) }
 			{ ...props }
+			variant="body-sm"
 		/>
 	);
 } );

--- a/packages/ui/src/badge/style.module.css
+++ b/packages/ui/src/badge/style.module.css
@@ -5,10 +5,6 @@
 		padding-inline: var(--wpds-dimension-padding-sm);
 		padding-block: var(--wpds-dimension-padding-xs);
 		border-radius: var(--wpds-border-radius-lg);
-		font-family: var(--wpds-typography-font-family-body);
-		font-size: var(--wpds-typography-font-size-sm);
-		font-weight: var(--wpds-typography-font-weight-regular);
-		line-height: var(--wpds-typography-line-height-xs);
 	}
 
 	.is-high-intent {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of the effort in #76929
(Also, similar changes to https://github.com/WordPress/gutenberg/pull/76642)

<!-- In a few words, what is the PR actually doing? -->
Refactors the Badge component to use the Text component for typography.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Typography values (font-family, font-size, font-weight, line-height) were duplicated in the badge's stylesheet rather than being owned by a single source of truth. Using Text with variant="body-sm" centralises this so the badge stays consistent with the rest of the design system automatically.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replaced the useRender hook pattern with an explicit JSX return wrapping content in `Text variant="body-sm"`
- Removed the four typography declarations from style.module.css since they are now inherited from Text

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open Storybook and navigate to Design System / Components / Badge
2. Verify all Badge stories render with the same typography as before (correct font size, weight, and line height)
3. Check each intent variant story — confirm colors are unaffected

## Use of AI Tools
Used Claude (claude.ai) to assist with code review and PR description drafting. All changes were reviewed and authored by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->