### PR TITLE
UI: Update `@base-ui/react` from `1.3.0` to `1.4.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4018,9 +4018,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -4080,16 +4080,15 @@
 			}
 		},
 		"node_modules/@base-ui/react": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.3.0.tgz",
-			"integrity": "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.0.tgz",
+			"integrity": "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"@base-ui/utils": "0.2.6",
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.2.7",
 				"@floating-ui/react-dom": "^2.1.8",
 				"@floating-ui/utils": "^0.2.11",
-				"tabbable": "^6.4.0",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"engines": {
@@ -4100,7 +4099,9 @@
 				"url": "https://opencollective.com/mui-org"
 			},
 			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
 				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
 				"react": "^17 || ^18 || ^19",
 				"react-dom": "^17 || ^18 || ^19"
 			},
@@ -4124,12 +4125,12 @@
 			}
 		},
 		"node_modules/@base-ui/utils": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.6.tgz",
-			"integrity": "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.28.6",
+				"@babel/runtime": "^7.29.2",
 				"@floating-ui/utils": "^0.2.11",
 				"reselect": "^5.1.1",
 				"use-sync-external-store": "^1.6.0"
@@ -62907,7 +62908,7 @@
 			"version": "0.10.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@base-ui/react": "^1.3.0",
+				"@base-ui/react": "^1.4.0",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -35,6 +35,7 @@
 -   Normalize `render` prop handling across components and document conventions in `CONTRIBUTING.md` ([#77160](https://github.com/WordPress/gutenberg/pull/77160)).
 -   `AlertDialog`: Rewrite internals to use Base UI's `AlertDialog` primitives directly instead of `Dialog` wrappers. Introduces an internal state machine for async confirm flows ([#76937](https://github.com/WordPress/gutenberg/pull/76937)).
 -   `Field.Label`, `Fieldset.Legend`, `Field.Details`: Refactor `VisuallyHidden` composition to preserve semantic HTML elements when visually hiding content.
+-   Update `@base-ui/react` from `1.3.0` to `1.4.0` ([#77308](https://github.com/WordPress/gutenberg/pull/77308)).
 
 ## 0.10.0 (2026-04-01)
 

--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -140,12 +140,12 @@ export const Title = forwardRef( function MyTitle(
 ```tsx
 // Render function — useful when the default needs to compose
 // other components or add additional props.
