### PR TITLE
Edit Post: Fix warning in 'useMetaBoxInitialization' hook

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -35,14 +35,13 @@ export const useMetaBoxInitialization = ( enabled ) => {
 				: false,
 			allMetaBoxes: enabled
 				? select( editPostStore ).getAllMetaBoxes()
-				: [],
+				: undefined,
 			rtcCompatibleIds:
 				select( editPostStore ).getRtcCompatibleMetaBoxIds(),
 		} ),
 		[ enabled ]
 	);
 	const { setCollaborationSupported } = unlock( useDispatch( coreStore ) );
-
 	const { initializeMetaBoxes } = useDispatch( editPostStore );
 
 	// The effect has to rerun when the editor is ready because initializeMetaBoxes
@@ -55,7 +54,7 @@ export const useMetaBoxInitialization = ( enabled ) => {
 			// Meta boxes marked with __rtc_compatible_meta_box on the server
 			// have their IDs stored via setRtcCompatibleMetaBoxIds().
 			if ( isCollaborationEnabled ) {
-				const hasIncompatibleMetaBoxes = allMetaBoxes.some(
+				const hasIncompatibleMetaBoxes = allMetaBoxes?.some(
 					( metaBox ) => ! rtcCompatibleIds.includes( metaBox.id )
 				);
 


### PR DESCRIPTION
## What?
This is a follow-up to #76939. Waiting for feedback on larger refactoring - https://github.com/WordPress/gutenberg/pull/76939#issuecomment-4242974637.

PR fixes `useSelect` warning triggered by `useMetaBoxInitialization`, which was returning a new array reference on each call when metaboxes are disabled.

See: https://make.wordpress.org/core/2025/03/12/data-a-helpful-performance-warning-for-developers-in-the-useselect-hook/

## How?
Return undefined when the feature is disabled and account for it later.

## Testing Instructions
1. Ensure `WP_DEBUG` and `SCRIPT_DEBUG`.
2. Disable metaboxes.
3. Open a post.
4. Confirm there's no warning in the console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="740" height="214" alt="CleanShot 2026-04-14 at 13 21 35" src="https://github.com/user-attachments/assets/ba9fcbfe-cd41-49e3-b363-69911c899fae" />

## Use of AI Tools

None.
