### PR TITLE
Accordion: expose Grid/Flex layout switching controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Displays a foldable layout that groups content in collapsible sections. ([Source
 -	**Name:** core/accordion
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout (allowSizingOnChildren, allowSwitching), listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -39,7 +39,10 @@
 			"blockGap": true
 		},
 		"shadow": true,
-		"layout": true,
+		"layout": {
+			"allowSwitching": true,
+			"allowSizingOnChildren": true
+		},
 		"ariaLabel": true,
 		"interactivity": true,
 		"typography": {


### PR DESCRIPTION
## What?
Related to #77281

This PR enables Accordion layout support options so users can access built-in layout switching controls in the editor.

## Why?
The Accordion block currently supports layout but does not expose layout switching controls in its UI. This limits users who want to use Gutenberg’s existing Flex/Grid layout controls directly on Accordion blocks.

## How?
Updated Accordion block metadata in block.json:
- Set `supports.layout.allowSwitching` to `true`
- Set `supports.layout.allowSizingOnChildren` to `true`

Updated generated core blocks docs:
- core-blocks.md

## Testing Instructions
1. Run:
   - `npm run dev`
   - `npm run wp-env start` (if not already running)
2. Open a post or page in the local editor.
3. Insert an **Accordion** block.
4. Select the Accordion parent block.
5. Open the settings sidebar and go to **Layout**.
6. Confirm layout switching controls are visible (including Flex/Grid options).
7. Change layout type and verify controls/behavior update normally.
8. Save and reload to confirm no block validation errors.

### Testing Instructions for Keyboard
1. Insert Accordion via keyboard (`/accordion` + Enter).
2. Use `Tab`/`Shift+Tab` to navigate to block settings.
3. Navigate to **Layout** controls using keyboard only.
4. Switch layout option using keyboard (arrow keys/Enter/Space).
5. Verify focus remains visible and interaction works without mouse.
6. Save and reload, then confirm no validation issues.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1612" height="921" alt="image" src="https://github.com/user-attachments/assets/526c5db3-d0d3-475b-a7ea-fc5672d43464" />|<img width="1612" height="951" alt="image" src="https://github.com/user-attachments/assets/189cec40-5ac3-48a9-9f78-cebf2f71599f" />|

## Use of AI Tools
I used GitHub Copilot (GPT-5.3-Codex) to help draft PR text and assist with implementation guidance. I reviewed and validated the final changes before submitting.