-const defaultRender = ( props: React.ComponentProps< typeof Stack > ) => (
+const DEFAULT_RENDER = ( props: React.ComponentProps< typeof Stack > ) => (
     <Stack { ...props } direction="column" gap="sm" />
 );
 
 export const Root = forwardRef( function MyRoot(
-    { className, render = defaultRender, ...restProps },
+    { className, render = DEFAULT_RENDER, ...restProps },
     ref
 ) {
     return (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@base-ui/react": "^1.3.0",
+		"@base-ui/react": "^1.4.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",

--- a/packages/ui/src/form/primitives/field/root.tsx
+++ b/packages/ui/src/form/primitives/field/root.tsx
@@ -5,7 +5,7 @@ import resetStyles from '../../../utils/css/resets.module.css';
 import type { FieldRootProps } from './types';
 import { Stack } from '../../../stack';
 
-const defaultRender = ( props: React.ComponentProps< typeof Stack > ) => (
+const DEFAULT_RENDER = ( props: React.ComponentProps< typeof Stack > ) => (
 	<Stack { ...props } direction="column" gap="sm" />
 );
 
@@ -19,7 +19,7 @@ const defaultRender = ( props: React.ComponentProps< typeof Stack > ) => (
  * accessible labeling. See examples for how to associate the label in different cases.
  */
 export const Root = forwardRef< HTMLDivElement, FieldRootProps >( function Root(
-	{ className, render = defaultRender, ...restProps },
+	{ className, render = DEFAULT_RENDER, ...restProps },
 	ref
 ) {
 	return (

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -7,7 +7,14 @@ export type SelectRootProps = Omit<
 	'multiple'
 >;
 
-export type SelectTriggerProps = Omit< _Select.Trigger.Props, 'children' > & {
+export type SelectTriggerProps = Omit<
+	_Select.Trigger.Props,
+	'children' | 'style'
+> & {
+	/**
+	 * CSS style applied to the trigger element.
+	 */
+	style?: React.CSSProperties;
 	/**
 	 * The size of the trigger.
 	 *
@@ -40,8 +47,12 @@ export type SelectPopupProps = Omit< _Select.Popup.Props, 'style' > & {
 
 export type SelectItemProps = Omit<
 	_Select.Item.Props,
-	'children' | 'value'
+	'children' | 'value' | 'style'
 > & {
+	/**
+	 * CSS style applied to the item element.
+	 */
+	style?: React.CSSProperties;
 	/**
 	 * A unique value that identifies this select item.
 	 */

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -27,7 +27,11 @@ export type SelectTriggerProps = Omit< _Select.Trigger.Props, 'children' > & {
 	children?: _Select.Value.Props[ 'children' ];
 };
 
-export type SelectPopupProps = _Select.Popup.Props & {
+export type SelectPopupProps = Omit< _Select.Popup.Props, 'style' > & {
+	/**
+	 * CSS style applied to the positioner element.
+	 */
+	style?: React.CSSProperties;
 	/**
 	 * A parent element to render the portal into.
 	 */

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -1,4 +1,5 @@
 import type { Select as _Select } from '@base-ui/react/select';
+import type { ComponentProps } from '../../../utils/types';
 import type { InputLayoutProps } from '../input-layout/types';
 
 // The second type parameter is the `multiple` flag (currently disabled).
@@ -7,14 +8,7 @@ export type SelectRootProps = Omit<
 	'multiple'
 >;
 
-export type SelectTriggerProps = Omit<
-	_Select.Trigger.Props,
-	'children' | 'style'
-> & {
-	/**
-	 * CSS style applied to the trigger element.
-	 */
-	style?: React.CSSProperties;
+export type SelectTriggerProps = ComponentProps< typeof _Select.Trigger > & {
 	/**
 	 * The size of the trigger.
 	 *
@@ -34,11 +28,11 @@ export type SelectTriggerProps = Omit<
 	children?: _Select.Value.Props[ 'children' ];
 };
 
-export type SelectPopupProps = Omit< _Select.Popup.Props, 'style' > & {
+export type SelectPopupProps = ComponentProps< typeof _Select.Popup > & {
 	/**
-	 * CSS style applied to the positioner element.
+	 * The content to be rendered inside the popup.
 	 */
-	style?: React.CSSProperties;
+	children?: React.ReactNode;
 	/**
 	 * A parent element to render the portal into.
 	 */
@@ -46,13 +40,9 @@ export type SelectPopupProps = Omit< _Select.Popup.Props, 'style' > & {
 };
 
 export type SelectItemProps = Omit<
-	_Select.Item.Props,
-	'children' | 'value' | 'style'
+	ComponentProps< typeof _Select.Item >,
+	'value'
 > & {
-	/**
-	 * CSS style applied to the item element.
-	 */
-	style?: React.CSSProperties;
 	/**
 	 * A unique value that identifies this select item.
 	 */

--- a/packages/ui/src/utils/types.ts
+++ b/packages/ui/src/utils/types.ts
@@ -14,12 +14,17 @@ type ComponentRenderFn< Props > = (
 
 export type ComponentProps< E extends ElementType > = Omit<
 	ComponentPropsWithoutRef< E >,
-	'className' | 'children' | 'render'
+	'className' | 'children' | 'render' | 'style'
 > & {
 	/**
 	 * CSS class name to apply to the component.
 	 */
 	className?: string;
+
+	/**
+	 * CSS style to apply to the component.
+	 */
+	style?: React.CSSProperties;
 
 	/**
 	 * Replaces the component's default HTML element using a given React

--- a/packages/ui/src/utils/types.ts
+++ b/packages/ui/src/utils/types.ts
@@ -17,12 +17,12 @@ export type ComponentProps< E extends ElementType > = Omit<
 	'className' | 'children' | 'render' | 'style'
 > & {
 	/**
-	 * CSS class name to apply to the component.
+	 * CSS class name to apply to the element.
 	 */
 	className?: string;
 
 	/**
-	 * CSS style to apply to the component.
+	 * CSS style to apply to the element.
 	 */
 	style?: React.CSSProperties;
 


### PR DESCRIPTION
## What?

Update `@base-ui/react` from `1.3.0` to `1.4.0` in `packages/ui`.

## Why?

[v1.4.0](https://base-ui.com/react/overview/releases/v1-4-0) was released on April 13, 2026. It is a bug-fix release with no breaking changes, bringing fixes for several components used by `@wordpress/ui`.

It also includes a fix for a specific issue that we had raised in https://github.com/mui/base-ui/issues/4361

## How?

- Bumped the version specifier in `packages/ui/package.json` from `^1.3.0` to `^1.4.0` and regenerated the lockfile.
- Reverted the `DEFAULT_RENDER` naming workaround in `Field.Root` (introduced in #76603). Base UI 1.4.0 [fixes](https://github.com/mui/base-ui/pull/4363) the false-positive render prop warning for screaming snake case constants, so the workaround is no longer needed. The `textareaRender` rename in `Textarea` is kept because PascalCase names are still warned about (correctly so).
- Fixed TypeScript errors caused by a new state-callback form added to the `style` prop in Base UI 1.4.0 (mirroring what `className` already had). Updated `ComponentProps` to strip and redefine `style` as plain `CSSProperties`, consistent with how `className` is already handled. Also overrode `style` in `SelectPopupProps` (forwarded to Positioner, different state type), `SelectTriggerProps`, and `SelectItemProps` (bypass `ComponentProps`, so needed explicit stripping for consistency).
- Updated `CONTRIBUTING.md` render prop example to match the reverted `DEFAULT_RENDER` naming.

<details>
<summary>Audit summary</summary>

### Version comparison
| | Version |
|-|-|
| **Previous (resolved)** | `1.3.0` |
| **Target** | `^1.4.0` (resolves to `1.4.0`) |
| **Latest on npm** | `1.4.0` |

### Changelog review

Bug-fix release — no breaking changes, no deprecations. Notable fixes relevant to `@wordpress/ui`:

- **Checkbox / Switch**: Fix uncontrolled default initialization; prevent input state changes in `readOnly` mode
- **Collapsible**: Fix open state when `keepMounted` has no transitions
- **Dialog / Alert Dialog**: Fix detached trigger HMR with recreated handles
- **Popover**: Remove stray focus guards around trigger when `modal`; sync hover open event state
- **Select**: Fix RTL-aligned popup positioning, touch reopen highlight, scroll arrows stopping short of edges
- **Tabs**: Fix `activationDirection` not updating on programmatic value changes; fix activation direction on first render; skip client-only prehydration scripts
- **General**: Fix `Positioner` not repositioning to a different trigger when reopened with `keepMounted`; fix outside-press dismissal in a shared shadow root

A new preview `OTPField` component was added but is not consumed by `@wordpress/ui`.

### Codebase audit

- **Render prop workaround reverted**: PR #76603 renamed `DEFAULT_RENDER` → `defaultRender` in `Field.Root` and `Render` → `textareaRender` in `Textarea` to avoid a false-positive render prop warning ([mui/base-ui#4361](https://github.com/mui/base-ui/issues/4361)). Base UI 1.4.0 [fixes this](https://github.com/mui/base-ui/pull/4363) for screaming snake case names, so the `DEFAULT_RENDER` rename is reverted. The `textareaRender` rename is kept since PascalCase names like `Render` are still caught by the (now correct) warning.
- **`style` prop type change**: Base UI 1.4.0 added a state-callback form to the `style` prop on all components (e.g. `style?: CSSProperties | ((state: State) => CSSProperties)`), mirroring what `className` already had. This caused TypeScript errors where our wrapper components forward `style` to elements that only accept plain `CSSProperties`. Fixed by stripping the callback form in `ComponentProps` (matching existing `className` treatment) and overriding `style` in `SelectPopupProps`, `SelectTriggerProps`, and `SelectItemProps` (these bypass `ComponentProps` and extend Base UI props directly).
- **Workaround TODOs**: Multiple test TODOs reference [mui/base-ui#2097](https://github.com/mui/base-ui/issues/2097) (`onValueChange` not firing for automatic tab selection). That issue is still open and the fix PR ([mui/base-ui#3758](https://github.com/mui/base-ui/pull/3758)) has not been merged yet — TODOs remain valid.
- **`tabbable` dependency**: Base UI 1.4.0 dropped `tabbable` from its own dependencies, but `packages/ui` uses it directly in `useDeprioritizedInitialFocus` — no action needed.
- **New optional peer deps**: `@date-fns/tz` and `date-fns` were added as optional peer deps (for the new `OTPField`). Not required by any components we use.

### Ecosystem compatibility

No sibling `@base-ui/*` packages are used as direct dependencies. The transitive sub-dependency `@base-ui/utils` was updated from `0.2.6` to `0.2.7`. `@floating-ui/react-dom` range is unchanged.

### Security check

`npm audit` shows no vulnerabilities for `@base-ui/react`. Pre-existing repo-wide vulnerabilities are unrelated.

### Build and test

All 270 tests across 32 test suites in `packages/ui` pass. Build succeeds. Minor `act(...)` console warnings in tabs tests are pre-existing and unrelated to this update.

</details>

## Testing Instructions

1. Run `npm run test:unit packages/ui` — all tests should pass.
2. Run `npm run build` — build should succeed.
3. Optionally, run Storybook (`cd packages/ui && npx storybook dev`) and smoke-test components wrapping Base UI: Button, Dialog, AlertDialog, Popover, Tabs, Collapsible, Select, Tooltip.

## Use of AI Tools

This PR was authored with the assistance of Cursor (Claude).
