### PR TITLE
Tests: Auto-fix some new 'eslint-plugin-playwright' warnings

### DIFF
--- a/test/e2e/specs/admin/font-library.spec.js
+++ b/test/e2e/specs/admin/font-library.spec.js
@@ -16,16 +16,16 @@ test.describe( 'Font Library', () => {
 			);
 		} );
 
-		test.afterAll( async ( { requestUtils } ) => {
-			await requestUtils.deactivatePlugin(
-				'gutenberg-test-delete-installed-fonts'
-			);
-		} );
-
 		test.beforeEach( async ( { admin } ) => {
 			await admin.visitAdminPage(
 				'admin.php',
 				'page=font-library-wp-admin'
+			);
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-delete-installed-fonts'
 			);
 		} );
 

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -271,12 +271,12 @@ test.describe( 'Buttons', () => {
 			await requestUtils.activateTheme( 'emptytheme' );
 		} );
 
-		test.afterAll( async ( { requestUtils } ) => {
-			await requestUtils.activateTheme( 'twentytwentyone' );
-		} );
-
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost();
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'twentytwentyone' );
 		} );
 
 		test( 'can resize width', async ( { editor, page } ) => {

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -142,7 +142,7 @@ test.describe( 'Classic', () => {
 		await expect( classicBlock ).toBeVisible();
 		await classicBlock.click();
 
-		expect( errors.length ).toBe( 0 );
+		expect( errors ).toHaveLength( 0 );
 		await expect.poll( editor.getEditedPostContent ).toBe( 'test' );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -18,12 +18,12 @@ test.use( {
 } );
 
 test.describe( 'Classic', () => {
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMedia();
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
 	} );
 
 	test( 'should be inserted', async ( { editor, page } ) => {

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -84,6 +84,7 @@ test.describe( 'Columns', () => {
 		await pageUtils.pressKeys( 'Tab' );
 		await expect( columnsChangeInput ).toHaveValue( '3' );
 	} );
+
 	test( 'Ungroup properly', async ( { editor } ) => {
 		await editor.insertBlock( {
 			name: 'core/columns',

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -969,12 +969,12 @@ test.describe( 'Image - lightbox', () => {
 		);
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMedia();
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
 	} );
 
 	test.describe( 'should respect theme.json settings and block overrides', () => {

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -11,14 +11,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		await requestUtils.deleteAllMenus();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		await requestUtils.deleteAllPages();
 		await requestUtils.deleteAllMenus();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test.describe( 'Overlay menu', () => {

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -4,11 +4,6 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Navigation block - Submenu Visibility', () => {
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMenus();
-		await requestUtils.deleteAllPages();
-	} );
-
 	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
 		await admin.createNewPost();
 
@@ -36,6 +31,11 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 		} );
 		await expect( navBlock ).toBeVisible();
 		await editor.selectBlocks( navBlock );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+		await requestUtils.deleteAllPages();
 	} );
 
 	test( 'When Always is selected, submenus are visible on the page', async ( {

--- a/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-submenu-visibility.spec.js
@@ -139,6 +139,7 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 		const pageListBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Page List',
 		} );
+
 		await test.step( 'Test setup', async () => {
 			// Create parent and child pages for testing
 			const parentPage = await requestUtils.createPage( {
@@ -206,6 +207,7 @@ test.describe( 'Navigation block - Submenu Visibility', () => {
 
 			await expect( submenuVisibilityGroup ).toBeVisible();
 		} );
+
 		await test.step( 'Set submenu visibility to always', async () => {
 			const settingsPanel = page
 				.getByRole( 'region', { name: 'Editor settings' } )

--- a/test/e2e/specs/editor/blocks/query.spec.js
+++ b/test/e2e/specs/editor/blocks/query.spec.js
@@ -13,13 +13,6 @@ test.describe( 'Query block', () => {
 		await requestUtils.createPost( { title: 'Post 1', status: 'publish' } );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.deleteAllPosts(),
-			requestUtils.deactivatePlugin( 'gutenberg-test-query-block' ),
-		] );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost( {
 			postType: 'page',
@@ -29,6 +22,13 @@ test.describe( 'Query block', () => {
 
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllPages();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deactivatePlugin( 'gutenberg-test-query-block' ),
+		] );
 	} );
 
 	test.describe( 'Query block insertion', () => {

--- a/test/e2e/specs/editor/blocks/search.spec.js
+++ b/test/e2e/specs/editor/blocks/search.spec.js
@@ -9,15 +9,15 @@ test.describe( 'Search', () => {
 		await admin.createNewPost();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMenus();
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.deleteAllPosts(),
 			requestUtils.deleteAllMenus(),
 		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
 	} );
 
 	test( 'should auto-configure itself to sensible defaults when inserted into a Navigation block', async ( {

--- a/test/e2e/specs/editor/plugins/block-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/block-hooks.spec.js
@@ -45,6 +45,7 @@ test.describe( 'Block Hooks API', () => {
 	].forEach( ( { name, postType, blockType, createMethod } ) => {
 		test.describe( `Hooked blocks in ${ name } (blocks)`, () => {
 			let postObject, containerPost;
+
 			test.beforeAll( async ( { requestUtils } ) => {
 				postObject = await requestUtils[ createMethod ]( {
 					title: name,
@@ -185,6 +186,7 @@ test.describe( 'Block Hooks API', () => {
 
 		test.describe( `Hooked blocks in ${ name } (classic)`, () => {
 			let postObject, containerPost;
+
 			test.beforeAll( async ( { requestUtils } ) => {
 				postObject = await requestUtils[ createMethod ]( {
 					title: name,
@@ -308,6 +310,7 @@ test.describe( 'Block Hooks API', () => {
 
 	test.describe( 'Hooked blocks in Navigation Menu', () => {
 		let postObject, containerPost;
+
 		test.beforeAll( async ( { requestUtils } ) => {
 			postObject = await requestUtils.createNavigationMenu( {
 				title: 'Navigation Menu',

--- a/test/e2e/specs/editor/plugins/format-api.spec.js
+++ b/test/e2e/specs/editor/plugins/format-api.spec.js
@@ -8,12 +8,12 @@ test.describe( 'Using Format API', () => {
 		await requestUtils.activatePlugin( 'gutenberg-test-format-api' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin( 'gutenberg-test-format-api' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'gutenberg-test-format-api' );
 	} );
 
 	test( 'Clicking the control wraps the selected text properly with HTML code', async ( {

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -9,12 +9,12 @@ test.describe( 'Using Hooks API', () => {
 		await requestUtils.activatePlugin( 'gutenberg-test-hooks-api' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin( 'gutenberg-test-hooks-api' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'gutenberg-test-hooks-api' );
 	} );
 
 	test( 'Should contain a reset block button on the sidebar', async ( {

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -10,14 +10,14 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		);
 	} );
 
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-innerblocks-allowed-blocks'
 		);
-	} );
-
-	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
 	} );
 
 	test( 'allows all blocks if the allowed blocks setting was not set', async ( {

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -113,14 +113,14 @@ test.describe( 'PHP-only auto-register blocks', () => {
 		);
 	} );
 
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-server-side-rendered-block'
 		);
-	} );
-
-	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
 	} );
 
 	test( 'should register blocks with autoRegister flag', async ( {

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -23,6 +23,7 @@ test.describe( 'Server-side rendered block', () => {
 			'gutenberg-test-server-side-rendered-block'
 		);
 	} );
+
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: 'test/server-side-rendered-block' } );

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -47,6 +47,7 @@ const userList = [
 		password: 'sm1lingsmyfavorite',
 	},
 ];
+
 test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all(
@@ -76,6 +77,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		[ 'Custom Completer', 'option' ],
 	].forEach( ( completerAndOptionType ) => {
 		const [ completer, type ] = completerAndOptionType;
+
 		test( `${ completer }: should insert ${ type }`, async ( {
 			page,
 			editor,

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -62,14 +62,14 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		await requestUtils.activatePlugin( 'gutenberg-test-autocompleter' );
 	} );
 
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllUsers();
 		await requestUtils.deactivatePlugin( 'gutenberg-test-autocompleter' );
 		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
-	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
 	} );
 
 	[

--- a/test/e2e/specs/editor/various/background-gradient.spec.js
+++ b/test/e2e/specs/editor/various/background-gradient.spec.js
@@ -10,12 +10,12 @@ test.describe( 'Background gradient block support', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test.describe( 'color.gradient read-through and migration', () => {

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -6,6 +6,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Registered sources', () => {
 	let imagePlaceholderSrc;
 	let testingImgSrc;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
 		await requestUtils.deleteAllMedia();
@@ -58,6 +59,7 @@ test.describe( 'Registered sources', () => {
 				page.getByLabel( 'Attributes options' )
 			).toBeHidden();
 		} );
+
 		test( 'It should show the attributes panel, no sources registered, readOnlyAttributes.', async ( {
 			editor,
 			page,
@@ -126,6 +128,7 @@ test.describe( 'Registered sources', () => {
 				previewPage.locator( '#connected-paragraph' )
 			).toHaveText( 'Text Field Value' );
 		} );
+
 		test( 'should show the returned value in heading content', async ( {
 			editor,
 		} ) => {
@@ -155,6 +158,7 @@ test.describe( 'Registered sources', () => {
 				previewPage.locator( '#connected-heading' )
 			).toHaveText( 'Text Field Value' );
 		} );
+
 		test( 'should show the returned values in button attributes', async ( {
 			editor,
 		} ) => {
@@ -190,6 +194,7 @@ test.describe( 'Registered sources', () => {
 			await expect( buttonDom ).toHaveText( 'Text Field Value' );
 			await expect( buttonDom ).toHaveAttribute( 'href', testingImgSrc );
 		} );
+
 		test( 'should show the returned values in image attributes', async ( {
 			editor,
 			page,
@@ -267,6 +272,7 @@ test.describe( 'Registered sources', () => {
 				'default title value'
 			);
 		} );
+
 		test( 'should fall back to source label when `getValues` is undefined', async ( {
 			editor,
 		} ) => {
@@ -289,6 +295,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await expect( paragraphBlock ).toHaveText( 'Server Source' );
 		} );
+
 		test( 'should fall back to null when `getValues` is undefined in URL attributes', async ( {
 			editor,
 		} ) => {
@@ -362,6 +369,7 @@ test.describe( 'Registered sources', () => {
 				'false'
 			);
 		}
+
 		test.describe( 'canUserEditValue returns false', () => {
 			test( 'paragraph', async ( { editor, page } ) => {
 				await testParagraphControlsAreLocked( {
@@ -370,6 +378,7 @@ test.describe( 'Registered sources', () => {
 					page,
 				} );
 			} );
+
 			test( 'heading', async ( { editor, page } ) => {
 				await editor.insertBlock( {
 					name: 'core/heading',
@@ -412,6 +421,7 @@ test.describe( 'Registered sources', () => {
 					'false'
 				);
 			} );
+
 			test( 'button', async ( { editor, page } ) => {
 				await editor.insertBlock( {
 					name: 'core/buttons',
@@ -479,6 +489,7 @@ test.describe( 'Registered sources', () => {
 						.getByRole( 'button', { name: 'Unlink' } )
 				).toBeHidden();
 			} );
+
 			test( 'image', async ( { editor, page } ) => {
 				await editor.insertBlock( {
 					name: 'core/image',
@@ -548,6 +559,7 @@ test.describe( 'Registered sources', () => {
 				).toHaveValue( 'Text Field Value' );
 			} );
 		} );
+
 		// The following tests just check the paragraph and assume is the case for the rest of the blocks.
 		test( 'canUserEditValue is not defined', async ( { editor, page } ) => {
 			await testParagraphControlsAreLocked( {
@@ -556,6 +568,7 @@ test.describe( 'Registered sources', () => {
 				page,
 			} );
 		} );
+
 		test( 'setValues is not defined', async ( { editor, page } ) => {
 			await testParagraphControlsAreLocked( {
 				source: 'testing/complete-source-undefined',
@@ -563,6 +576,7 @@ test.describe( 'Registered sources', () => {
 				page,
 			} );
 		} );
+
 		test( 'source is not defined', async ( { editor, page } ) => {
 			await testParagraphControlsAreLocked( {
 				source: 'testing/undefined-source',
@@ -613,6 +627,7 @@ test.describe( 'Registered sources', () => {
 				previewPage.locator( '#connected-paragraph' )
 			).toHaveText( 'new value' );
 		} );
+
 		// Related issue: https://github.com/WordPress/gutenberg/issues/62347
 		test( 'should be possible to use symbols and numbers as the custom field value', async ( {
 			editor,
@@ -647,6 +662,7 @@ test.describe( 'Registered sources', () => {
 				previewPage.locator( '#paragraph-binding' )
 			).toHaveText( '$10.00' );
 		} );
+
 		test( 'should be possible to edit the value of the url custom field from the button', async ( {
 			editor,
 			page,
@@ -701,6 +717,7 @@ test.describe( 'Registered sources', () => {
 				previewPage.locator( '#button-url-binding a' )
 			).toHaveAttribute( 'href', '#url-custom-field-modified' );
 		} );
+
 		test( 'should be possible to edit the value of the url custom field from the image', async ( {
 			editor,
 			page,
@@ -757,6 +774,7 @@ test.describe( 'Registered sources', () => {
 				previewPage.locator( '#image-url-binding img' )
 			).toHaveAttribute( 'src', testingImgSrc );
 		} );
+
 		test( 'should be possible to edit the value of the text custom field from the image alt', async ( {
 			editor,
 			page,
@@ -836,6 +854,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await expect( paragraphBlock ).toHaveText( 'Text Field Value' );
 		} );
+
 		test( 'should be possible to connect the paragraph content', async ( {
 			editor,
 			page,
@@ -849,6 +868,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await expect( contentAttribute ).toBeVisible();
 		} );
+
 		test( 'should be possible to connect the heading content', async ( {
 			editor,
 			page,
@@ -862,6 +882,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await expect( contentAttribute ).toBeVisible();
 		} );
+
 		test( 'should be possible to connect the button supported attributes', async ( {
 			editor,
 			page,
@@ -904,6 +925,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await expect( tagNameAttribute ).toBeHidden();
 		} );
+
 		test( 'should be possible to connect the image supported attributes', async ( {
 			editor,
 			page,
@@ -940,6 +962,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await expect( linkClassAttribute ).toBeHidden();
 		} );
+
 		test( 'should show all the available fields in the dropdown UI', async ( {
 			editor,
 			page,
@@ -975,6 +998,7 @@ test.describe( 'Registered sources', () => {
 			await expect( urlField ).toBeVisible();
 			await expect( urlField ).not.toBeChecked();
 		} );
+
 		test( 'should show the connected fields in the attributes panel', async ( {
 			editor,
 			page,
@@ -1033,6 +1057,7 @@ test.describe( 'Registered sources', () => {
 			await expect( newEmptyParagraph ).toHaveText( '' );
 			await expect( newEmptyParagraph ).toBeEditable();
 		} );
+
 		test( 'should add empty paragraph block when pressing enter in heading', async ( {
 			editor,
 			page,
@@ -1078,6 +1103,7 @@ test.describe( 'Registered sources', () => {
 			await expect( newEmptyParagraph ).toHaveText( '' );
 			await expect( newEmptyParagraph ).toBeEditable();
 		} );
+
 		test( 'should add empty button block when pressing enter in button', async ( {
 			editor,
 			page,
@@ -1123,6 +1149,7 @@ test.describe( 'Registered sources', () => {
 				newEmptyButton.getByRole( 'textbox' )
 			).toBeEditable();
 		} );
+
 		test( 'should show placeholder prompt when value is empty and can edit', async ( {
 			editor,
 		} ) => {
@@ -1154,6 +1181,7 @@ test.describe( 'Registered sources', () => {
 				'Add Empty Field Label'
 			);
 		} );
+
 		test( 'should show source label when value is empty, cannot edit, and `getFieldsList` is undefined', async ( {
 			editor,
 		} ) => {
@@ -1182,6 +1210,7 @@ test.describe( 'Registered sources', () => {
 				'Can User Edit: False'
 			);
 		} );
+
 		test( 'should show placeholder attribute over bindings placeholder', async ( {
 			editor,
 		} ) => {
@@ -1237,6 +1266,7 @@ test.describe( 'Registered sources', () => {
 		} );
 		await expect( contentButton ).toContainText( 'Server Source' );
 	} );
+
 	test( 'should show an "Source not registered" warning for not registered sources', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -19,6 +19,7 @@ test.describe( 'Post Data source', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
 	} );
+
 	test.describe( 'Post Data bindings UI.', () => {
 		test( 'should not include post data fields in UI to connect attributes on non date blocks', async ( {
 			editor,

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -67,6 +67,7 @@ test.describe( 'Post Meta source', () => {
 					'false'
 				);
 			} );
+
 			test( 'should show the default value if it is defined', async ( {
 				editor,
 			} ) => {
@@ -93,6 +94,7 @@ test.describe( 'Post Meta source', () => {
 					'Movie field default value'
 				);
 			} );
+
 			test( 'should fall back to the field label if the default value is not defined', async ( {
 				editor,
 			} ) => {
@@ -119,6 +121,7 @@ test.describe( 'Post Meta source', () => {
 					'Field with only label'
 				);
 			} );
+
 			test( 'should fall back to the field key if the field label is not defined', async ( {
 				editor,
 			} ) => {
@@ -174,6 +177,7 @@ test.describe( 'Post Meta source', () => {
 					'Movie field label'
 				);
 			} );
+
 			test( 'should fall back to the field key if the field label is not defined', async ( {
 				editor,
 				page,
@@ -234,6 +238,7 @@ test.describe( 'Post Meta source', () => {
 					.filter( { hasText: 'Movie field label' } );
 				await expect( movieField ).toBeVisible();
 			} );
+
 			test( 'should include global fields in UI to connect attributes', async ( {
 				page,
 			} ) => {
@@ -242,6 +247,7 @@ test.describe( 'Post Meta source', () => {
 					.filter( { hasText: 'text_custom_field' } );
 				await expect( globalField ).toBeVisible();
 			} );
+
 			test( 'should not include protected fields', async ( { page } ) => {
 				// Ensure the fields have loaded by checking the field is visible.
 				const globalField = page
@@ -258,6 +264,7 @@ test.describe( 'Post Meta source', () => {
 					.filter( { hasText: 'show_in_rest_false_field' } );
 				await expect( showInRestFalseField ).toBeHidden();
 			} );
+
 			test( 'should show the default value if it is defined', async ( {
 				page,
 			} ) => {
@@ -268,6 +275,7 @@ test.describe( 'Post Meta source', () => {
 					'Movie field default value'
 				);
 			} );
+
 			// We need to discuss this approach. As now is showing the label, like post-meta getValues function on the editor.
 			test( 'should not show anything if the default value is not defined', async ( {
 				page,
@@ -340,6 +348,7 @@ test.describe( 'Post Meta source', () => {
 
 			await expect( movieField ).toBeHidden();
 		} );
+
 		test( 'should show the key in attributes connected to post meta', async ( {
 			editor,
 		} ) => {
@@ -418,6 +427,7 @@ test.describe( 'Post Meta source', () => {
 				previewPage.locator( '#connected-paragraph' )
 			).toHaveText( 'Movie field default value' );
 		} );
+
 		test( 'should fall back to the key when custom field is not accessible', async ( {
 			editor,
 		} ) => {
@@ -446,6 +456,7 @@ test.describe( 'Post Meta source', () => {
 				'false'
 			);
 		} );
+
 		test( 'should not show or edit the value of a protected field', async ( {
 			editor,
 		} ) => {
@@ -474,6 +485,7 @@ test.describe( 'Post Meta source', () => {
 				'false'
 			);
 		} );
+
 		test( 'should not show or edit the value of a field with `show_in_rest` set to false', async ( {
 			editor,
 		} ) => {
@@ -504,6 +516,7 @@ test.describe( 'Post Meta source', () => {
 				'false'
 			);
 		} );
+
 		test( 'should be possible to edit the value of the connected custom fields', async ( {
 			editor,
 		} ) => {
@@ -616,6 +629,7 @@ test.describe( 'Post Meta source', () => {
 				.filter( { hasText: 'Movie field label' } );
 			await expect( movieField ).toBeVisible();
 		} );
+
 		test( 'should not be possible to connect non-supported fields through the attributes panel', async ( {
 			editor,
 			page,

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -322,6 +322,7 @@ test.describe( 'Content-only lock', () => {
 
 		// Select the content-locked group block.
 		await editor.selectBlocks( groupBlock );
+
 		await test.step( 'Blocks cannot be inserted before/after or duplicated', async () => {
 			// Test paragraph.
 			await editor.selectBlocks( heading );
@@ -459,6 +460,7 @@ test.describe( 'Content-only lock', () => {
 
 		// Select the content-locked group block.
 		await editor.selectBlocks( groupBlock );
+
 		await test.step( 'Blocks can be inserted before/after or duplicated', async () => {
 			// Test first list item.
 			await editor.selectBlocks( firstListItem );
@@ -623,7 +625,7 @@ test.describe( 'Content-only lock', () => {
 		// Verify no new paragraph was inserted in the Column.
 		const afterBlocks = await editor.getBlocks();
 		const afterColumn = afterBlocks[ 0 ].innerBlocks[ 0 ].innerBlocks[ 1 ];
-		expect( afterColumn.innerBlocks.length ).toBe( initialColumnChildren );
+		expect( afterColumn.innerBlocks ).toHaveLength( initialColumnChildren );
 	} );
 
 	test( 'should insert blocks via Add before and Add after for paragraphs in contentOnly mode', async ( {

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -182,7 +182,7 @@ test.describe( 'Copy/cut/paste', () => {
 			() => window.e2eTestPasteOnce
 		);
 
-		expect( blocksUpdated.length ).toEqual( 1 );
+		expect( blocksUpdated ).toHaveLength( 1 );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -236,7 +236,7 @@ test.describe( 'Copy/cut/paste', () => {
 			() => window.e2eTestPasteOnce
 		);
 
-		expect( blocksUpdated.length ).toEqual( 1 );
+		expect( blocksUpdated ).toHaveLength( 1 );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 

--- a/test/e2e/specs/editor/various/datepicker.spec.js
+++ b/test/e2e/specs/editor/various/datepicker.spec.js
@@ -15,6 +15,7 @@ const TIMEZONES = [ 'Pacific/Honolulu', 'UTC', 'Australia/Sydney' ];
 TIMEZONES.forEach( ( timezone ) => {
 	test.describe( `Datepicker: ${ timezone }`, () => {
 		let originalTimezone;
+
 		test.beforeAll( async ( { requestUtils } ) => {
 			originalTimezone = ( await requestUtils.getSiteSettings() )
 				.timezone;

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -10,13 +10,13 @@ test.use( {
 } );
 
 test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
+	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllBlocks();
 		await requestUtils.deleteAllPatternCategories();
 	} );
 
-	test.afterEach( async ( { requestUtils } ) => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
 		await requestUtils.deleteAllBlocks();
 		await requestUtils.deleteAllPatternCategories();
 	} );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -761,12 +761,14 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 test.describe( 'insert media from inserter', () => {
 	let uploadedMedia;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllMedia();
 		uploadedMedia = await requestUtils.uploadMedia(
 			'./assets/10x10_e2e_test_image_z9T8jK.png'
 		);
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.deleteAllMedia(),

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -16,12 +16,6 @@ test.describe( 'Unsynced pattern', () => {
 		await requestUtils.deleteAllPatternCategories();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -29,6 +23,12 @@ test.describe( 'Unsynced pattern', () => {
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllBlocks();
 		await requestUtils.deleteAllPatternCategories();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
 	} );
 
 	test( 'create a new unsynced pattern via the block options menu', async ( {
@@ -622,16 +622,16 @@ test.describe( 'Synced pattern', () => {
 		await admin.createNewPost();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllPosts();
 		await requestUtils.deleteAllBlocks();
 		await requestUtils.deleteAllPatternCategories();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
 	} );
 
 	test( 'create a new synced pattern via the block options menu', async ( {

--- a/test/e2e/specs/editor/various/post-title.spec.js
+++ b/test/e2e/specs/editor/various/post-title.spec.js
@@ -52,6 +52,7 @@ test.describe( 'Post title', () => {
 			await expect( pageTitleField ).toBeFocused();
 		} );
 	} );
+
 	test.describe( 'HTML handling', () => {
 		test( `should (visually) render any HTML in Post Editor's post title field when in Visual editing mode`, async ( {
 			page,

--- a/test/e2e/specs/editor/various/pref-modal.spec.js
+++ b/test/e2e/specs/editor/various/pref-modal.spec.js
@@ -24,6 +24,7 @@ test.describe( 'Preferences modal', () => {
 			await expect( prePublishToggle ).toBeVisible();
 		} );
 	} );
+
 	test.describe( 'Preferences modal adaps to viewport', () => {
 		test( 'Enable pre-publish checks is not visible on mobile', async ( {
 			page,

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -267,12 +267,6 @@ test.describe( 'Preview with Custom Fields enabled', () => {
 		);
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.beforeEach( async ( { admin, previewUtils } ) => {
 		await admin.createNewPost();
 		await previewUtils.toggleCustomFieldsOption( true );
@@ -280,6 +274,12 @@ test.describe( 'Preview with Custom Fields enabled', () => {
 
 	test.afterEach( async ( { previewUtils } ) => {
 		await previewUtils.toggleCustomFieldsOption( false );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
 	} );
 
 	// Catch regressions of https://github.com/WordPress/gutenberg/issues/12617

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -268,13 +268,13 @@ test.describe( 'Template and template part revisions', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	[

--- a/test/e2e/specs/editor/various/scheduling.spec.js
+++ b/test/e2e/specs/editor/various/scheduling.spec.js
@@ -11,6 +11,7 @@ test.describe( 'Scheduling', () => {
 	TIMEZONES.forEach( ( timezone ) => {
 		test.describe( `Timezone ${ timezone }`, () => {
 			let originalTimezone;
+
 			test.beforeAll( async ( { requestUtils } ) => {
 				originalTimezone = ( await requestUtils.getSiteSettings() )
 					.timezone;

--- a/test/e2e/specs/editor/various/template-resolution.spec.js
+++ b/test/e2e/specs/editor/various/template-resolution.spec.js
@@ -15,6 +15,7 @@ test.describe( 'Template resolution', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.deleteAllPages(),
@@ -25,9 +26,11 @@ test.describe( 'Template resolution', () => {
 			} ),
 		] );
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
+
 	test( 'Site editor proper front page template resolution when we have only set posts page in settings', async ( {
 		page,
 		admin,
@@ -43,6 +46,7 @@ test.describe( 'Template resolution', () => {
 			0
 		);
 	} );
+
 	test.describe( '`page_for_posts` setting', () => {
 		test( 'Post editor proper template resolution', async ( {
 			page,
@@ -65,6 +69,7 @@ test.describe( 'Template resolution', () => {
 				page.getByRole( 'button', { name: 'Template options' } )
 			).toHaveText( 'Index' );
 		} );
+
 		test( 'Site editor proper template resolution', async ( {
 			page,
 			editor,

--- a/test/e2e/specs/editor/various/write-design-mode.spec.js
+++ b/test/e2e/specs/editor/various/write-design-mode.spec.js
@@ -7,6 +7,7 @@ test.describe.skip( 'Write/Design mode', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
+
 	test.beforeEach( async ( { admin, page } ) => {
 		await page.addInitScript( () => {
 			window.__experimentalEditorWriteMode = true;
@@ -17,9 +18,11 @@ test.describe.skip( 'Write/Design mode', () => {
 			canvas: 'edit',
 		} );
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
+
 	test( 'Should prevent selecting intermediary blocks', async ( {
 		editor,
 		page,
@@ -176,6 +179,7 @@ test.describe.skip( 'Write/Design mode', () => {
 
 		await expect( nonContentBlock ).toBeHidden();
 	} );
+
 	test( 'prevents adding non-content blocks to content role containers', async ( {
 		editor,
 		page,
@@ -226,6 +230,7 @@ test.describe.skip( 'Write/Design mode', () => {
 			page.getByRole( 'option', { name: 'Group' } )
 		).toBeHidden();
 	} );
+
 	test( 'allows adding blocks to content role containers', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/site-editor/activate-theme.spec.js
+++ b/test/e2e/specs/site-editor/activate-theme.spec.js
@@ -8,9 +8,11 @@ test.describe( 'Activate theme', () => {
 		await admin.visitAdminPage( 'themes.php' );
 		await page.getByLabel( 'Live Preview Emptytheme' ).click();
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
+
 	test( 'activate block theme when live previewing from sidebar save button', async ( {
 		admin,
 		page,
@@ -27,6 +29,7 @@ test.describe( 'Activate theme', () => {
 		await admin.visitAdminPage( 'themes.php' );
 		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
 	} );
+
 	test( 'activate block theme when live previewing in edit mode', async ( {
 		editor,
 		admin,

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -8,16 +8,16 @@ test.describe( 'Site editor block removal prompt', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should appear when attempting to remove Query Block', async ( {

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -21,13 +21,6 @@ test.describe( 'Block Style Variations', () => {
 		stylesPostId = await requestUtils.getCurrentThemeGlobalStylesPostId();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.activateTheme( 'twentytwentyone' ),
-			requestUtils.deleteAllPages(),
-		] );
-	} );
-
 	test.beforeEach( async ( { requestUtils, admin } ) => {
 		await Promise.all( [
 			requestUtils.deleteAllPages(),
@@ -41,6 +34,13 @@ test.describe( 'Block Style Variations', () => {
 				.dispatch( 'core/editor' )
 				.setRenderingMode( 'post-only' );
 		}, [] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllPages(),
+		] );
 	} );
 
 	test( 'apply block styles variations to nested blocks', async ( {

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -11,6 +11,7 @@ test.use( {
 
 test.describe( 'Block Style Variations', () => {
 	let stylesPostId;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.activateTheme(

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -103,7 +103,7 @@ test.describe( 'Site editor command palette', () => {
 
 		// Results heading should appear, Suggestions should not.
 		await expect( list.getByText( 'Results' ) ).toBeVisible();
-		await expect( list.getByText( 'Suggestions' ) ).not.toBeVisible();
+		await expect( list.getByText( 'Suggestions' ) ).toBeHidden();
 	} );
 
 	test( 'Recent commands show after using a command', async ( {

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -8,16 +8,16 @@ test.describe( 'Site editor command palette', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
+	test.beforeEach( async ( { admin } ) => {
+		// Navigate to the site editor.
+		await admin.visitSiteEditor();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.activateTheme( 'twentytwentyone' ),
 			requestUtils.deleteAllPages(),
 		] );
-	} );
-
-	test.beforeEach( async ( { admin } ) => {
-		// Navigate to the site editor.
-		await admin.visitSiteEditor();
 	} );
 
 	test( 'Open the command palette and navigate to the page create page', async ( {

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -17,18 +17,18 @@ test.describe( 'Dataviews List Layout', () => {
 		} );
 	} );
 
+	test.beforeEach( async ( { admin, page } ) => {
+		// Go to the pages page, as it has the list layout enabled by default.
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Pages' } ).click();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		// Go back to the default theme.
 		await Promise.all( [
 			requestUtils.activateTheme( 'twentytwentyone' ),
 			requestUtils.deleteAllPages(),
 		] );
-	} );
-
-	test.beforeEach( async ( { admin, page } ) => {
-		// Go to the pages page, as it has the list layout enabled by default.
-		await admin.visitSiteEditor();
-		await page.getByRole( 'button', { name: 'Pages' } ).click();
 	} );
 
 	test( 'Items list is reachable via TAB', async ( { page } ) => {

--- a/test/e2e/specs/site-editor/dataviews-pagination.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-pagination.spec.js
@@ -21,14 +21,14 @@ test.describe( 'DataViews Pagination', () => {
 		);
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await requestUtils.deleteAllPages();
-	} );
-
 	test.beforeEach( async ( { admin, page } ) => {
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deleteAllPages();
 	} );
 
 	test( 'navigates forward, backward, and forward again correctly', async ( {

--- a/test/e2e/specs/site-editor/global-styles-button-states.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-button-states.spec.js
@@ -8,10 +8,6 @@ test.describe( 'Global Styles - Button States', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.deleteAllPosts();
 		await admin.visitSiteEditor( {
@@ -19,6 +15,10 @@ test.describe( 'Global Styles - Button States', () => {
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'As a user I want to set button hover background color and see it applied on the frontend', async ( {

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -8,16 +8,16 @@ test.describe( 'Global styles sidebar', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should filter blocks list results', async ( { page } ) => {

--- a/test/e2e/specs/site-editor/list-view.spec.js
+++ b/test/e2e/specs/site-editor/list-view.spec.js
@@ -8,10 +8,6 @@ test.describe( 'Site Editor List View', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		// Select a template part with a few blocks.
 		await admin.visitSiteEditor( {
@@ -19,6 +15,10 @@ test.describe( 'Site Editor List View', () => {
 			postType: 'wp_template_part',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should open by default when preference is enabled', async ( {

--- a/test/e2e/specs/site-editor/multi-entity-saving.spec.js
+++ b/test/e2e/specs/site-editor/multi-entity-saving.spec.js
@@ -11,19 +11,19 @@ test.describe( 'Site Editor - Multi-entity save flow', () => {
 		] );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.activateTheme( 'twentytwentyone' ),
-			requestUtils.deleteAllTemplates( 'wp_template' ),
-		] );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+		] );
 	} );
 
 	test( 'save flow should work as expected', async ( { editor, page } ) => {

--- a/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
+++ b/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
@@ -56,15 +56,15 @@ test.describe( 'Navigation Overlay Template Part', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		await requestUtils.deleteAllPages();
 		await requestUtils.deleteAllMenus();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test.describe( 'Creation', () => {

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -11,12 +11,12 @@ test.describe( 'Templates', () => {
 		] );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'Sorting', async ( { admin, page } ) => {

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -22,6 +22,12 @@ test.describe( 'Page List', () => {
 		await requestUtils.deleteAllMedia();
 	} );
 
+	test.beforeEach( async ( { admin, page } ) => {
+		// Go to the pages page, as it has the list layout enabled by default.
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Pages' } ).click();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		// Go back to the default theme.
 		await Promise.all( [
@@ -29,12 +35,6 @@ test.describe( 'Page List', () => {
 			requestUtils.deleteAllPages(),
 			requestUtils.deleteAllMedia(),
 		] );
-	} );
-
-	test.beforeEach( async ( { admin, page } ) => {
-		// Go to the pages page, as it has the list layout enabled by default.
-		await admin.visitSiteEditor();
-		await page.getByRole( 'button', { name: 'Pages' } ).click();
 	} );
 
 	test( 'Persists filter/search when switching layout', async ( {
@@ -363,6 +363,10 @@ test.describe( 'Page List', () => {
 			await row.getByRole( 'button', { name: 'Quick Edit' } ).click();
 		} );
 
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllUsers();
+		} );
+
 		Object.entries( fields ).forEach(
 			( [
 				key,
@@ -473,10 +477,6 @@ test.describe( 'Page List', () => {
 		// 		await expect( status ).toBeVisible();
 		// 	}
 		// } );
-
-		test.afterAll( async ( { requestUtils } ) => {
-			await requestUtils.deleteAllUsers();
-		} );
 	} );
 
 	test.describe( 'Quick Edit Date Timezone Consistency', () => {

--- a/test/e2e/specs/site-editor/pages-view-persistence.spec.js
+++ b/test/e2e/specs/site-editor/pages-view-persistence.spec.js
@@ -17,11 +17,6 @@ test.describe( 'Pages View Persistence', () => {
 		} );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await requestUtils.deleteAllPages();
-	} );
-
 	test.beforeEach( async ( { admin, page } ) => {
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Pages' } ).click();
@@ -36,6 +31,11 @@ test.describe( 'Pages View Persistence', () => {
 			await page.getByRole( 'button', { name: 'Reset view' } ).click();
 			await expect( modifiedIndicator ).toBeHidden();
 		}
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deleteAllPages();
 	} );
 
 	test( 'persists table layout across all tabs with unified view persistence', async ( {

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -76,20 +76,20 @@ test.describe( 'Pages', () => {
 		] );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await Promise.all( [
-			requestUtils.deleteAllTemplates( 'wp_template' ),
-			requestUtils.deleteAllPages(),
-		] );
-	} );
-
 	test.beforeEach( async ( { requestUtils, admin } ) => {
 		await Promise.all( [
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllPages(),
 		] );
 		await admin.visitSiteEditor();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await Promise.all( [
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
 	} );
 
 	test.skip( 'create a new page, edit template and toggle page template preview', async ( {

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -19,12 +19,12 @@ test.describe( 'Patterns', () => {
 		await requestUtils.deleteAllBlocks();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllBlocks();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'create a new pattern', async ( {

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -8,16 +8,16 @@ test.describe( 'Push to Global Styles button', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
 			postId: 'emptytheme//index',
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should apply Heading block styles to all Heading blocks', async ( {

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -9,19 +9,23 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 		// Enable the template activation feature.
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		// Disable the template activation feature.
 		await requestUtils.setGutenbergExperiments( [] );
 	} );
+
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 	} );
+
 	test( 'should work as expected', async ( { admin, page } ) => {
 		await admin.visitSiteEditor();
 		await page.evaluate( async () => {

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -10,12 +10,6 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		// Disable the template activation feature.
-		await requestUtils.setGutenbergExperiments( [] );
-	} );
-
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
@@ -24,6 +18,12 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		// Disable the template activation feature.
+		await requestUtils.setGutenbergExperiments( [] );
 	} );
 
 	test( 'should work as expected', async ( { admin, page } ) => {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -13,13 +13,13 @@ test.describe( 'Site Editor Inserter', () => {
 		] );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.visitSiteEditor();
 		await editor.canvas.locator( 'body' ).click();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test.use( {

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -15,19 +15,19 @@ test.describe( 'Site editor url navigation', () => {
 		);
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await requestUtils.deactivatePlugin(
-			'gutenberg-test-plugin-disable-client-side-media-processing'
-		);
-	} );
-
 	test.beforeEach( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.deleteAllPosts(),
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllTemplates( 'wp_template_part' ),
 		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
 	} );
 
 	test( 'Redirection after template creation', async ( {

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -14,10 +14,6 @@ test.describe( 'Style Book', () => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin, editor, styleBook, page } ) => {
 		await admin.visitSiteEditor();
 		await editor.canvas.locator( 'body' ).click();
@@ -25,6 +21,10 @@ test.describe( 'Style Book', () => {
 		await expect(
 			page.locator( 'role=region[name="Style Book"i]' )
 		).toBeVisible();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should disable toolbar buttons when open', async ( { page } ) => {

--- a/test/e2e/specs/site-editor/styles.spec.js
+++ b/test/e2e/specs/site-editor/styles.spec.js
@@ -8,16 +8,16 @@ test.describe( 'Styles', () => {
 		await requestUtils.activateTheme( 'twentytwentythree' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.afterEach( async ( { page } ) => {
 		await page.evaluate( async () => {
 			window.wp.data
 				.dispatch( 'core/editor' )
 				.setRenderingMode( 'post-only' );
 		}, [] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should override reset styles and library styles', async ( {

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -12,17 +12,17 @@ test.describe( 'Template Activate', () => {
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await admin.visitSiteEditor( { postType: 'wp_template' } );
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		// Disable the template activation experiment.
 		await requestUtils.setGutenbergExperiments( [] );
-	} );
-
-	test.beforeEach( async ( { admin, requestUtils } ) => {
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await admin.visitSiteEditor( { postType: 'wp_template' } );
 	} );
 
 	test( 'should duplicate and activate', async ( {

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -11,6 +11,7 @@ test.describe( 'Template Activate', () => {
 		// Enable the template activation feature.
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
@@ -18,6 +19,7 @@ test.describe( 'Template Activate', () => {
 		// Disable the template activation experiment.
 		await requestUtils.setGutenbergExperiments( [] );
 	} );
+
 	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await admin.visitSiteEditor( { postType: 'wp_template' } );

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -19,17 +19,17 @@ test.describe( 'Block template registration', () => {
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
 
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllPosts();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
 		// Disable the template activation experiment.
 		await requestUtils.setGutenbergExperiments( [] );
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await requestUtils.deleteAllPosts();
 	} );
 
 	test( 'templates can be registered and edited', async ( {

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -18,6 +18,7 @@ test.describe( 'Block template registration', () => {
 		// Enable the template activation feature.
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-block-template-registration'
@@ -25,6 +26,7 @@ test.describe( 'Block template registration', () => {
 		// Disable the template activation experiment.
 		await requestUtils.setGutenbergExperiments( [] );
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllPosts();

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -16,11 +16,13 @@ test.describe( 'Block template registration', () => {
 			'gutenberg-test-block-template-registration'
 		);
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllPosts();

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -17,15 +17,15 @@ test.describe( 'Block template registration', () => {
 		);
 	} );
 
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllPosts();
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-block-template-registration'
 		);
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await requestUtils.deleteAllPosts();
 	} );
 
 	test( 'templates can be registered and edited', async ( {

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -23,6 +23,11 @@ test.describe( 'Template Revert', () => {
 		);
 	} );
 
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await admin.visitSiteEditor( { canvas: 'edit' } );
+	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
@@ -30,11 +35,6 @@ test.describe( 'Template Revert', () => {
 		await requestUtils.deactivatePlugin(
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
-	} );
-
-	test.beforeEach( async ( { admin, requestUtils } ) => {
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await admin.visitSiteEditor( { canvas: 'edit' } );
 	} );
 
 	test( 'should delete the template after saving the reverted template', async ( {

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -22,6 +22,7 @@ test.describe( 'Template Revert', () => {
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
+
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
@@ -30,6 +31,7 @@ test.describe( 'Template Revert', () => {
 			'gutenberg-test-plugin-disable-client-side-media-processing'
 		);
 	} );
+
 	test.beforeEach( async ( { admin, requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await admin.visitSiteEditor( { canvas: 'edit' } );

--- a/test/e2e/specs/site-editor/templates.spec.js
+++ b/test/e2e/specs/site-editor/templates.spec.js
@@ -7,9 +7,11 @@ test.describe( 'Templates', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
+
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 	} );
+
 	test( 'Create a custom template', async ( { admin, page } ) => {
 		const templateName = 'demo';
 		await admin.visitSiteEditor();

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -16,6 +16,7 @@ test.use( {
 
 test.describe( 'Style Revisions', () => {
 	let stylesPostId;
+
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.activateTheme( 'emptytheme' ),

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -26,12 +26,12 @@ test.describe( 'Style Revisions', () => {
 		stylesPostId = await requestUtils.getCurrentThemeGlobalStylesPostId();
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'should display revisions UI when there is 1 revision', async ( {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -81,18 +81,18 @@ test.describe( 'Zoom Out', () => {
 		await requestUtils.activateTheme( 'twentytwentyfour' );
 	} );
 
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await requestUtils.deleteAllTemplates( 'wp_template' );
-		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-	} );
-
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
 			postId: 'twentytwentyfour//index',
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 	} );
 
 	test( 'Entering zoomed out mode zooms the canvas', async ( {

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -17,6 +17,14 @@ const test = base.extend( {
 } );
 
 test.describe( 'Widgets screen', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			// TODO: Ideally we can bundle our test theme directly in the repo.
+			requestUtils.activateTheme( 'twentytwenty' ),
+			requestUtils.deleteAllWidgets(),
+		] );
+	} );
+
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.visitAdminPage( 'widgets.php' );
 
@@ -27,14 +35,6 @@ test.describe( 'Widgets screen', () => {
 
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllWidgets();
-	} );
-
-	test.beforeAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			// TODO: Ideally we can bundle our test theme directly in the repo.
-			requestUtils.activateTheme( 'twentytwenty' ),
-			requestUtils.deleteAllWidgets(),
-		] );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What?
Related #76506.

PR fixes some annoying warnings for e2e tests. These became more visible after recent ESLint updates and are distracting when working with e2e tests.

Fixing `prefer-locator` would be nice, but bulk-fixing them could introduce merge conflicts, since they're usually used in test bodies.

## Testing Instructions
* CI checks are green. This is mostly placement/spacing changes.