### PR TITLE
Views: remove src from files list in package.json

### DIFF
--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -23,7 +23,6 @@
 		"npm": ">=8.19.2"
 	},
 	"files": [
-		"src",
 		"build",
 		"build-module",
 		"build-types",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes `src` from the `files` field in `package.json`.

Related to https://github.com/WordPress/gutenberg/issues/77274

---

## Why?

The `src` directory is not required in the published package. Removing it ensures that only necessary build artifacts are included, reducing package size and avoiding exposure of source files.

---

## How?

* Updated the `files` field in `package.json` to exclude the `src` directory
* Ensured only build outputs and required files are included in the package

---

## Testing Instructions

1. Run `npm pack --dry-run` locally
2. Inspect the generated tarball
3. Verify that the `src` directory is not included
4. Confirm that build files (e.g., `build/`, `build-module/`) are present and functional

---

## Screenshots or screencast

| Before | After |
|--------|-------|
| ![](https://github.com/user-attachments/assets/ef921bc8-277a-4e98-9e36-bbe461246622) | ![](https://github.com/user-attachments/assets/57179010-d309-4097-afba-4fa46e47fe5a) |