### PR TITLE
page.waitForFunction: fix call arguments

### DIFF
--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -426,6 +426,7 @@ test.describe( 'Fit Text', () => {
 					const el = document.querySelector( 'h2.has-fit-text' );
 					return el && el.style.fontSize && el.style.fontSize !== '';
 				},
+				undefined,
 				{ timeout: 5000 }
 			);
 
@@ -502,6 +503,7 @@ test.describe( 'Fit Text', () => {
 					const el = document.querySelector( 'p.has-fit-text' );
 					return el && el.style.fontSize && el.style.fontSize !== '';
 				},
+				undefined,
 				{ timeout: 5000 }
 			);
 

--- a/test/e2e/specs/editor/collaboration/collaboration-document-size-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-document-size-lock.spec.ts
@@ -62,6 +62,7 @@ test.describe( 'Collaboration with large documents', () => {
 				window?.wp?.data
 					?.select( 'core/editor' )
 					?.isCollaborationEnabledForCurrentPost?.() === false,
+			undefined,
 			{ timeout: 15000 }
 		);
 

--- a/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-metabox-lock.spec.ts
@@ -55,6 +55,7 @@ test.describe( 'Collaboration with meta boxes', () => {
 					window?.wp?.data
 						?.select( 'core/editor' )
 						?.isCollaborationEnabledForCurrentPost?.() === false,
+				undefined,
 				{ timeout: 15000 }
 			);
 
@@ -84,6 +85,7 @@ test.describe( 'Collaboration with meta boxes', () => {
 				// Wait for wp.data to be available on User 2's page.
 				await page2.waitForFunction(
 					() => window?.wp?.data && window?.wp?.blocks,
+					undefined,
 					{ timeout: 15000 }
 				);
 
@@ -160,6 +162,7 @@ test.describe( 'Collaboration with meta boxes', () => {
 					window?.wp?.data
 						?.select( 'core/editor' )
 						?.isCollaborationEnabledForCurrentPost?.() === true,
+				undefined,
 				{ timeout: 15000 }
 			);
 

--- a/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-persistence.spec.ts
@@ -65,6 +65,7 @@ test.describe( 'Collaboration - CRDT persistence', () => {
 		// wait for the entity record resolver to finish.
 		await page.waitForFunction(
 			() => ( window as any )._wpCollaborationEnabled === true,
+			undefined,
 			{ timeout: 5000 }
 		);
 		await collaborationUtils.waitForEntityReady( page, {

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -56,6 +56,7 @@ test.describe( 'Collaboration - Refresh', () => {
 				( window as any )._wpCollaborationEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
+			undefined,
 			{ timeout: 15000 }
 		);
 
@@ -96,6 +97,7 @@ test.describe( 'Collaboration - Refresh', () => {
 				( window as any )._wpCollaborationEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
+			undefined,
 			{ timeout: 15000 }
 		);
 		editor2 = new Editor( { page: page2 } );
@@ -142,6 +144,7 @@ test.describe( 'Collaboration - Refresh', () => {
 				( window as any )._wpCollaborationEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
+			undefined,
 			{ timeout: 15000 }
 		);
 

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -260,6 +260,7 @@ export default class CollaborationUtils {
 					.select( 'core/editor' )
 					.isSavingPost();
 			},
+			undefined,
 			{ timeout }
 		);
 	}
@@ -300,6 +301,7 @@ export default class CollaborationUtils {
 				( window as any )._wpCollaborationEnabled === true &&
 				window?.wp?.data &&
 				window?.wp?.blocks,
+			undefined,
 			{ timeout }
 		);
 	}

--- a/test/e2e/specs/editor/various/big-image-size-threshold.spec.js
+++ b/test/e2e/specs/editor/various/big-image-size-threshold.spec.js
@@ -89,6 +89,7 @@ test.describe( 'Big image size threshold', () => {
 				const items = uploadStore.getItems();
 				return items.length === 0;
 			},
+			undefined,
 			{ timeout: 120000 }
 		);
 
@@ -191,6 +192,7 @@ test.describe( 'Big image size threshold', () => {
 				const items = uploadStore.getItems();
 				return items.length === 0;
 			},
+			undefined,
 			{ timeout: 120000 }
 		);
 


### PR DESCRIPTION
Fixes calls to `page.waitForFunction` in e2e tests. When we want to specify a timeout, it must be the _third_ argument. The second argument are `args` to be passed to the function.

In our case, the `timeout` wasn't really applied, the value was instead sent to the callback as argument.

This is a spinoff from the React 19 upgrade in #61521 where it helped fix some e2e failures.