### PR TITLE
Remove 'src' directory from core-abilities package files

### DIFF
--- a/packages/core-abilities/package.json
+++ b/packages/core-abilities/package.json
@@ -24,7 +24,6 @@
 		"npm": ">=8.19.2"
 	},
 	"files": [
-		"src",
 		"build",
 		"build-module",
 		"build-types",


### PR DESCRIPTION
## What?

Part of https://github.com/WordPress/gutenberg/issues/77274

Removes `src` from the `files` field in `@wordpress/core-abilities` `package.json`.


## Why?

The package defines an `exports` field that only exposes built artifacts (`build/`, `build-module/`, `build-types/`). Per Node.js module resolution, consumers cannot access files outside of `exports`. Shipping the `src/` directory is unnecessary and inflates the published package size.


## How?

Removes `"src"` from the `files` array. 


## Testing Instructions

1. Verify the package builds: `npm run build`
2. Verify `npm pack --dry-run` in `packages/core-abilites/` no longer includes `src/`



## Screenshots
<img width="529" height="343" alt="Screenshot 2026-04-14 at 3 19 32 PM" src="https://github.com/user-attachments/assets/2d046d82-3729-4681-8a9b-3f743330ecdb" />



